### PR TITLE
mv: forbid creating views using tablets

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -87,6 +87,9 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
                 "Secondary indexes are not supported on COMPACT STORAGE tables that have clustering columns");
     }
 
+    if (!db.features().views_with_tablets && db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets()) {
+        throw exceptions::invalid_request_exception(format("Secondary indexes are not supported on base tables with tablets (keyspace '{}')", keyspace()));
+    }
     validate_for_local_index(*schema);
 
     std::vector<::shared_ptr<index_target>> targets;

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -140,6 +140,9 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
 
     schema_ptr schema = validation::validate_column_family(db, _base_name.get_keyspace(), _base_name.get_column_family());
 
+    if (!db.features().views_with_tablets && db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets()) {
+        throw exceptions::invalid_request_exception(format("Materialized views are not supported on base tables with tablets"));
+    }
     if (schema->is_counter()) {
         throw exceptions::invalid_request_exception(format("Materialized views are not supported on counter tables"));
     }


### PR DESCRIPTION
Materialized views with tablets are not stable yet, but we want them available as an experimental feature, mainly for teseting.

The feature was added in https://github.com/scylladb/scylladb/pull/21833, but currently it has no effect. All tests have been updated to use the feature, so we should finally make it work.
This patch prevents users from creating materialized views in keyspaces using tablets when the VIEWS_WITH_TABLETS feature is not enabled - such requests will now get rejected.

Fixes https://github.com/scylladb/scylladb/issues/21832

No need for backport