### PR TITLE
doc: add SStable support in 2025.1

### DIFF
--- a/docs/architecture/sstable/_common/sstable_what_is.rst
+++ b/docs/architecture/sstable/_common/sstable_what_is.rst
@@ -15,7 +15,7 @@ SSTable Version Support
      - ScyllaDB Enterprise Version
      - ScyllaDB Open Source Version
    * - 3.x ('me')
-     - 2022.2
+     - 2022.2 and above
      - 5.1 and above
    * - 3.x ('md')
      - 2021.1

--- a/docs/architecture/sstable/index.rst
+++ b/docs/architecture/sstable/index.rst
@@ -9,11 +9,7 @@ ScyllaDB SSTable Format
 
 .. include:: _common/sstable_what_is.rst
 
-* In ScyllaDB 6.0 and above, *me* format is enabled by default.
-
-* In ScyllaDB Enterprise 2021.1, ScyllaDB 4.3 and above, *md* format is enabled by default.
-  
-* In ScyllaDB 3.1 and above, *mc* format is enabled by default. 
+In ScyllaDB 6.0 and above, *me* format is enabled by default.
 
 For more information on each of the SSTable formats, see below:
 

--- a/docs/architecture/sstable/sstable3/index.rst
+++ b/docs/architecture/sstable/sstable3/index.rst
@@ -12,17 +12,7 @@ ScyllaDB SSTable - 3.x
 
 .. include:: ../_common/sstable_what_is.rst
 
-* In ScyllaDB 6.0 and above, the ``me`` format is mandatory, and ``md`` format is used only when upgrading from an existing cluster using ``md``. The ``sstable_format`` parameter is ignored if it is set to ``md``.
-* In ScyllaDB 5.1 and above, the ``me`` format is enabled by default.
-* In ScyllaDB 4.3 to 5.0, the ``md`` format is enabled by default.
-* In ScyllaDB 3.1 to 4.2, the ``mc`` format is enabled by default. 
-* In ScyllaDB 3.0, the ``mc`` format is disabled by default. You can enable it by adding the ``enable_sstables_mc_format`` parameter set to ``true`` in the ``scylla.yaml`` file. For example: 
-    
-    .. code-block:: shell
-    
-       enable_sstables_mc_format: true
-
-.. REMOVE IN FUTURE VERSIONS - Remove the note above in version 5.2.
+In ScyllaDB 6.0 and above, the ``me`` format is mandatory, and ``md`` format is used only when upgrading from an existing cluster using ``md``. The ``sstable_format`` parameter is ignored if it is set to ``md``.
 
 Additional Information
 -------------------------


### PR DESCRIPTION
This PR adds the information about SStable version support in 2025.1 by replacing "2022.2" with "2022.2 and above".

In addition, this PR removes information about versions that are no longer supported.

Fixes https://github.com/scylladb/scylladb/issues/22485

