### PR TITLE
config: specialize config_from_string() for sstring

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -20,6 +20,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/format.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/json/json_elements.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/log-cli.hh>
@@ -113,6 +114,12 @@ config_from_string(std::string_view value) {
     } else {
         throw boost::bad_lexical_cast(typeid(std::string_view), typeid(bool));
     }
+}
+
+template <>
+sstring
+config_from_string(std::string_view value) {
+    return sstring(value);
 }
 
 template <>

--- a/test/boost/virtual_table_test.cc
+++ b/test/boost/virtual_table_test.cc
@@ -95,6 +95,13 @@ SEASTAR_THREAD_TEST_CASE(test_system_config_table_update) {
     }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_system_config_table_set_empty) {
+    do_with_cql_env_thread([] (cql_test_env& env) {
+        env.execute_cql(format("UPDATE system.config SET value = '' WHERE name = 'allowed_repair_based_node_ops';")).get();
+        BOOST_REQUIRE_EQUAL(env.local_db().get_config().allowed_repair_based_node_ops(), sstring());
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_system_config_table_no_live_update) {
     do_with_cql_env_thread([] (cql_test_env& env) {
         BOOST_REQUIRE_THROW(

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -27,6 +27,9 @@ T config_from_string(std::string_view string_representation) {
 template <>
 bool config_from_string(std::string_view string_representation);
 
+template <>
+sstring config_from_string(std::string_view string_representation);
+
 }
 
 namespace YAML {


### PR DESCRIPTION
Specialize config_from_string() for sstring to resolve lexical_cast stream state parsing limitation. This enables correct handling of empty string configurations, such as setting an empty value in CQL:

```cql
UPDATE system.config SET value='' WHERE
name='allowed_repair_based_node_ops';
```
Previous implementation using boost::lexical_cast would fail due to EOF stream state, incorrectly rejecting valid empty string conversions.

Fixes scylladb/scylladb#22491
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this change addresses an edge case for empty string configuration values, so should be backported to all impacted LTS branches.