### PR TITLE
locator: do not include unused headers

### DIFF
--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -12,11 +12,9 @@
 #include <functional>
 #include <unordered_map>
 #include "gms/inet_address.hh"
-#include "locator/snitch_base.hh"
 #include "locator/token_range_splitter.hh"
 #include "dht/token-sharding.hh"
 #include "token_metadata.hh"
-#include "snitch_base.hh"
 #include "utils/maybe_yield.hh"
 #include "utils/sequenced_set.hh"
 #include "utils/simple_hashers.hh"

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -11,7 +11,7 @@
 #include "dht/token-sharding.hh"
 #include "locator/tablets.hh"
 #include "locator/token_metadata.hh"
-#include "utils/to_string.hh"
+#include <fmt/std.h>
 
 namespace locator {
 

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -15,7 +15,6 @@
 #include <functional>
 #include <unordered_set>
 #include <unordered_map>
-#include <compare>
 #include <iostream>
 #include <random>
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -20,6 +20,7 @@
 #include "service/qos/service_level_controller.hh"
 #include "service/topology_guard.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "locator/snitch_base.hh"
 #include "locator/tablets.hh"
 #include "locator/tablet_metadata_guard.hh"
 #include "inet_address_vectors.hh"

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <boost/range/adaptor/map.hpp>
 #include <fmt/ranges.h>
+#include <fmt/std.h>
 
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -11,6 +11,7 @@
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
 #include "locator/types.hh"
+#include "locator/snitch_base.hh"
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/sequenced_set.hh"

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -30,6 +30,7 @@
 #include "locator/tablet_replication_strategy.hh"
 #include "locator/tablet_sharder.hh"
 #include "locator/load_sketch.hh"
+#include "locator/snitch_base.hh"
 #include "utils/UUID_gen.hh"
 #include "utils/error_injection.hh"
 #include "utils/to_string.hh"


### PR DESCRIPTION
these unused includes were identifier by clang-include-cleaner. after auditing these source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.