### PR TITLE
tree: remove unused "#include"s

### DIFF
--- a/auth/ldap_role_manager.hh
+++ b/auth/ldap_role_manager.hh
@@ -9,11 +9,9 @@
 
 #pragma once
 
-#include <memory>
 #include <seastar/core/abort_source.hh>
 #include <stdexcept>
 
-#include "bytes.hh"
 #include "ent/ldap/ldap_connection.hh"
 #include "standard_role_manager.hh"
 

--- a/db/consistency_level.hh
+++ b/db/consistency_level.hh
@@ -12,7 +12,6 @@
 
 #include "db/consistency_level_type.hh"
 #include "db/read_repair_decision.hh"
-#include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
 #include "utils/log.hh"
 #include "replica/database_fwd.hh"

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "readers/queue.hh"
-#include <seastar/core/coroutine.hh>
 
 namespace mutation_writer {
 

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -17,8 +17,7 @@
 #include "mutation/mutation.hh"
 #include "mutation/mutation_consumer_concepts.hh"
 #include "reader_permit.hh"
-
-using seastar::future;
+#include "seastarx.hh"
 
 /// \brief Represents a stream of mutation fragments.
 ///

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -8,7 +8,6 @@
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/gate.hh>
-#include <seastar/core/rwlock.hh>
 
 #include "database_fwd.hh"
 #include "compaction/compaction_descriptor.hh"

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -12,11 +12,8 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/distributed.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/file.hh>
-#include <seastar/util/bool_class.hh>
 #include <vector>
 #include <functional>
-#include <filesystem>
 #include "seastarx.hh"
 #include "compaction/compaction_descriptor.hh"
 #include "db/system_keyspace.hh"

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -15,7 +15,6 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/format.hh>
 #include <seastar/core/sstring.hh>
-#include <seastar/core/timed_out_error.hh>
 
 namespace replica {
 

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -9,8 +9,6 @@
 #pragma once
 
 #include "types/types.hh"
-#include "types/tuple.hh"
-#include "types/list.hh"
 #include "timestamp.hh"
 #include "locator/tablets.hh"
 #include "schema/schema_fwd.hh"

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -19,6 +19,7 @@
 #include "transport/messages/result_message_base.hh"
 #include "transport/event.hh"
 #include "exceptions/coordinator_result.hh"
+#include "types/types.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>

--- a/transport/messages/result_message_base.hh
+++ b/transport/messages/result_message_base.hh
@@ -15,6 +15,7 @@
 #include "seastarx.hh"
 #include "locator/tablets.hh"
 #include "replica/tablets.hh"
+#include "types/tuple.hh"
 
 namespace cql_transport {
 namespace messages {


### PR DESCRIPTION
these unused includes were identifier by clang-include-cleaner. after auditing these source files, all of the reports have been confirmed.

in which, instead of using `seastarx.hh`, `readers/mutation_reader.hh`, use `using seastar::future` to include `future` in the global namespace, this makes `readers/mutation_reader.hh` a header exposing `future<>`, but this is not a good practice, because, unlike `seastarx.hh` or `seastar/core/future.hh`, `reader/mutation_reader.hh`  is not responsible for exposing seastar declarations. so, we trade the using statement for `#include "seastarx.hh"` in that file to decouple the source files including it from this header because of this statement.

---

it's a cleanup, hence no need to backport.