### PR TITLE
mv: make base_info in view schemas immutable

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1486,7 +1486,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
             }
         }
         const bool include_all_columns = true;
-        view_builder.with_view_info(*schema, include_all_columns, ""/*where clause*/);
+        view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
     }
 
     // FIXME: the following needs to be in a loop. If mm.announce() below
@@ -1771,7 +1771,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         }
                     }
                     const bool include_all_columns = true;
-                    view_builder.with_view_info(*schema, include_all_columns, ""/*where clause*/);
+                    view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
                     new_views.emplace_back(view_builder.build());
                 } else if (op == "Delete") {
                     elogger.trace("Deleting GSI {}", index_name);

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -284,7 +284,7 @@ void alter_table_statement::drop_column(const query_options& options, const sche
     }
 }
 
-std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_schema_update(data_dictionary::database db, const query_options& options) const {
+std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_schema_update(data_dictionary::database db, const query_options& options) const {
     auto s = validation::validate_column_family(db, keyspace(), column_family());
     if (s->is_view()) {
         throw exceptions::invalid_request_exception("Cannot use ALTER TABLE on Materialized View");
@@ -378,6 +378,9 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
             validate_column_rename(db, *s, *from, *to);
             cfm.rename_column(from->name(), to->name());
         }
+        // New view schemas contain the new column names, so we need to base them on the
+        // new base schema.
+        schema_ptr new_base_schema = cfm.build();
         // If the view includes a renamed column, it must be renamed in
         // the view table and the definition.
         for (auto&& view : cf.views()) {
@@ -402,22 +405,21 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
                 }
             }
             if (view_updated) {
-                builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
-                        view->view_info()->include_all_columns(), std::move(new_where));
+                builder.with_view_info(new_base_schema, view->view_info()->include_all_columns(), std::move(new_where));
                 view_updates.push_back(view_ptr(builder.build()));
             }
         }
-        break;
+        return make_pair(std::move(new_base_schema), std::move(view_updates));
     }
 
-    return make_pair(std::move(cfm), std::move(view_updates));
+    return make_pair(cfm.build(), std::move(view_updates));
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
 alter_table_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type ts) const {
   data_dictionary::database db = qp.db();
-  auto [cfm, view_updates] = prepare_schema_update(db, options);
-  auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), cfm.build(), std::move(view_updates), ts);
+  auto [s, view_updates] = prepare_schema_update(db, options);
+  auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), std::move(s), std::move(view_updates), ts);
 
   using namespace cql_transport;
   auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -377,28 +377,34 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
 
             validate_column_rename(db, *s, *from, *to);
             cfm.rename_column(from->name(), to->name());
-
-            // If the view includes a renamed column, it must be renamed in
-            // the view table and the definition.
-            for (auto&& view : cf.views()) {
+        }
+        // If the view includes a renamed column, it must be renamed in
+        // the view table and the definition.
+        for (auto&& view : cf.views()) {
+            schema_builder builder(view);
+            bool view_updated = false;
+            auto new_where = view->view_info()->where_clause();
+            for (auto&& entry : _renames) {
+                auto from = entry.first->prepare_column_identifier(*s);
+                auto to = entry.second->prepare_column_identifier(*s);
                 if (view->get_column_definition(from->name())) {
-                    schema_builder builder(view);
-
+                    view_updated = true;
                     auto view_from = entry.first->prepare_column_identifier(*view);
                     auto view_to = entry.second->prepare_column_identifier(*view);
                     validate_column_rename(db, *view, *view_from, *view_to);
                     builder.rename_column(view_from->name(), view_to->name());
 
-                    auto new_where = util::rename_column_in_where_clause(
-                            view->view_info()->where_clause(),
+                    new_where = util::rename_column_in_where_clause(
+                            new_where,
                             column_identifier::raw(view_from->text(), true),
                             column_identifier::raw(view_to->text(), true),
                             cql3::dialect{});
-                    builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
-                            view->view_info()->include_all_columns(), std::move(new_where));
-
-                    view_updates.push_back(view_ptr(builder.build()));
                 }
+            }
+            if (view_updated) {
+                builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
+                        view->view_info()->include_all_columns(), std::move(new_where));
+                view_updates.push_back(view_ptr(builder.build()));
             }
         }
         break;

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -69,7 +69,7 @@ private:
     void add_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void alter_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void drop_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
