### PR TITLE
repair: add repair_service gate

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3282,6 +3282,7 @@ future<> repair_service::stop() {
         rlogger.debug("Unregistering gossiper helper");
         co_await _gossiper.local().unregister_(_gossip_helper);
     }
+    co_await async_gate().close();
     _stopped = true;
     rlogger.info("Stopped repair_service");
   } catch (...) {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -107,6 +107,8 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     shared_ptr<row_level_repair_gossip_helper> _gossip_helper;
     bool _stopped = false;
 
+    gate _gate;
+
     size_t _max_repair_memory;
     seastar::semaphore _memory_sem;
     seastar::named_semaphore _load_parallelism_semaphore = {16, named_semaphore_exception_factory{"Load repair history parallelism"}};
@@ -195,6 +197,7 @@ public:
     size_t max_repair_memory() const { return _max_repair_memory; }
     seastar::semaphore& memory_sem() { return _memory_sem; }
     locator::host_id my_host_id() const noexcept;
+    gate& async_gate() noexcept { return _gate; }
 
     repair::task_manager_module& get_repair_module() noexcept {
         return *_repair_module;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -155,6 +155,14 @@ namespace {
 
 static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 
+static future<> do_with_repair_service(sharded<repair_service>& repair, std::function<future<>(repair_service&)> f) {
+    if (!repair.local_is_initialized()) {
+        throw seastar::abort_requested_exception();
+    }
+    gate::holder holder = repair.local().async_gate().hold();
+    co_await f(repair.local());
+}
+
 storage_service::storage_service(abort_source& abort_source,
     distributed<replica::database>& db, gms::gossiper& gossiper,
     sharded<db::system_keyspace>& sys_ks,
@@ -3963,7 +3971,9 @@ void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tok
         utils::get_local_injector().inject("delay_bootstrap_120s", std::chrono::seconds(120)).get();
 
         // Step 5: Sync data for bootstrap
-        _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), bootstrap_tokens).get();
+        do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+            return local_repair.bootstrap_with_repair(get_token_metadata_ptr(), bootstrap_tokens);
+        }).get();
         on_streaming_finished();
 
         // Step 6: Finish
@@ -4019,7 +4029,9 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             auto ignore_nodes = replace_info.ignore_nodes | std::views::transform([] (const auto& x) {
                 return x.first;
             }) | std::ranges::to<std::unordered_set<locator::host_id>>();
-            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id).get();
+            do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                return local_repair.replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id);
+            }).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), bootstrap_tokens, get_token_metadata_ptr());
@@ -4442,7 +4454,9 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             for (auto& node : req.leaving_nodes) {
                 if (is_repair_based_node_ops_enabled(streaming::stream_reason::removenode)) {
                     slogger.info("removenode[{}]: Started to sync data for removing node={} using repair, coordinator={}", req.ops_uuid, node, coordinator);
-                    _repair.local().removenode_with_repair(get_token_metadata_ptr(), _gossiper.get_host_id(node), ops).get();
+                    do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                        return local_repair.removenode_with_repair(get_token_metadata_ptr(), _gossiper.get_host_id(node), ops);
+                    }).get();
                 } else {
                     slogger.info("removenode[{}]: Started to sync data for removing node={} using stream, coordinator={}", req.ops_uuid, node, coordinator);
                     removenode_with_stream(get_token_metadata().get_host_id(node), topo_guard, as).get();
@@ -4883,7 +4897,9 @@ future<> storage_service::rebuild(utils::optional_param source_dc) {
             auto tmptr = ss.get_token_metadata_ptr();
             auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
             if (ss.is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
-                co_await ss._repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(source_dc));
+                co_await do_with_repair_service(ss._repair, [&] (repair_service& local_repair) {
+                    return local_repair.rebuild_with_repair(std::move(ks_erms), tmptr, std::move(source_dc));
+			    });
             } else {
                 auto streamer = make_lw_shared<dht::range_streamer>(ss._db, ss._stream_manager, tmptr, ss._abort_source,
                         tmptr->get_my_id(), ss._snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, null_topology_guard);
@@ -5005,7 +5021,9 @@ future<> storage_service::unbootstrap() {
     slogger.info("Finished batchlog replay for decommission");
 
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::decommission)) {
-        co_await _repair.local().decommission_with_repair(get_token_metadata_ptr());
+        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+            return local_repair.decommission_with_repair(get_token_metadata_ptr());
+	    });
     } else {
         std::unordered_map<sstring, std::unordered_multimap<dht::token_range, locator::host_id>> ranges_to_stream;
 
@@ -5677,7 +5695,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     if (is_repair_based_node_ops_enabled(streaming::stream_reason::bootstrap)) {
                                         co_await utils::get_local_injector().inject("delay_bootstrap_120s", std::chrono::seconds(120));
 
-                                        co_await _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens);
+                                        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                                            return local_repair.bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens);
+                                        });
                                     } else {
                                         dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                             locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
@@ -5703,7 +5723,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                     auto tmptr = get_token_metadata_ptr();
                                     auto replaced_node = locator::host_id(replaced_id.uuid());
-                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node);
+                                    co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                                        return local_repair.replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node);
+                                    });
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
@@ -5761,7 +5783,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     ignored_ips.push_back(*ip);
                                 }
                                 auto ops = seastar::make_shared<node_ops_info>(node_ops_id::create_random_id(), as, std::move(ignored_ips));
-                                return _repair.local().removenode_with_repair(get_token_metadata_ptr(), id, ops);
+                                return do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                                    return local_repair.removenode_with_repair(get_token_metadata_ptr(), id, ops);
+                                });
                             } else {
                                 return removenode_with_stream(id, _topology_state_machine._topology.session, as);
                             }
@@ -5787,7 +5811,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 if (!source_dc.empty()) {
                                     sdc_param.emplace(source_dc).set_user_provided().set_force(force);
                                 }
-                                co_await _repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param));
+                                co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+                                    return local_repair.rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param));
+                                });
                             } else {
                                 auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
                                         tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, _topology_state_machine._topology.session);
@@ -5976,7 +6002,9 @@ future<> storage_service::repair_tablet(locator::global_tablet_id tablet) {
 
         utils::get_local_injector().inject("repair_tablet_fail_on_rpc_call",
             [] { throw std::runtime_error("repair_tablet failed due to error injection"); });
-        co_await _repair.local().repair_tablet(_address_map, guard, tablet);
+        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
+            return local_repair.repair_tablet(_address_map, guard, tablet);
+        });
         co_return;
     });
 }


### PR DESCRIPTION
In main.cc storage_service is started before and stopped after repair_service. storage_service keeps a reference to sharded repair_service and calls its methods, but nothing ensures that repair_service's local instance would be alive for the whole execution of the method.

Add a gate to repair_service and enter it in storage_service before executing methods on local instances of repair_service.

Fixes: #21964.

Requires backport to 6.1. and 6.2. as they contain the bug