### PR TITLE
doc: remove Enterprise labels and directives

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -202,18 +202,14 @@ An example that excludes a datacenter while using ``replication_factor``::
 
     DESCRIBE KEYSPACE excalibur
         CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
-
-
-
-.. only:: opensource
   
-  Keyspace storage options :label-caution:`Experimental`
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Keyspace storage options :label-caution:`Experimental`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  By default, SStables of a keyspace are stored locally.
-  As an alternative, you can configure your keyspace to be stored
-  on Amazon S3 or another S3-compatible object store.
-  See :ref:`Keyspace storage options <admin-keyspace-storage-options>` for details.
+By default, SStables of a keyspace are stored locally.
+As an alternative, you can configure your keyspace to be stored
+on Amazon S3 or another S3-compatible object store.
+See :ref:`Keyspace storage options <admin-keyspace-storage-options>` for details.
 
 .. _tablets:
 

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -2,9 +2,6 @@
 ScyllaDB Auditing Guide
 ========================
 
-:label-tip:`ScyllaDB Enterprise`
-
-
 Auditing allows the administrator to monitor activities on a Scylla cluster, including queries and data changes. 
 The information is stored in a Syslog or a Scylla table.
 

--- a/docs/operating-scylla/security/ldap-authentication.rst
+++ b/docs/operating-scylla/security/ldap-authentication.rst
@@ -7,10 +7,6 @@ LDAP Authentication
 
    saslauthd
 
-:label-tip:`ScyllaDB Enterprise`
-
-.. versionadded:: 2021.1.2
-
 Scylla supports user authentication via an LDAP server by leveraging the SaslauthdAuthenticator.
 By configuring saslauthd correctly against your LDAP server, you enable Scylla to check the user’s credentials through it.
 

--- a/docs/operating-scylla/security/ldap-authorization.rst
+++ b/docs/operating-scylla/security/ldap-authorization.rst
@@ -2,10 +2,6 @@
 LDAP Authorization (Role Management)
 =====================================
 
-:label-tip:`ScyllaDB Enterprise`
-
-.. versionadded:: 2021.1.2
-
 Scylla Enterprise customers can manage and authorize users’ privileges via an :abbr:`LDAP (Lightweight Directory Access Protocol)` server.
 LDAP is an open, vendor-neutral, industry-standard protocol for accessing and maintaining distributed user access control over a standard IP network.
 If your users are already stored in an LDAP directory, you can now use the same LDAP server to regulate their roles in Scylla.


### PR DESCRIPTION
This PR removes the now redundant Enterprise labels and directives from the ScyllDB documentation.

```
:label-tip:`ScyllaDB Enterprise`
.. only:: opensource 
.. only:: enterprise
```

Fixes https://github.com/scylladb/scylladb/issues/22432