-    std::pair<schema_builder, std::vector<view_ptr>> prepare_schema_update(data_dictionary::database db, const query_options& options) const;
+    std::pair<schema_ptr, std::vector<view_ptr>> prepare_schema_update(data_dictionary::database db, const query_options& options) const;
 };
 
 class alter_table_statement::raw_statement : public raw::cf_statement {

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -378,7 +378,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     auto where_clause_text = util::relations_to_where_clause(_where_clause);
-    builder.with_view_info(schema->id(), schema->cf_name(), included.empty(), std::move(where_clause_text));
+    builder.with_view_info(schema, included.empty(), std::move(where_clause_text));
 
     return std::make_pair(view_ptr(builder.build()), std::move(warnings));
 }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -574,19 +574,23 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         // 2. The table was just created - the table is guaranteed to be published with the view in that case.
         // 3. The view itself was altered - in that case we already know the base table so we can take it from
         //    the database object.
-        view_ptr vp = create_view_from_mutations(proxy, std::move(sm));
+        query::result_set rs(sm.columnfamilies_mutation());
+        const query::result_set_row& view_row = rs.row(0);
+        auto ks_name = view_row.get_nonnull<sstring>("keyspace_name");
+        auto base_name = view_row.get_nonnull<sstring>("base_table_name");
+
         schema_ptr base_schema;
         for (auto&& altered : tables_diff.altered) {
             // Chose the appropriate version of the base table schema: old -> old, new -> new.
             schema_ptr s = side == schema_diff_side::left ? altered.old_schema : altered.new_schema;
-            if (s->ks_name() == vp->ks_name() && s->cf_name() == vp->view_info()->base_name() ) {
+            if (s->ks_name() == ks_name && s->cf_name() == base_name) {
                 base_schema = s;
                 break;
             }
         }
         if (!base_schema) {
             for (auto&& s : tables_diff.created) {
-                if (s.get()->ks_name() == vp->ks_name() && s.get()->cf_name() == vp->view_info()->base_name() ) {
+                if (s.get()->ks_name() == ks_name && s.get()->cf_name() == base_name) {
                     base_schema = s;
                     break;
                 }
@@ -594,8 +598,9 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         }
 
         if (!base_schema) {
-            base_schema = proxy.local().local_db().find_schema(vp->ks_name(), vp->view_info()->base_name());
+            base_schema = proxy.local().local_db().find_schema(ks_name, base_name);
         }
+        view_ptr vp = create_view_from_mutations(proxy, std::move(sm), base_schema);
 
         // Now when we have a referenced base - sanity check that we're not registering an old view
         // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -605,8 +605,6 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         // Now when we have a referenced base - sanity check that we're not registering an old view
         // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)
         check_no_legacy_secondary_index_mv_schema(proxy.local().get_db().local(), vp, base_schema);
-
-        vp->view_info()->set_base_info(vp->view_info()->make_base_dependent_view_info(*base_schema));
         return vp;
     });
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -287,7 +287,7 @@ std::vector<mutation> make_drop_table_mutations(lw_shared_ptr<keyspace_metadata>
 
 schema_ptr create_table_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
 
-view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
+view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, schema_ptr, std::optional<table_schema_version> version = {});
 
 future<std::vector<view_ptr>> create_views_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result::mapped_type& result);
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -79,9 +79,10 @@ static inline void inject_failure(std::string_view operation) {
             [operation] { throw std::runtime_error(std::string(operation)); });
 }
 
-view_info::view_info(const schema& schema, const raw_view_info& raw_view_info)
+view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema)
         : _schema(schema)
         , _raw(raw_view_info)
+        , _base_info(make_base_dependent_view_info(*base_schema))
         , _has_computed_column_depending_on_base_non_primary_key(false)
 { }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3260,6 +3260,7 @@ public:
 
     stop_iteration consume_end_of_partition() {
         inject_failure("view_builder_consume_end_of_partition");
+        utils::get_local_injector().inject("view_builder_consume_end_of_partition_delay", utils::wait_for_message(std::chrono::seconds(60))).get();
         flush_fragments();
         return stop_iteration(_step.build_status.empty());
     }

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -67,15 +67,6 @@ public:
     base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk, std::optional<bytes>&& column_missing_in_base);
 };
 
