### PR TITLE
utils: config_file: forward_declare boost::program_options classes

### DIFF
--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -30,6 +30,8 @@
 #include "service/storage_proxy.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 
+#include <boost/lexical_cast.hpp>
+
 template<typename T = void>
 using coordinator_result = exceptions::coordinator_result<T>;
 

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -10,6 +10,7 @@
 
 #include <boost/range/algorithm.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/json/json_elements.hh>

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -36,6 +36,8 @@
 #include "utils/hashing.hh"
 #include "utils/hashers.hh"
 
+#include <boost/lexical_cast.hpp>
+
 constexpr int32_t schema::NAME_LENGTH;
 
 extern logging::logger dblog;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -83,6 +83,8 @@
 #include "release.hh"
 #include "utils/build_id.hh"
 
+#include <boost/lexical_cast.hpp>
+
 thread_local disk_error_signal_type sstable_read_error;
 thread_local disk_error_signal_type sstable_write_error;
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -60,6 +60,7 @@
 #include <ftw.h>
 #include <unistd.h>
 #include <boost/icl/interval_map.hpp>
+#include <boost/lexical_cast.hpp>
 #include "test/lib/test_services.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -14,8 +14,6 @@
 #include <unordered_map>
 #include <string_view>
 
-#include <boost/program_options/options_description.hpp>
-
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
 #include <seastar/util/log.hh>
@@ -27,6 +25,13 @@
 namespace seastar { class file; }
 namespace seastar::json { class json_return_type; }
 namespace YAML { class Node; }
+
+namespace boost::program_options {
+
+class options_description;
+class options_description_easy_init;
+
+}
 
 namespace utils {
 

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -11,6 +11,9 @@
 
 #include <boost/any.hpp>
 #include <boost/regex.hpp>
+#include <boost/program_options/errors.hpp>
+#include <boost/program_options/value_semantic.hpp>
+#include <boost/lexical_cast.hpp>
 #include <yaml-cpp/node/convert.h>
 
 #include <seastar/core/smp.hh>


### PR DESCRIPTION
Avoid pulling in boost dependencies when all we need is the class name.

This is a build time improvement, so no backport is needed.