### PR TITLE
mutation_writer,redis: do not include unused headers

### DIFF
--- a/mutation_writer/partition_based_splitting_writer.hh
+++ b/mutation_writer/partition_based_splitting_writer.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <seastar/util/noncopyable_function.hh>
 #include "readers/mutation_reader.hh"
 
 namespace mutation_writer {

--- a/mutation_writer/shard_based_splitting_writer.hh
+++ b/mutation_writer/shard_based_splitting_writer.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <seastar/util/noncopyable_function.hh>
 #include "readers/mutation_reader.hh"
 
 namespace mutation_writer {

--- a/redis/abstract_command.hh
+++ b/redis/abstract_command.hh
@@ -7,17 +7,9 @@
  */
 
 #pragma once
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include <seastar/core/future.hh>
-#include <seastar/core/sstring.hh>
-#include "redis/request.hh"
 #include "redis/reply.hh"
-#include "db/consistency_level_type.hh"
-#include "db/timeout_clock.hh"
-#include "db/system_keyspace.hh"
-#include "keys.hh"
-#include "timestamp.hh"
-#include <unordered_map>
 
 class service_permit;
 

--- a/redis/exceptions.hh
+++ b/redis/exceptions.hh
@@ -8,9 +8,7 @@
 
 #pragma once
 
-#include <seastar/core/format.hh>
-
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 
 #include "seastarx.hh"
 

--- a/redis/lolwut.hh
+++ b/redis/lolwut.hh
@@ -10,7 +10,7 @@
 
 #include <seastar/core/future.hh>
 
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "seastarx.hh"
 
 namespace redis {

--- a/redis/mutation_utils.hh
+++ b/redis/mutation_utils.hh
@@ -9,7 +9,7 @@
 #pragma once
 #include <vector>
 #include <seastar/core/future.hh>
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "seastarx.hh"
 
 class service_permit;

--- a/redis/query_processor.hh
+++ b/redis/query_processor.hh
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <seastar/core/sharded.hh>
-#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/metrics_registration.hh>
 

--- a/redis/query_utils.hh
+++ b/redis/query_utils.hh
@@ -10,7 +10,7 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/future.hh>
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 #include "gc_clock.hh"
 #include "query-request.hh"
 

--- a/redis/reply.hh
+++ b/redis/reply.hh
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include "bytes.hh"
-#include <seastar/core/sharded.hh>
+#include "bytes_fwd.hh"
+#include <map>
+#include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
-#include <seastar/core/format.hh>
 #include <seastar/core/scattered_message.hh>
 #include "redis/exceptions.hh"
 

--- a/redis/request.hh
+++ b/redis/request.hh
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <vector>
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 
 namespace redis {
 

--- a/redis/version.hh
+++ b/redis/version.hh
@@ -7,7 +7,7 @@
  */
 
 #pragma once
-#include "bytes.hh"
+#include "bytes_fwd.hh"
 
 namespace redis {
 


### PR DESCRIPTION
the changes porting enterprise features to oss brought some used include to the tree. so let's remove them. these unused includes were identified by clang-include-cleaner.

---

it's a cleanup, hence no need to backport.