### PR TITLE
main, encryption: correct misspellings

### DIFF
--- a/ent/encryption/encrypted_file_impl.cc
+++ b/ent/encryption/encrypted_file_impl.cc
@@ -45,7 +45,7 @@ static inline bool is_aligned(size_t n, size_t a) {
  *
  * Since all writes are assumed to be done by us, and must be aligned,
  * we can assume in turn that any resizing should be made by our truncate
- * method. If we attept to truncate to a size not a multiple of our
+ * method. If we attempt to truncate to a size not a multiple of our
  * _key_ block size (typically 16), we add the same size to the actual
  * truncation size.
  * On read we then check the file size. If we're reading from a file

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -966,7 +966,7 @@ future<seastar::shared_ptr<encryption_context>> register_extensions(const db::co
 
         // modify schemas for tables holding sensitive data to use encryption w. key described
         // by the opts.
-        // since schemas are duplicated across shards, we must call to each shard and augument
+        // since schemas are duplicated across shards, we must call to each shard and augment
         // them all.
         // Since we are in pre-init phase, this should be safe.
         f = f.then([opts = *opts, &exts] {

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -936,17 +936,17 @@ future<seastar::shared_ptr<encryption_context>> register_extensions(const db::co
     
     auto maybe_get_options = [&](const utils::config_file::string_map& map, const sstring& what) -> std::optional<options> {
         options opts(map.begin(), map.end());
-        opt_wrapper sie(opts);
-        if (!::strcasecmp(sie("enabled").value_or("false").c_str(), "false")) {
+        opt_wrapper get_opt(opts);
+        if (!::strcasecmp(get_opt("enabled").value_or("false").c_str(), "false")) {
             return std::nullopt;
         }
         // commitlog/system table encryption/global user encryption should not use replicated keys,
         // We default to local keys, but KMIP/KMS is ok as well (better in fact).
-        opts[KEY_PROVIDER] = sie(KEY_PROVIDER).value_or(LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY);
-        if (opts[KEY_PROVIDER] == LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY && !sie(SECRET_KEY_FILE)) {
+        opts[KEY_PROVIDER] = get_opt(KEY_PROVIDER).value_or(LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY);
+        if (opts[KEY_PROVIDER] == LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY && !get_opt(SECRET_KEY_FILE)) {
             // system encryption uses different key folder than user tables.
             // explicitly set the key file path
-            opts[SECRET_KEY_FILE] = (bfs::path(cfg.system_key_directory()) / bfs::path("system") / bfs::path(sie("key_name").value_or("system_table_keytab"))).string();
+            opts[SECRET_KEY_FILE] = (bfs::path(cfg.system_key_directory()) / bfs::path("system") / bfs::path(get_opt("key_name").value_or("system_table_keytab"))).string();
         }
         // forbid replicated. we cannot guarantee being able to open sstables on populate
         if (opts[KEY_PROVIDER] == REPLICATED_KEY_PROVIDER_FACTORY) {

--- a/ent/encryption/encryption_config.cc
+++ b/ent/encryption/encryption_config.cc
@@ -83,7 +83,7 @@ Actual connection can be either an explicit endpoint (<host>:<port>), or selecte
 
 If aws_use_ec2_region is true, regions is instead queried from EC2 metadata.
 
-Authentication can be explicit with aws_access_key_id and aws_secret_access_key. Either secret or both can be ommitted
+Authentication can be explicit with aws_access_key_id and aws_secret_access_key. Either secret or both can be omitted
 in which case the provider will try to read them from AWS credentials in ~/.aws/credentials
 
 If aws_use_ec2_credentials is true, authentication is instead queried from EC2 metadata.

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -581,7 +581,7 @@ future<rjson::value> encryption::gcp_host::impl::send_request(std::string_view u
     rjson::value v;
     co_await send_request(uri, std::move(body), content_type, [&](const http::reply& rep, std::string_view s) {
         if (rep._status != http::reply::status_type::ok) {
-            gcp_log.trace("Got unexpected reponse ({})", rep._status);
+            gcp_log.trace("Got unexpected response ({})", rep._status);
             for (auto& [k, v] : rep._headers) {
                 gcp_log.trace("{}: {}", k, v);
             }
@@ -660,7 +660,7 @@ future<> encryption::gcp_host::impl::send_request(std::string_view uri, std::str
         auto&lh = handler;
         auto lin = std::move(in);
         auto result = co_await util::read_entire_stream_contiguous(lin);
-        gcp_log.trace("Got reponse {}: {}", int(rep._status), result);
+        gcp_log.trace("Got response {}: {}", int(rep._status), result);
         lh(rep, result);
     });
 
@@ -874,7 +874,7 @@ future<encryption::gcp_host::impl::key_and_id_type> encryption::gcp_host::impl::
      * I.e. something like:
      *   mykeyring:mykey:e56sadfafa3324ff=/wfsdfwssdf
      *
-     * The actual data key can be retreived by doing a KMS "Decrypt" of the data blob part
+     * The actual data key can be retrieved by doing a KMS "Decrypt" of the data blob part
      * using the KMS key referenced by the key ID. This gives back actual key data that can
      * be used to create a symmetric_key with algo, length etc as specified by metadata.
      *

--- a/ent/encryption/kmip_host.cc
+++ b/ent/encryption/kmip_host.cc
@@ -334,7 +334,7 @@ future<> kmip_host::impl::connection::connect() {
         return seastar::net::dns::resolve_name(name).then([this, cred, port](seastar::net::inet_address addr) {
             return seastar::tls::connect(cred, seastar::ipv4_addr{addr, uint16_t(port)}).then([this](seastar::connected_socket s) {
                 kmip_log.debug("Successfully connected {}", _host);
-                // #998 Set keepalive to try avoiding connection going stale inbetween commands. 
+                // #998 Set keepalive to try avoiding connection going stale in between commands.
                 s.set_keepalive_parameters(net::tcp_keepalive_params{60s, 60s, 10});
                 s.set_keepalive(true);
                 _input = s.input();
@@ -564,7 +564,7 @@ future<int> kmip_host::impl::do_cmd(KMIP_CMD* cmd, con_ptr cp, Func& f, bool ret
             release(cmd, cp, retain_connection_after_command);
             return make_ready_future<opt_int>(res);
         default:
-            // error. connection is dicarded. close it.
+            // error. connection is discarded. close it.
             return cp->close().then_wrapped([cp, res](auto f) {
                 // ignore any exception thrown from the close.
                 // ensure we provide the kmip error instead.

--- a/main.cc
+++ b/main.cc
@@ -2480,7 +2480,7 @@ int main(int ac, char** av) {
     }
 
     // We have to override p11-kit config path before p11-kit initialization.
-    // And the initialization will invoke on seastar initalization, so it has to
+    // And the initialization will invoke on seastar initialization, so it has to
     // be before app.run()
     // #3583 - need to potentially ensure this for tools as well, since at least
     // sstable* might need crypto libraries.


### PR DESCRIPTION
in this changeset, some misspellings identified by codespell were corrected.

---

it's a cleanup, hence no need to backport.