### PR TITLE
Phased barrier improvements

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1684,7 +1684,11 @@ table::stop() {
     // Allow `compaction_group::stop` to stop ongoing compactions
     // while they may still hold the table _async_gate
     auto gate_closed_fut = _async_gate.close();
-    co_await await_pending_ops();
+    co_await when_all(
+        _pending_reads_phaser.close(),
+        _pending_writes_phaser.close(),
+        _pending_streams_phaser.close(),
+        _pending_flushes_phaser.close());
     co_await _sg_manager->stop_storage_groups();
     co_await _sstable_deletion_gate.close();
     co_await std::move(gate_closed_fut);

--- a/utils/phased_barrier.hh
+++ b/utils/phased_barrier.hh
@@ -62,6 +62,10 @@ public:
     // It is fine to start multiple awaits in parallel.
     // Cannot fail.
     future<> advance_and_await() noexcept {
+        if (!operations_in_progress()) {
+            ++_phase;
+            return make_ready_future();
+        }
         auto new_gate = [] {
             seastar::memory::scoped_critical_alloc_section _;
             return make_lw_shared<gate>();

--- a/utils/phased_barrier.hh
+++ b/utils/phased_barrier.hh
@@ -58,6 +58,14 @@ public:
         return { _gate };
     }
 
+    future<> close() noexcept {
+        return _gate->close();
+    }
+
+    bool is_closed() const noexcept {
+        return _gate->is_closed();
+    }
+
     // Starts a new phase and waits for all operations started in any of the earlier phases.
     // It is fine to start multiple awaits in parallel.
     // Cannot fail.


### PR DESCRIPTION
- utils: phased_barrier: advance_and_await: allocate new gate only when needed
- utils: phased_barrier: add close() method
  - and use in existing services

* Improvement. No backport needed
