### PR TITLE
[Backport 6.2] docs: fix monospace formatting for `rm` command

### DIFF
--- a/docs/troubleshooting/drop-table-space-up.rst
+++ b/docs/troubleshooting/drop-table-space-up.rst
@@ -16,6 +16,4 @@ Solution
 2. If you are deleting an entire keyspace, repeat the procedure above for every table inside the keyspace.
 3. This behavior is controlled by the ``auto_snapshot`` flag in ``/etc/scylla/scylla.yaml``, which set to true by default. To stop taking snapshots on deletion, set that flag to false and restart all your scylla nodes.
 
-.. note:: Alternatively you can use the``rm`` Linux utility to remove the files. If you do, keep in mind that the ``rm`` Linux utility is not aware if some snapshots are still associated with existing keyspaces, but nodetool is. 
- 
-
+.. note:: Alternatively you can use the ``rm`` Linux utility to remove the files. If you do, keep in mind that the ``rm`` Linux utility is not aware if some snapshots are still associated with existing keyspaces, but nodetool is.


### PR DESCRIPTION
Add missing space before `rm` to ensure proper rendering in monospace font within documentation.

Fixes scylladb/scylladb#22255
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

Closes scylladb/scylladb#21576

(cherry picked from commit 6955b8238e2b70e961d77ecf316bebbb454cfa1d)

---

this addresses a glitch in the user-facing document, so should be backported to all LTS branches.

Parent PR: https://github.com/scylladb/scylladb/pull/21576