### PR TITLE
api/storage_service: Remove unimplemented truncate API

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -1649,38 +1649,6 @@
          ]
       },
       {
-         "path":"/storage_service/truncate/{keyspace}",
-         "operations":[
-            {
-               "method":"POST",
-               "summary":"Truncates (deletes) the given columnFamily from the provided keyspace. Calling truncate results in actual deletion of all data in the cluster under the given columnFamily and it will fail unless all hosts are up. All data in the given column family will be deleted, but its definition will not be affected.",
-               "type":"void",
-               "nickname":"truncate",
-               "produces":[
-                  "application/json"
-               ],
-               "parameters":[
-                  {
-                     "name":"keyspace",
-                     "description":"The keyspace",
-                     "required":true,
-                     "allowMultiple":false,
-                     "type":"string",
-                     "paramType":"path"
-                  },
-                  {
-                     "name":"cf",
-                     "description":"Column family name",
-                     "required":false,
-                     "allowMultiple":false,
-                     "type":"string",
-                     "paramType":"query"
-                  }
-               ]
-            }
-         ]
-      },
-      {
          "path":"/storage_service/keyspaces",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -990,13 +990,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
             return make_ready_future<json::json_return_type>(json_void());
         });
     });
-    ss::truncate.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        //TBD
-        unimplemented();
-        auto keyspace = validate_keyspace(ctx, req);
-        auto column_family = req->get_query_param("cf");
-        return make_ready_future<json::json_return_type>(json_void());
-    });
 
     ss::get_keyspaces.set(r, [&ctx](const_req req) {
         auto type = req.get_query_param("type");
@@ -1633,7 +1626,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::is_starting.unset(r);
     ss::get_drain_progress.unset(r);
     ss::drain.unset(r);
-    ss::truncate.unset(r);
     ss::get_keyspaces.unset(r);
     ss::stop_gossiping.unset(r);
     ss::start_gossiping.unset(r);


### PR DESCRIPTION
The API /storage_service/truncate/{ks} returns an unimplemented error when invoked. As we already have a CQL command, `TRUNCATE TABLE ks.cf` that causes the table to be truncated on all nodes, the API can be dropped. Due to the error, it is unused.

Fixes https://github.com/scylladb/scylladb/issues/10520

No backport is required. A small cleanup of not working API.