### PR TITLE
api: include "smaller" header

### DIFF
--- a/api/service_levels.hh
+++ b/api/service_levels.hh
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "api.hh"
+#include "api/api_init.hh"
 
 namespace api {
 


### PR DESCRIPTION
Previously, `api/service_levels.hh` includes `api/api.hh` for accessing symbols like `api/http_context`. but these symbols are already available in a "smaller" header -- `api/api_init.hh`. so, in order to improve the build efficiency, let's include smaller headers in favor of "larger" ones.

---

it's a cleanup, hence no need to backport.