### PR TITLE
Simplify loading_cache_test and use manual_clock

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1338,6 +1338,7 @@ scylla_tests_generic_dependencies = [
     'test/lib/test_utils.cc',
     'test/lib/tmpdir.cc',
     'test/lib/sstable_run_based_compaction_strategy_for_tests.cc',
+    'test/lib/eventually.cc',
 ]
 
 scylla_tests_dependencies = scylla_core + alternator + idls + scylla_tests_generic_dependencies + [
@@ -1379,6 +1380,7 @@ scylla_perfs = ['test/perf/perf_alternator.cc',
                 'test/lib/key_utils.cc',
                 'test/lib/random_schema.cc',
                 'test/lib/data_model.cc',
+                'test/lib/eventually.cc',
                 'seastar/tests/perf/linux_perf_event.cc']
 
 deps = {
@@ -1573,11 +1575,11 @@ deps['test/boost/duration_test'] += ['test/lib/exception_utils.cc']
 deps['test/boost/schema_loader_test'] += ['tools/schema_loader.cc', 'tools/read_mutation.cc']
 deps['test/boost/rust_test'] += ['rust/inc/src/lib.rs']
 
-deps['test/raft/replication_test'] = ['test/raft/replication_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
-deps['test/raft/raft_server_test'] = ['test/raft/raft_server_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
+deps['test/raft/replication_test'] = ['test/raft/replication_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc', 'test/lib/eventually.cc'] + scylla_raft_dependencies
+deps['test/raft/raft_server_test'] = ['test/raft/raft_server_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc', 'test/lib/eventually.cc'] + scylla_raft_dependencies
 deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/failure_detector_test'] = ['test/raft/failure_detector_test.cc', 'direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
-deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
+deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc', 'test/lib/eventually.cc'] + scylla_raft_dependencies
 deps['test/raft/fsm_test'] =  ['test/raft/fsm_test.cc', 'test/raft/helpers.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 deps['test/raft/etcd_test'] =  ['test/raft/etcd_test.cc', 'test/raft/helpers.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 deps['test/raft/raft_sys_table_storage_test'] = ['test/raft/raft_sys_table_storage_test.cc'] + \

--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -269,7 +269,7 @@ SEASTAR_TEST_CASE(test_loading_cache_update_config) {
             loading_cache.get_ptr(i, loader).discard_result().get();
         }
 
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.size(), 2);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return loading_cache.size(); }, 2);
     });
 }
 
@@ -345,14 +345,14 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_expiry_eviction) {
         // Check unprivileged section eviction
         BOOST_REQUIRE(loading_cache.size() == 1);
         sleep(20ms).get();
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.size(), 0);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return loading_cache.size(); }, 0);
 
         // Check privileged section eviction
         loading_cache.get_ptr(0, loader).discard_result().get();
         BOOST_REQUIRE(loading_cache.find(0) != nullptr);
 
         sleep(20ms).get();
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.size(), 0);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return loading_cache.size(); }, 0);
     });
 }
 
@@ -385,7 +385,7 @@ SEASTAR_TEST_CASE(test_loading_cache_loading_expiry_reset_on_sync_op) {
         }
 
         sleep(30ms).get();
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.size(), 0);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return loading_cache.size(); }, 0);
     });
 }
 
@@ -505,8 +505,8 @@ SEASTAR_TEST_CASE(test_loading_cache_eviction_unprivileged) {
         }
 
         // Make sure that the value we touched twice is eventually evicted
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.find(-1), nullptr);
-        REQUIRE_EVENTUALLY_EQUAL(loading_cache.size(), 0);
+        REQUIRE_EVENTUALLY_EQUAL<utils::loading_cache<int, sstring, 1>::value_ptr>([&] { return loading_cache.find(-1); }, nullptr);
+        REQUIRE_EVENTUALLY_EQUAL<size_t>([&] { return loading_cache.size(); }, 0);
     });
 }
 

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -469,7 +469,7 @@ SEASTAR_TEST_CASE(reader_restriction_file_tracking) {
         }
 
         // All units should have been deposited back.
-        REQUIRE_EVENTUALLY_EQUAL(4 * 1024, semaphore.available_resources().memory);
+        REQUIRE_EVENTUALLY_EQUAL<ssize_t>([&] { return semaphore.available_resources().memory; }, 4 * 1024);
     });
 }
 
@@ -513,7 +513,7 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_timeout) {
        }
 
         // All units should have been deposited back.
-        REQUIRE_EVENTUALLY_EQUAL(replica::new_reader_base_cost, semaphore.available_resources().memory);
+        REQUIRE_EVENTUALLY_EQUAL<ssize_t>([&] { return semaphore.available_resources().memory; }, replica::new_reader_base_cost);
     });
 }
 
