### PR TITLE
Introduce LDAP role manager & saslauthd authenticator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ add_subdirectory(compaction)
 add_subdirectory(cql3)
 add_subdirectory(data_dictionary)
 add_subdirectory(dht)
+add_subdirectory(ent)
 add_subdirectory(gms)
 add_subdirectory(idl)
 add_subdirectory(index)
@@ -311,6 +312,7 @@ set(scylla_libs
     idl
     index
     lang
+    ldap
     locator
     message
     mutation

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -1,4 +1,6 @@
 include(add_whole_archive)
+find_package(OpenLDAP REQUIRED
+  ldap)
 
 add_library(scylla_auth STATIC)
 target_sources(scylla_auth
@@ -10,6 +12,7 @@ target_sources(scylla_auth
     certificate_authenticator.cc
     common.cc
     default_authorizer.cc
+    ldap_role_manager.cc
     password_authenticator.cc
     passwords.cc
     permission.cc
@@ -18,6 +21,7 @@ target_sources(scylla_auth
     role_or_anonymous.cc
     roles-metadata.cc
     sasl_challenge.cc
+    saslauthd_authenticator.cc
     service.cc
     standard_role_manager.cc
     transitional.cc
@@ -31,8 +35,10 @@ target_link_libraries(scylla_auth
     xxHash::xxhash
   PRIVATE
     absl::headers
+    OpenLDAP::ldap
     cql3
     idl
+    ldap
     wasmtime_bindings
     libxcrypt::libxcrypt)
 

--- a/auth/authenticator.cc
+++ b/auth/authenticator.cc
@@ -14,6 +14,8 @@
 
 const sstring auth::authenticator::USERNAME_KEY("username");
 const sstring auth::authenticator::PASSWORD_KEY("password");
+const sstring auth::authenticator::SERVICE_KEY("service");
+const sstring auth::authenticator::REALM_KEY("realm");
 
 future<std::optional<auth::authenticated_user>> auth::authenticator::authenticate(session_dn_func) const {
     return make_ready_future<std::optional<auth::authenticated_user>>(std::nullopt);

--- a/auth/authenticator.hh
+++ b/auth/authenticator.hh
@@ -67,6 +67,12 @@ public:
     ///
     static const sstring PASSWORD_KEY;
 
+    /// Service for SASL authentication.
+    static const sstring SERVICE_KEY;
+
+    /// Realm for SASL authentication.
+    static const sstring REALM_KEY;
+
     using credentials_map = std::unordered_map<sstring, sstring>;
 
     virtual ~authenticator() = default;

--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -1,0 +1,345 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "ldap_role_manager.hh"
+
+#include <boost/algorithm/string/replace.hpp>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ldap.h>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/net/dns.hh>
+#include <seastar/util/log.hh>
+#include <seastar/core/coroutine.hh>
+#include <vector>
+
+#include "common.hh"
+#include "cql3/query_processor.hh"
+#include "exceptions/exceptions.hh"
+#include "seastarx.hh"
+#include "service/raft/raft_group0_client.hh"
+#include "utils/class_registrator.hh"
+#include "db/config.hh"
+#include "utils/exponential_backoff_retry.hh"
+
+namespace {
+
+logger mylog{"ldap_role_manager"}; // `log` is taken by math.
+
+struct url_desc_deleter {
+    void operator()(LDAPURLDesc *p) {
+        ldap_free_urldesc(p);
+    }
+};
+
+using url_desc_ptr = std::unique_ptr<LDAPURLDesc, url_desc_deleter>;
+
+url_desc_ptr parse_url(std::string_view url) {
+    LDAPURLDesc *desc = nullptr;
+    if (ldap_url_parse(url.data(), &desc)) {
+        mylog.error("error in ldap_url_parse({})", url);
+    }
+    return url_desc_ptr(desc);
+}
+
+/// Extracts attribute \p attr from all entries in \p res.
+std::vector<sstring> get_attr_values(LDAP* ld, LDAPMessage* res, const char* attr) {
+    std::vector<sstring> values;
+    mylog.debug("Analyzing search results");
+    for (auto e = ldap_first_entry(ld, res); e; e = ldap_next_entry(ld, e)) {
+        struct deleter {
+            void operator()(berval** p) { ldap_value_free_len(p); }
+            void operator()(char* p) { ldap_memfree(p); }
+        };
+        const std::unique_ptr<char, deleter> dname(ldap_get_dn(ld, e));
+        mylog.debug("Analyzing entry {}", dname.get());
+        const std::unique_ptr<berval*, deleter> vals(ldap_get_values_len(ld, e, attr));
+        if (!vals) {
+            mylog.warn("LDAP entry {} has no attribute {}", dname.get(), attr);
+            continue;
+        }
+        for (size_t i = 0; vals.get()[i]; ++i) {
+            values.emplace_back(vals.get()[i]->bv_val, vals.get()[i]->bv_len);
+        }
+    }
+    mylog.debug("Done analyzing search results; extracted roles {}", values);
+    return values;
+}
+
+const char* ldap_role_manager_full_name = "com.scylladb.auth.LDAPRoleManager";
+
+} // anonymous namespace
+
+namespace auth {
+
+static const class_registrator<
+    role_manager,
+    ldap_role_manager,
+    cql3::query_processor&,
+    ::service::raft_group0_client&,
+    ::service::migration_manager&> registration(ldap_role_manager_full_name);
+
+ldap_role_manager::ldap_role_manager(
+        std::string_view query_template, std::string_view target_attr, std::string_view bind_name, std::string_view bind_password,
+        cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm)
+        : _std_mgr(qp, rg0c, mm), _group0_client(rg0c), _query_template(query_template), _target_attr(target_attr), _bind_name(bind_name)
+        , _bind_password(bind_password)
+        , _connection_factory(bind(std::mem_fn(&ldap_role_manager::reconnect), std::ref(*this))) {
+}
+
+ldap_role_manager::ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm)
+    : ldap_role_manager(
+            qp.db().get_config().ldap_url_template(),
+            qp.db().get_config().ldap_attr_role(),
+            qp.db().get_config().ldap_bind_dn(),
+            qp.db().get_config().ldap_bind_passwd(),
+            qp,
+            rg0c,
+            mm) {
+}
+
+std::string_view ldap_role_manager::qualified_java_name() const noexcept {
+    return ldap_role_manager_full_name;
+}
+
+const resource_set& ldap_role_manager::protected_resources() const {
+    return _std_mgr.protected_resources();
+}
+
+future<> ldap_role_manager::start() {
+    if (!parse_url(get_url("dummy-user"))) { // Just need host and port -- any user should do.
+        return make_exception_future(
+                std::runtime_error(fmt::format("error getting LDAP server address from template {}", _query_template)));
+    }
+    return _std_mgr.start();
+}
+
+using conn_ptr = lw_shared_ptr<ldap_connection>;
+
+future<conn_ptr> ldap_role_manager::connect() {
+    const auto desc = parse_url(get_url("dummy-user")); // Just need host and port -- any user should do.
+    if (!desc) {
+        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("connect attempted before a successful start")));
+    }
+    net::inet_address host = co_await net::dns::resolve_name(desc->lud_host);
+    const socket_address addr(host, uint16_t(desc->lud_port));
+    connected_socket sock = co_await seastar::connect(addr);
+    auto conn = make_lw_shared<ldap_connection>(std::move(sock));
+    sstring error;
+    try {
+        ldap_msg_ptr response = co_await conn->simple_bind(_bind_name.c_str(), _bind_password.c_str());
+        if (!response || ldap_msgtype(response.get()) != LDAP_RES_BIND) {
+            error = format("simple_bind error: {}", conn->get_error());
+        }
+    } catch (...) {
+        error = format("connect error: {}", std::current_exception());
+    }
+    if (!error.empty()) {
+        co_await conn->close();
+        co_return coroutine::exception(std::make_exception_ptr(std::runtime_error(std::move(error))));
+    }
+    co_return std::move(conn);
+}
+
+future<conn_ptr> ldap_role_manager::reconnect() {
+    unsigned retries_left = 5;
+    using namespace std::literals::chrono_literals;
+    conn_ptr conn = co_await exponential_backoff_retry::do_until_value(1s, 32s, _as, [this, &retries_left] () -> future<std::optional<conn_ptr>> {
+        if (!retries_left) {
+            co_return conn_ptr{};
+        }
+        mylog.trace("reconnect() retrying ({} attempts left)", retries_left);
+        --retries_left;
+        try {
+            co_return co_await connect();
+        } catch (...) {
+            mylog.error("error in reconnect: {}", std::current_exception());
+        }
+        co_return std::nullopt;
+    });
+
+    mylog.trace("reconnect() finished backoff, conn={}", reinterpret_cast<void*>(conn.get()));
+    if (conn) {
+        co_return std::move(conn);
+    }
+    co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("reconnect failed after 5 attempts")));
+}
+
+future<> ldap_role_manager::stop() {
+    _as.request_abort();
+    return _std_mgr.stop().then([this] { return _connection_factory.stop(); });
+}
+
+future<> ldap_role_manager::create(std::string_view name, const role_config& config, ::service::group0_batch& mc) {
+    return _std_mgr.create(name, config, mc);
+}
+
+future<> ldap_role_manager::drop(std::string_view name, ::service::group0_batch& mc) {
+    return _std_mgr.drop(name, mc);
+}
+
+future<> ldap_role_manager::alter(std::string_view name, const role_config_update& config, ::service::group0_batch& mc) {
+    return _std_mgr.alter(name, config, mc);
+}
+
+future<> ldap_role_manager::grant(std::string_view, std::string_view, ::service::group0_batch& mc) {
+    return make_exception_future<>(exceptions::invalid_request_exception("Cannot grant roles with LDAPRoleManager."));
+}
+
+future<> ldap_role_manager::revoke(std::string_view, std::string_view, ::service::group0_batch& mc) {
+    return make_exception_future<>(exceptions::invalid_request_exception("Cannot revoke roles with LDAPRoleManager."));
+}
+
+future<role_set> ldap_role_manager::query_granted(std::string_view grantee_name, recursive_role_query) {
+    const auto url = get_url(grantee_name.data());
+    auto desc = parse_url(url);
+    if (!desc) {
+        return make_exception_future<role_set>(std::runtime_error(format("Error parsing URL {}", url)));
+    }
+    return _connection_factory.with_connection([this, desc = std::move(desc), grantee_name_ = sstring(grantee_name)]
+                                               (ldap_connection& conn) -> future<role_set> {
+        sstring grantee_name = std::move(grantee_name_);
+        ldap_msg_ptr res = co_await conn.search(desc->lud_dn, desc->lud_scope, desc->lud_filter, desc->lud_attrs,
+                           /*attrsonly=*/0, /*serverctrls=*/nullptr, /*clientctrls=*/nullptr,
+                           /*timeout=*/nullptr, /*sizelimit=*/0);
+        mylog.trace("query_granted: got search results");
+        const auto mtype = ldap_msgtype(res.get());
+        if (mtype != LDAP_RES_SEARCH_ENTRY && mtype != LDAP_RES_SEARCH_RESULT && mtype != LDAP_RES_SEARCH_REFERENCE) {
+            mylog.error("ldap search yielded result {} of type {}", static_cast<const void*>(res.get()), mtype);
+            co_return coroutine::exception(std::make_exception_ptr(std::runtime_error("ldap_role_manager: search result has wrong type")));
+        }
+        std::vector<sstring> values = get_attr_values(conn.get_ldap(), res.get(), _target_attr.c_str());
+        auth::role_set valid_roles{grantee_name};
+
+        // Each value is a role to be granted.
+        co_await parallel_for_each(values, [this, &valid_roles] (const sstring& ldap_role) {
+            return _std_mgr.exists(ldap_role).then([&valid_roles, &ldap_role] (bool exists) {
+                if (exists) {
+                    valid_roles.insert(ldap_role);
+                } else {
+                    mylog.error("unrecognized role received from LDAP: {}", ldap_role);
+                }
+            });
+        });
+
+        co_return std::move(valid_roles);
+    });
+}
+
+future<role_to_directly_granted_map>
+ldap_role_manager::query_all_directly_granted() {
+    role_to_directly_granted_map result;
+    auto roles = co_await query_all();
+    for (auto& role: roles) {
+        auto granted_set = co_await query_granted(role, recursive_role_query::no);
+        for (auto& granted: granted_set) {
+            if (granted != role) {
+                result.insert({role, granted});
+            }
+        }
+    }
+    co_return result;
+}
+
+future<role_set> ldap_role_manager::query_all() {
+    return _std_mgr.query_all();
+}
+
+future<> ldap_role_manager::create_role(std::string_view role_name) {
+    return smp::submit_to(0, [this, role_name] () -> future<> {
+        int retries = 10;
+        while (true) {
+            auto guard = co_await _group0_client.start_operation(_as, ::service::raft_timeout{});
+            ::service::group0_batch batch(std::move(guard));
+            auto cfg = role_config{.can_login = true};
+            try {
+                co_await create(role_name, cfg, batch);
+                co_await std::move(batch).commit(_group0_client, _as, ::service::raft_timeout{});
+            } catch (const role_already_exists&) {
+                // ok
+            } catch (const ::service::group0_concurrent_modification& ex) {
+                mylog.warn("Failed to auto-create role \"{}\" due to guard conflict.{}.",
+                        role_name, retries ? " Retrying" : " Number of retries exceeded, giving up");
+                if (retries--) {
+                    continue;
+                }
+                throw;
+            }
+            break;
+        }
+        // make sure to wait until create mutations are applied locally
+        (void)(co_await _group0_client.start_operation(_as, ::service::raft_timeout{}));
+    });
+}
+
+future<bool> ldap_role_manager::exists(std::string_view role_name) {
+    bool exists = co_await _std_mgr.exists(role_name);
+    if (exists) {
+        co_return true;
+    }
+    role_set roles = co_await query_granted(role_name, recursive_role_query::yes);
+    // A role will get auto-created if it's already assigned any permissions.
+    // The role set will always contains at least a single entry (the role itself),
+    // so auto-creation is only triggered if at least one more external role is assigned.
+    if (roles.size() > 1) {
+        mylog.info("Auto-creating user {}", role_name);
+        try {
+            co_await create_role(role_name);
+            exists = true;
+        } catch (...) {
+            mylog.error("Failed to auto-create role {}: {}", role_name, std::current_exception());
+            exists = false;
+        }
+        co_return exists;
+    }
+    mylog.debug("Role {} will not be auto-created", role_name);
+    co_return false;
+}
+
+future<bool> ldap_role_manager::is_superuser(std::string_view role_name) {
+    return _std_mgr.is_superuser(role_name);
+}
+
+future<bool> ldap_role_manager::can_login(std::string_view role_name) {
+    return _std_mgr.can_login(role_name);
+}
+
+future<std::optional<sstring>> ldap_role_manager::get_attribute(
+        std::string_view role_name, std::string_view attribute_name) {
+    return _std_mgr.get_attribute(role_name, attribute_name);
+}
+
+future<role_manager::attribute_vals> ldap_role_manager::query_attribute_for_all(std::string_view attribute_name) {
+    return _std_mgr.query_attribute_for_all(attribute_name);
+}
+
+future<> ldap_role_manager::set_attribute(
+        std::string_view role_name, std::string_view attribute_name, std::string_view attribute_value, ::service::group0_batch& mc) {
+    return _std_mgr.set_attribute(role_name, attribute_value, attribute_value, mc);
+}
+
+future<> ldap_role_manager::remove_attribute(std::string_view role_name, std::string_view attribute_name, ::service::group0_batch& mc) {
+    return _std_mgr.remove_attribute(role_name, attribute_name, mc);
+}
+
+sstring ldap_role_manager::get_url(std::string_view user) const {
+    return boost::replace_all_copy(_query_template, "{USER}", user);
+}
+
+future<std::vector<cql3::description>> ldap_role_manager::describe_role_grants() {
+    // Since grants are performed by the ldap admin, we shouldn't echo them back
+    co_return std::vector<cql3::description>();
+}
+
+future<> ldap_role_manager::ensure_superuser_is_created() {
+    // ldap is responsible for users
+    co_return;
+}
+
+} // namespace auth

