### PR TITLE
view_builder: register listener for new views before reading views

### DIFF
--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2053,8 +2053,8 @@ future<> view_builder::start_in_background(service::migration_manager& mm, utils
         co_await barrier.arrive_and_wait();
         units.return_all();
 
-        co_await calculate_shard_build_step(vbi);
         _mnotifier.register_listener(this);
+        co_await calculate_shard_build_step(vbi);
         _current_step = _base_to_build_step.begin();
         // Waited on indirectly in stop().
         (void)_build_step.trigger();


### PR DESCRIPTION
When starting the view builder, we find all existing views in `calculate_shard_build_step` and then register a listener for new views. Between these steps we may yield and create a new view, then we miss initializing the view build step for the new view, and we won't start building it.

To fix this we first register the listener and then read existing views, so a view can't be missed.

Fixes scylladb/scylladb#20338

backport is not required, it is mostly affecting CI stability