### PR TITLE
docs/kb: correct referenced git sha1 and version number

### DIFF
--- a/docs/kb/garbage-collection-ics.rst
+++ b/docs/kb/garbage-collection-ics.rst
@@ -31,7 +31,7 @@ The process above has several drawbacks; for example:
 Making Garbage Collection Efficient in ICS
 ---------------------------------------------
 
-As a remedy to the known problem described above, a new process was introduced to ScyllaDB with `this commit <https://github.com/scylladb/scylla-enterprise/commit/7d90911c5fb3fa891ad64a62147c3a6ca26d61b1>`_.
+As a remedy to the known problem described above, a new process was introduced to ScyllaDB with `this commit <https://github.com/scylladb/scylladb/commit/c97325436237516fcec97eeb1f283674ea1fef1c>`_.
 The process inherits the cross-tier compaction idea from SAG, but instead of using a space-amplification-based trigger, 
 it uses a tombstone-density trigger instead. It can co-exist with SAG, if enabled.
 
@@ -51,7 +51,7 @@ procedure.
 How to Use It
 ---------------
 
-ICS garbage collection is enabled by default starting from version 2021.1.9.
+ICS garbage collection is enabled by default.
 
 As in STCS, you can use the compaction options ``tombstone_threshold`` and ``tombstone_compaction_interval`` to tweak the behavior 
 of the GC process.


### PR DESCRIPTION
in 047ce136, we cherry-picked the change adding
garbage-collection-ics.rst to the document. but it was still referencing the git sha1 and version number in enterprise.

this change updates kb/garbage-collection-ics.rst, so that it

* references the git commit sha1 in this repo
* references the version number of the packages built from this this repo.

---

no need to backport this change, as the change introducing the changed file has not been included by any LTS branches yet.