### PR TITLE
raft: Handle non-critical config update errors in when changing voter status.

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -857,6 +857,10 @@ future<add_entry_reply> server_impl::execute_modify_config(server_id from,
 }
 
 future<> server_impl::modify_config(std::vector<config_member> add, std::vector<server_id> del, seastar::abort_source* as) {
+    utils::get_local_injector().inject("raft/throw_commit_status_unknown_in_modify_config", [] {
+        throw raft::commit_status_unknown();
+    });
+
     if (!_config.enable_forwarding) {
         const auto leader = _fsm->current_leader();
         if (leader != _id) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -973,10 +973,9 @@ future<> raft_group0::modify_raft_voter_status(
 }
 
 future<> raft_group0::remove_from_raft_config(raft::server_id id) {
-    // TODO: add a timeout mechanism? This could get stuck (and _abort_source is only called on shutdown).
     co_await run_op_with_retry(_abort_source, [this, id]() -> future<operation_result> {
         try {
-            co_await _raft_gr.group0().modify_config({}, {id}, &_abort_source);
+            co_await _raft_gr.group0_with_timeouts().modify_config({}, {id}, &_abort_source, raft_timeout{});
         } catch (const raft::commit_status_unknown& e) {
             group0_log.info("remove_from_raft_config({}): modify_config returned \"{}\", retrying", id, e);
             co_return operation_result::failure;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -780,7 +780,15 @@ future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3
             // Just bootstrapped and joined as non-voter. Become a voter.
             auto pause_shutdown = _shutdown_gate.hold();
             raft::server_address my_addr{my_id, {}};
-            co_await _raft_gr.group0().modify_config({{my_addr, true}}, {}, &_abort_source);
+            co_await run_op_with_retry(_abort_source, [this, my_addr]() -> future<operation_result> {
+                try {
+                    co_await _raft_gr.group0().modify_config({{my_addr, true}}, {}, &_abort_source);
+                } catch (const raft::commit_status_unknown& e) {
+                    group0_log.info("finish_setup_after_join({}): modify_config returned \"{}\", retrying", my_addr, e);
+                    co_return operation_result::failure;
+                }
+                co_return operation_result::success;
+            }, "finish_setup_after_join->modify_config", {});
             group0_log.info("finish_setup_after_join: became a group 0 voter.");
 
             // No need to run `upgrade_to_group0()` since we must have bootstrapped with Raft

--- a/test/topology_custom/test_error_becoming_voter.py
+++ b/test/topology_custom/test_error_becoming_voter.py
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import logging
+import pytest
+import asyncio
+import time
+
+from cassandra import ConsistencyLevel  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.xfail(reason="issue #20814")
+@pytest.mark.asyncio
+async def test_error_while_becoming_voter(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """
+    Test that a node is starting successfully if while joining a cluster and becoming a voter, it
+    receives an unknown commit status error.
+    Issue https://github.com/scylladb/scylladb/issues/20814
+
+    1. Create a new cluster, start 2 nodes normally.
+    2. Run one node with error injection for throwing an exception commit_status_unknown in modify_config,
+       so that after bootstrapping the node would get a commit_status_unknown error.
+    3. Make sure the node was started successfully. In case the error with the handling of commit_status_unknown is
+       not handled properly, the node will fail to start.
+
+    """
+    logger.info("Creating a new cluster")
+    await manager.servers_add(2)
+
+    srv = await manager.server_add(config={
+        "error_injections_at_startup": [
+            {"name": "raft/throw_commit_status_unknown_in_modify_config", "one_shot": True}
+        ]
+    })
+    await manager.server_start(srv.server_id)

--- a/test/topology_custom/test_error_becoming_voter.py
+++ b/test/topology_custom/test_error_becoming_voter.py
@@ -17,7 +17,6 @@ from test.pylib.util import wait_for_cql_and_get_hosts
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.xfail(reason="issue #20814")
 @pytest.mark.asyncio
 async def test_error_while_becoming_voter(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """


### PR DESCRIPTION
When a node is bootstrapped and joined a cluster as a non-voter and changes it's role to a voter, errors can occur while committing a new Raft record, for instance, if the Raft leader changes during this time. These errors are not critical and should not cause a node crash, as the action can be retried.

Fixes scylladb/scylladb#20814

Backport: This issue occurs frequently and disrupts the CI workflow to some extent. Backports are needed for versions 6.1 and 6.2.