### PR TITLE
DEBUG [Backport 6.1] Do not reset quarantine list in non raft mode

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1703,7 +1703,18 @@ void gossiper::mark_alive(inet_address addr) {
         _pending_mark_alive_endpoints.erase(addr);
     });
 
+<<<<<<< HEAD
     msg_addr id = get_msg_addr(addr);
+||||||| parent of 3368019982 (gossiper: do not send echo message to yourself)
+    auto id = get_host_id(addr);
+=======
+    auto id = get_host_id(addr);
+    if (id == my_host_id()) {
+        // We are here because this node changed address and now tries to
+        // ping an old gossip entry.
+        return;
+    }
+>>>>>>> 3368019982 (gossiper: do not send echo message to yourself)
     auto generation = my_endpoint_state().get_heart_beat_state().get_generation();
     // Enter the _background_msg gate so stop() would wait on it
     auto gh = _background_msg.hold();

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -681,6 +681,10 @@ future<> gossiper::apply_state_locally(std::map<inet_address, endpoint_state> ma
                 // If there is no host id in the new state there should be one locally
                 hid = get_host_id(ep);
             }
+            if (hid == my_host_id()) {
+                 logger.trace("Ignoring gossip for {} because it maps to local id, but is not local address", ep);
+                 return make_ready_future<>();
+            }
             if (_topo_sm->_topology.left_nodes.contains(raft::server_id(hid.uuid()))) {
                 logger.trace("Ignoring gossip for {} because it left", ep);
                 return make_ready_future<>();

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -328,8 +328,10 @@ public:
 
     void set_topology_state_machine(service::topology_state_machine* m) {
         _topo_sm = m;
-        // In raft topology mode the coodinator maintains banned nodes list
-        _just_removed_endpoints.clear();
+        if (m) {
+            // In raft topology mode the coodinator maintains banned nodes list
+            _just_removed_endpoints.clear();
+        }
     }
 
 private:


### PR DESCRIPTION
The series contains small fixes to the gossiper one of which fixes #21930. Others I noticed while debugged the issue.

Fixes: #21930

- (cherry picked from commit e80355d3a1178f97c5b6cac91daa7f7bb4a4d6fd)

- (cherry picked from commit 336801998241b924b91b52a347fba3d0ddebad8f)

- (cherry picked from commit e318dfb83a03db5dd7691db743034eb84c31e83b)

Parent PR: #21956