### PR TITLE
tools/scylla-sstable: also try reading scylla.yaml from /etc/scylla

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3172,9 +3172,19 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         if (app_config.count("scylla-yaml-file")) {
             scylla_yaml_path = app_config["scylla-yaml-file"].as<sstring>();
             scylla_yaml_path_source = "user provided";
+        } else if (std::getenv("SCYLLA_CONF") || std::getenv("SCYLLA_HOME")) {
+            scylla_yaml_path = db::config::get_conf_sub("scylla.yaml").string();
+            scylla_yaml_path_source = "environment provided";
         } else {
             scylla_yaml_path = db::config::get_conf_sub("scylla.yaml").string();
-            scylla_yaml_path_source = "default";
+            scylla_yaml_path_source = "dev default";
+
+            // On production machines, the default of ./conf/scylla.yaml will not
+            // work, try /etc/scylla/scylla.yaml instead.
+            if (!file_exists(scylla_yaml_path).get()) {
+                scylla_yaml_path = "/etc/scylla/scylla.yaml";
+                scylla_yaml_path_source = "prod default";
+            }
         }
 
         if (file_exists(scylla_yaml_path).get()) {


### PR DESCRIPTION
scylla-sstable tries to read scylla.yaml via the following sequence:
 1) Use user-provided location is provided (--scylla-yaml-file parameter)
 2) Use the environment variables SCYLLA_HOME and/or SCYLLA_CONF if set
 3) Use the default location ./conf/scylla.yaml

Step 3 is fine on dev machines, where the binaries are usually invoked from scylla.git, which does have conf/scylla.yaml, but it doesn't work on production machines, where the default location for scylla.yaml is /etc/scylla/scylla.yaml. To reduce friction when used on production machines, add another fallback in case (3) fails, which tries to read scylla.yaml from /etc/scylla/scylla.yaml location.

Fixes: scylladb/scylladb#22202

Improvement, no backport needed.