### PR TITLE
test/topology/conftest: manager: fix test_py_log_test for calling gather_related_logs

### DIFF
--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -186,7 +186,7 @@ async def manager(request, manager_internal, record_property, build_mode):
                         )
     test_log = suite_testpy_log.parent / f"{suite_testpy_log.stem}.{test_case_name}.log"
     # this should be consistent with scylla_cluster.py handler name in _before_test method
-    test_py_log_test = suite_testpy_log.parent / f"{test_case_name}.log"
+    test_py_log_test = suite_testpy_log.parent / f"{suite_testpy_log.stem}.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
     await manager_client.before_test(test_case_name, test_log)


### PR DESCRIPTION
The filename givcen is incorrect.
This shows up as, e.g.:
```
test/topology/conftest.py:204: in manager
    await manager_client.gather_related_logs(
test/pylib/manager_client.py:167: in gather_related_logs
    shutil.copyfile(log, failed_test_path_dir / name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

src = PosixPath('/home/bhalevy/dev/scylla/testlog/dev/test_upgrade_to_ssl.1.dev.1.log')
dst = PosixPath('/home/bhalevy/dev/scylla/testlog/dev/failed_test/test_upgrade_to_ssl.1.dev.1/test_py.log')

    def copyfile(src, dst, *, follow_symlinks=True):
        """Copy data from src to dst in the most efficient way possible.

        If follow_symlinks is not set and src is a symbolic link, a new
        symlink will be created instead of copying the file it points to.

        """
        sys.audit("shutil.copyfile", src, dst)

        if _samefile(src, dst):
            raise SameFileError("{!r} and {!r} are the same file".format(src, dst))

        file_size = 0
        for i, fn in enumerate([src, dst]):
            try:
                st = _stat(fn)
            except OSError:
                # File most likely does not exist
                pass
            else:
                # XXX What about other special files? (sockets, devices...)
                if stat.S_ISFIFO(st.st_mode):
                    fn = fn.path if isinstance(fn, os.DirEntry) else fn
                    raise SpecialFileError("`%s` is a named pipe" % fn)
                if _WINDOWS and i == 0:
                    file_size = st.st_size

        if not follow_symlinks and _islink(src):
            os.symlink(os.readlink(src), dst)
        else:
>           with open(src, 'rb') as fsrc:
E           FileNotFoundError: [Errno 2] No such file or directory: '/home/bhalevy/dev/scylla/testlog/dev/test_upgrade_to_ssl.1.dev.1.log'
```

Fixes #22387

* Introduced in https://github.com/scylladb/scylladb/commit/bce53efd36195bdb95c29725cb8c8285d6eb5ea4, hence requires backport to all live OSS versions and to 2024.2