### PR TITLE
test/cqlpy/run: fix regression in "--release" option

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -384,6 +384,8 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--kernel-page-cache=1')
         cmd.remove('--flush-schema-tables-after-modification=false')
         cmd.remove('--strict-allow-filtering=true')
+    if major <= [6,2] or (enterprise and major <= [2025,1]):
+        cmd.remove('--experimental-features=views-with-tablets')
     if major <= [4,5]:
         cmd.remove('--max-networking-io-control-blocks=1000')
     if major == [5,4] or major == [2024,1]:


### PR DESCRIPTION
The way that the "test/cqlpy/run --release" feature runs older Scylla releases is that it takes *today*'s command line parameters and "fixes" it to conform to what old releases took. This approach was easy to implement (and the resulting "--release" feature is super useful), but the downside is that we need to update this fixup code whenever we add new options to the Scylla command line used by test/cqlpy/run.py.

Commit d04f376 made test/cqlpy/run.py use a new option "--experimental-features=views-with-tablets", so now we need to remove it when running older versions of Scylla. So this is what we do in this patch.

Fixes #22349