### PR TITLE
.github: use the toolchain specified by tools/toolchain/image

### DIFF
--- a/.github/workflows/seastar.yaml
+++ b/.github/workflows/seastar.yaml
@@ -15,10 +15,13 @@ env:
   BUILD_DIR: build
 
 jobs:
+  read-toolchain:
+    uses: ./.github/workflows/read-toolchain.yaml
   build-with-the-latest-seastar:
+    needs:
+      - read-toolchain
     runs-on: ubuntu-latest
-    # be consistent with tools/toolchain/image
-    container: scylladb/scylla-toolchain:fedora-40-20240621
+    container: ${{ needs.read-toolchain.outputs.image }}
     strategy:
       matrix:
         build_type:


### PR DESCRIPTION
Previously, we hardwire the container to a previous frozen toolchain image. but at the time of writing, the tree does not compile in the specified toolchain image anymore, after the required building environment is updated, and toolchain was updated accordingly.

in order to improve the maintability, let's reuse `read-toolchain.yaml` job which reads `tools/toolchain/image`, so we don't have to hardwire the container used for building the tree with the latest seastar. this should address the build failure surfaced recently.

---

this change addresses the recent failures of the `seastar.yaml` workflow, and it has no compactions to the production, so no need to backport.