### PR TITLE
Introduce workload prioritization for service levels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 16 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 19 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,7 @@ target_sources(scylla-main
     tombstone_gc_options.cc
     tombstone_gc.cc
     reader_concurrency_semaphore.cc
+    reader_concurrency_semaphore_group.cc
     row_cache.cc
     schema_mutations.cc
     serializer.cc

--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -42,6 +42,7 @@ set(swagger_files
   api-doc/messaging_service.json
   api-doc/metrics.json
   api-doc/raft.json
+  api-doc/service_levels.json
   api-doc/storage_proxy.json
   api-doc/storage_service.json
   api-doc/stream_manager.json
@@ -82,6 +83,7 @@ target_sources(api
     lsa.cc
     messaging_service.cc
     raft.cc
+    service_levels.cc
     storage_proxy.cc
     storage_service.cc
     stream_manager.cc

--- a/api/api-doc/service_levels.json
+++ b/api/api-doc/service_levels.json
@@ -1,0 +1,56 @@
+{
+    "apiVersion":"0.0.1",
+    "swaggerVersion":"1.2",
+    "basePath":"{{Protocol}}://{{Host}}",
+    "resourcePath":"/service_levels",
+    "produces":[
+        "application/json"
+    ],
+    "apis":[
+        {
+            "path":"/service_levels/switch_tenants",
+            "operations":[
+                {
+                    "method":"POST",
+                    "summary":"Switch tenants on all opened connections if needed",
+                    "type":"void",
+                    "nickname":"do_switch_tenants",
+                    "produces":[
+                        "application/json"
+                    ],
+                    "parameters":[]
+                }
+            ]
+        },
+        {
+            "path":"/service_levels/count_connections",
+            "operations":[
+                {
+                    "method":"GET",
+                    "summary":"Count opened CQL connections per scheduling group per user",
+                    "type":"connections_count_map",
+                    "nickname":"count_connections",
+                    "produces":[
+                        "application/json"
+                    ],
+                    "parameters":[]
+                }
+            ]
+        }
+    ],
+    "models":{},
+    "components": {
+        "schemas": {
+          "connections_count_map": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      }
+
+}

--- a/api/api.cc
+++ b/api/api.cc
@@ -36,6 +36,7 @@
 #include "tasks.hh"
 #include "raft.hh"
 #include "gms/gossip_address_map.hh"
+#include "service_levels.hh"
 
 logging::logger apilog("api");
 
@@ -357,6 +358,12 @@ future<> unset_server_cql_server_test(http_context& ctx) {
 }
 
 #endif
+
+future<> set_server_service_levels(http_context &ctx, cql_transport::controller& ctl, sharded<cql3::query_processor>& qp) {
+    return register_api(ctx, "service_levels", "The service levels API", [&ctl, &qp] (http_context& ctx, routes& r) {
+        set_service_levels(ctx, r, ctl, qp);
+    });
+}
 
 future<> set_server_tasks_compaction_module(http_context& ctx, sharded<service::storage_service>& ss, sharded<db::snapshot_ctl>& snap_ctl) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -73,6 +73,10 @@ namespace tasks {
 class task_manager;
 }
 
+namespace cql3 {
+class query_processor;
+}
+
 namespace api {
 
 struct http_context {
@@ -141,6 +145,7 @@ future<> set_format_selector(http_context& ctx, db::sstables_format_selector& se
 future<> unset_format_selector(http_context& ctx);
 future<> set_server_cql_server_test(http_context& ctx, cql_transport::controller& ctl);
 future<> unset_server_cql_server_test(http_context& ctx);
+future<> set_server_service_levels(http_context& ctx, cql_transport::controller& ctl, sharded<cql3::query_processor>& qp);
 future<> set_server_commitlog(http_context& ctx, sharded<replica::database>&);
 future<> unset_server_commitlog(http_context& ctx);
 

--- a/api/cql_server_test.cc
+++ b/api/cql_server_test.cc
@@ -26,21 +26,24 @@ struct connection_sl_params : public json::json_base {
     json::json_element<sstring> _role_name;
     json::json_element<sstring> _workload_type;
     json::json_element<sstring> _timeout;
+    json::json_element<sstring> _scheduling_group;
 
-    connection_sl_params(const sstring& role_name, const sstring& workload_type, const sstring& timeout) {
+    connection_sl_params(const sstring& role_name, const sstring& workload_type, const sstring& timeout, const sstring& scheduling_group) {
         _role_name = role_name;
         _workload_type = workload_type;
         _timeout = timeout;
+        _scheduling_group = scheduling_group;
         register_params();
     }
 
     connection_sl_params(const connection_sl_params& params)
-        : connection_sl_params(params._role_name(), params._workload_type(), params._timeout()) {}
+        : connection_sl_params(params._role_name(), params._workload_type(), params._timeout(), params._scheduling_group()) {}
 
     void register_params() {
         add(&_role_name, "role_name");
         add(&_workload_type, "workload_type");
         add(&_timeout, "timeout");
+        add(&_scheduling_group, "scheduling_group");
     }    
 };
 
@@ -54,7 +57,8 @@ void set_cql_server_test(http_context& ctx, seastar::httpd::routes& r, cql_trans
             return connection_sl_params(
                     std::move(params.role_name), 
                     sstring(qos::service_level_options::to_string(params.workload_type)), 
-                    to_string(cql_duration(months_counter{0}, days_counter{0}, nanoseconds_counter{nanos})));
+                    to_string(cql_duration(months_counter{0}, days_counter{0}, nanoseconds_counter{nanos})),
+                    std::move(params.scheduling_group_name));
         });
         co_return result;
     });

--- a/api/service_levels.cc
+++ b/api/service_levels.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "service_levels.hh"
+#include "api/api-doc/service_levels.json.hh"
+#include "cql3/query_processor.hh"
+#include "cql3/untyped_result_set.hh"
+#include "db/consistency_level_type.hh"
+#include "seastar/json/json_elements.hh"
+#include "transport/controller.hh"
+#include <unordered_map>
+
+
+namespace api {
+
+namespace sl = httpd::service_levels_json;
+using namespace json;
+using namespace seastar::httpd;
+
+
+void set_service_levels(http_context& ctx, routes& r, cql_transport::controller& ctl, sharded<cql3::query_processor>& qp) {
+    sl::do_switch_tenants.set(r, [&ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        co_await ctl.update_connections_scheduling_group();
+        co_return json_void();
+    });
+
+    sl::count_connections.set(r, [&qp] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        auto connections = co_await qp.local().execute_internal(
+            "SELECT username, scheduling_group FROM system.clients WHERE client_type='cql' ALLOW FILTERING",
+            db::consistency_level::LOCAL_ONE,
+            cql3::query_processor::cache_internal::no
+        );
+
+        using connections_per_user = std::unordered_map<sstring, uint64_t>;
+        using connections_per_scheduling_group = std::unordered_map<sstring, connections_per_user>;
+        connections_per_scheduling_group result;
+
+        for (auto it = connections->begin(); it != connections->end(); it++) {
+            auto user = it->get_as<sstring>("username");
+            auto shg = it->get_as<sstring>("scheduling_group");
+
+            if (result.contains(shg)) {
+                result[shg][user]++;
+            }
+            else {
+                result[shg] = {{user, 1}};
+            }
+        }
+
+        co_return result;
+    });
+
+}
+
+
+
+
+}

--- a/api/service_levels.hh
+++ b/api/service_levels.hh
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2023-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "api.hh"
+
+namespace api {
+
+void set_service_levels(http_context& ctx, httpd::routes& r, cql_transport::controller& ctl, sharded<cql3::query_processor>& qp);
+
+}

--- a/client_data.hh
+++ b/client_data.hh
@@ -45,6 +45,7 @@ struct client_data {
     std::optional<bool> ssl_enabled;
     std::optional<sstring> ssl_protocol;
     std::optional<sstring> username;
+    std::optional<sstring> scheduling_group_name;
 
     sstring stage_str() const { return to_string(connection_stage); }
     sstring client_type_str() const { return to_string(ct); }

--- a/configure.py
+++ b/configure.py
@@ -1215,6 +1215,8 @@ api = ['api/api.cc',
        Json2Code('api/api-doc/raft.json'),
        Json2Code('api/api-doc/cql_server_test.json'),
        'api/cql_server_test.cc',
+       'api/service_levels.cc',
+       Json2Code('api/api-doc/service_levels.json'),
        ]
 
 alternator = [

--- a/configure.py
+++ b/configure.py
@@ -1160,6 +1160,7 @@ scylla_core = (['message/messaging_service.cc',
                 'service/topology_coordinator.cc',
                 'node_ops/node_ops_ctl.cc',
                 'node_ops/task_manager_module.cc',
+                'reader_concurrency_semaphore_group.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] \
                   + scylla_raft_core
                )

--- a/configure.py
+++ b/configure.py
@@ -1871,7 +1871,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=16',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=19',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -2127,6 +2127,7 @@ basic_unreserved_keyword returns [sstring str]
         | K_SERVICE_LEVELS
         | K_ATTACHED
         | K_FOR
+        | K_SHARES
         | K_GROUP
         | K_TIMEOUT
         | K_SERVICE
@@ -2335,6 +2336,7 @@ K_SERVICE: S E R V I C E;
 K_LEVEL: L E V E L;
 K_LEVELS: L E V E L S;
 K_EFFECTIVE: E F F E C T I V E;
+K_SHARES: S H A R E S;
 
 K_SCYLLA_TIMEUUID_LIST_INDEX: S C Y L L A '_' T I M E U U I D '_' L I S T '_' I N D E X;
 K_SCYLLA_COUNTER_SHARD_LIST: S C Y L L A '_' C O U N T E R '_' S H A R D '_' L I S T; 

--- a/cql3/statements/alter_service_level_statement.cc
+++ b/cql3/statements/alter_service_level_statement.cc
@@ -38,6 +38,7 @@ alter_service_level_statement::execute(query_processor& qp,
         service::query_state &state,
         const query_options &, std::optional<service::group0_guard> guard) const {
     service::group0_batch mc{std::move(guard)};
+    validate_shares_option(qp, _slo);
     qos::service_level& sl = state.get_service_level_controller().get_service_level(_service_level);
     qos::service_level_options slo = _slo.replace_defaults(sl.slo);
     auto& slc = state.get_service_level_controller();

--- a/cql3/statements/list_effective_service_level_statement.cc
+++ b/cql3/statements/list_effective_service_level_statement.cc
@@ -53,6 +53,20 @@ static bytes_opt decompose_timeout (const qos::service_level_options::timeout_ty
     }, duration);
 };
 
+static bytes_opt decompose_shares(const qos::service_level_options::shares_type& shares) {
+    return std::visit(overloaded_functor{
+        [&] (const qos::service_level_options::unset_marker&) {
+            return bytes_opt();
+        },
+        [&] (const qos::service_level_options::delete_marker&) {
+            return bytes_opt();
+        },
+        [&] (const int32_t& s) -> bytes_opt {
+            return utf8_type->decompose(fmt::format("{}", s));
+        },
+    }, shares);
+};
+
 future<::shared_ptr<cql_transport::messages::result_message>>
 list_effective_service_level_statement::execute(query_processor& qp, service::query_state& state, const query_options&, std::optional<service::group0_guard>) const {
     static thread_local const std::vector<lw_shared_ptr<column_specification>> metadata({
@@ -83,6 +97,11 @@ list_effective_service_level_statement::execute(query_processor& qp, service::qu
         utf8_type->decompose("timeout"),
         utf8_type->decompose(slo->effective_names->timeout),
         decompose_timeout(slo->timeout)
+    });
+    rs->add_row({
+        utf8_type->decompose("shares"),
+        utf8_type->decompose(slo->effective_names->shares),
+        decompose_shares(slo->shares)
     });
 
     auto rows = ::make_shared<cql_transport::messages::result_message::rows>(result(std::move(std::move(rs))));

--- a/cql3/statements/service_level_statement.cc
+++ b/cql3/statements/service_level_statement.cc
@@ -7,6 +7,8 @@
  */
 
 #include "service_level_statement.hh"
+#include "service/storage_proxy.hh"
+#include "gms/feature_service.hh"
 
 namespace cql3 {
 
@@ -26,6 +28,12 @@ future<> service_level_statement::check_access(query_processor& qp, const servic
 
 bool service_level_statement::needs_guard(query_processor&, service::query_state& state) const {
     return state.get_service_level_controller().is_v2();
+}
+
+void service_level_statement::validate_shares_option(const query_processor& qp, const qos::service_level_options& slo) const {
+    if (!std::holds_alternative<qos::service_level_options::unset_marker>(slo.shares) && !qp.proxy().features().workload_prioritization) {
+        throw exceptions::invalid_request_exception("`shares` option can only be used when the cluster is fully upgraded to enterprise");
+    }
 }
 
 }

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -11,6 +11,7 @@
 #include "cql3/cql_statement.hh"
 #include "cql3/query_processor.hh"
 #include "raw/parsed_statement.hh"
+#include "service/qos/qos_common.hh"
 #include "service/query_state.hh"
 
 namespace cql3 {
@@ -49,6 +50,8 @@ public:
     bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
 
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
+protected:
+    void validate_shares_option(const query_processor& qp, const qos::service_level_options& slo) const;
 };
 
 }

--- a/cql3/statements/sl_prop_defs.cc
+++ b/cql3/statements/sl_prop_defs.cc
@@ -17,7 +17,7 @@ namespace statements {
 
 void sl_prop_defs::validate() {
     static std::set<sstring> timeout_props {
-        "timeout", "workload_type"
+        "timeout", "workload_type",  sstring(KW_SHARES),
     };
     auto get_duration = [&] (const std::optional<sstring>& repr) -> qos::service_level_options::timeout_type {
         if (!repr) {
@@ -42,6 +42,7 @@ void sl_prop_defs::validate() {
 
     property_definitions::validate(timeout_props);
     _slo.timeout = get_duration(get_simple("timeout"));
+
     auto workload_string_opt = get_simple("workload_type");
     if (workload_string_opt) {
         auto workload = qos::service_level_options::parse_workload_type(*workload_string_opt);
@@ -54,6 +55,15 @@ void sl_prop_defs::validate() {
         if (_slo.workload == qos::service_level_options::workload_type::unspecified) {
             _slo.workload = qos::service_level_options::workload_type::delete_marker;
         }
+    }
+
+    if (has_property(KW_SHARES)) {
+        auto shares = get_int(KW_SHARES, SHARES_DEFAULT_VAL);
+        if ((shares < SHARES_MIN_VAL) || (shares > SHARES_MAX_VAL )) {
+            throw exceptions::syntax_exception(format("'SHARES' can only take values of {}-{} (given {})",
+                    SHARES_MIN_VAL, SHARES_MAX_VAL, shares));
+        }
+        _slo.shares = shares;
     }
 }
 

--- a/cql3/statements/sl_prop_defs.hh
+++ b/cql3/statements/sl_prop_defs.hh
@@ -18,8 +18,13 @@ namespace statements {
 class sl_prop_defs : public property_definitions {
     qos::service_level_options _slo;
 public:
-
     void validate();
+
+    static constexpr auto KW_SHARES = "shares";
+    static constexpr int SHARES_DEFAULT_VAL = 1000;
+    static constexpr int SHARES_MIN_VAL = 1;
+    static constexpr int SHARES_MAX_VAL = 1000;
+
     qos::service_level_options get_service_level_options() const;
 };
 

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -13,6 +13,7 @@
 #include "replica/database.hh"
 #include "db/consistency_level_type.hh"
 #include "db/system_keyspace.hh"
+#include "db/config.hh"
 #include "schema/schema_builder.hh"
 #include "timeout_config.hh"
 #include "types/types.hh"
@@ -21,6 +22,8 @@
 #include "cdc/generation.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
+#include "gms/feature_service.hh"
+
 #include "service/migration_manager.hh"
 #include "locator/host_id.hh"
 
@@ -152,8 +155,14 @@ static const sstring CDC_TIMESTAMPS_KEY = "timestamps";
 schema_ptr service_levels() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS);
-        return schema_builder(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS, std::make_optional(id))
+        auto builder = schema_builder(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS, std::make_optional(id))
                 .with_column("service_level", utf8_type, column_kind::partition_key)
+                .with_column("shares", int32_type);
+        if (utils::get_local_injector().is_enabled("service_levels_v1_table_without_shares")) {
+            builder.remove_column("shares");
+        }
+
+        return builder
                 .with_hash_version()
                 .build();
     }();
@@ -207,9 +216,12 @@ system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& 
         , _sp(sp) {
 }
 
-static thread_local std::pair<std::string_view, data_type> new_columns[] {
-    {"timeout", duration_type},
-    {"workload_type", utf8_type}
+static std::vector<std::pair<std::string_view, data_type>> new_service_levels_columns(bool workload_prioritization_enabled) {
+    std::vector<std::pair<std::string_view, data_type>> new_columns {{"timeout", duration_type}, {"workload_type", utf8_type}};
+    if (workload_prioritization_enabled) {
+        new_columns.push_back({"shares", int32_type});
+    }
+    return new_columns;
 };
 
 static schema_ptr get_current_service_levels(data_dictionary::database db) {
@@ -218,11 +230,11 @@ static schema_ptr get_current_service_levels(data_dictionary::database db) {
             : service_levels();
 }
 
-static schema_ptr get_updated_service_levels(data_dictionary::database db) {
+static schema_ptr get_updated_service_levels(data_dictionary::database db, bool workload_prioritization_enabled) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto schema = get_current_service_levels(db);
     schema_builder b(schema);
-    for (const auto& col : new_columns) {
+    for (const auto& col : new_service_levels_columns(workload_prioritization_enabled)) {
         auto& [col_name, col_type] = col;
         bytes options_name = to_bytes(col_name.data());
         if (schema->get_column_definition(options_name)) {
@@ -234,20 +246,20 @@ static schema_ptr get_updated_service_levels(data_dictionary::database db) {
     return b.build();
 }
 
-future<> system_distributed_keyspace::start() {
+future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tables) {
     if (this_shard_id() != 0) {
         _started = true;
         co_return;
     }
 
     auto db = _sp.data_dictionary();
-    auto tables = ensured_tables();
 
     while (true) {
         // Check if there is any work to do before taking the group 0 guard.
+        bool workload_prioritization_enabled = _sp.features().workload_prioritization;
         bool keyspaces_setup = db.has_keyspace(NAME) && db.has_keyspace(NAME_EVERYWHERE);
         bool tables_setup = std::all_of(tables.begin(), tables.end(), [db] (schema_ptr t) { return db.has_schema(t->ks_name(), t->cf_name()); } );
-        bool service_levels_up_to_date = get_current_service_levels(db)->equal_columns(*get_updated_service_levels(db));
+        bool service_levels_up_to_date = get_current_service_levels(db)->equal_columns(*get_updated_service_levels(db, workload_prioritization_enabled));
         if (keyspaces_setup && tables_setup && service_levels_up_to_date) {
             dlogger.info("system_distributed(_everywhere) keyspaces and tables are up-to-date. Not creating");
             _started = true;
@@ -287,12 +299,12 @@ future<> system_distributed_keyspace::start() {
         // Get mutations for creating and updating tables.
         auto num_keyspace_mutations = mutations.size();
         co_await coroutine::parallel_for_each(ensured_tables(),
-                [this, &mutations, db, ts, sd_ksm, sde_ksm] (auto&& table) -> future<> {
+                [this, &mutations, db, ts, sd_ksm, sde_ksm, workload_prioritization_enabled] (auto&& table) -> future<> {
             auto ksm = table->ks_name() == NAME ? sd_ksm : sde_ksm;
 
             // Ensure that the service_levels table contains new columns.
             if (table->cf_name() == SERVICE_LEVELS) {
-                table = get_updated_service_levels(db);
+                table = get_updated_service_levels(db, workload_prioritization_enabled);
             }
 
             if (!db.has_schema(table->ks_name(), table->cf_name())) {
@@ -323,6 +335,24 @@ future<> system_distributed_keyspace::start() {
         _started = true;
         co_return;
     }
+}
+
+ future<> system_distributed_keyspace::start_workload_prioritization() {
+    if (this_shard_id() != 0) {
+        co_return;
+    }
+    if (_qp.db().features().workload_prioritization) {
+       co_await create_tables({get_updated_service_levels(_qp.db(), true)});
+    }
+}
+
+future<> system_distributed_keyspace::start() {
+    if (this_shard_id() != 0) {
+        _started = true;
+        co_return;
+    }
+
+    co_await create_tables(ensured_tables());
 }
 
 future<> system_distributed_keyspace::stop() {
@@ -738,6 +768,13 @@ system_distributed_keyspace::get_cdc_desc_v1_timestamps(context ctx) {
         return make_ready_future<stop_iteration>(stop_iteration::no);
     });
     co_return res;
+}
+
+bool system_distributed_keyspace::workload_prioritization_tables_exists() {
+    auto wp_table = get_updated_service_levels(_qp.db(), true);
+    auto table = _qp.db().try_find_table(NAME, wp_table->cf_name());
+
+    return table && table->schema()->equal_columns(*wp_table);
 }
 
 future<qos::service_levels_info> system_distributed_keyspace::get_service_levels(qos::query_context ctx) const {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -82,6 +82,7 @@ public:
     system_distributed_keyspace(cql3::query_processor&, service::migration_manager&, service::storage_proxy&);
 
     future<> start();
+    future<> start_workload_prioritization();
     future<> stop();
 
     bool started() const { return _started; }
@@ -116,6 +117,10 @@ public:
     future<qos::service_levels_info> get_service_level(sstring service_level_name) const;
     future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const;
     future<> drop_service_level(sstring service_level_name) const;
+    bool workload_prioritization_tables_exists();
+
+private:
+    future<> create_tables(std::vector<schema_ptr> tables);
 };
 
 }

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1157,6 +1157,7 @@ schema_ptr system_keyspace::service_levels_v2() {
                 .with_column("service_level", utf8_type, column_kind::partition_key)
                 .with_column("timeout", duration_type)
                 .with_column("workload_type", utf8_type)
+                .with_column("shares", int32_type)
                 .with_hash_version()
                 .build();
     }();

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -736,6 +736,7 @@ class clients_table : public streaming_virtual_table {
             .with_column("ssl_enabled", boolean_type)
             .with_column("ssl_protocol", utf8_type)
             .with_column("username", utf8_type)
+            .with_column("scheduling_group", utf8_type)
             .with_hash_version()
             .build();
     }
@@ -842,6 +843,9 @@ class clients_table : public streaming_virtual_table {
                     set_cell(cr.cells(), "ssl_protocol", *cd.ssl_protocol);
                 }
                 set_cell(cr.cells(), "username", cd.username ? *cd.username : sstring("anonymous"));
+                if (cd.scheduling_group_name) {
+                    set_cell(cr.cells(), "scheduling_group", *cd.scheduling_group_name);
+                }
                 co_await result.emit_row(std::move(cr));
             }
             co_await result.emit_partition_end();

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -159,6 +159,37 @@ If you don't know the name of the table, you can try a forbidden operation
 and the AccessDeniedException error will contain the name of the table
 that was lacking permissions.
 
+## Workload Isolation
+
+In DynamoDB read/write capacity of each table can be defined either to a fixed
+value (provisioned mode) or to be adaptive (on-demand). On top of that requests
+are also subject to per table and per account quotas.
+
+Due to the nature of Alternator deployment the whole cluster is available to serve
+user requests and underlying hardware can be utilized to its full capacity. When
+there is a need to allow more resources to given workload on the expense of some competing
+one we offer feature called **Workload Prioritization**.
+
+To use this feature define service level with a fixed amount of shares
+(higher value means proportionally more capacity) and attach it to a role
+which then will be used to authorize requests. This can be currently done
+only via CQL API, here is an example on how to do that:
+```cql
+CREATE ROLE alice WITH PASSWORD = 'abcd' AND LOGIN = true;
+CREATE ROLE bob WITH PASSWORD = 'abcd' AND LOGIN = true;
+
+CREATE SERVICE_LEVEL IF NOT EXISTS olap WITH SHARES = 100;
+CREATE SERVICE_LEVEL IF NOT EXISTS oltp WITH SHARES = 1000;
+
+ATTACH SERVICE_LEVEL olap TO alice;
+ATTACH SERVICE_LEVEL oltp TO bob;
+```
+Note that `alternator_enforce_authorization` has to be enabled in Scylla configuration.
+
+See [Authorization](##Authorization) section to learn more about roles and authorization.
+See <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>
+to read about **Workload Prioritization** in detail.
+
 ## Metrics
 
 Scylla has an advanced and extensive monitoring framework for inspecting

--- a/docs/features/index.rst
+++ b/docs/features/index.rst
@@ -14,6 +14,7 @@ This document highlights ScyllaDB's key data modeling features.
    Counters </features/counters/>
    Change Data Capture </features/cdc/index>
    Workload Attributes </features/workload-attributes>
+   Workload Prioritization </features/workload-prioritization>
 
 .. panel-box::
   :title: ScyllaDB Features

--- a/docs/features/workload-attributes.rst
+++ b/docs/features/workload-attributes.rst
@@ -13,7 +13,7 @@ You can define a workload's attribute using the *service level* concept. The ser
 attributes to users and roles. When a user logs into the system, all of the attributes attached to that user and to the roles 
 granted to that user are combined and become a set of workload attributes.
 
-See `Service Level Management <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html#workload-prioritization-workflow>`_ for more information about service levels.
+See :ref:`Service Level Management <workload-priorization-service-level-management>` for more information about service levels.
 
 Prerequisites
 ---------------
@@ -126,7 +126,7 @@ Available Workload Types
    * - ``unspecified``
      - A generic workload without any specific characteristics (default).
    * - ``interactive``
-     - A workload sensitive to latency, expected to have high/unbounded concurrency, with dynamic characteristics. For example, a workload assigned to users clicking on a website and generating events with their clicks.
+     - A workload sensitive to latency, expected to have high/unbounded concurrency, with dynamic characteristics, :doc:`OLTP </features/workload-prioritization>`. For example, a workload assigned to users clicking on a website and generating events with their clicks.
    * -  ``batch``
-     - A workload for processing large amounts of data, not sensitive to latency, expected to have fixed concurrency. For example, a workload assigned to processing billions of historical sales records to generate statistics.
+     - A workload for processing large amounts of data, not sensitive to latency, expected to have fixed concurrency, :doc:`OLAP </features/workload-prioritization>`. For example, a workload assigned to processing billions of historical sales records to generate statistics.
 

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -1,0 +1,448 @@
+========================
+Workload Prioritization
+========================
+
+:label-tip:`ScyllaDB Enterprise`
+
+In a typical database there are numerous workloads running at the same time.
+Each workload type dictates a different acceptable level of latency and throughput.
+For example, consider the following two workloads:
+
+* OLTP ( Online Transaction Processing) - backend database for your application
+
+  - High volume of requests 
+  - Fast processing 
+  - In essence - Latency sensitive
+
+* OLAP (Online Analytical Processing ) - performs data analytics in the background
+
+  - High volume of data
+  - Slow queries 
+  - In essence - Latency agnostic
+
+Using Service Level CQL commands, database administrators (working on Scylla Enterprise) can set different workload prioritization levels (levels of service) for each workload without sacrificing latency or throughput.
+By assigning each service level to the different roles within your organization, DBAs ensure that each role_ receives the level of service the role requires.
+
+.. _`role` : /operating-scylla/security/rbac_usecase/
+
+Prerequisites
+=============
+To create a level of service and assign it to a role, you need:
+
+* An :doc:`authenticated </operating-scylla/security/runtime-authentication>` and :doc:`authorized </operating-scylla/security/enable-authorization>` user 
+* At least one :ref:`role created <create-role-statement>`.
+
+Work by Example
+---------------
+
+To follow the examples in this document, create the roles `spark` and `web`. You can assign permissions to these roles later, if needed.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   CREATE ROLE Spark;
+   CREATE ROLE Web;
+
+Workload Prioritization Workflow
+================================
+
+1. `Create a Service Level`_
+2. `Assign a Service Level to a Role`_
+
+.. _workload-priorization-service-level-management:
+
+Service Level Management
+========================
+
+These commands set, list, and edit the level of service. 
+
+Create a Service Level
+----------------------
+
+When you create a service level, you allocate a percentage of resources to the service level. Remember to use the correct naming convention to name your service level. If you decide to use :doc:`Reserved Keywords </cql/reserved-keywords>`, enclose them in either single or double quotes (for example ``'primary'``).
+
+**Syntax**
+
+.. code-block:: none
+
+   CREATE SERVICE_LEVEL [IF NOT EXISTS] <service_level_name> [WITH SHARES = <shares_number>];
+
+Where:
+
+* ``service_level_name`` - Specifies the name of the service you're creating. This can be any string without spaces. The name should be meaningful, such as class names (silver, gold, diamond, platinum), or categories (OLAP or OLTP), etc.
+* ``shares_number`` - The number of shares of the resources you're granting to the service level name.  You can use any number within the range from 1 to 1000. **Default : 1000**
+
+Example
+.......
+
+There are 3 service levels (OLAP, OLTP, Default) where: (the percentage of resources = (Assigned Shares / Total Shares) x 100). Total Shares in this case is the total of all allocated shares + the Default SLA (1000). The percentage of resources would be:
+
+.. list-table::
+   :widths: 30 30 30 
+   :header-rows: 1
+
+   * - Service Level Name
+     - Shares
+     - Percentage of Resources 
+   * - OLAP
+     - 100
+     - 4%
+   * - OLTP
+     - 1000
+     - 48%
+   * - Default
+     - 1000
+     - 48%
+   * - Total 
+     - 2100
+     - 100%
+
+**Procedure**
+
+1. To create these service levels, run the following CQL commands:
+
+.. code-block:: cql
+
+   CREATE SERVICE_LEVEL IF NOT EXISTS OLAP WITH SHARES = 100;
+   CREATE SERVICE_LEVEL IF NOT EXISTS OLTP WITH SHARES = 1000;
+
+2. Confirm the service level change reflects the new service level allocations:
+
+.. code-block:: cql
+
+   LIST ALL SERVICE_LEVELS;
+
+   service_level | shares
+   --------------+-------
+            olap |    100
+   --------------+-------
+            oltp |   1000
+   (2 rows)
+
+Change Resource Allocation for a Service Level 
+-----------------------------------------------
+
+You can change resource allocation for a given service level. If you don't specify the number the shares, the default setting (1000) is used.
+
+**Syntax**
+
+.. code-block:: none
+
+   ALTER SERVICE_LEVEL <service_level_name> 
+        WITH SHARES = <shares_number>;  
+
+
+Where: 
+
+* ``service_level_name``  - Specifies the name of the service level you created. See `Create a Service Level`_. 
+* ``shares_number`` - The number of shares in the CPU that you're granting to the service level name.   You can use any number within the range from 1 to 1000. **Default : 1000**
+
+
+.. warning::
+
+   Altering the SERVICE LEVEL does not affect active sessions (see `#12923 <https://github.com/scylladb/scylladb/issues/12923>`_).
+   
+   To apply a new timeout to existing clients, execute a :doc:`rolling restart </operating-scylla/procedures/config-change/rolling-restart>` after the ALTER command.
+
+
+Example
+........
+
+Analysts are complaining that they don't have enough resources. To increase the resources, you change the service level attributes for the OLAP service level.
+
+**Procedure**
+
+1. Run the following:
+
+.. code-block:: cql
+
+   ALTER SERVICE_LEVEL OLAP WITH SHARES = 500; 
+
+2. Confirm the service level change reflects the new service level allocation:
+
+.. code-block:: cql
+
+   LIST SERVICE_LEVEL OLAP; 
+
+   service_level | shares
+   --------------+-------
+            olap |    500
+   (1 rows)
+
+3. To change it back to the original setting (or to remain consistent for the examples that follow) change the shares amount back to the original.
+
+.. code-block:: cql
+
+   ALTER SERVICE_LEVEL OLAP WITH SHARES = 100; 
+
+Display Specified Service Level Parameters
+------------------------------------------
+
+Lists the specified service level with its class parameters. If the service level is attached to a role it does not appear in this list. 
+
+**Syntax**
+
+.. code-block:: none
+
+   LIST SERVICE_LEVEL <service_level_name>; 
+
+Where: 
+
+* ``service_level_name`` - Specifies the name of the service level you created. See `Create a Service Level`_.
+
+Example
+.......
+
+In this example you list the service level parameters for OLTP.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   LIST SERVICE_LEVEL OLTP; 
+
+   service_level | shares
+   --------------+-------
+            oltp |   1000
+   (1 rows)
+
+Display All Service Levels and Parameters
+-----------------------------------------
+
+Lists all service levels with their class parameters. This list contains all service levels including those which are assigned to roles. 
+
+**Syntax**
+
+.. code-block:: none
+
+   LIST ALL SERVICE_LEVELS;
+
+Example
+.......
+
+In this example, you list all service levels and their parameters.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   LIST ALL SERVICE_LEVELS; 
+
+   service_level  | shares
+   ---------------+--------
+             olap |     100
+             oltp |    1000
+   (2 rows)
+
+
+Delete a Service Level
+----------------------
+
+Permanently removes the service level. Any role attached to this service level is automatically assigned to the Default SLA if there is no other service level attached to the role.
+
+**Syntax**
+
+.. code-block:: none
+
+   DROP SERVICE_LEVEL IF EXISTS <service_level_name>;
+
+Where:
+
+* ``service_level_name`` - Specifies the name of the service level you created. See `Create a Service Level`_.
+* ``IF EXISTS`` - If the service level does not exist and IF EXISTS is not used an error is returned.
+
+
+Example
+.......
+
+In this example you drop the OLTP service level.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   DROP SERVICE_LEVEL IF EXISTS OLTP;
+
+Manage Roles with Service Levels
+================================
+
+Once you have created roles and service levels you can attach and remove the service levels from the roles and list which roles are attached to which service levels. 
+
+Assign a Service Level to a Role
+--------------------------------
+
+If you have created a role and a service level, you can attach the service level to the role. 
+
+.. note:: A role can only be assigned **one** service level. However, the same service level can be attached to many roles. If a role inherits a service level from another role, the highest level of service from all the roles wins. 
+
+**Syntax**
+
+.. code-block:: none
+
+   ATTACH SERVICE_LEVEL <service_level_name> TO <role_name>;
+
+Where:
+
+* ``service_level_name`` - Specifies the name of the service level you created. See `Create a Service Level`_.
+* ``role_name`` - Specifies the role that you want to use the service level on. This is the role you created with :ref:`create role <create-role-statement>`. 
+
+.. note:: Any role which does not have an SLA attached to it, receives the default SLA.
+
+Example
+.......
+
+Continuing from the example in `Create a Service Level`_, you can attach the service levels that you created to different roles in your organization as follows:
+
+.. list-table::
+   :widths: 50 50 
+   :header-rows: 1
+
+   * - Service Level Name
+     - Role Name
+   * - OLAP
+     - Spark
+   * - OLTP
+     - Web
+
+
+**Procedure**
+
+To assign these service levels to the roles, run the following CQL commands:
+
+.. code-block:: cql
+
+   ATTACH SERVICE_LEVEL OLAP TO Spark;
+   ATTACH SERVICE_LEVEL OLTP TO Web;
+
+List All Attached Service Levels for All Roles
+----------------------------------------------
+
+Lists all directly attached service levels for all roles. This does not include any service level which the role inherits from other roles.
+
+**Syntax**
+
+.. code-block:: none
+
+   LIST ALL ATTACHED SERVICE_LEVELS; 
+
+Example
+.......
+
+In this example you list all service levels attached to any role.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   LIST ALL ATTACHED SERVICE_LEVELS; 
+
+   role   | service_level
+   -------+---------------
+   spark  |          olap     
+   -------+---------------
+     web  |          oltp      
+
+   (2 rows)
+
+List the Roles Assigned to a Specific Service Level
+----------------------------------------------------
+
+Lists all roles directly attached to a service level. This does not include any service level which the role inherits from other roles. 
+
+**Syntax**
+
+.. code-block:: none
+
+   LIST ATTACHED SERVICE_LEVEL OF <role_name>; 
+
+Where:
+
+* ``role_name`` - Specifies the role that you want to use the service level on. This is the role you created with :ref:`create role <create-role-statement>`.
+
+Example
+.......
+
+In this example, you list all of Roles which are assigned to the OLAP Service Level.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   LIST ATTACHED SERVICE_LEVEL OF Spark; 
+
+   role   | service_level
+   -------+---------------
+   spark  |  olap     
+
+   (1 rows) 
+
+Remove a Service Level from a Role
+----------------------------------
+
+Removes a service level from a specified role.  Once the service level is removed from a role, if there are other service levels attached to roles which that role inherits, the service level in the hierarchy with the most amount of shares wins.
+
+**Syntax**
+
+.. code-block:: none
+
+   DETACH SERVICE_LEVEL FROM <role_name>;
+
+Where: 
+
+* ``role_name`` - Specifies the role that you want to use the service level on. This is the role you created with :ref:`create role <create-role-statement>`.
+
+Example
+.......
+
+In this example, you re-assign the Spark to a different level of service by detaching it from one level of service and attaching it to another.
+
+**Procedure**
+
+Run the following:
+
+.. code-block:: cql
+
+   DETACH SERVICE_LEVEL FROM Spark;
+
+At this point, the Spark role receives the Default SLA, until it is assigned another service level. You assign a new service level to this role using `Assign a Service Level to a Role`_.
+
+Using Workload Prioritization with your Application
+===================================================
+
+In order for workload prioritization to take effect, application users need to be assigned to a relevant role. In addition, each role you create needs to be assigned to a specific Service Level. Any user that signs into the application without a role is automatically assigned the `Default` service level.  This is always be the case with users who sign in anonymously.
+
+
+Limits
+======
+Scylla Enterprise is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
+
+
+Additional References
+=====================
+
+`OLAP or OLTP? Why Not Both? <https://www.youtube.com/watch?v=GhmgwN6ZraI>`_ Session by Glauber Costa from Scylla Summit 2018
+
+`Scylla University: Workload Prioritization lesson <https://university.scylladb.com/courses/scylla-operations/lessons/workload-prioritization/>`_ - The lesson covers: 
+
+* The evolving requirements for operational (OLTP) and analytics (OLAP) workloads in the modern datacenter
+* How Scylla provides built-in control over workload priority and makes it easy for administrators to configure workload priorities
+* The impact of minimizing integrations and maintenance tasks, while also shrinking the datacenter footprint and maximizing utilization
+* Test results of how it performs in real-world settings
+
+
+
+
+

--- a/docs/operating-scylla/security/rbac-usecase.rst
+++ b/docs/operating-scylla/security/rbac-usecase.rst
@@ -22,7 +22,7 @@ In the same manner, should someone leave the organization, all you would have to
 Should someone change positions at the company, just assign the new employee to the new role and revoke roles no longer required for the new position.
    
 To build an RBAC environment, you need to create the roles and their associated permissions and then assign or grant the roles to the individual users. Roles inherit the permissions of any other roles that they are granted. The hierarchy of roles can be either simple or extremely complex. This gives great flexibility to database administrators, where they can  create specific permission conditions without incurring a huge administrative burden.
-In addition to standard roles, `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_ users can implement `Workload Prioritization <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>`_, which allows you to attach roles to Service Levels, thus granting resources to roles as the role demands.
+In addition to standard roles, ScyllaDB Enterprise users can implement :doc:`Workload Prioritization </features/workload-prioritization/>`, which allows you to attach roles to Service Levels, thus granting resources to roles as the role demands.
 
 .. _rbac-usecase-grant-roles-and-permissions:
 
@@ -213,4 +213,4 @@ Additional References
 
 * :doc:`Authorization</operating-scylla/security/authorization/>`
 * :doc:`CQLSh the CQL shell</cql/cqlsh>`
-* `Workload Prioritization <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>`_ - to attach a service level to a role. Only available in `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_.
+* :doc:`Workload Prioritization </features/workload-prioritization/>` - to attach a service level to a role

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -156,6 +156,7 @@ public:
     gms::feature test_only_feature { *this, "TEST_ONLY_FEATURE"sv };
     gms::feature address_nodes_by_host_ids { *this, "ADDRESS_NODES_BY_HOST_IDS"sv };
 
+    gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
 public:
 

--- a/main.cc
+++ b/main.cc
@@ -1516,7 +1516,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             netw::messaging_service::scheduling_config scfg;
             scfg.statement_tenants = {
-                    {dbcfg.statement_scheduling_group, "$user"},
                     {default_scheduling_group(), "$system"},
                     {dbcfg.streaming_scheduling_group, "$maintenance", false}
             };
@@ -1535,7 +1534,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }
 
             // Delay listening messaging_service until gossip message handlers are registered
-            messaging.start(mscfg, scfg, creds, std::ref(feature_service), std::ref(gossip_address_map), std::ref(compressor_tracker)).get();
+            messaging.start(mscfg, scfg, creds, std::ref(feature_service), std::ref(gossip_address_map), std::ref(compressor_tracker), std::ref(sl_controller)).get();
             auto stop_ms = defer_verbose_shutdown("messaging service", [&messaging] {
                 messaging.invoke_on_all(&netw::messaging_service::stop).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1347,7 +1347,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             //starting service level controller
             qos::service_level_options default_service_level_configuration;
             default_service_level_configuration.shares = 1000;
-            sl_controller.start(std::ref(auth_service), std::ref(token_metadata), std::ref(stop_signal.as_sharded_abort_source()), default_service_level_configuration).get();
+            sl_controller.start(std::ref(auth_service), std::ref(token_metadata), std::ref(stop_signal.as_sharded_abort_source()), default_service_level_configuration, dbcfg.statement_scheduling_group).get();
             sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
             auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {
                 sl_controller.stop().get();

--- a/main.cc
+++ b/main.cc
@@ -1346,6 +1346,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             //starting service level controller
             qos::service_level_options default_service_level_configuration;
+            default_service_level_configuration.shares = 1000;
             sl_controller.start(std::ref(auth_service), std::ref(token_metadata), std::ref(stop_signal.as_sharded_abort_source()), default_service_level_configuration).get();
             sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
             auto stop_sl_controller = defer_verbose_shutdown("service level controller", [] {

--- a/main.cc
+++ b/main.cc
@@ -2286,6 +2286,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Register controllers after drain_on_shutdown() below, so that even on start
             // failure drain is called and stops controllers
             cql_transport::controller cql_server_ctl(auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, cql_sg_stats_key, maintenance_socket_enabled::no, dbcfg.statement_scheduling_group);
+
+            api::set_server_service_levels(ctx, cql_server_ctl, qp).get();
+
             alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, auth_service, sl_controller, *cfg, dbcfg.statement_scheduling_group);
             redis::controller redis_ctl(proxy, auth_service, mm, *cfg, gossiper, dbcfg.statement_scheduling_group);
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -18,6 +18,8 @@
 #include "message/messaging_service.hh"
 #include <seastar/core/distributed.hh>
 #include "gms/gossiper.hh"
+#include "service/storage_service.hh"
+#include "service/qos/service_level_controller.hh"
 #include "streaming/prepare_message.hh"
 #include "gms/gossip_digest_syn.hh"
 #include "gms/gossip_digest_ack.hh"
@@ -275,10 +277,11 @@ messaging_service::messaging_service(
     uint16_t port,
     gms::feature_service& feature_service,
     gms::gossip_address_map& address_map,
-    utils::walltime_compressor_tracker& wct)
+    utils::walltime_compressor_tracker& wct,
+    qos::service_level_controller& sl_controller)
     : messaging_service(config{std::move(id), ip, ip, port},
                         scheduling_config{{{{}, "$default"}}, {}, {}},
-                        nullptr, feature_service, address_map, wct)
+                        nullptr, feature_service, address_map, wct, sl_controller)
 {}
 
 static
@@ -386,9 +389,10 @@ void messaging_service::do_start_listen() {
     //        the first by wrapping its server_socket, but not the second.
     auto limits = rpc_resource_limits(_cfg.rpc_memory_limit);
     limits.isolate_connection = [this] (sstring isolation_cookie) {
-        rpc::isolation_config cfg;
-        cfg.sched_group = scheduling_group_for_isolation_cookie(isolation_cookie);
-        return cfg;
+
+        return scheduling_group_for_isolation_cookie(isolation_cookie).then([] (scheduling_group sg) {
+            return rpc::isolation_config{.sched_group = sg};
+        });
     };
     if (!_server[0] && _cfg.encrypt != encrypt_what::all && _cfg.port) {
         auto listen = [&] (const gms::inet_address& a, rpc::streaming_domain_type sdomain) {
@@ -467,7 +471,7 @@ void messaging_service::do_start_listen() {
 }
 
 messaging_service::messaging_service(config cfg, scheduling_config scfg, std::shared_ptr<seastar::tls::credentials_builder> credentials, gms::feature_service& feature_service,
-                                     gms::gossip_address_map& address_map, utils::walltime_compressor_tracker& arct)
+                                     gms::gossip_address_map& address_map, utils::walltime_compressor_tracker& arct, qos::service_level_controller& sl_controller)
     : _cfg(std::move(cfg))
     , _rpc(new rpc_protocol_wrapper(serializer { }))
     , _credentials_builder(credentials ? std::make_unique<seastar::tls::credentials_builder>(*credentials) : nullptr)
@@ -476,6 +480,7 @@ messaging_service::messaging_service(config cfg, scheduling_config scfg, std::sh
     , _scheduling_config(scfg)
     , _scheduling_info_for_connection_index(initial_scheduling_info())
     , _feature_service(feature_service)
+    , _sl_controller(sl_controller)
     , _compressor_factory_wrapper(std::make_unique<compressor_factory_wrapper>(arct, _cfg.enable_advanced_rpc_compression))
     , _address_map(address_map)
 {
@@ -743,13 +748,21 @@ msg_addr messaging_service::addr_for_host_id(locator::host_id hid) {
 }
 
 unsigned
-messaging_service::get_rpc_client_idx(messaging_verb verb) const {
+messaging_service::get_rpc_client_idx(messaging_verb verb) {
     auto idx = s_rpc_client_idx_table[static_cast<size_t>(verb)];
 
     if (idx < PER_SHARD_CONNECTION_COUNT) {
         return idx;
     }
 
+    // this is just a workaround for a wrong initialization order in messaging_service's
+    // constructor that causes _connection_index_for_tenant to be queried before it is
+    // initialized. This WA makes the behaviour match OSS in this case and it should be
+    // removed once it is fixed in OSS. If it isn't removed the behaviour will still be
+    // correct but we will lose cycles on an unnecesairy check.
+    if (_connection_index_for_tenant.size() == 0) {
+        return idx;
+    }
     const auto curr_sched_group = current_scheduling_group();
     for (unsigned i = 0; i < _connection_index_for_tenant.size(); ++i) {
         if (_connection_index_for_tenant[i].sched_group == curr_sched_group) {
@@ -757,16 +770,42 @@ messaging_service::get_rpc_client_idx(messaging_verb verb) const {
                 // i == 0: the default tenant maps to the default client indexes belonging to the interval
                 // [PER_SHARD_CONNECTION_COUNT, PER_SHARD_CONNECTION_COUNT + PER_TENANT_CONNECTION_COUNT).
                 idx += i * PER_TENANT_CONNECTION_COUNT;
-                break;
+                return idx;
             } else {
                 // If the tenant is disable, immediately return current index to
                 // use $system tenant.
                 return idx;
             }
         }
+
     }
 
-    return idx;
+    // if we got here - it means that two conditions are met:
+    // 1. We are trying to get a client for a statement/statement_ack verb.
+    // 2. We are running in a scheduling group that is not assigned to one of the
+    // static tenants (e.g $system)
+    // If this scheduling group is of one of the system's static statement tenants we
+    // whould have caught it in the loop above.
+    // The other posibility is that we are running in a scheduling group belongs to
+    // a service level, maybe a deleted one, this is why it is possible that we will
+    // not find the service level name.
+
+    std::optional<sstring> service_level = _sl_controller.get_active_service_level();
+    scheduling_group sg_for_tenant = curr_sched_group;
+    if (!service_level) {
+        service_level = qos::service_level_controller::default_service_level_name;
+        sg_for_tenant = _sl_controller.get_default_scheduling_group();
+    }
+    auto it = _dynamic_tenants_to_client_idx.find(*service_level);
+    // the second part of this condition checks that the service level didn't "suddenly"
+    // changed scheduling group. If it did, it means probably that it was dropped and
+    // added again, if it happens we will update it's connection indexes since it is
+    // basically a new tenant with the same name.
+    if (it == _dynamic_tenants_to_client_idx.end() ||
+            _scheduling_info_for_connection_index[it->second].sched_group != sg_for_tenant) {
+        return add_statement_tenant(*service_level,sg_for_tenant) + (idx - PER_SHARD_CONNECTION_COUNT);
+    }
+    return it->second;
 }
 
 std::vector<messaging_service::scheduling_info_for_connection_index>
@@ -802,25 +841,96 @@ messaging_service::scheduling_group_for_verb(messaging_verb verb) const {
     return _scheduling_info_for_connection_index[idx].sched_group;
 }
 
-scheduling_group
+future<scheduling_group>
 messaging_service::scheduling_group_for_isolation_cookie(const sstring& isolation_cookie) const {
     // Once per connection, so a loop is fine.
     for (auto&& info : _scheduling_info_for_connection_index) {
         if (info.isolation_cookie == isolation_cookie) {
-            return info.sched_group;
+            return make_ready_future<scheduling_group>(info.sched_group);
         }
     }
-    // Check for the case of the client using a connection class we don't
-    // recognize, but we know its a tenant, not a system connection.
-    // Fall-back to the default tenant in this case.
-    for (auto&& connection_prefix : _connection_types_prefix) {
-        if (isolation_cookie.find(connection_prefix.data()) == 0) {
-            return _scheduling_config.statement_tenants.front().sched_group;
+
+    // We first check if this is a statement isolation cookie - if it is, we will search for the
+    // appropriate service level in the service_level_controller since in can be that
+    // _scheduling_info_for_connection_index is not yet updated (drop readd case for example)
+    // in the future we will only fall back here for new service levels that havn't been referenced
+    // before.
+    // It is safe to assume that an unknown connection type can be rejected since a connection
+    // with an unknown purpose on the inbound side is useless.
+    // However, until we get rid of the backward compatibility code below, we can't reject the
+    // connection since there is a slight chance that this connection comes from an old node that
+    // still doesn't use the "connection type prefix" convention.
+    auto tenant_connection = [] (const sstring& isolation_cookie) -> bool {
+        for (auto&& connection_prefix : _connection_types_prefix) {
+            if(isolation_cookie.find(connection_prefix.data()) == 0) {
+                return true;
+            }
         }
+        return false;
+    };
+
+    std::string service_level_name = "";
+    if (tenant_connection(isolation_cookie)) {
+        // Extract the service level name from the connection isolation cookie.
+        service_level_name = isolation_cookie.substr(std::string(isolation_cookie).find_first_of(':') + 1);
+    } else if (_sl_controller.has_service_level(isolation_cookie)) {
+        // Backward Compatibility Code - This entire "else if" block should be removed
+        // in the major version that follows the one that contains this code.
+        // When upgrading from an older enterprise version the isolation cookie is not
+        // prefixed with "statement:" or any other connection type prefix, so an isolation cookie
+        // that comes from an older node will simply contain the service level name.
+        // we do an extra step to be also future proof and make sure it is indeed a service
+        // level's name, since if this is the older version and we upgrade to a new one
+        // we could have more connection classes (eg: streaming,gossip etc...) and we wouldn't
+        // want it to overload the default statement's scheduling group.
+        // it is not bulet proof in the sense that if a new tenant class happens to have the exact
+        // name as one of the service levels it will be diverted to the default statement scheduling
+        // group but it has a small chance of happening.
+        service_level_name = isolation_cookie;
+        mlogger.info("Trying to allow an rpc connection from an older node for service level {}", service_level_name);
+    } else {
+        // Client is using a new connection class that the server doesn't recognize yet.
+        // Assume it's important, after server upgrade we'll recognize it.
+        service_level_name = isolation_cookie;
+        mlogger.warn("Assuming an unknown cookie is from an older node and represent some not yet discovered service level {} - Trying to allow it.", service_level_name);
     }
-    // Client is using a new connection class that the server doesn't recognize yet.
-    // Assume it's important, after server upgrade we'll recognize it.
-    return default_scheduling_group();
+
+    if (_sl_controller.has_service_level(service_level_name)) {
+        return make_ready_future<scheduling_group>(_sl_controller.get_scheduling_group(service_level_name));
+    } else if (service_level_name.starts_with('$')) {
+        // Tenant names starting with '$' are reserved for internal ones. If the tenant is not recognized
+        // to this point, it means we are in the middle of cluster upgrade and we don't know this tenant yet.
+        // Hardwire it to the default service level to keep things simple.
+        // This also includes `$user` tenant which is used in OSS and may appear in mixed OSS/Enterprise cluster.
+        return make_ready_future<scheduling_group>(_sl_controller.get_default_scheduling_group());
+    } else {
+        mlogger.info("Service level {} is still unknown, will try to create it now and allow the RPC connection.", service_level_name);
+        // If the service level don't exist there are two possibilities, it is either created but still not known by this
+        // node. Or it has been deleted and the initiating node hasn't caught up yet, in both cases it is safe to __try__ and
+        // create a new service level (internally), it will naturally catch up eventually and by creating it here we prevent
+        // an rpc connection for a valid service level to permanently get stuck in the default service level scheduling group.
+        // If we can't create the service level (we already have too many service levels), we will reject the connection by returning
+        // an exeptional future.
+        qos::service_level_options slo;
+        // We put here the minimal ammount of shares for this service level to be functional. When the node catches up it will
+        // be either deleted or the number of shares and other configuration options will be updated.
+        slo.shares.emplace<int32_t>(1000);
+        slo.shares_name.emplace(service_level_name);
+        return _sl_controller.add_service_level(service_level_name, slo).then([this, service_level_name] () {
+            if (_sl_controller.has_service_level(service_level_name)) {
+                return make_ready_future<scheduling_group>(_sl_controller.get_scheduling_group(service_level_name));
+            } else {
+                // The code until here is best effort, to provide fast catchup in case the configuration changes very quickly and being used
+                // before this node caught up, or alternatively during startup while the configuration table hasn't been consulted yet.
+                // If for some reason we couldn't add the service level, it is better to wait for the configuration to settle,
+                // this occasion should be rare enough, even if it happen, two paths are possible, either the initiating node will
+                // catch up, figure out the service level has been deleted and will not reattempt this rpc connection, or that this node will
+                // eventually catch up with the correct configuration (mainly some service levels that have been deleted and "made room" for this service level) and
+                // will eventually allow the connection.
+                return make_exception_future<scheduling_group>(std::runtime_error(fmt::format("Rejecting RPC connection for service level: {}, probably only a transitional effect", service_level_name)));
+            }
+        });
+    }
 }
 
 
@@ -1247,6 +1357,37 @@ future<> messaging_service::unregister_repair_get_full_row_hashes_with_rpc_strea
 }
 
 // Wrappers for verbs
+
+unsigned messaging_service::add_statement_tenant(sstring tenant_name, scheduling_group sg) {
+    auto idx = _clients.size();
+    auto scheduling_info_for_connection_index_size = _scheduling_info_for_connection_index.size();
+    auto undo = defer([&] {
+        _clients.resize(idx);
+        _clients_with_host_id.resize(idx);
+        _scheduling_info_for_connection_index.resize(scheduling_info_for_connection_index_size);
+    });
+    _clients.resize(_clients.size() + PER_TENANT_CONNECTION_COUNT);
+    _clients_with_host_id.resize(_clients_with_host_id.size() + PER_TENANT_CONNECTION_COUNT);
+    // this functions as a way to delete an obsolete tenant with the same name but keeping _clients
+    // indexing and _scheduling_info_for_connection_index indexing in sync.
+    sstring first_cookie = sstring(_connection_types_prefix[0]) + tenant_name;
+    for (unsigned i = 0; i < _scheduling_info_for_connection_index.size(); i++) {
+        if (_scheduling_info_for_connection_index[i].isolation_cookie == first_cookie) {
+            // remove all connections associated with this tenant, since we are reinserting it.
+            for (size_t j = 0; j < _connection_types_prefix.size() ; j++) {
+                _scheduling_info_for_connection_index[i + j].isolation_cookie = "";
+            }
+            break;
+        }
+    }
+    for (auto&& connection_prefix : _connection_types_prefix) {
+        sstring isolation_cookie = sstring(connection_prefix) + tenant_name;
+        _scheduling_info_for_connection_index.emplace_back(scheduling_info_for_connection_index{sg, isolation_cookie});
+    }
+    _dynamic_tenants_to_client_idx.insert_or_assign(tenant_name, idx);
+    undo.cancel();
+    return idx;
+}
 
 // Wrapper for TASKS_CHILDREN_REQUEST
 void messaging_service::register_tasks_get_children(std::function<future<tasks::get_children_response> (const rpc::client_info& cinfo, tasks::get_children_request)>&& func) {

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -124,6 +124,8 @@ public:
         uint64_t sstables_read = 0;
         // Permits waiting on something: admission, memory or execution
         uint64_t waiters = 0;
+
+        friend auto operator<=>(const stats&, const stats&) = default;
     };
 
     using permit_list_type = bi::list<

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "reader_concurrency_semaphore_group.hh"
+
+// Calling adjust is serialized since 2 adjustments can't happen simultaneosly,
+// if they did the behaviour would be undefined.
+future<> reader_concurrency_semaphore_group::adjust() {
+    return with_semaphore(_operations_serializer, 1, [this] () {
+        ssize_t distributed_memory = 0;
+        for (auto& [sg, wsem] : _semaphores) {
+            const ssize_t memory_share = std::floor((double(wsem.weight) / double(_total_weight)) * _total_memory);
+            wsem.sem.set_resources({_max_concurrent_reads, memory_share});
+            distributed_memory += memory_share;
+        }
+        // Slap the remainder on one of the semaphores.
+        // This will be a few bytes, doesn't matter where we add it.
+        auto& sem = _semaphores.begin()->second.sem;
+        sem.set_resources(sem.initial_resources() + reader_resources{0, _total_memory - distributed_memory});
+    });
+}
+
+// The call to change_weight is serialized as a consequence of the call to adjust.
+future<> reader_concurrency_semaphore_group::change_weight(weighted_reader_concurrency_semaphore& sem, size_t new_weight) {
+    auto diff = new_weight - sem.weight;
+    if (diff) {
+        sem.weight += diff;
+        _total_weight += diff;
+        return adjust();
+    }
+    return make_ready_future<>();
+}
+
+future<> reader_concurrency_semaphore_group::wait_adjust_complete() {
+    return with_semaphore(_operations_serializer, 1, [] {
+        return make_ready_future<>();
+    });
+}
+
+future<> reader_concurrency_semaphore_group::stop() noexcept {
+    return parallel_for_each(_semaphores, [] (auto&& item) {
+        return item.second.sem.stop();
+    }).then([this] {
+        _semaphores.clear();
+    });
+}
+
+reader_concurrency_semaphore& reader_concurrency_semaphore_group::get(scheduling_group sg) {
+    return _semaphores.at(sg).sem;
+}
+reader_concurrency_semaphore* reader_concurrency_semaphore_group::get_or_null(scheduling_group sg) {
+    auto it = _semaphores.find(sg);
+    if (it == _semaphores.end()) {
+        return nullptr;
+    } else {
+        return &(it->second.sem);
+    }
+}
+reader_concurrency_semaphore& reader_concurrency_semaphore_group::add_or_update(scheduling_group sg, size_t shares) {
+    auto result = _semaphores.try_emplace(
+            sg,
+            0,
+            _max_concurrent_reads,
+            _name_prefix ? format("{}_{}", *_name_prefix, sg.name()) : sg.name(),
+            _max_queue_length,
+            _serialize_limit_multiplier,
+            _kill_limit_multiplier,
+            _cpu_concurrency
+        );
+    auto&& it = result.first;
+    // since we serialize all group changes this change wait will be queues and no further operations
+    // will be executed until this adjustment ends.
+    (void)change_weight(it->second, shares);
+    return it->second.sem;
+}
+
+future<> reader_concurrency_semaphore_group::remove(scheduling_group sg) {
+    auto node_handle =  _semaphores.extract(sg);
+    if (!node_handle.empty()) {
+        weighted_reader_concurrency_semaphore& sem = node_handle.mapped();
+        return sem.sem.stop().then([this, &sem] {
+            return change_weight(sem, 0);
+        }).finally([node_handle = std::move(node_handle)] () {
+            // this holds on to the node handle until we destroy it only after the semaphore
+            // is stopped properly.
+        });
+    }
+    return make_ready_future();
+}
+
+size_t reader_concurrency_semaphore_group::size() {
+    return _semaphores.size();
+}
+
+void reader_concurrency_semaphore_group::foreach_semaphore(std::function<void(scheduling_group, reader_concurrency_semaphore&)> func) {
+    for (auto& [sg, wsem] : _semaphores) {
+        func(sg, wsem.sem);
+    }
+}
+
+future<>
+reader_concurrency_semaphore_group::foreach_semaphore_async(std::function<future<> (scheduling_group, reader_concurrency_semaphore&)> func) {
+    auto units = co_await get_units(_operations_serializer, 1);
+    for (auto& [sg, wsem] : _semaphores) {
+        co_await func(sg, wsem.sem);
+    }
+}

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ */
+
+#pragma once
+
+#include <unordered_map>
+#include <optional>
+#include "reader_concurrency_semaphore.hh"
+#include <boost/range/adaptor/map.hpp>
+#include <boost/range/numeric.hpp>
+
+// The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory,
+// the memory is dynamically divided between them according to a relative slice of shares each semaphore
+// is given.
+// All of the mutating operations on the group are asynchronic and serialized. The semaphores are created
+// and managed by the group.
+
+class reader_concurrency_semaphore_group {
+    size_t _total_memory;
+    size_t _total_weight;
+    size_t _max_concurrent_reads;
+    size_t _max_queue_length;
+    utils::updateable_value<uint32_t> _serialize_limit_multiplier;
+    utils::updateable_value<uint32_t> _kill_limit_multiplier;
+    utils::updateable_value<uint32_t> _cpu_concurrency;
+
+    friend class database_test_wrapper;
+
+    struct weighted_reader_concurrency_semaphore {
+        size_t weight;
+        ssize_t memory_share;
+        reader_concurrency_semaphore sem;
+        weighted_reader_concurrency_semaphore(size_t shares, int count, sstring name, size_t max_queue_length,
+                utils::updateable_value<uint32_t> serialize_limit_multiplier,
+                utils::updateable_value<uint32_t> kill_limit_multiplier,
+                utils::updateable_value<uint32_t> cpu_concurrency)
+                : weight(shares)
+                , memory_share(0)
+                , sem(utils::updateable_value(count), 0, name, max_queue_length, std::move(serialize_limit_multiplier), std::move(kill_limit_multiplier),
+                      std::move(cpu_concurrency), reader_concurrency_semaphore::register_metrics::yes) {}
+    };
+
+    std::unordered_map<scheduling_group, weighted_reader_concurrency_semaphore> _semaphores;
+    seastar::semaphore _operations_serializer;
+    std::optional<sstring> _name_prefix;
+
+    future<> change_weight(weighted_reader_concurrency_semaphore& sem, size_t new_weight);
+
+public:
+    reader_concurrency_semaphore_group(size_t memory, size_t max_concurrent_reads, size_t max_queue_length,
+            utils::updateable_value<uint32_t> serialize_limit_multiplier,
+            utils::updateable_value<uint32_t> kill_limit_multiplier,
+            utils::updateable_value<uint32_t> cpu_concurrency,
+            std::optional<sstring> name_prefix = std::nullopt)
+            : _total_memory(memory)
+            , _total_weight(0)
+            , _max_concurrent_reads(max_concurrent_reads)
+            ,  _max_queue_length(max_queue_length)
+            , _serialize_limit_multiplier(std::move(serialize_limit_multiplier))
+            , _kill_limit_multiplier(std::move(kill_limit_multiplier))
+            , _cpu_concurrency(std::move(cpu_concurrency))
+            , _operations_serializer(1)
+            , _name_prefix(std::move(name_prefix)) { }
+
+    ~reader_concurrency_semaphore_group() {
+        assert(_semaphores.empty());
+    }
+    future<> adjust();
+    future<> wait_adjust_complete();
+
+    future<> stop() noexcept;
+    reader_concurrency_semaphore& get(scheduling_group sg);
+    reader_concurrency_semaphore* get_or_null(scheduling_group sg);
+    reader_concurrency_semaphore& add_or_update(scheduling_group sg, size_t shares);
+    future<> remove(scheduling_group sg);
+    size_t size();
+    void foreach_semaphore(std::function<void(scheduling_group, reader_concurrency_semaphore&)> func);
+
+    future<> foreach_semaphore_async(std::function<future<> (scheduling_group, reader_concurrency_semaphore&)> func);
+
+    auto sum_read_concurrency_sem_var(std::invocable<reader_concurrency_semaphore&> auto member) {
+        using ret_type = std::invoke_result_t<decltype(member), reader_concurrency_semaphore&>;
+        return boost::accumulate(_semaphores | boost::adaptors::map_values | boost::adaptors::transformed([=] (weighted_reader_concurrency_semaphore& wrcs) { return std::invoke(member, wrcs.sem); }), ret_type(0));
+    }
+};

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -137,6 +137,14 @@ service_level_options service_level_options::merge_with(const service_level_opti
     return ret;
 }
 
+sstring service_level_options::to_string(timeout_type tt) {
+    return std::visit(make_visitor(
+        [] (unset_marker) -> sstring { return "null"; },
+        [] (delete_marker) -> sstring { return "<delete_marker>"; },
+        [] (lowres_clock::duration value) { return seastar::format("{}", value); }
+    ), tt);
+}
+
 std::string_view service_level_options::to_string(const workload_type& wt) {
     switch (wt) {
     case workload_type::unspecified: return "unspecified";
@@ -160,6 +168,14 @@ std::optional<service_level_options::workload_type> service_level_options::parse
         return workload_type::batch;
     }
     return std::nullopt;
+}
+
+sstring service_level_options::to_string(shares_type st) {
+    return std::visit(make_visitor(
+        [] (unset_marker) -> sstring { return "default"; },
+        [] (delete_marker) -> sstring { return "<delete_marker>"; },
+        [] (int32_t value) { return seastar::format("{}", value); }
+    ), st);
 }
 
 void service_level_options::init_effective_names(std::string_view service_level_name) {

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <variant>
 #include <seastar/core/lowres_clock.hh>
+#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 class query_processor;
@@ -90,9 +91,9 @@ using service_levels_info = std::map<sstring, service_level_options>;
 ///
 /// A logical argument error for a service_level statement operation.
 ///
-class service_level_argument_exception : public std::invalid_argument {
+class service_level_argument_exception : public exceptions::invalid_request_exception {
 public:
-    using std::invalid_argument::invalid_argument;
+    using exceptions::invalid_request_exception::invalid_request_exception;
 };
 
 ///

--- a/service/qos/qos_common.hh
+++ b/service/qos/qos_common.hh
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <variant>
 #include <seastar/core/lowres_clock.hh>
+#include <optional>
 #include "exceptions/exceptions.hh"
 
 namespace cql3 {
@@ -62,6 +63,11 @@ struct service_level_options {
     timeout_type timeout = unset_marker{};
     workload_type workload = workload_type::unspecified;
 
+    using shares_type = std::variant<unset_marker, delete_marker, int32_t>;
+    shares_type shares = unset_marker{};
+
+    std::optional<sstring> shares_name; // service level name, if shares is set
+
     service_level_options replace_defaults(const service_level_options& other) const;
     // Merges the values of two service level options. The semantics depends
     // on the type of the parameter - e.g. for timeouts, a min value is preferred.
@@ -75,6 +81,7 @@ struct service_level_options {
     struct slo_effective_names {
         sstring timeout;
         sstring workload;
+        sstring shares;
 
         bool operator==(const slo_effective_names& other) const = default;
         bool operator!=(const slo_effective_names& other) const = default;

--- a/service/qos/qos_configuration_change_subscriber.hh
+++ b/service/qos/qos_configuration_change_subscriber.hh
@@ -15,6 +15,7 @@ namespace qos {
 
     struct service_level_info {
         sstring name;
+        seastar::scheduling_group sg;
     };
     class qos_configuration_change_subscriber {
     public:

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -60,11 +60,26 @@ future<> raft_service_level_distributed_data_accessor::set_service_level(sstring
     validate_state(_group0_client);
     
     static sstring insert_query = format("INSERT INTO {}.{} (service_level, timeout, workload_type) VALUES (?, ?, ?);", db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2);
+    static sstring update_shares_query = format("UPDATE {}.{} SET shares = ? WHERE service_level = ?", db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2);
     data_value workload = slo.workload == qos::service_level_options::workload_type::unspecified
             ? data_value::make_null(utf8_type)
             : data_value(qos::service_level_options::to_string(slo.workload));
 
     auto muts = co_await _qp.get_mutations_internal(insert_query, qos_query_state(), mc.write_timestamp(), {service_level_name, timeout_to_data_value(slo.timeout), workload});
+    auto muts_shares = co_await std::visit(overloaded_functor {
+        [&] (const service_level_options::unset_marker& um) -> future<std::vector<mutation>> {
+            co_return std::vector<mutation>();
+        },
+        [&] (const service_level_options::delete_marker& dm) -> future<std::vector<mutation>> {
+            co_return co_await _qp.get_mutations_internal(update_shares_query, qos_query_state(), mc.write_timestamp(), {data_value::make_null(int32_type), data_value(service_level_name)});
+        },
+        [&] (const int32_t& s) -> future<std::vector<mutation>> {
+            co_return co_await _qp.get_mutations_internal(update_shares_query, qos_query_state(), mc.write_timestamp(), {data_value(s), data_value(service_level_name)});
+        }
+    }, slo.shares);
+
+    muts.insert(muts.end(), muts_shares.begin(), muts_shares.end());
+
     mc.add_mutations(std::move(muts), format("service levels internal statement: {}", insert_query));
 }
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -536,6 +536,17 @@ scheduling_group service_level_controller::get_scheduling_group(sstring service_
     }
 }
 
+future<scheduling_group> service_level_controller::get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr) {
+    if (usr && usr->name) {
+        auto sl_opt = co_await find_effective_service_level(*usr->name);
+        auto& sl_name = (sl_opt && sl_opt->shares_name) ? *sl_opt->shares_name : default_service_level_name;
+        co_return get_scheduling_group(sl_name);
+    }
+    else {
+        co_return get_default_scheduling_group();
+    }
+}
+
 std::optional<sstring> service_level_controller::get_active_service_level() {
     unsigned sched_idx = internal::scheduling_group_index(current_scheduling_group());
     if (_sl_lookup[sched_idx].first) {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -917,7 +917,7 @@ future<> service_level_controller::unregister_subscriber(qos_configuration_chang
 static sstring describe_service_level(std::string_view sl_name, const service_level_options& sl_opts) {
     using slo = service_level_options;
 
-    utils::small_vector<sstring, 2> opts{};
+    utils::small_vector<sstring, 3> opts{};
 
     const sstring sl_name_formatted = cql3::util::maybe_quote(sl_name);
 
@@ -941,6 +941,10 @@ static sstring describe_service_level(std::string_view sl_name, const service_le
             // `slo::workload_typ::delete_marker` is only set temporarily. When a service level
             // is actually created, it never has this workload type set anymore.
             on_internal_error(sl_logger, "Unexpected workload type");
+    }
+
+    if (auto* maybe_shares = std::get_if<int32_t>(&sl_opts.shares)) {
+        opts.push_back(seastar::format("SHARES = {}", *maybe_shares));
     }
 
     if (opts.size() == 0) {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -150,6 +150,7 @@ private:
     std::map<sstring, service_level_options> _effective_service_levels_db;
     // Keeps names of effectively dropped service levels. Those service levels exits in the table but are not present in _service_levels_db cache
     std::set<sstring> _effectively_dropped_sls;
+    std::pair<const sstring*, service_level*> _sl_lookup[max_scheduling_groups()];
     service_level _default_service_level;
     service_level_distributed_data_accessor_ptr _sl_data_accessor;
     sharded<auth::service>& _auth_service;
@@ -226,6 +227,19 @@ public:
      * @return the default service level scheduling group (see service_level_controller::initialize).
      */
     scheduling_group get_default_scheduling_group();
+    /**
+     * Get the scheduling group for a specific service level.
+     * @param service_level_name - the service level which it's scheduling group
+     * should be returned.
+     * @return if the service level exists the service level's scheduling group. else
+     * get_scheduling_group("default")
+     */
+    scheduling_group get_scheduling_group(sstring service_level_name);
+    /**
+     * @return the name of the currently active service level if such exists or an empty
+     * optional if no active service level.
+     */
+    std::optional<sstring> get_active_service_level();
 
     /**
      * Start legacy update loop if RAFT_SERVICE_LEVELS_CHANGE feature is not enabled yet 

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -99,6 +99,8 @@ using update_both_cache_levels = bool_class<class update_both_cache_levels_tag>;
  */
 class service_level_controller : public peering_sharded_service<service_level_controller>, public service::endpoint_lifecycle_subscriber {
 public:
+    static inline const int32_t default_shares = 1000;
+
     class service_level_distributed_data_accessor {
     public:
         virtual future<qos::service_levels_info> get_service_levels(qos::query_context ctx = qos::query_context::unspecified) const = 0;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -206,6 +206,23 @@ public:
     void abort_group0_operations();
 
     /**
+     * this is an executor of a function with arguments under a specific
+     * service level.
+     * @param service_level_name
+     * @param func - the function to be executed
+     * @param args - the arguments to  pass to the function.
+     * @return a future that is resolved when the function's operation is resolved
+     * (if it returns a future). or a ready future containing the returned value
+     * from the function/
+     */
+    template <typename Func, typename Ret = std::invoke_result_t<Func>>
+    requires std::invocable<Func>
+    futurize_t<Ret> with_service_level(sstring service_level_name, Func&& func) {
+        service_level& sl = get_service_level(service_level_name);
+        return with_scheduling_group(sl.sg, std::move(func));
+    }
+
+    /**
      * @return the default service level scheduling group (see service_level_controller::initialize).
      */
     scheduling_group get_default_scheduling_group();

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -19,8 +19,7 @@ namespace db {
     class system_distributed_keyspace;
 }
 namespace qos {
-class standard_service_level_distributed_data_accessor : public service_level_controller::service_level_distributed_data_accessor,
-         public ::enable_shared_from_this<standard_service_level_distributed_data_accessor> {
+class standard_service_level_distributed_data_accessor : public service_level_controller::service_level_distributed_data_accessor {
 private:
     db::system_distributed_keyspace& _sys_dist_ks;
 public:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -28,6 +28,7 @@
 #include "dht/token_range_endpoints.hh"
 #include <seastar/core/sleep.hh>
 #include "gms/application_state.hh"
+#include "gms/feature.hh"
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/gate.hh>
 #include "replica/database_fwd.hh"
@@ -174,6 +175,7 @@ private:
     using client_shutdown_hook = noncopyable_function<void()>;
     std::vector<protocol_server*> _protocol_servers;
     std::vector<std::any> _listeners;
+    gms::feature::listener_registration _workload_prioritization_registration;
     gate _async_gate;
 
     condition_variable _tablet_split_monitor_event;

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -115,6 +115,19 @@ run.wait_for_services(pid, [
     lambda: check_alternator(alternator_url),
 ])
 
+# Set up the the proper authentication credentials needed by the Alternator
+# test. Currently this can only be done through CQL, which is why above we
+# needed to make sure CQL is available.
+cluster = run.get_cql_cluster(ip)
+cql = cluster.connect()
+
+# Additional role and service level are created to test the feature properly (alternator doesn't have it's own API to set it up so we need to use CQL).
+cql.execute("INSERT INTO system_auth_v2.roles (role, salted_hash) VALUES ('alternator_custom_sl', 'secret_pass')")
+cql.execute("CREATE SERVICE LEVEL sl_alternator")
+cql.execute("ATTACH SERVICE LEVEL sl_alternator TO alternator_custom_sl")
+
+cluster.shutdown()
+
 # Finally run pytest:
 success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
 

--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -1,5 +1,10 @@
 type: Python
 pool_size: 6
+prepare_cql:
+    - INSERT INTO system.roles (role, can_login, salted_hash) VALUES ('alternator_custom_sl', true, 'secret_pass')
+    - CREATE SERVICE LEVEL sl_alternator
+    - ATTACH SERVICE LEVEL sl_alternator TO alternator_custom_sl
+
 run_first:
     - test_streams
     - test_scan

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -95,13 +95,13 @@ def get_metric(metrics, name, requested_labels=None, the_metrics=None):
 # of the specified metrics. Helps reduce the amount of code duplication
 # below.
 @contextmanager
-def check_increases_metric(metrics, metric_names):
+def check_increases_metric(metrics, metric_names, requested_labels=None):
     the_metrics = get_metrics(metrics)
-    saved_metrics = { x: get_metric(metrics, x, None, the_metrics) for x in metric_names }
+    saved_metrics = { x: get_metric(metrics, x, requested_labels, the_metrics) for x in metric_names }
     yield
     the_metrics = get_metrics(metrics)
     for n in metric_names:
-        assert saved_metrics[n] < get_metric(metrics, n, None, the_metrics), f'metric {n} did not increase'
+        assert saved_metrics[n] < get_metric(metrics, n, requested_labels, the_metrics), f'metric {n} did not increase'
 
 @contextmanager
 def check_increases_metric_exact(metrics, metric_name, increase_value):

--- a/test/alternator/test_service_levels.py
+++ b/test/alternator/test_service_levels.py
@@ -1,0 +1,95 @@
+# Copyright 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import pytest
+from test.alternator.util import random_string, is_aws
+from test.alternator.conftest import new_dynamodb_session
+from test.alternator.test_metrics import metrics, get_metrics, check_increases_metric
+from contextlib import contextmanager
+from cassandra.auth import PlainTextAuthProvider
+from cassandra.cluster import Cluster, ExecutionProfile, EXEC_PROFILE_DEFAULT, ConsistencyLevel
+from cassandra.policies import RoundRobinPolicy
+import time
+import re
+
+# Quote an identifier if it needs to be double-quoted in CQL. Quoting is
+# *not* needed if the identifier matches [a-z][a-z0-9_]*, otherwise it does.
+# double-quotes ('"') in the string are doubled.
+def maybe_quote(identifier):
+    if re.match('^[a-z][a-z0-9_]*$', identifier):
+        return identifier
+    return '"' + identifier.replace('"', '""') + '"'
+
+# Convenience context manager for temporarily GRANTing some permission and
+# then revoking it.
+@contextmanager
+def temporary_grant(cql, permission, resource, role):
+    role = maybe_quote(role)
+    cql.execute(f"GRANT {permission} ON {resource} TO {role}")
+    try:
+        yield
+    finally:
+        cql.execute(f"REVOKE {permission} ON {resource} FROM {role}")
+
+# Convenience function for getting the full CQL table name (ksname.cfname)
+# for the given Alternator table. This uses our insider knowledge that
+# table named "x" is stored in keyspace called "alternator_x", and if we
+# ever change this we'll need to change this function too.
+def cql_table_name(tab):
+    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name)
+
+# This file is all about testing RBAC as configured via CQL, so we need to
+# connect to CQL to set these tests up. The "cql" fixture below enables that.
+# If we're not testing Scylla, or the CQL port is not available on the same
+# IP address as the Alternator IP address, a test using this fixture will
+# be skipped with a message about the CQL API not being available.
+@pytest.fixture(scope="module")
+def cql(dynamodb):
+    if is_aws(dynamodb):
+        pytest.skip('Scylla-only CQL API not supported by AWS')
+    url = dynamodb.meta.client._endpoint.host
+    host, = re.search(r'.*://([^:]*):', url).groups()
+    profile = ExecutionProfile(
+        load_balancing_policy=RoundRobinPolicy(),
+        consistency_level=ConsistencyLevel.LOCAL_QUORUM,
+        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL)
+    cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+        contact_points=[host],
+        port=9042,
+        protocol_version=4,
+        auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
+    )
+    try:
+        ret = cluster.connect()
+        # "BEGIN BATCH APPLY BATCH" is the closest to do-nothing I could find
+        ret.execute("BEGIN BATCH APPLY BATCH")
+    except NoHostAvailable:
+        pytest.skip('Could not connect to Scylla-only CQL API')
+    yield ret
+    cluster.shutdown()
+
+def test_service_level_metrics(test_table, request, dynamodb, cql, metrics):
+    print("Please make sure authorization is enforced in your Scylla installation: alternator_enforce_authorization: true")
+    p = random_string()
+    c = random_string()
+    _ = get_metrics(metrics)
+    # Use additional user created by test/alternator/run to execute write under sl_alternator service level.
+    ses = new_dynamodb_session(request, dynamodb, user='alternator_custom_sl')
+    # service_level_controler acts asynchronously in a loop so we can fail metric check
+    # if it hasn't processed service level update yet. It can take as long as 10 seconds.
+    started = time.time()
+    timeout = 30
+    while True:
+        try:
+            with temporary_grant(cql, 'MODIFY', cql_table_name(test_table), 'alternator_custom_sl'):
+              with check_increases_metric(metrics,
+                                        ['scylla_storage_proxy_coordinator_write_latency_count'],
+                                        {'scheduling_group_name': 'sl:sl_alternator'}):
+                ses.meta.client.put_item(TableName=test_table.name, Item={'p': p, 'c': c})
+            break # no exception, test passed
+        except:
+            if time.time() - started > timeout:
+                raise
+            else:
+                time.sleep(0.5) # retry

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -15,6 +15,7 @@
 
 #include <seastar/core/future.hh>
 #include "seastarx.hh"
+#include "service/qos/qos_common.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "test/lib/test_utils.hh"
 #include <seastar/testing/thread_test_case.hh>
@@ -112,22 +113,202 @@ SEASTAR_THREAD_TEST_CASE(subscriber_simple) {
     sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group).get();
     qos_configuration_change_suscriber_simple ccss;
     sl_controller.local().register_subscriber(&ccss);
-    sl_controller.local().add_service_level("sl1", service_level_options{}).get();
-    sl_controller.local().add_service_level("sl2", service_level_options{}).get();
+    sl_controller.local().add_service_level("sl1", sl_options).get();
+    sl_controller.local().add_service_level("sl2", sl_options).get();
+    sl_controller.local().add_service_level("sl3", service_level_options{}).get();
     service_level_options slo;
+    slo.shares.emplace<int32_t>(500);
     slo.workload = service_level_options::workload_type::interactive;
     sl_controller.local().add_service_level("sl1", slo).get();
     sl_controller.local().remove_service_level("sl2", false).get();
 
     std::vector<service_level_op> expected_result = {
-        add_op{"sl1", service_level_options{}},
-        add_op{"sl2", service_level_options{}},
-        change_op{"sl1", service_level_options{}, slo},
+        add_op{"sl1", sl_options},
+        add_op{"sl2", sl_options},
+        add_op{"sl3", service_level_options{}},
+        change_op{"sl1", sl_options, slo},
         remove_op{"sl2"},
     };
 
     sl_controller.local().unregister_subscriber(&ccss).get();
     BOOST_REQUIRE_EQUAL(ccss.ops, expected_result);
+    as.invoke_on_all([] (auto& as) { as.request_abort(); }).get();
+    sl_controller.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(too_many_service_levels) {
+    class data_accessor : public service_level_controller::service_level_distributed_data_accessor {
+    public:
+        mutable service_levels_info configuration;
+        future<qos::service_levels_info> get_service_levels(qos::query_context) const override {
+            return make_ready_future<service_levels_info>(configuration);
+        }
+        future<qos::service_levels_info> get_service_level(sstring service_level_name) const override {
+            service_levels_info ret;
+            if (configuration.contains(service_level_name)) {
+                ret[service_level_name] = configuration[service_level_name];
+            }
+            return make_ready_future<service_levels_info>(ret);
+        }
+        future<> set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch&) const override {
+            configuration[service_level_name] = slo;
+            return make_ready_future<>();
+        }
+        future<> drop_service_level(sstring service_level_name, service::group0_batch&) const override {
+            if (configuration.contains(service_level_name)) {
+                configuration.erase(service_level_name);
+            }
+            return make_ready_future<>();
+        }    
+        virtual bool is_v2() const override {
+            return true;
+        }
+        virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override {
+            return make_shared<data_accessor>();
+        }
+        virtual future<> commit_mutations(service::group0_batch&& mc, abort_source& as) const override {
+            return make_ready_future<>();
+        }
+
+    };
+    
+    shared_ptr<data_accessor> test_accessor = make_shared<data_accessor>();
+    sharded<service_level_controller> sl_controller;
+    sharded<auth::service> auth_service;
+    service_level_options sl_options;
+    sl_options.shares.emplace<int32_t>(1000);
+    sl_options.workload = service_level_options::workload_type::interactive;
+    scheduling_group default_scheduling_group = create_scheduling_group("sl_default_sg1", 1.0).get();
+    locator::shared_token_metadata tm({}, {locator::topology::config{ .local_dc_rack = locator::endpoint_dc_rack::default_location }});
+    sharded<abort_source> as;
+    as.start().get();
+    auto stop_as = defer([&as] { as.stop().get(); });
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    sl_controller.local().set_distributed_data_accessor(test_accessor);
+    int service_level_id = 0;
+    unsigned service_level_count = 0;
+    std::vector<sstring> expected_service_levels;
+    while (service_level_count <= max_scheduling_groups()) {
+        try {
+            sstring sl_name = format("sl{:020}",service_level_id);
+            sl_controller.local().add_service_level(sl_name, sl_options).get();
+            test_accessor->configuration[sl_name] = sl_options;
+            expected_service_levels.emplace_back(sl_name);
+            // create the service levels with gaps, this will allow to later "push" another service
+            // level between two others if odd id numbers are used.
+            service_level_id+=2;
+            service_level_count++;
+        } catch (std::runtime_error) {
+            break;
+        }
+    }
+    // If we have failed to create at least 2 service levels the test can pass but it will
+    // not really test anything. We know that there are a lot more available scheduling groups
+    // than only two.
+    BOOST_REQUIRE(service_level_count >= 2);
+    // make sure the service levels we believe to be active really have been created.
+    sl_controller.local().update_service_levels_cache().get();
+    for (auto&& sl : expected_service_levels) {
+        BOOST_REQUIRE(sl_controller.local().has_service_level(sl));
+    }
+    // Squize a service level betwin  id 0 and id 2 - only to the configuration since 
+    // we know that a creation of another service level will fail.
+    test_accessor->configuration[format("sl{:020}",1)] = sl_options;
+    
+    // do a config poll round
+    // we expect a failure to apply the configuration since it contains more service levels
+    // than available scheduling groups.
+    try {
+        sl_controller.local().update_service_levels_cache().get();
+    } catch (std::runtime_error) {
+    }
+    expected_service_levels.clear();
+    // Record the state of service levels after a configuration round (with a bad configuration).
+    for (auto&& sl : test_accessor->configuration) {
+        const auto& [sl_name, slo] = sl;
+        if (sl_controller.local().has_service_level(sl_name)) {
+            expected_service_levels.emplace_back(sl_name);
+        }
+    }
+    sl_controller.stop().get();
+    // Simulate a rebooted node which haven't "witnesed" the configuration change and only knows
+    // the current configuration.
+    sharded<service_level_controller> new_sl_controller;
+    default_scheduling_group = create_scheduling_group("sl_default_sg2", 1.0).get();
+    new_sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    new_sl_controller.local().set_distributed_data_accessor(test_accessor);
+    try {
+        new_sl_controller.local().update_service_levels_cache().get();
+    } catch (std::runtime_error) {
+    }
+    // Finally, make sure that this rebooted node have the same service levels as the node
+    // that did "witness" the configuration change.
+    for (auto&& sl : expected_service_levels) {
+        BOOST_REQUIRE(new_sl_controller.local().has_service_level(sl));
+    }
+    new_sl_controller.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(add_remove_bad_sequence) {
+    sharded<service_level_controller> sl_controller;
+    sharded<auth::service> auth_service;
+    service_level_options sl_options;
+    sl_options.shares.emplace<int32_t>(1000);
+    scheduling_group default_scheduling_group = create_scheduling_group("sl_default_sg3", 1.0).get();
+    locator::shared_token_metadata tm({}, {locator::topology::config{ .local_dc_rack = locator::endpoint_dc_rack::default_location }});
+    sharded<abort_source> as;
+    as.start().get();
+    auto stop_as = defer([&as] { as.stop().get(); });
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group, true).get();
+    service_level_options slo;
+    slo.shares.emplace<int32_t>(500);
+    slo.workload = service_level_options::workload_type::interactive;
+    sl_controller.local().add_service_level("a", slo).get();
+    sl_controller.local().add_service_level("b", slo).get();
+    sl_controller.local().remove_service_level("b", false).get();
+    sl_controller.local().remove_service_level("a", false).get();
+    sl_controller.local().add_service_level("a", slo).get();
+    sl_controller.local().remove_service_level("a", false).get();
+    sl_controller.stop().get();
+}
+
+SEASTAR_THREAD_TEST_CASE(verify_unset_shares_in_cache_when_service_level_created_without_shares) {
+    using std::literals::chrono_literals::operator""ms;
+
+    sharded<service_level_controller> sl_controller;
+    sharded<auth::service> auth_service;
+
+    service_level_options sl_options;
+    sl_options.shares.emplace<int32_t>(1000);
+    scheduling_group default_scheduling_group = create_scheduling_group("sl_default_sg", 1.0).get();
+    locator::shared_token_metadata tm({}, {locator::topology::config{ .local_dc_rack = locator::endpoint_dc_rack::default_location }});
+    sharded<abort_source> as;
+
+    as.start().get();
+    auto stop_as = defer([&as] { as.stop().get(); });
+    sl_controller.start(std::ref(auth_service), std::ref(tm), std::ref(as), sl_options, default_scheduling_group).get();
+
+    using timeout_duration = typename seastar::lowres_clock::duration;
+    using workload_type = typename service_level_options::workload_type;
+
+    std::pair<sstring, service_level_options> configs[] = {
+        {"sl_all_default", service_level_options{}},
+        {"sl_timeout_set", service_level_options{.timeout = timeout_duration(10ms)}},
+        {"sl_workload_set", service_level_options{.workload = workload_type::batch}},
+        {"sl_shares_set", service_level_options {.shares = 100}},
+        {"sl_timeout_and_workload_set", service_level_options{.timeout = timeout_duration(100ms), .workload = workload_type::interactive}},
+        {"sl_timeout_and_shares_set", service_level_options{.timeout = timeout_duration(200ms), .shares = 50}},
+        {"sl_workload_and_shares_set", service_level_options{.workload = workload_type::interactive, .shares = 250}},
+        {"sl_everything_set", service_level_options{.timeout = timeout_duration(50ms), .workload = workload_type::interactive, .shares = 700}}
+    };
+
+    for (const auto& [name, opts] : configs) {
+        sl_controller.local().add_service_level(name, opts).get();
+        const auto& sl = sl_controller.local().get_service_level(name);
+        BOOST_REQUIRE_MESSAGE(opts == sl.slo, seastar::format("Comparing options of {}", name));
+        sl_controller.local().remove_service_level(name, false).get();
+    }
+
     as.invoke_on_all([] (auto& as) { as.request_abort(); }).get();
     sl_controller.stop().get();
 }

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -1488,19 +1488,28 @@ class AuthSLContext:
                 self.cql.execute(f"DROP SERVICE LEVEL {make_identifier(sl, quotation_mark='"')}")
 
 class ServiceLevel:
-    def __init__(self, name: str, timeout: int|None = None, wl_type: str|None = None):
+    default_shares_value = 1000
+    
+    def __init__(self, name: str, timeout: int|None = None, wl_type: str|None = None, shares: int|None = None):
         self.name = name
         self.timeout = timeout
         self.wl_type = wl_type
+        self.shares = shares
 
-    def get_create_stmt(self) -> str:
+    # replace_default_shares - Scylla automatically assigns default value of shares it they are not
+    #                          specified. Set this argument to True to include the default shares in create statement
+    #                          to match describe result.
+    def get_create_stmt(self, replace_default_shares = False) -> str:
         # Note: `CREATE SERVICE LEVEL` statements returned by `DESC SCHEMA WITH INTERNALS` always uses
         #       `std::chrono::milliseconds` as its resolution. For that reason, we use milliseconds in
         #       create statements too so that they're easy to compare with Scylla's output.
         timeout = None if not self.timeout else f"TIMEOUT = {self.timeout}ms"
         wl_type = None if not self.wl_type else f"WORKLOAD_TYPE = '{self.wl_type}'"
+        shares = None if not self.shares else f"SHARES = {self.shares}"
+        if shares is None and replace_default_shares:
+            shares = f"SHARES = {self.default_shares_value}"
         
-        opts = [opt for opt in [timeout, wl_type] if opt is not None]
+        opts = [opt for opt in [timeout, wl_type, shares] if opt is not None]
         if opts:
             return f"CREATE SERVICE LEVEL {self.name} WITH {" AND ".join(opts)};"
 
@@ -2358,7 +2367,7 @@ def test_desc_service_levels_format(cql):
         assert result.keyspace_name == None
         assert result.type == "service_level"
         assert result.name == sl.name
-        assert result.create_statement == sl.get_create_stmt()
+        assert result.create_statement == sl.get_create_stmt(replace_default_shares=True)
 
 def test_desc_service_levels_quotation_marks(cql):
     """
@@ -2387,8 +2396,8 @@ def test_desc_service_levels_quotation_marks(cql):
         desc_iter = extract_create_statements(desc_elements)
 
         expected_result = {
-            sl1_double_quote.get_create_stmt(),
-            sl2_double_quote.get_create_stmt()
+            sl1_double_quote.get_create_stmt(replace_default_shares=True),
+            sl2_double_quote.get_create_stmt(replace_default_shares=True)
         }
 
         assert set(desc_iter) == expected_result
@@ -2412,7 +2421,7 @@ def test_desc_service_levels_uppercase(cql):
         assert list(sl_iter) == [sl.name]
 
         desc_iter = extract_create_statements(desc_elements)
-        assert list(desc_iter) == [sl.get_create_stmt()]
+        assert list(desc_iter) == [sl.get_create_stmt(replace_default_shares=True)]
 
 def test_desc_service_levels_unicode(cql):
     """
@@ -2433,7 +2442,7 @@ def test_desc_service_levels_unicode(cql):
         assert list(sl_iter) == [sl.name]
 
         desc_iter = extract_create_statements(desc_elements)
-        assert list(desc_iter) == [sl.get_create_stmt()]
+        assert list(desc_iter) == [sl.get_create_stmt(replace_default_shares=True)]
 
 def test_desc_auth_service_levels(cql):
     """
@@ -2452,8 +2461,12 @@ def test_desc_auth_service_levels(cql):
             # Timeout and workload parameter.
             ServiceLevel("sl7", timeout=25000, wl_type="interactive")
         }
+        service_levels |= { ServiceLevel(sl.name + 's', wl_type=sl.wl_type, timeout=sl.timeout, shares=400) for sl in service_levels }
 
-        sl_create_stmts = set(map(lambda sl: sl.get_create_stmt(), service_levels))
+        sl_create_stmts = set(map(lambda sl: sl.get_create_stmt(replace_default_shares=True), service_levels))
+
+        # Enterprise is limited in the number of service levels it supports
+        sl_create_stmts = set(random.sample(list(sl_create_stmts), k=5))
 
         for stmt in sl_create_stmts:
             cql.execute(stmt)
@@ -2463,6 +2476,33 @@ def test_desc_auth_service_levels(cql):
         desc_iter = extract_create_statements(desc_iter)
 
         assert sl_create_stmts == set(desc_iter)
+
+def test_desc_service_levels_default_shares(cql):
+    """
+    Verify that DESCRIBE handles the default value of shares correctly:
+    (a) when a service level is created without specifying the number of shares,
+        we should get a create statement with the default number of shares,
+    (b) when a service level is created with the default number of shares but specified explicitly,
+        we should get a create statement with that number of shares too.
+    """
+
+    with AuthSLContext(cql):
+        default_share_count = 1000
+
+        stmts = [
+            "CREATE SERVICE LEVEL sl_default;",
+            f"CREATE SERVICE LEVEL sl_set WITH SHARES = {default_share_count};",
+        ]
+
+        for stmt in stmts:
+            cql.execute(stmt)
+
+        desc_iter = cql.execute("DESC SCHEMA WITH INTERNALS")
+        desc_iter = filter_service_levels(desc_iter)
+        desc_iter = extract_create_statements(desc_iter)
+
+        stmts[0] = f"CREATE SERVICE LEVEL sl_default WITH SHARES = {default_share_count};"
+        assert stmts == list(desc_iter)
 
 def test_desc_attach_service_level_format(cql):
     """

--- a/test/cqlpy/test_service_level_api.py
+++ b/test/cqlpy/test_service_level_api.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+# Copyright 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+########################################
+# Tests for the service levels HTTP API.
+########################################
+
+import pytest
+from .rest_api import get_request, post_request
+from .util import new_session, unique_name
+import time
+
+def count_opened_connections(cql, retry_unauthenticated=True):
+    response = get_request(cql, "service_levels/count_connections")
+    return response
+
+def switch_tenants(cql):
+    return post_request(cql, "service_levels/switch_tenants")
+
+def count_opened_connections_from_table(cql):
+    connections = cql.execute("SELECT username, scheduling_group FROM system.clients WHERE client_type='cql' ALLOW FILTERING")
+    result = {}
+    for row in connections:
+        user = row[0]
+        shg = row[1]
+
+        if shg in result:
+            if user in result[shg]:
+                result[shg][user] += 1
+            else:
+                result[shg][user] = 1
+        else:
+            result[shg] = {user: 1}
+    
+    return result
+
+def wait_until_all_connections_authenticated(cql, wait_s = 1, timeout_s = 30):
+    start_time = time.time()
+    while time.time() - start_time < timeout_s:
+        result = cql.execute("SELECT COUNT(*) FROM system.clients WHERE username='anonymous' ALLOW FILTERING")
+        if result.one()[0] == 0:
+            return
+        else:
+            time.sleep(wait_s)
+    
+    raise RuntimeError(f"Awaiting for connections authentication timed out.")
+
+def wait_for_scheduling_group_assignment(cql, user, scheduling_group, wait_s = 2, timeout_s = 60):
+    start_time = time.time()
+    while time.time() - start_time < timeout_s:
+        connections = cql.execute(f"SELECT username, scheduling_group FROM system.clients WHERE client_type='cql' AND username='{user}' ALLOW FILTERING")
+        
+        require_wait = False
+        for row in connections:
+            if row[1] != f"sl:{scheduling_group}":
+                require_wait = True
+                break
+        if require_wait:
+            time.sleep(wait_s)
+            continue
+        return
+
+    raise RuntimeError(f"Awaiting for user '{user}' to switch tenant to scheduling group '{scheduling_group}' timed out.")
+
+# Test if `/service_levels/count_connections` prints counted CQL connections
+# per scheduling group per user.
+def test_count_opened_cql_connections(cql):
+    user = f"test_user_{unique_name()}"
+    sl = f"sl_{unique_name()}"
+
+    cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}'")
+    cql.execute(f"CREATE SERVICE LEVEL {sl} WITH shares = 100")
+    cql.execute(f"ATTACH SERVICE LEVEL {sl} TO {user}")
+
+    # Service level controller updates in 10 seconds interval, so wait
+    # for sl1 to be assgined to test_user
+    time.sleep(10)
+    try:
+        with new_session(cql, user): # new sessions is created only to create user's connection to Scylla
+            wait_until_all_connections_authenticated(cql)
+            wait_for_scheduling_group_assignment(cql, user, sl)
+
+            api_response = count_opened_connections(cql)
+            assert f"sl:{sl}" in api_response
+            assert user in api_response[f"sl:{sl}"]
+
+            table_response = count_opened_connections_from_table(cql)
+            assert api_response == table_response
+    finally:
+        cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
+        cql.execute(f"DROP ROLE {user}")
+        cql.execute(f"DROP SERVICE LEVEL {sl}")
+
+# Test if `/service_levels/switch_tenants` updates scheduling group 
+# of CQL connections without restarting them.
+# 
+# This test creates a `test_user` and 2 service levels `sl1` and `sl2`.
+# Firstly the user is assigned to `sl1` and his connections is created.
+# Then the test changes user's service level to `sl2` and 
+# `/service_levels/switch_tenants` endpoint is called.
+def test_switch_tenants(cql):
+    user = f"test_user_{unique_name()}"
+    sl1 = f"sl1_{unique_name()}"
+    sl2 = f"sl2_{unique_name()}"
+
+
+    cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}'")
+    cql.execute(f"CREATE SERVICE LEVEL {sl1} WITH shares = 100")
+    cql.execute(f"CREATE SERVICE LEVEL {sl2} WITH shares = 200")
+    cql.execute(f"ATTACH SERVICE LEVEL {sl1} TO {user}")
+
+    # Service level controller updates in 10 seconds interval, so wait
+    # for sl1 to be assgined to test_user
+    time.sleep(10)
+    try:
+        with new_session(cql, user): # new sessions is created only to create user's connection to Scylla
+            wait_until_all_connections_authenticated(cql)
+            wait_for_scheduling_group_assignment(cql, user, sl1)
+
+            user_connections_sl1 = cql.execute(f"SELECT scheduling_group FROM system.clients WHERE username='{user}' ALLOW FILTERING")
+            for conn in user_connections_sl1:
+                assert conn[0] == f"sl:{sl1}"
+
+            cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
+            cql.execute(f"ATTACH SERVICE LEVEL {sl2} TO {user}")
+            # Again wait for service level controller to notice the change
+            time.sleep(10)
+
+            switch_tenants(cql)
+            wait_for_scheduling_group_assignment(cql, user, sl2)
+
+            user_connections_sl2 = cql.execute(f"SELECT scheduling_group FROM system.clients WHERE username='{user}' ALLOW FILTERING")
+            print(count_opened_connections(cql))
+            for conn in user_connections_sl2:
+                assert conn[0] == f"sl:{sl2}"
+    finally:
+        cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
+        cql.execute(f"DROP ROLE {user}")
+        cql.execute(f"DROP SERVICE LEVEL {sl1}")
+        cql.execute(f"DROP SERVICE LEVEL {sl2}")
+
+
+            
+
+
+            

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -659,7 +659,7 @@ private:
 
             set_abort_on_internal_error(true);
             const gms::inet_address listen("127.0.0.1");
-            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{.shares = 1000}).get();
+            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{.shares = 1000}, scheduling_groups.statement_scheduling_group).get();
             auto stop_sl_controller = defer([this] { _sl_controller.stop().get(); });
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -659,7 +659,7 @@ private:
 
             set_abort_on_internal_error(true);
             const gms::inet_address listen("127.0.0.1");
-            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{}).get();
+            _sl_controller.start(std::ref(_auth_service), std::ref(_token_metadata), std::ref(abort_sources), qos::service_level_options{.shares = 1000}).get();
             auto stop_sl_controller = defer([this] { _sl_controller.stop().get(); });
             _sl_controller.invoke_on_all(&qos::service_level_controller::start).get();
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -731,7 +731,8 @@ private:
                     }
                     // Don't start listening so tests can be run in parallel if cfg_in.ms_listen is not set to true explicitly.
                     _ms.start(host_id, listen, std::move(port), std::ref(_feature_service),
-                              std::ref(_gossip_address_map), std::ref(_compressor_tracker)).get();
+                              std::ref(_gossip_address_map), std::ref(_compressor_tracker),
+                              std::ref(_sl_controller)).get();
                     stop_ms = defer(stop_type(stop_ms_func));
 
                     if (cfg_in.ms_listen) {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -16,6 +16,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include "service/qos/service_level_controller.hh"
 #include "replica/database.hh"
 #include "transport/messages/result_message_base.hh"
 #include "cql3/query_options_fwd.hh"

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -184,6 +184,8 @@ public:
     virtual sharded<tasks::task_manager>& get_task_manager() = 0;
 
     data_dictionary::database data_dictionary();
+
+    virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;
 };
 
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});

--- a/test/topology_custom/test_alternator.py
+++ b/test/topology_custom/test_alternator.py
@@ -140,7 +140,8 @@ async def test_alternator_ttl_scheduling_group(manager: ManagerClient):
         for ip in ips:
             metrics = await manager.metrics.query(ip)
             ms_streaming += metrics.get('scylla_scheduler_runtime_ms', {'group': 'streaming'})
-            ms_statement += metrics.get('scylla_scheduler_runtime_ms', {'group': 'statement'})
+            # in enterprise, default execution is in sl:default, not statement
+            ms_statement += metrics.get('scylla_scheduler_runtime_ms', {'group': 'sl:default'})
         return (ms_streaming, ms_statement)
 
     ms_streaming_before, ms_statement_before = await get_cpu_metrics()

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -380,7 +380,7 @@ std::vector<cql3::raw_value> trace_keyspace_helper::make_event_mutation_data(gms
         cql3::raw_value::make_value(utf8_type->decompose(record.message)),
         cql3::raw_value::make_value(inet_addr_type->decompose(my_address.addr())),
         cql3::raw_value::make_value(int32_type->decompose(elapsed_to_micros(record.elapsed))),
-        cql3::raw_value::make_value(utf8_type->decompose(_local_tracing.get_thread_name())),
+        cql3::raw_value::make_value(utf8_type->decompose(fmt::format("{}/{}", _local_tracing.get_thread_name(), record.scheduling_group_name))),
         cql3::raw_value::make_value(long_type->decompose(int64_t(session_records.parent_id.get_id()))),
         cql3::raw_value::make_value(long_type->decompose(int64_t(session_records.my_span_id.get_id()))),
         cql3::raw_value::make_value(int32_type->decompose((int32_t)(session_records.ttl.count())))

--- a/tracing/tracing.hh
+++ b/tracing/tracing.hh
@@ -175,6 +175,7 @@ struct event_record {
     std::string message;
     elapsed_clock::duration elapsed;
     i_tracing_backend_helper::wall_clock::time_point event_time_point;
+    sstring scheduling_group_name = current_scheduling_group().name();
 
     event_record(sstring message_, elapsed_clock::duration elapsed_, i_tracing_backend_helper::wall_clock::time_point event_time_point_)
         : message(std::move(message_))

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -351,6 +351,16 @@ future<utils::chunked_vector<client_data>> controller::get_client_data() {
     return _server ? _server->local().get_client_data() : protocol_server::get_client_data();
 }
 
+future<> controller::update_connections_scheduling_group() {
+    if (!_server) {
+        co_return;
+    }
+
+    co_await _server->invoke_on_all([] (auto& server) {
+        return server.update_connections_scheduling_group();
+    });
+}
+
 future<std::vector<connection_service_level_params>> controller::get_connections_service_level_params() {
     if (!_server) {
         co_return std::vector<connection_service_level_params>();

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -79,6 +79,7 @@ public:
     virtual future<> stop_server() override;
     virtual future<> request_stop_server() override;
     virtual future<utils::chunked_vector<client_data>> get_client_data() override;
+    future<> update_connections_scheduling_group();
 
     future<std::vector<connection_service_level_params>> get_connections_service_level_params();
 };

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2115,7 +2115,7 @@ future<std::vector<connection_service_level_params>> cql_server::get_connections
                 ? (user->name ? *(user->name) : "ANONYMOUS") 
                 : "UNAUTHENTICATED";
 
-        sl_params.emplace_back(std::move(role_name), client_state.get_timeout_config(), client_state.get_workload_type());
+        sl_params.emplace_back(std::move(role_name), client_state.get_timeout_config(), client_state.get_workload_type(), cql_conn.get_scheduling_group().name());
     });
     co_return sl_params;
 }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -142,6 +142,7 @@ struct connection_service_level_params {
     sstring role_name;
     timeout_config timeout_config;
     qos::service_level_options::workload_type workload_type;
+    sstring scheduling_group_name;
 };
 
 class cql_server : public seastar::peering_sharded_service<cql_server>, public generic_server::server {
@@ -252,6 +253,7 @@ private:
         const service::client_state& get_client_state() const { return _client_state; }
         void update_scheduling_group();
         service::client_state& get_client_state() { return _client_state; }
+        scheduling_group get_scheduling_group() const { return _current_scheduling_group; }
     private:
         friend class process_request_executor;
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);


### PR DESCRIPTION
This series introduces workload prioritization: an extension of the service levels feature which allows specifying "shares" per service level. The number of shares determines the priority of the user which has this service level attached (if multiple are attached then the one with the lowest shares wins).

Different service levels will be isolated in the following way:

- Each service level gets its own scheduling group with the number of shares (corresponding to the service level's number of shares), which controls the priority of the CPU and I/O used for user operations running on that service level.
- Each service level gets two reader concurrency semaphores, one for user reads and the other for read-before-write done for view updates.
- Each service level gets its own TCP connections for RPC to prevent priority inversion issues.

Because of the mandatory use of scheduling groups, which are a globally limited resource, the number of service levels is now limited to 7 user created service levels + 1 created by default that cannot be removed.

This feature has been previously only available in ScyllaDB Enterprise but has been made available for the source available ScyllaDB. The series was created by comparing the master branch with source-available-workbranch / enterprise branch and taking the workload prioritization related parts from the diff, then molding the resulting diff into a proper series. Some very minor changes were made such as fixing whitespace, removing unused or unnecessary code, adding some boilerplate (in api/) which was missing, but otherwise no major changes have been made.

No backport is required.