### PR TITLE
api: task_manager: do not unregister finish task when its status is queried

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -253,6 +253,30 @@
                ]
             }
          ]
+      },
+      {
+         "path":"/task_manager/drain/{module}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Drain finished local tasks",
+               "type":"void",
+               "nickname":"drain_tasks",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"module",
+                     "description":"The module to drain",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
       }
    ],
    "models":{

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -232,6 +232,32 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         uint32_t user_ttl = cfg.user_task_ttl_seconds();
         co_return json::json_return_type(user_ttl);
     });
+
+    tm::drain_tasks.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+        co_await tm.invoke_on_all([&req] (tasks::task_manager& tm) -> future<> {
+            tasks::task_manager::module_ptr module;
+            try {
+                module = tm.find_module(req->get_path_param("module"));
+            } catch (...) {
+                throw bad_param_exception(fmt::format("{}", std::current_exception()));
+            }
+
+            const auto& local_tasks = module->get_local_tasks();
+            std::vector<tasks::task_id> ids;
+            ids.reserve(local_tasks.size());
+            std::transform(begin(local_tasks), end(local_tasks), std::back_inserter(ids), [] (const auto& task) {
+                return task.second->is_complete() ? task.first : tasks::task_id::create_null_id();
+            });
+
+            for (auto&& id : ids) {
+                if (id) {
+                    module->unregister_task(id);
+                }
+                co_await maybe_yield();
+            }
+        });
+        co_return json_void();
+    });
 }
 
 void unset_task_manager(http_context& ctx, routes& r) {
@@ -243,6 +269,7 @@ void unset_task_manager(http_context& ctx, routes& r) {
     tm::get_task_status_recursively.unset(r);
     tm::get_and_update_ttl.unset(r);
     tm::get_ttl.unset(r);
+    tm::drain_tasks.unset(r);
 }
 
 }

--- a/docs/dev/task_manager.md
+++ b/docs/dev/task_manager.md
@@ -64,14 +64,14 @@ Briefly:
 - `/task_manager/list_module_tasks/{module}` -
         lists (by default non-internal) tasks in the module;
 - `/task_manager/task_status/{task_id}` -
-        gets the task's status, unregisters the task if it's finished;
+        gets the task's status;
 - `/task_manager/abort_task/{task_id}` -
         aborts the task if it's abortable;
 - `/task_manager/wait_task/{task_id}` -
         waits for the task and gets its status;
 - `/task_manager/task_status_recursive/{task_id}` -
         gets statuses of the task and all its descendants in BFS
-        order, unregisters the task;
+        order;
 - `/task_manager/ttl` -
         gets or sets new ttl.
 - `/task_manager/user_ttl` -

--- a/docs/dev/task_manager.md
+++ b/docs/dev/task_manager.md
@@ -76,6 +76,8 @@ Briefly:
         gets or sets new ttl.
 - `/task_manager/user_ttl` -
         gets or sets new user ttl.
+- `/task_manager/drain/{module}` -
+        unregisters all finished local tasks in the module.
 
 # Virtual tasks
 

--- a/docs/operating-scylla/admin-tools/task-manager.rst
+++ b/docs/operating-scylla/admin-tools/task-manager.rst
@@ -74,13 +74,13 @@ API calls
 	- *keyspace* - if set, tasks are filtered to contain only the ones working on this keyspace;
 	- *table* - if set, tasks are filtered to contain only the ones working on this table;
 
-* ``/task_manager/task_status/{task_id}`` - gets the task's status, unregisters the task if it's finished;
+* ``/task_manager/task_status/{task_id}`` - gets the task's status;
 * ``/task_manager/abort_task/{task_id}`` - aborts the task if it's abortable, otherwise 403 status code is returned;
-* ``/task_manager/wait_task/{task_id}`` - waits for the task and gets its status (does not unregister the tasks); query params:
+* ``/task_manager/wait_task/{task_id}`` - waits for the task and gets its status; query params:
 
 	- *timeout* - timeout in seconds; if set - 408 status code is returned if waiting times out;
 
