### PR TITLE
dist/common/scripts/scylla_raid_setup: reduce XFS metadata overhead

### DIFF
--- a/dist/common/scripts/scylla_raid_setup
+++ b/dist/common/scripts/scylla_raid_setup
@@ -229,7 +229,7 @@ if __name__ == '__main__':
     # and it also cannot be smaller than the sector size.
     block_size = max(1024, sector_size)
     run('udevadm settle', shell=True, check=True)
-    run(f'mkfs.xfs -b size={block_size} {fsdev} -K', shell=True, check=True)
+    run(f'mkfs.xfs -b size={block_size} {fsdev} -K -m rmapbt=0 -m reflink=0', shell=True, check=True)
     run('udevadm settle', shell=True, check=True)
 
     if is_debian_variant():


### PR DESCRIPTION
The block size of 1k is significantly increasing metadata overhead with xfs since it reserves space upfront for btree expansion. With CRC disabled, this reservation doesn't happen. Smaller btree blocks reduce the fanout factor, increasing btree height and the reservation size. So block size implies a trade-off between write amplification and metadata size. Bigger blocks, smaller metadata, more write ampl. Smaller blocks, more metadata, and less write ampl.

Let's disable both `rmapbt` and `relink` since we replicate data, and we can afford to rebuild a replica on local corruption.

Fixes: https://github.com/scylladb/scylladb/issues/22028

**This fix will affect only new installations, no need to backport**

### Testing
- [x] https://jenkins.scylladb.com/job/scylla-master/job/byo/job/byo_build_tests_dtest/2659/ (for building AMI)
- [x] https://jenkins.scylladb.com/job/releng-testing/job/artifacts/job/artifacts-ami-test/14/ (Artifact test for custom AMI)