### PR TITLE
scylla-sstable: introduce the query command

### DIFF
--- a/cql3/type_json.hh
+++ b/cql3/type_json.hh
@@ -11,9 +11,23 @@
 #include "types/types.hh"
 #include "utils/rjson.hh"
 
+struct value_and_type {
+    sstring value;
+    rjson::type type; // type of the top-level value
+};
+
 bytes from_json_object(const abstract_type &t, const rjson::value& value);
-sstring to_json_string(const abstract_type &t, bytes_view bv);
-sstring to_json_string(const abstract_type &t, const managed_bytes_view& bv);
+
+value_and_type to_json_value(const abstract_type &t, bytes_view bv);
+value_and_type to_json_value(const abstract_type &t, const managed_bytes_view& bv);
+
+inline sstring to_json_string(const abstract_type &t, bytes_view bv) {
+    return to_json_value(t, bv).value;
+}
+
+inline sstring to_json_string(const abstract_type &t, const managed_bytes_view& bv) {
+    return to_json_value(t, bv).value;
+}
 
 inline sstring to_json_string(const abstract_type &t, const bytes& b) {
     return to_json_string(t, bytes_view(b));

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -7,6 +7,7 @@
 #############################################################################
 
 import contextlib
+import collections
 import glob
 import itertools
 import functools
@@ -16,12 +17,15 @@ import pathlib
 import pytest
 import subprocess
 import tempfile
+import textwrap
 import random
 import re
 import shutil
+import uuid
 from . import nodetool
 from . import util
 from typing import Iterable, Type, Union
+from cassandra.util import Duration
 
 
 def simple_no_clustering_table(cql, keyspace):
@@ -140,6 +144,10 @@ def table_with_counters(cql, keyspace):
     return table, schema
 
 
+def get_sstables_for_table(data_dir, keyspace, table):
+    return glob.glob(os.path.join(data_dir, keyspace, table + '-*', '*-Data.db'))
+
+
 @contextlib.contextmanager
 def scylla_sstable(table_factory, cql, ks, data_dir):
     table, schema = table_factory(cql, ks)
@@ -148,7 +156,7 @@ def scylla_sstable(table_factory, cql, ks, data_dir):
     with open(schema_file, "w") as f:
         f.write(schema)
 
-    sstables = glob.glob(os.path.join(data_dir, ks, table + '-*', '*-Data.db'))
+    sstables = get_sstables_for_table(data_dir, ks, table)
 
     try:
         yield (table, schema_file, sstables)
@@ -1294,3 +1302,333 @@ def test_scylla_sstable_format_version(cql, test_keyspace, scylla_data_dir):
             # "system.scylla_local" system tables has a different setting. but in a
             # new installation of scylla, this setting does not exist.
             assert sstable_version == "me", f"unexpected sstable format: {sstable_version}"
+
+
+class sstable_query_tester:
+    def __init__(self, cql, scylla_path, sstables, keyspace, table, temp_workdir):
+        self._cql = cql
+        self._scylla_path = scylla_path
+        self._sstables = sstables
+        self._keyspace = keyspace
+        self._table = table
+        self._temp_workdir = temp_workdir
+
+    def test_json(self, query_template):
+        cql_query_result = self._cql.execute(query_template.replace("SELECT", "SELECT JSON").format(f"{self._keyspace}.{self._table}"))
+        cql_query_result = list(map(lambda row: json.loads(row[0]), cql_query_result))
+
+        with open(os.path.join(self._temp_workdir, "query.cql"), "w+t") as query_file:
+            query_file.write(query_template.format(f"scylla_sstable.{self._table}"))
+            query_file.flush()
+
+            sstable_query_result = json.loads(subprocess.check_output([
+                self._scylla_path, "sstable", "query",
+                "--logger-log-level", "scylla-sstable=debug",
+                "--output-format", "json",
+                "--schema-tables",
+                "--query-file", query_file.name] + self._sstables))
+
+        assert sstable_query_result == cql_query_result
+
+    def test_text(self, query_cmd_line_params):
+        if "select" in query_cmd_line_params:
+            select = ",".join(query_cmd_line_params["select"])
+        else:
+            select = "*"
+
+        if "where" in query_cmd_line_params:
+            where = " WHERE " + " AND ".join(query_cmd_line_params["where"])
+        else:
+            where = ""
+
+        if query_cmd_line_params.get("allow_filtering", False):
+            allow_filtering  = " ALLOW FILTERING"
+        else:
+            allow_filtering = ""
+
+        cql_query_result = self._cql.execute(f"SELECT JSON {select} FROM {self._keyspace}.{self._table}{where}{allow_filtering}")
+        cql_query_result = list(map(lambda row: json.loads(row[0]), cql_query_result))
+
+        params = [self._scylla_path, "sstable", "query",
+            "--logger-log-level", "scylla-sstable=debug",
+            "--output-format", "text",
+            "--schema-tables"]
+        for select in query_cmd_line_params.get("select", []):
+            params += ["--select", select]
+        for where in query_cmd_line_params.get("where", []):
+            params += ["--where", where]
+        if "allow_filtering" in query_cmd_line_params:
+            params += ["--allow-filtering"]
+        params += self._sstables
+
+        sstable_query_result = subprocess.check_output(params, text=True)
+
+        column_names = []
+        for line_index, line in enumerate(sstable_query_result.split('\n')):
+            if not line:
+                continue
+
+            columns = list(map(str.strip, line.split('|')))
+            if line_index == 0:
+                # header
+                column_names = columns
+            elif line_index == 1:
+                continue # header-body separator line
+            else:
+                # body
+                cql_row = cql_query_result[line_index - 2]
+
+                assert len(columns) == len(cql_row)
+
+                for column_index, column_value in enumerate(columns):
+                    column_name = column_names[column_index]
+
+                    assert column_name in cql_row
+                    assert str(cql_row[column_name]) == column_value
+
+
+scylla_sstable_query_simple_table_param = collections.namedtuple('scylla_sstable_query_simple_table_param',
+                                                                 ['schema', 'insert_statement', 'insert_statement_parameters', 'prepare', 'teardown'])
+
+scylla_sstable_query_simple_all_types_param = scylla_sstable_query_simple_table_param(
+textwrap.dedent("""
+    CREATE TABLE {}.{} (
+        pk int,
+        ck int,
+        col_ascii ascii,
+        col_bigint bigint,
+        col_blob blob,
+        col_boolean boolean,
+        col_date date,
+        col_decimal decimal,
+        col_double double,
+        col_duration duration,
+        col_float float,
+        col_inet inet,
+        col_int int,
+        col_smallint smallint,
+        col_text text,
+        col_time time,
+        col_timestamp timestamp,
+        col_timeuuid timeuuid,
+        col_tinyint tinyint,
+        col_uuid uuid,
+        col_varint varint,
+        PRIMARY KEY (pk, ck)
+    ) WITH
+        compaction = {{'class': 'NullCompactionStrategy'}};
+    """),
+textwrap.dedent("""
+    INSERT INTO {}.{} (
+        pk,
+        ck,
+        col_ascii,
+        col_bigint,
+        col_blob,
+        col_boolean,
+        col_date,
+        col_decimal,
+        col_double,
+        col_duration,
+        col_float,
+        col_inet,
+        col_int,
+        col_smallint,
+        col_text,
+        col_time,
+        col_timestamp,
+        col_timeuuid,
+        col_tinyint,
+        col_uuid,
+        col_varint
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    """),
+(
+        0,
+        0,
+        "asasdfasfd",
+        99999999,
+        bytearray(b'\x78\xcc\xaf'),
+        True,
+        "2012-03-04",
+        87689.2123,
+        0.7567645,
+        Duration(months=10, days=1),
+        0.11,
+        "127.0.0.1",
+        100,
+        10,
+        "kjhknnhjhghgsdf",
+        "08:12:54",
+        1299038700000,
+        uuid.UUID("f06fdf50-bdf7-11ef-84c5-e1cf2fa2d062"),
+        1,
+        uuid.UUID("123e4567-e89b-12d3-a456-426655440000"),
+        8876876876,
+),
+    None,
+    None,
+)
+
+my_udt = collections.namedtuple('my_type', ['field_1', 'field_2'])
+
+scylla_sstable_query_simple_collection_types_param = scylla_sstable_query_simple_table_param(
+textwrap.dedent("""
+    CREATE TABLE {}.{} (
+        pk int PRIMARY KEY,
+        col_list list<text>,
+        col_set set<text>,
+        col_map map<int, text>,
+        col_tuple tuple<text, int>,
+        col_udt my_type
+    ) WITH
+        compaction = {{'class': 'NullCompactionStrategy'}};
+"""),
+    "INSERT INTO {}.{} (pk, col_list, col_set, col_map, col_tuple, col_udt) VALUES (?, ?, ?, ?, ?, ?)",
+    (0, ['adads', '3443sd'], {'asdafasdf', 'aasd'}, {1: 'ak', 2: 'pa'}, ('adadad', 1), my_udt(10, 'aasdad')),
+    "CREATE TYPE {}.my_type (field_1 int, field_2 text)",
+    "DROP TYPE {}.my_type",
+)
+
+scylla_sstable_query_simple_counter_param = scylla_sstable_query_simple_table_param(
+textwrap.dedent("""
+    CREATE TABLE {}.{} (
+        pk int PRIMARY KEY,
+        col_counter counter
+    ) WITH
+        compaction = {{'class': 'NullCompactionStrategy'}};
+"""),
+    "UPDATE {}.{} SET col_counter = col_counter + 10 WHERE pk = ?",
+    (0,),
+    None,
+    None,
+)
+
+@pytest.mark.parametrize("test_keyspace", ["tablets", "vnodes"], indirect=True)
+@pytest.mark.parametrize("test_table", [
+        scylla_sstable_query_simple_all_types_param,
+        scylla_sstable_query_simple_collection_types_param,
+        scylla_sstable_query_simple_counter_param,
+])
+def test_scylla_sstable_query_data_types(request, cql, test_keyspace, test_table, scylla_path, scylla_data_dir, temp_workdir):
+    """Check read-all queries with all data-types.
+
+    Run the same query via CQL and via scylla-sstable query and check that the
+    results match.
+    Test both with --query-file and the command-line query composition params.
+    Test both json and text output. To reduce the amount of cases, --query-file
+    is tested with json output, while command-line query is tested with text
+    output.
+
+    This test focuses on checkig the correct formatting and handling of all CQL
+    data-types.
+    """
+    if test_table == scylla_sstable_query_simple_counter_param and util.keyspace_has_tablets(cql, test_keyspace):
+        request.node.add_marker(pytest.mark.xfail(reason="counters are not supported with tablets, see #18180"))
+
+    if test_table.prepare is not None:
+        cql.execute(test_table.prepare.format(test_keyspace))
+
+    table = util.unique_name()
+    schema = test_table.schema.format(test_keyspace, table)
+
+    cql.execute(schema)
+
+    insert_statement = cql.prepare(test_table.insert_statement.format(test_keyspace, table))
+    cql.execute(insert_statement, test_table.insert_statement_parameters)
+
+    nodetool.flush(cql, f"{test_keyspace}.{table}")
+    nodetool.flush_keyspace(cql, "system_schema")
+
+    sstables = get_sstables_for_table(scylla_data_dir, test_keyspace, table)
+
+    with nodetool.no_autocompaction_context(cql, "system_schema"):
+        tester = sstable_query_tester(cql, scylla_path, sstables, test_keyspace, table, temp_workdir)
+
+        tester.test_json("SELECT * FROM {}")
+
+    cql.execute(f"DROP TABLE {test_keyspace}.{table}")
+
+    if test_table.teardown is not None:
+        cql.execute(test_table.teardown.format(test_keyspace))
+
+
+def test_scylla_sstable_query_advanced_queries(cql, test_keyspace, scylla_path, scylla_data_dir, temp_workdir):
+    """Check more advanced queries.
+
+    Run the same query via CQL and via scylla-sstable query and check that the
+    results match.
+    Test both with --query-file and the command-line query composition params.
+    Test both json and text output. To reduce the amount of cases, --query-file
+    is tested with json output, while command-line query is tested with text
+    output.
+
+    This test focuses on checkig the correct handling of more advanced queries,
+    which select a subset of fields and use restrictions and even aggregation.
+    No attempt is made to cover all CQL featues.
+    """
+    table = util.unique_name()
+    schema = f"CREATE TABLE {test_keyspace}.{table} (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
+
+    cql.execute(schema)
+
+    insert_statement = cql.prepare(f"INSERT INTO {test_keyspace}.{table} (pk, ck, v) VALUES (?, ?, ?)")
+    for pk in range(0, 10):
+        for ck in range(0, 10):
+            cql.execute(insert_statement, (pk, ck, pk + ck))
+
+    nodetool.flush(cql, f"{test_keyspace}.{table}")
+    nodetool.flush_keyspace(cql, "system_schema")
+
+    sstables = get_sstables_for_table(scylla_data_dir, test_keyspace, table)
+
+    with nodetool.no_autocompaction_context(cql, "system_schema"):
+        tester = sstable_query_tester(cql, scylla_path, sstables, test_keyspace, table, temp_workdir)
+
+        tester.test_text({})
+        tester.test_json("SELECT count(*) FROM {} WHERE pk = 0")
+        tester.test_json("SELECT ck, v FROM {} WHERE pk = 0 and ck = 0")
+        tester.test_text({"select": ("ck", "v"), "where": ("pk=0",)})
+        tester.test_json("SELECT * FROM {} WHERE pk = 0 AND v = 0 ALLOW FILTERING")
+        tester.test_text({"select": ("pk", "v"), "where": ("pk=0", "v=0"), "allow_filtering": True})
+
+    cql.execute(f"DROP TABLE {test_keyspace}.{table}")
+
+
+def test_scylla_sstable_query_bad_command_line(cql, scylla_path, scylla_data_dir):
+    """Check that not-allowed command line param combinations are refused."""
+    nodetool.flush_keyspace(cql, "system_schema")
+
+    with nodetool.no_autocompaction_context(cql, "system_schema"):
+        sstables = get_sstables_for_table(scylla_data_dir, "system_schema", "columns")
+
+        common_params = [scylla_path, "sstable", "query", "--system-schema", "--query-file", "whatever.cql"]
+
+        def check(bad_params):
+            res = subprocess.run(common_params + bad_params + sstables, text=True, capture_output=True)
+            assert res.returncode == 1
+            assert res.stdout == ""
+            assert "error processing arguments: cannot provide both --query-file and --select|--where|--allow-filtering" in res.stderr
+
+        check(["--select", "keyspace_name"])
+        check(["--where", "keyspace_name=system"])
+        check(["--allow-filtering"])
+        check(["--select", "keyspace_name", "--where", "keyspace_name=system", "--allow-filtering"])
+
+
+def test_scylla_sstable_query_temp_dir(cql, scylla_path, scylla_data_dir):
+    """Check that --temp-dir is respected.
+
+    This is very hard to test with a positive test, because cql_test_env removes
+    its temp-dir on exit. So we test with a negative test: give an impossible
+    path and check that creating the temp-dir fails.
+    """
+    nodetool.flush_keyspace(cql, "system_schema")
+
+    with nodetool.no_autocompaction_context(cql, "system_schema"):
+        sstables = get_sstables_for_table(scylla_data_dir, "system_schema", "columns")
+
+        res = subprocess.run([scylla_path, "sstable", "query", "--system-schema", "--temp-dir", "/dev/null"] + sstables, text=True, capture_output=True)
+        assert res.returncode == 2
+        assert res.stdout == ""
+        assert "error running operation: std::filesystem::__cxx11::filesystem_error (error generic:20, filesystem error: cannot create directories: Not a directory [/dev/null/" in res.stderr

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -442,6 +442,11 @@ public:
         });
     }
 
