### PR TITLE
docs: remove "ScyllaDB Enterprise" labels

### DIFF
--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -257,8 +257,6 @@ The following options only apply to IncrementalCompactionStrategy:
 
 ``space_amplification_goal`` (default: null)
 
-:label-tip:`ScyllaDB Enterprise`
-
    .. versionadded:: 2020.1.6
 
    This is a threshold of the ratio of the sum of the sizes of the two largest tiers to the size of the largest tier,

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -2,8 +2,6 @@
 Workload Prioritization
 ========================
 
-:label-tip:`ScyllaDB Enterprise`
-
 In a typical database there are numerous workloads running at the same time.
 Each workload type dictates a different acceptable level of latency and throughput.
 For example, consider the following two workloads:

--- a/docs/kb/compaction.rst
+++ b/docs/kb/compaction.rst
@@ -43,7 +43,7 @@ A compaction strategy is what determines which of the SSTables will be compacted
 
 * `Size-tiered compaction strategy (STCS)`_ - (default setting) triggered when the system has enough similarly sized SSTables.
 * `Leveled compaction strategy (LCS)`_ - the system uses small, fixed-size (by default 160 MB) SSTables divided into different levels and  lowers both Read and Space Amplification. 
-* :ref:`Incremental compaction strategy (ICS) <incremental-compaction-strategy-ics>` - :label-tip:`ScyllaDB Enterprise` Uses runs of sorted, fixed size (by default 1 GB) SSTables in a similar way that LCS does, organized into size-tiers, similar to STCS size-tiers. If you are an Enterprise customer ICS is an updated strategy meant to replace STCS. It has the same read and write amplification, but has lower space amplification due to the reduction of temporary space overhead is reduced to a constant manageable level. 
+* :ref:`Incremental compaction strategy (ICS) <incremental-compaction-strategy-ics>` - Uses runs of sorted, fixed size (by default 1 GB) SSTables in a similar way that LCS does, organized into size-tiers, similar to STCS size-tiers. ICS is an updated strategy meant to replace STCS. It has the same read and write amplification, but has lower space amplification due to the reduction of temporary space overhead is reduced to a constant manageable level.
 * `Time-window compaction strategy (TWCS)`_ - designed for time series data and puts data in time order. TWCS uses STCS to prevent accumulating  SSTables in a window not yet closed. When the window closes, TWCS works towards reducing the SSTables in a time window to one.
 
 How to Set a Compaction Strategy
@@ -115,8 +115,8 @@ Likewise, when :term:`bootstrapping<Bootstrap>` a new node, SSTables are streame
 
 .. _incremental-compaction-strategy-ics:
 
-Incremental Compaction Strategy (ICS) :label-tip:`ScyllaDB Enterprise`
-------------------------------------------------------------------------
+Incremental Compaction Strategy (ICS)
+-------------------------------------
 
 .. versionadded:: 2019.1.4
 

--- a/docs/operating-scylla/procedures/config-change/advanced-internode-compression.rst
+++ b/docs/operating-scylla/procedures/config-change/advanced-internode-compression.rst
@@ -2,8 +2,6 @@
 Advanced Internode (RPC) Compression
 ==========================================
 
-:label-tip:`Available with the Premium plan`
-
 Internode (RPC) compression controls whether traffic between nodes is
 compressed. If enabled, it reduces network bandwidth usage.
 

--- a/docs/operating-scylla/security/security-checklist.rst
+++ b/docs/operating-scylla/security/security-checklist.rst
@@ -41,8 +41,8 @@ Configure ScyllaDB to use TLS/SSL for all the connections. Use TLS/SSL to encryp
 
 * :doc:`Encryption Data in Transit Node to Node </operating-scylla/security/node-node-encryption>`
 
-Encryption at Rest :label-tip:`ScyllaDB Enterprise`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Encryption at Rest
+~~~~~~~~~~~~~~~~~~
 Encryption at Rest is available in `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_.
 
 Encryption at Rest protects the privacy of your user's data, reduces the risk of data breaches, and helps meet regulatory requirements. 


### PR DESCRIPTION
remove the "ScyllaDB Enterprise" labels in document. because there is no need to differentiate ScyllaDB Enterprise from its OSS variant, let's stop adding the "ScyllaDB Enterprise" labels to enterprise-only features. this helps to reduce the confusion.

as we are still in the process of porting the enterprise features to this repo, this change does not fix scylladb/scylladb#22175. we will review the document again when completing the migration.

Refs scylladb/scylladb#22175
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

the enterprise migration only applies to the master branch, hence no need to backport.