### PR TITLE
cdc,index: replace boost::ends_with() with .ends_with()

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -10,7 +10,6 @@
 #include <algorithm>
 
 #include <boost/range/irange.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/core/metrics.hh>
 
@@ -420,7 +419,7 @@ static const sstring cdc_deleted_column_prefix = cdc_meta_column_prefix + "delet
 static const sstring cdc_deleted_elements_column_prefix = cdc_meta_column_prefix + "deleted_elements_";
 
 bool is_log_name(const std::string_view& table_name) {
-    return boost::ends_with(table_name, cdc_log_suffix);
+    return table_name.ends_with(cdc_log_suffix);
 }
 
 bool is_cdc_metacolumn_name(const sstring& name) {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -21,7 +21,6 @@
 #include "db/tags/extension.hh"
 
 #include <boost/range/adaptor/map.hpp>
-#include <boost/algorithm/string/predicate.hpp>
 
 namespace secondary_index {
 
@@ -156,7 +155,7 @@ sstring index_table_name(const sstring& index_name) {
 }
 
 sstring index_name_from_table_name(const sstring& table_name) {
-    if (table_name.size() < 7 || !boost::algorithm::ends_with(table_name, "_index")) {
+    if (table_name.size() < 7 || !table_name.ends_with("_index")) {
         throw std::runtime_error(format("Table {} does not have _index suffix", table_name));
     }
     return table_name.substr(0, table_name.size() - 6); // remove the _index suffix from an index name;


### PR DESCRIPTION
since C++20, std::string and std::string_view started providing `ends_with()` member function, the same applies to `seastar::sstring`, so there is no need to use `boost::ends_with()` anymore.

in this change, we switch from `boost::ends_with()` to the member functions variant to

- improve the readability
- reduce the header dependency

---

it's a cleanup, hence no need to backport.