### PR TITLE
utils: do not include unused headers

### DIFF
--- a/api/config.cc
+++ b/api/config.cc
@@ -14,6 +14,7 @@
 #include "replica/database.hh"
 #include "db/config.hh"
 #include <sstream>
+#include <fmt/ranges.h>
 #include <boost/algorithm/string/replace.hpp>
 #include <seastar/http/exception.hh>
 

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -10,8 +10,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <fmt/ranges.h>
-#include <fmt/ostream.h>
 
 #include <unordered_map>
 #include <string_view>

--- a/utils/disk_space_monitor.hh
+++ b/utils/disk_space_monitor.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <filesystem>
 
 #include <boost/signals2/connection.hpp>
@@ -18,7 +17,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
-#include <seastar/core/timer.hh>
 #include <seastar/util/optimized_optional.hh>
 
 #include "seastarx.hh"


### PR DESCRIPTION
these unused includes were identifier by clang-include-cleaner. after auditing these source files, all of the reports have been confirmed.

---

it's a cleanup, hence no need to backport.