### PR TITLE
compaction: switch boost::algorithm::any_of to std::ranges::any_of

### DIFF
--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -11,7 +11,6 @@
 #include "compaction_manager.hh"
 #include "incremental_compaction_strategy.hh"
 #include "incremental_backlog_tracker.hh"
-#include <boost/algorithm/cxx11/any_of.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/adaptors.hpp>
@@ -152,7 +151,7 @@ bool incremental_compaction_strategy::is_bucket_interesting(const std::vector<ss
 }
 
 bool incremental_compaction_strategy::is_any_bucket_interesting(const std::vector<std::vector<sstables::frozen_sstable_run>>& buckets, size_t min_threshold) const {
-    return boost::algorithm::any_of(buckets, [&] (const std::vector<sstables::frozen_sstable_run>& bucket) {
+    return std::ranges::any_of(buckets, [&] (const std::vector<sstables::frozen_sstable_run>& bucket) {
         return this->is_bucket_interesting(bucket, min_threshold);
     });
 }
@@ -282,7 +281,7 @@ incremental_compaction_strategy::find_garbage_collection_job(const compaction::t
     };
     auto compaction_time = gc_clock::now();
     auto can_garbage_collect = [&] (const size_bucket_t& bucket) {
-        return boost::algorithm::any_of(bucket, [&] (const frozen_sstable_run& r) {
+        return std::ranges::any_of(bucket, [&] (const frozen_sstable_run& r) {
             return worth_dropping_tombstones(*r, compaction_time);
         });
     };


### PR DESCRIPTION
std::any_of was included by C++11, and boost::algorithm::any_of() is provided by Boost for users stuck in the pre-C++11 era. in our case, we've moved into C++23, where the ranges variant of this algorithm is available.

in order to reduce the header dependency, let's switch to `std::ranges::any_of()`.

---

it's a cleanup, hence no need to backport.