### PR TITLE
test/alternator: close boto3 client before shutting down

### DIFF
--- a/test/alternator/test_service_levels.py
+++ b/test/alternator/test_service_levels.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 import pytest
-from test.alternator.conftest import new_dynamodb_session
 from test.alternator.test_metrics import metrics, get_metrics, check_increases_metric
 from contextlib import contextmanager
 from cassandra.auth import PlainTextAuthProvider


### PR DESCRIPTION
For several years now, we have seen a strange, and very rare, flakiness in Alternator tests described in issue #17564: We see all the test pass, pytest declares them to have passed, and while Python is existing, it crashes with a signal 11 (SIGSEGV). Because this happens exclusively in test/alternator and never in the test/cqlpy, we suspect that something that the test/alternator leaves behind but test/cqlpy does not, causes some race and crashes during shutdown.

The immediate suspect is the boto3 library, or rather, the urllib3 library which it uses. This is more-or-less the only thing that test/alternator does which test/cqlpy doesn't. The urllib3 library keeps around pools of reusable connections, and it's possible (although I don't actually have any proof for it) that these open connections may cause a crash during shutdown.

So in this patch I add to the "dynamodb" and "dynamodbstreams" fixtures (which all Alternator tests use to connect to the server), a teardown which calls close() for the boto3 client object. This close() call percolates down to calling clear() on urllib3's PoolManager. Hopefully, this will make some difference in the chance to crash during shutdown - and if it doesn't, it won't hurt.

Refs #17564