--- a/auth/ldap_role_manager.hh
+++ b/auth/ldap_role_manager.hh
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+
+#pragma once
+
+#include <memory>
+#include <seastar/core/abort_source.hh>
+#include <stdexcept>
+
+#include "bytes.hh"
+#include "ent/ldap/ldap_connection.hh"
+#include "standard_role_manager.hh"
+
+namespace auth {
+
+/// Queries an LDAP server for roles.
+///
+/// Since LDAP grants and revokes roles, calling grant() and revoke() is disallowed.
+///
+/// We query LDAP for a list of a particular user's roles, and the results must match roles that exist in the
+/// database.  Furthermore, the user must have already authenticated to Scylla, meaning it, too, exists in the
+/// database.  Therefore, some of the role_manager functionality is provided by a standard_role_manager under
+/// the hood.  For example, listing all roles or checking if the user can login cannot currently be determined
+/// by querying LDAP, so they are delegated to the standard_role_manager.
+class ldap_role_manager : public role_manager {
+    standard_role_manager _std_mgr;
+    ::service::raft_group0_client& _group0_client;
+    seastar::sstring _query_template; ///< LDAP URL dictating which query to make.
+    seastar::sstring _target_attr; ///< LDAP entry attribute containing the Scylla role name.
+    seastar::sstring _bind_name; ///< Username for LDAP simple bind.
+    seastar::sstring _bind_password; ///< Password for LDAP simple bind.
+    mutable ldap_reuser _connection_factory; // Potentially modified by query_granted().
+    seastar::abort_source _as;
+  public:
+    ldap_role_manager(
+            std::string_view query_template, ///< LDAP query template as described in Scylla documentation.
+            std::string_view target_attr, ///< LDAP entry attribute containing the Scylla role name.
+            std::string_view bind_name, ///< LDAP bind credentials.
+            std::string_view bind_password, ///< LDAP bind credentials.
+            cql3::query_processor& qp, ///< Passed to standard_role_manager.
+            ::service::raft_group0_client& rg0c, ///< Passed to standard_role_manager.
+            ::service::migration_manager& mm ///< Passed to standard_role_manager.
+    );
+
+    /// Retrieves LDAP configuration entries from qp and invokes the other constructor.  Required by
+    /// class_registrator<role_manager>.
+    ldap_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm);
+
+    /// Thrown when query-template parsing fails.
+    struct url_error : public std::runtime_error {
+        using runtime_error::runtime_error;
+    };
+
+    std::string_view qualified_java_name() const noexcept override;
+
+    const resource_set& protected_resources() const override;
+
+    future<> start() override;
+
+    future<> stop() override;
+
+    future<> create(std::string_view, const role_config&, ::service::group0_batch& mc) override;
+
+    future<> drop(std::string_view, ::service::group0_batch& mc) override;
+
+    future<> alter(std::string_view, const role_config_update&, ::service::group0_batch& mc) override;
+
+    future<> grant(std::string_view, std::string_view, ::service::group0_batch& mc) override;
+
+    future<> revoke(std::string_view, std::string_view, ::service::group0_batch& mc) override;
+
+    future<role_set> query_granted(std::string_view, recursive_role_query) override;
+
+    future<role_to_directly_granted_map> query_all_directly_granted() override;
+
+    future<role_set> query_all() override;
+
+    future<bool> exists(std::string_view) override;
+
+    future<bool> is_superuser(std::string_view) override;
+
+    future<bool> can_login(std::string_view) override;
+
+    future<std::optional<sstring>> get_attribute(std::string_view, std::string_view) override;
+
+    future<role_manager::attribute_vals> query_attribute_for_all(std::string_view) override;
+
+    future<> set_attribute(std::string_view, std::string_view, std::string_view, ::service::group0_batch& mc) override;
+
+    future<> remove_attribute(std::string_view, std::string_view, ::service::group0_batch& mc) override;
+
+    future<std::vector<cql3::description>> describe_role_grants() override;
+  private:
+    /// Connects to the LDAP server indicated by _query_template and executes LDAP bind using _bind_name and
+    /// _bind_password.  Returns the resulting ldap_connection.
+    future<lw_shared_ptr<ldap_connection>> connect();
+
+    /// Invokes connect() repeatedly with backoff, until it succeeds or retry limit is reached.
+    future<seastar::lw_shared_ptr<ldap_connection>> reconnect();
+
+    /// Macro-expands _query_template, returning the result.
+    sstring get_url(std::string_view user) const;
+
+    /// Used to auto-create roles returned by ldap.
+    future<> create_role(std::string_view role_name);
+
+    future<> ensure_superuser_is_created() override;
+};
+
+} // namespace auth

--- a/auth/saslauthd_authenticator.cc
+++ b/auth/saslauthd_authenticator.cc
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "auth/saslauthd_authenticator.hh"
+
+#include <algorithm>
+#include <seastar/core/reactor.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/api.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/util/log.hh>
+#include <system_error>
+#include "common.hh"
+#include "cql3/query_processor.hh"
+#include "db/config.hh"
+#include "utils/log.hh"
+#include "seastarx.hh"
+#include "utils/class_registrator.hh"
+
+namespace auth {
+
+static logging::logger mylog("saslauthd_authenticator");
+
+// To ensure correct initialization order, we unfortunately need to use a string literal.
+static const class_registrator<
+        authenticator,
+        saslauthd_authenticator,
+        cql3::query_processor&,
+        ::service::raft_group0_client&,
+        ::service::migration_manager&> saslauthd_auth_reg("com.scylladb.auth.SaslauthdAuthenticator");
+
+saslauthd_authenticator::saslauthd_authenticator(cql3::query_processor& qp, ::service::raft_group0_client&, ::service::migration_manager&)
+    : _socket_path(qp.db().get_config().saslauthd_socket_path())
+{}
+
+future<> saslauthd_authenticator::start() {
+    return once_among_shards([this] {
+        return file_exists(_socket_path).then([this] (bool exists) {
+            if (!exists) {
+                mylog.warn("saslauthd socket file {} doesn't exist -- is saslauthd running?", _socket_path);
+            }
+            return make_ready_future();
+        });
+    });
+}
+
+future<> saslauthd_authenticator::stop() { return make_ready_future(); }
+
+std::string_view saslauthd_authenticator::qualified_java_name() const {
+    return "com.scylladb.auth.SaslauthdAuthenticator";
+}
+
+bool saslauthd_authenticator::require_authentication() const {
+    return true;
+}
+
+authentication_option_set saslauthd_authenticator::supported_options() const {
+    return authentication_option_set{authentication_option::password, authentication_option::options};
+}
+
+authentication_option_set saslauthd_authenticator::alterable_options() const {
+    return supported_options();
+}
+
+namespace {
+
+// Note the saslauthd protocol description:
+// https://github.com/cyrusimap/cyrus-sasl/blob/f769dde423e1b3ae8bfb35b826fca3d5f1e1f6fe/saslauthd/saslauthd-main.c#L74
+
+constexpr size_t len_size = sizeof(htons(0));
+
+char* pack(std::string_view s, char* p) {
+    uint16_t size = s.size();
+    produce_be(p, size);
+    memcpy(p, s.data(), size);
+    return p + size;
+}
+
+temporary_buffer<char> make_saslauthd_message(const saslauthd_credentials& creds) {
+    temporary_buffer<char> message(
+            creds.username.size() + creds.password.size() + creds.service.size() + creds.realm.size()
+            + 4 * len_size);
+    auto p = pack(creds.username, message.get_write());
+    p = pack(creds.password, p);
+    p = pack(creds.service, p);
+    p = pack(creds.realm, p);
+    return message;
+}
+
+/// An exception handler that reports saslauthd socket IO error.
+future<bool> as_authentication_exception(std::exception_ptr ex) {
+    return make_exception_future<bool>(
+            exceptions::authentication_exception(format("saslauthd socket IO error: {}", ex)));
+}
+
+} // anonymous namespace
+
+future<bool> authenticate_with_saslauthd(sstring saslauthd_socket_path, const saslauthd_credentials& creds) {
+    socket_address addr((unix_domain_addr(saslauthd_socket_path)));
+    // TODO: switch to seastar::connect() when it supports Unix domain sockets.
+    return engine().net().connect(addr).then([creds = std::move(creds)] (connected_socket s) {
+        return do_with(
+                s.input(), s.output(),
+                [creds = std::move(creds)] (input_stream<char>& in, output_stream<char>& out) {
+                    return out.write(make_saslauthd_message(creds)).then([&in, &out] () mutable {
+                        return out.flush().then([&in] () mutable {
+                            return in.read_exactly(2).then([&in] (temporary_buffer<char> len) mutable {
+                                if (len.size() < 2) {
+                                    return make_exception_future<bool>(
+                                            exceptions::authentication_exception(
+                                                    "saslauthd closed connection before completing response"));
+                                }
+                                const auto paylen = read_be<uint16_t>(len.get());
+                                return in.read_exactly(paylen).then([paylen] (temporary_buffer<char> resp) {
+                                    mylog.debug("saslauthd response: {}", std::string_view(resp.get(), resp.size()));
+                                    if (resp.size() != paylen) {
+                                        return make_exception_future<bool>(
+                                            exceptions::authentication_exception(
+                                                    // We say "different" here, though we could just as well say
+                                                    // "shorter".  A longer response is cut to size by
+                                                    // read_exactly().
+                                                    "saslauthd response length different than promised"));
+                                    }
+                                    bool ok = (resp.size() >= 2 && resp[0] == 'O' && resp[1] == 'K');
+                                    return make_ready_future<bool>(ok);
+                                });
+                            }).finally([&in] () mutable { return in.close(); });
+                        }).handle_exception(as_authentication_exception).finally([&out] () mutable {
+                            return out.close();
+                        });
+                    });
+                });
+    }).handle_exception_type([] (std::system_error& e) {
+        return make_exception_future<bool>(
+                exceptions::authentication_exception(format("saslauthd socket connection error: {}", e.what())));
+    });
+}
+
+future<authenticated_user> saslauthd_authenticator::authenticate(const credentials_map& credentials) const {
+    const auto username_found = credentials.find(USERNAME_KEY);
+    if (username_found == credentials.end()) {
+        throw exceptions::authentication_exception(format("Required key '{}' is missing", USERNAME_KEY));
+    }
+    const auto password_found = credentials.find(PASSWORD_KEY);
+    if (password_found == credentials.end()) {
+        throw exceptions::authentication_exception(format("Required key '{}' is missing", PASSWORD_KEY));
+    }
+    const auto service_found = credentials.find(SERVICE_KEY);
+    const auto realm_found = credentials.find(REALM_KEY);
+
+    sstring username = username_found->second;
+    return authenticate_with_saslauthd(_socket_path, {username, password_found->second,
+            service_found == credentials.end() ? "" : service_found->second,
+            realm_found == credentials.end() ? "" : realm_found->second}).then([username] (bool ok) {
+                if (!ok) {
+                    throw exceptions::authentication_exception("Incorrect credentials");
+                }
+                return make_ready_future<authenticated_user>(username);
+            });
+}
+
+future<> saslauthd_authenticator::create(std::string_view role_name, const authentication_options& options, ::service::group0_batch& mc) {
+    if (!options.credentials) {
+        return make_ready_future<>();
+    }
+    throw exceptions::authentication_exception("Cannot create passwords with SaslauthdAuthenticator");
+}
+
+future<> saslauthd_authenticator::alter(std::string_view role_name, const authentication_options& options, ::service::group0_batch& mc) {
+    if (!options.credentials) {
+        return make_ready_future<>();
+    }
+    throw exceptions::authentication_exception("Cannot modify passwords with SaslauthdAuthenticator");
+}
+
+future<> saslauthd_authenticator::drop(std::string_view name, ::service::group0_batch& mc) {
+    throw exceptions::authentication_exception("Cannot delete passwords with SaslauthdAuthenticator");
+}
+
+future<custom_options> saslauthd_authenticator::query_custom_options(std::string_view role_name) const {
+    return make_ready_future<custom_options>();
+}
+
+const resource_set& saslauthd_authenticator::protected_resources() const {
+    static const resource_set empty;
+    return empty;
+}
+
+::shared_ptr<sasl_challenge> saslauthd_authenticator::new_sasl_challenge() const {
+    return ::make_shared<plain_sasl_challenge>([this](std::string_view username, std::string_view password) {
+        return this->authenticate(credentials_map{{USERNAME_KEY, sstring(username)}, {PASSWORD_KEY, sstring(password)}});
+    });
+}
+
+} // namespace auth

--- a/auth/saslauthd_authenticator.hh
+++ b/auth/saslauthd_authenticator.hh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ *
+ * Modified by ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "auth/authenticator.hh"
+
+namespace cql3 {
+class query_processor;
+}
+
+namespace service {
+class migration_manager;
+class raft_group0_client;
+}
+
+namespace auth {
+
+/// Delegates authentication to saslauthd.  When this class is asked to authenticate, it passes the credentials
+/// to saslauthd, gets its response, and allows or denies authentication based on that response.
+class saslauthd_authenticator : public authenticator {
+    sstring _socket_path; ///< Path to the domain socket on which saslauthd is listening.
+public:
+    saslauthd_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
+
+    future<> start() override;
+
+    future<> stop() override;
+
+    std::string_view qualified_java_name() const override;
+
+    bool require_authentication() const override;
+
+    authentication_option_set supported_options() const override;
+
+    authentication_option_set alterable_options() const override;
+
+    future<authenticated_user> authenticate(const credentials_map& credentials) const override;
+
+    future<> create(std::string_view role_name, const authentication_options& options, ::service::group0_batch& mc) override;
+
+    future<> alter(std::string_view role_name, const authentication_options& options, ::service::group0_batch& mc) override;
+
+    future<> drop(std::string_view role_name, ::service::group0_batch& mc) override;
+
+    future<custom_options> query_custom_options(std::string_view role_name) const override;
+
+    const resource_set& protected_resources() const override;
+
+    ::shared_ptr<sasl_challenge> new_sasl_challenge() const override;
+};
+
+/// A set of four credential strings that saslauthd expects.
+struct saslauthd_credentials {
+    sstring username, password, service, realm;
+};
+
+future<bool> authenticate_with_saslauthd(sstring saslauthd_socket_path, const saslauthd_credentials& creds);
+
+}
+

--- a/bytes.hh
+++ b/bytes.hh
@@ -20,6 +20,8 @@
 #include "utils/mutable_view.hh"
 #include "utils/simple_hashers.hh"
 
+using sstring_view = std::string_view;
+
 inline bytes to_bytes(bytes&& b) {
     return std::move(b);
 }

--- a/cmake/FindOpenLDAP.cmake
+++ b/cmake/FindOpenLDAP.cmake
@@ -1,0 +1,46 @@
+#
+# Copyright 2024-present ScyllaDB
+#
+
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+find_package(PkgConfig REQUIRED)
+
+foreach(component ${OpenLDAP_FIND_COMPONENTS})
+  pkg_search_module(PC_${component} QUIET ${component})
+  find_path (OpenLDAP_${component}_INCLUDE_DIR
+    NAMES lber.h
+    HINTS
+      ${PC_${component}_INCLUDEDIR}
+      ${PC_${component}_INCLUDE_DIRS})
+  find_library(OpenLDAP_${component}_LIBRARY
+    NAMES ${component}
+    HINTS
+      ${PC_${component}_LIBDIR}
+      ${PC_${component}_LIBRARY_DIRS})
+  list(APPEND OpenLDAP_INCLUDE_DIRS OpenLDAP_${component}_INCLUDE_DIR)
+  list(APPEND OpenLDAP_LIBRARIES OpenLDAP_${component}_LIBRARY)
+endforeach()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(OpenLDAP
+  DEFAULT_MSG
+  ${OpenLDAP_INCLUDE_DIRS}
+  ${OpenLDAP_LIBRARIES})
+
+mark_as_advanced(
+  ${OpenLDAP_INCLUDE_DIRS}
+  ${OpenLDAP_LIBRARIES})
+
+if(OpenLDAP_FOUND)
+  foreach(component ${OpenLDAP_FIND_COMPONENTS})
+    if(NOT TARGET OpenLDAP::${component})
+      add_library(OpenLDAP::${component} UNKNOWN IMPORTED)
+      set_target_properties(OpenLDAP::${component} PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${OpenLDAP_${component}_INCLUDE_DIR}"
+        IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+        IMPORTED_LOCATION "${OpenLDAP_${component}_LIBRARY}")
+    endif()
+  endforeach()
+endif()

--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -244,7 +244,11 @@ batch_size_fail_threshold_in_kb: 1024
 # - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
 #   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
 #   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+# - com.scylladb.auth.SaslauthdAuthenticator outsources authentication to a running saslauthd
+#   daemon. When using this authenticator, you must set the saslauthd_socket_path property to the
+#   Unix domain socket on which saslauthd is listening.
 # authenticator: AllowAllAuthenticator
+# saslauthd_socket_path: /var/state/saslauthd/mux
 
 # Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
 # Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,

--- a/configure.py
+++ b/configure.py
@@ -436,6 +436,12 @@ modes = {
     },
 }
 