+    static void do_with_noreentrant_thread(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in, std::optional<cql_test_init_configurables> init_configurables) {
+        single_node_cql_env env;
+        env.run_in_thread(std::move(func), std::move(cfg_in), std::move(init_configurables));
+    }
+
 private:
     void run_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in, std::optional<cql_test_init_configurables> init_configurables) {
             using namespace std::filesystem;
@@ -1104,6 +1109,10 @@ future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_tes
             return func(e);
         });
     }, std::move(cfg_in), std::move(init_configurables));
+}
+
+void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config cfg_in, std::optional<cql_test_init_configurables> init_configurables) {
+    single_node_cql_env::do_with_noreentrant_thread(std::move(func), std::move(cfg_in), std::move(init_configurables));
 }
 
 // this function should be called in seastar thread

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -479,7 +479,11 @@ private:
             if (!cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.is_set()) {
                 cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
             }
-            tmpdir data_dir;
+            fs::path temp_dir_path = fs::temp_directory_path();
+            if (init_configurables.tmp_dir_path) {
+                temp_dir_path = *init_configurables.tmp_dir_path;
+            }
+            tmpdir data_dir(temp_dir_path);
             auto data_dir_path = data_dir.path().string();
             if (!cfg->data_file_directories.is_set()) {
                 cfg->data_file_directories.set({data_dir_path});

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -189,6 +189,8 @@ public:
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
 future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, std::optional<cql_test_init_configurables> = {});
 
