### PR TITLE
tree: restore header compilation (${mode}-headers)

### DIFF
--- a/test/boost/bptree_validation.hh
+++ b/test/boost/bptree_validation.hh
@@ -10,6 +10,7 @@
 
 #include <stddef.h>
 #include <iostream>
+#include <fmt/format.h>
 #include "utils/bptree.hh"
 
 namespace bplus {

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -11,6 +11,7 @@
 #include <memory>
 #include <random>
 #include <bit>
+#include <fmt/std.h>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/sleep.hh>


### PR DESCRIPTION
Our CI accidentally switched to using CMake to compile scylla and it looks like CMake doesn't run the `${mode}-headers` command correctly and some missing-include in headers managed to slip in.

Compile fix, no backport needed.