+ldap_tests = set([
+    'test/ldap/ldap_connection_test',
+    'test/ldap/role_manager_test',
+    'test/ldap/saslauthd_authenticator_test'
+])
+
 scylla_tests = set([
     'test/boost/combined_tests',
     'test/boost/UUID_test',
@@ -586,7 +592,7 @@ scylla_tests = set([
     'test/unit/row_cache_stress_test',
     'test/unit/cross_shard_barrier_test',
     'test/boost/address_map_test',
-])
+]) | ldap_tests
 
 perf_tests = set([
     'test/perf/perf_mutation_readers',
@@ -1100,11 +1106,13 @@ scylla_core = (['message/messaging_service.cc',
                 'auth/permissions_cache.cc',
                 'auth/service.cc',
                 'auth/standard_role_manager.cc',
+                'auth/ldap_role_manager.cc',
                 'auth/transitional.cc',
                 'auth/maintenance_socket_role_manager.cc',
                 'auth/role_or_anonymous.cc',
                 'auth/sasl_challenge.cc',
                 'auth/certificate_authenticator.cc',
+                'auth/saslauthd_authenticator.cc',
                 'tracing/tracing.cc',
                 'tracing/trace_keyspace_helper.cc',
                 'tracing/trace_state.cc',
@@ -1120,6 +1128,7 @@ scylla_core = (['message/messaging_service.cc',
                 'utils/arch/powerpc/crc32-vpmsum/crc32_wrapper.cc',
                 'querier.cc',
                 'mutation_writer/multishard_writer.cc',
+                'ent/ldap/ldap_connection.cc',
                 'multishard_mutation_query.cc',
                 'reader_concurrency_semaphore.cc',
                 'sstables_loader.cc',
@@ -1995,7 +2004,7 @@ pkgs.append('lua53' if have_pkg('lua53') else 'lua')
 
 
 libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-lz', '-lsnappy',
-                 ' -lstdc++fs', ' -lcrypt', ' -lcryptopp', ' -lpthread',
+                 ' -lstdc++fs', ' -lcrypt', ' -lcryptopp', ' -lpthread', ' -lldap -llber',
                  # Must link with static version of libzstd, since
                  # experimental APIs that we use are only present there.
                  maybe_static(True, '-lzstd'),

--- a/db/config.hh
+++ b/db/config.hh
@@ -503,6 +503,12 @@ public:
 
     named_value<uint32_t> service_levels_interval;
 
+    named_value<sstring> ldap_url_template;
+    named_value<sstring> ldap_attr_role;
+    named_value<sstring> ldap_bind_dn;
+    named_value<sstring> ldap_bind_passwd;
+    named_value<sstring> saslauthd_socket_path;
+
     seastar::logging_settings logging_settings(const log_cli::options&) const;
 
     const db::extensions& extensions() const;

--- a/docs/operating-scylla/security/index.rst
+++ b/docs/operating-scylla/security/index.rst
@@ -18,7 +18,8 @@ Security
    node-node-encryption
    generate-certificate
    saslauthd
-      
+   ldap-authentication
+   ldap-authorization
 
 .. panel-box::
   :title: Security

--- a/docs/operating-scylla/security/ldap-authentication.rst
+++ b/docs/operating-scylla/security/ldap-authentication.rst
@@ -1,0 +1,52 @@
+===================
+LDAP Authentication
+===================
+
+.. toctree::
+   :hidden:
+
+   saslauthd
+
+:label-tip:`ScyllaDB Enterprise`
+
+.. versionadded:: 2021.1.2
+
+Scylla supports user authentication via an LDAP server by leveraging the SaslauthdAuthenticator.
+By configuring saslauthd correctly against your LDAP server, you enable Scylla to check the user’s credentials through it.
+
+
+Configure saslauthd for LDAP
+----------------------------
+**Before You Begin**
+
+This procedure requires you to install and configure saslauthd.
+The general instructions are :doc:`here </operating-scylla/security/saslauthd>`.
+
+#. Follow all of the steps in :doc:`this procedure </operating-scylla/security/saslauthd>` and use the code snippets below to list LDAP as the authentication mechanism.
+
+#. You must list LDAP as saslauthd’s authentication mechanism:
+
+   .. tabs::
+
+      .. group-tab:: rpm-based distros
+
+         Edit ``/etc/sysconfig/saslauthd`` and add:
+
+         .. code-block:: none
+
+            MECH=ldap
+
+      .. group-tab:: deb-based distros
+
+         Edit ``/etc/default/saslauthd`` and add:
+
+         .. code-block:: none
+
+            MECHANISMS=ldap
+
+
+#. You also have to edit the /etc/saslauthd.conf file to provide adequate `parameter <https://github.com/cyrusimap/cyrus-sasl/blob/cyrus-sasl-2.1.27/saslauthd/LDAP_SASLAUTHD#L74>`_ values for your LDAP server.
+
+
+
+

--- a/docs/operating-scylla/security/ldap-authorization.rst
+++ b/docs/operating-scylla/security/ldap-authorization.rst
@@ -1,0 +1,153 @@
+=====================================
+LDAP Authorization (Role Management)
+=====================================
+
+:label-tip:`ScyllaDB Enterprise`
+
+.. versionadded:: 2021.1.2
+
+Scylla Enterprise customers can manage and authorize users’ privileges via an :abbr:`LDAP (Lightweight Directory Access Protocol)` server.
+LDAP is an open, vendor-neutral, industry-standard protocol for accessing and maintaining distributed user access control over a standard IP network.
+If your users are already stored in an LDAP directory, you can now use the same LDAP server to regulate their roles in Scylla.
+
+
+Introduction
+------------
+
+Scylla can use LDAP to manage which roles a user has. This behavior is triggered by setting the ``role_manager`` entry in scylla.yaml to *com.scylladb.auth.LDAPRoleManager*.
+When this role manager is chosen, Scylla forbids ``GRANT`` and ``REVOKE`` role statements (CQL commands) as all users get their roles from the contents in the LDAP directory.
+
+.. _note:
+
+.. note:: Scylla still allows ``GRANT`` and ``REVOKE`` permission statements, such as ``GRANT permission ON resource TO role``, which are handled by the authorizer, not role manager.
+   This allows permissions to be granted to and revoked from LDAP-managed roles. In addition, if you have nested Scylla roles, LDAP authorization does not allow them. A role cannot be a member of another role.
+   In LDAP only login users can be members of a role.
+
+When LDAP Authorization is enabled and a Scylla user authenticates to Scylla, a query is sent to the LDAP server, whose response sets the user's roles for that login session.
+The user keeps the granted roles until logout; any subsequent changes to the LDAP directory are only effective at the user's next login to Scylla.
+
+The precise form of the LDAP query is configured by Scylla administrator in the scylla.yaml configuration file.
+This configuration takes the form of a query template which is defined in the scylla.yaml configuration file using the parameter ``ldap_url_template``.
+The value of ``ldap_url_template`` parameter should contain a valid LDAP URL (e.g., as returned by the ldapurl utility from OpenLDAP) representing an LDAP query that returns entries for all the user's roles.
+Scylla will replace the text ``{USER}`` in the URL with the user's Scylla username before querying LDAP.
+
+Workflow
+--------
+
+**Before you begin**
+On your LDAP server, create LDAP directory entries for Scylla users and roles.
+
+**Workflow**
+
+#. :ref:`Create a Query Template <example-template>`
+#. Ensure Scylla has the same users and roles as listed in the LDAP directory.
+#. :ref:`Enable LDAP as the role manager in Scylla <role-ldap>`
+#. Make Scylla reload the configuration (SIGHUP or restart)
+
+.. _example-template:
+
+Example: Query Template
+=======================
+
+Use this example to create a query that will retrieve from your LDAP server the information you need to create a template.
+For example, this template URL will query LDAP server at ``localhost:5000`` for all entries under ``base_dn`` that list the user's username as one of their ``uniqueMember`` attribute values:
+
+.. code-block:: none
+
+   ldap://localhost:5000/base_dn?cn?sub?(uniqueMember={USER})
+
+After Scylla queries LDAP and obtains the resulting entries, it looks for a particular attribute in each entry and uses that attribute's value as a Scylla role this user will have.
+The name of this attribute can be configured in scylla.yaml by setting the ``ldap_attr_role`` parameter there.
+
+When the LDAP query returns multiple entries, multiple roles will be granted to the user.
+Each role must already exist in Scylla, created via the :ref:`CREATE ROLE <create-role-statement>` CQL command beforehand.
+
+For example, if the LDAP query returns the following results:
+
+.. code-block:: none
+
+   # extended LDIF
+   #
+   # LDAPv3
+
+   # role1, example.com
+   dn: cn=role1,dc=example,dc=com
+   objectClass: groupOfUniqueNames
+   cn: role1
+   scyllaName: sn1
+   uniqueMember: uid=jsmith,ou=People,dc=example,dc=com
+   uniqueMember: uid=cassandra,ou=People,dc=example,dc=com
+
+   # role2, example.com
+   dn: cn=role2,dc=example,dc=com
+   objectClass: groupOfUniqueNames
+   cn: role2
+   scyllaName: sn2
+   uniqueMember: uid=cassandra,ou=People,dc=example,dc=com
+
+   # role3, example.com
+   dn: cn=role3,dc=example,dc=com
+   objectClass: groupOfUniqueNames
+   cn: role3
+   uniqueMember: uid=jdoe,ou=People,dc=example,dc=com
+
+If ``ldap_attr_role`` is set to *cn*, then the resulting role set will be { role1, role2, role3 } (assuming, of course, that these roles already exist in Scylla).
+However, if ``ldap_attr_role`` is set to *scyllaName*, then the resulting role set will be { sn1, sn2 }.
+If an LDAP entry does not have the ``ldap_attr_role`` attribute, it is simply ignored.
+Before Scylla attempts to query the LDAP server, it first performs an LDAP bind operation, to gain access to the directory information.
+Scylla executes a simple bind with credentials configured in scylla.yaml.
+The parameters ``ldap_bind_dn`` and ``ldap_bind_passwd`` must contain, respectively, the distinguished name and password that Scylla uses to perform the simple bind.
+
+.. _role-ldap:
+
+Enable LDAP Authorization
+-------------------------
+
+Enables Scylla to use LDAP Authorization. LDAP will manage the roles, not Scylla. See :ref:`Note <note>` above
+
+#. Open the scylla.yaml file in an editor. The file is located in /etc/scylla/scylla.yaml by default.
+#. Edit the ``role_manager`` section. Change the entry to ``com.scylladb.auth.LDAPRoleManager``. If this section does not exist, add it to the file.
+   Configure the parameters according to your organization's IT and Security Policy.
+
+   .. code-block:: yaml
+
+      role_manager: "com.scylladb.auth.LDAPRoleManager"
+      ldap_url_template: "ldap://localhost:123/dc=example,dc=com?cn?sub?(uniqueMember=uid={USER},ou=People,dc=example,dc=com)"
+      ldap_attr_role: "cn"
+      ldap_bind_dn: "cn=root,dc=example,dc=com"
+      ldap_bind_passwd: "secret"
+
+#. Restart the scylla-server service or kill the scylla process.
+  
+   .. include:: /rst_include/scylla-commands-restart-index.rst
+
+Disable LDAP Authorization
+--------------------------
+
+#. Open the scylla.yaml file in an editor. The file is located in /etc/scylla/scylla.yaml by default.
+#. Comment out or delete the role_manager section.
+#. Restart the scylla-server service or kill the scylla process. 
+  
+   .. include:: /rst_include/scylla-commands-restart-index.rst
+
+
+Troubleshooting
+---------------
+
+Before configuring Scylla, it is a good idea to validate the query template by manually ensuring that the LDAP server returns the correct entries when queried.
+This can be accomplished by using an LDAP search tool such as `ldapsearch <https://www.openldap.org/software/man.cgi?query=ldapsearch&apropos=0&sektion=0&manpath=OpenLDAP+2.0-Release&format=html>`_.
+
+If manual querying does not yield correct results, then Scylla cannot see correct results, either.
+Try to adjust ldapsearch parameters until it returns the correct role entries for **one** user.
+
+Once that works as expected, you can use the `ldapurl <https://linux.die.net/man/1/ldapurl>`_ utility to transform the parameters into a URL providing a basis for the ldap_url_template.
+
+.. tip:: Always provide an explicit ``-s`` flag to both ``ldapsearch`` and ``ldapurl``; the default ``-s`` value differs among the two tools.
+
+Remember to replace the specific user name with ``{USER}`` in the URL template.
+You can turn on debug logging in the LDAP role manager by passing the following argument to the Scylla executable: ``--logger-log-level ldap_role_manager=debug``.
+This will make Scylla log useful additional details about the LDAP responses it receives.
+
+If ldapsearch yields expected results but Scylla queries do not, first check the host and port parts of the URL template and make sure both ldapsearch and
+Scylla are actually querying the same LDAP server.
+Then check the LDAP logs and see if there are any subtle differences between the logged queries of ldapsearch and Scylla.

--- a/ent/CMakeLists.txt
+++ b/ent/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(ldap)

--- a/ent/ldap/CMakeLists.txt
+++ b/ent/ldap/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(OpenLDAP REQUIRED
+  ldap lber)
+add_library(ldap STATIC)
+target_sources(ldap
+  PRIVATE
+    ldap_connection.cc)
+target_include_directories(ldap
+  PUBLIC
+    ${CMAKE_SOURCE_DIR})
+target_link_libraries(ldap
+  PUBLIC
+    Seastar::seastar
+  PRIVATE
+    OpenLDAP::ldap OpenLDAP::lber)
+
+check_headers(check-headers ldap
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/ent/ldap/ldap_connection.cc
+++ b/ent/ldap/ldap_connection.cc
@@ -1,0 +1,487 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#define LDAP_DEPRECATED 1
+
+#include "ldap_connection.hh"
+
+#include <cerrno>
+#include <cstring>
+#include <fmt/format.h>
+#include <stdexcept>
+#include <string>
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/log.hh>
+
+#include "seastarx.hh"
+
+extern "C" {
+// Declared in `ldap_pvt.h`, but this header is not usually installed by distributions even though
+// it's considered public by upstream.
+int ldap_init_fd(int, int, const char *, LDAP**);
+}
+
+namespace {
+
+logger mylog{"ldap_connection"}; // `log` is taken by math.
+
+constexpr int failure_code{-1}, success_code{0}; // LDAP return codes.
+
+/// Helper function for Sockbuf_IO work.
+ldap_connection* connection(Sockbuf_IO_Desc* sid) {
+    return reinterpret_cast<ldap_connection*>(sid->sbiod_pvt);
+}
+
+/// Sockbuf_IO setup function for ldap_connection.
+int ssbi_setup(Sockbuf_IO_Desc* sid, void* arg) {
+    sid->sbiod_pvt = arg; // arg is ldap_connection, already set up.
+    return success_code;
+}
+
+/// Sockbuf_IO remove function for ldap_connection.
+int ssbi_remove(Sockbuf_IO_Desc* sid) {
+    return success_code; // ldap_connection will be destructed by its owner.
+}
+
+void throw_if_failed(int status, const char* op, const ldap_connection& conn, int success = LDAP_SUCCESS) {
+    if (status != success) {
+        throw std::runtime_error(fmt::format("{} returned {}: {}", op, status, conn.get_error()));
+    }
+}
+
+} // anonymous namespace
+
+std::mutex ldap_connection::_global_init_mutex;
+
+void ldap_connection::ldap_deleter::operator()(LDAP* ld) {
+    mylog.trace("ldap_deleter: invoking unbind");
+    int status = ldap_unbind(ld);
+    if (status != LDAP_SUCCESS) {
+        mylog.error("ldap_unbind failed with status {}", status);
+    }
+    mylog.trace("ldap_deleter done");
+}
+
+ldap_connection::ldap_connection(seastar::connected_socket&& socket) :
+        _fd(file_desc::eventfd(0, EFD_NONBLOCK)) // Never ready for read, always ready for write.
+    , _socket(std::move(socket))
+    , _input_stream(_socket.input())
+    , _output_stream(_socket.output())
+    , _status(status::up)
+    , _read_consumer(now())
+    , _read_in_progress(false)
+    , _outstanding_write(now())
+    , _currently_polling(false) {
+    // Proactively initiate Seastar read, before ldap_connection::read() is first called.
+    read_ahead();
+
+    // Libldap determines if we're ready for an sbi_write by polling _fd.  We're always ready to
+    // accept an sbi_write because we chain writes as continuations.  Therefore, _fd always polls
+    // ready to write.
+    //
+    // Libldap determines if we're ready for an sbi_read by first calling sbi_ctrl(DATA_READY); only
+    // if that returns false does libldap then poll _fd.  We are ready to accept an sbi_read when a
+    // prior Seastar read completed successfully and delivered some data into our _read_buffer.
+    // Only sbi_ctrl() knows that, which is why _fd always polls NOT READY to read.
+    //
+    // NB: libldap never actually reads or writes directly to _fd.  It reads and writes through the
+    // custom Sockbuf_IO we provide it.
+    static constexpr int LDAP_PROTO_EXT = 4; // From ldap_pvt.h, which isn't always available.
+    mylog.trace("constructor invoking ldap_init");
+    LDAP* init_result;
+    {
+        std::lock_guard<std::mutex> global_init_lock{_global_init_mutex};
+        throw_if_failed(ldap_init_fd(_fd.get(), LDAP_PROTO_EXT, nullptr, &init_result), "ldap_init_fd", *this);
+    }
+    _ldap.reset(init_result);
+    static constexpr int opt_v3 = LDAP_VERSION3;
+    throw_if_failed(
+            ldap_set_option(_ldap.get(), LDAP_OPT_PROTOCOL_VERSION, &opt_v3), // Encouraged by ldap_set_option manpage.
+            "ldap_set_option protocol version",
+            *this,
+            LDAP_OPT_SUCCESS);
+    throw_if_failed(
+            ldap_set_option(_ldap.get(), LDAP_OPT_RESTART, LDAP_OPT_ON), // Retry on EINTR, rather than return error.
+            "ldap_set_option restart",
+            *this,
+            LDAP_OPT_SUCCESS);
+    throw_if_failed(
+            // Chasing referrals with this setup results in libldap crashing.
+            ldap_set_option(_ldap.get(), LDAP_OPT_REFERRALS, LDAP_OPT_OFF),
+            "ldap_set_option no referrals",
+            *this,
+            LDAP_OPT_SUCCESS);
+
+    Sockbuf* sb;
+    throw_if_failed(ldap_get_option(_ldap.get(), LDAP_OPT_SOCKBUF, &sb), "ldap_get_option", *this, LDAP_OPT_SUCCESS);
+    mylog.trace("constructor adding Sockbuf_IO");
+    throw_if_failed(
+            ber_sockbuf_add_io(sb, const_cast<Sockbuf_IO*>(&seastar_sbio), LBER_SBIOD_LEVEL_PROVIDER, this),
+            "ber_sockbuf_add_io",
+            *this);
+    mylog.trace("constructor done");
+}
+
+future<> ldap_connection::close() {
+    if (_status == status::down) {
+        mylog.error("close called while connection is down");
+        return make_exception_future<>(std::runtime_error("double close() of ldap_connection"));
+    }
+    _ldap.reset(); // Sends one last message to the server before reclaiming memory.
+    return when_all(
+            _read_consumer.finally([this] { return _input_stream.close(); })
+            .handle_exception([] (std::exception_ptr ep) {
+                mylog.error("Seastar input stream closing failed: {}", ep);
+            }),
+            _outstanding_write.finally([this] { return _output_stream.close(); })
+            .handle_exception([] (std::exception_ptr ep) {
+                mylog.error("Seastar output stream closing failed: {}", ep);
+            })
+    ).discard_result().then([this] {
+        shutdown();
+        return make_ready_future<>();
+    });
+}
+
+future<ldap_msg_ptr> ldap_connection::await_result(int msgid) {
+    mylog.trace("await_result({})", msgid);
+
+    if (_status != status::up) {
+        mylog.error("await_result({}) error: connection is not up", msgid);
+        ldap_abandon_ext(get_ldap(), msgid, /*sctrls=*/nullptr, /*cctrls=*/nullptr);
+        return make_exception_future<ldap_msg_ptr>(std::runtime_error("ldap_connection status set to error"));
+    }
+
+    try {
+        return _msgid_to_promise[msgid].get_future();
+    } catch (...) {
+        auto ex = std::current_exception();
+        mylog.error("await_result({}) error: {}", msgid, ex);
+        // Tell LDAP to abandon this msgid, since we failed to register it.
+        ldap_abandon_ext(get_ldap(), msgid, /*sctrls=*/nullptr, /*cctrls=*/nullptr);
+        return make_exception_future<ldap_msg_ptr>(ex);
+    }
+}
+
+future<ldap_msg_ptr> ldap_connection::await_result(int status, int msgid) {
+    mylog.trace("await_result({}, {})", status, msgid);
+    if (status == LDAP_SUCCESS) {
+        return await_result(msgid);
+    } else {
+        const char* err = ldap_err2string(status);
+        mylog.trace("await_result({}, {}) reporting error {}", status, msgid, err);
+        return make_exception_future<ldap_msg_ptr>(
+                std::runtime_error(fmt::format("ldap operation error: {}", err)));
+    }
+}
+
+future<ldap_msg_ptr> ldap_connection::simple_bind(const char *who, const char *passwd) {
+    mylog.trace("simple_bind({})", who);
+    if (_status != status::up) {
+        mylog.error("simple_bind({}) punting, connection down", who);
+        return make_exception_future<ldap_msg_ptr>(
+                std::runtime_error("bind operation attempted on a closed ldap_connection"));
+    }
+    const int msgid = ldap_simple_bind(get_ldap(), who, passwd);
+    if (msgid == -1) {
+        const auto err = get_error();
+        mylog.error("ldap simple bind error: {}", err);
+        return make_exception_future<ldap_msg_ptr>(
+                std::runtime_error(fmt::format("ldap simple bind error: {}", err)));
+    } else {
+        mylog.trace("simple_bind: msgid {}", msgid);
+        return await_result(msgid);
+    }
+}
+
+future<ldap_msg_ptr> ldap_connection::search(
+        char *base,
+        int scope,
+        char *filter,
+        char *attrs[],
+        int attrsonly,
+        LDAPControl **serverctrls,
+        LDAPControl **clientctrls,
+        struct timeval *timeout,
+        int sizelimit) {
+    mylog.trace("search");
+    int msgid;
+    if (_status != status::up) {
+        mylog.error("search punting, connection down");
+        return make_exception_future<ldap_msg_ptr>(
+                std::runtime_error("search operation attempted on a closed ldap_connection"));
+    }
+    const int status = ldap_search_ext(
+            get_ldap(), base, scope, filter, attrs, attrsonly, serverctrls, clientctrls, timeout, sizelimit, &msgid);
+    return await_result(status, msgid);
+}
+
+sstring ldap_connection::get_error() const {
+    int result_code;
+    int status = ldap_get_option(get_ldap(), LDAP_OPT_RESULT_CODE, reinterpret_cast<void*>(&result_code));
+    if (status != LDAP_OPT_SUCCESS) {
+        mylog.error("ldap_get_option returned {}", status);
+        return "error description unavailable";
+    }
+    return ldap_err2string(result_code);
+}
+
+int ldap_connection::sbi_ctrl(Sockbuf_IO_Desc* sid, int opt, void* arg) noexcept {
+    mylog.debug("sbi_ctrl({}/{}, {}, {})", static_cast<void*>(sid), sid->sbiod_pvt, opt, arg);
+    auto conn = connection(sid);
+    switch (opt) {
+    case LBER_SB_OPT_DATA_READY:
+        return !conn->_read_buffer.empty()
+               || conn->_status != status::up; // Let sbi_read proceed and report status; otherwise, LDAP loops forever.
+    case LBER_SB_OPT_GET_FD:
+        if (conn->_status == status::down) {
+            errno = ENOTCONN;
+            return -1;
+        }
+        *reinterpret_cast<ber_socket_t*>(arg) = conn->_fd.get();
+        return 1;
+    }
+    return 0;
+}
+
+ber_slen_t ldap_connection::sbi_read(Sockbuf_IO_Desc* sid, void* buffer, ber_len_t size) noexcept {
+    mylog.trace("sbi_read {}/{}", static_cast<const void*>(sid), static_cast<const void*>(sid->sbiod_pvt));
+    try {
+        return connection(sid)->read(reinterpret_cast<char*>(buffer), size);
+    } catch (...) {
+        mylog.error("Unexpected error while reading: {}", std::current_exception());
+        return failure_code;
+    }
+}
+
+ber_slen_t ldap_connection::sbi_write(Sockbuf_IO_Desc* sid, void* buffer, ber_len_t size) noexcept {
+    mylog.trace("sbi_write {}/{}", static_cast<const void*>(sid), static_cast<const void*>(sid->sbiod_pvt));
+    try {
+        return connection(sid)->write(reinterpret_cast<const char*>(buffer), size);
+    } catch (...) {
+        mylog.error("Unexpected error while writing: {}", std::current_exception());
+        return failure_code;
+    }
+}
+
+int ldap_connection::sbi_close(Sockbuf_IO_Desc* sid) noexcept {
+    mylog.debug("sbi_close {}/{}", static_cast<const void*>(sid), static_cast<const void*>(sid->sbiod_pvt));
+    // Leave actual closing to the owner of *this.  Note sbi_close() will be invoked during
+    // ldap_unbind(), which also calls sbi_write() to convey one last message to the server.  We
+    // remain open here, to try to communicate that message.
+    return success_code;
+}
+
+const Sockbuf_IO ldap_connection::seastar_sbio{
+    // Strictly speaking, designated initializers like this are not in the standard, but they're
+    // supported by both major compilers we use.
+    .sbi_setup = &ssbi_setup,
+    .sbi_remove = &ssbi_remove,
+    .sbi_ctrl = &ldap_connection::sbi_ctrl,
+    .sbi_read = &ldap_connection::sbi_read,
+    .sbi_write = &ldap_connection::sbi_write,
+    .sbi_close = &ldap_connection::sbi_close
+};
+
+void ldap_connection::read_ahead() {
+    if (_read_in_progress) { // Differs from _read_consumer.available(), because handle_exception adds a continuation.
+        mylog.warn("read_ahead called while a prior Seastar read is already in progress");
+        return;
+    }
+    if (_input_stream.eof()) {
+        mylog.error("read_ahead encountered EOF");
+        set_status(status::eof);
+        return;
+    }
+    mylog.trace("read_ahead");
+    _read_in_progress = true;
+    mylog.trace("read_ahead invoking socket read");
+    _read_consumer = _input_stream.read().then([this] (temporary_buffer<char> b) {
+        if (b.empty()) {
+            mylog.debug("read_ahead received empty buffer; assuming EOF");
+            set_status(status::eof);
+            return;
+        }
+        mylog.trace("read_ahead received data of size {}", b.size());
+        if (!_read_buffer.empty()) { // Shouldn't happen; read_ahead's purpose is to replenish empty _read_buffer.
+            mylog.error("read_ahead dropping {} unconsumed bytes", _read_buffer.size());
+        }
+        _read_buffer = std::move(b);
+        _read_in_progress = false;
+        poll_results();
+    }).handle_exception([this] (std::exception_ptr ep) {
+        mylog.error("Seastar read failed: {}", ep);
+        set_status(status::err);
+    });
+    mylog.trace("read_ahead done");
+}
+
+ber_slen_t ldap_connection::write(char const* b, ber_len_t size) {
+    mylog.trace("write({})", size);
+    switch (_status) {
+    case status::err:
+        mylog.trace("write({}) reporting error", size);
+        errno = ECONNRESET;
+        return -1;
+    case status::down:
+        mylog.trace("write({}) invoked after shutdown", size);
+        errno = ENOTCONN;
+        return -1;
+    case status::up:
+    case status::eof:
+        ; // Proceed.
+    }
+    _outstanding_write = _outstanding_write.then([this, buf = temporary_buffer(b, size)] () mutable {
+        if (_status != status::up) {
+            return make_ready_future<>();
+        }
+        mylog.trace("write invoking socket write");
+        return _output_stream.write(std::move(buf)).then([this] {
+            // Sockbuf_IO doesn't seem to have the notion of flushing the stream, so we flush after
+            // every write.
+            mylog.trace("write invoking flush");
+            return _output_stream.flush();
+        }).handle_exception([this] (std::exception_ptr ep) {
+            mylog.error("Seastar write failed: {}", ep);
+            set_status(status::err);
+        });
+    });
+    mylog.trace("write({}) done, status={}", size, _status);
+    return _status == status::up ? size : -1; // _status can be err here if _outstanding_write threw.
+}
+
+ber_slen_t ldap_connection::read(char* b, ber_len_t size) {
+    mylog.trace("read({})", size);
+    switch (_status) {
+    case status::eof:
+        mylog.trace("read({}) reporting eof", size);
+        return 0;
+    case status::err:
+        mylog.trace("read({}) reporting error", size);
+        errno = ECONNRESET;
+        return -1;
+    case status::down:
+        mylog.trace("read({}) invoked after shutdown", size);
+        errno = ENOTCONN;
+        return -1;
+    case status::up:
+        ; // Proceed.
+    }
+    if (_read_buffer.empty()) { // Can happen because libldap doesn't always wait for data to be ready.
+        mylog.trace("read({}) found empty read buffer", size);
+        // Don't invoke read_ahead() here; it was already invoked as soon as _read_buffer was
+        // drained.  In fact, its Seastar read might have actually completed, and the buffer is
+        // about to be filled by a waiting continuation.  We DON'T want another read_ahead() before
+        // that data is consumed.
+        errno = EWOULDBLOCK;
+        return 0;
+    }
+    const auto byte_count = std::min(_read_buffer.size(), size);
+    std::copy_n(_read_buffer.begin(), byte_count, b);
+    _read_buffer.trim_front(byte_count);
+    if (_read_buffer.empty()) {
+        mylog.trace("read({}) replenishing buffer", size);
+        read_ahead();
+    }
+    mylog.trace("read({}) returning {}", size, byte_count);
+    return byte_count;
+}
+
+void ldap_connection::shutdown()  {
+    mylog.trace("shutdown");
+    set_status(status::down);
+    mylog.trace("shutdown: shutdown input");
+    _socket.shutdown_input();
+    mylog.trace("shutdown: shutdown output");
+    _socket.shutdown_output();
+    mylog.trace("shutdown done");
+}
+
+void ldap_connection::poll_results() {
+    mylog.trace("poll_results");
+    if (!_ldap) { // Could happen during close(), which unbinds.
+        mylog.debug("poll_results: _ldap is null, punting");
+        return;
+    }
+    if (_currently_polling) {
+        // This happens when ldap_result() calls read_ahead() and runs its inner continuation immediately.
+        mylog.debug("poll_results: _currently_polling somewhere up the call-stack, punting");
+        return;
+    }
+
+    // Ensure that _currently_polling is true until we return.
+    class flag_guard {
+        bool& _flag;
+      public:
+        flag_guard(bool& flag) : _flag(flag) { flag = true; }
+        ~flag_guard() { _flag = false; }
+    } guard(_currently_polling);
+
+    LDAPMessage *result;
+    while (!_read_buffer.empty() && _status == status::up) {
+        static timeval zero_duration{};
+        mylog.trace("poll_results: {} in buffer, invoking ldap_result", _read_buffer.size());
+        const int status = ldap_result(get_ldap(), LDAP_RES_ANY, /*all=*/1, &zero_duration, &result);
+        if (status > 0) {
+            ldap_msg_ptr result_ptr(result);
+            const int id = ldap_msgid(result);
+            mylog.trace("poll_results: ldap_result returned status {}, id {}", status, id);
+            const auto found = _msgid_to_promise.find(id);
+            if (found == _msgid_to_promise.end()) {
+                mylog.error("poll_results: got valid result for unregistered id {}, dropping it", id);
+                ldap_msgfree(result);
+            } else {
+                found->second.set_value(std::move(result_ptr));
+                _msgid_to_promise.erase(found);
+            }
+        } else if (status < 0) {
+            mylog.error("poll_results: ldap_result returned status {}, error: {}", status, get_error());
+            set_status(status::err);
+        }
+    }
+    mylog.trace("poll_results done");
+}
+
+void ldap_connection::set_status(ldap_connection::status s) {
+    _status = s;
+    if (s != status::up) {
+        mylog.trace("set_status: signal result-waiting futures");
+        for (auto& e : _msgid_to_promise) {
+            e.second.set_exception(std::runtime_error("ldap_connection status set to error"));
+        }
+        _msgid_to_promise.clear();
+    }
+}
+
+ldap_reuser::ldap_reuser(sequential_producer<ldap_reuser::conn_ptr>::factory_t&& f)
+    : _make_conn(std::move(f)), _reaper(now()) {
+}
+
+void ldap_reuser::reap(conn_ptr& conn) {
+    if (!conn) {
+        return;
+    }
+    if (auto p = conn.release()) { // Safe to close, other fibers are done with it.
+        _reaper = _reaper.then([p = std::move(p)] () mutable {
+            return p->close().then_wrapped([p = std::move(p)] (future<> fut) {
+                if (fut.failed()) {
+                    mylog.warn("failure closing dead ldap_connection: {}", fut.get_exception());
+                }
+                /* p disposed here */
+            });
+        });
+    }
+}
+
+future<> ldap_reuser::stop() {
+    reap(_conn);
+    return std::move(_reaper);
+}

--- a/ent/ldap/ldap_connection.hh
+++ b/ent/ldap/ldap_connection.hh
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+
+#pragma once
+
+#include <ldap.h>
+#include <memory>
+#include <unordered_map>
+
+#include <seastar/core/iostream.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/net/api.hh>
+
+#include "utils/sequential_producer.hh"
+
+/// Functor to invoke ldap_msgfree.
+struct ldap_msg_deleter {
+    void operator()(LDAPMessage* p) {
+        ldap_msgfree(p);
+    }
+};
+
+using ldap_msg_ptr = std::unique_ptr<LDAPMessage, ldap_msg_deleter>;
+
+/// A connection to an LDAP server with custom networking over a Seastar socket.  Constructor takes
+/// a connected socket and generates an LDAP structure hooked up to it.  The LDAP object is obtained
+/// using get_ldap(); its custom networking is valid as long as its ldap_connection host is alive.
+class ldap_connection {
+    seastar::file_desc _fd; ///< Libldap polls this to determine if we're ready for reading/writing.
+    seastar::connected_socket _socket;
+    seastar::input_stream<char> _input_stream; ///< _socket's input.
+    seastar::output_stream<char> _output_stream; ///< _socket's output.
+    seastar::temporary_buffer<char> _read_buffer; ///< Everything read by Seastar but not yet consumed by Sockbuf_IO.
+    static std::mutex _global_init_mutex; ///< Mutex for protecting global ldap data initialization for older ldap libs -
+                                         /// ref:https://github.com/openldap/openldap/commit/877faea723ecc5721291b0b2f53e34f7921e0f7c
+    enum class status {
+        // Lowercase, to avoid inadvertently invoking macros:
+        up,             ///< Connected, operating normally.
+        down,           ///< Shut down.
+        eof,            ///< Read encountered EOF, write should be OK.
+        err             ///< IO error encountered.
+    };
+#if FMT_VERSION >= 9'00'00
+    friend auto format_as(status s) { return fmt::underlying(s); }
+#endif
+    status _status; ///< When not OK, all \c read() and \c write() calls will immediately return without action.
+    seastar::future<> _read_consumer; ///< Consumes Seastar read data.
+    bool _read_in_progress; ///< Is there a Seastar read in progress?
+    seastar::future<> _outstanding_write; ///< Captures Seastar write continuation.
+    /// When LDAP yields a result for one of these msgids, forward it to the corresponding promise:
+    std::unordered_map<int, seastar::promise<ldap_msg_ptr>> _msgid_to_promise;
+    bool _currently_polling; ///< True iff poll_results() is in progress.
+
+    /// Deallocates an LDAP structure.
+    struct ldap_deleter {
+        void operator()(LDAP*);
+    };
+    std::unique_ptr<LDAP, ldap_deleter> _ldap;
+
+  public:
+    /// Creates LDAP with custom Seastar networking.
+    ldap_connection(seastar::connected_socket&& socket);
+
+    /// A pointer to the LDAP customized with Seastar IO.  *this keeps ownership.
+    ///
+    /// \warning Do not call ldap_result() on this object, nor any ldap_* operations that generate
+    /// network traffic.  This includes at least:
+    /// - ldap_abandon
+    /// - ldap_add
+    /// - ldap_bind
+    /// - ldap_compare
+    /// - ldap_delete
+    /// - ldap_extended_operation
+    /// - ldap_modify
+    /// - ldap_rename
+    /// - ldap_search
+    /// - ldap_unbind()
+    LDAP* get_ldap() const { return _ldap.get(); }
+
+    /// Before destroying *this, user must wait on the future returned:
+    seastar::future<> close();
+
+    /// Performs LDAP simple bind operation.  See man ldap_bind.
+    seastar::future<ldap_msg_ptr> simple_bind(const char *who, const char *passwd);
+
+    /// Performs LDAP search operation.  See man ldap_search.
+    seastar::future<ldap_msg_ptr> search(
+              char *base,
+              int scope,
+              char *filter,
+              char *attrs[],
+              int attrsonly,
+              LDAPControl **serverctrls,
+              LDAPControl **clientctrls,
+              struct timeval *timeout,
+              int sizelimit);
+
+    /// The last error reported by an LDAP operation.
+    seastar::sstring get_error() const;
+
+    /// Cannot be moved, since it spawns continuations that capture \c this.
+    ldap_connection(ldap_connection&&) = delete;
+
+    bool is_live() const { return _status == status::up; }
+
+  private:
+    // Sockbuf_IO functionality (see Sockbuf_IO manpage):
+    static int sbi_ctrl(Sockbuf_IO_Desc* sid, int option, void* value) noexcept;
+    static ber_slen_t sbi_read(Sockbuf_IO_Desc* sid, void* buffer, ber_len_t size) noexcept;
+    static ber_slen_t sbi_write(Sockbuf_IO_Desc* sid, void* buffer, ber_len_t size) noexcept;
+    static int sbi_close(Sockbuf_IO_Desc* sid) noexcept;
+    static const Sockbuf_IO seastar_sbio;
+
+    /// Efficiently waits for ldap_result of msgid, returning the result object in the future.  If
+    /// an error occurs at any point, the future will be exceptional.
+    ///
+    /// \warning You must call await_result() immediately after obtaining msgid from an ldap_*
+    /// function, without yielding to Seastar in between.  Otherwise, the result may be dropped.
+    seastar::future<ldap_msg_ptr> await_result(int msgid);
+
+    /// If status is LDAP_SUCCESS, returns await_result(msgid).  Otherwise, returns an exceptional
+    /// future with the error report.
+    seastar::future<ldap_msg_ptr> await_result(int status, int msgid);
+
+    /// Schedules a Seastar write of (copied) b[:size].  On success, returns size.  On failure,
+    /// returns LDAP's failure code.
+    ber_slen_t write(char const* b, ber_len_t size);
+
+    /// Consumes at most \p size bytes from what Seastar has read so far and writes them to b.  On
+    /// success, returns the number of bytes so consumed (possibly less than \p size).  On failure,
+    /// returns LDAP's failure code.
+    ber_slen_t read(char* b, ber_len_t size);
+
+    /// Shuts down all internal state that can be shut down immediately.  See also close().
+    void shutdown();
+
+    /// Initiates a Seastar read that will procure data for \c read() to consume.  Data consumption
+    /// will happen in a future captured by _read_consumer.  If _read_consumer is currently active,
+    /// however (because the previous Seastar read hasn't been consumed yet), this method does
+    /// nothing.
+    void read_ahead();
+
+    /// Invokes ldap_result for all elements of _msgid_to_promise.  For every ready result, fulfills
+    /// its promise and removes it from _msgid_to_promise.
+    void poll_results();
+
+    /// Sets _status to \p s.  If s != status::up, sends an exception to each _msgid_to_promise
+    /// element, then clears _msgid_to_promise.
+    void set_status(ldap_connection::status s);
+};
+
+/// Reuses an ldap_connection as long as it is live, then transparently creates a new one, ad infinitum.  Cleans up
+/// all the created connections.
+class ldap_reuser {
+  public:
+    using conn_ptr = seastar::lw_shared_ptr<ldap_connection>;
+
+  private:
+    sequential_producer<conn_ptr> _make_conn; // TODO: This type can be a parameter.
+    conn_ptr _conn;
+    seastar::future<> _reaper; ///< Closes and deletes all connections produced.
+
+  public:
+    ldap_reuser(sequential_producer<conn_ptr>::factory_t&& f);
+    ldap_reuser(ldap_reuser&&) = delete; // Spawns continuations that capture *this; don't move it, pls.
+    ldap_reuser& operator=(ldap_reuser&&) = delete; // Spawns continuations that capture *this; don't move it, pls.
+
+    /// Must resolve before destruction.
+    seastar::future<> stop();
+
+    /// Invokes fn on a valid ldap_connection, managing its lifetime and validity.
+    template<std::invocable<ldap_connection&> Func>
+    std::invoke_result_t<Func, ldap_connection&> with_connection(Func fn) {
+        if (_conn && _conn->is_live()) {
+            return invoke(std::move(fn));
+        } else {
+            return _make_conn().then([this, fn = std::move(fn)] (conn_ptr&& conn) mutable {
+                if (_conn) {
+                    if (!_conn->is_live()) {
+                        reap(_conn);
+                    } else {
+                        reap(conn); // apparently lost the race
+                    }
+                }
+                if (!_conn) {
+                    _conn = std::move(conn);
+                }
+                _make_conn.clear(); // So _make_conn doesn't keep a shared-pointer copy that escapes reaping.
+                return invoke(std::move(fn));
+            });
+        }
+    }
+
+  private:
+    /// Invokes fn on a copy of _conn and schedules its reaping.
+    template<std::invocable<ldap_connection&> Func>
+    std::invoke_result_t<Func, ldap_connection&> invoke(Func fn) {
+        conn_ptr conn(_conn);
+        return fn(*conn).finally([this, conn = std::move(conn)] () mutable { reap(conn); });
+    }
+
+    /// Decreases conn reference count.  If this is the last fiber using conn, closes and disposes of it.
+    void reap(conn_ptr& conn);
+};

--- a/test.py
+++ b/test.py
@@ -23,12 +23,15 @@ import resource
 import shlex
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
 import traceback
 import xml.etree.ElementTree as ET
 import yaml
+from random import randint
+from tempfile import TemporaryDirectory
 
 from abc import ABC, abstractmethod
 from io import StringIO
@@ -58,6 +61,73 @@ all_modes = {'debug': 'Debug',
              'sanitize': 'Sanitize',
              'coverage': 'Coverage'}
 debug_modes = {'debug', 'sanitize'}
+
+LDAP_SERVER_CONFIGURATION_FILE = os.path.join(os.path.dirname(__file__), 'test', 'resource', 'slapd.conf')
+
+DEFAULT_ENTRIES = [
+    """dn: dc=example,dc=com
+objectClass: dcObject
+objectClass: organization
+dc: example
+o: Example
+description: Example directory.
+""",
+    """dn: cn=root,dc=example,dc=com
+objectClass: organizationalRole
+cn: root
+description: Directory manager.
+""",
+    """dn: ou=People,dc=example,dc=com
+objectClass: organizationalUnit
+ou: People
+description: Our people.
+""",
+    """# Default superuser for Scylla
+dn: uid=cassandra,ou=People,dc=example,dc=com
+objectClass: organizationalPerson
+objectClass: uidObject
+cn: cassandra
+ou: People
+sn: cassandra
+userid: cassandra
+userPassword: cassandra
+""",
+    """dn: uid=jsmith,ou=People,dc=example,dc=com
+objectClass: organizationalPerson
+objectClass: uidObject
+cn: Joe Smith
+ou: People
+sn: Smith
+userid: jsmith
+userPassword: joeisgreat
+""",
+    """dn: uid=jdoe,ou=People,dc=example,dc=com
+objectClass: organizationalPerson
+objectClass: uidObject
+cn: John Doe
+ou: People
+sn: Doe
+userid: jdoe
+userPassword: pa55w0rd
+""",
+    """dn: cn=role1,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: role1
+uniqueMember: uid=jsmith,ou=People,dc=example,dc=com
+uniqueMember: uid=cassandra,ou=People,dc=example,dc=com
+""",
+    """dn: cn=role2,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: role2
+uniqueMember: uid=cassandra,ou=People,dc=example,dc=com
+""",
+    """dn: cn=role3,dc=example,dc=com
+objectClass: groupOfUniqueNames
+cn: role3
+uniqueMember: uid=jdoe,ou=People,dc=example,dc=com
+""",
+]
+
 
 def create_formatter(*decorators) -> Callable[[Any], str]:
     """Return a function which decorates its argument with the given
@@ -481,6 +551,19 @@ class BoostTestSuite(UnitTestSuite):
     def boost_tests(self) -> Iterable['Tests']:
         return self.tests
 
+
+class LdapTestSuite(UnitTestSuite):
+    """TestSuite for ldap unit tests"""
+
+    async def create_test(self, shortname, casename, suite, args):
+        test = LdapTest(self.next_id((shortname, self.suite_key)), shortname, suite, args)
+        self.tests.append(test)
+
+    def junit_tests(self):
+        """Ldap tests produce an own XML output, so are not included in a junit report"""
+        return []
+
+
 class PythonTestSuite(TestSuite):
     """A collection of Python pytests against a single Scylla instance"""
 
@@ -737,6 +820,16 @@ class Test:
     def print_summary(self) -> None:
         pass
 
+    async def setup(self, port, options):
+        """
+        Performs any necessary setup steps before running a test.
+        Returns (fn, txt, test_env) where:
+        fn  - is a cleanup function to call unconditionally after the test stops running
+        txt - is failure-injection description.
+        test_env - is a dictionary containing environment variables map specific for the test
+        """
+        return (lambda: 0, None,{})
+
     def check_log(self, trim: bool) -> None:
         """Check and trim logs and xml output for tests which have it"""
         if trim:
@@ -883,6 +976,113 @@ class BoostTest(Test):
     def print_summary(self) -> None:
         print("Output of {} {}:".format(self.path, " ".join(self.args)))
         print(read_log(self.log_filename))
+
+
+def can_connect(address, family=socket.AF_INET):
+    s = socket.socket(family)
+    try:
+        s.connect(address)
+        return True
+    except OSError as e:
+        if 'AF_UNIX path too long' in str(e):
+            raise OSError(e.errno, "{} ({})".format(str(e), address)) from None
+        else:
+            return False
+    except:
+        return False
+
+
+def try_something_backoff(something):
+    sleep_time = 0.05
+    while not something():
+        if sleep_time > 30:
+            return False
+        time.sleep(sleep_time)
+        sleep_time *= 2
+    return True
+
+def make_saslauthd_conf(port, instance_path):
+    """Creates saslauthd.conf with appropriate contents under instance_path.  Returns the path to the new file."""
+    saslauthd_conf_path = os.path.join(instance_path, 'saslauthd.conf')
+    with open(saslauthd_conf_path, 'w') as f:
+        f.write('ldap_servers: ldap://localhost:{}\nldap_search_base: dc=example,dc=com'.format(port))
+    return saslauthd_conf_path
+
+
+class LdapTest(BoostTest):
+    """A unit test which can produce its own XML output, and needs an ldap server"""
+
+    def __init__(self, test_no, shortname, args, suite):
+        super().__init__(test_no, shortname, args, suite, None, False, None)
+
+    async def setup(self, port, options):
+        instances_root = os.path.join(options.tmpdir, self.mode, 'ldap_instances');
+        instance_path = os.path.join(os.path.abspath(instances_root), str(port))
+        slapd_pid_file = os.path.join(instance_path, 'slapd.pid')
+        saslauthd_socket_path = TemporaryDirectory()
+        os.makedirs(instance_path, exist_ok=True)
+        # This will always fail because it lacks the permissions to read the default slapd data
+        # folder but it does create the instance folder so we don't want to fail here.
+        try:
+            subprocess.check_output(['slaptest', '-f', LDAP_SERVER_CONFIGURATION_FILE, '-F', instance_path],
+                                    stderr=subprocess.DEVNULL)
+        except:
+            pass
+        # Set up failure injection.
+        proxy_name = 'p{}'.format(port)
+        subprocess.check_output([
+            'toxiproxy-cli', 'c', proxy_name,
+            '--listen', 'localhost:{}'.format(port + 2), '--upstream', 'localhost:{}'.format(port)])
+        # Sever the connection after byte_limit bytes have passed through:
+        byte_limit = options.byte_limit if options.byte_limit else randint(0, 2000)
+        subprocess.check_output(['toxiproxy-cli', 't', 'a', proxy_name, '-t', 'limit_data', '-n', 'limiter',
+                                 '-a', 'bytes={}'.format(byte_limit)])
+        # Change the data folder in the default config.
+        replace_expression = 's/olcDbDirectory:.*/olcDbDirectory: {}/g'.format(
+            os.path.abspath(instance_path).replace('/', r'\/'))
+        subprocess.check_output(
+            ['find', instance_path, '-type', 'f', '-exec', 'sed', '-i', replace_expression, '{}', ';'])
+        # Change the pid file to be kept with the instance.
+        replace_expression = 's/olcPidFile:.*/olcPidFile: {}/g'.format(
+            os.path.abspath(slapd_pid_file).replace('/', r'\/'))
+        subprocess.check_output(
+            ['find', instance_path, '-type', 'f', '-exec', 'sed', '-i', replace_expression, '{}', ';'])
+        # Put the test data in.
+        cmd = ['slapadd', '-F', instance_path]
+        subprocess.check_output(
+            cmd, input='\n\n'.join(DEFAULT_ENTRIES).encode('ascii'), stderr=subprocess.STDOUT)
+        # Set up the server.
+        SLAPD_URLS='ldap://:{}/ ldaps://:{}/'.format(port, port + 1)
+        def can_connect_to_slapd():
+            return can_connect(('127.0.0.1', port)) and can_connect(('127.0.0.1', port + 1)) and can_connect(('127.0.0.1', port + 2))
+        def can_connect_to_saslauthd():
+            return can_connect(os.path.join(saslauthd_socket_path.name, 'mux'), socket.AF_UNIX)
+        slapd_proc = subprocess.Popen(['prlimit', '-n1024', 'slapd', '-F', instance_path, '-h', SLAPD_URLS, '-d', '0'])
+        saslauthd_conf_path = make_saslauthd_conf(port, instance_path)
+        test_env = {
+            "SEASTAR_LDAP_PORT" : str(port),
+            "SASLAUTHD_MUX_PATH" : os.path.join(saslauthd_socket_path.name, "mux")
+        }
+
+        saslauthd_proc = subprocess.Popen(
+            ['saslauthd', '-d', '-n', '1', '-a', 'ldap', '-O', saslauthd_conf_path, '-m', saslauthd_socket_path.name],
+            stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
+        def finalize():
+            slapd_proc.terminate()
+            slapd_proc.wait() # Wait for slapd to remove slapd.pid, so it doesn't race with rmtree below.
+            saslauthd_proc.kill() # Somehow, invoking terminate() here also terminates toxiproxy-server. o_O
+            shutil.rmtree(instance_path)
+            saslauthd_socket_path.cleanup()
+            subprocess.check_output(['toxiproxy-cli', 'd', proxy_name])
+        try:
+            if not try_something_backoff(can_connect_to_slapd):
+                raise Exception('Unable to connect to slapd')
+            if not try_something_backoff(can_connect_to_saslauthd):
+                raise Exception('Unable to connect to saslauthd')
+        except:
+            finalize()
+            raise
+        return finalize, '--byte-limit={}'.format(byte_limit), test_env
 
 
 class CQLApprovalTest(Test):
@@ -1301,17 +1501,31 @@ class TabularConsoleOutput:
             msg += " {:.2f}s".format(test.time_end - test.time_start)
             print(msg)
 
+toxiproxy_id_gen = 0
 
 async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, env=dict()) -> bool:
     """Run test program, return True if success else False"""
 
     with test.log_filename.open("wb") as log:
-
-        def report_error(error):
+        global toxiproxy_id_gen
+        toxiproxy_id = toxiproxy_id_gen
+        toxiproxy_id_gen += 1
+        ldap_port = 5000 + (toxiproxy_id * 3) % 55000
+        cleanup_fn = None
+        finject_desc = None
+        def report_error(error, failure_injection_desc = None):
             msg = "=== TEST.PY SUMMARY START ===\n"
             msg += "{}\n".format(error)
             msg += "=== TEST.PY SUMMARY END ===\n"
+            if failure_injection_desc is not None:
+                msg += 'failure injection: {}'.format(failure_injection_desc)
             log.write(msg.encode(encoding="UTF-8"))
+
+        try:
+            cleanup_fn, finject_desc, test_env = await test.setup(ldap_port, options)
+        except Exception as e:
+            report_error("Test setup failed ({})\n{}".format(str(e), traceback.format_exc()))
+            return False
         process = None
         stdout = None
         logging.info("Starting test %s: %s %s", test.uname, test.path, " ".join(test.args))
@@ -1327,6 +1541,19 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             "detect_stack_use_after_return=1",
             os.getenv("ASAN_OPTIONS"),
         ]
+        ldap_instance_path = os.path.join(
+            os.path.abspath(os.path.join(options.tmpdir, test.mode, 'ldap_instances')),
+            str(ldap_port))
+        saslauthd_mux_path = os.path.join(ldap_instance_path, 'mux')
+        if options.manual_execution:
+            print('Please run the following shell command, then press <enter>:')
+            test_env_string = " ".join([f"{k}={v}" for k,v in test_env.items()])
+            print('{} {}'.format(
+                test_env_string, ' '.join([shlex.quote(e) for e in [test.path, *test.args]])))
+            input('-- press <enter> to continue --')
+            if cleanup_fn is not None:
+                cleanup_fn()
+            return True
         try:
             resource_gather = get_resource_gather(options.gather_metrics, test, options.tmpdir)
             resource_gather.make_cgroup()
@@ -1335,6 +1562,8 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
                 ":".join(filter(None, UBSAN_OPTIONS))).encode(encoding="UTF-8"))
             log.write("export ASAN_OPTIONS='{}'\n".format(
                 ":".join(filter(None, ASAN_OPTIONS))).encode(encoding="UTF-8"))
+            for k,v in test_env.items():
+                log.write(f"export {k}={v}\n".encode(encoding="UTF-8"))
             log.write("{} {}\n".format(test.path, " ".join(test.args)).encode(encoding="UTF-8"))
             log.write("=== TEST.PY TEST {} OUTPUT ===\n".format(test.uname).encode(encoding="UTF-8"))
             log.flush()
@@ -1350,11 +1579,8 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             test_running_event = asyncio.Event()
             test_resource_watcher = resource_gather.cgroup_monitor(test_event=test_running_event)
 
-            process = await asyncio.create_subprocess_exec(
-                path, *args,
-                stderr=log,
-                stdout=log,
-                env=dict(os.environ,
+            test_env.update(
+                dict(os.environ,
                          UBSAN_OPTIONS=":".join(filter(None, UBSAN_OPTIONS)),
                          ASAN_OPTIONS=":".join(filter(None, ASAN_OPTIONS)),
                          # TMPDIR env variable is used by any seastar/scylla
@@ -1362,7 +1588,13 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
                          TMPDIR=os.path.join(options.tmpdir, test.mode),
                          SCYLLA_TEST_ENV='yes',
                          **env,
-                         ),
+                 )
+            )
+            process = await asyncio.create_subprocess_exec(
+                path, *args,
+                stderr=log,
+                stdout=log,
+                env=test_env,
                 preexec_fn=resource_gather.put_process_to_cgroup,
             )
             stdout, _ = await asyncio.wait_for(process.communicate(), options.timeout)
@@ -1406,6 +1638,9 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
                 report_error("Test was cancelled: the parent process is exiting")
         except Exception as e:
             report_error("Failed to run the test:\n{e}".format(e=e))
+        finally:
+            if cleanup_fn is not None:
+                cleanup_fn()
     return False
 
 
@@ -1504,6 +1739,10 @@ def parse_cmd_line() -> argparse.Namespace:
     parser.add_argument("--cluster-pool-size", action="store", default=None, type=int,
                         help="Set the pool_size for PythonTest and its descendants. Alternatively environment variable "
                              "CLUSTER_POOL_SIZE can be used to achieve the same")
+    parser.add_argument('--manual-execution', action='store_true', default=False,
+                        help='Let me manually run the test executable at the moment this script would run it')
+    parser.add_argument('--byte-limit', action="store", default=None, type=int,
+                        help="Specific byte limit for failure injection (random by default)")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
@@ -1951,20 +2190,39 @@ async def main() -> int:
                          for t in TestSuite.all_tests()]))
         return 0
 
+    if options.manual_execution and TestSuite.test_count() > 1:
+        print('--manual-execution only supports running a single test, but multiple selected: {}'.format(
+            [t.path for t in TestSuite.tests()][:3])) # Print whole t.path; same shortname may be in different dirs.
+        return 1
+
     signaled = asyncio.Event()
     stop_event = asyncio.Event()
     resource_watcher = run_resource_watcher(options.gather_metrics, signaled, stop_event, options.tmpdir)
 
     setup_signal_handlers(asyncio.get_running_loop(), signaled)
 
+    tp_server = None
     try:
-        await run_all_tests(signaled, options)
-        stop_event.set()
-        async with asyncio.timeout(5):
-            await resource_watcher
-    except Exception as e:
-        print(palette.fail(e))
-        raise
+        if [t for t in TestSuite.all_tests() if isinstance(t, LdapTest)]:
+            tp_server = subprocess.Popen('toxiproxy-server', stderr=subprocess.DEVNULL)
+            def can_connect_to_toxiproxy():
+                return can_connect(('127.0.0.1', 8474))
+            if not try_something_backoff(can_connect_to_toxiproxy):
+                raise Exception('Could not connect to toxiproxy')
+
+        try:
+            logging.info('running all tests')
+            await run_all_tests(signaled, options)
+            logging.info('after running all tests')
+            stop_event.set()
+            async with asyncio.timeout(5):
+                await resource_watcher
+        except Exception as e:
+            print(palette.fail(e))
+            raise
+    finally:
+        if tp_server is not None:
+            tp_server.terminate()
 
     if signaled.is_set():
         return -signaled.signo      # type: ignore

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -97,6 +97,7 @@ if(BUILD_TESTING)
     add_dependencies(tests scylla)
 
     add_subdirectory(boost)
+    add_subdirectory(ldap)
     add_subdirectory(manual)
     add_subdirectory(unit)
     add_subdirectory(raft)

--- a/test/ldap/CMakeLists.txt
+++ b/test/ldap/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_scylla_test(ldap_connection_test
+  KIND SEASTAR)
+add_scylla_test(ldap_role_manager_test
+  KIND SEASTAR
+  SOURCES role_manager_test.cc)
+add_scylla_test(saslauthd_authenticator_test
+  KIND SEASTAR)
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/suite.yaml")
+    set(scylla_tests "${scylla_tests}" PARENT_SCOPE)
+endif()

--- a/test/ldap/ldap_common.hh
+++ b/test/ldap/ldap_common.hh
@@ -1,0 +1,25 @@
+
+/*
+ * Copyright (C) 2015 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/net/socket_defs.hh>
+
+// Common values used in multiple LDAP tests.
+namespace {
+
+constexpr auto base_dn = "dc=example,dc=com";
+constexpr auto manager_dn = "cn=root,dc=example,dc=com";
+constexpr auto manager_password = "secret";
+const auto ldap_envport = std::getenv("SEASTAR_LDAP_PORT");
+const std::string ldap_port(ldap_envport ? ldap_envport : "389");
+const seastar::socket_address local_ldap_address(seastar::ipv4_addr("127.0.0.1", std::stoi(ldap_port)));
+const seastar::socket_address local_fail_inject_address(seastar::ipv4_addr("127.0.0.1", std::stoi(ldap_port) + 2));
+
+} // anonymous namespace

--- a/test/ldap/ldap_connection_test.cc
+++ b/test/ldap/ldap_connection_test.cc
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2019 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#define LDAP_DEPRECATED 1
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <cassert>
+#include <exception>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/log.hh>
+#include <seastar/util/defer.hh>
+#include <set>
+#include <string>
+
+#include "ent/ldap/ldap_connection.hh"
+#include "test/lib/exception_utils.hh"
+#include "ldap_common.hh"
+#include "seastarx.hh"
+
+extern "C" {
+#include <ldap.h>
+}
+
+namespace {
+
+logger mylog{"ldap_connection_test"}; // `log` is taken by math.
+
+void set_defbase() {
+    ldap_set_option(nullptr, LDAP_OPT_DEFBASE, base_dn);
+}
+
+const std::set<std::string> results_expected_from_search_base_dn{
+    "dc=example,dc=com",
+    "cn=root,dc=example,dc=com",
+    "ou=People,dc=example,dc=com",
+    "uid=cassandra,ou=People,dc=example,dc=com",
+    "uid=jsmith,ou=People,dc=example,dc=com",
+    "uid=jdoe,ou=People,dc=example,dc=com",
+    "cn=role1,dc=example,dc=com",
+    "cn=role2,dc=example,dc=com",
+    "cn=role3,dc=example,dc=com",
+};
+
+/// Ignores exceptions from LDAP operations.  Useful for failure-injection tests, which must
+/// tolerate aborted communication.
+ldap_msg_ptr ignore(std::exception_ptr) {
+    return ldap_msg_ptr();
+}
+
+/// Extracts entries from an ldap_search result.
+std::set<std::string> entries(LDAP* ld, LDAPMessage* res) {
+    BOOST_REQUIRE_EQUAL(LDAP_RES_SEARCH_ENTRY, ldap_msgtype(res));
+    std::set<std::string> entry_set;
+    for (auto e = ldap_first_entry(ld, res); e; e = ldap_next_entry(ld, e)) {
+        char* dn = ldap_get_dn(ld, e);
+        entry_set.insert(dn);
+        ldap_memfree(dn);
+    }
+    return entry_set;
+}
+
+future<ldap_msg_ptr> search(ldap_connection& conn, const char* term) {
+    return conn.search(
+            const_cast<char*>(term),
+            LDAP_SCOPE_SUBTREE,
+            /*filter=*/nullptr,
+            /*attrs=*/nullptr,
+            /*attrsonly=*/0,
+            /*serverctrls=*/nullptr,
+            /*clientctrls=*/nullptr,
+            /*timeout=*/nullptr,
+            /*sizelimit=*/0);
+}
+
+future<ldap_msg_ptr> bind(ldap_connection& conn) {
+    return conn.simple_bind(manager_dn, manager_password);
+}
+
+
+/// Creates an ldap_connection, invokes a function on it, then waits for its closing.  Must be
+/// invoked from Seastar thread.
+void with_ldap_connection(seastar::connected_socket&& socket, std::function<void(ldap_connection&)> f) {
+    mylog.trace("with_ldap_connection");
+    ldap_connection c(std::move(socket));
+    auto do_close = defer([&] { c.close().get(); });
+    mylog.trace("with_ldap_connection: invoking f");
+    f(c);
+    mylog.trace("with_ldap_connection done");
+}
+
+/// Connects to an address, then invokes with_ldap_connection on the resulting socket.  Must be
+/// invoked from Seastar thread.
+void with_ldap_connection(const seastar::socket_address& a, std::function<void(ldap_connection&)> f) {
+    with_ldap_connection(connect(a).get(), f);
+}
+
+} // anonymous namespace
+
+// Tests default (non-custom) libber networking.  Failure here indicates a likely bug in test.py's
+// LDAP setup.
+SEASTAR_THREAD_TEST_CASE(bind_with_default_io) {
+    set_defbase();
+    const auto server_uri = "ldap://localhost:" + ldap_port;
+    LDAP *manager_client_state{nullptr};
+    BOOST_REQUIRE_EQUAL(LDAP_SUCCESS, ldap_initialize(&manager_client_state, server_uri.c_str()));
+    static constexpr int v3 = LDAP_VERSION3;
+    BOOST_REQUIRE_EQUAL(LDAP_OPT_SUCCESS, ldap_set_option(manager_client_state, LDAP_OPT_PROTOCOL_VERSION, &v3));
+    // Retry on EINTR, rather than return error:
+    BOOST_REQUIRE_EQUAL(LDAP_OPT_SUCCESS, ldap_set_option(manager_client_state, LDAP_OPT_RESTART, LDAP_OPT_ON));
+    BOOST_REQUIRE_EQUAL(LDAP_SUCCESS, ldap_simple_bind_s(manager_client_state, manager_dn, manager_password));
+    BOOST_REQUIRE_EQUAL(LDAP_SUCCESS, ldap_unbind(manager_client_state));
+}
+
+SEASTAR_THREAD_TEST_CASE(bind_with_custom_sockbuf_io) {
+    set_defbase();
+    mylog.trace("bind_with_custom_sockbuf_io");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) {
+        mylog.trace("bind_with_custom_sockbuf_io invoking bind");
+        const auto res = bind(c).get();
+        BOOST_REQUIRE_EQUAL(LDAP_RES_BIND, ldap_msgtype(res.get()));
+    });
+    mylog.trace("bind_with_custom_sockbuf_io done");
+}
+
+SEASTAR_THREAD_TEST_CASE(search_with_custom_sockbuf_io) {
+    set_defbase();
+    mylog.trace("search_with_custom_sockbuf_io");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) {
+        mylog.trace("search_with_custom_sockbuf_io: invoking search");
+        const auto res = search(c, base_dn).get();
+        mylog.trace("search_with_custom_sockbuf_io: got result");
+        const auto actual = entries(c.get_ldap(), res.get());
+        const std::set<std::string>& expected = results_expected_from_search_base_dn;
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(actual.cbegin(), actual.cend(), expected.cbegin(), expected.cend());
+    });
+    mylog.trace("search_with_custom_sockbuf_io done");
+}
+
+SEASTAR_THREAD_TEST_CASE(multiple_outstanding_operations) {
+    set_defbase();
+    mylog.trace("multiple_outstanding_operations");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) {
+        mylog.trace("multiple_outstanding_operations: bind");
+        BOOST_REQUIRE_EQUAL(LDAP_RES_BIND, ldap_msgtype(bind(c).get().get()));
+
+        std::vector<future<ldap_msg_ptr>> results_base;
+        for (size_t i = 0; i < 30; ++i) {
+            mylog.trace("multiple_outstanding_operations: invoking search base #{}", i);
+            results_base.push_back(search(c, base_dn));
+            mylog.trace("multiple_outstanding_operations: search base #{} got future {}", i, static_cast<const void*>(&results_base.back()));
+        }
+
+        std::vector<future<ldap_msg_ptr>> results_jsmith;
+        for (size_t i = 0; i < 30; ++i) {
+            mylog.trace("multiple_outstanding_operations: invoking search jsmith #{}", i);
+            results_jsmith.push_back(search(c, "uid=jsmith,ou=People,dc=example,dc=com"));
+            mylog.trace("multiple_outstanding_operations: search jsmith #{} got future {}", i, static_cast<const void*>(&results_jsmith.back()));
+        }
+
+        using boost::test_tools::per_element;
+        mylog.trace("multiple_outstanding_operations: check base results");
+        future<> base_result_fut = parallel_for_each(results_base, [&c] (future<ldap_msg_ptr>& res) {
+            const auto actual_base = entries(c.get_ldap(), res.get().get());
+            BOOST_TEST_INFO("result for " << &res);
+            BOOST_TEST(actual_base == results_expected_from_search_base_dn, per_element());
+            return make_ready_future();
+        });
+
+        mylog.trace("multiple_outstanding_operations: check jsmith result");
+        static const std::set<std::string> expected_jsmith{"uid=jsmith,ou=People,dc=example,dc=com"};
+        future<> jsmith_result_fut = parallel_for_each(results_jsmith, [&c] (future<ldap_msg_ptr>& res) {
+            const auto actual_jsmith = entries(c.get_ldap(), res.get().get());
+            BOOST_TEST_INFO("result for " << &res);
+            BOOST_TEST(actual_jsmith == expected_jsmith, per_element());
+            return make_ready_future();
+        });
+
+        when_all(std::move(base_result_fut), std::move(jsmith_result_fut)).get();
+    });
+    mylog.trace("multiple_outstanding_operations done");
+}
+
+SEASTAR_THREAD_TEST_CASE(early_shutdown) {
+    set_defbase();
+    mylog.trace("early_shutdown: noop");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection&) {});
+    mylog.trace("early_shutdown: bind");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) { bind(c).handle_exception(&ignore).get(); });
+    mylog.trace("early_shutdown: search");
+    with_ldap_connection(
+            local_ldap_address, [] (ldap_connection& c) { search(c, base_dn).handle_exception(&ignore).get(); });
+}
+
+SEASTAR_THREAD_TEST_CASE(bind_after_fail) {
+    set_defbase();
+    mylog.trace("bind_after_fail: wonky connection");
+    with_ldap_connection(local_fail_inject_address, [] (ldap_connection& wonky_conn) {
+        bind(wonky_conn).handle_exception(&ignore).get();
+    });
+    mylog.trace("bind_after_fail: solid connection");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) {
+        const auto res = bind(c).get();
+        BOOST_REQUIRE_EQUAL(LDAP_RES_BIND, ldap_msgtype(res.get()));
+    });
+    mylog.trace("bind_after_fail done");
+}
+
+SEASTAR_THREAD_TEST_CASE(search_after_fail) {
+    set_defbase();
+    mylog.trace("search_after_fail: wonky connection");
+    with_ldap_connection(local_fail_inject_address, [] (ldap_connection& wonky_conn) {
+        search(wonky_conn, base_dn).handle_exception(&ignore).get();
+    });
+    mylog.trace("search_after_fail: solid connection");
+    with_ldap_connection(local_ldap_address, [] (ldap_connection& c) {
+        const auto res = search(c, base_dn).get();
+        mylog.trace("search_after_fail: got search result");
+        const auto actual = entries(c.get_ldap(), res.get());
+        BOOST_REQUIRE_EQUAL_COLLECTIONS(
+                actual.cbegin(), actual.cend(),
+                results_expected_from_search_base_dn.cbegin(), results_expected_from_search_base_dn.cend());
+    });
+    mylog.trace("search_after_fail done");
+}
+
+SEASTAR_THREAD_TEST_CASE(multiple_outstanding_operations_on_failing_connection) {
+    set_defbase();
+    mylog.trace("multiple_outstanding_operations_on_failing_connection");
+    with_ldap_connection(local_fail_inject_address, [] (ldap_connection& c) {
+        mylog.trace("multiple_outstanding_operations_on_failing_connection: invoking bind");
+        bind(c).handle_exception(&ignore).get();;
+
+        std::vector<future<ldap_msg_ptr>> results_base;
+        for (size_t i = 0; i < 10; ++i) {
+            mylog.trace("multiple_outstanding_operations_on_failing_connection: invoking search base");
+            results_base.push_back(search(c, base_dn).handle_exception(&ignore));
+        }
+
+        std::vector<future<ldap_msg_ptr>> results_jsmith;
+        for (size_t i = 0; i < 10; ++i) {
+            mylog.trace("multiple_outstanding_operations_on_failing_connection: invoking search jsmith");
+            results_jsmith.push_back(search(c, "uid=jsmith,ou=People,dc=example,dc=com").handle_exception(&ignore));
+        }
+
+        mylog.trace("multiple_outstanding_operations_on_failing_connection: getting base results");
+        when_all_succeed(results_base.begin(), results_base.end()).get();
+        mylog.trace("multiple_outstanding_operations_on_failing_connection: getting jsmith results");
+        when_all_succeed(results_jsmith.begin(), results_jsmith.end()).get();
+    });
+    mylog.trace("multiple_outstanding_operations_on_failing_connection done");
+}
+
+using exception_predicate::message_contains;
+
+SEASTAR_THREAD_TEST_CASE(bind_after_close) {
+    set_defbase();
+    ldap_connection c(connect(local_ldap_address).get());
+    c.close().get();
+    BOOST_REQUIRE_EXCEPTION(bind(c).get(), std::runtime_error, message_contains("ldap_connection"));
+}
+
+SEASTAR_THREAD_TEST_CASE(search_after_close) {
+    set_defbase();
+    ldap_connection c(connect(local_ldap_address).get());
+    c.close().get();
+    BOOST_REQUIRE_EXCEPTION(search(c, base_dn).get(), std::runtime_error, message_contains("ldap_connection"));
+}
+
+SEASTAR_THREAD_TEST_CASE(close_after_close) {
+    set_defbase();
+    ldap_connection c(connect(local_ldap_address).get());
+    c.close().get();
+    BOOST_REQUIRE_EXCEPTION(c.close().get(), std::runtime_error, message_contains("ldap_connection"));
+}
+
+SEASTAR_THREAD_TEST_CASE(severed_connection_yields_exceptional_future) {
+    set_defbase();
+    with_ldap_connection(local_fail_inject_address, [] (ldap_connection& c) {
+        int up = 1;
+        while (up) {
+            search(c, base_dn)
+                    .handle_exception_type([&] (std::runtime_error&) { up = 0; return ldap_msg_ptr(); })
+                    .get();
+        }
+    });
+}

--- a/test/ldap/role_manager_test.cc
+++ b/test/ldap/role_manager_test.cc
@@ -1,0 +1,537 @@
+/*
+ * Copyright (C) 2017 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "auth/standard_role_manager.hh"
+#include "auth/ldap_role_manager.hh"
+#include "auth/password_authenticator.hh"
+#include "db/config.hh"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include "utils/to_string.hh"
+#include <seastar/testing/test_case.hh>
+
+#include "test/lib/exception_utils.hh"
+#include "test/lib/test_utils.hh"
+#include "ldap_common.hh"
+#include "service/migration_manager.hh"
+#include "test/lib/cql_test_env.hh"
+
+auto make_manager(cql_test_env& env) {
+    auto stop_role_manager = [] (auth::standard_role_manager* m) {
+        m->stop().get();
+        std::default_delete<auth::standard_role_manager>()(m);
+    };
+    return std::unique_ptr<auth::standard_role_manager, decltype(stop_role_manager)>(
+            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(),  env.migration_manager().local()),
+            std::move(stop_role_manager));
+}
+
+SEASTAR_TEST_CASE(create_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_manager(env);
+        m->start().get();
+
+        const auto anon = auth::authenticated_user();
+
+        //
+        // Create a role, and verify its properties.
+        //
+
+        auth::role_config c;
+        c.is_superuser = true;
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("admin", c, b).get();
+        });
+        BOOST_REQUIRE_EQUAL(m->exists("admin").get(), true);
+        BOOST_REQUIRE_EQUAL(m->can_login("admin").get(), false);
+        BOOST_REQUIRE_EQUAL(m->is_superuser("admin").get(), true);
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("admin", auth::recursive_role_query::yes).get(),
+                std::unordered_set<sstring>{"admin"});
+
+        //
+        // Creating a role that already exists is an error.
+        //
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->create("admin", c, b).get(), auth::role_already_exists);
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(drop_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_manager(env);
+        m->start().get();
+
+        const auto anon = auth::authenticated_user();
+
+        //
+        // Create a role, then drop it, then verify it's gone.
+        //
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("lord", auth::role_config(), b).get();
+        });
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->drop("lord", b).get();
+        });
+        BOOST_REQUIRE_EQUAL(m->exists("lord").get(), false);
+
+        //
+        // Dropping a role revokes it from other roles and revokes other roles from it.
+        //
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("peasant", auth::role_config(), b).get();
+            m->create("lord", auth::role_config(), b).get();
+            m->create("king", auth::role_config(), b).get();
+        });
+
+        auth::role_config tim_config;
+        tim_config.is_superuser = false;
+        tim_config.can_login = true;
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("tim", tim_config, b).get();
+        });
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->grant("lord", "peasant", b).get();
+            m->grant("king", "lord", b).get();
+            m->grant("tim", "lord", b).get();
+        });
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->drop("lord", b).get();
+        });
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("tim", auth::recursive_role_query::yes).get(),
+                std::unordered_set<sstring>{"tim"});
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("king", auth::recursive_role_query::yes).get(),
+                std::unordered_set<sstring>{"king"});
+
+        //
+        // Dropping a role that does not exist is an error.
+        //
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->drop("emperor", b).get(), auth::nonexistant_role);
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(grant_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_manager(env);
+        m->start().get();
+
+        const auto anon = auth::authenticated_user();
+
+        auth::role_config jsnow_config;
+        jsnow_config.is_superuser = false;
+        jsnow_config.can_login = true;
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("jsnow", jsnow_config, b).get();
+
+            m->create("lord", auth::role_config(), b).get();
+            m->create("king", auth::role_config(), b).get();
+        });
+
+        //
+        // All kings have the rights of lords, and 'jsnow' is a king.
+        //
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->grant("king", "lord", b).get();
+            m->grant("jsnow", "king", b).get();
+        });
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("king", auth::recursive_role_query::yes).get(),
+                (std::unordered_set<sstring>{"king", "lord"}));
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("jsnow", auth::recursive_role_query::no).get(),
+               (std::unordered_set<sstring>{"jsnow", "king"}));
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("jsnow", auth::recursive_role_query::yes).get(),
+                (std::unordered_set<sstring>{"jsnow", "king", "lord"}));
+
+        // A non-existing role cannot be granted.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->grant("jsnow", "doctor", b).get(), auth::nonexistant_role);
+        });
+
+        // A role cannot be granted to a non-existing role.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->grant("hpotter", "lord", b).get(), auth::nonexistant_role);
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(revoke_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_manager(env);
+        m->start().get();
+
+        const auto anon = auth::authenticated_user();
+
+        auth::role_config rrat_config;
+        rrat_config.is_superuser = false;
+        rrat_config.can_login = true;
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("rrat", rrat_config, b).get();
+
+            m->create("chef", auth::role_config(), b).get();
+            m->create("sous_chef", auth::role_config(), b).get();
+        });
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->grant("chef", "sous_chef", b).get();
+            m->grant("rrat", "chef", b).get();
+        });
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->revoke("chef", "sous_chef", b).get();
+        });
+
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("rrat", auth::recursive_role_query::yes).get(),
+                (std::unordered_set<sstring>{"chef", "rrat"}));
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->revoke("rrat", "chef", b).get();
+        });
+        BOOST_REQUIRE_EQUAL(
+                m->query_granted("rrat", auth::recursive_role_query::yes).get(),
+                std::unordered_set<sstring>{"rrat"});
+
+        // A non-existing role cannot be revoked.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->revoke("rrat", "taster", b).get(), auth::nonexistant_role);
+        });
+
+        // A role cannot be revoked from a non-existing role.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->revoke("ccasper", "chef", b).get(), auth::nonexistant_role);
+        });
+
+        // Revoking a role not granted is an error.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->revoke("rrat", "sous_chef", b).get(), auth::revoke_ungranted_role);
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(alter_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_manager(env);
+        m->start().get();
+
+        const auto anon = auth::authenticated_user();
+
+        auth::role_config tsmith_config;
+        tsmith_config.is_superuser = true;
+        tsmith_config.can_login = true;
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->create("tsmith", tsmith_config, b).get();
+        });
+
+        auth::role_config_update u;
+        u.can_login = false;
+
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            m->alter("tsmith", u, b).get();
+        });
+
+        BOOST_REQUIRE_EQUAL(m->is_superuser("tsmith").get(), true);
+        BOOST_REQUIRE_EQUAL(m->can_login("tsmith").get(), false);
+
+        // Altering a non-existing role is an error.
+        do_with_mc(env, [&] (::service::group0_batch& b) {
+            BOOST_REQUIRE_THROW(m->alter("hjones", u, b).get(), auth::nonexistant_role);
+        });
+    });
+}
+
+namespace {
+
+const auto default_query_template = fmt::format(
+        "ldap://localhost:{}/{}?cn?sub?(uniqueMember=uid={{USER}},ou=People,dc=example,dc=com)",
+        ldap_port, base_dn);
+
+const auto flaky_server_query_template = fmt::format(
+        "ldap://localhost:{}/{}?cn?sub?(uniqueMember=uid={{USER}},ou=People,dc=example,dc=com)",
+        std::stoi(ldap_port) + 2, base_dn);
+
+auto make_ldap_manager(cql_test_env& env, sstring query_template = default_query_template) {
+    auto stop_role_manager = [] (auth::ldap_role_manager* m) {
+        m->stop().get();
+        std::default_delete<auth::ldap_role_manager>()(m);
+    };
+    return std::unique_ptr<auth::ldap_role_manager, decltype(stop_role_manager)>(
+            new auth::ldap_role_manager(query_template, /*target_attr=*/"cn", manager_dn, manager_password,
+                                        env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local()),
+            std::move(stop_role_manager));
+}
+
+void create_ldap_roles(cql_test_env& env, auth::role_manager& rmgr) {
+  do_with_mc(env, [&] (::service::group0_batch& b) {
+    rmgr.create("jsmith", auth::role_config(), b).get();
+    rmgr.create("role1", auth::role_config(), b).get();
+    rmgr.create("role2", auth::role_config(), b).get();
+  });
+}
+
+} // anonymous namespace
+
+using auth::role_set;
+
+SEASTAR_TEST_CASE(ldap_single_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        const role_set expected{"jsmith", "role1"};
+        BOOST_REQUIRE_EQUAL(expected, m->query_granted("jsmith", auth::recursive_role_query::no).get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_two_roles) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        const role_set expected{"cassandra", "role1","role2"};
+        BOOST_REQUIRE_EQUAL(expected, m->query_granted("cassandra", auth::recursive_role_query::no).get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_no_roles) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        BOOST_REQUIRE_EQUAL(role_set{"dontexist"},
+                            m->query_granted("dontexist", auth::recursive_role_query::no).get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_wrong_role) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        BOOST_REQUIRE_EQUAL(role_set{"jdoe"}, m->query_granted("jdoe", auth::recursive_role_query::no).get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_reconnect) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env, flaky_server_query_template);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        std::vector<future<role_set>> queries;
+        constexpr int noq = 1000;
+        queries.reserve(noq);
+        for (int i = 0; i < noq; ++i) {
+            queries.push_back(m->query_granted("jsmith", auth::recursive_role_query::no)
+                              .handle_exception([] (std::exception_ptr) { return role_set{}; }));
+        }
+        when_all(queries.begin(), queries.end()).get();
+    });
+}
+
+using exception_predicate::message_contains;
+
+SEASTAR_TEST_CASE(ldap_wrong_url) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env, "wrong:/UR?L");
+        BOOST_REQUIRE_EXCEPTION(m->start().get(), std::runtime_error, message_contains("server address"));
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_wrong_server_name) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env, "ldap://server.that.will.never.exist.scylladb.com");
+        m->start().get();
+        BOOST_REQUIRE_EXCEPTION(m->query_granted("jdoe", auth::recursive_role_query::no).get(),
+                                std::runtime_error, message_contains("reconnect fail"));
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_wrong_port) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env, "ldap://localhost:2");
+        m->start().get();
+        BOOST_REQUIRE_EXCEPTION(m->query_granted("jdoe", auth::recursive_role_query::no).get(),
+                                std::runtime_error, message_contains("reconnect fail"));
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_qualified_name) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        const sstring name(make_ldap_manager(env)->qualified_java_name());
+        static const sstring suffix = "LDAPRoleManager";
+        BOOST_REQUIRE_EQUAL(name.find(suffix), name.size() - suffix.size());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_delegates_drop) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        BOOST_REQUIRE(m->exists("role1").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->drop("role1", b).get();
+        });
+        BOOST_REQUIRE(!m->exists("role1").get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_delegates_query_all) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        create_ldap_roles(env, *m);
+        const auto roles = m->query_all().get();
+        BOOST_REQUIRE_EQUAL(1, roles.count("role1"));
+        BOOST_REQUIRE_EQUAL(1, roles.count("role2"));
+        BOOST_REQUIRE_EQUAL(1, roles.count("jsmith"));
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_delegates_config) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->create("super", auth::role_config{/*is_superuser=*/true, /*can_login=*/false}, b).get();
+        });
+        BOOST_REQUIRE(m->is_superuser("super").get());
+        BOOST_REQUIRE(!m->can_login("super").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->create("user", auth::role_config{/*is_superuser=*/false, /*can_login=*/true}, b).get();
+        });
+        BOOST_REQUIRE(!m->is_superuser("user").get());
+        BOOST_REQUIRE(m->can_login("user").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->alter("super", auth::role_config_update{/*is_superuser=*/true, /*can_login=*/true}, b).get();
+        });
+        BOOST_REQUIRE(m->can_login("super").get());
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_delegates_attributes) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->create("r", auth::role_config{}, b).get();
+        });
+        BOOST_REQUIRE(!m->get_attribute("r", "a").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->set_attribute("r", "a", "3", b).get();
+        });
+        // TODO: uncomment when failure is fixed.
+        //BOOST_REQUIRE_EQUAL("3", *m->get_attribute("r", "a").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->remove_attribute("r", "a", b).get();
+        });
+        BOOST_REQUIRE(!m->get_attribute("r", "a").get());
+    });
+}
+
+using exceptions::invalid_request_exception;
+
+SEASTAR_TEST_CASE(ldap_forbids_grant) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            BOOST_REQUIRE_EXCEPTION(m->grant("a", "b", b).get(), invalid_request_exception,
+                                message_contains("with LDAPRoleManager."));
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_forbids_revoke) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            BOOST_REQUIRE_EXCEPTION(m->revoke("a", "b", b).get(), invalid_request_exception,
+                                message_contains("with LDAPRoleManager."));
+        });
+    });
+}
+
+SEASTAR_TEST_CASE(ldap_autocreate_user) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        auto m = make_ldap_manager(env);
+        m->start().get();
+        bool jsmith_exists = m->exists("jsmith").get();
+        // JSmith cannot be auto-created - he's not assigned any existing roles in the system.
+        // He does belong to role1, but role1 was not explicitly created in Scylla yet.
+        BOOST_REQUIRE(!jsmith_exists);
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->create("role1", auth::role_config(), b).get();
+        });
+        // JSmith is now assigned an existing role - role1 - so he can be auto-created.
+        jsmith_exists = m->exists("jsmith").get();
+        BOOST_REQUIRE(jsmith_exists);
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            m->drop("jsmith", b).get();
+            m->drop("role1", b).get();
+        });
+        // JSmith was revoked role1 (simulated by dropping it from Scylla, which is easier),
+        // and his account was deleted. No auto-creation for you, Joe, move on.
+        jsmith_exists = m->exists("jsmith").get();
+        BOOST_REQUIRE(!jsmith_exists);
+        // JDeer does not exist at all and is not assigned any roles, even in LDAP,
+        // which translates to no auto-creation.
+        bool jdeer_exists = m->exists("jdeer").get();
+        BOOST_REQUIRE(!jdeer_exists);
+    });
+}
+
+namespace {
+
+shared_ptr<db::config> make_ldap_config() {
+    auto p = make_shared<db::config>();
+    p->role_manager("com.scylladb.auth.LDAPRoleManager");
+    p->authenticator(sstring(auth::password_authenticator_name));
+    p->ldap_url_template(default_query_template);
+    p->ldap_attr_role("cn");
+    p->ldap_bind_dn(manager_dn);
+    p->ldap_bind_passwd(manager_password);
+    return p;
+}
+
+} // anonymous namespace
+
+SEASTAR_TEST_CASE(ldap_config) {
+    return do_with_cql_env_thread([](cql_test_env& env) {
+        const auto& svc = env.local_auth_service();
+        BOOST_REQUIRE_EQUAL(role_set{"cassandra"}, svc.get_roles("cassandra").get());
+        do_with_mc(env, [&] (service::group0_batch& b) {
+            auth::create_role(svc, "role1", auth::role_config{}, auth::authentication_options{}, b).get();
+        });
+        const role_set expected{"cassandra", "role1"};
+        BOOST_REQUIRE_EQUAL(expected, svc.get_roles("cassandra").get());
+    },
+        make_ldap_config());
+}

--- a/test/ldap/saslauthd_authenticator_test.cc
+++ b/test/ldap/saslauthd_authenticator_test.cc
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2020 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include <cstdlib>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/net/api.hh>
+
+#include <fmt/ranges.h>
+#include "utils/to_string.hh"
+
+#include "auth/saslauthd_authenticator.hh"
+#include "db/config.hh"
+#include "test/ldap/ldap_common.hh"
+#include "test/lib/cql_test_env.hh"
+#include "test/lib/exception_utils.hh"
+#include "test/lib/test_utils.hh"
+#include "seastarx.hh"
+
+const auto sockpath = std::getenv("SASLAUTHD_MUX_PATH");
+
+using exceptions::authentication_exception;
+using exception_predicate::message_contains;
+
+SEASTAR_THREAD_TEST_CASE(simple_password_checking) {
+    BOOST_REQUIRE(!auth::authenticate_with_saslauthd(sockpath, {"jdoe", "xxxxxxxx", "", ""}).get());
+    BOOST_REQUIRE(auth::authenticate_with_saslauthd(sockpath, {"jdoe", "pa55w0rd", "", ""}).get());
+    BOOST_REQUIRE(!auth::authenticate_with_saslauthd(sockpath, {"", "", "", ""}).get());
+    BOOST_REQUIRE(!auth::authenticate_with_saslauthd(sockpath, {"", "", ".", "."}).get());
+    BOOST_REQUIRE_EXCEPTION(
+            auth::authenticate_with_saslauthd("/a/nonexistent/path", {"jdoe", "pa55w0rd", "", ""}).get(),
+            authentication_exception, message_contains("socket connection error"));
+}
+
+namespace {
+
+void fail_test(std::exception_ptr ex) {
+    BOOST_FAIL(format("{}", ex));
+}
+
+/// Creates a network response that saslauthd would send to convey this payload.  If lie_size is provided,
+/// force-write it into the response's first two bytes, even if that results in an invalid response.
+temporary_buffer<char> make_saslauthd_response(std::string_view payload, std::optional<uint16_t> lie_size = std::nullopt) {
+    const uint16_t sz = payload.size();
+    temporary_buffer<char> resp(sz + 2);
+    auto p = resp.get_write();
+    produce_be(p, lie_size.value_or(sz));
+    std::copy_n(payload.begin(), sz, p);
+    return resp;
+}
+
+/// Invokes authenticate_with_saslauthd against a mock saslauthd instance that sends this response through this
+/// domain socket.
+///
+/// authenticate_with_saslauthd is invoked with correct credentials, and its result is returned.
+///
+/// Must be invoked inside a Seastar thread.
+bool authorize_against_this_response(temporary_buffer<char> resp, sstring socket_path) {
+    auto socket = seastar::listen(socket_address(unix_domain_addr(socket_path)));
+    auto [result, closing] = when_all(
+            auth::authenticate_with_saslauthd(socket_path, {"jdoe", "pa55w0rd", "", ""}),
+            socket.accept().then([resp = std::move(resp), socket_path] (accept_result ar) mutable {
+                return do_with(
+                        ar.connection.input(), ar.connection.output(), socket_path,
+                        [resp = std::move(resp)] (input_stream<char>& in, output_stream<char>& out, sstring& socket_path) mutable {
+                            return in.read().then(
+                                    [&out, resp=std::move(resp)] (temporary_buffer<char>) mutable {
+                                        return out.write(std::move(resp)).finally([&out] { return out.close(); });
+                                    }).handle_exception(fail_test).finally([&] {
+                                        return in.close().finally([&] { return remove_file(socket_path); });
+                                    });
+                        });
+            })).get();
+    return result.get();
+}
+
+/// Temp file name unique to this test run and this suffix.
+sstring tmpfile(const sstring& suffix) {
+    return seastar::format("saslauthd_authenticator_test.tmpfile.{}.{}", ldap_port, suffix);
+}
+
+shared_ptr<db::config> make_config() {
+    auto p = make_shared<db::config>();
+    p->authenticator("com.scylladb.auth.SaslauthdAuthenticator");
+    p->saslauthd_socket_path(sockpath);
+    return p;
+}
+
+auth::authenticator& authenticator(cql_test_env& env) {
+    return env.local_auth_service().underlying_authenticator();
+}
+
+/// Creates a cql_test_env with saslauthd_authenticator in a Seastar thread, then invokes func with the env's
+/// authenticator.
+future<> do_with_authenticator_thread(std::function<void(auth::authenticator&, service::group0_batch& b)> func) {
+    return do_with_cql_env_thread([func = std::move(func)] (cql_test_env& env) {
+        return do_with_mc(env, [&] (service::group0_batch& b) {
+            return func(authenticator(env), b);
+        });
+    }, make_config());
+}
+
+} // anonymous namespace
+
+SEASTAR_THREAD_TEST_CASE(empty_response) {
+    BOOST_REQUIRE_EXCEPTION(authorize_against_this_response(temporary_buffer<char>(0), tmpfile("0")),
+                            authentication_exception, message_contains("closed connection"));
+}
+
+SEASTAR_THREAD_TEST_CASE(single_byte_response) {
+    BOOST_REQUIRE_EXCEPTION(
+            authorize_against_this_response(temporary_buffer<char>(1), tmpfile("1")),
+            authentication_exception, message_contains("closed connection"));
+}
+
+SEASTAR_THREAD_TEST_CASE(two_byte_response) {
+    BOOST_REQUIRE(!authorize_against_this_response(make_saslauthd_response(""), tmpfile("2")));
+    BOOST_REQUIRE_EXCEPTION(
+            authorize_against_this_response(make_saslauthd_response("", 1), tmpfile("2")),
+            authentication_exception, message_contains("response length different"));
+    BOOST_REQUIRE_EXCEPTION(
+            authorize_against_this_response(make_saslauthd_response("", 100), tmpfile("2")),
+            authentication_exception, message_contains("response length different"));
+}
+
+SEASTAR_THREAD_TEST_CASE(three_byte_response) {
+    BOOST_REQUIRE(!authorize_against_this_response(make_saslauthd_response("O"), tmpfile("3")));
+    // If advertised size is 0, the payload isn't read even if sent.  No exception is expected:
+    BOOST_REQUIRE(!authorize_against_this_response(make_saslauthd_response("O", 0), tmpfile("3")));
+    BOOST_REQUIRE_EXCEPTION(
+            authorize_against_this_response(make_saslauthd_response("O", 100), tmpfile("3")),
+            authentication_exception, message_contains("response length different"));
+}
+
+SEASTAR_THREAD_TEST_CASE(ok_response_wrong_length) {
+    BOOST_REQUIRE_EXCEPTION(
+            authorize_against_this_response(make_saslauthd_response("OK", 100), tmpfile("3")),
+            authentication_exception, message_contains("response length different"));
+    // Extra payload beyond advertised size is not read.  No exception is expected:
+    BOOST_REQUIRE(!authorize_against_this_response(make_saslauthd_response("OK", 1), tmpfile("3")));
+}
+
+SEASTAR_TEST_CASE(require_authentication) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        BOOST_REQUIRE(authr.require_authentication());
+    });
+}
+
+SEASTAR_TEST_CASE(authenticate) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        const auto user = auth::authenticator::USERNAME_KEY, pwd = auth::authenticator::PASSWORD_KEY;
+        BOOST_REQUIRE_EQUAL(authr.authenticate({{user, "jdoe"}, {pwd, "pa55w0rd"}}).get().name, "jdoe");
+        BOOST_REQUIRE_EXCEPTION(
+                authr.authenticate({{user, "jdoe"}, {pwd, ""}}).get(),
+                authentication_exception, message_contains("Incorrect credentials"));
+        BOOST_REQUIRE_EXCEPTION(
+                authr.authenticate({{user, "jdoe"}}).get(),
+                authentication_exception, message_contains("password' is missing"));
+        BOOST_REQUIRE_EXCEPTION(
+                authr.authenticate({{pwd, "pwd"}}).get(),
+                authentication_exception, message_contains("username' is missing"));
+    });
+}
+
+SEASTAR_TEST_CASE(create) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        BOOST_REQUIRE_EXCEPTION(
+                authr.create("new-role", {auth::password_option{"password"}}, b).get(),
+                authentication_exception, message_contains("Cannot create"));
+    });
+}
+
+SEASTAR_TEST_CASE(alter) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        BOOST_REQUIRE_EXCEPTION(
+                authr.alter("jdoe", {auth::password_option{"password"}}, b).get(),
+                authentication_exception, message_contains("Cannot modify"));
+    });
+}
+
+SEASTAR_TEST_CASE(drop) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        BOOST_REQUIRE_EXCEPTION(authr.drop("jdoe", b).get(), authentication_exception, message_contains("Cannot delete"));
+    });
+}
+
+SEASTAR_TEST_CASE(sasl_challenge) {
+    return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
+        constexpr char creds[] = "\0jdoe\0pa55w0rd";
+        const auto ch = authr.new_sasl_challenge();
+        BOOST_REQUIRE(ch->evaluate_response(bytes(creds, creds + 14)).empty());
+        BOOST_REQUIRE_EQUAL("jdoe", ch->get_authenticated_user().get().name);
+        BOOST_REQUIRE(ch->evaluate_response(bytes(creds, creds + 13)).empty());
+        BOOST_REQUIRE_EXCEPTION(
+                ch->get_authenticated_user().get(),
+                authentication_exception, message_contains("Incorrect credentials"));
+    });
+}

--- a/test/ldap/suite.yaml
+++ b/test/ldap/suite.yaml
@@ -1,0 +1,3 @@
+type: ldap
+# Custom command line arguments for some of the tests
+custom_args: {}

--- a/test/resource/slapd.conf
+++ b/test/resource/slapd.conf
@@ -1,0 +1,16 @@
+# before the first database definition
+database config
+# NOTE: the suffix is hardcoded as cn=config and
+# MUST not have a suffix directive
+# normal rules apply - rootdn can be anything you want
+# but MUST be under cn=config
+rootdn "cn=admin,cn=config"
+
+pidfile ./pidfile.pid
+include /etc/openldap/schema/core.schema
+
+database mdb
+suffix "dc=example,dc=com"
+rootdn "cn=root,dc=example,dc=com"
+rootpw secret
+index objectClass eq

--- a/utils/sequential_producer.hh
+++ b/utils/sequential_producer.hh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <functional>
+#include <seastar/core/shared_future.hh>
+#include <stdexcept>
+
+/// Invokes a factory to produce an object, but sequentially: only one fiber at a time may be executing the
+/// factory.  Any other fiber requesting the object will wait for the existing factory invocation to finish, then
+/// copy the result.
+///
+/// TODO: Move to Seastar.
+template<typename T>
+class sequential_producer {
+  public:
+    using factory_t = std::function<seastar::future<T>()>;
+
+  private:
+    factory_t _factory;
+    seastar::shared_future<T> _churning; ///< Resolves when the previous _factory call completes.
+
+  public:
+    sequential_producer(factory_t&& f) : _factory(std::move(f))
+    {
+        clear();
+    }
+
+    seastar::future<T> operator()() {
+        if (_churning.available()) {
+            _churning = _factory();
+        }
+        return _churning.get_future();
+    }
+
+    void clear() {
+        _churning = seastar::make_exception_future<T>(
+                std::logic_error("initial future used in sequential_producer"));
+    }
+};


### PR DESCRIPTION
This PR extends authentication with 2 mechanisms:
- a new role_manager subclass, which allows managing users via
LDAP server,
- a new authenticator, which delegates plaintext authentication
to a running saslauthd daemon.

The features have been ported from the enterprise repository
with their test.py tests and the documentation as part of
changing license to source available.

Fixes: scylladb/scylla-enterprise#5000
Fixes: scylladb/scylla-enterprise#5001

No backport required.