### PR TITLE
test.py:topology_random_failures: enable tests deselected  for #21534

### DIFF
--- a/test/topology_random_failures/cluster_events.py
+++ b/test/topology_random_failures/cluster_events.py
@@ -67,14 +67,6 @@ def deselect_for(reason: str, error_injections: list[str] | None = None) -> Call
 #       >>> await anext(cluster_event, None)
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def sleep_for_30_seconds(manager: ManagerClient,
                                random_tables: RandomTables,
                                error_injection: str) -> AsyncIterator[None]:
@@ -533,14 +525,6 @@ async def remove_node(manager: ManagerClient,
     yield
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def restart_non_coordinator_node(manager: ManagerClient,
                                        random_tables: RandomTables,
                                        error_injection: str) -> AsyncIterator[None]:
@@ -552,14 +536,6 @@ async def restart_non_coordinator_node(manager: ManagerClient,
     yield
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def restart_coordinator_node(manager: ManagerClient,
                                    random_tables: RandomTables,
                                    error_injection: str) -> AsyncIterator[None]:
@@ -570,14 +546,6 @@ async def restart_coordinator_node(manager: ManagerClient,
 
     yield
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
                                                random_tables: RandomTables,
                                                error_injection: str) -> AsyncIterator[None]:
@@ -589,14 +557,6 @@ async def stop_non_coordinator_node_gracefully(manager: ManagerClient,
     yield
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def stop_coordinator_node_gracefully(manager: ManagerClient,
                                            random_tables: RandomTables,
                                            error_injection: str) -> AsyncIterator[None]:
@@ -608,14 +568,6 @@ async def stop_coordinator_node_gracefully(manager: ManagerClient,
     yield
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def kill_non_coordinator_node(manager: ManagerClient,
                                     random_tables: RandomTables,
                                     error_injection: str) -> AsyncIterator[None]:
@@ -630,14 +582,6 @@ async def kill_non_coordinator_node(manager: ManagerClient,
     yield
 
 
-@deselect_for(
-    # TODO: remove this skip when #21534 will be resolved.
-    error_injections=[
-        "stop_after_setting_mode_to_normal_raft_topology",
-        "stop_before_becoming_raft_voter",
-    ],
-    reason="See issue #21534 (assertion 'local_is_initialized()' failed during shutdown after a failed boot)",
-)
 async def kill_coordinator_node(manager: ManagerClient,
                                 random_tables: RandomTables,
                                 error_injection: str) -> AsyncIterator[None]:


### PR DESCRIPTION
removed tests deselectios for issue #21534
as it closed now

fixes https://github.com/scylladb/scylladb/issues/21711

all enabled random test combinations were run locally and passed on latest master:
```
ERROR_INJECTIONS = (
    "stop_after_setting_mode_to_normal_raft_topology",
    "stop_before_becoming_raft_voter",
)
```

```
CLUSTER_EVENTS: tuple[ClusterEventType, ...] = (
    sleep_for_30_seconds,
    restart_non_coordinator_node,
    restart_coordinator_node,
    stop_non_coordinator_node_gracefully,
    stop_coordinator_node_gracefully,
    kill_non_coordinator_node,
    kill_coordinator_node,
)
```

```
TESTS_COUNT = None  # number of tests from the whole matrix to run, None to run the full matrix.
```