### PR TITLE
test/pytest.ini: ignore warning on deprecated record_property fixture

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -14,8 +14,18 @@ norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,
 # so we need to do this here.
+#
+# Ignore warning of
+#   PytestWarning: record_property is incompatible with junit_family 'xunit2' (use 'legacy' or 'xunit1')
+# Because `record_property` adds <properties> inside <testcase>, which is not allowed
+# as per the latest xunit2 schema. see
+# https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsdtestcase,
+# an alternative is `record_testsuite_property`, but we want to attach test
+# log on a per-test basis. so let's continue using this feature before
+# switching to xunit1 or legacy.
 filterwarnings =
     ignore::urllib3.exceptions.InsecureRequestWarning
+    ignore:record_property is incompatible with junit_family:pytest.PytestWarning
 
 tmp_path_retention_count = 1
 tmp_path_retention_policy = failed


### PR DESCRIPTION
`record_property` generates XML which is not compatible with xunit2, so pytest decided to deprecated it when  generating xunit reports. and pytest generates following warning when a test failure is reported using this fixture:

```
  object_store/test_backup.py:337: PytestWarning: record_property is incompatible with junit_family 'xunit2' (use 'legacy' or 'xunit1')
```

this warning is not related to the test, but more about how we report a failure using pytrest. it is distracting, so let's silence it.

See also https://github.com/pytest-dev/pytest/issues/5202

---

it's a cleanup, hence no need to backport.