### PR TITLE
docs: Remove configuration_encryptor

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -8,7 +8,6 @@
 * :doc:`cassandra-stress </operating-scylla/admin-tools/cassandra-stress/>` A tool for benchmarking and load testing a ScyllaDB and Cassandra clusters.
 * :doc:`SSTabledump </operating-scylla/admin-tools/sstabledump>`
 * :doc:`SSTableMetadata </operating-scylla/admin-tools/sstablemetadata>`
-* configuration_encryptor - :doc:`encrypt at rest </operating-scylla/security/encryption-at-rest>` sensitive scylla configuration entries using system key.
 * scylla local-file-key-generator - Generate a local file (system) key for :doc:`encryption at rest </operating-scylla/security/encryption-at-rest>`, with the provided length, Key algorithm, Algorithm block mode and Algorithm padding method.
 * `scyllatop <https://www.scylladb.com/2016/03/22/scyllatop/>`_ - A terminal base top-like tool for scylladb collectd/prometheus metrics.
 * :doc:`scylla_dev_mode_setup</getting-started/installation-common/dev-mod>` - run ScyllaDB in Developer Mode.

--- a/docs/operating-scylla/security/encryption-at-rest.rst
+++ b/docs/operating-scylla/security/encryption-at-rest.rst
@@ -143,8 +143,6 @@ Depending on your key provider, you will either have the option of allowing Scyl
 * Replicated Key Provider - you must generate a system key yourself
 * Local Key Provider - If you do not generate your own secret key, ScyllaDB will create one for you
 
-When encrypting ScyllaDB config by ``configuration_encryptor``, you also need to generate a secret key and upload the key to all nodes.
-
 
 Use the key generator script
 ================================
@@ -820,32 +818,6 @@ Once this encryption is enabled, it is used for all system data.
 
    .. wasn't able to test this successfully
 
-.. Encrypt and Decrypt Configuration Files
-.. =======================================
-
-.. Using the Configuration Encryption tool, you can encrypt parts of the scylla.yaml file which contain encryption configuration settings. 
-
-.. **Procedure**
-
-.. 1.  Run the Configuration Encryption script:
-
-.. test code-block: none
-
-.. /bin/configuration_encryptor [options] [key-path]
-
-.. Where:
-
-.. * ``-c, --config`` - the path to the configuration file (/etc/scylla/scylla.yaml, for example)
-.. * ``-d, --decrypt`` - decrypts the configuration file at the specified path
-.. * ``-o, --output`` - (optional) writes the configuration file to a specified target. This can be the same location as the source file. 
-.. * ``-h. --help`` - help for this command
-
-.. For example:
-
-.. test code-block: none
-
-.. sudo -u scylla /bin/configuration_encryptor -c /etc/scylla/scylla.yaml /etc/scylla/encryption_keys/secret_key
-.. end of test
 
 When a Key is Lost
 ----------------------


### PR DESCRIPTION
Fixes #21993

Removes configuration_encryptor mention from docs. The tool itself (java) is not included in the main branch java tools, thus need not remove from there. Only the words.
