### PR TITLE
tree: Replace boost::ranges::join with utils::views::concat 

### DIFF
--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -23,7 +23,6 @@
 #include <boost/range/algorithm/transform.hpp>
 #include <boost/range/adaptor/indirected.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/join.hpp>
 
 #include <fmt/ranges.h>
 
@@ -44,6 +43,7 @@
 #include "map_difference.hh"
 #include <seastar/coroutine/all.hh>
 #include "utils/log.hh"
+#include "utils/concat_view.hh"
 #include "frozen_schema.hh"
 #include "schema/schema_registry.hh"
 #include "system_keyspace.hh"
@@ -272,7 +272,7 @@ static future<std::set<sstring>> merge_keyspaces(distributed<service::storage_pr
     // 1. changes made to non-null columns...
     altered.insert(sk_diff.entries_differing.begin(), sk_diff.entries_differing.end());
     // 2. ... and new or deleted entries - these change only when ALTERing, not CREATE'ing or DROP'ing
-    for (auto&& ks : boost::range::join(sk_diff.entries_only_on_right, sk_diff.entries_only_on_left)) {
+    for (auto&& ks : utils::views::concat(sk_diff.entries_only_on_right, sk_diff.entries_only_on_left)) {
         if (!created.contains(ks) && !dropped.contains(ks)) {
             altered.emplace(ks);
         }
@@ -646,7 +646,7 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
     co_await db.invoke_on_all([&](replica::database& db) -> future<> {
         std::vector<bool> columns_changed;
         columns_changed.reserve(tables_diff.altered.size() + views_diff.altered.size());
-        for (auto&& altered : boost::range::join(tables_diff.altered, views_diff.altered)) {
+        for (auto&& altered : utils::views::concat(tables_diff.altered, views_diff.altered)) {
             columns_changed.push_back(db.update_column_family(altered.new_schema));
             co_await coroutine::maybe_yield();
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -66,13 +66,13 @@
 #include "streaming/stream_blob.hh"
 #include "dht/range_streamer.hh"
 #include <boost/range/algorithm.hpp>
-#include <boost/range/join.hpp>
 #include "transport/server.hh"
 #include <seastar/core/rwlock.hh>
 #include "db/batchlog_manager.hh"
 #include "db/commitlog/commitlog.hh"
 #include "db/hints/manager.hh"
 #include "utils/exceptions.hh"
+#include "utils/concat_view.hh"
 #include "message/messaging_service.hh"
 #include "supervisor.hh"
 #include "compaction/compaction_manager.hh"
@@ -7141,7 +7141,7 @@ void storage_service::init_messaging_service() {
                 }
             }
 
-            for (const auto& table : boost::join(params.tables, additional_tables)) {
+            for (const auto& table : utils::views::concat(params.tables, additional_tables)) {
                 auto schema = ss._db.local().find_schema(table);
                 auto muts = co_await ss.get_system_mutations(schema);
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -50,6 +50,7 @@
 #include "service/topology_state_machine.hh"
 #include "topology_mutation.hh"
 #include "utils/assert.hh"
+#include "utils/concat_view.hh"
 #include "utils/error_injection.hh"
 #include "utils/stall_free.hh"
 #include "utils/to_string.hh"
@@ -62,8 +63,6 @@
 #include "idl/storage_proxy.dist.hh"
 
 #include "service/topology_coordinator.hh"
-
-#include <boost/range/join.hpp>
 
 using token = dht::token;
 using inet_address = gms::inet_address;
@@ -422,7 +421,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             const std::unordered_set<raft::server_id>& exclude_nodes,
             drop_guard_and_retake drop_and_retake = drop_guard_and_retake::yes) {
         rtlogger.info("executing global topology command {}, excluded nodes: {}", cmd.cmd, exclude_nodes);
-        auto nodes = boost::range::join(_topo_sm._topology.normal_nodes, _topo_sm._topology.transition_nodes)
+        auto nodes = utils::views::concat(_topo_sm._topology.normal_nodes, _topo_sm._topology.transition_nodes)
             | std::views::filter([&cmd, &exclude_nodes] (const std::pair<const raft::server_id, replica_state>& n) {
                 // We must send barrier and barrier_and_drain to the decommissioning node
                 // as it might be accepting or coordinating requests.

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -58,6 +58,8 @@ add_scylla_test(compound_test
   KIND SEASTAR)
 add_scylla_test(compress_test
   KIND BOOST)
+add_scylla_test(concat_view_test
+  KIND BOOST)
 add_scylla_test(config_test
   KIND SEASTAR)
 add_scylla_test(continuous_data_consumer_test

--- a/test/boost/concat_view_test.cc
+++ b/test/boost/concat_view_test.cc
@@ -1,0 +1,130 @@
+#define BOOST_TEST_MODULE test-ranges
+
+#include <boost/test/unit_test.hpp>
+#include <list>
+#include <vector>
+#include <string>
+#include <ranges>
+
+#include "utils/concat_view.hh"
+
+BOOST_AUTO_TEST_CASE(test_empty_ranges)
+{
+    std::vector<int> v1{};
+    std::vector<int> v2{};
+
+    auto result = utils::views::concat(v1, v2);
+    BOOST_CHECK(std::ranges::empty(result));
+    // auto result_vec = std::vector<int>(result.begin(), result.end());
+
+    // BOOST_CHECK(result_vec.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_first_empty)
+{
+    std::vector<int> v1{};
+    std::vector<int> v2{1, 2, 3};
+
+    auto result = utils::views::concat(std::views::all(v1), std::views::all(v2));
+    auto result_vec = std::vector<int>(result.begin(), result.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(result_vec.begin(), result_vec.end(),
+                                  v2.begin(), v2.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_second_empty)
+{
+    std::vector<int> v1{1, 2, 3};
+    std::vector<int> v2{};
+
+    auto result = utils::views::concat(std::views::all(v1), std::views::all(v2));
+    auto result_vec = std::vector<int>(result.begin(), result.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(result_vec.begin(), result_vec.end(),
+                                  v1.begin(), v1.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_non_empty_ranges)
+{
+    std::vector<int> v1{1, 2, 3};
+    std::vector<int> v2{4, 5, 6};
+    std::vector<int> expected{1, 2, 3, 4, 5, 6};
+
+    auto result = utils::views::concat(std::views::all(v1), std::views::all(v2));
+    auto result_vec = std::vector<int>(result.begin(), result.end());
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(result_vec.begin(), result_vec.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_with_string_view)
+{
+    std::string_view s1 = "Hello";
+    std::string_view s2 = "World";
+    std::string expected = "HelloWorld";
+
+    auto result = utils::views::concat(s1, s2);
+    auto result_str = std::string(result.begin(), result.end());
+
+    BOOST_CHECK_EQUAL(result_str, expected);
+}
+
+BOOST_AUTO_TEST_CASE(test_with_transform)
+{
+    std::vector<int> v1{1, 2, 3};
+    std::vector<int> v2{4, 5, 6};
+    std::vector<int> expected{2, 4, 6, 8, 10, 12};
+
+    auto result = utils::views::concat(v1, v2)
+        | std::views::transform([](int x) { return x * 2; })
+        | std::ranges::to<std::vector>();
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_iterator_operations)
+{
+    std::vector<int> v1{1, 2};
+    std::vector<int> v2{3, 4};
+
+    auto result = utils::views::concat(std::views::all(v1), std::views::all(v2));
+    auto it = result.begin();
+
+    BOOST_CHECK_EQUAL(*it, 1);
+    ++it;
+    BOOST_CHECK_EQUAL(*it, 2);
+    ++it;
+    BOOST_CHECK_EQUAL(*it, 3);
+    ++it;
+    BOOST_CHECK_EQUAL(*it, 4);
+    ++it;
+    BOOST_CHECK(it == result.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_different_range_types_same_element)
+{
+    // Different range types with int elements
+    std::vector<int> v1{1, 2, 3};
+    std::array<int, 3> arr{4, 5, 6};
+
+    auto result = utils::views::concat(v1, arr);
+    auto result_vec = std::vector<int>(result.begin(), result.end());
+
+    std::vector<int> expected{1, 2, 3, 4, 5, 6};
+    BOOST_CHECK_EQUAL_COLLECTIONS(result_vec.begin(), result_vec.end(),
+                                  expected.begin(), expected.end());
+}
+
+BOOST_AUTO_TEST_CASE(test_vector_and_list_concatenation)
+{
+    std::vector<std::string> v1{"Hello", "World"};
+    std::list<std::string> lst{"!"};
+
+    auto result = utils::views::concat(v1, lst);
+    auto result_vec = std::vector<std::string>(result.begin(), result.end());
+
+    std::vector<std::string> expected{"Hello", "World", "!"};
+    BOOST_CHECK_EQUAL_COLLECTIONS(result_vec.begin(), result_vec.end(),
+                                  expected.begin(), expected.end());
+}

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -23,6 +23,7 @@
 #include "readers/combined.hh"
 #include "replica/memtable.hh"
 #include "utils/to_string.hh"
+#include "utils/concat_view.hh"
 
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
@@ -31,8 +32,6 @@
 #include "test/lib/test_utils.hh"
 
 #include "readers/from_mutations_v2.hh"
-
-#include <boost/range/join.hpp>
 
 SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
     return seastar::async([] {
@@ -154,9 +153,9 @@ composite cell_name(const schema& s, const clustering_key& ck, const column_defi
         return composite::serialize_value(ck.components(s), s.is_compound());
     } else {
         const managed_bytes_view column_name = bytes_view(col.name());
-        return composite::serialize_value(boost::range::join(
-                boost::make_iterator_range(ck.begin(s), ck.end(s)),
-                boost::make_iterator_range(&column_name, &column_name + 1)),
+        return composite::serialize_value(utils::views::concat(
+                std::ranges::subrange(ck.begin(s), ck.end(s)),
+                std::ranges::subrange(&column_name, &column_name + 1)),
             s.is_compound());
     }
 }

--- a/utils/concat_view.hh
+++ b/utils/concat_view.hh
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#pragma once
+
+#include <ranges>
+#include <concepts>
+#include <iterator>
+
+#ifdef __cpp_lib_ranges_concat
+#warning "use std::views::concat instead"
+#endif
+/**
+ * @brief A view that concatenates two input ranges into a single view.
+ *
+ * @tparam First The type of the first input range (must be a view)
+ * @tparam Second The type of the second input range (must be a view)
+ *
+ * This view allows treating two ranges as a single contiguous range,
+ * iterating through the first range followed by the second range.
+ *
+ * @note Requires both input ranges to have the same value type
+ * @note Satisfies the requirements of a standard view
+ *
+ * @warning Differences from C++26 std::views::concat:
+ * - This implementation is more restrictive: both ranges must be of the same value type
+ * - C++26's concat supports ranges with convertible value types
+ * - C++26's concat can concatenate more than two ranges (variadic)
+ * - C++26's concat offers operator[] if the concatenated ranges satisfy random_access_range
+ * - This implementation is a simplified, pre-standard version
+ *
+ * @code{.cpp}
+ * std::vector<int> v1{1, 2, 3};
+ * std::vector<int> v2{4, 5, 6};
+ *
+ * auto result = utils::views::concat(v1, v2);
+ * @endcode
+ */
+namespace utils {
+
+template<std::ranges::input_range First, std::ranges::input_range Second>
+requires std::ranges::view<First> && std::ranges::view<Second> &&
+         std::same_as<std::ranges::range_value_t<First>, std::ranges::range_value_t<Second>>
+class concat_view : public std::ranges::view_interface<concat_view<First, Second>> {
+private:
+    First _first;
+    Second _second;
+
+    class iterator {
+    private:
+        using first_iterator = std::ranges::iterator_t<First>;
+        using second_iterator = std::ranges::iterator_t<Second>;
+
+        concat_view* _parent = nullptr;
+        first_iterator _first_it{};
+        second_iterator _second_it{};
+
+    public:
+        using iterator_category = std::input_iterator_tag;
+        using value_type = std::ranges::range_value_t<First>;
+        using difference_type = std::common_type_t<
+            std::ranges::range_difference_t<First>,
+            std::ranges::range_difference_t<Second>>;
+        using pointer = value_type*;
+        using reference = std::ranges::range_reference_t<First>;
+
+        iterator() = default;
+
+        iterator(concat_view& parent,
+                 first_iterator first_it,
+                 second_iterator second_it)
+            : _parent(&parent)
+            , _first_it(first_it)
+            , _second_it(second_it) {}
+
+        reference operator*() const {
+            if (_first_it == std::ranges::end(_parent->_first)) {
+                return *_second_it;
+            }
+            return *_first_it;
+        }
+
+        iterator& operator++() {
+            if (_first_it != std::ranges::end(_parent->_first)) {
+                ++_first_it;
+            } else {
+                ++_second_it;
+            }
+            return *this;
+        }
+
+        iterator operator++(int) {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
+
+        friend bool operator==(const iterator& x, const iterator& y) {
+            return (x._first_it == y._first_it &&
+                    x._second_it == y._second_it);
+        }
+    };
+
+public:
+    concat_view() = default;
+    concat_view(First first, Second second)
+        : _first(std::move(first))
+        , _second(std::move(second)) {}
+
+    iterator begin() {
+        return {*this, std::ranges::begin(_first), std::ranges::begin(_second)};
+    }
+
+    iterator end() {
+        return {*this, std::ranges::end(_first), std::ranges::end(_second)};
+    }
+
+    template<typename V1 = First, typename V2 = Second>
+    requires std::ranges::sized_range<V1> && std::ranges::sized_range<V2>
+    size_t size() const {
+        return std::ranges::size(_first) && std::ranges::size(_second);
+    }
+
+    bool empty() const {
+        return std::ranges::empty(_first) && std::ranges::empty(_second);
+    }
+};
+
+template<class First, class Second>
+concat_view(First&&, Second&&) -> concat_view<std::views::all_t<First>, std::views::all_t<Second>>;
+
+namespace detail {
+
+struct concat_fn {
+    template<std::ranges::viewable_range First, std::ranges::viewable_range Second>
+    constexpr auto operator()(First&& first, Second&& second) const {
+        return concat_view(std::forward<First>(first), std::forward<Second>(second));
+    }
+};
+
+} // namespace detail
+
+namespace views {
+    inline constexpr detail::concat_fn concat;
+} // namespace views
+} // namespace utils


### PR DESCRIPTION
In order to reduce the header dependency to boost ranges library, `boost::ranges::join` is being phased out, while `std::views::concat` is a more modern and standard-compliant approach.

In this changeset:

- we implement a custom concat view
- switch  `boost::ranges::join` to the concat view as a temporary solution

despite that std::views::concat is already available in libstdc++ 15, but we are not yet using it. we are also not currently
using C++26, which is required for std::ranges::concat. in future, once we migrate to C++26, we will be able to seamlessly
switch to std::ranges::concat.

---

it's a cleanup, hence no need to backport.