### PR TITLE
Clean up test/alternator mistakes that service levels introduced

### DIFF
--- a/test/alternator/run
+++ b/test/alternator/run
@@ -115,19 +115,6 @@ run.wait_for_services(pid, [
     lambda: check_alternator(alternator_url),
 ])
 
-# Set up the the proper authentication credentials needed by the Alternator
-# test. Currently this can only be done through CQL, which is why above we
-# needed to make sure CQL is available.
-cluster = run.get_cql_cluster(ip)
-cql = cluster.connect()
-
-# Additional role and service level are created to test the feature properly (alternator doesn't have it's own API to set it up so we need to use CQL).
-cql.execute("INSERT INTO system_auth_v2.roles (role, salted_hash) VALUES ('alternator_custom_sl', 'secret_pass')")
-cql.execute("CREATE SERVICE LEVEL sl_alternator")
-cql.execute("ATTACH SERVICE LEVEL sl_alternator TO alternator_custom_sl")
-
-cluster.shutdown()
-
 # Finally run pytest:
 success = run.run_pytest(sys.path[0], ['--url', alternator_url] + sys.argv[1:])
 

--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -1,10 +1,5 @@
 type: Python
 pool_size: 6
-prepare_cql:
-    - INSERT INTO system.roles (role, can_login, salted_hash) VALUES ('alternator_custom_sl', true, 'secret_pass')
-    - CREATE SERVICE LEVEL sl_alternator
-    - ATTACH SERVICE LEVEL sl_alternator TO alternator_custom_sl
-
 run_first:
     - test_streams
     - test_scan

--- a/test/alternator/test_service_levels.py
+++ b/test/alternator/test_service_levels.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import pytest
-from test.alternator.util import random_string, is_aws
 from test.alternator.conftest import new_dynamodb_session
 from test.alternator.test_metrics import metrics, get_metrics, check_increases_metric
 from contextlib import contextmanager
@@ -13,83 +12,47 @@ from cassandra.policies import RoundRobinPolicy
 import time
 import re
 
-# Quote an identifier if it needs to be double-quoted in CQL. Quoting is
-# *not* needed if the identifier matches [a-z][a-z0-9_]*, otherwise it does.
-# double-quotes ('"') in the string are doubled.
-def maybe_quote(identifier):
-    if re.match('^[a-z][a-z0-9_]*$', identifier):
-        return identifier
-    return '"' + identifier.replace('"', '""') + '"'
+from .util import random_string, is_aws, unique_table_name
+from .test_cql_rbac import new_role, new_dynamodb
 
-# Convenience context manager for temporarily GRANTing some permission and
-# then revoking it.
+# new_service_level() is a context manager for temporarily creating a new
+# service level with a unique name and attaching it to the given role.
+# The fixture returns the new service level's name.
 @contextmanager
-def temporary_grant(cql, permission, resource, role):
-    role = maybe_quote(role)
-    cql.execute(f"GRANT {permission} ON {resource} TO {role}")
+def new_service_level(cql, role):
+    # The service level name is not a table's name but it doesn't matter.
+    # Because our unique_table_name() uses (deliberately) a non-lower-case
+    # character, the role name has to be quoted in double quotes when used
+    # in CQL below.
+    sl = unique_table_name()
+    cql.execute(f'CREATE SERVICE LEVEL "{sl}"')
+    cql.execute(f'ATTACH SERVICE LEVEL "{sl}" TO "{role}"')
     try:
-        yield
+        yield sl
     finally:
