### PR TITLE
[Backport 6.2] test.py: deselect random failures which can cause #21534

### DIFF
--- a/test/topology_random_failures/cluster_events.py
+++ b/test/topology_random_failures/cluster_events.py
@@ -67,6 +67,14 @@ def deselect_for(reason: str, error_injections: list[str] | None = None) -> Call
 #       >>> await anext(cluster_event, None)
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def sleep_for_30_seconds(manager: ManagerClient,
                                random_tables: RandomTables,
                                error_injection: str) -> AsyncIterator[None]:
@@ -525,6 +533,14 @@ async def remove_node(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def restart_non_coordinator_node(manager: ManagerClient,
                                        random_tables: RandomTables,
                                        error_injection: str) -> AsyncIterator[None]:
@@ -536,6 +552,14 @@ async def restart_non_coordinator_node(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def restart_coordinator_node(manager: ManagerClient,
                                    random_tables: RandomTables,
                                    error_injection: str) -> AsyncIterator[None]:
@@ -546,7 +570,14 @@ async def restart_coordinator_node(manager: ManagerClient,
 
     yield
 
-
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
                                                random_tables: RandomTables,
                                                error_injection: str) -> AsyncIterator[None]:
@@ -562,6 +593,7 @@ async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
     # TODO: remove this skip when #21534 will be resolved.
     error_injections=[
         "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
     ],
     reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
 )
@@ -576,6 +608,14 @@ async def stop_coordinator_node_gracefully(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def kill_non_coordinator_node(manager: ManagerClient,
                                     random_tables: RandomTables,
                                     error_injection: str) -> AsyncIterator[None]:
@@ -594,6 +634,7 @@ async def kill_non_coordinator_node(manager: ManagerClient,
     # TODO: remove this skip when #21534 will be resolved.
     error_injections=[
         "stop_after_setting_mode_to_normal_raft_topology",
+        "stop_before_becoming_raft_voter",
     ],
     reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
 )

--- a/test/topology_random_failures/cluster_events.py
+++ b/test/topology_random_failures/cluster_events.py
@@ -558,6 +558,13 @@ async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def stop_coordinator_node_gracefully(manager: ManagerClient,
                                            random_tables: RandomTables,
                                            error_injection: str) -> AsyncIterator[None]:
@@ -583,6 +590,13 @@ async def kill_non_coordinator_node(manager: ManagerClient,
     yield
 
 
+@deselect_for(
+    # TODO: remove this skip when #21534 will be resolved.
+    error_injections=[
+        "stop_after_setting_mode_to_normal_raft_topology",
+    ],
+    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
+)
 async def kill_coordinator_node(manager: ManagerClient,
                                 random_tables: RandomTables,
                                 error_injection: str) -> AsyncIterator[None]:

--- a/test/topology_random_failures/error_injections.py
+++ b/test/topology_random_failures/error_injections.py
@@ -28,3 +28,11 @@ ERROR_INJECTIONS = (
     "stop_after_streaming",
     "stop_after_bootstrapping_initial_raft_configuration",
 )
+
+# Error injections which can cause a node's hang due to some timeouts.
+ERROR_INJECTIONS_NODE_MAY_HANG = (
+    "stop_after_sending_join_node_request",
+    "stop_after_updating_cdc_generation",
+    "stop_before_streaming",
+    "stop_after_bootstrapping_initial_raft_configuration",
+)

--- a/test/topology_random_failures/test_random_failures.py
+++ b/test/topology_random_failures/test_random_failures.py
@@ -135,6 +135,7 @@ async def test_random_failures(manager: ManagerClient,
         expected_statuses=[
             psutil.STATUS_STOPPED,
         ],
+        deadline=time.time() + 180,
     )
 
     LOGGER.info("Run the cluster event main step.")

--- a/test/topology_random_failures/test_random_failures.py
+++ b/test/topology_random_failures/test_random_failures.py
@@ -23,7 +23,7 @@ from test.topology.util import wait_for_token_ring_and_group0_consistency, get_c
 from test.topology.conftest import skip_mode
 from test.pylib.internal_types import ServerUpState
 from test.topology_random_failures.cluster_events import CLUSTER_EVENTS, TOPOLOGY_TIMEOUT
-from test.topology_random_failures.error_injections import ERROR_INJECTIONS
+from test.topology_random_failures.error_injections import ERROR_INJECTIONS, ERROR_INJECTIONS_NODE_MAY_HANG
 
 if TYPE_CHECKING:
     from test.pylib.random_tables import RandomTables
@@ -150,14 +150,19 @@ async def test_random_failures(manager: ManagerClient,
 
     server_log = await manager.server_open_log(server_id=s_info.server_id)
 
-    if cluster_event_duration + 1 >= WAIT_FOR_IP_TIMEOUT and error_injection in (  # give one more second for a tolerance
-        "stop_after_sending_join_node_request",
-        "stop_after_bootstrapping_initial_raft_configuration",
-    ):
+    if cluster_event_duration + 1 >= WAIT_FOR_IP_TIMEOUT and error_injection in ERROR_INJECTIONS_NODE_MAY_HANG:
         LOGGER.info("Expecting the added node can hang and we'll have a message in the coordinator's log.  See #18638.")
         coordinator = await get_coordinator_host(manager=manager)
         coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)
-        if matches := await coordinator_log.grep(r"The node may hang\. It's safe to shut it down manually now\."):
+        coordinator_log_pattern = r"The node may hang\. It's safe to shut it down manually now\."
+        if matches := await server_log.grep(r"init - Setting local host id to (?P<hostid>[0-9a-f-]+)"):
+            line, match = matches[-1]
+            LOGGER.info("Found following message in the coordinator's log:\n\t%s", line)
+            coordinator_log_pattern += (
+                rf"|updating topology state: rollback {match.group('hostid')} after bootstrapping failure, moving"
+                rf" transition state to left token ring and setting cleanup flag"
+            )
+        if matches := await coordinator_log.grep(coordinator_log_pattern):
             LOGGER.info("Found following message in the coordinator's log:\n\t%s", matches[-1][0])
             await manager.server_stop(server_id=s_info.server_id)
 


### PR DESCRIPTION
We run topology_random_failures in debug mode only and sometimes Scylla is too slow in this mode. Increase timeout for Scylla startup from 30s to 180s to reduce flakiness.

* (cherry picked from commit [5d254b1](https://github.com/scylladb/scylladb/commit/5d254b1fdf06fa14d46d7c9f3e6ad750692715db))


Parent PR: #21659

---

Following combinations of error injections and cluster events can cause #21534. Disable them for now because they break CI.

* (cherry picked from commit [1e9d780](https://github.com/scylladb/scylladb/commit/1e9d780e892a98badc95c654084b0a711f4605ad))


Parent PR: #21658

---

There are many CI failures (repros of #21534) which caused by `stop_after_setting_mode_to_normal_raft_topology` and `stop_before_becoming_raft_voter` error injections in combination with some cluster events.

Need to deselect them for now to make CI more stable. First batch deselected in #21658

Also, add the handling of topology state rollback caused by `stop_before_streaming` or `stop_after_updating_cdc_generation` error injections as a separate commit.

See also #21872 and #21957

* (cherry picked from commit [f337ecb](https://github.com/scylladb/scylladb/commit/f337ecbafa30ac2d3ee7217e9bd37efdcd08683c))

* (cherry picked from commit [5992e8b](https://github.com/scylladb/scylladb/commit/5992e8b031526234e9b3f0d3951aec79c64d0c58))


Parent PR: #22044

---

Fixes https://github.com/scylladb/scylladb/issues/22170
