### PR TITLE
cmake: add the `-dynamic-linker=...` form to the -dynamic-linker regex

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -72,7 +72,7 @@ function(get_padded_dynamic_linker_option output length)
     ERROR_VARIABLE driver_command_line
     ERROR_STRIP_TRAILING_WHITESPACE)
   # extract the argument for the "-dynamic-linker" option
-  if(driver_command_line MATCHES ".*\"?${dynamic_linker_option}\"? \"?([^ \"]*)\"? .*")
+  if(driver_command_line MATCHES ".*\"?${dynamic_linker_option}\"?[ =]\"?([^ \"]*)\"?[ \n].*")
     set(dynamic_linker ${CMAKE_MATCH_1})
   else()
     message(FATAL_ERROR "Unable to find ${dynamic_linker_option} in driver-generated command: "

--- a/configure.py
+++ b/configure.py
@@ -1672,19 +1672,11 @@ def generate_version(date_stamp):
 # the program headers.
 def dynamic_linker_option():
     gcc_linker_output = subprocess.check_output(['gcc', '-###', '/dev/null', '-o', 't'], stderr=subprocess.STDOUT).decode('utf-8')
-    original_dynamic_linker = re.search('-dynamic-linker ([^ ]*)', gcc_linker_output).groups()[0]
+    original_dynamic_linker = re.search('"?-dynamic-linker"?[ =]"?([^ "]*)"?[ \n]', gcc_linker_output).groups()[0]
 
-    employ_ld_trickery = True
-    # distro-specific setup
-    if os.environ.get('NIX_CC'):
-        employ_ld_trickery = False
-
-    if employ_ld_trickery:
-        # gdb has a SO_NAME_MAX_PATH_SIZE of 512, so limit the path size to
-        # that. The 512 includes the null at the end, hence the 511 below.
-        dynamic_linker = '/' * (511 - len(original_dynamic_linker)) + original_dynamic_linker
-    else:
-        dynamic_linker = original_dynamic_linker
+    # gdb has a SO_NAME_MAX_PATH_SIZE of 512, so limit the path size to
+    # that. The 512 includes the null at the end, hence the 511 below.
+    dynamic_linker = '/' * (511 - len(original_dynamic_linker)) + original_dynamic_linker
     return f'--dynamic-linker={dynamic_linker}'
 
 forced_ldflags = '-Wl,'


### PR DESCRIPTION
On my system (Nix), the compiler produces a `-dynamic-linker=/nix/store/...` in the linker call scanned by get_padded_dynamic_linker_option. But the regex can't deal with the `=` there, it requires a ` `. Fix that.

Could be backported, but it's not needed for anything.