### PR TITLE
Enhance s3 client perf test with "uploading" facility and related tunables

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -237,7 +237,7 @@ client::group_client& client::find_or_create_client() {
         // Limit the maximum number of connections this group's http client
         // may have proportional to its shares. Shares are typically in the
         // range of 100...1000, thus resulting in 1..10 connections
-        auto max_connections = std::max((unsigned)(sg.get_shares() / 100), 1u);
+        unsigned max_connections = _cfg->max_connections.has_value() ? *_cfg->max_connections : std::max((unsigned)(sg.get_shares() / 100), 1u);
         it = _https.emplace(std::piecewise_construct,
             std::forward_as_tuple(sg),
             std::forward_as_tuple(std::move(factory), max_connections)

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -32,6 +32,8 @@ struct endpoint_config {
     std::string region;
     // Amazon Resource Names (ARNs) to access AWS resources
     std::string role_arn;
+    std::optional<unsigned> max_connections;
+
     std::strong_ordering operator<=>(const endpoint_config& o) const = default;
 };
 


### PR DESCRIPTION
The existing test measures latencies of object GET-s. That's nice (though incomplete), but we want to measure upload performance. Here it is.

refs: #22460 