### PR TITLE
systemd: map libraries close to the executable

### DIFF
--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -12,6 +12,9 @@ LimitMEMLOCK=infinity
 LimitNOFILE=800000
 LimitAS=infinity
 LimitNPROC=8096
+# Intel Golden Cove branches > 2GB occupy more slots in the branch target buffer,
+# so map libraries close to the executable for shorter branches.
+Environment=LD_PREFER_MAP_32BIT_EXEC=1
 EnvironmentFile=/etc/sysconfig/scylla-server
 EnvironmentFile=/etc/scylla.d/*.conf
 ExecStartPre=+/opt/scylladb/scripts/scylla_prepare


### PR DESCRIPTION
The Intel Optimizaton Manual states that branches with relative offsets greater than 2GB suffer a penalty. They cite a 6% improvement when this is avoided. Our code doesn't rely heavily on dynamically linked libraries, so I don't expect a similar win, but it's still better to do it than not.

Eliminate long branches by asking the dynamic linker to restrict itself to the lower 4GB of the address space. I saw that it maps libraries at 1GB+ addresses, so this satisfies the limitation.

Fix is from the Intel Optimization Manual as well.

This change was ported from ScyllaDB Enterprise.

New minor optimization, does not merit a backport.