### PR TITLE
test.py: Mark the cluster dirty after each test for topology

### DIFF
--- a/test.py
+++ b/test.py
@@ -1349,8 +1349,8 @@ class PythonTest(Test):
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
             status = await run_test(self, options, env=self.suite.scylla_env)
-            if self.shortname in self.suite.dirties_cluster:
-                cluster.is_dirty = True
+            # if self.shortname in self.suite.dirties_cluster:
+            cluster.is_dirty = True
             cluster.after_test(self.uname, status)
             self.is_after_test_ok = True
             self.success = status


### PR DESCRIPTION
Currently, tests are reusing the cluster. This leads to the situation when a test passes and leaves the cluster broken, that the next tests will try to clean up the Scylla working directory during starting the node. Timeout for starting is set to two minutes by default and sometimes cleaning the mess after several tests can take more time, so tests fail during adding the node to the cluster.
Current PR marks the cluster dirty after the test, so no need to clean the Scylla working directory. The disadvantage of this way is increasing the time for tests execution. 

It's a step back from the original idea of reusing cluster between tests to decrease execution time. But this introduces a painful flakiness in CI and even without reusing performance degradation doesn't look too bad. This can be counted as a temporary solution.

This should fix https://github.com/scylladb/scylladb/issues/21912, but since the issue is flaky better to merge this solution and observe the CI for improvements, and after that https://github.com/scylladb/scylladb/issues/21912 can be closed.

There will be some degradation in performance: master dev mode 22min 35s, this PR dev mode 23min 41s.
Results for [x86-64](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/xtrey/job/byo_scylladb/132/allure/) and [arm](https://jenkins.scylladb.com/view/staging/job/scylla-staging/job/xtrey/job/byo_scylladb/133/allure/) for tests for debug with repeat count 10 for x86-64 and repeat count 3 for arm. One boost test failed for x86-64, but it's not related to the current PR, since in this PR only python tests can be affected. The issue is not reproduced so far, but taking in account that the [issue](https://github.com/scylladb/scylladb/issues/21912) is flaky, we need to monitor after merge that it has really gone.