### PR TITLE
encryption: Fix encrypted components mask check in describe

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -660,7 +660,7 @@ public:
                             sstables::component_type::Statistics,
                             sstables::component_type::TemporaryStatistics,
             }) {
-                if (mask & int(c)) {
+                if (mask & (1 << int(c))) {
                     ccs.emplace_back(c);
                 }
             }


### PR DESCRIPTION
Fixes #22401

In the fix for scylladb/scylla-enterprise#892, the extraction and check for sstable component encryption mask was copied to a subroutine for description purposes, but a very important 1 << <value> shift was somehow left on the floor.

Without this, the check for whether we actually contain a component encrypted can be wholly broken for some components.
