### PR TITLE
Remove sharded<system_distributed_keyspace>& argument from storage_service::join_cluster()

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2151,7 +2151,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             const auto generation_number = gms::generation_type(sys_ks.local().increment_and_get_generation().get());
 
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                return ss.local().join_cluster(sys_dist_ks, proxy, service::start_hint_manager::yes, generation_number);
+                return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();
 
             dictionary_service dict_service(

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2931,7 +2931,7 @@ bool storage_service::is_topology_coordinator_enabled() const {
     return raft_topology_change_enabled();
 }
 
-future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
+future<> storage_service::join_cluster(sharded<service::storage_proxy>& proxy,
         start_hint_manager start_hm, gms::generation_type new_generation) {
     SCYLLA_ASSERT(this_shard_id() == 0);
 
@@ -3063,7 +3063,7 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
         slogger.info("peer={}, supported_features={}", x.first, x.second);
     }
 
-    co_return co_await join_topology(sys_dist_ks, proxy, std::move(initial_contact_nodes),
+    co_return co_await join_topology(_sys_dist_ks, proxy, std::move(initial_contact_nodes),
             std::move(loaded_endpoints), std::move(loaded_peer_features), get_ring_delay(), start_hm, new_generation);
 }
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -836,7 +836,7 @@ private:
     future<> _raft_state_monitor = make_ready_future<>();
     // This fibers monitors raft state and start/stops the topology change
     // coordinator fiber
-    future<> raft_state_monitor_fiber(raft::server&, gate::holder, sharded<db::system_distributed_keyspace>& sys_dist_ks);
+    future<> raft_state_monitor_fiber(raft::server&, gate::holder);
 
 public:
     bool topology_global_queue_empty() const {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -387,7 +387,7 @@ public:
     future<> check_for_endpoint_collision(std::unordered_set<gms::inet_address> initial_contact_nodes,
             const std::unordered_map<gms::inet_address, sstring>& loaded_peer_features);
 
-    future<> join_cluster(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy,
+    future<> join_cluster(sharded<service::storage_proxy>& proxy,
             start_hint_manager start_hm, gms::generation_type new_generation);
 
     void set_group0(service::raft_group0&);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -407,8 +407,7 @@ private:
     bool should_bootstrap();
     bool is_replacing();
     bool is_first_node();
-    future<> join_topology(sharded<db::system_distributed_keyspace>& sys_dist_ks,
-            sharded<service::storage_proxy>& proxy,
+    future<> join_topology(sharded<service::storage_proxy>& proxy,
             std::unordered_set<gms::inet_address> initial_contact_nodes,
             std::unordered_map<locator::host_id, gms::loaded_endpoint_state> loaded_endpoints,
             std::unordered_map<gms::inet_address, sstring> loaded_peer_features,

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -926,7 +926,7 @@ public:
 private:
     // Tracks progress of the upgrade to topology coordinator.
     future<> _upgrade_to_topology_coordinator_fiber = make_ready_future<>();
-    future<> track_upgrade_progress_to_topology_coordinator(sharded<db::system_distributed_keyspace>& sys_dist_ks, sharded<service::storage_proxy>& proxy);
+    future<> track_upgrade_progress_to_topology_coordinator(sharded<service::storage_proxy>& proxy);
 
     future<> transit_tablet(table_id, dht::token, noncopyable_function<std::tuple<std::vector<canonical_mutation>, sstring>(const locator::tablet_map& tmap, api::timestamp_type)> prepare_mutations);
     future<service::group0_guard> get_guard_for_tablet_update();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1013,7 +1013,7 @@ private:
             const auto generation_number = gms::generation_type(_sys_ks.local().increment_and_get_generation().get());
 
             try {
-                _ss.local().join_cluster(_sys_dist_ks, _proxy, service::start_hint_manager::no, generation_number).get();
+                _ss.local().join_cluster(_proxy, service::start_hint_manager::no, generation_number).get();
             } catch (std::exception& e) {
                 // if any of the defers crashes too, we'll never see
                 // the error


### PR DESCRIPTION
There's such a reference on storage_service itself, it can use this->_sys_dist_ks instead thus making its API (both internal and external) a bit simpler.