+void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
+
 // this function should be called in seastar thread
 void do_with_mc(cql_test_env& env, std::function<void(service::group0_batch&)> func);
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -104,7 +104,7 @@ public:
 };
 
 struct cql_test_init_configurables {
-    db::extensions& extensions;
+    db::extensions* extensions{nullptr};
 };
 
 class cql_test_env {
@@ -186,10 +186,10 @@ public:
     data_dictionary::database data_dictionary();
 };
 
-future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
-future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, std::optional<cql_test_init_configurables> = {});
+future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, cql_test_init_configurables = {});
+future<> do_with_cql_env_thread(std::function<void(cql_test_env&)> func, cql_test_config = {}, thread_attributes thread_attr = {}, cql_test_init_configurables = {});
 
-void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});
+void do_with_cql_env_noreentrant_in_thread(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, cql_test_init_configurables = {});
 
 // this function should be called in seastar thread
 void do_with_mc(cql_test_env& env, std::function<void(service::group0_batch&)> func);

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -105,6 +105,7 @@ public:
 
 struct cql_test_init_configurables {
     db::extensions* extensions{nullptr};
+    std::optional<std::filesystem::path> tmp_dir_path;
 };
 
 class cql_test_env {

--- a/test/lib/tmpdir.cc
+++ b/test/lib/tmpdir.cc
@@ -31,8 +31,8 @@ tmpdir::sweeper::~sweeper() {
     }
 }
 
