### PR TITLE
sstables: use std::variant instead of boost::variant

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -4529,11 +4529,14 @@ class scylla_sstables(gdb.Command):
             sm = std_optional(sc['scylla_metadata'])
             if sm:
                 for tag, value in unordered_map(sm.get()['data']['data']):
-                    bv = boost_variant(value)
-                    # FIXME: only gdb.Type.template_argument(0) works for boost::variant<>
-                    if bv.which() != 0:
-                        continue
-                    val = bv.get()['value']
+                    try:
+                        v = std_variant(value)
+                    except gdb.error: # scylla 6.2 compatibility
+                        v = boost_variant(value)
+                        # FIXME: only gdb.Type.template_argument(0) works for boost::variant<>
+                        if v.which() != 0:
+                            continue
+                    val = v.get()['value']
                     if str(val.type) == 'sstables::sharding_metadata':
                         sm_size += chunked_vector(val['token_ranges']['elements']).external_memory_footprint()
             size += sm_size

--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -420,7 +420,7 @@ class std_variant:
     def get(self):
         index = self.index()
         current_type = self.member_types[index].strip_typedefs()
-        return self.get_with_type(index, current_type)
+        return self.get_with_type(current_type)
 
 
 class std_map:

--- a/sstables/disk_types.hh
+++ b/sstables/disk_types.hh
@@ -11,9 +11,8 @@
 #include "bytes.hh"
 #include "utils/chunked_vector.hh"
 #include <seastar/core/enum.hh>
-#include <boost/variant/variant.hpp>
-#include <boost/variant/get.hpp>
 #include <unordered_map>
+#include <variant>
 #include <type_traits>
 #include "mutation/atomic_cell.hh"
 
@@ -106,7 +105,7 @@ struct disk_set_of_tagged_union {
     using tag_type = TagType;
     using key_type = std::conditional_t<std::is_enum<TagType>::value, std::underlying_type_t<TagType>, TagType>;
     using hash_type = std::conditional_t<std::is_enum<TagType>::value, enum_hash<TagType>, TagType>;
-    using value_type = boost::variant<Members...>;
+    using value_type = std::variant<Members...>;
     std::unordered_map<tag_type, value_type, hash_type> data;
 
     template <TagType Tag, typename T>
@@ -116,7 +115,7 @@ struct disk_set_of_tagged_union {
         if (i == data.end()) {
             return nullptr;
         } else {
-            return &boost::get<disk_tagged_union_member<TagType, Tag, T>>(i->second).value;
+            return &std::get<disk_tagged_union_member<TagType, Tag, T>>(i->second).value;
         }
     }
     template <TagType Tag, typename T>

--- a/sstables/disk_types.hh
+++ b/sstables/disk_types.hh
@@ -100,12 +100,6 @@ struct disk_tagged_union_member {
     T value;
 };
 
-template <typename TagType, typename... Members>
-struct disk_tagged_union {
-    using variant_type = boost::variant<Members...>;
-    variant_type data;
-};
-
 // Each element of Members... is a disk_tagged_union_member<>
 template <typename TagType, typename... Members>
 struct disk_set_of_tagged_union {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -418,13 +418,13 @@ struct single_tagged_union_member_serdes_for final : single_tagged_union_member_
     using value_type = typename base::value_type;
     virtual future<> do_parse(const schema& s, sstable_version_types version, random_access_reader& in, value_type& v) const override {
         v = Member();
-        return parse(s, version, in, boost::get<Member>(v).value);
+        return parse(s, version, in, std::get<Member>(v).value);
     }
     virtual uint32_t do_size(sstable_version_types version, const value_type& v) const override {
-        return serialized_size(version, boost::get<Member>(v).value);
+        return serialized_size(version, std::get<Member>(v).value);
     }
     virtual void do_write(sstable_version_types version, file_writer& out, const value_type& v) const override {
-        write(version, out, boost::get<Member>(v).value);
+        write(version, out, std::get<Member>(v).value);
     }
 };
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1499,7 +1499,7 @@ const char* to_string(sstables::ext_timestamp_stats_type t) {
     std::abort();
 }
 
-class scylla_metadata_visitor : public boost::static_visitor<> {
+class scylla_metadata_visitor {
     json_writer& _writer;
 
 public:
@@ -1620,7 +1620,7 @@ void dump_scylla_metadata_operation(schema_ptr schema, reader_permit permit, con
             continue;
         }
         for (const auto& [k, v] : m->data.data) {
-            boost::apply_visitor(scylla_metadata_visitor(writer), v);
+            std::visit(scylla_metadata_visitor(writer), v);
         }
         writer.EndObject();
     }


### PR DESCRIPTION
Continue replacing boost types with std one where possible.

Improvement, no backport needed