### PR TITLE
everywhere: add skeletal support for the in_memory_tables feature

### DIFF
--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -180,6 +180,9 @@ void compaction_strategy_impl::validate_options_for_strategy_type(const std::map
             break;
         default:
             break;
+        case compaction_strategy_type::null:
+        case compaction_strategy_type::in_memory:
+            return;
     }
 
     unchecked_options.erase("class");
@@ -761,6 +764,13 @@ compaction_strategy make_compaction_strategy(compaction_strategy_type strategy, 
         break;
     case compaction_strategy_type::time_window:
         impl = ::make_shared<time_window_compaction_strategy>(options);
+        break;
+    case compaction_strategy_type::in_memory:
+        compaction_strategy_logger.warn(
+                "{} is no longer supported. Defaulting to {}.",
+                compaction_strategy::name(compaction_strategy_type::in_memory),
+                compaction_strategy::name(compaction_strategy_type::null));
+        impl = ::make_shared<null_compaction_strategy>();
         break;
     case compaction_strategy_type::incremental:
         impl = make_shared<incremental_compaction_strategy>(incremental_compaction_strategy(options));

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -70,6 +70,8 @@ public:
             return "LeveledCompactionStrategy";
         case compaction_strategy_type::time_window:
             return "TimeWindowCompactionStrategy";
+        case compaction_strategy_type::in_memory:
+            return "InMemoryCompactionStrategy";
         case compaction_strategy_type::incremental:
             return "IncrementalCompactionStrategy";
         default:
@@ -88,6 +90,8 @@ public:
             return compaction_strategy_type::leveled;
         } else if (short_name == "TimeWindowCompactionStrategy") {
             return compaction_strategy_type::time_window;
+        } else if (short_name == "InMemoryCompactionStrategy") {
+            return compaction_strategy_type::in_memory;
         } else if (short_name == "IncrementalCompactionStrategy") {
             return compaction_strategy_type::incremental;
         } else {

--- a/compaction/compaction_strategy_type.hh
+++ b/compaction/compaction_strategy_type.hh
@@ -17,6 +17,7 @@ enum class compaction_strategy_type {
     size_tiered,
     leveled,
     time_window,
+    in_memory,
     incremental,
 };
 

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -464,6 +464,9 @@ std::optional<sstring> check_restricted_table_properties(
     // Evaluate whether the strategy to evaluate was explicitly passed
     auto cs = (strategy) ? strategy : current_strategy;
 
+    if (cs == sstables::compaction_strategy_type::in_memory) {
+        throw exceptions::configuration_exception(format("{} has been deprecated.", sstables::compaction_strategy::name(*cs)));
+    }
     if (cs == sstables::compaction_strategy_type::time_window) {
         std::map<sstring, sstring> options = (strategy) ? cfprops.get_compaction_type_options() : (*schema)->compaction_strategy_options();
         sstables::time_window_compaction_strategy_options twcs_options(options);

--- a/db/schema_features.hh
+++ b/db/schema_features.hh
@@ -27,6 +27,9 @@ enum class schema_feature {
 
     // When enabled we'll add a new column to the `system_schema.scylla_tables` table.
     GROUP0_SCHEMA_VERSIONING,
+
+    // Unused.  Defined for backward compatibility only
+    IN_MEMORY_TABLES,
 };
 
 using schema_features = enum_set<super_enum<schema_feature,
@@ -35,7 +38,8 @@ using schema_features = enum_set<super_enum<schema_feature,
     schema_feature::SCYLLA_KEYSPACES,
     schema_feature::SCYLLA_AGGREGATES,
     schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY,
-    schema_feature::GROUP0_SCHEMA_VERSIONING
+    schema_feature::GROUP0_SCHEMA_VERSIONING,
+    schema_feature::IN_MEMORY_TABLES
     >>;
 
 }

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -302,11 +302,12 @@ schema_ptr tables() {
 
 // Holds Scylla-specific table metadata.
 schema_ptr scylla_tables(schema_features features) {
-    static thread_local schema_ptr schemas[2]{};
+    static thread_local schema_ptr schemas[2][2]{};
 
     bool has_group0_schema_versioning = features.contains(schema_feature::GROUP0_SCHEMA_VERSIONING);
+    bool has_in_memory = features.contains(schema_feature::IN_MEMORY_TABLES);
 
-    schema_ptr& s = schemas[has_group0_schema_versioning];
+    schema_ptr& s = schemas[has_in_memory][has_group0_schema_versioning];
     if (!s) {
         auto id = generate_legacy_id(NAME, SCYLLA_TABLES);
         auto sb = schema_builder(NAME, SCYLLA_TABLES, std::make_optional(id))
@@ -318,6 +319,10 @@ schema_ptr scylla_tables(schema_features features) {
 
         // PER_TABLE_PARTITIONERS
         sb.with_column("partitioner", utf8_type);
+
+        if (has_in_memory) {
+            sb.with_column("in_memory", boolean_type);
+        }
 
         if (has_group0_schema_versioning) {
             // If true, this table's latest schema was committed by group 0.
@@ -1728,6 +1733,9 @@ mutation make_scylla_tables_mutation(schema_ptr table, api::timestamp_type times
         auto& cdef = *scylla_tables()->get_column_definition("partitioner");
         m.set_clustered_cell(ckey, cdef, atomic_cell::make_dead(timestamp, gc_clock::now()));
     }
+    // In-memory tables are deprecated since scylla-2024.1.0
+    // FIXME: delete the column when there's no live version supporting it anymore.
+    // Writing it here breaks upgrade rollback to versions that do not support the in_memory schema_feature
     return m;
 }
 
@@ -2197,6 +2205,18 @@ schema_ptr create_table_from_mutations(const schema_ctxt& ctxt, schema_mutations
 
     prepare_builder_from_table_row(ctxt, builder, table_row);
 
+    if (sm.scylla_tables()) {
+        table_rs = query::result_set(*sm.scylla_tables());
+        if (!table_rs.empty()) {
+            query::result_set_row table_row = table_rs.row(0);
+            auto in_mem = table_row.get<bool>("in_memory");
+            auto in_mem_enabled = in_mem.value_or(false);
+            if (in_mem_enabled) {
+                slogger.warn("Support for in_memory tables has been deprecated.");
+            }
+            builder.set_in_memory(in_mem_enabled);
+        }
+    }
     v3_columns columns(std::move(column_defs), is_dense, is_compound);
     columns.apply_to(builder);
 

--- a/docs/architecture/sstable/sstable2/sstable-interpretation.rst
+++ b/docs/architecture/sstable/sstable2/sstable-interpretation.rst
@@ -22,7 +22,7 @@ is just a **mutation**, a list of changed (added or deleted) columns and
 their new values (or "tombstone" for a deleted column), and a timestamp
 for each such change (this timestamp is used for reconciling conflicting
 mutations). The full data row needed by a request will be composed from
-potentially multiple sstables and/or the in-memory table(s).
+potentially multiple sstables.
 
 As we'll explain below when discussing clustering columns, the best term
 for what we read from one row in the SSTable isn't a "row", but rather a

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -233,6 +233,7 @@ db::schema_features feature_service::cluster_schema_features() const {
     f.set_if<db::schema_feature::SCYLLA_AGGREGATES>(aggregate_storage_options);
     f.set_if<db::schema_feature::TABLE_DIGEST_INSENSITIVE_TO_EXPIRY>(table_digest_insensitive_to_expiry);
     f.set_if<db::schema_feature::GROUP0_SCHEMA_VERSIONING>(group0_schema_versioning);
+    f.set_if<db::schema_feature::IN_MEMORY_TABLES>(bool(in_memory_tables));
     return f;
 }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -156,6 +156,7 @@ public:
     gms::feature test_only_feature { *this, "TEST_ONLY_FEATURE"sv };
     gms::feature address_nodes_by_host_ids { *this, "ADDRESS_NODES_BY_HOST_IDS"sv };
 
+    gms::feature in_memory_tables { *this, "IN_MEMORY_TABLES"sv };
     gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
 public:

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -581,6 +581,7 @@ bool operator==(const schema& x, const schema& y)
         && indirect_equal_to<std::unique_ptr<::view_info>>()(x._view_info, y._view_info)
         && x._raw._indices_by_name == y._raw._indices_by_name
         && x._raw._is_counter == y._raw._is_counter
+        && x._raw._in_memory == y._raw._in_memory
         ;
 }
 
@@ -839,6 +840,7 @@ auto fmt::formatter<schema>::format(const schema& s, fmt::format_context& ctx) c
     out = fmt::format_to(out, ",speculativeRetry={}", s._raw._speculative_retry.to_sstring());
     out = fmt::format_to(out, ",triggers=[]");
     out = fmt::format_to(out, ",isDense={}", s._raw._is_dense);
+    out = fmt::format_to(out, ",in_memory={}", s._raw._in_memory);
     out = fmt::format_to(out, ",version={}", s.version());
 
     out = fmt::format_to(out, ",droppedColumns={{");

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -563,6 +563,7 @@ private:
         // Sharding info is not stored in the schema mutation and does not affect
         // schema digest. It is also not set locally on a schema tables.
         std::reference_wrapper<const dht::static_sharder> _sharder;
+        bool _in_memory = false;
         std::optional<raw_view_info> _view_info;
     };
     raw_schema _raw;
@@ -759,6 +760,10 @@ public:
     replica::table& table() const;
 
     bool has_custom_partitioner() const;
+
+    bool is_in_memory() const {
+        return _raw._in_memory;
+    }
 
     const column_definition* get_column_definition(const bytes& name) const;
     const column_definition& column_at(column_kind, column_id) const;

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -222,6 +222,11 @@ public:
 
     schema_builder& with_partitioner(sstring name);
     schema_builder& with_sharder(unsigned shard_count, unsigned sharding_ignore_msb_bits);
+    schema_builder& set_in_memory(bool in_memory) {
+        _raw._in_memory = in_memory;
+        return *this;
+    }
+
     class default_names {
     public:
         default_names(const schema_builder&);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -121,6 +121,7 @@ void migration_manager::init_messaging_service()
                 _feature_listeners.push_back(feature.when_enabled(reload_schema_in_bg));
             }
         }
+        _feature_listeners.push_back(_feat.in_memory_tables.when_enabled(reload_schema_in_bg));
     }
 
     ser::migration_manager_rpc_verbs::register_definitions_update(&_messaging, [this] (const rpc::client_info& cinfo, std::vector<frozen_mutation>, rpc::optional<std::vector<canonical_mutation>> cm) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -54,6 +54,8 @@ namespace data_dictionary {
 class storage_options;
 }
 
+class in_memory_config_type;
+
 namespace db {
 class large_data_handler;
 }
@@ -1046,6 +1048,8 @@ public:
 
     future<std::optional<uint32_t>> read_digest();
     future<lw_shared_ptr<checksum>> read_checksum();
+
+    friend in_memory_config_type;
 };
 
 // Validate checksums

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -1158,7 +1158,7 @@ SEASTAR_TEST_CASE(test_system_schema_version_is_stable) {
 
         // If you changed the schema of system.batchlog then this is expected to fail.
         // Just replace expected version with the new version.
-        BOOST_REQUIRE_EQUAL(s->version(), table_schema_version(utils::UUID("776f1766-8688-3d52-908b-a5228900dc00")));
+        BOOST_REQUIRE_EQUAL(s->version(), table_schema_version(utils::UUID("3febbbce-8841-304a-abb9-170078ac173d")));
     });
 }
 


### PR DESCRIPTION
Forward-ported from scylla-enterprise.
Note that the feature has been deprecated and the implementation is provided only for backward compatibility with pre-existing features and schema.

Tested manually after adding the following to feature_service:
```
    gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
```

Launched a single-node cluster running 2023.1.10
```
cqlsh> create KEYSPACE ks WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
cqlsh> create TABLE ks.test ( pk int PRIMARY KEY, val int ) WITH compaction = {'class': 'InMemoryCompactionStrategy'};
```

log:
```
Scylla version 2023.1.10-0.20241227.21cffccc1ccd with build-id bd65b8399cb13b713a87e57fe333cfcabfd50be7 starting ...
...
INFO  2024-12-27 19:45:16,563 [shard 0] migration_manager - Create new ColumnFamily: org.apache.cassandra.config.CFMetaData@0x600000f1b400[cfId=5529c630-c47a-11ef-bd1d-4295734ce5a8,ksName=ks,cfName=test,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type),comment=,readRepairChance=0,dcLocalReadRepairChance=0,tombstoneGcOptions={"mode":"timeout","propagation_delay_in_seconds":"3600"},gcGraceSeconds=864000,keyValidator=org.apache.cassandra.db.marshal.Int32Type,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=pk, type=org.apache.cassandra.db.marshal.Int32Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=val, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.InMemoryCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},cdc={},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,in_memory=false,version=5529c631-c47a-11ef-bd1d-4295734ce5a8,droppedColumns={},collections={},indices={}]
INFO  2024-12-27 19:45:16,564 [shard 0] schema_tables - Creating ks.test id=5529c630-c47a-11ef-bd1d-4295734ce5a8 version=ec88d510-6aff-344a-914d-541d37081440
```

Upgraded to this branch and started scylla.
Verified that ks.test was successfuly loaded:

log:
```
INFO  2024-12-27 19:48:58,115 [shard 0:main] init - Scylla version 6.3.0~dev-0.20241227.a64c6dfc153e with build-id f9496134a09cf2e55d3865b9e9ff499f672aa7da starting ...
...
WARN  2024-12-27 19:53:02,948 [shard 1:main] CompactionStrategy - InMemoryCompactionStrategy is no longer supported. Defaulting to NullCompactionStrategy.
...
INFO  2024-12-27 19:53:02,948 [shard 0:main] database - Keyspace ks: Reading CF test id=5529c630-c47a-11ef-bd1d-4295734ce5a8 version=ec88d510-6aff-344a-914d-541d37081440 storage=/home/bhalevy/scylladb/data/ks/test-5529c630c47a11efbd1d4295734ce5a8
```

Then, tested:
```
cqlsh> describe KEYSPACE ks;

CREATE KEYSPACE ks WITH replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true AND tablets = {'enabled': false};

CREATE TABLE ks.test (
    pk int,
    val int,
    PRIMARY KEY (pk)
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
    AND comment = ''
    AND compaction = {'class': 'InMemoryCompactionStrategy'}
    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND speculative_retry = '99.0PERCENTILE';

cqlsh> alter TABLE ks.test with compaction = {'class': 'SizeTieredCompactionStrategy'};
cqlsh> describe KEYSPACE ks;

CREATE KEYSPACE ks WITH replication = {'class': 'org.apache.cassandra.locator.SimpleStrategy', 'replication_factor': '1'} AND durable_writes = true AND tablets = {'enabled': false};

CREATE TABLE ks.test (
    pk int,
    val int,
    PRIMARY KEY (pk)
) WITH bloom_filter_fp_chance = 0.01
    AND caching = {'keys': 'ALL', 'rows_per_partition': 'ALL'}
    AND comment = ''
    AND compaction = {'class': 'SizeTieredCompactionStrategy'}
    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
    AND crc_check_chance = 1
    AND default_time_to_live = 0
    AND gc_grace_seconds = 864000
    AND max_index_interval = 2048
    AND memtable_flush_period_in_ms = 0
    AND min_index_interval = 128
    AND speculative_retry = '99.0PERCENTILE'
    AND tombstone_gc = {'mode': 'timeout', 'propagation_delay_in_seconds': '3600'};
```

log:
```
INFO  2024-12-27 19:56:40,465 [shard 0:stmt] migration_manager - Update table 'ks.test' From org.apache.cassandra.config.CFMetaData@0x60000362d800[cfId=5529c630-c47a-11ef-bd1d-4295734ce5a8,ksName==ks,cfName=test,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type),comment=,tombstoneGcOptions={"mode":"timeout","propagation_delay_in_seconds":"3600"},gcGraceSeconds=864000,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=pk, type=org.apache.cassandra.db.marshal.Int32Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=val, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.InMemoryCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},cdc={},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,version=ec88d510-6aff-344a-914d-541d37081440,droppedColumns={},collections={},indices={}] To org.apache.cassandra.config.CFMetaData@0x60000336e000[cfId=5529c630-c47a-11ef-bd1d-4295734ce5a8,ksName==ks,cfName=test,cfType=Standard,comparator=org.apache.cassandra.db.marshal.CompositeType(org.apache.cassandra.db.marshal.UTF8Type),comment=,tombstoneGcOptions={"mode":"timeout","propagation_delay_in_seconds":"3600"},gcGraceSeconds=864000,minCompactionThreshold=4,maxCompactionThreshold=32,columnMetadata=[ColumnDefinition{name=pk, type=org.apache.cassandra.db.marshal.Int32Type, kind=PARTITION_KEY, componentIndex=0, droppedAt=-9223372036854775808}, ColumnDefinition{name=val, type=org.apache.cassandra.db.marshal.Int32Type, kind=REGULAR, componentIndex=null, droppedAt=-9223372036854775808}],compactionStrategyClass=class org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy,compactionStrategyOptions={enabled=true},compressionParameters={sstable_compression=org.apache.cassandra.io.compress.LZ4Compressor},bloomFilterFpChance=0.01,memtableFlushPeriod=0,caching={"keys":"ALL","rows_per_partition":"ALL"},cdc={},defaultTimeToLive=0,minIndexInterval=128,maxIndexInterval=2048,speculativeRetry=99.0PERCENTILE,triggers=[],isDense=false,version=ecccf010-c47b-11ef-b52c-622f2f0e87c4,droppedColumns={},collections={},indices={}]
INFO  2024-12-27 19:56:40,466 [shard 0: gms] schema_tables - Altering ks.test id=5529c630-c47a-11ef-bd1d-4295734ce5a8 version=ecccf010-c47b-11ef-b52c-622f2f0e87c4
```

* Forward port to source-available version, no backport needed