### PR TITLE
test.py: new Python dependencies for dtest->test.py migration

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -88,6 +88,8 @@ fedora_packages=(
     python3-unidiff
     python3-humanfriendly
     python3-jinja2
+    python3-deepdiff
+    python3-cryptography
     dnf-utils
     pigz
     net-tools
@@ -151,14 +153,16 @@ fedora_python3_packages=(
 
 # an associative array from packages to constrains
 declare -A pip_packages=(
-    [scylla-driver]=
+    [scylla-driver]=""
     [geomet]="<0.3,>=0.1"
-    [traceback-with-variables]=
-    [scylla-api-client]=
-    [treelib]=
-    [allure-pytest]=
-    [pytest-xdist]=
-    [pykmip]=
+    [traceback-with-variables]=""
+    [scylla-api-client]=""
+    [treelib]=""
+    [allure-pytest]=""
+    [pytest-xdist]=""
+    [pykmip]=""
+    [universalasync]=""
+    [boto3-stubs[dynamodb]]=""
 )
 
 pip_symlinks=(


### PR DESCRIPTION
3rd-party library which provide compatibility between sync and async code:

  universalasync

Few deps from scylla-dtest:

  deepdiff
  cryptography
  boto3-stubs[dynamodb]

Also added explicit empty string (`""`) as values for `pip_packages` array elements to make the linter happy: https://github.com/koalaman/shellcheck/wiki/SC2192
