### PR TITLE
test.py: new Python dependencies for dtest->test.py migration

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -88,6 +88,8 @@ fedora_packages=(
     python3-unidiff
     python3-humanfriendly
     python3-jinja2
+    python3-deepdiff
+    python3-cryptography
     dnf-utils
     pigz
     net-tools
@@ -159,6 +161,8 @@ declare -A pip_packages=(
     [allure-pytest]=
     [pytest-xdist]=
     [pykmip]=
+    [universalasync]=""
+    [boto3-stubs[dynamodb]]=""
 )
 
 pip_symlinks=(

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-41-20250205
+docker.io/scylladb/scylla-toolchain:fedora-41-20250209


### PR DESCRIPTION
3rd-party library which provide compatibility between sync and async code:

  universalasync

Few deps from scylla-dtest:

  deepdiff
  cryptography
  boto3-stubs[dynamodb]

[avi: regenerate frozen toolchain with optimized clang from

  https://devpkg.scylladb.com/clang/clang-19.1.7-Fedora-41-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-19.1.7-Fedora-41-x86_64.tar.gz
]

No backport - preparing for dtest->test.py migration.