### PR TITLE
test.py: pass "count" to re.sub() with kwarg

### DIFF
--- a/test.py
+++ b/test.py
@@ -1540,7 +1540,7 @@ def parse_cmd_line() -> argparse.Namespace:
             # [1/1] List configured modes
             # debug release dev
             args.modes = re.sub(r'.* List configured modes\n(.*)\n', r'\1',
-                                out, 1, re.DOTALL).split("\n")[-1].split(' ')
+                                out, count=1, flags=re.DOTALL).split("\n")[-1].split(' ')
         except Exception:
             print(palette.fail("Failed to read output of `ninja mode_list`: please run ./configure.py first"))
             raise


### PR DESCRIPTION
since Python 3.13, passing count to `re.sub()` as positional argument has been deprecated. and when runnint `test.py` with Python 3.13, we have following warning:

```
/home/kefu/dev/scylladb/./test.py:1540: DeprecationWarning: 'count' is passed as positional argument
  args.modes = re.sub(r'.* List configured modes\n(.*)\n', r'\1',
```

see also https://github.com/python/cpython/issues/56166

in order to silence this distracting warning, let's pass `count` using kwarg.

this change was created in the same spirit of c3be4a36af.

---

it's a cleanup, hence no need to backport.