### PR TITLE
main: rename `cql_sg_stats` metrics on scheduling group rename

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1202,6 +1202,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             make_scheduling_group_key_config<cql_transport::cql_sg_stats>(maintenance_socket_enabled::yes);
             auto maintenance_cql_sg_stats_key = scheduling_group_key_create(maintenance_cql_sg_stats_cfg).get();
             scheduling_group_key_config cql_sg_stats_cfg = make_scheduling_group_key_config<cql_transport::cql_sg_stats>(maintenance_socket_enabled::no);
+            cql_sg_stats_cfg.rename = [] (void* ptr) {
+                reinterpret_cast<cql_transport::cql_sg_stats*>(ptr)->rename_metrics();
+            };
             auto cql_sg_stats_key = scheduling_group_key_create(cql_sg_stats_cfg).get();
 
             supervisor::notify("starting disk space monitor");


### PR DESCRIPTION
This PR contains the missing part of a fix for scylladb/scylla-enterprise#4912 which was omitted during migration of workload prioritization to the source available repository. Even though the regression test for it was ported, it was silently made ineffective by a different fix (scylladb/scylla-enterprise#4764), so this PR also improves the test.

Fixes: scylladb/scylladb#22404

No need to backport - service levels are not yet a part of any source-available release.