### PR TITLE
backup_task: remove a component once it is uploaded 

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -813,6 +813,14 @@
                           "allowMultiple":false,
                           "type":"string",
                           "paramType":"query"
+                      },
+                      {
+                          "name":"move_files",
+                          "description":"Move component files instead of copying them",
+                          "required":false,
+                          "allowMultiple":false,
+                          "type":"boolean",
+                          "paramType":"query"
                       }
                   ]
               }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1799,13 +1799,14 @@ void set_snapshot(http_context& ctx, routes& r, sharded<db::snapshot_ctl>& snap_
         auto bucket = req->get_query_param("bucket");
         auto prefix = req->get_query_param("prefix");
         auto snapshot_name = req->get_query_param("snapshot");
+        auto move_files = req_param<bool>(*req, "move_files", false);
         if (snapshot_name.empty()) {
             // TODO: If missing, snapshot should be taken by scylla, then removed
             throw httpd::bad_param_exception("The snapshot name must be specified");
         }
 
         auto& ctl = snap_ctl.local();
-        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(prefix), std::move(keyspace), std::move(table), std::move(snapshot_name));
+        auto task_id = co_await ctl.start_backup(std::move(endpoint), std::move(bucket), std::move(prefix), std::move(keyspace), std::move(table), std::move(snapshot_name), move_files);
         co_return json::json_return_type(fmt::to_string(task_id));
     });
 

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -56,9 +56,8 @@ future<> snapshot_ctl::check_snapshot_not_exist(sstring ks_name, sstring name, s
     });
 }
 
-template <typename Func>
-std::invoke_result_t<Func> snapshot_ctl::run_snapshot_modify_operation(Func&& f) {
-    return with_gate(_ops, [f = std::move(f), this] () {
+future<> snapshot_ctl::run_snapshot_modify_operation(noncopyable_function<future<>()>&& f) {
+    return with_gate(_ops, [f = std::move(f), this] () mutable {
         return container().invoke_on(0, [f = std::move(f)] (snapshot_ctl& snap) mutable {
             return with_lock(snap._lock.for_write(), std::move(f));
         });

--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -137,10 +137,10 @@ future<int64_t> snapshot_ctl::true_snapshots_size() {
     }));
 }
 
-future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring table, sstring snapshot_name) {
+future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring table, sstring snapshot_name, bool move_files) {
     if (this_shard_id() != 0) {
         co_return co_await container().invoke_on(0, [&](auto& local) {
-            return local.start_backup(endpoint, bucket, prefix, keyspace, table, snapshot_name);
+            return local.start_backup(endpoint, bucket, prefix, keyspace, table, snapshot_name, move_files);
         });
     }
 
@@ -175,7 +175,7 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
                 sstables::snapshots_dir /
                 std::string_view(snapshot_name));
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir);
+        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
     co_return task->id();
 }
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -105,7 +105,7 @@ public:
      */
     future<> clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name);
 
-    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring table, sstring snapshot_name);
+    future<tasks::task_id> start_backup(sstring endpoint, sstring bucket, sstring prefix, sstring keyspace, sstring table, sstring snapshot_name, bool move_files);
 
     future<std::unordered_map<sstring, db_snapshot_details>> get_snapshot_details();
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -121,8 +121,7 @@ private:
 
     future<> check_snapshot_not_exist(sstring ks_name, sstring name, std::optional<std::vector<sstring>> filter = {});
 
-    template <typename Func>
-    std::invoke_result_t<Func> run_snapshot_modify_operation(Func&&);
+    future<> run_snapshot_modify_operation(noncopyable_function<future<>()> &&);
 
     template <typename Func>
     std::invoke_result_t<Func> run_snapshot_list_operation(Func&& f) {

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -24,6 +24,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
+    bool _remove_on_uploaded;
     s3::upload_progress _progress = {};
 
     future<> do_backup();
@@ -39,7 +40,8 @@ public:
                      sstring bucket,
                      sstring prefix,
                      sstring ks,
-                     std::filesystem::path snapshot_dir) noexcept;
+                     std::filesystem::path snapshot_dir,
+                     bool move_files) noexcept;
 
     virtual std::string type() const override;
     virtual tasks::is_internal is_internal() const noexcept override;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -27,6 +27,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     s3::upload_progress _progress = {};
 
     future<> do_backup();
+    future<> upload_component(sstring name);
 
 protected:
     virtual future<> run() override;

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -318,7 +318,7 @@ class ScyllaRESTAPIClient():
         """Flush all keyspaces"""
         await self.client.post(f"/storage_service/flush", host=node_ip)
 
-    async def backup(self, node_ip: str, ks: str, table: str, tag: str, dest: str, bucket: str, prefix: str) -> str:
+    async def backup(self, node_ip: str, ks: str, table: str, tag: str, dest: str, bucket: str, prefix: str, **kwargs) -> str:
         """Backup keyspace's snapshot"""
         params = {"keyspace": ks,
                   "table": table,
@@ -326,6 +326,13 @@ class ScyllaRESTAPIClient():
                   "bucket": bucket,
                   "prefix": prefix,
                   "snapshot": tag}
+        # add optional args. for instance, "move_files".
+        for key, value in kwargs.items():
+            if isinstance(value, bool):
+                params[key] = 'true' if value else 'false'
+            else:
+                assert any(isinstance(value, t) for t in (str, int, float))
+                params[key] = value
         return await self.client.post_json(f"/storage_service/backup", host=node_ip, params=params)
 
     async def restore(self, node_ip: str, ks: str, cf: str, dest: str, bucket: str, prefix: str, sstables: list[str], scope: str = None) -> str:


### PR DESCRIPTION
Previously, during backup, SSTable components are preserved in the
snapshot directory even after being uploaded. This leads to redundant
uploads in case of failed backups or restarts, wasting time and
resources (S3 API calls).

This change removes SSTable components from the snapshot directory once
they are successfully uploaded to the target location. This prevents
re-uploading the same files and reduces disk usage.

This change only "Refs" https://github.com/scylladb/scylladb/issues/20655, because, we can further optimize
the backup process, consider:

- Sending HEAD requests to S3 to check for existing files before uploading.
- Implementing support for resuming partially uploaded files.

Fixes https://github.com/scylladb/scylladb/issues/21799
Refs https://github.com/scylladb/scylladb/issues/20655

---

the backup API is not used in production yet, so no need to backport.