### PR TITLE
test.py: BoostTestSuite: fix combined_tests exe_path

### DIFF
--- a/test.py
+++ b/test.py
@@ -373,7 +373,7 @@ class BoostTestSuite(UnitTestSuite):
 
     def _generate_cache(self) -> None:
         # Apply combined test only for test/boost
-        exe_path = pathlib.Path(self.mode, "test", self.name, 'combined_tests')
+        exe_path = pathlib.Path("build", self.mode, "test", self.name, 'combined_tests')
         if self.name != 'boost' or not exe_path.exists():
             return
         exe = path_to(self.mode, "test", self.name, 'combined_tests')


### PR DESCRIPTION
The current exe_path is missing the build/ component so it is never found and so the test cases cache
is not populated for all the tests in contains.

Fixes #22086

* No backport required since combined_tests is currently only in the master branch