### PR TITLE
Disable -Wexplicit-specialization-storage-class

### DIFF
--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -51,6 +51,9 @@ public:
     json::json_return_type to_json(const void* value) const;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wexplicit-specialization-storage-class"
+
 template <typename T>
 extern const config_type config_type_for;
 
@@ -68,6 +71,8 @@ extern const config_type config_type_for<std::unordered_map<sstring, sstring>>;
 
 template<>
 extern const config_type config_type_for<std::unordered_map<sstring, std::unordered_map<sstring, sstring>>>;
+
+#pragma GCC diagnostic pop
 
 class config_file {
     static thread_local unsigned s_shard_id;


### PR DESCRIPTION
I couldn't find a solution to this warning
as we need the variables declared extern
to exist in config_file.hh

Since the code worked in this way for quite a while
I don't expect that suppressing the warnings changes
behavior.

Fixes: #22328

Signed-off-by: Ran Regev <regev.ran@gmail.com>

No need to backport as explained in other PRs dealing with it.
