### PR TITLE
build: cmake: use wasm32-wasip1 as an alternative of wasm32-wasi

### DIFF
--- a/test/resource/wasm/rust/CMakeLists.txt
+++ b/test/resource/wasm/rust/CMakeLists.txt
@@ -1,14 +1,33 @@
 find_program(CARGO cargo
   REQUIRED)
+find_program(RUSTC rustc
+  REQUIRED)
 
+function(pick_rustc_target output_var candidates)
+  execute_process(
+    COMMAND
+      ${RUSTC} --print target-list
+    OUTPUT_VARIABLE
+      output
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  string(REPLACE "\n" ";" target_list "${output}")
+  set(${output_var} "")
+  foreach(candidate ${candidates})
+    if(candidate IN_LIST target_list)
+      message(STATUS "wasm32 compiled to ${candidate}")
+      set(${output_var} "${candidate}")
+      break()
+    endif()
+  endforeach()
+  return(PROPAGATE ${output_var})
+endfunction()
 
-function(compile_rust_to_wasm input)
+function(compile_rust_to_wasm target input)
   cmake_parse_arguments(parsed_args "" "WASM;OUT_DIR" "" ${ARGN})
   get_filename_component(basename ${input} NAME_WE)
   set(input "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
   set(output_dir "${parsed_args_OUT_DIR}")
   set(output "${output_dir}/${basename}.wasm")
-  set(target "wasm32-wasi")
   set(mode "debug")
   set(package "examples")
   add_custom_command(
@@ -32,6 +51,8 @@ function(compile_rust_to_wasm input)
   set(${parsed_args_WASM} ${output} PARENT_SCOPE)
 endfunction(compile_rust_to_wasm)
 
+pick_rustc_target(rustc_target "wasm32-wasi;wasm32-wasip1")
+
 set(rust_srcs
   return_input.rs
   test_complex_null_values.rs
@@ -40,7 +61,7 @@ set(rust_srcs
   test_types_with_and_without_nulls.rs)
 
 foreach(rust_src ${rust_srcs})
-  compile_rust_to_wasm(${rust_src}
+  compile_rust_to_wasm(${rustc_target} ${rust_src}
     OUT_DIR "${CMAKE_BINARY_DIR}/wasm"
     WASM wasm)
   wasm2wat(${wasm}


### PR DESCRIPTION
wasm32-wasi has been removed in Rust 1.84 (Jan 5th, 2025). if one compiles the tree with Rust 1.84 or up, following build failure is expected:

```
[2/305] Building WASM /home/kefu/dev/scylladb/build/wasm/return_input.wasm
FAILED: wasm/return_input.wasm /home/kefu/dev/scylladb/build/wasm/return_input.wasm
cd /home/kefu/dev/scylladb/test/resource/wasm/rust && /usr/bin/cargo build --target=wasm32-wasi --example=return_input --locked --manifest-path=Cargo.toml --target-dir=/home/kefu/dev/scylladb/build/test/resource/wasm/rust && wasm-opt /home/kefu/dev/scylladb/build/test/resource/wasm/rust/wasm32-wasi//debug/examples/return_input.wasm -Oz -o /home/kefu/dev/scylladb/build/wasm/return_input.wasm && wasm-strip /home/kefu/dev/scylladb/build/wasm/return_input.wasm
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target wasm32-wasi --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "wasm32-wasi". Run `rustc --print target-list` for a list of built-in targets
```

in order to workaround this issue, let's check for supported target, and use wasm32-wasip1 if wasm32-wasi is not listed as the supported target.

Refs #20878

---

this change addresses the build failure on fedora 41, which is not used in our CI, so no need to backport.