@@ -545,7 +545,7 @@ SEASTAR_TEST_CASE(reader_concurrency_semaphore_max_queue_length) {
             }
         }
 
-        REQUIRE_EVENTUALLY_EQUAL(replica::new_reader_base_cost, semaphore.available_resources().memory);
+        REQUIRE_EVENTUALLY_EQUAL<ssize_t>([&] { return semaphore.available_resources().memory; }, replica::new_reader_base_cost);
     });
 }
 
@@ -1167,7 +1167,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_evict_inactive_reads_
 
     // Marking p2 as awaits should eventually allow p3 to be admitted by evicting p1
     rd2.mark_as_awaits();
-    REQUIRE_EVENTUALLY_EQUAL(semaphore.get_stats().waiters, 0);
+    REQUIRE_EVENTUALLY_EQUAL<uint64_t>([&] { return semaphore.get_stats().waiters; }, 0);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().need_cpu_permits, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().awaits_permits, 1);
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
@@ -1212,7 +1212,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_set_resources) {
     BOOST_REQUIRE_EQUAL(semaphore.get_stats().waiters, 1);
 
     semaphore.set_resources({4, 4 * 1024});
-    REQUIRE_EVENTUALLY_EQUAL(semaphore.get_stats().waiters, 0);
+    REQUIRE_EVENTUALLY_EQUAL<uint64_t>([&] { return semaphore.get_stats().waiters; }, 0);
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(1, 1024));
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(4, 4 * 1024));
     permit3_fut.get();
@@ -2101,7 +2101,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
         ncpu_guard.reset();
-        REQUIRE_EVENTUALLY_EQUAL(bool(handle), false);
+        REQUIRE_EVENTUALLY_EQUAL<bool>([&] { return bool(handle); }, false);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
 
@@ -2130,7 +2130,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_necessary_evicting) {
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 1);
 
         ncpu_guard.reset();
-        REQUIRE_EVENTUALLY_EQUAL(bool(handle), false);
+        REQUIRE_EVENTUALLY_EQUAL<bool>([&] { return bool(handle); }, false);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().inactive_reads, 0);
         BOOST_REQUIRE_EQUAL(semaphore.get_stats().permit_based_evictions, ++evicted_reads);
 

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -464,7 +464,7 @@ SEASTAR_TEST_CASE(test_view_update_generator) {
             }
             const auto qsz = db::view::view_update_generator::registration_queue_size;
             when_all(register_futures.begin(), register_futures.end()).get();
