### PR TITLE
test: Fix inconsistent naming of the log files.

### DIFF
--- a/test.py
+++ b/test.py
@@ -1388,7 +1388,7 @@ class TopologyTest(PythonTest):
         self._prepare_pytest_params(options)
 
         test_path = os.path.join(self.suite.options.tmpdir, self.mode)
-        async with get_cluster_manager(self.mode + '/' + self.uname, self.suite.clusters, test_path) as manager:
+        async with get_cluster_manager(self.uname, self.suite.clusters, test_path) as manager:
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
             if options.artifacts_dir_url:

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -186,7 +186,7 @@ async def manager(request, manager_internal, record_property, build_mode):
                         )
     test_log = suite_testpy_log.parent / f"{suite_testpy_log.stem}.{test_case_name}.log"
     # this should be consistent with scylla_cluster.py handler name in _before_test method
-    test_py_log_test = suite_testpy_log.parent / f"{test_case_name}.log"
+    test_py_log_test = suite_testpy_log.parent / f"{suite_testpy_log.stem}_{test_case_name}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
     await manager_client.before_test(test_case_name, test_log)


### PR DESCRIPTION
The log file names created in `scylla_cluster.py` by `ScyllaClusterManager`
and files to be collected in conftest.py by `manager` should be in sync. This patch fixes the issue, originally introduced in scylladb/scylladb#22192

Fixes: scylladb/scylladb#22387

Backports: 6.1 and 6.2.