-tmpdir::tmpdir()
-    : _path(fs::temp_directory_path() / fs::path(fmt::format(FMT_STRING("scylla-{}"), utils::make_random_uuid()))) {
+tmpdir::tmpdir(fs::path tmp_dir_path)
+    : _path(tmp_dir_path / fs::path(fmt::format(FMT_STRING("scylla-{}"), utils::make_random_uuid()))) {
     fs::create_directories(_path);
 }
 

--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -29,7 +29,7 @@ private:
     };
 
 public:
-    tmpdir();
+    tmpdir(fs::path tmp_dir_path = fs::temp_directory_path());
 
     tmpdir(tmpdir&& other) noexcept;
     tmpdir(const tmpdir&) = delete;

--- a/utils/rjson.hh
+++ b/utils/rjson.hh
@@ -389,6 +389,7 @@ public:
     bool Uint64(uint64_t i) { return _writer.Uint64(i); }
     bool Double(double d) { return _writer.Double(d); }
     bool RawNumber(std::string_view str) { return _writer.RawNumber(str.data(), str.size(), false); }
+    bool RawValue(std::string_view json, type root_type) { return _writer.RawValue(json.data(), json.size(), root_type); }
     bool String(std::string_view str) { return _writer.String(str.data(), str.size(), false); }
     bool StartObject() { return _writer.StartObject(); }
     bool Key(std::string_view str) { return _writer.Key(str.data(), str.size(), false); }


