### PR TITLE
nodetool: tasks: print empty string for start_time/end_time if unspec…

### DIFF
--- a/docs/operating-scylla/nodetool-commands/tasks/status.rst
+++ b/docs/operating-scylla/nodetool-commands/tasks/status.rst
@@ -23,10 +23,10 @@ Example output
    type: repair
    kind: node
    scope: keyspace
-   state: done
+   state: running
    is_abortable: true
    start_time: 2024-07-29T15:48:55Z
-   end_time: 2024-07-29T15:48:55Z
+   end_time:
    error:
    parent_id: none
    sequence_number: 5


### PR DESCRIPTION
…ified

If start_time/end_time is unspecified for a task, task_manager API returns epoch. Nodetool prints the value in task status.

Fix nodetool tasks commands to print empty string for start_time/end_time if it isn't specified.

Modify nodetool tasks status docs to show empty end_time.

Fixes: https://github.com/scylladb/scylladb/issues/22373.

Needs backport to 6.2 as it introduces the nodetool tasks commands.