### PR TITLE
.github: add action to make PR ready for review when conflicts label was removed

### DIFF
--- a/.github/workflows/make-pr-ready-for-review.yaml
+++ b/.github/workflows/make-pr-ready-for-review.yaml
@@ -1,0 +1,36 @@
+name: PR Ready for Review on Label Removal
+
+on:
+  pull_request:
+    types:
+      - unlabeled
+
+env:
+  DEFAULT_BRANCH: 'master'
+
+jobs:
+  mark-ready:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if specific label was removed
+        id: check-label
+        run: |
+          if [[ "${{ github.event.label.name }}" == "conflicts" ]]; then
+            echo "The removed label is conflicts."
+            echo "removed_conflicts=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ env.DEFAULT_BRANCH }}
+          token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
+          fetch-depth: 1
+
+      - name: Mark pull request as ready for review
+        if: steps.check-label.outputs.removed_conflicts == 'true'
+        run:  gh pr ready "${{ github.event.pull_request.number }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}


### PR DESCRIPTION
Moving a PR out of draft is only allowed to users with write access, adding a GitHub action to switch PR to `ready for review` once the `conflicts` label was removed

**This will allow developers to make their PR ready for review, since this action is been triggered from `master` there is no need for backport**