### PR TITLE
api: include used header

### DIFF
--- a/api/system.cc
+++ b/api/system.cc
@@ -13,6 +13,7 @@
 #include "db/sstables-format-selector.hh"
 
 #include <rapidjson/document.h>
+#include <boost/lexical_cast.hpp>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/relabel_config.hh>


### PR DESCRIPTION
when building the tree on fedora 41, we could have following build failure:

```
FAILED: api/CMakeFiles/api.dir/Debug/system.cc.o
/usr/bin/clang++ -DDEBUG -DDEBUG_LSA_SANITIZER -DSANITIZE -DSCYLLA_BUILD_MODE=debug -DSCYLLA_ENABLE_ERROR_INJECTION -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Debug\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/gen -isystem /home/kefu/dev/scylladb/seastar/include -isystem /home/kefu/dev/scylladb/build/Debug/seastar/gen/include -isystem /home/kefu/dev/scylladb/build/rust -isystem /home/kefu/dev/scylladb/abseil -I/usr/include/p11-kit-1 -g -Og -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-enum-constexpr-conversion -Wno-explicit-specialization-storage-class -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -march=westmere -Xclang -fexperimental-assignment-tracking=disabled -std=gnu++23 -Werror=unused-result -fstack-clash-protection -fsanitize=address -fsanitize=undefined -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=19 -DSEASTAR_DEBUG -DSEASTAR_DEFAULT_ALLOCATOR -DSEASTAR_SHUFFLE_TASK_QUEUE -DSEASTAR_DEBUG_SHARED_PTR -DSEASTAR_DEBUG_PROMISE -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_TYPE_ERASE_MORE -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_DYN_LINK -DFMT_SHARED -DWITH_GZFILEOP -MD -MT api/CMakeFiles/api.dir/Debug/system.cc.o -MF api/CMakeFiles/api.dir/Debug/system.cc.o.d -o api/CMakeFiles/api.dir/Debug/system.cc.o -c /home/kefu/dev/scylladb/api/system.cc
/home/kefu/dev/scylladb/api/system.cc:116:47: error: no member named 'lexical_cast' in namespace 'boost'
  116 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                        ~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:116:78: error: expected '(' for function-style cast or type construction
  116 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                                            ~~~~~~~~~~~~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:118:25: error: no type named 'bad_lexical_cast' in namespace 'boost'
  118 |         } catch (boost::bad_lexical_cast& e) {
      |                  ~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:136:47: error: no member named 'lexical_cast' in namespace 'boost'
  136 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                        ~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:136:78: error: expected '(' for function-style cast or type construction
  136 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                                            ~~~~~~~~~~~~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:140:25: error: no type named 'bad_lexical_cast' in namespace 'boost'
  140 |         } catch (boost::bad_lexical_cast& e) {
      |                  ~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:148:47: error: no member named 'lexical_cast' in namespace 'boost'
  148 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                        ~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:148:78: error: expected '(' for function-style cast or type construction
  148 |             logging::log_level level = boost::lexical_cast<logging::log_level>(std::string(req.get_query_param("level")));
      |                                                            ~~~~~~~~~~~~~~~~~~^
/home/kefu/dev/scylladb/api/system.cc:150:25: error: no type named 'bad_lexical_cast' in namespace 'boost'
  150 |         } catch (boost::bad_lexical_cast& e) {
      |                  ~~~~~~~^
```

in this change, we include the used header to address the build failure.

---

it's a cleanup, hence no need to backport.