### PR TITLE
TLS: reduce inotify usage by sharing reloadability across shards

### DIFF
--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -24,7 +24,7 @@ namespace alternator {
 
 using chunked_content = rjson::chunked_content;
 
-class server {
+class server : public peering_sharded_service<server> {
     static constexpr size_t content_length_limit = 16*MB;
     using alternator_callback = std::function<future<executor::request_return_type>(executor&, executor::client_state&,
             tracing::trace_state_ptr, service_permit, rjson::value, std::unique_ptr<http::request>)>;
@@ -51,6 +51,8 @@ class server {
 
     semaphore* _memory_limiter;
     utils::updateable_value<uint32_t> _max_concurrent_requests;
+
+    ::shared_ptr<seastar::tls::server_credentials> _credentials;
 
     class json_parser {
         static constexpr size_t yieldable_parsing_threshold = 16*KB;

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -104,6 +104,7 @@ protected:
     };
     std::list<gentle_iterator> _gentle_iterators;
     std::vector<server_socket> _listeners;
+    shared_ptr<seastar::tls::server_credentials> _credentials;
 
 public:
     server(const sstring& server_name, logging::logger& logger);
@@ -119,7 +120,12 @@ public:
     future<> shutdown();
     future<> stop();
 
-    future<> listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> creds, bool is_shard_aware, bool keepalive, std::optional<file_permissions> unix_domain_socket_permissions);
+    future<> listen(socket_address addr, 
+        std::shared_ptr<seastar::tls::credentials_builder> creds, 
+        bool is_shard_aware, bool keepalive, 
+        std::optional<file_permissions> unix_domain_socket_permissions,
+        std::function<server&()> get_shard_instance = {}
+        );
 
     future<> do_accepts(int which, bool keepalive, socket_address server_addr);
 

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -92,7 +92,7 @@ future<> controller::listen(seastar::sharded<auth::service>& auth_service, db::c
 
             return f.then([server, configs = std::move(configs), keepalive] {
                 return parallel_for_each(configs, [server, keepalive](const listen_cfg & cfg) {
-                    return server->invoke_on_all(&redis_transport::redis_server::listen, cfg.addr, cfg.cred, false, keepalive, std::nullopt).then([cfg] {
+                    return server->invoke_on_all(&redis_transport::redis_server::listen, cfg.addr, cfg.cred, false, keepalive, std::nullopt, [&c = *server]() -> auto& { return c.local(); }).then([cfg] {
                         slogger.info("Starting listening for REDIS clients on {} ({})", cfg.addr, cfg.cred ? "encrypted" : "unencrypted");
                     });
                 });

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -73,7 +73,7 @@ future<> controller::start_server() {
 
 static future<> listen_on_all_shards(sharded<cql_server>& cserver, socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> creds, bool is_shard_aware, bool keepalive, std::optional<file_permissions> unix_domain_socket_permissions) {
     co_await cserver.invoke_on_all([addr, creds, is_shard_aware, keepalive, unix_domain_socket_permissions] (cql_server& server) {
-        return server.listen(addr, creds, is_shard_aware, keepalive, unix_domain_socket_permissions);
+        return server.listen(addr, creds, is_shard_aware, keepalive, unix_domain_socket_permissions, [&c = server.container()]() -> auto& { return c.local(); });
     });
 }
 


### PR DESCRIPTION
Refs https://github.com/scylladb/seastar/issues/2513

Reloadable certificates use inotify instances. On a loaded test (CI) server, we've seen cases where we literally run out of capacity. This patch uses the extended callback and reload capability of seastar TLS to only create actual reloadable certificate objects on shard 0 for our main TLS points (encryption only does TLS on shard 0 already).
