### PR TITLE
Add open-coredump script depndencies to install-dependencies.sh

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -54,6 +54,10 @@ debian_base_packages=(
     slapd
     ldap-utils
     libcpp-jwt-dev
+    elfutils
+    curl
+    jq
+    git-lfs
 )
 
 fedora_packages=(
@@ -135,8 +139,10 @@ fedora_packages=(
 
     podman
     buildah
-
+    
     https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm
+    elfutils
+    jq
 )
 
 fedora_python3_packages=(


### PR DESCRIPTION
Added an option in the open-coredump script to make the script install the required dependencies.
The script itself is nicely automated, if you have all the dependencies. If you don't, it's a bit annoying because you have to either go in the script and see the list, copy it, install dependencies, re-run, or just run and wait for the script to tell you the missing deps one by one. 