### PR TITLE
raft topology: Add support for raft topology init to happen before group0 initialization

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -23,6 +23,7 @@
 #include "gms/feature_service.hh"
 #include "system_keyspace_view_types.hh"
 #include "schema/schema_builder.hh"
+#include "timestamp.hh"
 #include "utils/assert.hh"
 #include "utils/hashers.hh"
 #include "utils/log.hh"
@@ -2931,9 +2932,8 @@ future<std::optional<mutation>> system_keyspace::get_service_levels_version_muta
     return get_scylla_local_mutation(_db, SERVICE_LEVELS_VERSION_KEY);
 }
 
-future<mutation> system_keyspace::make_service_levels_version_mutation(int8_t version, const service::group0_guard& guard) {
+future<mutation> system_keyspace::make_service_levels_version_mutation(int8_t version, api::timestamp_type timestamp) {
     static sstring query = format("INSERT INTO {}.{} (key, value) VALUES (?, ?);", db::system_keyspace::NAME, db::system_keyspace::SCYLLA_LOCAL);
-    auto timestamp = guard.write_timestamp();
     auto muts = co_await _qp.get_mutations_internal(query, internal_system_query_state(), timestamp, {SERVICE_LEVELS_VERSION_KEY, format("{}", version)});
 
     if (muts.size() != 1) {

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -654,7 +654,7 @@ public:
 public:
     future<std::optional<int8_t>> get_service_levels_version();
     
-    future<mutation> make_service_levels_version_mutation(int8_t version, const service::group0_guard& guard);
+    future<mutation> make_service_levels_version_mutation(int8_t version, api::timestamp_type timestamp);
     future<std::optional<mutation>> get_service_levels_version_mutation();
 
     // Publishes a new compression dictionary to `dicts`,

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -95,6 +95,7 @@ public:
     const migration_notifier& get_notifier() const { return _notifier; }
     service::storage_proxy& get_storage_proxy() { return _storage_proxy; }
     const service::storage_proxy& get_storage_proxy() const { return _storage_proxy; }
+    const service::raft_group0_client& get_group0_client() const { return _group0_client; }
     abort_source& get_abort_source() noexcept { return _as; }
     const abort_source& get_abort_source() const noexcept { return _as; }
     serialized_action& get_group0_barrier() noexcept { return _group0_barrier; }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -856,7 +856,7 @@ future<> service_level_controller::migrate_to_v2(size_t nodes_count, db::system_
         migration_muts.push_back(std::move(muts[0]));
     }
 
-    auto status_mut = co_await sys_ks.make_service_levels_version_mutation(2, guard);
+    auto status_mut = co_await sys_ks.make_service_levels_version_mutation(2, guard.write_timestamp());
     migration_muts.push_back(std::move(status_mut));
 
     service::write_mutations change {

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -99,7 +99,7 @@ static future<> mutate_locally(utils::chunked_vector<canonical_mutation> muts, s
     });
 }
 
-static bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db) {
+bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db) {
     if (!db.has_schema(db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY)) {
         return false;
     }
@@ -120,7 +120,7 @@ static bool should_flush_system_topology_after_applying(const mutation& mut, con
     return false;
 }
 
-static future<> write_mutations_to_database(storage_proxy& proxy, gms::inet_address from, std::vector<canonical_mutation> cms) {
+future<> write_mutations_to_database(storage_proxy& proxy, gms::inet_address from, std::vector<canonical_mutation> cms) {
     std::vector<frozen_mutation_and_schema> mutations;
     mutations.reserve(cms.size());
     bool need_system_topology_flush = false;

--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -10,6 +10,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/abort_source.hh>
 
+#include "data_dictionary/data_dictionary.hh"
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "raft/raft.hh"
 #include "service/raft/group0_state_id_handler.hh"
@@ -121,5 +122,10 @@ public:
     future<> transfer_snapshot(raft::server_id from_id, raft::snapshot_descriptor snp) override;
     future<> abort() override;
 };
+
+bool should_flush_system_topology_after_applying(const mutation& mut, const data_dictionary::database db);
+
+// Used to write data to topology and other tables except schema tables.
+future<> write_mutations_to_database(storage_proxy& proxy, gms::inet_address from, std::vector<canonical_mutation> cms);
 
 } // end of namespace service

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -7,6 +7,7 @@
  */
 #pragma once
 
+#include "service/raft/join_node.hh"
 #include "service/raft/raft_group_registry.hh"
 #include "service/raft/discovery.hh"
 #include "service/raft/group0_fwd.hh"
@@ -177,7 +178,8 @@ public:
     //
     // Also make sure to call `finish_setup_after_join` after the node has joined the cluster and entered NORMAL state.
     future<> setup_group0(db::system_keyspace&, const std::unordered_set<gms::inet_address>& initial_contact_nodes, shared_ptr<group0_handshaker> handshaker,
-                          std::optional<replace_info>, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool topology_change_enabled);
+                          std::optional<replace_info>, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool topology_change_enabled,
+                          const join_node_request_params& params);
 
     // Call during the startup procedure before networking is enabled.
     //
@@ -363,7 +365,8 @@ private:
     // Preconditions: Raft local feature enabled
     // and we haven't initialized group 0 yet after last Scylla start (`joined_group0()` is false).
     // Postcondition: `joined_group0()` is true.
-    future<> join_group0(std::vector<gms::inet_address> seeds, shared_ptr<group0_handshaker> handshaker, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, db::system_keyspace& sys_ks, bool topology_change_enabled);
+    future<> join_group0(std::vector<gms::inet_address> seeds, shared_ptr<group0_handshaker> handshaker, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, db::system_keyspace& sys_ks, bool topology_change_enabled,
+            const join_node_request_params& params);
 
     // Start an existing Raft server for the cluster-wide group 0.
     // Assumes the server was already added to the group earlier so we don't attempt to join it again.

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -150,6 +150,10 @@ bool group0_guard::with_raft() const {
 
 void release_guard(group0_guard guard) {}
 
+gc_clock::duration raft_group0_client::get_history_gc_duration() const {
+    return _history_gc_duration;
+}
+
 void raft_group0_client::set_history_gc_duration(gc_clock::duration d) {
     _history_gc_duration = d;
 }
@@ -231,7 +235,7 @@ future<> raft_group0_client::add_entry_unguarded(group0_command group0_cmd, seas
     }
 }
 
-static utils::UUID generate_group0_state_id(utils::UUID prev_state_id) {
+utils::UUID raft_group0_client::generate_group0_state_id(utils::UUID prev_state_id) {
     auto ts = api::new_timestamp();
     if (prev_state_id != utils::UUID{}) {
         auto lower_bound = utils::UUID_gen::micros_timestamp(prev_state_id);

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -203,12 +203,14 @@ public:
 
     bool in_recovery() const;
 
+    gc_clock::duration get_history_gc_duration() const;
     // for test only
     void set_history_gc_duration(gc_clock::duration d);
     semaphore& operation_mutex();
 
     query_result_guard create_result_guard(utils::UUID query_id);
     void set_query_result(utils::UUID query_id, service::broadcast_tables::query_result qr);
+    static utils::UUID generate_group0_state_id(utils::UUID prev_state_id);
 };
 
 using mutations_generator = coroutine::experimental::generator<mutation>;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -117,6 +117,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <stdexcept>
 #include <unistd.h>
+#include <variant>
 
 using token = dht::token;
 using UUID = utils::UUID;
@@ -666,9 +667,7 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     _topology_state_machine._topology = co_await _sys_ks.local().load_topology_state(tablet_hosts);
     _topology_state_machine.reload_count++;
 
-    if (_manage_topology_change_kind_from_group0) {
-        set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
-    }
+    set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
 
     if (_topology_state_machine._topology.upgrade_state != topology::upgrade_state_type::done) {
         co_return;
@@ -1173,8 +1172,8 @@ std::unordered_set<raft::server_id> storage_service::ignored_nodes_from_join_par
     return ignored_nodes;
 }
 
-std::vector<canonical_mutation> storage_service::build_mutation_from_join_params(const join_node_request_params& params, service::group0_guard& guard) {
-    topology_mutation_builder builder(guard.write_timestamp());
+std::vector<canonical_mutation> storage_service::build_mutation_from_join_params(const join_node_request_params& params, api::timestamp_type write_timestamp) {
+    topology_mutation_builder builder(write_timestamp);
     auto ignored_nodes = ignored_nodes_from_join_params(params);
 
     if (!ignored_nodes.empty()) {
@@ -1209,7 +1208,7 @@ std::vector<canonical_mutation> storage_service::build_mutation_from_join_params
     }
     node_builder.set("request_id", params.request_id);
     topology_request_tracking_mutation_builder rtbuilder(params.request_id, _db.local().features().topology_requests_type_column);
-    rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
+    rtbuilder.set("initiating_host", params.host_id.uuid())
              .set("done", false);
     rtbuilder.set("request_type", params.replaced_id ? topology_request::replace : topology_request::join);
 
@@ -1272,20 +1271,6 @@ public:
 };
 
 future<> storage_service::raft_initialize_discovery_leader(const join_node_request_params& params) {
-    // No other server can become a member of the cluster until
-    // we finish adding ourselves. This is ensured by
-    // waiting in join_node_request_handler for
-    // _topology_state_machine._topology.normal_nodes to be not empty.
-    // We cannot mark ourselves as dead during this process.
-    // This means there is no valid way we can lose quorum here,
-    // but some subsystems may just become unreasonably slow for various reasons,
-    // so we nonetheless use raft_timeout{} here.
-
-    if (_topology_state_machine._topology.is_empty()) {
-        co_await _group0->group0_server_with_timeouts().read_barrier(&_group0_as, raft_timeout{});
-    }
-
-    while (_topology_state_machine._topology.is_empty()) {
         if (params.replaced_id.has_value()) {
             throw std::runtime_error(::format("Cannot perform a replace operation because this is the first node in the cluster"));
         }
@@ -1294,40 +1279,48 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
             throw std::runtime_error("Cannot start the first node in the cluster as zero-token");
         }
 
-        rtlogger.info("adding myself as the first node to the topology");
-        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+        const auto new_group0_state_id = raft_group0_client::generate_group0_state_id(utils::UUID{});
+        auto write_timestamp = utils::UUID_gen::micros_timestamp(new_group0_state_id);
 
-        auto insert_join_request_mutations = build_mutation_from_join_params(params, guard);
+        rtlogger.info("adding myself as the first node to the topology");
+
+        auto insert_join_request_mutations = build_mutation_from_join_params(params, write_timestamp);
 
         // We are the first node and we define the cluster.
         // Set the enabled_features field to our features.
-        topology_mutation_builder builder(guard.write_timestamp());
+        topology_mutation_builder builder(write_timestamp);
         builder.add_enabled_features(params.supported_features | std::ranges::to<std::set<sstring>>())
                 .set_upgrade_state(topology::upgrade_state_type::done); // Skip upgrade, start right in the topology-on-raft mode
         auto enable_features_mutation = builder.build();
-
         insert_join_request_mutations.push_back(std::move(enable_features_mutation));
 
-        auto sl_status_mutation = co_await _sys_ks.local().make_service_levels_version_mutation(2, guard);
+        auto sl_status_mutation = co_await _sys_ks.local().make_service_levels_version_mutation(2, write_timestamp);
         insert_join_request_mutations.emplace_back(std::move(sl_status_mutation));
-        
-        insert_join_request_mutations.emplace_back(
-                co_await _sys_ks.local().make_auth_version_mutation(guard.write_timestamp(), db::system_keyspace::auth_version_t::v2));
+
+        insert_join_request_mutations.emplace_back(co_await _sys_ks.local().make_auth_version_mutation(write_timestamp, db::system_keyspace::auth_version_t::v2));
 
         if (!utils::get_local_injector().is_enabled("skip_vb_v2_version_mut")) {
             insert_join_request_mutations.emplace_back(
-                    co_await _sys_ks.local().make_view_builder_version_mutation(guard.write_timestamp(), db::system_keyspace::view_builder_version_t::v2));
+                    co_await _sys_ks.local().make_view_builder_version_mutation(write_timestamp, db::system_keyspace::view_builder_version_t::v2));
         }
 
         topology_change change{std::move(insert_join_request_mutations)};
-        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
-                "bootstrap: adding myself as the first node to the topology");
-        try {
-            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
-        } catch (group0_concurrent_modification&) {
-            rtlogger.info("bootstrap: concurrent operation is detected, retrying.");
-        }
-    }
+        
+        auto history_append = db::system_keyspace::make_group0_history_state_id_mutation(new_group0_state_id,
+                _migration_manager.local().get_group0_client().get_history_gc_duration(), "bootstrap: adding myself as the first node to the topology");
+        auto mutation_creator_addr = _sys_ks.local().local_db().get_token_metadata().get_topology().my_address();
+
+        co_await write_mutations_to_database(_qp.proxy(), mutation_creator_addr, std::move(change.mutations));
+        co_await _qp.proxy().mutate_locally({history_append}, nullptr);
+}
+
+future<> storage_service::initialize_done_topology_upgrade_state() {
+    const sstring insert_query = format("UPDATE {}.{} SET upgrade_state='done' WHERE key='topology'",
+        db::system_keyspace::NAME, db::system_keyspace::TOPOLOGY);
+    co_await _qp.execute_internal(
+            insert_query,
+            {},
+            cql3::query_processor::cache_internal::no).discard_result();
 }
 
 future<> storage_service::update_topology_with_local_metadata(raft::server& raft_server) {
@@ -1764,7 +1757,7 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
             ? ::make_shared<join_node_rpc_handshaker>(*this, join_params)
             : _group0->make_legacy_handshaker(can_vote::no);
     co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
-            raft_replace_info, *this, _qp, _migration_manager.local(), raft_topology_change_enabled());
+            raft_replace_info, *this, _qp, _migration_manager.local(), raft_topology_change_enabled(), join_params);
 
     raft::server* raft_server = co_await [this] () -> future<raft::server*> {
         if (!raft_topology_change_enabled()) {
@@ -1811,12 +1804,6 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
             _group0_as.request_abort();
             _topology_state_machine.event.broken(make_exception_ptr(abort_requested_exception()));
         });
