### PR TITLE
error_injection: replace boost::lexical_cast with std::from_chars

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -13,6 +13,7 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/join.hpp>
+#include <boost/lexical_cast.hpp>
 #include <map>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/future-util.hh>

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "utils/assert.hh"
+#include "utils/from_chars_exactly.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/seastar.hh>
@@ -26,9 +27,6 @@
 #include <type_traits>
 #include <optional>
 #include <unordered_map>
-
-#include <boost/lexical_cast.hpp>
-
 
 namespace utils {
 
@@ -163,7 +161,10 @@ class error_injection {
             if constexpr (std::is_same_v<T, std::string_view>) {
                 return s;
             } else {
-                return boost::lexical_cast<T>(s.data(), s.size());
+                return utils::from_chars_exactly<T>(s, [&] (std::string_view s) {
+                    return std::runtime_error(fmt::format("Failed to convert injected value [{}] for parameter [{}], injection [{}]",
+                        s, name, injection_name));
+                });
             }
         }
     };

--- a/utils/from_chars_exactly.hh
+++ b/utils/from_chars_exactly.hh
@@ -1,0 +1,26 @@
+// Copyright (C) 2025-present ScyllaDB
+// SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+#pragma once
+
+#include <charconv>
+#include <concepts>
+#include <string_view>
+
+namespace utils {
+
+// Parses a string into a number, throwing an exception if the entire string is not consumed
+// or a conversion error happens. The exception is created by calling the provided callable.
+template <typename T>
+requires std::integral<T> || std::floating_point<T>
+T
+from_chars_exactly(std::string_view str, std::invocable<std::string_view> auto&& make_exception) {
+    T result;
+    auto [ptr, ec] = std::from_chars(str.data(), str.data() + str.size(), result);
+    if (ptr != str.data() + str.size() || ec != std::errc{}) {
+        throw make_exception(str);
+    }
+    return result;
+}
+
+}


### PR DESCRIPTION
Replace boost with a standard facility; this reduces dependencies as lexical_cast depends on boost ranges.

Since std::from_chars() is chatty, we introduce utils::from_chars_exactly() to trade some flexibility for conciseness.


Small build time improvement, no backport needed.