-// Immutable snapshot of view's base-schema-dependent part.
-using base_info_ptr = lw_shared_ptr<const base_dependent_view_info>;
-
-// Snapshot of the view schema and its base-schema-dependent part.
-struct view_and_base {
-    view_ptr view;
-    base_info_ptr base;
-};
-
 // An immutable representation of a clustering or static row of the base table.
 struct clustering_or_static_row {
 private:
@@ -207,18 +198,11 @@ class view_updates final {
     view_ptr _view;
     const view_info& _view_info;
     schema_ptr _base;
-    base_info_ptr _base_info;
+    const base_dependent_view_info& _base_info;
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
     size_t _op_count = 0;
 public:
-    explicit view_updates(view_and_base vab)
-            : _view(std::move(vab.view))
-            , _view_info(*_view->view_info())
-            , _base(vab.base->base_schema())
-            , _base_info(vab.base)
-            , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view))
-    {
-    }
+    explicit view_updates(view_ptr vab);
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
@@ -308,7 +292,7 @@ view_update_builder make_view_update_builder(
         data_dictionary::database db,
         const replica::table& base_table,
         const schema_ptr& base_schema,
-        std::vector<view_and_base>&& views_to_update,
+        std::vector<view_ptr>&& views_to_update,
         mutation_reader&& updates,
         mutation_reader_opt&& existings,
         gc_clock::time_point now);
@@ -318,9 +302,9 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
-        const std::vector<view_and_base>& views);
+        const std::vector<view_ptr>& views);
 
-bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views);
+bool needs_static_row(const mutation_partition& mp, const std::vector<view_ptr>& views);
 
 // Whether this node and shard should generate and send view updates for the given token.
 // Checks that the node is one of the replicas (not a pending replicas), and is ready for reads.
@@ -342,13 +326,6 @@ size_t memory_usage_of(const frozen_mutation_and_schema& mut);
  *        When type is a multi-cell collection, so will be the virtual column.
  */
  void create_virtual_column(schema_builder& builder, const bytes& name, const data_type& type);
