### PR TITLE
build: disable explicit-specialization-storage-class warning

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -6,6 +6,7 @@ set(disabled_warnings
   overloaded-virtual
   unsupported-friend
   enum-constexpr-conversion
+  explicit-specialization-storage-class
   unused-parameter)
 include(CheckCXXCompilerFlag)
 foreach(warning ${disabled_warnings})

--- a/configure.py
+++ b/configure.py
@@ -1603,6 +1603,7 @@ def get_warning_options(cxx):
         '-Werror',
         '-Wextra',
         '-Wimplicit-fallthrough',
+        '-Wno-explicit-specialization-storage-class',
         '-Wno-mismatched-tags',  # clang-only
         '-Wno-c++11-narrowing',
         '-Wno-overloaded-virtual',


### PR DESCRIPTION
before this change, when building the tree with clang-19, we had:

```
FAILED: utils/CMakeFiles/utils.dir/Debug/config_file.cc.o
/usr/bin/clang++ -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DDEBUG -DDEBUG_LSA_SANITIZER -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Debug\" -I/home/kefu/dev/scylladb -isystem /home/kefu/dev/scylladb/seastar/include -isystem /home/kefu/dev/scylladb/build/Debug/seastar/gen/include -I/usr/include/p11-kit-1 -g -Og -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-enum-constexpr-conversion -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -march=westmere -Xclang -fexperimental-assignment-tracking=disabled -std=gnu++23 -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=19 -DSEASTAR_DEBUG -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEBUG_PROMISE -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_TYPE_ERASE_MORE -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_DYN_LINK -DFMT_SHARED -DWITH_GZFILEOP -MD -MT utils/CMakeFiles/utils.dir/Debug/config_file.cc.o -MF utils/CMakeFiles/utils.dir/Debug/config_file.cc.o.d -o utils/CMakeFiles/utils.dir/Debug/config_file.cc.o -c /home/kefu/dev/scylladb/utils/config_file.cc
In file included from /home/kefu/dev/scylladb/utils/config_file.cc:31:
/home/kefu/dev/scylladb/utils/config_file.hh:57:1: error: explicit specialization cannot have a storage class [-Werror,-Wexplicit-specialization-storage-class]
   57 | extern const config_type config_type_for<uint32_t>;
      | ^~~~~~
/home/kefu/dev/scylladb/utils/config_file.hh:60:1: error: explicit specialization cannot have a storage class [-Werror,-Wexplicit-specialization-storage-class]
   60 | extern const config_type config_type_for<sstring>;
      | ^~~~~~
/home/kefu/dev/scylladb/utils/config_file.hh:63:1: error: explicit specialization cannot have a storage class [-Werror,-Wexplicit-specialization-storage-class]
   63 | extern const config_type config_type_for<bool>;
      | ^~~~~~
/home/kefu/dev/scylladb/utils/config_file.hh:66:1: error: explicit specialization cannot have a storage class [-Werror,-Wexplicit-specialization-storage-class]
   66 | extern const config_type config_type_for<std::unordered_map<sstring, sstring>>;
      | ^~~~~~
/home/kefu/dev/scylladb/utils/config_file.hh:69:1: error: explicit specialization cannot have a storage class [-Werror,-Wexplicit-specialization-storage-class]
   69 | extern const config_type config_type_for<std::unordered_map<sstring, std::unordered_map<sstring, sstring>>>;
      | ^~~~~~
5 errors generated.
```

because C++ standard forbids specifying storage class for explicit specialization. but without the `extern` specifier, the compiler would consider the declarations as definitions, and fail the build because `config_type` is not default constructible. but these specializations are defined and constructed in `db/config.cc` not in the header file.

this is a dilemma. on one hand we need to provide the forward declaration for `encryption/encryption_config.cc`, which is another translation unit than `db/config.cc`, on the other hand, C++ does not allow us to provide a forward declaration of a template specialization of a variable.

before we have a solution, let's disable this warning.

---

no need to backport, as this addresses a build failure caused by a recent change (commit 7ed89266b3), which is only included by master.