### PR TITLE
dist/docker,docs: replace "--experimental" with "--experimental-features"

### DIFF
--- a/dist/docker/commandlineparser.py
+++ b/dist/docker/commandlineparser.py
@@ -4,7 +4,7 @@ import argparse
 def parse():
     parser = argparse.ArgumentParser()
     parser.add_argument('--developer-mode', default='1', choices=['0', '1'], dest='developerMode')
-    parser.add_argument('--experimental', default=0, choices=['0', '1'])
+    parser.add_argument('--experimental-features', action='append', help='Unlock experimental features. Can be repeated')
     parser.add_argument('--seeds', default=None, help="specify seeds - if left empty will use container's own IP")
     parser.add_argument('--cpuset', default=None, help="e.g. --cpuset 0-3 for the first four CPUs")
     parser.add_argument('--smp', default=None, help="e.g --smp 2 to use two CPUs")

--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -23,7 +23,7 @@ class ScyllaSetup:
         self._reserveMemory = arguments.reserveMemory
         self._overprovisioned = arguments.overprovisioned
         self._housekeeping = not arguments.disable_housekeeping
-        self._experimental = arguments.experimental
+        self._experimental_features = arguments.experimental_features
         self._authenticator = arguments.authenticator
         self._authorizer = arguments.authorizer
         self._clusterName = arguments.clusterName
@@ -146,8 +146,9 @@ class ScyllaSetup:
         if self._authorizer is not None:
             args += ["--authorizer %s" % self._authorizer]
 
-        if self._experimental == "1":
-            args += ["--experimental=on"]
+        if self._experimental_features is not None:
+            for feature in self._experimental_features:
+                args += [f"--experimental-features {feature}"]
 
         if self._clusterName is not None:
             args += ["--cluster-name %s" % self._clusterName]

--- a/docs/dev/docker-hub.md
+++ b/docs/dev/docker-hub.md
@@ -326,16 +326,16 @@ For example, to disable developer mode:
 $ docker run --name some-scylla -d scylladb/scylla --developer-mode 0
 ```
 
-#### `--experimental ENABLE`
+#### `--experimental-features FEATURE`
 
-The `--experimental` command line option enables ScyllaDB's experimental mode
-If no `--experimental` command line option is defined, ScyllaDB defaults to running with experimental mode *disabled*.
-It is highly recommended to disable experimental mode for production deployments.
+The `--experimental-features` command line option enables ScyllaDB's experimental feature individually. If no feature flags are specified, ScyllaDB runs with only *stable* features enabled.
 
-For example, to enable experimental mode:
+Running experimental features in production environments is not recommended.
+
+For example, to enable the User Defined Functions (UDF) feature:
 
 ```console
-$ docker run --name some-scylla -d scylladb/scylla --experimental 1
+$ docker run --name some-scylla -d scylladb/scylla --experimental-feature=udf
 ```
 
 **Since: 2.0**

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -104,14 +104,35 @@ You can clean snapshots by using :doc:`nodetool clearsnapshot </operating-scylla
   
 Features
 --------
-I want to try out new features.  How do I enable experimental mode?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-You need to add the line :code:`experimental: true`  to your :code:`scylla.yaml` file.
 
-1. Launch the file in a text editor: :code:`$ vi /etc/scylla/scylla.yaml`. (Alternately, on docker, it's :code:`$ docker exec -it your_node vi /etc/scylla/scylla.yaml`);
-2. Add the line :code:`experimental: true`;
+I want to try out new features.  How do I enable them?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ScyllaDB features can be enabled individually either through the configuration file or via command-line flags.
+
+To configure using :code:`scylla.yaml` file:
+
+1. Open the file in a text editor:
+
+   On Linux systems
+
+   :code:`$ vi /etc/scylla/scylla.yaml`
+
+   On Docker
+
+   :code:`$ docker exec -it your_node vi /etc/scylla/scylla.yaml`
+
+2. Add the features you want to enable
+
+   .. code-block:: yaml
+
+      # Example: enabling UDF and Alternator Streams features
+      experimental_features:
+         - udf
+         - alternator-streams
+
 3. Save the file and exit.
-4. Stop and restart the node. 
+4. Restart the node.
 
    On RedHat Enterprise Linux, CentOS or Ubuntu:
    
@@ -121,11 +142,15 @@ You need to add the line :code:`experimental: true`  to your :code:`scylla.yaml`
    
    :code:`$ docker stop <your_node> && docker start <your_node>`
 
-   Alternately, starting from ScyllaDB 2.0, you can start ScyllaDB for Docker with the :code:`experimental` flag as follows:
+Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Alternator Streams:
 
-   :code:`$ docker run --name <your_node> -d scylladb/scylla --experimental 1`
+.. code-block:: console
 
-You should now be able to use the experimental features available in your version of ScyllaDB.
+   $ docker run --name <your_node> -d scylladb/scylla \
+       --experimental-features=udf \
+       --experimental-features=alternator-streams
+
+You should now be able to use the specified experimental features.
 
 How do I check the current version of ScyllaDB that I am running?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
+++ b/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
@@ -289,17 +289,17 @@ To disable developer mode:
 
   docker run --name some-scylla -d scylladb/scylla --developer-mode 0
 
---experimental ENABLE
----------------------
-The ``--experimental`` command line option enables ScyllaDB's experimental mode. If no ``--experimental`` command line option is defined, ScyllaDB defaults to running with experimental mode disabled.
+--experimental-features FEATURE
+-------------------------------
+The ``--experimental-features`` command line option enables ScyllaDB's experimental feature individually. If no feature flags are specified, ScyllaDB runs with only stable features enabled.
 
-**It is highly recommended to disable experimental mode for production deployments.**
+**Running experimental features in production environments is not recommended.**
 
-For example, to enable experimental mode:
+For example, to enable the User Defined Functions (UDF) feature:
 
 .. code-block:: console
 
-  docker run --name some-scylla -d scylladb/scylla --experimental 1
+  docker run --name some-scylla -d scylladb/scylla --experimental-features=udf
 
 Other Useful Tips and Tricks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The "--experimental" option was removed in commit https://github.com/tchaikov/scylladb/commit/f6cca741eaa21c4c34362305c240058758ee3ddb. Using this deprecated option now causes Scylla to fail with the error:

```
error: the argument ('on') for option '--experimental-features' is invalid
```

So, in this change, let's update the docker entry point script to use `--experimental-features` command line option instead. The related document is updated accordingly.

Fixes scylladb/scylladb#22207

---

it's an improvement in document mainly targeting developers willing to try out experimental features, hence no need to backport.