-            REQUIRE_EVENTUALLY_EQUAL(view_update_generator.available_register_units(), qsz);
+            REQUIRE_EVENTUALLY_EQUAL<ssize_t>([&] { return view_update_generator.available_register_units(); }, qsz);
         };
         register_and_check_semaphore(ssts.begin(), ssts.begin() + 10);
         register_and_check_semaphore(ssts.begin() + 10, ssts.end());

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -17,7 +17,8 @@ target_sources(test-lib
     result_set_assertions.cc
     sstable_run_based_compaction_strategy_for_tests.cc
     sstable_utils.cc
-    data_model.cc)
+    data_model.cc
+    eventually.cc)
 target_include_directories(test-lib
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/test/lib/eventually.cc
+++ b/test/lib/eventually.cc
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2019-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "test/lib/eventually.hh"
+
+sleep_fn seastar_sleep_fn = [] (std::chrono::milliseconds ms) -> future<> {
+    return seastar::sleep(ms);
+};

--- a/test/lib/eventually.cc
+++ b/test/lib/eventually.cc
@@ -11,3 +11,11 @@
 sleep_fn seastar_sleep_fn = [] (std::chrono::milliseconds ms) -> future<> {
     return seastar::sleep(ms);
 };
+
+sleep_fn manual_clock_sleep_fn = [] (std::chrono::milliseconds ms) -> future<> {
+    auto end = manual_clock::now() + ms;
+    while (manual_clock::now() < end) {
+        manual_clock::advance(std::chrono::milliseconds(1));
+        co_await yield();
+    }
+};

--- a/test/lib/eventually.hh
+++ b/test/lib/eventually.hh
@@ -10,14 +10,19 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/later.hh>
 
 #include "seastarx.hh"
 
 using sleep_fn = std::function<future<>(std::chrono::milliseconds)>;
 
 extern sleep_fn seastar_sleep_fn;
+
+extern sleep_fn manual_clock_sleep_fn;
 
 inline
 void eventually(noncopyable_function<void ()> f, size_t max_attempts = 17, sleep_fn sleep = seastar_sleep_fn) {
@@ -46,7 +51,7 @@ bool eventually_true(noncopyable_function<bool ()> f, sleep_fn sleep = seastar_s
         }
 
         if (++attempts < max_attempts) {
-            seastar::sleep(std::chrono::milliseconds(1 << attempts)).get();
+            sleep(std::chrono::milliseconds(1 << attempts)).get();
         } else {
             return false;
         }

--- a/test/lib/eventually.hh
+++ b/test/lib/eventually.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <boost/test/unit_test.hpp>
+
 #include <seastar/core/sleep.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -49,5 +51,16 @@ bool eventually_true(noncopyable_function<bool ()> f) {
     return false;
 }
 
-#define REQUIRE_EVENTUALLY_EQUAL(a, b) BOOST_REQUIRE(eventually_true([&] { return a == b; }))
-#define CHECK_EVENTUALLY_EQUAL(a, b) BOOST_CHECK(eventually_true([&] { return a == b; }))
+// Must be called in a seastar thread
+template <typename T>
+void REQUIRE_EVENTUALLY_EQUAL(std::function<T()> a, T b) {
+    eventually_true([&] { return a() == b; });
+    BOOST_REQUIRE_EQUAL(a(), b);
+}
+
+// Must be called in a seastar thread
+template <typename T>
+void CHECK_EVENTUALLY_EQUAL(std::function<T()> a, T b) {
+    eventually_true([&] { return a() == b; });
+    BOOST_CHECK_EQUAL(a(), b);
+}

--- a/test/lib/eventually.hh
+++ b/test/lib/eventually.hh
@@ -15,8 +15,12 @@
 
 #include "seastarx.hh"
 
+using sleep_fn = std::function<future<>(std::chrono::milliseconds)>;
+
+extern sleep_fn seastar_sleep_fn;
+
 inline
-void eventually(noncopyable_function<void ()> f, size_t max_attempts = 17) {
+void eventually(noncopyable_function<void ()> f, size_t max_attempts = 17, sleep_fn sleep = seastar_sleep_fn) {
     size_t attempts = 0;
     while (true) {
         try {
@@ -33,7 +37,7 @@ void eventually(noncopyable_function<void ()> f, size_t max_attempts = 17) {
 }
 
 inline
-bool eventually_true(noncopyable_function<bool ()> f) {
+bool eventually_true(noncopyable_function<bool ()> f, sleep_fn sleep = seastar_sleep_fn) {
     const unsigned max_attempts = 15;
     unsigned attempts = 0;
     while (true) {
@@ -53,14 +57,14 @@ bool eventually_true(noncopyable_function<bool ()> f) {
 
 // Must be called in a seastar thread
 template <typename T>
-void REQUIRE_EVENTUALLY_EQUAL(std::function<T()> a, T b) {
-    eventually_true([&] { return a() == b; });
+void REQUIRE_EVENTUALLY_EQUAL(std::function<T()> a, T b, sleep_fn sleep = seastar_sleep_fn) {
+    eventually_true([&] { return a() == b; }, sleep);
     BOOST_REQUIRE_EQUAL(a(), b);
 }
 
 // Must be called in a seastar thread
 template <typename T>
-void CHECK_EVENTUALLY_EQUAL(std::function<T()> a, T b) {
-    eventually_true([&] { return a() == b; });
+void CHECK_EVENTUALLY_EQUAL(std::function<T()> a, T b, sleep_fn sleep = seastar_sleep_fn) {
+    eventually_true([&] { return a() == b; }, sleep);
     BOOST_CHECK_EQUAL(a(), b);
 }

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -1235,7 +1235,7 @@ future<> raft_cluster<Clock>::check_rpc_config(::check_rpc_config cc) {
     for (auto& node: cc.nodes) {
         BOOST_CHECK(node.id < _servers.size());
         co_await seastar::async([&] {
-            CHECK_EVENTUALLY_EQUAL(_servers[node.id].rpc->known_peers(), as);
+            BOOST_CHECK(eventually_true([&] { return _servers[node.id].rpc->known_peers() == as; }));
         });
     }
 }


### PR DESCRIPTION
This series exposes a Clock template parameter for loading_cache so that the test could use
the manual_clock rather than the lowres_clock, since relying on the latter is flaky.

In addition, the test load function is simplified to sleep some small random time and co_return the expected string,
rather than reading it from a real file, since the latter's timing might also be flaky, and it out-of-scope for this test.

Fixes #20322

* The test was flaky forever, so backport is required for all live versions.