### PR TITLE
types: explicitly instantiate map_type_impl::deserialize()

### DIFF
--- a/types/types.cc
+++ b/types/types.cc
@@ -1194,6 +1194,7 @@ map_type_impl::deserialize(View in) const {
     return make_value(std::move(m));
 }
 template data_value map_type_impl::deserialize<>(ser::buffer_view<bytes_ostream::fragment_iterator>) const;
+template data_value map_type_impl::deserialize<>(managed_bytes_view) const;
 
 template <FragmentedView View>
 static void validate_aux(const map_type_impl& t, View v) {


### PR DESCRIPTION
The definition of the template is in a source translation unit, but there are also uses outside the translation unit. Without lto/pgo it worked due to the definition in the translation unit, but with lto/pgo we can presume the definition was inlined, so callers outside the translation unit did not have anything to link with.

Fix by explicitly instantiating the template function.

Fixes a bug newly introduced (or rather, a latenct bug that only now has impact), so no backport is needed.