### PR TITLE
Remove BETA from metrics and API references

### DIFF
--- a/docs/reference/_common/reference-toc.rst
+++ b/docs/reference/_common/reference-toc.rst
@@ -8,5 +8,5 @@
    Configuration Parameters </reference/configuration-parameters>
    Glossary </reference/glossary>
    Limits </reference/limits>
-   API Reference (BETA) </reference/api-reference>
-   Metrics (BETA) </reference/metrics>
+   API Reference </reference/api-reference>
+   Metrics </reference/metrics>

--- a/docs/reference/api-reference.rst
+++ b/docs/reference/api-reference.rst
@@ -1,6 +1,6 @@
 :exclude-doctools:
 
-API Reference (BETA)
+API Reference
 ====================
 
 .. scylladb_swagger_inc::

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -13,6 +13,6 @@ Reference
 * :doc:`Configuration Parameters </reference/configuration-parameters>` - ScyllaDB properties configurable in the ``scylla.yaml`` configuration file.
 * :doc:`Glossary </reference/glossary>` - ScyllaDB-related terms and definitions.
 * :doc:`Limits </reference/limits>`
-* :doc:`API Reference (BETA) </reference/api-reference>`
-* :doc:`Metrics (BETA) </reference/metrics>`
+* :doc:`API Reference </reference/api-reference>`
+* :doc:`Metrics </reference/metrics>`
 * .. scylladb_include_flag:: enterprise-vs-oss-matrix-link.rst

--- a/docs/reference/metrics.rst
+++ b/docs/reference/metrics.rst
@@ -1,5 +1,5 @@
 ==============
-Metrics (BETA)
+Metrics
 ==============
 
 .. scylladb_metrics::


### PR DESCRIPTION
Metrics and API docs are mature enough to remove the BETA from the title.
Also, it looks like the features are in BETA, while the docs (autogenerated) were in BETA.

Fix https://github.com/scylladb/scylladb/issues/22091