### PR TITLE
messaging_service: fix the piece of code which clears clients on shutdown()

### DIFF
--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -571,7 +571,10 @@ future<> messaging_service::stop_client() {
             });
         });
     };
-    co_await coroutine::all(std::bind(stop_clients, _clients), std::bind(stop_clients, _clients_with_host_id));
+    co_await coroutine::all(
+        [&] { return stop_clients(_clients); },
+        [&] { return stop_clients(_clients_with_host_id); }
+    );
 }
 
 future<> messaging_service::shutdown() {


### PR DESCRIPTION
While this isn't strictly needed for anything, messaging_service is supposed to clear its RPC connection objects on stop, for debuggability reasons.

But a recent change in this area broke that.
std::bind creates copies of its arguments, so the `m.clear()` statement in stop_client() only clears a copy of the vector of shared pointers, instead of clearing the original vector. This patch fixes that.

Fixes #22245

Doesn't need a backport, since it only fixes a recent change (c51263d0854e74181c541bd47c0510b112a7793f) in master.