### PR TITLE
build: cmake: do not add absl::headers as a link directory

### DIFF
--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -77,9 +77,6 @@ add_custom_target(idl-sources
   DEPENDS ${idl_sources})
 add_library(idl INTERFACE)
 add_dependencies(idl idl-sources)
-target_link_directories(idl
-  INTERFACE
-    absl::headers)
 target_include_directories(idl
   INTERFACE
     ${scylla_gen_build_dir})


### PR DESCRIPTION
In 0b0e661a85, we brought abseil back as a submodule, and we added absl::headers as an interface library for importing abseil headers' include directory.

In this change, we remove `absl::headers` from
`target_link_directories()` as it's an interface library that only provides header files, not linkable libraries. This fixes the incorrect inclusion of absl::headers in the rpath of the scylla executable.

Additionally, remove abseil library dependencies from the idl target since none of the idl source files directly include abseil headers.

Fixes #22265
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

no need to backport, as the change (https://github.com/scylladb/scylla-pkg/pull/4707) in scylla-pkg which switched the building system to CMake was only merged 3 weeks ago.