-
-        // Nodes that are not discovery leaders have their join request inserted
-        // on their behalf by an existing node in the cluster during the handshake.
-        // Discovery leaders on the other need to insert the join request themselves,
-        // we do that here.
-        co_await raft_initialize_discovery_leader(join_params);
 
         // start topology coordinator fiber
         _raft_state_monitor = raft_state_monitor_fiber(*raft_server, _group0->hold_group0_gate(), sys_dist_ks);
@@ -6873,7 +6860,7 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
             }
         }
 
-        auto mutation = build_mutation_from_join_params(params, guard);
+        auto mutation = build_mutation_from_join_params(params, guard.write_timestamp());
 
         topology_change change{{std::move(mutation)}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1834,9 +1834,6 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
             }
         }
 
-        // If we were the first node in the cluster, at this point `upgrade_state` will be
-        // initialized properly. Yield control to group 0
-        _manage_topology_change_kind_from_group0 = true;
         set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
 
         co_await update_topology_with_local_metadata(*raft_server);
@@ -1870,7 +1867,6 @@ future<> storage_service::join_topology(sharded<db::system_distributed_keyspace>
         co_return;
     }
 
-    _manage_topology_change_kind_from_group0 = true;
     set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
 
     // We bootstrap if we haven't successfully bootstrapped before, as long as we are not a seed.
