### PR TITLE
[Backport 6.1] raft: improve logs for abort while waiting for apply

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -586,7 +586,9 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
     check_not_aborted();
 
     if (as && as->abort_requested()) {
-        throw request_aborted(format("Abort requested before waiting for entry with idx: {}, term: {}", eid.idx, eid.term));
+        throw request_aborted(format(
+                "Abort requested before waiting for entry with idx: {}, term: {}; last committed entry: {}, last applied entry: {}",
+                eid.idx, eid.term, _fsm->commit_idx(), _applied_idx));
     }
 
     auto& container = type == wait_type::committed ? _awaited_commits : _awaited_applies;
@@ -634,9 +636,11 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
     }
     assert(inserted);
     if (as) {
-        it->second.abort = as->subscribe([it = it, &container] noexcept {
+        it->second.abort = as->subscribe([this, it = it, &container] noexcept {
             it->second.done.set_exception(
-                request_aborted(format("Abort requested while waiting for entry with idx: {}, term: {}", it->first, it->second.term)));
+                request_aborted(format(
+                        "Abort requested while waiting for entry with idx: {}, term: {}; last committed entry: {}, last applied entry: {}",
+                        it->first, it->second.term, _fsm->commit_idx(), _applied_idx)));
             container.erase(it);
         });
         assert(it->second.abort);
@@ -1447,7 +1451,9 @@ term_t server_impl::get_current_term() const {
 
 future<> server_impl::wait_for_apply(index_t idx, abort_source* as) {
     if (as && as->abort_requested()) {
-        throw request_aborted(format("Aborted before waiting for applying entry: {}, last applied entry: {}", idx, _applied_idx));
+        throw request_aborted(format(
+                "Aborted before waiting for applying entry: {}, last committed entry: {}, last applied entry: {}",
+                idx, _fsm->commit_idx(), _applied_idx));
     }
 
     check_not_aborted();
@@ -1459,7 +1465,9 @@ future<> server_impl::wait_for_apply(index_t idx, abort_source* as) {
         if (as) {
             it->second.abort = as->subscribe([this, it] noexcept {
                 it->second.promise.set_exception(
-                    request_aborted(format("Aborted while waiting to apply entry: {}, last applied entry: {}", it->first, _applied_idx)));
+                    request_aborted(format(
+                            "Aborted while waiting to apply entry: {}, last committed entry: {}, last applied entry: {}",
+                            it->first, _fsm->commit_idx(), _applied_idx)));
                 _awaited_indexes.erase(it);
             });
             assert(it->second.abort);


### PR DESCRIPTION
New logs allow us to easily distinguish two cases in which
waiting for apply times out:
- the node didn't receive the entry it was waiting for,
- the node received the entry but didn't apply it in time.

Distinguishing these cases simplifies reasoning about failures.
The first case indicates that something went wrong on the leader.
The second case indicates that something went wrong on the node
on which waiting for apply timed out.

As it turns out, many different bugs result in the `read_barrier`
(which calls `wait_for_apply`) timeout. This change should help
us in debugging bugs like these.

We want to backport this change to all supported branches so that
it helps us in all tests.

Fixes scylladb/scylladb#22160