### PR TITLE
treewide: migrate from boost::adaptors::reversed to std::views::reverse

### DIFF
--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -11,7 +11,6 @@
 #include "size_tiered_compaction_strategy.hh"
 #include "cql3/statements/property_definitions.hh"
 
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/range/algorithm.hpp>
 
 namespace sstables {
@@ -241,7 +240,7 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
     // ratio is greater than threshold.
     // prefer oldest sstables from biggest size tiers because they will be easier to satisfy conditions for
     // tombstone purge, i.e. less likely to shadow even older data.
-    for (auto&& sstables : buckets | boost::adaptors::reversed) {
+    for (auto&& sstables : buckets | std::views::reverse) {
         // filter out sstables which droppable tombstone ratio isn't greater than the defined threshold.
         auto e = boost::range::remove_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
             return !worth_dropping_tombstones(sst, compaction_time, table_s);

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -10,7 +10,6 @@
 
 #include <boost/range/algorithm/equal.hpp>
 #include <boost/range/algorithm/transform.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/raw_selector.hh"

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -13,8 +13,6 @@
 #include <malloc.h>
 #include <boost/regex.hpp>
 #include <filesystem>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <unordered_map>
 #include <unordered_set>
 #include <exception>

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -19,8 +19,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/as_future.hh>
 
-#include <boost/range/adaptor/reversed.hpp>
-
 #include <fmt/ostream.h>
 
 logging::logger mmq_log("multishard_mutation_query");

--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/adaptor/reversed.hpp>
 #include "range_tombstone_list.hh"
 #include "utils/assert.hh"
 #include "utils/allocation_strategy.hh"
+#include <boost/range/algorithm/equal.hpp>
 #include <seastar/util/variant_utils.hh>
 
 range_tombstone_list::range_tombstone_list(const range_tombstone_list& x)
@@ -386,7 +386,7 @@ void range_tombstone_list::reverter::update(range_tombstones_type::iterator it, 
 }
 
 void range_tombstone_list::reverter::revert() noexcept {
-    for (auto&& rt : _ops | boost::adaptors::reversed) {
+    for (auto&& rt : _ops | std::views::reverse) {
         seastar::visit(rt, [this] (auto& op) {
             op.undo(_s, _dst);
         });

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -8,7 +8,6 @@
 
 #include "cql3/util.hh"
 #include "utils/assert.hh"
-#include <boost/range/adaptor/reversed.hpp>
 #include <chrono>
 
 #include <seastar/core/sleep.hh>
@@ -325,7 +324,7 @@ future<> service_level_controller::update_effective_service_levels_cache() {
     // role1 in `sorted` vector.
     // That's why if we iterate over the vector in reversed order, we will visit the roles from the bottom
     // and we can use already calculated effective service levels for all of the subroles.
-    for (auto& role: sorted | boost::adaptors::reversed) {
+    for (auto& role: sorted | std::views::reverse) {
         std::optional<service_level_options> sl_options;
 
         if (auto sl_name_it = attributes.find(role); sl_name_it != attributes.end()) {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -9,7 +9,6 @@
 
 #include <boost/range/irange.hpp>
 #include <boost/range/algorithm.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -13,7 +13,6 @@
 #include "dht/i_partitioner.hh"
 #include "dht/murmur3_partitioner.hh"
 #include <boost/range/irange.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include "sstables/version.hh"
 #include "test/lib/mutation_reader_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -20,7 +20,6 @@
 #include "utils/assert.hh"
 #include "utils/overloaded_functor.hh"
 #include <boost/program_options.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <iostream>
 #include <fmt/ranges.h>
 #include <seastar/util/defer.hh>
@@ -521,7 +520,7 @@ static sstring toc_filename(const sstring& dir, schema_ptr schema, sstables::gen
 }
 
 future<shared_sstable> test_env::reusable_sst(schema_ptr schema, sstring dir, sstables::generation_type generation) {
-    for (auto v : boost::adaptors::reverse(all_sstable_versions)) {
+    for (auto v : std::views::reverse(all_sstable_versions)) {
         if (co_await file_exists(toc_filename(dir, schema, generation, v))) {
             co_return co_await reusable_sst(schema, dir, generation, v);
         }

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -21,7 +21,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/reversed.hpp>
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>
@@ -4525,7 +4524,7 @@ operation_func get_operation_function(const operation& op) noexcept {
     name.pop_back();
 
     // Check suboperations.
-    for (auto n : name | boost::adaptors::reversed) {
+    for (auto n : name | std::views::reverse) {
         action = action.suboperation_funcs.at(n);
     }
 

--- a/utils/dynamic_bitset.cc
+++ b/utils/dynamic_bitset.cc
@@ -8,8 +8,7 @@
 
 #include <seastar/core/bitops.hh>
 #include <seastar/core/align.hh>
-#include <boost/range/adaptor/reversed.hpp>
-#include <boost/range/irange.hpp>
+#include <ranges>
 
 #include "utils/dynamic_bitset.hh"
 #include "seastarx.hh"
@@ -43,7 +42,7 @@ void dynamic_bitset::clear(size_t n) noexcept {
 size_t dynamic_bitset::find_first_set() const noexcept
 {
     size_t pos = 0;
-    for (auto& vv : _bits | boost::adaptors::reversed) {
+    for (auto& vv : _bits | std::views::reverse) {
         auto v = vv[pos];
         pos *= bits_per_int;
         if (v) {
@@ -94,7 +93,7 @@ size_t dynamic_bitset::find_next_set(size_t n) const noexcept
 size_t dynamic_bitset::find_last_set() const noexcept
 {
     size_t pos = 0;
-    for (auto& vv : _bits | boost::adaptors::reversed) {
+    for (auto& vv : _bits | std::views::reverse) {
         auto v = vv[pos];
         pos *= bits_per_int;
         if (v) {


### PR DESCRIPTION
now that we are allowed to use C++23. we now have the luxury of using `std::views::reverse`.

- replace `boost::adaptors::transformed` with `std::views::transform`
- remove unused `#include <boost/range/adaptor/reversed.hpp>`

this change is part of our ongoing effort to modernize our codebase and reduce external dependencies where possible.

---

it's a cleanup, hence no need to backport.