### PR TITLE
Fix repair vs storage services initialization order

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1719,6 +1719,20 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 co_await utils::announce_dict_to_shards(compressor_tracker, std::move(dict));
             };
 
+            supervisor::notify("starting repair service");
+            auto max_memory_repair = memory::stats().total_memory() * 0.1;
+            repair.start(std::ref(tsm), std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(bm), std::ref(sys_ks), std::ref(view_builder), std::ref(task_manager), std::ref(mm), max_memory_repair).get();
+            auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {
+                repair.stop().get();
+            });
+            repair.invoke_on_all(&repair_service::start).get();
+            api::set_server_repair(ctx, repair, gossip_address_map).get();
+            auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
+                api::unset_server_repair(ctx).get();
+            });
+
+            utils::get_local_injector().inject("stop_after_starting_repair", [] { std::raise(SIGSTOP); });
+
             supervisor::notify("initializing storage service");
             debug::the_storage_service = &ss;
             ss.start(std::ref(stop_signal.as_sharded_abort_source()),
@@ -1917,24 +1931,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     return lifecycle_notifier.local().unregister_subscriber(&local_proxy);
                 }).get();
             });
-
-            // ATTN -- sharded repair reference already sits on storage_service and if
-            // it calls repair.local() before this place it'll crash (now it doesn't do
-            // both)
-            supervisor::notify("starting repair service");
-            auto max_memory_repair = memory::stats().total_memory() * 0.1;
-            repair.start(std::ref(tsm), std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(bm), std::ref(sys_ks), std::ref(view_builder), std::ref(task_manager), std::ref(mm), max_memory_repair).get();
-            auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {
-                repair.stop().get();
-            });
-            repair.invoke_on_all(&repair_service::start).get();
-            api::set_server_repair(ctx, repair, gossip_address_map).get();
-            auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
-                api::unset_server_repair(ctx).get();
-            });
-
-            utils::get_local_injector().inject("stop_after_starting_repair",
-                [] { std::raise(SIGSTOP); });
 
             supervisor::notify("starting CDC Generation Management service");
             /* This service uses the system distributed keyspace.

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3294,7 +3294,6 @@ future<> repair_service::stop() {
         rlogger.debug("Unregistering gossiper helper");
         co_await _gossiper.local().unregister_(_gossip_helper);
     }
-    co_await async_gate().close();
     _stopped = true;
     rlogger.info("Stopped repair_service");
   } catch (...) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2676,6 +2676,9 @@ public:
         , _start_time(start_time)
         , _is_tablet(_shard_task.db.local().find_column_family(_table_id).uses_tablets())
     {
+        if (!_shard_task.rs.get_view_builder().local_is_initialized()) {
+            throw std::runtime_error(format("Node {} is not fully initialized for repair, try again later", shard_task.rs.my_host_id()));
+        }
         repair_neighbors r_neighbors = _shard_task.get_repair_neighbors(_range);
         auto& map = r_neighbors.shard_map;
         for (auto& n : _all_live_peer_nodes) {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -107,8 +107,6 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     shared_ptr<row_level_repair_gossip_helper> _gossip_helper;
     bool _stopped = false;
 
-    gate _gate;
-
     size_t _max_repair_memory;
     seastar::semaphore _memory_sem;
     seastar::named_semaphore _load_parallelism_semaphore = {16, named_semaphore_exception_factory{"Load repair history parallelism"}};
@@ -197,7 +195,6 @@ public:
     size_t max_repair_memory() const { return _max_repair_memory; }
     seastar::semaphore& memory_sem() { return _memory_sem; }
     locator::host_id my_host_id() const noexcept;
-    gate& async_gate() noexcept { return _gate; }
 
     repair::task_manager_module& get_repair_module() noexcept {
         return *_repair_module;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -159,14 +159,6 @@ namespace {
 
 static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 
-static future<> do_with_repair_service(sharded<repair_service>& repair, std::function<future<>(repair_service&)> f) {
-    if (!repair.local_is_initialized()) {
-        throw seastar::abort_requested_exception();
-    }
-    gate::holder holder = repair.local().async_gate().hold();
-    co_await f(repair.local());
-}
-
 storage_service::storage_service(abort_source& abort_source,
     distributed<replica::database>& db, gms::gossiper& gossiper,
     sharded<db::system_keyspace>& sys_ks,
@@ -3958,9 +3950,7 @@ void storage_service::run_bootstrap_ops(std::unordered_set<token>& bootstrap_tok
         utils::get_local_injector().inject("delay_bootstrap_120s", std::chrono::seconds(120)).get();
 
         // Step 5: Sync data for bootstrap
-        do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-            return local_repair.bootstrap_with_repair(get_token_metadata_ptr(), bootstrap_tokens);
-        }).get();
+        _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), bootstrap_tokens).get();
         on_streaming_finished();
 
         // Step 6: Finish
@@ -4016,9 +4006,7 @@ void storage_service::run_replace_ops(std::unordered_set<token>& bootstrap_token
             auto ignore_nodes = replace_info.ignore_nodes | std::views::transform([] (const auto& x) {
                 return x.first;
             }) | std::ranges::to<std::unordered_set<locator::host_id>>();
-            do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                return local_repair.replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id);
-            }).get();
+            _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), bootstrap_tokens, std::move(ignore_nodes), replace_info.host_id).get();
         } else {
             slogger.info("replace[{}]: Using streaming based node ops to sync data", uuid);
             dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(), _snitch.local()->get_location(), bootstrap_tokens, get_token_metadata_ptr());
@@ -4441,9 +4429,7 @@ future<node_ops_cmd_response> storage_service::node_ops_cmd_handler(gms::inet_ad
             for (auto& node : req.leaving_nodes) {
                 if (is_repair_based_node_ops_enabled(streaming::stream_reason::removenode)) {
                     slogger.info("removenode[{}]: Started to sync data for removing node={} using repair, coordinator={}", req.ops_uuid, node, coordinator);
-                    do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                        return local_repair.removenode_with_repair(get_token_metadata_ptr(), _gossiper.get_host_id(node), ops);
-                    }).get();
+                    _repair.local().removenode_with_repair(get_token_metadata_ptr(), _gossiper.get_host_id(node), ops).get();
                 } else {
                     slogger.info("removenode[{}]: Started to sync data for removing node={} using stream, coordinator={}", req.ops_uuid, node, coordinator);
                     removenode_with_stream(_gossiper.get_host_id(node), topo_guard, as).get();
@@ -4892,9 +4878,7 @@ future<> storage_service::rebuild(utils::optional_param source_dc) {
             auto tmptr = ss.get_token_metadata_ptr();
             auto ks_erms = ss._db.local().get_non_local_strategy_keyspaces_erms();
             if (ss.is_repair_based_node_ops_enabled(streaming::stream_reason::rebuild)) {
-                co_await do_with_repair_service(ss._repair, [&] (repair_service& local_repair) {
-                    return local_repair.rebuild_with_repair(std::move(ks_erms), tmptr, std::move(source_dc));
-			    });
+                co_await ss._repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(source_dc));
             } else {
                 auto streamer = make_lw_shared<dht::range_streamer>(ss._db, ss._stream_manager, tmptr, ss._abort_source,
                         tmptr->get_my_id(), ss._snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, null_topology_guard);
@@ -5016,9 +5000,7 @@ future<> storage_service::unbootstrap() {
     slogger.info("Finished batchlog replay for decommission");
 
     if (is_repair_based_node_ops_enabled(streaming::stream_reason::decommission)) {
-        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-            return local_repair.decommission_with_repair(get_token_metadata_ptr());
-	    });
+        co_await _repair.local().decommission_with_repair(get_token_metadata_ptr());
     } else {
         std::unordered_map<sstring, std::unordered_multimap<dht::token_range, locator::host_id>> ranges_to_stream;
 
@@ -5679,9 +5661,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     if (is_repair_based_node_ops_enabled(streaming::stream_reason::bootstrap)) {
                                         co_await utils::get_local_injector().inject("delay_bootstrap_120s", std::chrono::seconds(120));
 
-                                        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                                            return local_repair.bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens);
-                                        });
+                                        co_await _repair.local().bootstrap_with_repair(get_token_metadata_ptr(), rs.ring.value().tokens);
                                     } else {
                                         dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                             locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
@@ -5707,9 +5687,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     auto ks_erms = _db.local().get_non_local_strategy_keyspaces_erms();
                                     auto tmptr = get_token_metadata_ptr();
                                     auto replaced_node = locator::host_id(replaced_id.uuid());
-                                    co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                                        return local_repair.replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node);
-                                    });
+                                    co_await _repair.local().replace_with_repair(std::move(ks_erms), std::move(tmptr), rs.ring.value().tokens, std::move(ignored_nodes), replaced_node);
                                 } else {
                                     dht::boot_strapper bs(_db, _stream_manager, _abort_source, get_token_metadata_ptr()->get_my_id(),
                                                           locator::endpoint_dc_rack{rs.datacenter, rs.rack}, rs.ring.value().tokens, get_token_metadata_ptr());
@@ -5767,9 +5745,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                     ignored_ips.push_back(*ip);
                                 }
                                 auto ops = seastar::make_shared<node_ops_info>(node_ops_id::create_random_id(), as, std::move(ignored_ips));
-                                return do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                                    return local_repair.removenode_with_repair(get_token_metadata_ptr(), id, ops);
-                                });
+                                return _repair.local().removenode_with_repair(get_token_metadata_ptr(), id, ops);
                             } else {
                                 return removenode_with_stream(id, _topology_state_machine._topology.session, as);
                             }
@@ -5795,9 +5771,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                                 if (!source_dc.empty()) {
                                     sdc_param.emplace(source_dc).set_user_provided().set_force(force);
                                 }
-                                co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) {
-                                    return local_repair.rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param));
-                                });
+                                co_await _repair.local().rebuild_with_repair(std::move(ks_erms), tmptr, std::move(sdc_param));
                             } else {
                                 auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, tmptr, _abort_source,
                                         tmptr->get_my_id(), _snitch.local()->get_location(), "Rebuild", streaming::stream_reason::rebuild, _topology_state_machine._topology.session);
@@ -5987,12 +5961,8 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
 
         utils::get_local_injector().inject("repair_tablet_fail_on_rpc_call",
             [] { throw std::runtime_error("repair_tablet failed due to error injection"); });
-        service::tablet_operation_repair_result result;
-        co_await do_with_repair_service(_repair, [&] (repair_service& local_repair) -> future<> {
-            auto time = co_await local_repair.repair_tablet(_address_map, guard, tablet);
-            result = service::tablet_operation_repair_result{time};
-        });
-        co_return result;
+        auto time = co_await _repair.local().repair_tablet(_address_map, guard, tablet);
+        co_return service::tablet_operation_repair_result{time};
     });
     if (std::holds_alternative<service::tablet_operation_repair_result>(result)) {
         co_return std::get<service::tablet_operation_repair_result>(result);


### PR DESCRIPTION
Repair service is started after storage service, while storage service needs to reference repair one for its needs. Recently it was noticed, that this reverse order may cause troubles and was fixed with the help of an extra gate. That's not nice and makes the start-stop mess even worse. The correct fix is to fix the order both services start/stop in.