### PR TITLE
test/pylib: two trivial cleanups

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -301,7 +301,7 @@ class ScyllaServer:
         self.resources_certificate_file = self.resourcesdir / "scylla.crt"
         self.resources_keyfile_file = self.resourcesdir / "scylla.key"
 
-        if property_file and not "endpoint_snitch" in config_options:
+        if property_file and "endpoint_snitch" not in config_options:
             config_options["endpoint_snitch"] = "GossipingPropertyFileSnitch"
 
         # Sum of basic server configuration and the user-provided config options.

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -88,7 +88,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'seed_provider': [{
             'class_name': 'org.apache.cassandra.locator.SimpleSeedProvider',
             'parameters': [{
-                'seeds': '{}'.format(','.join(seed_addrs))
+                'seeds': ','.join(seed_addrs)
                 }]
             }],
 
@@ -335,7 +335,7 @@ class ScyllaServer:
         if self.is_running:
             raise RuntimeError(f"Can't change seeds of a running server {self.ip_addr}.")
         self.seeds = seeds
-        self.config['seed_provider'][0]['parameters'][0]['seeds'] = '{}'.format(','.join(seeds))
+        self.config['seed_provider'][0]['parameters'][0]['seeds'] = ','.join(seeds)
         self._write_config_file()
 
     @property


### PR DESCRIPTION
- use "foo not in bar" instead of "not foo in bar"
- test/pylib: use foo instead of `'{}'.format(foo)`

---

it's a cleanup, hence no need to backport.