### PR TITLE
utils/dict_trainer: silence an ERROR log when raft is aborted during dict publication

### DIFF
--- a/utils/dict_trainer.cc
+++ b/utils/dict_trainer.cc
@@ -14,6 +14,7 @@
 #include "utils/alien_worker.hh"
 #include "utils/shared_dict.hh"
 #include "utils/hashers.hh"
+#include "raft/raft.hh"
 #include <zdict.h>
 
 using namespace seastar;
@@ -152,6 +153,8 @@ seastar::future<> dict_training_loop::start(
             dict_trainer_logger.debug("dict_training_loop: publishing...");
             co_await emit(dict_data);
             dict_trainer_logger.debug("dict_training_loop: published...");
+        } catch (const raft::request_aborted&) {
+            dict_trainer_logger.debug("dict_training_loop: raft aborted while publishing");
         } catch (...) {
             if (_cancelled.abort_requested()) {
                 dict_trainer_logger.debug("dict_training_loop: cancelled");


### PR DESCRIPTION
The dict publication routine might throw raft::request_aborted when the node is aborted. This doesn't deserve an ERROR log. Let's demote the log printed in this case from ERROR to DEBUG.

Fixes scylladb/scylladb#22081

Dictionary training isn't in any stable open-source branches yet, so no backport needed. We might want to backport it to stable enterprise branches, though.