### PR TITLE
.github/scripts/auto-backport.py: fix wrong username param

### DIFF
--- a/.github/scripts/auto-backport.py
+++ b/.github/scripts/auto-backport.py
@@ -49,7 +49,7 @@ def create_pull_request(repo, new_branch_name, base_branch_name, pr, backport_pr
         backport_pr.add_to_assignees(pr.user)
         if is_draft:
             backport_pr.add_to_labels("conflicts")
-            pr_comment = f"@{pr.user} - This PR was marked as draft because it has conflicts\n"
+            pr_comment = f"@{pr.user.login} - This PR was marked as draft because it has conflicts\n"
             pr_comment += "Please resolve them and mark this PR as ready for review"
             backport_pr.create_issue_comment(pr_comment)
         logging.info(f"Assigned PR to original author: {pr.user}")


### PR DESCRIPTION
In 2e6755ecca76d6d358dc6a8110d308cfd5f6db37 I have added a comment when PR has conflicts so the assignee can get a notification about it. There was a problem with the user mention param (a missing `.login`)

Fixing it

**fixing auto backport improvement, no need for backporting**