-* ``/task_manager/task_status_recursive/{task_id}`` - gets statuses of the task and all its descendants in BFS order, unregisters the root task;
+* ``/task_manager/task_status_recursive/{task_id}`` - gets statuses of the task and all its descendants in BFS order;
 * ``/task_manager/ttl`` - gets or sets new ttl; query params (if setting):
 
 	- *ttl* - new ttl value.

--- a/docs/operating-scylla/admin-tools/task-manager.rst
+++ b/docs/operating-scylla/admin-tools/task-manager.rst
@@ -89,6 +89,8 @@ API calls
 
 	- *user_ttl* - new user ttl value.
 
+* ``/task_manager/drain/{module}`` - unregisters all finished local tasks in the module.
+
 Cluster tasks are not unregistered from task manager with API calls.
 
 Tasks API

--- a/docs/operating-scylla/nodetool-commands/tasks/drain.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/drain.rst
@@ -1,0 +1,21 @@
+Nodetool tasks drain
+====================
+**tasks drain** - Unregisters all finished local tasks from the module.
+If a module is not specified, finished tasks in all modules are unregistered.
+
+Syntax
+-------
+.. code-block:: console
+
+   nodetool tasks drain [--module <module>]
+
+Options
+-------
+
+* ``--module`` - if set, only the specified module is drained.
+
+For example:
+
+.. code-block:: shell
+
+   > nodetool tasks drain --module repair

--- a/docs/operating-scylla/nodetool-commands/tasks/index.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/index.rst
@@ -24,10 +24,6 @@ Task Status Retention
 
 * When a task completes, its status is temporarily stored on the executing node
 * Status information is retained for up to :confval:`task_ttl_in_seconds` seconds
-* The status information of a completed task is automatically removed after being queried with ``tasks status`` or ``tasks tree``
-* ``tasks wait`` returns the status, but it does not remove the task information of the queried task
-
-.. note:: Multiple status queries using ``tasks status`` and ``tasks tree`` for the same completed task will only receive a response for the first query, since the status is removed after being retrieved.
 
 Supported tasks suboperations
 -----------------------------

--- a/docs/operating-scylla/nodetool-commands/tasks/index.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/index.rst
@@ -5,6 +5,7 @@ Nodetool tasks
    :hidden:
 
    abort <abort>
+   drain <drain>
    user-ttl <user-ttl>
    list <list>
    modules <modules>
@@ -32,6 +33,7 @@ Supported tasks suboperations
 -----------------------------
 
 * :doc:`abort </operating-scylla/nodetool-commands/tasks/abort>` - Aborts the task.
+* :doc:`drain </operating-scylla/nodetool-commands/tasks/drain>` - Unregisters all finished local tasks.
 * :doc:`user-ttl </operating-scylla/nodetool-commands/tasks/user-ttl>` - Gets or sets user_task_ttl value.
 * :doc:`list </operating-scylla/nodetool-commands/tasks/list>` - Lists tasks in the module.
 * :doc:`modules </operating-scylla/nodetool-commands/tasks/modules>` - Lists supported modules.

--- a/docs/operating-scylla/nodetool-commands/tasks/status.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/status.rst
@@ -1,6 +1,6 @@
 Nodetool tasks status
 =========================
-**tasks status** - Gets the status of a task manager task. If the task was finished it is unregistered.
+**tasks status** - Gets the status of a task manager task.
 
 Syntax
 -------

--- a/docs/operating-scylla/nodetool-commands/tasks/tree.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/tree.rst
@@ -1,7 +1,7 @@
 Nodetool tasks tree
 =======================
 **tasks tree** - Gets the statuses of a task manager task and all its descendants.