-
-/**
- * Converts a collection of view schema snapshots into a collection of
- * view_and_base objects, which are snapshots of both the view schema
- * and the base-schema-dependent part of view description.
- */
-std::vector<view_and_base> with_base_info_snapshot(std::vector<view_ptr>);
 
 std::optional<locator::host_id> get_view_natural_endpoint(
     locator::host_id node,

--- a/db/view/view_builder.hh
+++ b/db/view/view_builder.hh
@@ -135,6 +135,7 @@ class view_builder final : public service::migration_listener::only_view_notific
         // Ensure we pin the column_family. It may happen that all views are removed,
         // and that the base table is too before we can detect it.
         lw_shared_ptr<replica::column_family> base;
+        schema_ptr base_schema;
         query::partition_slice pslice;
         dht::partition_range prange;
         mutation_reader reader{nullptr};
@@ -227,7 +228,9 @@ public:
     future<> upgrade_to_v2();
 
     void init_virtual_table();
-
+    future<> update_base_schema(const replica::column_family& base);
+    future<> drop_view(const sstring& ks_name, const sstring& view_name, build_step& step);
+    virtual void on_update_column_family(const sstring& ks_name, const sstring& cf_name, bool columns_changed) override;
     virtual void on_create_view(const sstring& ks_name, const sstring& view_name) override;
     virtual void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override;
     virtual void on_drop_view(const sstring& ks_name, const sstring& view_name) override;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -329,7 +329,7 @@ static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_sc
  * @return a future that resolves when the updates have been acknowledged by the view replicas
  */
 future<> view_update_generator::populate_views(const replica::table& table,
-        std::vector<view_and_base> views,
+        std::vector<view_ptr> views,
         dht::token base_token,
         mutation_reader&& reader,
         gc_clock::time_point now) {
@@ -402,7 +402,7 @@ struct view_update_generation_timeout_exception : public seastar::timed_out_erro
 future<> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
         const schema_ptr& base,
         reader_permit permit,
-        std::vector<view_and_base>&& views,
+        std::vector<view_ptr>&& views,
         mutation&& m,
         mutation_reader_opt existings,
         tracing::trace_state_ptr tr_state,

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -11,6 +11,7 @@
 #include "sstables/shared_sstable.hh"
 #include "db/timeout_clock.hh"
 #include "utils/chunked_vector.hh"
+#include "schema/schema.hh"
 #include "schema/schema_fwd.hh"
 #include "gc_clock.hh"
 
@@ -51,7 +52,6 @@ using allow_hints = bool_class<allow_hints_tag>;
 namespace db::view {
 
 class stats;
-struct view_and_base;
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 
@@ -104,7 +104,7 @@ public:
 
     // Reader's schema must be the same as the base schema of each of the views.
     future<> populate_views(const replica::table& base,
-            std::vector<view_and_base>,
+            std::vector<view_ptr>,
             dht::token base_token,
             mutation_reader&&,
             gc_clock::time_point);
@@ -112,7 +112,7 @@ public:
     future<> generate_and_propagate_view_updates(const replica::table& table,
             const schema_ptr& base,
             reader_permit permit,
-            std::vector<view_and_base>&& views,
+            std::vector<view_ptr>&& views,
             mutation&& m,
             mutation_reader_opt existings,
             tracing::trace_state_ptr tr_state,

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -27,6 +27,6 @@ public:
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;
     frozen_schema& operator=(frozen_schema&&) = default;
-    schema_ptr unfreeze(const db::schema_ctxt&) const;
+    schema_ptr unfreeze(const db::schema_ctxt&, std::optional<schema_ptr> base = std::nullopt) const;
     const bytes_ostream& representation() const;
 };

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -136,6 +136,7 @@ public:
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
     gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
     gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };
+    gms::feature immutable_base_info { *this, "IMMUTABLE_BASE_INFO"sv };
 
     // Whether to allow fragmented commitlog entries. While this is a node-local feature as such, hide
     // behind a feature to ensure an upgrading cluster appears to be at least functional before using,

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -302,7 +302,7 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
         (target_type == cql3::statements::index_target::target_type::regular_values) ?
         format("{} IS NOT NULL", index_target->name_as_cql_string()) :
         "";
-    builder.with_view_info(*schema, false, where_clause);
+    builder.with_view_info(schema, false, where_clause);
     // A local secondary index should be backed by a *synchronous* view,
     // see #16371. A view is marked synchronous with a tag. Non-local indexes
     // do not need the tags schema extension at all.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -956,14 +956,6 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
 }
 
 future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new) {
-    if (schema->is_view()) {
-        try {
-            auto base_schema = find_schema(schema->view_info()->base_id());
-            schema->view_info()->set_base_info(schema->view_info()->make_base_dependent_view_info(*base_schema));
-        } catch (no_such_column_family&) {
-            throw std::invalid_argument("The base table " + schema->view_info()->base_name() + " was already dropped");
-        }
-    }
     schema = local_schema_registry().learn(schema);
     auto&& rs = ks.get_replication_strategy();
     locator::effective_replication_map_ptr erm;
@@ -1009,14 +1001,6 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema, is_ne
 }
 
 bool database::update_column_family(schema_ptr new_schema) {
-    if (new_schema->is_view()) {
-        try {
-            auto base_schema = find_schema(new_schema->view_info()->base_id());
-            new_schema->view_info()->set_base_info(new_schema->view_info()->make_base_dependent_view_info(*base_schema));
-        } catch (no_such_column_family&) {
-            throw std::invalid_argument("The base table " + new_schema->view_info()->base_name() + " was already dropped");
-        }
-    }
     column_family& cfm = find_column_family(new_schema->id());
     bool columns_changed = !cfm.schema()->equal_columns(*new_schema);
     auto s = local_schema_registry().learn(new_schema);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3795,7 +3795,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
         co_return row_locker::lock_holder();
     }
 
