### PR TITLE
treewide: fix misspellings

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -785,8 +785,8 @@ messaging_service::get_rpc_client_idx(messaging_verb verb) {
     // 2. We are running in a scheduling group that is not assigned to one of the
     // static tenants (e.g $system)
     // If this scheduling group is of one of the system's static statement tenants we
-    // whould have caught it in the loop above.
-    // The other posibility is that we are running in a scheduling group belongs to
+    // would have caught it in the loop above.
+    // The other possibility is that we are running in a scheduling group belongs to
     // a service level, maybe a deleted one, this is why it is possible that we will
     // not find the service level name.
 
@@ -852,8 +852,8 @@ messaging_service::scheduling_group_for_isolation_cookie(const sstring& isolatio
 
     // We first check if this is a statement isolation cookie - if it is, we will search for the
     // appropriate service level in the service_level_controller since in can be that
-    // _scheduling_info_for_connection_index is not yet updated (drop readd case for example)
-    // in the future we will only fall back here for new service levels that havn't been referenced
+    // _scheduling_info_for_connection_index is not yet updated (drop read case for example)
+    // in the future we will only fall back here for new service levels that haven't been referenced
     // before.
     // It is safe to assume that an unknown connection type can be rejected since a connection
     // with an unknown purpose on the inbound side is useless.
@@ -910,9 +910,9 @@ messaging_service::scheduling_group_for_isolation_cookie(const sstring& isolatio
         // create a new service level (internally), it will naturally catch up eventually and by creating it here we prevent
         // an rpc connection for a valid service level to permanently get stuck in the default service level scheduling group.
         // If we can't create the service level (we already have too many service levels), we will reject the connection by returning
-        // an exeptional future.
+        // an exceptional future.
         qos::service_level_options slo;
-        // We put here the minimal ammount of shares for this service level to be functional. When the node catches up it will
+        // We put here the minimal amount of shares for this service level to be functional. When the node catches up it will
         // be either deleted or the number of shares and other configuration options will be updated.
         slo.shares.emplace<int32_t>(1000);
         slo.shares_name.emplace(service_level_name);

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -8,7 +8,7 @@
 
 #include "reader_concurrency_semaphore_group.hh"
 
-// Calling adjust is serialized since 2 adjustments can't happen simultaneosly,
+// Calling adjust is serialized since 2 adjustments can't happen simultaneously,
 // if they did the behaviour would be undefined.
 future<> reader_concurrency_semaphore_group::adjust() {
     return with_semaphore(_operations_serializer, 1, [this] () {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2253,7 +2253,7 @@ future<> database::start(sharded<qos::service_level_controller>& sl_controller) 
     if (!_reader_concurrency_semaphores_group.get_or_null(_dbcfg.statement_scheduling_group)) {
         // This is super ugly, we need to either force the database to use system scheduling group for non-user queries
         // or, if we have user queries running on this scheduling group make it's definition more robust (what runs in it).
-        // Another ugly thing here is that we have to have a pre-existing knowladge about the shares ammount this group was
+        // Another ugly thing here is that we have to have a pre-existing knowledge about the shares amount this group was
         // built with. I think we should have a followup that makes this more robust.
         _reader_concurrency_semaphores_group.add_or_update(_dbcfg.statement_scheduling_group, 1000);
         _view_update_read_concurrency_semaphores_group.add_or_update(_dbcfg.statement_scheduling_group, 1000);
@@ -2269,7 +2269,7 @@ future<> database::start(sharded<qos::service_level_controller>& sl_controller) 
     for (auto&& service_level_record : service_levels) {
         auto service_level = sl_controller.local().get_service_level(service_level_record.first);
         if (service_level.slo.shares_name && *service_level.slo.shares_name != qos::service_level_controller::default_service_level_name) {
-            // We know slo.shares is valid becuse we know that slo.shares_name is valid
+            // We know slo.shares is valid because we know that slo.shares_name is valid
             _reader_concurrency_semaphores_group.add_or_update(service_level.sg, std::get<int32_t>(service_level.slo.shares));
             _view_update_read_concurrency_semaphores_group.add_or_update(service_level.sg, std::get<int32_t>(service_level.slo.shares));
         }


### PR DESCRIPTION
these misspellings were identified by codespell. let's fix them.

---

it's a cleanup, hence no need to backport.