### PR TITLE
Update seastar submodule

### DIFF
--- a/test/boost/group0_test.cc
+++ b/test/boost/group0_test.cc
@@ -46,7 +46,7 @@ SEASTAR_TEST_CASE(test_abort_server_on_background_error) {
         auto get_metric_ui64 = [&](sstring name) {
             const auto& value_map = seastar::metrics::impl::get_value_map();
             const auto& metric_family = value_map.at("raft_group0_" + name);
-            const auto& registered_metric = metric_family.at({{"shard", "0"}});
+            const auto& registered_metric = metric_family.at(make_lw_shared<const metrics::impl::labels_type>({{"shard", "0"}}));
             return (*registered_metric)().ui();
         };
 

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -184,8 +184,8 @@ std::unordered_map<sstring, uint64_t> get_query_metrics() {
     const auto values = all_metrics->values[distance(cbegin(all_metadata), qp_group)];
     std::vector<sstring> labels;
     for (const auto& metric : qp_group->metrics) {
-        const auto found = metric.id.labels().find("consistency_level");
-        BOOST_REQUIRE(found != metric.id.labels().cend());
+        const auto found = metric.labels().find("consistency_level");
+        BOOST_REQUIRE(found != metric.labels().cend());
         labels.push_back(found->second);
     }
     BOOST_REQUIRE(values.size() == level_count);


### PR DESCRIPTION
* seastar 3133ecdd...a9bef537 (24):
  > file: add file_system_space
  > future: avoid inheriting from future payload type
  > treewide: include fmt/ostream.h for using fmt::print()
  > build: remove messages used for debugging
  > demos: Rename websocket demo to websocket_server demo
  > demos: Add a way to set port from cmd line in websocket demo
  > tls: Add optional builder + future-wait to cert reload callback + expose rebuild
  > rwlock: add try_hold_{read,write}_lock methods
  > json: add moving push to json_list
  > github: add a step to build "check-include-style"
  > build: add a target for checking include style
  > scheduling_group: use map for key configs instead of vector
  > scheduling_group: fix indentation
  > scheduling_group: fix race between scheduling group and key creation
  > http: Make request writing functions public
  > http: Expose connection_factory implementations
  > metrics: Use separate type for shared metadata
  > file: unexpected throw from inside noexcept
  > metrics: Internalize metric label sets
  > thread: optimize maybe_yield
  > reactor: fix crash in pending registration task after poller dtor
  > net: Fix ipv6 socket_address comparision
  > reactor, linux-aio: factor out get_smp_count() lambda
  > reactor, linux-aio: restore "available_aio" meaning after "reserve_iocbs"

Fixed usage of seastar metric label sets due to:
scylladb/seastar@733420d57 Merge 'metrics: Internalize metric label sets' from Stephan Dollberg

* Update of seastar submodule, no backport required.