### PR TITLE
utils: correct misspellings

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1737,7 +1737,7 @@ def prepare_advanced_optimizations(*, modes, build_modes, args):
         # Absolute path (in case of the initial profile) or path
         # beginning with $builddir (in case of generated profiles),
         # for use in ninja dependency rules.
-        # Using absoulte paths only would work too, but we use
+        # Using absolute paths only would work too, but we use
         # $builddir for consistency with all other ninja targets.
         profile_target = None
         # Absolute path to the profile, for use in compiler flags.

--- a/docs/dev/advanced_rpc_compression.md
+++ b/docs/dev/advanced_rpc_compression.md
@@ -248,14 +248,14 @@ one copy of each dictionary, on shard 0, kept alive by foreign shared pointers.
 
 Likewise, we keep only a single compressor and a single decompressor for each algorithm,
 and whenever a connection needs to use it, it plugs the correct dictionary in. 
-Switching dictionaries should be cheaper than keeping mulitple copies of the compressors.
+Switching dictionaries should be cheaper than keeping multiple copies of the compressors.
 
 ### Wire protocol details
 
 This section describes the layout of a compressed frame produced by `advanced_rpc_compressor::compress()`.
 
 The compression algorithm is selected on per-message basis.
-(Rationale: this allows the sender to weaken the compression unilaterally if it doens't have the resources for the "normal" algorithm.)
+(Rationale: this allows the sender to weaken the compression unilaterally if it doesn't have the resources for the "normal" algorithm.)
 The 7 least significant bits of byte 0 of each compressed message
 contain an enum value describing the compression algorithm used for this message.
 

--- a/utils/dict_trainer.hh
+++ b/utils/dict_trainer.hh
@@ -60,7 +60,7 @@ public:
     //
     // If the abort source is triggered before the min_sampling_bytes threshold is met,
     // the sampling will be canceled and the returned future will resolve to the aborting exception.
-    // In reasonable use cases, min_sampling_duration should be abortable withe the same abort source.
+    // In reasonable use cases, min_sampling_duration should be abortable with the same abort source.
     seastar::future<std::vector<page_type>> sample(request, seastar::abort_source&);
 
     // When in the sampling phase, this will feed the data to the sampler.

--- a/utils/stream_compressor.cc
+++ b/utils/stream_compressor.cc
@@ -167,7 +167,7 @@ void lz4_cstream::resetFast() noexcept {
 }
 
 // When new data arrives in `in`, we copy an arbitrary amount of it to `_buf`,
-// (the amount is arbirary, but it has to fit contiguously in `_buf`),
+// (the amount is arbitrary, but it has to fit contiguously in `_buf`),
 // compress the new block from `_buf` to `_lz4_scratch`,
 // then we copy everything from `_lz4_scratch` to `out`.
 // Repeat until `in` is empty.
@@ -182,7 +182,7 @@ size_t lz4_cstream::compress(ZSTD_outBuffer* out, ZSTD_inBuffer* in, ZSTD_EndDir
             _buf_pos = 0;
         }
         // We will compress the biggest prefix of `in` that fits contiguously inside `buf`.
-        // In principle, this is sligthly suboptimal -- ideally, if `in` is smaller than the contiguous space in `buf`,
+        // In principle, this is slightly suboptimal -- ideally, if `in` is smaller than the contiguous space in `buf`,
         // we should only copy `in` to `buf` and wait with the compressor call until future `in`s
         // fill the contiguous space entirely, or `end` is `ZSTD_e_flush` or `ZSTD_e_end`.
         // But for streaming LZ4 it doesn't really make a difference.

--- a/utils/stream_compressor.hh
+++ b/utils/stream_compressor.hh
@@ -132,7 +132,7 @@ class lz4_cstream final : public stream_compressor {
     // has a matching decompression call with decompressor's _buf as target,
     // with the same length and offset in _buf.
     std::vector<char> _buf;
-    // The current position in the ringbuffer _buf. New input will be appened at this position.
+    // The current position in the ringbuffer _buf. New input will be appended at this position.
     size_t _buf_pos = 0;
     // This pair describes the compressed data in `_lz4_scratch`, which is pending output.
     // We have to copy it out before we can compress new data to the scratch buffer.
@@ -147,7 +147,7 @@ public:
     void reset() noexcept override;
     void resetFast() noexcept;
     // When new data arrives in `in`, we copy an arbitrary amount of it to `_buf`,
-    // (the amount is arbirary, but it has to fit contiguously in `_buf`),
+    // (the amount is arbitrary, but it has to fit contiguously in `_buf`),
     // compress the new block from `_buf` to `_lz4_scratch`,
     // then we copy everything from `_lz4_scratch` to `out`.
     // Repeat until `in` is empty.


### PR DESCRIPTION
these misspellings were identified by codespell. let's fix them.

---

this change corrects a couple of misspellings which are not user-visible, hence no need to backport.