@@ -2948,8 +2944,7 @@ future<> storage_service::join_cluster(sharded<db::system_distributed_keyspace>&
         slogger.info("Raft recovery - starting in legacy topology operations mode");
         set_topology_change_kind(topology_change_kind::legacy);
     } else if (_group0->joined_group0()) {
-        // We are a part of group 0. The _topology_change_kind_enabled flag is maintained from there.
-        _manage_topology_change_kind_from_group0 = true;
+        // We are a part of group 0.
         set_topology_change_kind(upgrade_state_to_topology_op_kind(_topology_state_machine._topology.upgrade_state));
         if (_db.local().get_config().force_gossip_topology_changes() && raft_topology_change_enabled()) {
             throw std::runtime_error("Cannot force gossip topology changes - the cluster is using raft-based topology");

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -48,6 +48,7 @@
 #include "service/topology_state_machine.hh"
 #include "service/tablet_allocator.hh"
 #include "service/tablet_operation.hh"
+#include "timestamp.hh"
 #include "utils/user_provided_param.hh"
 #include "utils/sequenced_set.hh"
 
@@ -843,6 +844,8 @@ public:
     bool topology_global_queue_empty() const {
         return !_topology_state_machine._topology.global_request.has_value();
     }
+    future<> raft_initialize_discovery_leader(const join_node_request_params& params);
+    future<> initialize_done_topology_upgrade_state();
 private:
      // State machine that is responsible for topology change
     topology_state_machine& _topology_state_machine;
@@ -871,7 +874,6 @@ private:
 
     future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
 
-    future<> raft_initialize_discovery_leader(const join_node_request_params& params);
     future<> raft_decommission();
     future<> raft_removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params);
     future<> raft_rebuild(utils::optional_param source_dc);
@@ -979,7 +981,7 @@ private:
     // raft_group0_client::_read_apply_mutex must be held
     future<> merge_topology_snapshot(raft_snapshot snp);
 
-    std::vector<canonical_mutation> build_mutation_from_join_params(const join_node_request_params& params, service::group0_guard& guard);
+    std::vector<canonical_mutation> build_mutation_from_join_params(const join_node_request_params& params, api::timestamp_type write_timestamp);
     std::unordered_set<raft::server_id> ignored_nodes_from_join_params(const join_node_request_params& params);
 
     future<join_node_request_result> join_node_request_handler(join_node_request_params params);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -809,13 +809,6 @@ private:
     // After the node successfully joins, the control over the variable is yielded
     // to `topology_state_load`, so that it can control it during the upgrade from gossiper
     // based topology to raft-based topology.
-    // FIXME: This boolean flag is mostly needed because, shortly after starting
-    // a new group 0, the state of `system.topology` is empty, and updating the
-    // `_topology_change_kind_enabled` variable from group 0 state would lead
-    // to wrong results. This could be fixed by writing an initial `system.topology`
-    // state before creating the group 0 (also making sure to set the correct
-    // group 0 state id so that the timestamps of further mutations are correct).
-    bool _manage_topology_change_kind_from_group0 = false;
     topology_change_kind _topology_change_kind_enabled = topology_change_kind::unknown;
 
     // Throws an exception if the node is either starting and didn't determine which


### PR DESCRIPTION
In the current scenario, the problem discovered is that there is a time gap between group0 creation and raft_initialize_discovery_leader call. Because of that, the group0 snapshot/apply entry enters wrong values from the disk(null) and updates the in-memory variables to wrong values. During the above time gap, the in-memory variables have wrong values and perform absurd actions.

This PR removes the variable `_manage_topology_change_kind_from_group0`
which was used earlier as a work around for correctly handling `topology_change_kind` variable, it was brittle and had some bugs(causing issues like scylladb/scylladb#21114). The reason for this bug that _manage_topology_change_kind used to block reading from disk and was enabled after group0 initialization and starting raft server for the restart case. Similarly, it was hard to manage `topology_change_kind` using `_manage_topology_change_kind_from_group0` correctly in bug free manner.

Post `_manage_topology_change_kind_from_group0` removal, careful management of `topology_change_kind` variable was needed for maintaining correct `topology_change_kind` in all scenarios. So this PR also performs a refactoring to populate all init data to system tables even before group0 creation(via `raft_initialize_discovery_leader` function). Now because `raft_initialize_discovery_leader` happens before the group 0 creation, we write mutations directly to system tables instead of a group 0 command. Hence, post group0 creation, the node can read the correct values from system tables and correct values are maintained throughout. 

Added a new function `initialize_done_topology_upgrade_state` which takes care of updating the correct upgrade state to system tables before starting group0 server. This ensures that the node can read the correct values from system tables and correct values are maintained throughout.

By moving `raft_initialize_discovery_leader` logic to happen before starting group0 server, and not as group0 command post server start, we also get rid of the potential problem of init group0 command not being the 1st command on the server. Hence ensuring full integrity as expected by programmer.

This PR fixes a bug. Hence we need to backport it.

Fixes: scylladb/scylladb#21114