### PR TITLE
test.py: rethrow CancelledError caught while running a test

### DIFF
--- a/test.py
+++ b/test.py
@@ -246,6 +246,7 @@ class TestSuite(ABC):
                     break
         except asyncio.CancelledError:
             test.is_cancelled = True
+            raise
         finally:
             self.pending_test_count -= 1
             self.n_failed += int(test.failed)


### PR DESCRIPTION
Commit 870f3b00fcfe05c733d59f67d0d4af834aebc9bb,
"Add option to fail after number of failures" adds tracking on the number of cancelled tests.

For the purpose, it intercepts CancelledError
and sets test's is_cancelled flag.

This introduced a regression reported in gh-21636: Ctrl-C no longer works, since CancelledError is muted.

There was no intent to mute the exception,
re-throw it after accounting the test as cancelled.

Fixes #21636 