### PR TITLE
test/boost: memtable_test: unflake memtable_test_period

### DIFF
--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1037,7 +1037,7 @@ SEASTAR_TEST_CASE(memtable_flush_period) {
 
         sleep(500ms).get(); // wait until memtable will be flushed at least once
 
-        BOOST_REQUIRE_EQUAL(t.sstables_count(), 1); // check sstable exists after flush
+        eventually_true([&] { return t.sstables_count() == 1; }); // check sstable exists after flush
 
         // Check mutation presents in the table
         mutation_source ms = t.as_mutation_source();


### PR DESCRIPTION
Said test creates a table with no flush period, then manually alters it with a flush period of 200ms and expects a flush to happen in < 500ms. This assumes a flush can complete in 300ms, which sounds reasonable enough but have proven to be overly tight timeline on overloaded CI machines.
Change the check to eventually_true() to remove the flakyness from this test.

Fixes: #21965

Test not present in any release yet, no backport needed.