### PR TITLE
compaction: do not include unused headers

### DIFF
--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -6,6 +6,7 @@
 
 #include "incremental_backlog_tracker.hh"
 #include "sstables/sstables.hh"
+#include <boost/range/adaptor/map.hpp>
 
 using namespace sstables;
 

--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -11,6 +11,7 @@
 #include "compaction_manager.hh"
 #include "incremental_compaction_strategy.hh"
 #include "incremental_backlog_tracker.hh"
+#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptors.hpp>

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -7,12 +7,7 @@
 #pragma once
 
 #include "compaction_strategy_impl.hh"
-#include "compaction.hh"
-#include <boost/range/adaptor/transformed.hpp>
-#include <boost/range/adaptors.hpp>
 #include <boost/range/algorithm.hpp>
-#include <boost/algorithm/cxx11/any_of.hpp>
-#include "size_tiered_compaction_strategy.hh"
 
 class incremental_backlog_tracker;
 


### PR DESCRIPTION
these unused includes are identified by clang-include-cleaner.

---

it's a cleanup, hence no need to backport.