### PR TITLE
tasks: use host_id in task manager

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -317,13 +317,13 @@ future<> unset_server_commitlog(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_commitlog(ctx, r); });
 }
 
-future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg) {
+future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg, sharded<gms::gossiper>& gossiper) {
     auto rb = std::make_shared < api_registry_builder > (ctx.api_doc);
 
-    return ctx.http_server.set_routes([rb, &ctx, &tm, &cfg = *cfg](routes& r) {
+    return ctx.http_server.set_routes([rb, &ctx, &tm, &cfg = *cfg, &gossiper](routes& r) {
         rb->register_function(r, "task_manager",
                 "The task manager API");
-        set_task_manager(ctx, r, tm, cfg);
+        set_task_manager(ctx, r, tm, cfg, gossiper);
     });
 }
 

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -131,7 +131,7 @@ future<> unset_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx, sharded<compaction_manager>& cm);
 future<> unset_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);
-future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg);
+future<> set_server_task_manager(http_context& ctx, sharded<tasks::task_manager>& tm, lw_shared_ptr<db::config> cfg, sharded<gms::gossiper>& gossiper);
 future<> unset_server_task_manager(http_context& ctx);
 future<> set_server_task_manager_test(http_context& ctx, sharded<tasks::task_manager>& tm);
 future<> unset_server_task_manager_test(http_context& ctx);

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -81,7 +81,7 @@ tm::task_stats make_stats(tasks::task_stats stats) {
     return res;
 }
 
-void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg) {
+void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>& tm, db::config& cfg, sharded<gms::gossiper>& gossiper) {
     tm::get_modules.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         std::vector<std::string> v = tm.local().get_modules() | std::views::keys | std::ranges::to<std::vector>();
         co_return v;

--- a/api/task_manager.cc
+++ b/api/task_manager.cc
@@ -14,6 +14,7 @@
 #include "api/api.hh"
 #include "api/api-doc/task_manager.json.hh"
 #include "db/system_keyspace.hh"
+#include "gms/gossiper.hh"
 #include "tasks/task_handler.hh"
 #include "utils/overloaded_functor.hh"
 
@@ -32,12 +33,16 @@ static ::tm get_time(db_clock::time_point tp) {
     return t;
 }
 
-tm::task_status make_status(tasks::task_status status) {
+tm::task_status make_status(tasks::task_status status, sharded<gms::gossiper>& gossiper) {
     std::vector<tm::task_identity> tis{status.children.size()};
-    std::ranges::transform(status.children, tis.begin(), [] (const auto& child) {
+    std::ranges::transform(status.children, tis.begin(), [&gossiper] (const auto& child) {
         tm::task_identity ident;
+        gms::inet_address addr{};
+        if (gossiper.local_is_initialized()) {
+            addr = gossiper.local().get_address_map().find(child.host_id).value_or(gms::inet_address{});
+        }
         ident.task_id = child.task_id.to_sstring();
-        ident.node = fmt::format("{}", child.node);
+        ident.node = fmt::format("{}", addr);
         return ident;
     });
 
@@ -139,7 +144,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return std::move(f);
     });
 
-    tm::get_task_status.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::get_task_status.set(r, [&tm, &gossiper] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->get_path_param("task_id")}};
         tasks::task_status status;
         try {
@@ -148,7 +153,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         } catch (tasks::task_manager::task_not_found& e) {
             throw bad_param_exception(e.what());
         }
-        co_return make_status(status);
+        co_return make_status(status, gossiper);
     });
 
     tm::abort_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
@@ -164,7 +169,7 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         co_return json_void();
     });
 