-The statuses are listed in BFS order. If the task was finished it is unregistered.
+The statuses are listed in BFS order.
 
 If task_id isn't specified, trees of all non-internal tasks are printed
 (internal tasks are the ones that have a parent or cover an operation that

--- a/tasks/task_handler.cc
+++ b/tasks/task_handler.cc
@@ -85,9 +85,6 @@ future<status_helper> task_handler::get_status_helper() {
             [id = _id] (task_manager::task_variant task_v, tasks::virtual_task_hint hint) -> future<status_helper> {
         return std::visit(overloaded_functor{
             [] (task_manager::task_ptr task) -> future<status_helper> {
-                if (task->is_complete()) {
-                    task->unregister_task();
-                }
                 co_return status_helper{
                     .status = co_await get_task_status(task),
                     .task = task

--- a/test/nodetool/test_tasks.py
+++ b/test/nodetool/test_tasks.py
@@ -29,6 +29,15 @@ def test_abort_failure(nodetool, scylla_only):
             {"expected_requests": []},
             ["required parameter is missing"])
 
+def test_drain(nodetool, scylla_only):
+    nodetool("tasks", "drain", expected_requests=[
+        expected_request("GET", "/task_manager/list_modules", response=["repair", "compaction"]),
+        expected_request("POST", "/task_manager/drain/repair"),
+        expected_request("POST", "/task_manager/drain/compaction")])
+
+    nodetool("tasks", "drain", "--module", "repair", expected_requests=[
+        expected_request("POST", "/task_manager/drain/repair")])
+
 def test_user_ttl(nodetool, scylla_only):
     nodetool("tasks", "user-ttl", expected_requests=[
         expected_request("GET", "/task_manager/user_ttl")])

--- a/test/rest_api/task_manager_utils.py
+++ b/test/rest_api/task_manager_utils.py
@@ -70,9 +70,11 @@ def check_child_parent_relationship(rest_api, status_tree, parent, allow_no_chil
 
 def drain_module_tasks(rest_api, module_name):
     tasks = [task for task in list_tasks(rest_api, module_name, True)]
+    # Wait for all tasks.
     for task in tasks:
-        # Wait for task and unregister it.
         resp = rest_api.send("GET", f"task_manager/wait_task/{task['task_id']}")
-        resp = rest_api.send("GET", f"task_manager/task_status/{task['task_id']}")
         # The task may be already unregistered.
         assert resp.status_code == requests.codes.ok or resp.status_code == requests.codes.bad_request, "Invalid status code"
+
+    resp = rest_api.send("POST", f"task_manager/drain/{module_name}")
+    resp.raise_for_status()

--- a/test/rest_api/test_task_manager.py
+++ b/test/rest_api/test_task_manager.py
@@ -56,7 +56,6 @@ def test_task_manager_status_done(rest_api):
 
                 status = get_task_status(rest_api, task0)
                 check_status_correctness(status, { "id": task0, "state": "done", "sequence_number": 1, "keyspace": "keyspace0", "table": "table0" })
-                assert_task_does_not_exist(rest_api, task0)
 
 def test_task_manager_status_failed(rest_api):
     with new_test_module(rest_api):
@@ -70,7 +69,6 @@ def test_task_manager_status_failed(rest_api):
 
                 status = get_task_status(rest_api, task0)
                 check_status_correctness(status, { "id": task0, "state": "failed", "error": "Test task failed", "sequence_number": 1, "keyspace": "keyspace0", "table": "table0" })
-                assert_task_does_not_exist(rest_api, task0)
 
 def test_task_manager_not_abortable(rest_api):
     with new_test_module(rest_api):

--- a/test/topology_tasks/task_manager_client.py
+++ b/test/topology_tasks/task_manager_client.py
@@ -75,5 +75,4 @@ class TaskManagerClient():
         tasks = await self.list_tasks(node_ip, module_name, internal=internal)
         await asyncio.gather(*(self.api.client.get(f"/task_manager/wait_task/{stats.task_id}", host=node_ip,
                                                 allow_failed=True) for stats in tasks))
-        await asyncio.gather(*(self.api.client.get(f"/task_manager/task_status/{stats.task_id}", host=node_ip,
-                                                allow_failed=True) for stats in tasks))
+        await self.api.client.get(f"/task_manager/drain/{module_name}", host=node_ip)


### PR DESCRIPTION
Currently, when the status of a task is queried and the task is already finished, 
it gets unregistered. Getting the status shouldn't be a one-time operation. 

Stop removing the task after its status is queried. Adjust tests not to rely
on this behavior. Add task_manager/drain API and nodetool tasks drain 
command to remove finished tasks in the module.

Fixes: https://github.com/scylladb/scylladb/issues/21388.

It's a fix to task_manager API, should be backported to all branches