### PR TITLE
partition_range_compat: drop dependency on boost ranges

### DIFF
--- a/partition_range_compat.hh
+++ b/partition_range_compat.hh
@@ -12,7 +12,6 @@
 #include <vector>
 #include "interval.hh"
 #include "dht/ring_position.hh"
-#include <boost/range/iterator_range_core.hpp>
 
 namespace compat {
 


### PR DESCRIPTION
Unused anyway.

Simple code cleanup; so no backport is needed.