### PR TITLE
doc: enable the FIPS note in the ScyllaDB docs

### DIFF
--- a/docs/operating-scylla/security/security-checklist.rst
+++ b/docs/operating-scylla/security/security-checklist.rst
@@ -31,11 +31,9 @@ Encryption on Transit, Client to Node and Node to Node
 Encryption on Transit protects your communication against a 3rd interception on the network connection.
 Configure ScyllaDB to use TLS/SSL for all the connections. Use TLS/SSL to encrypt communication between ScyllaDB nodes and client applications.
 
-.. only:: enterprise
-
-    Starting with version 2023.1.1, you can run ScyllaDB Enterprise on FIPS-enabled Ubuntu, 
-    which uses FIPS 140-2 certified libraries (such as OpenSSL, GnuTLS, and more) and Linux 
-    kernel in FIPS mode.
+You can run ScyllaDB on FIPS-enabled Ubuntu, 
+which uses FIPS 140-2 certified libraries (such as OpenSSL, GnuTLS, and more) and Linux 
+kernel in FIPS mode.
 
 * :doc:`Encryption Data in Transit Client to Node </operating-scylla/security/client-node-encryption>`
 


### PR DESCRIPTION
This commit removes the information about FIPS out of the '.. only:: enterprise' directive. As a result, the information will now show in the doc in the ScyllaDB repo (previously, the directive included the note in the Enterprise docs only).

Refs https://github.com/scylladb/scylla-enterprise/issues/5020

