### PR TITLE
tools/scylla-sstable: dump-statistics: fix handling of {min,max}_column_names

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -450,8 +450,8 @@ The content is dumped in JSON, using the following schema:
         "estimated_tombstone_drop_time": $STREAMING_HISTOGRAM,
         "sstable_level": Uint,
         "repaired_at": Uint64,
-        "min_column_names": [Uint, ...],
-        "max_column_names": [Uint, ...],
+        "min_column_names": [String, ...],
+        "max_column_names": [String, ...],
         "has_legacy_counter_shards": Bool,
         "columns_count": Int64, // >= MC only
         "rows_count": Int64, // >= MC only

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1187,15 +1187,21 @@ class json_dumper {
     json_writer& _writer;
     sstables::sstable_version_types _version;
     std::function<std::string_view(const void* const)> _name_resolver;
+    std::function<sstring(const void* const, bytes_view)> _disk_string_converter;
+
+public:
+    static sstring default_disk_string_converter(const void* const, bytes_view value) {
+        return sstring(value.begin(), value.end());
+    }
 
 private:
-    void visit(int8_t val) { _writer.Int(val); }
-    void visit(uint8_t val) { _writer.Uint(val); }
-    void visit(int val) { _writer.Int(val); }
-    void visit(unsigned val) { _writer.Uint(val); }
-    void visit(int64_t val) { _writer.Int64(val); }
-    void visit(uint64_t val) { _writer.Uint64(val); }
-    void visit(double val) {
+    void visit(const void* const field, int8_t val) { _writer.Int(val); }
+    void visit(const void* const field, uint8_t val) { _writer.Uint(val); }
+    void visit(const void* const field, int val) { _writer.Int(val); }
+    void visit(const void* const field, unsigned val) { _writer.Uint(val); }
+    void visit(const void* const field, int64_t val) { _writer.Int64(val); }
+    void visit(const void* const field, uint64_t val) { _writer.Uint64(val); }
+    void visit(const void* const field, double val) {
         if (std::isnan(val)) {
             _writer.String("NaN");
         } else {
@@ -1204,42 +1210,42 @@ private:
     }
 
     template <typename Integer>
-    void visit(const sstables::disk_string<Integer>& val) {
-        _writer.String(disk_string_to_string(val));
+    void visit(const void* const field, const sstables::disk_string<Integer>& val) {
+        _writer.String(_disk_string_converter(field, val.value));
     }
 
     template <typename Contents>
-    void visit(const std::optional<Contents>& val) {
+    void visit(const void* const field, const std::optional<Contents>& val) {
         if (bool(val)) {
-            visit(*val);
+            visit(field, *val);
         } else {
             _writer.Null();
         }
     }
 
     template <typename Integer, typename T>
-    void visit(const sstables::disk_array<Integer, T>& val) {
+    void visit(const void* const field, const sstables::disk_array<Integer, T>& val) {
         _writer.StartArray();
         for (const auto& elem : val.elements) {
-            visit(elem);
+            visit(field, elem);
         }
         _writer.EndArray();
     }
 
-    void visit(const sstables::disk_string_vint_size& val) {
-        _writer.String(sstring(val.value.begin(), val.value.end()));
+    void visit(const void* const field, const sstables::disk_string_vint_size& val) {
+        _writer.String(_disk_string_converter(field, val.value));
     }
 
     template <typename T>
-    void visit(const sstables::disk_array_vint_size<T>& val) {
+    void visit(const void* const field, const sstables::disk_array_vint_size<T>& val) {
         _writer.StartArray();
         for (const auto& elem : val.elements) {
-            visit(elem);
+            visit(field, elem);
         }
         _writer.EndArray();
     }
 
-    void visit(const utils::estimated_histogram& val) {
+    void visit(const void* const field, const utils::estimated_histogram& val) {
         _writer.StartArray();
         for (size_t i = 0; i < val.buckets.size(); i++) {
             _writer.StartObject();
@@ -1252,7 +1258,7 @@ private:
         _writer.EndArray();
     }
 
-    void visit(const utils::streaming_histogram& val) {
+    void visit(const void* const field, const utils::streaming_histogram& val) {
         _writer.StartObject();
         for (const auto& [k, v] : val.bin) {
             _writer.Key(format("{}", k));
@@ -1261,7 +1267,7 @@ private:
         _writer.EndObject();
     }
 
-    void visit(const db::replay_position& val) {
+    void visit(const void* const field, const db::replay_position& val) {
         _writer.StartObject();
         _writer.Key("id");
         _writer.Uint64(val.id);
@@ -1270,30 +1276,30 @@ private:
         _writer.EndObject();
     }
 
-    void visit(const sstables::commitlog_interval& val) {
+    void visit(const void* const field, const sstables::commitlog_interval& val) {
         _writer.StartObject();
         _writer.Key("start");
-        visit(val.start);
+        visit(field, val.start);
         _writer.Key("end");
-        visit(val.end);
+        visit(field, val.end);
         _writer.EndObject();
     }
 
-    void visit(const utils::UUID& uuid) {
+    void visit(const void* const field, const utils::UUID& uuid) {
         _writer.String(fmt::to_string(uuid));
     }
 
     template <typename Tag>
-    void visit(const utils::tagged_uuid<Tag>& id) {
-        visit(id.uuid());
+    void visit(const void* const field, const utils::tagged_uuid<Tag>& id) {
+        visit(field, id.uuid());
     }
 
     template <typename Integer>
-    void visit(const sstables::vint<Integer>& val) {
-        visit(val.value);
+    void visit(const void* const field, const sstables::vint<Integer>& val) {
+        visit(field, val.value);
     }
 
-    void visit(const sstables::serialization_header::column_desc& val) {
+    void visit(const void* const field, const sstables::serialization_header::column_desc& val) {
         auto prev_name_resolver = std::exchange(_name_resolver, [&val] (const void* const field) {
             if (field == &val.name) { return "name"; }
             else if (field == &val.type_name) { return "type_name"; }
@@ -1307,28 +1313,34 @@ private:
         _name_resolver = std::move(prev_name_resolver);
     }
 
-    json_dumper(json_writer& writer, sstables::sstable_version_types version, std::function<std::string_view(const void* const)> name_resolver)
-        : _writer(writer), _version(version), _name_resolver(std::move(name_resolver)) {
+    json_dumper(json_writer& writer, sstables::sstable_version_types version, std::function<std::string_view(const void* const)> name_resolver,
+        std::function<sstring(const void* const, bytes_view string)> disk_string_converter)
+        : _writer(writer), _version(version), _name_resolver(std::move(name_resolver)), _disk_string_converter(std::move(disk_string_converter)) {
     }
 
 public:
     template <typename Arg1>
     void operator()(Arg1& arg1) {
         _writer.Key(_name_resolver(&arg1));
-        visit(arg1);
+        visit(&arg1, arg1);
     }
 
     template <typename Arg1, typename... Arg>
     void operator()(Arg1& arg1, Arg&... arg) {
         _writer.Key(_name_resolver(&arg1));
-        visit(arg1);
+        visit(&arg1, arg1);
         (*this)(arg...);
     }
 
     template <typename T>
-    static void dump(json_writer& writer, sstables::sstable_version_types version, const T& obj, std::string_view name,
-            std::function<std::string_view(const void* const)> name_resolver) {
-        json_dumper dumper(writer, version, std::move(name_resolver));
+    static void dump(
+            json_writer& writer,
+            sstables::sstable_version_types version,
+            const T& obj,
+            std::string_view name,
+            std::function<std::string_view(const void* const)> name_resolver,
+            std::function<sstring(const void* const, bytes_view string)> disk_string_converter = &json_dumper::default_disk_string_converter) {
+        json_dumper dumper(writer, version, std::move(name_resolver), std::move(disk_string_converter));
         writer.Key(name);
         writer.StartObject();
         const_cast<T&>(obj).describe_type(version, std::ref(dumper));
@@ -1376,6 +1388,11 @@ void dump_stats_metadata(json_writer& writer, sstables::sstable_version_types ve
         else if (field == &metadata.commitlog_intervals) { return "commitlog_intervals"; }
         else if (field == &metadata.originating_host_id) { return "originating_host_id"; }
         else { throw std::invalid_argument("invalid field offset"); }
+    }, [&metadata] (const void* const field, bytes_view value) {
+        if (field == &metadata.min_column_names || field == &metadata.max_column_names) {
+            return to_hex(value);
+        }
+        return json_dumper::default_disk_string_converter(field, value);
     });
 }
 


### PR DESCRIPTION
Said fields in statistics are of type `disk_array<uint32_t, disk_string<uint16_t>>` and currently are handled as array of regular strings. However these fields store exploded clustering keys, so the elements store binary data and converting to string can yield invalid UTF-8 characters that certain JSON parsers (jq, or python's json) can choke on. Fix this by treating them as binary and using `to_hex()` to convert them to string. This requires some massaging of the json_dumper: passing field offset to all visit() methods and using a caller-provided disk-string to sstring converter to convert disk strings to sstring, so in the case of statistics, these fields can be intercepted and properly handled.

While at it, the type of these fields is also fixed in the documentation.

Before:

    "min_column_names": [
      "��Z���\u0011�\u0012ŷ4^��<",
      "�2y\u0000�}\u007f"
    ],
    "max_column_names": [
      "��Z���\u0011�\u0012ŷ4^��<",
      "}��B\u0019l%^"
    ],

After:

    "min_column_names": [
      "9dd55a92bc8811ef12c5b7345eadf73c",
      "80327900e2827d7f"
    ],
    "max_column_names": [
      "9dd55a92bc8811ef12c5b7345eadf73c",
      "7df79242196c255e"
    ],

Fixes: https://github.com/scylladb/scylladb/issues/22078

This PR fixes an annoying bug which is present in all release and which prevents us from using scylla-sstable effectively in the field.