-    auto views = db::view::with_base_info_snapshot(affected_views(gen, base, m));
+    auto views = affected_views(gen, base, m);
     if (views.empty()) {
         co_return row_locker::lock_holder();
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3237,18 +3237,6 @@ void table::set_schema(schema_ptr s) {
     }
     _schema = std::move(s);
 
-    for (auto&& v : _views) {
-        auto base_info = v->view_info()->make_base_dependent_view_info(*_schema);
-        v->view_info()->set_base_info(base_info);
-        if (v->registry_entry()) {
-            v->registry_entry()->update_base_schema(_schema);
-        }
-        if (auto reverse_schema = local_schema_registry().get_or_null(reversed(v->version()))) {
-            reverse_schema->view_info()->set_base_info(base_info);
-            reverse_schema->registry_entry()->update_base_schema(_schema);
-        }
-    }
-
     set_compaction_strategy(_schema->compaction_strategy());
     trigger_compaction();
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -2057,7 +2057,7 @@ schema_ptr schema::get_reversed() const {
             return {frozen_schema(s), s->view_info()->base_info().base_schema()};
         }
         return {frozen_schema(s)};
-    });
+    }, is_view() ? std::make_optional(view_info()->base_info().base_schema()->version()) : std::nullopt);
 }
 
 raw_view_info::raw_view_info(table_id base_id, sstring base_name, bool include_all_columns, sstring where_clause)

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -521,7 +521,7 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
 
     rebuild();
     if (o.is_view()) {
-        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), o.view_info()->base_info()->base_schema());
+        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), o.view_info()->base_info().base_schema());
     }
 }
 
@@ -1277,7 +1277,7 @@ schema_builder::schema_builder(const schema_ptr s)
     : schema_builder(s->_raw)
 {
     if (s->is_view()) {
-        _base_schema = s->view_info()->base_info()->base_schema();
+        _base_schema = s->view_info()->base_info().base_schema();
         _view_info = s->view_info()->raw();
     }
 }
@@ -2054,10 +2054,7 @@ schema_ptr schema::get_reversed() const {
         auto s = make_reversed();
 
         if (s->is_view()) {
-            if (!s->view_info()->base_info()) {
-                on_internal_error(dblog, format("Tried to make a reverse schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-            }
-            return {frozen_schema(s), s->view_info()->base_info()->base_schema()};
+            return {frozen_schema(s), s->view_info()->base_info().base_schema()};
         }
         return {frozen_schema(s)};
     });

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -522,9 +522,6 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
     rebuild();
     if (o.is_view()) {
         _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), o.view_info()->base_info()->base_schema());
-        if (o.view_info()->base_info()) {
-            _view_info->set_base_info(o.view_info()->base_info());
-        }
     }
 }
 

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -625,7 +625,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, const schema_static_props& props);
+    schema(private_tag, const raw_schema&, const schema_static_props& props, std::optional<schema_ptr> base_schema);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -29,6 +29,7 @@ private:
     std::optional<compact_storage> _compact_storage;
     std::variant<from_time, from_hash, table_schema_version> _version = from_time{};
     std::optional<raw_view_info> _view_info;
+    std::optional<schema_ptr> _base_schema;
     schema_builder(const schema::raw_schema&);
     static std::vector<static_configurator>& static_configurators();
 public:
@@ -273,10 +274,7 @@ public:
     // of table_schema_version (even in ABA changes).
     schema_builder& with_hash_version();
 
