### PR TITLE
scylla sstable: Add standard extensions and propagate to schema load 

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -27,6 +27,7 @@
 #include "cdc/cdc_extension.hh"
 #include "tombstone_gc_extension.hh"
 #include "db/per_partition_rate_limit_extension.hh"
+#include "db/paxos_grace_seconds_extension.hh"
 #include "db/tags/extension.hh"
 #include "config.hh"
 #include "extensions.hh"
@@ -1304,6 +1305,18 @@ void db::config::add_tags_extension() {
 
 void db::config::add_tombstone_gc_extension() {
     _extensions->add_schema_extension<tombstone_gc_extension>(tombstone_gc_extension::NAME);
+}
+
+void db::config::add_paxos_grace_seconds_extension() {
+    _extensions->add_schema_extension<db::paxos_grace_seconds_extension>(db::paxos_grace_seconds_extension::NAME);
+}
+
+void db::config::add_all_default_extensions() {
+    add_cdc_extension();
+    add_per_partition_rate_limit_extension();
+    add_tags_extension();
+    add_tombstone_gc_extension();
+    add_paxos_grace_seconds_extension();
 }
 
 void db::config::setup_directories() {

--- a/db/config.hh
+++ b/db/config.hh
@@ -141,6 +141,9 @@ public:
     void add_per_partition_rate_limit_extension();
     void add_tags_extension();
     void add_tombstone_gc_extension();
+    void add_paxos_grace_seconds_extension();
+
+    void add_all_default_extensions();
 
     /// True iff the feature is enabled.
     bool check_experimental(experimental_features_t::feature f) const;

--- a/main.cc
+++ b/main.cc
@@ -92,11 +92,7 @@
 
 #include "redis/controller.hh"
 #include "cdc/log.hh"
-#include "cdc/cdc_extension.hh"
 #include "cdc/generation_service.hh"
-#include "tombstone_gc_extension.hh"
-#include "db/tags/extension.hh"
-#include "db/paxos_grace_seconds_extension.hh"
 #include "service/qos/standard_service_level_distributed_data_accessor.hh"
 #include "service/storage_proxy.hh"
 #include "service/mapreduce_service.hh"
@@ -104,7 +100,6 @@
 #include "alternator/ttl.hh"
 #include "tools/entry_point.hh"
 #include "test/perf/entry_point.hh"
-#include "db/per_partition_rate_limit_extension.hh"
 #include "lang/manager.hh"
 #include "sstables/sstables_manager.hh"
 #include "db/virtual_tables.hh"
@@ -722,14 +717,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
     app_template app(std::move(app_cfg));
 
     auto ext = std::make_shared<db::extensions>();
-    ext->add_schema_extension<db::tags_extension>(db::tags_extension::NAME);
-    ext->add_schema_extension<cdc::cdc_extension>(cdc::cdc_extension::NAME);
-    ext->add_schema_extension<db::paxos_grace_seconds_extension>(db::paxos_grace_seconds_extension::NAME);
-    ext->add_schema_extension<tombstone_gc_extension>(tombstone_gc_extension::NAME);
-    ext->add_schema_extension<db::per_partition_rate_limit_extension>(db::per_partition_rate_limit_extension::NAME);
-
     auto cfg = make_lw_shared<db::config>(ext);
     auto init = app.get_options_description().add_options();
+
+    cfg->add_all_default_extensions();
 
     init("version", bpo::bool_switch(), "print version number and exit");
     init("build-id", bpo::bool_switch(), "print build-id and exit");

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -103,10 +103,7 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
     // if /tmp is not tmpfs.
     db_config->commitlog_use_o_dsync.set(false);
 
-    db_config->add_cdc_extension();
-    db_config->add_per_partition_rate_limit_extension();
-    db_config->add_tags_extension();
-    db_config->add_tombstone_gc_extension();
+    db_config->add_all_default_extensions();
 
     db_config->flush_schema_tables_after_modification.set(false);
     db_config->commitlog_use_o_dsync(false);

--- a/tombstone_gc.cc
+++ b/tombstone_gc.cc
@@ -257,7 +257,12 @@ void validate_tombstone_gc_options(const tombstone_gc_options* options, data_dic
         throw exceptions::configuration_exception("tombstone_gc option not supported by the cluster");
     }
 
-    if (options->mode() == tombstone_gc_mode::repair && !needs_repair_before_gc(db.real_database(), ks_name)) {
+    auto real_db_ptr = db.real_database_ptr();
+    if (!real_db_ptr) {
+        return;
+    }
+
+    if (options->mode() == tombstone_gc_mode::repair && !needs_repair_before_gc(*real_db_ptr, ks_name)) {
         throw exceptions::configuration_exception("tombstone_gc option with mode = repair not supported for table with RF one or local replication strategy");
     }
 }

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -54,7 +54,6 @@ struct keyspace;
 struct table;
 
 struct database {
-    db::extensions extensions;
     const db::config& cfg;
     gms::feature_service& features;
     std::list<keyspace> keyspaces;
@@ -194,7 +193,7 @@ private:
         return unwrap(db).cfg;
     }
     virtual const db::extensions& get_extensions(data_dictionary::database db) const override {
-        return unwrap(db).extensions;
+        return get_config(db).extensions();
     }
     virtual const gms::feature_service& get_features(data_dictionary::database db) const override {
         return unwrap(db).features;

--- a/tools/utils.cc
+++ b/tools/utils.cc
@@ -237,6 +237,7 @@ int tool_app_template::run_async(int argc, char** argv, noncopyable_function<int
     if (_cfg.db_cfg_ext) {
         auto init = app.get_options_description().add_options();
         configurable::append_all(*_cfg.db_cfg_ext->db_cfg, init);
+        _cfg.db_cfg_ext->db_cfg->add_all_default_extensions();
     }
 
     return app.run(argc, argv, [this, &main_func, &app, found_op] {


### PR DESCRIPTION
Fixes #22314
    
Adds expected schema extensions to the tools extension set (if used). Also uses the source config extensions in schema loader instead of temp one, to ensure we can, for example, load a schema.cql with things like `tombstone_gc` or encryption attributes in them.

Bundles together the setup of "always on" schema extensions into a single call, and uses this from the three (3) init points. 
Could have opted for static reg via `configurables`, but since we are moving to a single code base, the need for this is going away, hence explicit init seems more in line.