### PR DESCRIPTION
The scylla-sstable dump-* command suite has proven invaluable  in many investigations. In certain cases however, I found that `dump-data` is quite cumbersome. An example would be trying to find certain values in an sstable, or trying to read the content of system tables when a node is down. For these cases, `dump-data`  is very cumbersome: one has to trudge through tons of uninteresting metadata and do compaction in their heads. This PR introduces the new scylla-sstable query command, specifically targeted at situations like this: it allows executing queries on sstables, exposing to the user all the power of CQL, to tailor the output as they see fit.

### Examples

Select everything from a table:

    $ scylla sstable query --system-schema /path/to/data/system_schema/keyspaces-*/*-big-Data.db
     keyspace_name                 | durable_writes | replication
    -------------------------------+----------------+-------------------------------------------------------------------------------------
            system_replicated_keys |           true |                         ({class : org.apache.cassandra.locator.EverywhereStrategy})
                       system_auth |           true |   ({class : org.apache.cassandra.locator.SimpleStrategy}, {replication_factor : 1})
                     system_schema |           true |                              ({class : org.apache.cassandra.locator.LocalStrategy})
                system_distributed |           true |   ({class : org.apache.cassandra.locator.SimpleStrategy}, {replication_factor : 3})
                            system |           true |                              ({class : org.apache.cassandra.locator.LocalStrategy})
                                ks |           true | ({class : org.apache.cassandra.locator.NetworkTopologyStrategy}, {datacenter1 : 1})
                     system_traces |           true |   ({class : org.apache.cassandra.locator.SimpleStrategy}, {replication_factor : 2})
     system_distributed_everywhere |           true |                         ({class : org.apache.cassandra.locator.EverywhereStrategy})

Select everything from a single SSTable, use the JSON output (filtered through `jq <https://jqlang.github.io/jq/>_` for better readability):

    $ scylla sstable query --system-schema --output-format=json /path/to/data/system_schema/keyspaces-*/me-3gm7_127s_3ndxs28xt4llzxwqz6-big-Data.db | jq
    [
      {
        "keyspace_name": "system_schema",
        "durable_writes": true,
        "replication": {
          "class": "org.apache.cassandra.locator.LocalStrategy"
        }
      },
      {
        "keyspace_name": "system",
        "durable_writes": true,
        "replication": {
          "class": "org.apache.cassandra.locator.LocalStrategy"
        }
      }
    ]

Select a specific field in a specific partition using the command-line:

    $ scylla sstable query --system-schema --select "replication" --where "keyspace_name='ks'" ./scylla-workdir/data/system_schema/keyspaces-*/*-Data.db
     replication
    -------------------------------------------------------------------------------------
     ({class : org.apache.cassandra.locator.NetworkTopologyStrategy}, {datacenter1 : 1})

Select a specific field in a specific partition using ``--query-file``:

    $ echo "SELECT replication FROM scylla_sstable.keyspaces WHERE keyspace_name='ks';" > query.cql
    $ scylla sstable query --system-schema --query-file=./query.cql ./scylla-workdir/data/system_schema/keyspaces-*/*-Data.db
     replication
    -------------------------------------------------------------------------------------
     ({class : org.apache.cassandra.locator.NetworkTopologyStrategy}, {datacenter1 : 1})

 
New functionality: no backport needed.