-        cql.execute(f"REVOKE {permission} ON {resource} FROM {role}")
-
-# Convenience function for getting the full CQL table name (ksname.cfname)
-# for the given Alternator table. This uses our insider knowledge that
-# table named "x" is stored in keyspace called "alternator_x", and if we
-# ever change this we'll need to change this function too.
-def cql_table_name(tab):
-    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name)
-
-# This file is all about testing RBAC as configured via CQL, so we need to
-# connect to CQL to set these tests up. The "cql" fixture below enables that.
-# If we're not testing Scylla, or the CQL port is not available on the same
-# IP address as the Alternator IP address, a test using this fixture will
-# be skipped with a message about the CQL API not being available.
-@pytest.fixture(scope="module")
-def cql(dynamodb):
-    if is_aws(dynamodb):
-        pytest.skip('Scylla-only CQL API not supported by AWS')
-    url = dynamodb.meta.client._endpoint.host
-    host, = re.search(r'.*://([^:]*):', url).groups()
-    profile = ExecutionProfile(
-        load_balancing_policy=RoundRobinPolicy(),
-        consistency_level=ConsistencyLevel.LOCAL_QUORUM,
-        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL)
-    cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-        contact_points=[host],
-        port=9042,
-        protocol_version=4,
-        auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
-    )
-    try:
-        ret = cluster.connect()
-        # "BEGIN BATCH APPLY BATCH" is the closest to do-nothing I could find
-        ret.execute("BEGIN BATCH APPLY BATCH")
-    except NoHostAvailable:
-        pytest.skip('Could not connect to Scylla-only CQL API')
-    yield ret
-    cluster.shutdown()
+        cql.execute(f'DROP SERVICE LEVEL "{sl}"')
 
 def test_service_level_metrics(test_table, request, dynamodb, cql, metrics):
     print("Please make sure authorization is enforced in your Scylla installation: alternator_enforce_authorization: true")
     p = random_string()
     c = random_string()
     _ = get_metrics(metrics)
-    # Use additional user created by test/alternator/run to execute write under sl_alternator service level.
-    ses = new_dynamodb_session(request, dynamodb, user='alternator_custom_sl')
-    # service_level_controler acts asynchronously in a loop so we can fail metric check
-    # if it hasn't processed service level update yet. It can take as long as 10 seconds.
-    started = time.time()
-    timeout = 30
-    while True:
-        try:
-            with temporary_grant(cql, 'MODIFY', cql_table_name(test_table), 'alternator_custom_sl'):
-              with check_increases_metric(metrics,
-                                        ['scylla_storage_proxy_coordinator_write_latency_count'],
-                                        {'scheduling_group_name': 'sl:sl_alternator'}):
-                ses.meta.client.put_item(TableName=test_table.name, Item={'p': p, 'c': c})
-            break # no exception, test passed
-        except:
-            if time.time() - started > timeout:
-                raise
-            else:
-                time.sleep(0.5) # retry
+    with new_role(cql, superuser=True) as (role, key):
+        with new_service_level(cql, role) as sl:
+            with new_dynamodb(dynamodb, role, key) as ses:
+            # service_level_controler acts asynchronously in a loop so we can fail metric check
+            # if it hasn't processed service level update yet. It can take as long as 10 seconds.
+                started = time.time()
+                timeout = 30
+                while True:
+                    try:
+                        with check_increases_metric(metrics,
+                                            ['scylla_storage_proxy_coordinator_write_latency_count'],
+                                            {'scheduling_group_name': f'sl:{sl}'}):
+                            ses.meta.client.put_item(TableName=test_table.name, Item={'p': p, 'c': c})
+                        break # no exception, test passed
+                    except:
+                        if time.time() - started > timeout:
+                            raise
+                        else:
+                            time.sleep(0.5) # retry


### PR DESCRIPTION
The recent pull request https://github.com/scylladb/scylladb/pull/22031 introduced some regressions into the test/alternator framework. For a long time now, tests can create their own CQL roles for testing role-based features. But the new service levels test changed the "run" script and test.py's "suite.yaml" to create a new role and service level just for one test. This is not only ugly (the test code is now split to two places) and unnecessary, this setup also means that you can't run this test against an already-running copy of Scylla which wasn't prepared with the "right" role and service level. Even worse - the code that was added test/alternator/run was plain wrong - it used an outdated keyspace name (the code in suite.yaml was fine).

So in this patch I remove that extra run and suite.yaml code, and replace it by code inside the service level test to create the role and service level that it wants to test rather than assume it already exists.
While at it, I also removed a lot of duplicate and unnecessary code from this test.

After this patch, test/alternator/run returns to work correctly, after #22031 broke it.

This patch fixes a recent testing-framework regression, so doesn't need to be backported (unless that regression is backported).

Fixes #22047.