### PR TITLE
test.py: added more log info if the server is broken

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -217,7 +217,7 @@ async def manager(request, manager_internal, record_property, build_mode):
     cluster_status = await manager_client.after_test(test_case_name, not failed)
     await manager_client.stop()  # Stop client session and close driver after each test
     if cluster_status["server_broken"]:
-        pytest.fail(f"test case {test_case_name} leave unfinished tasks on Scylla server. Server marked as broken")
+        pytest.fail(f"test case {test_case_name} leave unfinished tasks on Scylla server. Server marked as broken, server_broken_reason: {cluster_status["message"]}")
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object


### PR DESCRIPTION
attribute server_broken_reason into the server was introduced, to store the raw information
regarding why the server was broken

additional information was added in the error messages in case of "server
broken"

fixes: #21630

messages examples:

```
ScyllaClusterManager BROKEN, Previous test broke ScyllaClusterManager server, server_broken_reason: tasks leakage found  {<Task finished name='Task-26' coro=<RequestHandler._handle_request() done, defined at /usr/lib64/python3.12/site-packages/aiohttp/web_protocol.py:442> result=(<Response OK eof>, False)>: <Request GET /cluster/all-servers >}, test case release/topology_custom.test_repr.1::test_decommissioned_node_cant_rejoin.1.release.1 BROKE ScyllaClusterManager
```

```
Failed: test case test_decommissioned_node_cant_rejoin.1.release.1 leave unfinished tasks on Scylla server. Server marked as broken, server_broken_reason: tasks leakage found  {<Task finished name='Task-26' coro=<RequestHandler._handle_request() done, defined at /usr/lib64/python3.12/site-packages/aiohttp/web_protocol.py:442> result=(<Response OK eof>, False)>: <Request GET /cluster/all-servers >}, test case release/topology_custom.test_repr.1::test_decommissioned_node_cant_rejoin.1.release.1 BROKE ScyllaClusterManager
```