### PR TITLE
node_ops: filter topology_requests entries shown by node_ops_virtual_task

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3413,7 +3413,7 @@ future<system_keyspace::topology_requests_entry> system_keyspace::get_topology_r
     co_return topology_request_row_to_entry(id, row);
 }
 
-future<system_keyspace::topology_requests_entries> system_keyspace::get_topology_request_entries(db_clock::time_point end_time_limit) {
+future<system_keyspace::topology_requests_entries> system_keyspace::get_node_ops_request_entries(db_clock::time_point end_time_limit) {
     // Running requests.
     auto rs_running = co_await execute_cql(
         format("SELECT * FROM system.{} WHERE done = false AND request_type IN ('{}', '{}', '{}', '{}', '{}') ALLOW FILTERING", TOPOLOGY_REQUESTS,

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3416,12 +3416,14 @@ future<system_keyspace::topology_requests_entry> system_keyspace::get_topology_r
 future<system_keyspace::topology_requests_entries> system_keyspace::get_topology_request_entries(db_clock::time_point end_time_limit) {
     // Running requests.
     auto rs_running = co_await execute_cql(
-        format("SELECT * FROM system.{} WHERE done = false ALLOW FILTERING", TOPOLOGY_REQUESTS));
+        format("SELECT * FROM system.{} WHERE done = false AND request_type IN ('{}', '{}', '{}', '{}', '{}') ALLOW FILTERING", TOPOLOGY_REQUESTS,
+            service::topology_request::join, service::topology_request::replace, service::topology_request::rebuild, service::topology_request::leave, service::topology_request::remove));
 
 
     // Requests which finished after end_time_limit.
     auto rs_done = co_await execute_cql(
-        format("SELECT * FROM system.{} WHERE end_time > {} ALLOW FILTERING", TOPOLOGY_REQUESTS, end_time_limit.time_since_epoch().count()));
+        format("SELECT * FROM system.{} WHERE end_time > {} AND request_type IN ('{}', '{}', '{}', '{}', '{}') ALLOW FILTERING", TOPOLOGY_REQUESTS, end_time_limit.time_since_epoch().count(),
+            service::topology_request::join, service::topology_request::replace, service::topology_request::rebuild, service::topology_request::leave, service::topology_request::remove));
 
     topology_requests_entries m;
     for (const auto& row: *rs_done) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -643,7 +643,7 @@ public:
     future<service::topology_request_state> get_topology_request_state(utils::UUID id, bool require_entry);
     topology_requests_entry topology_request_row_to_entry(utils::UUID id, const cql3::untyped_result_set_row& row);
     future<topology_requests_entry> get_topology_request_entry(utils::UUID id, bool require_entry);
-    future<topology_requests_entries> get_topology_request_entries(db_clock::time_point end_time_limit);
+    future<topology_requests_entries> get_node_ops_request_entries(db_clock::time_point end_time_limit);
 
 public:
     future<std::optional<int8_t>> get_service_levels_version();

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -114,7 +114,7 @@ future<std::optional<tasks::virtual_task_hint>> node_ops_virtual_task::contains(
     }
 
     auto entry = co_await _ss._sys_ks.local().get_topology_request_entry(task_id.uuid(), false);
-    co_return bool(entry.id) ? empty_hint : std::nullopt;
+    co_return bool(entry.id) && entry.request_type ? empty_hint : std::nullopt;
 }
 
 future<tasks::is_abortable> node_ops_virtual_task::is_abortable(tasks::virtual_task_hint) const {

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -56,7 +56,7 @@ static std::set<tasks::task_id> get_pending_ids(service::topology& topology) {
 
 static future<db::system_keyspace::topology_requests_entries> get_entries(db::system_keyspace& sys_ks, service::topology& topology, std::chrono::seconds ttl) {
     // Started requests.
-    auto entries = co_await sys_ks.get_topology_request_entries(db_clock::now() - ttl);
+    auto entries = co_await sys_ks.get_node_ops_request_entries(db_clock::now() - ttl);
 
     // Pending requests.
     for (auto& id : get_pending_ids(topology)) {

--- a/test/topology_tasks/test_node_ops_tasks.py
+++ b/test/topology_tasks/test_node_ops_tasks.py
@@ -203,6 +203,13 @@ async def test_node_ops_tasks_tree(manager: ManagerClient):
     servers = [await manager.server_add() for _ in range(3)]
     assert module_name in await tm.list_modules(servers[0].ip_addr), "node_ops module wasn't registered"
 
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+    await cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({1}, {1});")
+    await cql.run_async(f"TRUNCATE test.test;")
+
+
     servers, vt_ids = await check_bootstrap_tasks_tree(tm, module_name, servers)
     servers, vt_ids = await check_replace_tasks_tree(manager, tm, module_name, servers, vt_ids)
     servers, vt_ids = await check_rebuild_tasks_tree(manager, tm, module_name, servers, vt_ids)


### PR DESCRIPTION
node_ops_virtual_task does not filter the entries of system.topology_request 
and so it creates statuses of operations that aren't node ops.

Filter the entries used by node_ops_virtual_task. With this change, the status 
of a bootstrap of the first node will not be visible.

Fixes: https://github.com/scylladb/scylladb/issues/22008.

Needs backport to 6.2 that introduced node_ops_virtual_task