### PR TITLE
tree: migrate from boost::adaptors::transformed to std::views::transform

### DIFF
--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -31,7 +31,7 @@ incremental_backlog_tracker::calculate_sstables_backlog_contribution(const std::
 
     if (!all.empty()) {
       auto freeze = [] (const sstable_run& run) { return make_lw_shared<const sstable_run>(run); };
-      for (auto& bucket : incremental_compaction_strategy::get_buckets(boost::copy_range<std::vector<frozen_sstable_run>>(all | boost::adaptors::map_values | boost::adaptors::transformed(freeze)), options)) {
+      for (auto& bucket : incremental_compaction_strategy::get_buckets(all | std::views::values | std::views::transform(freeze) | std::ranges::to<std::vector>(), options)) {
         if (!incremental_compaction_strategy::is_bucket_interesting(bucket, threshold)) {
             continue;
         }

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -85,6 +85,6 @@ public:
 
     auto sum_read_concurrency_sem_var(std::invocable<reader_concurrency_semaphore&> auto member) {
         using ret_type = std::invoke_result_t<decltype(member), reader_concurrency_semaphore&>;
-        return boost::accumulate(_semaphores | boost::adaptors::map_values | boost::adaptors::transformed([=] (weighted_reader_concurrency_semaphore& wrcs) { return std::invoke(member, wrcs.sem); }), ret_type(0));
+        return std::ranges::fold_left(_semaphores | std::views::values | std::views::transform([=] (weighted_reader_concurrency_semaphore& wrcs) { return std::invoke(member, wrcs.sem); }), ret_type(0), std::plus{});
     }
 };

--- a/service/qos/qos_common.cc
+++ b/service/qos/qos_common.cc
@@ -12,8 +12,6 @@
 #include "cql3/query_processor.hh"
 #include "cql3/result_set.hh"
 #include "cql3/untyped_result_set.hh"
-#include <boost/algorithm/string/join.hpp>
-#include <boost/range/adaptor/transformed.hpp>
 #include <string_view>
 
 namespace qos {
@@ -212,11 +210,11 @@ static qos::service_level_options::shares_type get_shares(const cql3::untyped_re
     return *shares_opt;
 }
 
-static sstring get_columns(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name) {
+static std::string get_columns(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name) {
     auto schema = qp.db().find_schema(ks_name, cf_name);
-    return boost::algorithm::join(schema->all_columns() | boost::adaptors::transformed([] (const auto& col) {
+    return fmt::to_string(fmt::join(schema->all_columns() | std::views::transform([] (const auto& col) {
         return col.name_as_cql_string();
-    }), " ,");
+    }), " ,"));
 }
 
 future<qos::service_levels_info> get_service_levels(cql3::query_processor& qp, std::string_view ks_name, std::string_view cf_name, db::consistency_level cl, qos::query_context ctx) {

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -13,7 +13,6 @@
 #include "tasks/task_handler.hh"
 #include "tasks/virtual_task_hint.hh"
 #include <seastar/coroutine/maybe_yield.hh>
-#include <boost/range/adaptor/transformed.hpp>
 
 namespace service {
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -28,8 +28,6 @@
 #include <cfloat>
 #include <algorithm>
 
-#include <boost/range/adaptor/transformed.hpp>
-
 static logging::logger llog("sstables_loader");
 
 namespace {
@@ -398,7 +396,7 @@ future<> sstable_streamer::stream_sstables(const dht::partition_range& pr, std::
         auto ops_uuid = streaming::plan_id{utils::make_random_uuid()};
         llog.info("load_and_stream: started ops_uuid={}, process [{}-{}] out of {} sstables=[{}]",
             ops_uuid, nr_sst_current, nr_sst_current + sst_processed.size(), nr_sst_total,
-            fmt::join(sst_processed | boost::adaptors::transformed([] (auto sst) { return sst->get_filename(); }), ", "));
+            fmt::join(sst_processed | std::views::transform([] (auto sst) { return sst->get_filename(); }), ", "));
         nr_sst_current += sst_processed.size();
         co_await stream_sstable_mutations(ops_uuid, pr, std::move(sst_processed));
         if (progress) {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1245,8 +1245,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group) {
     const auto max_sched_groups = 8;
 
     auto check_sem_group = [&] {
-        const auto total_shares = boost::accumulate(scheduling_groups
-                | boost::adaptors::transformed([] (const scheduling_group_with_shares& sgs) { return sgs.shares; }), size_t(0));
+        const auto total_shares = std::ranges::fold_left(scheduling_groups
+                | std::views::transform([] (const scheduling_group_with_shares& sgs) { return sgs.shares; }), size_t(0), std::plus{});
         ssize_t total_memory = 0;
         sem_group.foreach_semaphore([&] (scheduling_group sg, reader_concurrency_semaphore& sem) {
             const auto res = sem.available_resources();


### PR DESCRIPTION
Replace remaining uses of boost::adaptors::transformed with std::views::transform to reduce Boost dependencies, following the migration pattern established in bab12e3a. This change addresses recently merged code that reintroduced Boost header dependencies through boost::adaptors::transformed usage.

---

it's a cleanup, hence no need to backport.