-    schema_builder& with_view_info(table_id base_id, sstring base_name, bool include_all_columns, sstring where_clause);
-    schema_builder& with_view_info(const schema& base_schema, bool include_all_columns, sstring where_clause) {
-        return with_view_info(base_schema.id(), base_schema.cf_name(), include_all_columns, where_clause);
-    }
+    schema_builder& with_view_info(schema_ptr base_schema, bool include_all_columns, sstring where_clause);
 
     schema_builder& with_index(const index_metadata& im);
     schema_builder& without_index(const sstring& name);

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -234,7 +234,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
 schema_ptr schema_registry_entry::get_schema() {
     if (!_schema) {
         slogger.trace("Activating {}", _version);
-        auto s = _frozen_schema->unfreeze(*_registry._ctxt);
+        schema_ptr s = _frozen_schema->unfreeze(*_registry._ctxt, _base_schema);
         if (s->version() != _version) {
             throw std::runtime_error(format("Unfrozen schema version doesn't match entry version ({}): {}", _version, *s));
         }

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -238,10 +238,6 @@ schema_ptr schema_registry_entry::get_schema() {
         if (s->version() != _version) {
             throw std::runtime_error(format("Unfrozen schema version doesn't match entry version ({}): {}", _version, *s));
         }
-        if (s->is_view()) {
-            // We may encounter a no_such_column_family here, which means that the base table was deleted and we should fail the request
-            s->view_info()->set_base_info(s->view_info()->make_base_dependent_view_info(**_base_schema));
-        }
         _erase_timer.cancel();
         s->_registry_entry = this;
         _schema = &*s;

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -188,7 +188,7 @@ schema_ptr schema_registry_entry::load(base_and_view_schemas fs) {
 schema_ptr schema_registry_entry::load(schema_ptr s) {
     _frozen_schema = frozen_schema(s);
     if (s->is_view()) {
-        _base_schema = s->view_info()->base_info()->base_schema();
+        _base_schema = s->view_info()->base_info().base_schema();
     }
     _schema = &*s;
     _schema->_registry_entry = this;
@@ -376,10 +376,7 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
         } else {
             return local_schema_registry().get_or_load(s->version(), [&s] (table_schema_version) -> base_and_view_schemas {
                 if (s->is_view()) {
-                    if (!s->view_info()->base_info()) {
-                        on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-                    }
-                    return {frozen_schema(s), s->view_info()->base_info()->base_schema()};
+                    return {frozen_schema(s), s->view_info()->base_info().base_schema()};
                 } else {
                     return {frozen_schema(s)};
                 }
@@ -389,7 +386,7 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
 
     schema_ptr s = ensure_registry_entry(ptr);
     if (s->is_view()) {
-        _base_schema = ensure_registry_entry(s->view_info()->base_info()->base_schema());
+        _base_schema = ensure_registry_entry(s->view_info()->base_info().base_schema());
     }
     _ptr = s;
 }

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -99,7 +99,7 @@ public:
     void on_create_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
 
     void on_update_keyspace(const sstring& ks_name) override {}
-    void on_update_column_family(const sstring& ks_name, const sstring& cf_name, bool columns_changed) override {}
+    // Updates to base table schemas change the view schemas, so leave on_update_column_family override
     void on_update_user_type(const sstring& ks_name, const sstring& type_name) override {}
     void on_update_function(const sstring& ks_name, const sstring& function_name) override {}
     void on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name) override {}
@@ -114,6 +114,7 @@ public:
 
 class migration_listener::empty_listener : public only_view_notifications {
 public:
+    void on_update_column_family(const sstring& ks_name, const sstring& cf_name, bool columns_changed) override {};
     void on_create_view(const sstring& ks_name, const sstring& view_name) override {};
     void on_update_view(const sstring& ks_name, const sstring& view_name, bool columns_changed) override {};
     void on_drop_view(const sstring& ks_name, const sstring& view_name) override {};

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4130,7 +4130,7 @@ SEASTAR_TEST_CASE(test_view_with_two_regular_base_columns_in_key) {
                 .with_column(to_bytes("v2"), int32_type, column_kind::clustering_key)
                 .with_column(to_bytes("p"), int32_type, column_kind::clustering_key)
                 .with_column(to_bytes("c"), int32_type, column_kind::clustering_key)
-                .with_view_info(*schema, false, "v1 IS NOT NULL AND v2 IS NOT NULL AND p IS NOT NULL AND c IS NOT NULL");
+                .with_view_info(schema, false, "v1 IS NOT NULL AND v2 IS NOT NULL AND p IS NOT NULL AND c IS NOT NULL");
 
         schema_ptr view_schema = view_builder.build();
         auto& mm = e.migration_manager().local();

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -288,7 +288,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
     auto view_schema = schema_builder("ks", "cf_view")
             .with_column("v", int32_type, column_kind::partition_key)
             .with_column("pk", int32_type)
-            .with_view_info(*base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
+            .with_view_info(base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
             .build();
     view_schema->view_info()->set_base_info(view_schema->view_info()->make_base_dependent_view_info(*base_schema));
     local_schema_registry().get_or_load(view_schema->version(),

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -294,7 +294,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
         [view_schema, base_schema] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(view_schema), base_schema}; });
     auto view_registry_schema = local_schema_registry().get_or_null(view_schema->version());
     BOOST_REQUIRE(view_registry_schema);
-    BOOST_REQUIRE(view_registry_schema->view_info()->base_info());
+    BOOST_REQUIRE(view_registry_schema->view_info()->base_info().base_schema()->version() == base_schema->version());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -272,10 +272,7 @@ SEASTAR_THREAD_TEST_CASE(test_schema_is_recovered_after_dying) {
         [base_schema] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(base_schema)}; });
     base_registry_schema = nullptr;
     auto recovered_registry_schema = local_schema_registry().get_or_null(base_schema->version());
-    BOOST_REQUIRE(recovered_registry_schema);
-    recovered_registry_schema = nullptr;
-    seastar::sleep(dummy.grace_period).get();
-    BOOST_REQUIRE(!local_schema_registry().get_or_null(base_schema->version()));
+    BOOST_REQUIRE(recovered_registry_schema->version() == base_schema->version());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -290,7 +290,6 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
             .with_column("pk", int32_type)
             .with_view_info(base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
             .build();
-    view_schema->view_info()->set_base_info(view_schema->view_info()->make_base_dependent_view_info(*base_schema));
     local_schema_registry().get_or_load(view_schema->version(),
         [view_schema, base_schema] (table_schema_version) -> base_and_view_schemas { return {frozen_schema(view_schema), base_schema}; });
     auto view_registry_schema = local_schema_registry().get_or_null(view_schema->version());

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -113,3 +113,26 @@ async def test_view_building_with_tablet_move(manager: ManagerClient, build_mode
 
         for view in views:
             await wait_for_view(cql, view, len(servers))
+
+# While view building is in progress, drop the view and change the schema
+# of the base table. The view table's state may become inconsistent with
+# the base table because they are detached.
+@pytest.mark.asyncio
+async def test_view_building_during_drop_view(manager: ManagerClient):
+    server = await manager.server_add()
+    cql = manager.get_cql()
+    await manager.api.enable_injection(server.ip_addr, "view_builder_consume_end_of_partition_delay", one_shot=True)
+
+    await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
+    await cql.run_async(f"CREATE TABLE ks.tab (p int, c int, PRIMARY KEY (p, c))")
+    await cql.run_async("INSERT INTO ks.tab (p,c) VALUES (123, 1000)")
+
+    await cql.run_async("CREATE INDEX idx1 ON ks.tab (c)")
+    # wait for view building to start
+    await asyncio.sleep(1)
+
+    # while view building is delayed, we drop the view and change the schema of the base table
+    await cql.run_async("DROP INDEX ks.idx1")
+    await manager.api.message_injection(server.ip_addr, "view_builder_consume_end_of_partition_delay")
+
+    await cql.run_async("DROP TABLE ks.tab")

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -1711,3 +1711,12 @@ def test_reverse_read_from_view(cql, test_keyspace):
             assert {(1,),(2,)} == set(cql.execute(f'select a from {mv} where b=1'))
             assert [(1,),(2,)] == list(cql.execute(f'select a from {mv} where b=1 order by a asc'))
             assert [(2,),(1,)] == list(cql.execute(f'select a from {mv} where b=1 order by a desc'))
+
+# Test that we can rename multiple columns in the base table at the same time
+# without causing any issues for view updates.
+# Reproduces issue https://github.com/scylladb/scylladb/issues/22194
+def test_rename_multiple_columns(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'pk int, ck int, PRIMARY KEY (pk, ck)') as table:
+        with new_materialized_view(cql, table, '*', 'ck, pk', 'pk IS NOT NULL AND ck IS NOT NULL'):
+            cql.execute(f'ALTER TABLE {table} RENAME pk TO pk2 AND ck TO ck2')
+            cql.execute(f'INSERT INTO {table} (pk2, ck2) VALUES (0,0)')

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -476,7 +476,11 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     schema_mutations muts(std::move(*tables), std::move(*columns), std::move(view_virtual_columns), std::move(computed_columns), std::move(indexes),
             std::move(dropped_columns), std::move(scylla_tables));
     if (muts.is_view()) {
-        return db::schema_tables::create_view_from_mutations(ctxt, muts);
+        query::result_set rs(muts.columnfamilies_mutation());
+        const query::result_set_row& view_row = rs.row(0);
+        auto base_name = view_row.get_nonnull<sstring>("base_table_name");
+        auto base_schema = do_load_schema_from_schema_tables(dbcfg, scylla_data_path, keyspace, base_name);
+        return db::schema_tables::create_view_from_mutations(ctxt, muts, std::move(base_schema));
     } else {
         return db::schema_tables::create_table_from_mutations(ctxt, muts);
     }

--- a/view_info.hh
+++ b/view_info.hh
@@ -29,7 +29,7 @@ class view_info final {
     // partition key columns of the base, maybe in a different order.
     mutable bool _is_partition_key_permutation_of_base_partition_key;
 public:
-    view_info(const schema& schema, const raw_view_info& raw_view_info);
+    view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
 
     const raw_view_info& raw() const {
         return _raw;

--- a/view_info.hh
+++ b/view_info.hh
@@ -76,7 +76,6 @@ public:
     /// The snapshot of both the view schema and base_dependent_view_info is represented
     /// by view_and_base. See with_base_info_snapshot().
     const db::view::base_info_ptr& base_info() const { return _base_info; }
-    void set_base_info(db::view::base_info_ptr);
     db::view::base_info_ptr make_base_dependent_view_info(const schema& base_schema) const;
 
     friend bool operator==(const view_info& x, const view_info& y) {

--- a/view_info.hh
+++ b/view_info.hh
@@ -22,12 +22,17 @@ class view_info final {
     // The following fields are used to select base table rows.
     mutable shared_ptr<cql3::statements::select_statement> _select_statement;
     mutable std::optional<query::partition_slice> _partition_slice;
-    db::view::base_info_ptr _base_info;
-    mutable bool _has_computed_column_depending_on_base_non_primary_key;
+    db::view::base_dependent_view_info _base_info;
+    bool _has_computed_column_depending_on_base_non_primary_key;
 
     // True if the partition key columns of the view are the same as the
     // partition key columns of the base, maybe in a different order.
-    mutable bool _is_partition_key_permutation_of_base_partition_key;
+    bool _is_partition_key_permutation_of_base_partition_key;
+
+    db::view::base_dependent_view_info make_base_dependent_view_info(const schema& base_schema) const;
+    bool make_has_computed_column_depending_on_base_non_primary_key() const;
+    bool make_is_partition_key_permutation_of_base_partition_key(const schema& base_schema) const;
+
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
 
@@ -64,19 +69,7 @@ public:
         return _is_partition_key_permutation_of_base_partition_key;
     }
 
-    /// Returns a pointer to the base_dependent_view_info which matches the current
-    /// schema of the base table.
-    ///
-    /// base_dependent_view_info lives separately from the view schema.
-    /// It can change without the view schema changing its value.
-    /// This pointer is updated on base table schema changes as long as this view_info
-    /// corresponds to the current schema of the view. After that the pointer stops tracking
-    /// the base table schema.
-    ///
-    /// The snapshot of both the view schema and base_dependent_view_info is represented
-    /// by view_and_base. See with_base_info_snapshot().
-    const db::view::base_info_ptr& base_info() const { return _base_info; }
-    db::view::base_info_ptr make_base_dependent_view_info(const schema& base_schema) const;
+    const db::view::base_dependent_view_info& base_info() const { return _base_info; }
 
     friend bool operator==(const view_info& x, const view_info& y) {
         return x._raw == y._raw;


### PR DESCRIPTION
Currently, the `base_info` may or may not be set in view schemas.
Even when it's set, it may be modified. This necessitates extra
checks when handling view schemas, as we'll as potentially causing
errors when we forget to set it at some point.

Instead, we want to make the base info an immutable member of view
schemas (inside `view_info`). For this, we need to set the base info on
construction, and then we'll be able to avoid making `base_info`
snapshots, and we'll no longer need to update the `base_info` of existing
view schemas ever after.

When the base schema is updated, instead of altering the `base_info` in
a view schema, we want to create a new view schema with an updated
base info. For that we update all paths for altering base schema, and issue
updates to all its view schemas as well.

This change requires updates to the view building code - we used to take
the most recent base schema from the base `column_family` and assume
that the `base_info` in view schemas was already updated. With this patch
we'll react to base schema updates and use the new view schemas together
with the new base schema.

Fixes https://github.com/scylladb/scylladb/issues/9059
Fixes https://github.com/scylladb/scylladb/issues/21292
Fixes https://github.com/scylladb/scylladb/issues/22194
Fixes https://github.com/scylladb/scylladb/issues/22410