-    tm::wait_task.set(r, [&tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::wait_task.set(r, [&tm, &gossiper] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto id = tasks::task_id{utils::UUID{req->get_path_param("task_id")}};
         tasks::task_status status;
         std::optional<std::chrono::seconds> timeout = std::nullopt;
@@ -179,24 +184,24 @@ void set_task_manager(http_context& ctx, routes& r, sharded<tasks::task_manager>
         } catch (timed_out_error& e) {
             throw httpd::base_exception{e.what(), http::reply::status_type::request_timeout};
         }
-        co_return make_status(status);
+        co_return make_status(status, gossiper);
     });
 
-    tm::get_task_status_recursively.set(r, [&_tm = tm] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
+    tm::get_task_status_recursively.set(r, [&_tm = tm, &gossiper] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& tm = _tm;
         auto id = tasks::task_id{utils::UUID{req->get_path_param("task_id")}};
         try {
             auto task = tasks::task_handler{tm.local(), id};
             auto res = co_await task.get_status_recursively(true);
 
-            std::function<future<>(output_stream<char>&&)> f = [r = std::move(res)] (output_stream<char>&& os) -> future<> {
+            std::function<future<>(output_stream<char>&&)> f = [r = std::move(res), &gossiper] (output_stream<char>&& os) -> future<> {
                 auto s = std::move(os);
                 auto res = std::move(r);
                 co_await s.write("[");
                 std::string delim = "";
                 for (auto& status: res) {
                     co_await s.write(std::exchange(delim, ", "));
-                    co_await formatter::write(s, make_status(status));
+                    co_await formatter::write(s, make_status(status, gossiper));
                 }
                 co_await s.write("]");
                 co_await s.close();

--- a/api/task_manager.hh
+++ b/api/task_manager.hh
@@ -18,7 +18,7 @@ namespace tasks {
 
 namespace api {
 
-void set_task_manager(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm, db::config& cfg);
+void set_task_manager(http_context& ctx, httpd::routes& r, sharded<tasks::task_manager>& tm, db::config& cfg, sharded<gms::gossiper>& gossiper);
 void unset_task_manager(http_context& ctx, httpd::routes& r);
 
 }

--- a/configure.py
+++ b/configure.py
@@ -1328,7 +1328,7 @@ idls = ['idl/gossip_digest.idl.hh',
         'idl/gossip.idl.hh',
         'idl/migration_manager.idl.hh',
         "idl/node_ops.idl.hh",
-
+        "idl/tasks.idl.hh"
         ]
 
 scylla_tests_generic_dependencies = [

--- a/idl/CMakeLists.txt
+++ b/idl/CMakeLists.txt
@@ -65,6 +65,7 @@ set(idl_headers
   gossip.idl.hh
   migration_manager.idl.hh
   node_ops.idl.hh
+  tasks.idl.hh
   )
 
 foreach(idl_header ${idl_headers})

--- a/idl/tasks.idl.hh
+++ b/idl/tasks.idl.hh
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "idl/uuid.idl.hh"
+
+verb [[with_client_info]] tasks_get_children (tasks::get_children_request req) -> tasks::get_children_response;

--- a/main.cc
+++ b/main.cc
@@ -1595,6 +1595,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // Task manager's messaging handlers need to be set like this because of dependency chain:
             // messaging -(needs)-> sys_ks -> db -> cm -> task_manager.
             task_manager.invoke_on_all([&] (auto& tm) {
+                tm.set_host_id(host_id);
                 tm.init_ms_handlers(messaging.local());
             }).get();
             auto uninit_tm_ms_handlers = defer([&task_manager] () {

--- a/main.cc
+++ b/main.cc
@@ -1170,7 +1170,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 task_manager.stop().get();
             });
 
-            api::set_server_task_manager(ctx, task_manager, cfg).get();
+            api::set_server_task_manager(ctx, task_manager, cfg, gossiper).get();
             auto stop_tm_api = defer_verbose_shutdown("task manager API", [&ctx] {
                 api::unset_server_task_manager(ctx).get();
             });

--- a/main.cc
+++ b/main.cc
@@ -1162,7 +1162,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return tasks::task_manager::config {
                     .task_ttl = cfg->task_ttl_seconds,
                     .user_task_ttl = cfg->user_task_ttl_seconds,
-                    .broadcast_address = broadcast_addr
                 };
             });
             task_manager.start(std::move(get_tm_cfg), std::ref(stop_signal.as_sharded_abort_source())).get();

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -85,6 +85,7 @@
 #include "idl/storage_service.dist.hh"
 #include "idl/join_node.dist.hh"
 #include "idl/migration_manager.dist.hh"
+#include "idl/tasks.dist.hh"
 #include "message/rpc_protocol_impl.hh"
 #include "idl/consistency_level.dist.impl.hh"
 #include "idl/tracing.dist.impl.hh"
@@ -128,6 +129,7 @@
 #include "idl/mapreduce_request.dist.impl.hh"
 #include "idl/storage_service.dist.impl.hh"
 #include "idl/join_node.dist.impl.hh"
+#include "idl/tasks.dist.impl.hh"
 #include "gms/feature_service.hh"
 
 namespace netw {
@@ -1426,17 +1428,6 @@ unsigned messaging_service::add_statement_tenant(sstring tenant_name, scheduling
     _dynamic_tenants_to_client_idx.insert_or_assign(tenant_name, idx);
     undo.cancel();
     return idx;
-}
-
-// Wrapper for TASKS_CHILDREN_REQUEST
-void messaging_service::register_tasks_get_children(std::function<future<tasks::get_children_response> (const rpc::client_info& cinfo, tasks::get_children_request)>&& func) {
-    register_handler(this, messaging_verb::TASKS_GET_CHILDREN, std::move(func));
-}
-future<> messaging_service::unregister_tasks_get_children() {
-    return unregister_handler(messaging_verb::TASKS_GET_CHILDREN);
-}
-future<tasks::get_children_response> messaging_service::send_tasks_get_children(msg_addr id, tasks::get_children_request req) {
-    return send_message<future<tasks::get_children_response>>(this, messaging_verb::TASKS_GET_CHILDREN, std::move(id), std::move(req));
 }
 
 } // namespace net

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -440,11 +440,6 @@ public:
     void register_repair_get_full_row_hashes_with_rpc_stream(std::function<future<rpc::sink<repair_hash_with_cmd>> (const rpc::client_info& cinfo, uint32_t repair_meta_id, rpc::source<repair_stream_cmd> source, rpc::optional<shard_id> dst_cpu_id_opt)>&& func);
     future<> unregister_repair_get_full_row_hashes_with_rpc_stream();
 
-    // Wrapper for TASKS_GET_CHILDREN
-    void register_tasks_get_children(std::function<future<tasks::get_children_response> (const rpc::client_info& cinfo, tasks::get_children_request)>&& func);
-    future<> unregister_tasks_get_children();
-    future<tasks::get_children_response> send_tasks_get_children(msg_addr id, tasks::get_children_request);
-
     void foreach_server_connection_stats(std::function<void(const rpc::client_info&, const rpc::stats&)>&& f) const;
 
     // Drops all connections from the given host and prevents further communication from it to happen.

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -206,7 +206,7 @@ task_manager_module::task_manager_module(tasks::task_manager& tm, service::stora
     , _ss(ss)
 {}
 
-std::set<gms::inet_address> task_manager_module::get_nodes() const {
+std::set<locator::host_id> task_manager_module::get_nodes() const {
     return get_task_manager().get_nodes(_ss);
 }
 

--- a/node_ops/task_manager_module.hh
+++ b/node_ops/task_manager_module.hh
@@ -67,7 +67,7 @@ private:
 public:
     task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept;
 
-    virtual std::set<gms::inet_address> get_nodes() const override;
+    virtual std::set<locator::host_id> get_nodes() const override;
 };
 
 }

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -281,7 +281,7 @@ task_manager_module::task_manager_module(tasks::task_manager& tm, service::stora
     , _ss(ss)
 {}
 
-std::set<gms::inet_address> task_manager_module::get_nodes() const {
+std::set<locator::host_id> task_manager_module::get_nodes() const {
     return get_task_manager().get_nodes(_ss);
 }
 

--- a/service/task_manager_module.hh
+++ b/service/task_manager_module.hh
@@ -52,6 +52,6 @@ private:
 public:
     task_manager_module(tasks::task_manager& tm, service::storage_service& ss) noexcept;
 
-    std::set<gms::inet_address> get_nodes() const override;
+    std::set<locator::host_id> get_nodes() const override;
 };
 }

--- a/tasks/task_handler.hh
+++ b/tasks/task_handler.hh
@@ -15,7 +15,7 @@
 namespace tasks {
 
 struct task_identity {
-    gms::inet_address node;
+    locator::host_id host_id;
     task_id task_id;
 };
 

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -658,6 +658,14 @@ gms::inet_address task_manager::get_broadcast_address() const noexcept {
     return _cfg.broadcast_address;
 }
 
+locator::host_id task_manager::get_host_id() const noexcept {
+    return _host_id;
+}
+
+void task_manager::set_host_id(locator::host_id host_id) noexcept {
+    _host_id = host_id;
+}
+
 task_manager::modules& task_manager::get_modules() noexcept {
     return _modules;
 }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -654,10 +654,6 @@ task_manager::task_manager() noexcept
     , _user_task_ttl(0)
 {}
 
-gms::inet_address task_manager::get_broadcast_address() const noexcept {
-    return _cfg.broadcast_address;
-}
-
 locator::host_id task_manager::get_host_id() const noexcept {
     return _host_id;
 }

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -18,7 +18,6 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "db_clock.hh"
 #include "utils/log.hh"
-#include "gms/inet_address.hh"
 #include "locator/host_id.hh"
 #include "schema/schema_fwd.hh"
 #include "tasks/types.hh"
@@ -65,7 +64,6 @@ public:
     struct config {
         utils::updateable_value<uint32_t> task_ttl;
         utils::updateable_value<uint32_t> user_task_ttl;
-        gms::inet_address broadcast_address;
     };
     using task_ptr = lw_shared_ptr<task_manager::task>;
     using virtual_task_ptr = lw_shared_ptr<task_manager::virtual_task>;
@@ -382,7 +380,6 @@ public:
     task_manager(config cfg, seastar::abort_source& as) noexcept;
     task_manager() noexcept;
 
-    gms::inet_address get_broadcast_address() const noexcept;
     // Returns empty host_id if local info isn't resolved yet.
     locator::host_id get_host_id() const noexcept;
     void set_host_id(locator::host_id host_id) noexcept;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -19,6 +19,7 @@
 #include "db_clock.hh"
 #include "utils/log.hh"
 #include "gms/inet_address.hh"
+#include "locator/host_id.hh"
 #include "schema/schema_fwd.hh"
 #include "tasks/types.hh"
 #include "utils/chunked_vector.hh"
@@ -84,6 +85,7 @@ private:
     tasks_collection _tasks;
     modules _modules;
     config _cfg;
+    locator::host_id _host_id = locator::host_id::create_null_id();
     seastar::abort_source _as;
     optimized_optional<seastar::abort_source::subscription> _abort_subscription;
     utils::updateable_value<uint32_t> _task_ttl;
@@ -381,6 +383,9 @@ public:
     task_manager() noexcept;
 
     gms::inet_address get_broadcast_address() const noexcept;
+    // Returns empty host_id if local info isn't resolved yet.
+    locator::host_id get_host_id() const noexcept;
+    void set_host_id(locator::host_id host_id) noexcept;
     modules& get_modules() noexcept;
     const modules& get_modules() const noexcept;
     task_map& get_local_tasks() noexcept;

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -340,7 +340,7 @@ public:
         tasks_collection& get_tasks_collection() noexcept;
         const tasks_collection& get_tasks_collection() const noexcept;
         // Returns a set of nodes on which some of virtual tasks on this module can have their children.
-        virtual std::set<gms::inet_address> get_nodes() const;
+        virtual std::set<locator::host_id> get_nodes() const;
         future<utils::chunked_vector<task_stats>> get_stats(is_internal internal, std::function<bool(std::string&, std::string&)> filter) const;
 
         void register_task(task_ptr task);
@@ -396,7 +396,7 @@ public:
     const tasks_collection& get_tasks_collection() const noexcept;
     future<std::vector<task_id>> get_virtual_task_children(task_id parent_id);
 
-    std::set<gms::inet_address> get_nodes(service::storage_service& ss) const;
+    std::set<locator::host_id> get_nodes(service::storage_service& ss) const;
 
     module_ptr make_module(std::string name);
     void register_module(std::string name, module_ptr module);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -730,6 +730,10 @@ private:
                 _gossip_address_map.stop().get();
             });
 
+            _task_manager.invoke_on_all([&] (auto& tm) {
+                tm.set_host_id(host_id);
+            }).get();
+
             auto arct_cfg = [&] {
                 return utils::advanced_rpc_compressor::tracker::config{
                     .zstd_quota_fraction{1.0},


### PR DESCRIPTION
Use host_id in a children list of a task in task manager to indicate 
a node on which the child was created.

Move TASKS_CHILDREN_REQUEST to IDL. Send it by host_id.

Fixes: https://github.com/scylladb/scylladb/issues/22284.

Ip to host_id transition; backport isn't needed.