### PR TITLE
gdb: protect debug::the_database from lto

### DIFF
--- a/debug.cc
+++ b/debug.cc
@@ -10,6 +10,6 @@
 
 namespace debug {
 
-seastar::sharded<replica::database>* the_database = nullptr;
+seastar::sharded<replica::database>* volatile the_database = nullptr;
 
 }

--- a/debug.hh
+++ b/debug.hh
@@ -16,7 +16,7 @@ class database;
 
 namespace debug {
 
-extern seastar::sharded<replica::database>* the_database;
+extern seastar::sharded<replica::database>* volatile the_database;
 
 
 }


### PR DESCRIPTION
Clang 18.1 with lto gained the ability to eliminate dead stores. Since debug::the_database is write-only as far as the compiler understands (it is read only by gdb), all writes to it are eliminated.

Protect writes to the variable by marking it volatile.

No backport needed, because it's only needed with LTO, which isn't in any stable branch.