### PR TITLE
storage_proxy: stop: await_pending_writes

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6931,7 +6931,7 @@ future<> storage_proxy::abort_view_writes() {
 
 future<>
 storage_proxy::stop() {
-    return make_ready_future<>();
+    return await_pending_writes();
 }
 
 locator::token_metadata_ptr storage_proxy::get_token_metadata_ptr() const noexcept {


### PR DESCRIPTION
We take care to start_write() in the write response handlers,
but we don't await them on stop().  await_pending_writes() is
currently only used by storage_service::sstable_cleanup_fiber
to wait for all local writes to complete before cleanup.

await_pending_writes() also in stop() to make sure there are no
pending writes hanging around after storage_proxy is stopped.

A follow-up change will add utils::phased_barrier::close() to prevent new operations from starting after the service is stopped.

* Although this does not fix a known issue, I recommend backporting it to all live version, to be on the safe side.