### PR TITLE
.github: add more subdirectories to CLEANER_DIR

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -11,7 +11,7 @@ env:
   CLEANER_OUTPUT_PATH: build/clang-include-cleaner.log
   # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
   # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
-  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation
+  CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation mutation_writer node_ops redis replica
 
 permissions: {}
 


### PR DESCRIPTION
in order to prevent future inclusion of unused headers, let's include

- mutation_writer
- node_ops
- redis
- replica

subdirectories to CLEANER_DIR, so that this workflow can identify the regressions in future.

---

this is an improvement in the CI workflow, hence no need to backport.