### PR TITLE
repair: Introduce Host and DC filter support

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2872,6 +2872,22 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"hosts_filter",
+                     "description":"Repair replicas listed in the comma-separated host_id list.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"dcs_filter",
+                     "description":"Repair replicas listed in the comma-separated DC list",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1697,8 +1697,19 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
         } else {
             tokens_variant = tokens;
         }
+        auto hosts = req->get_query_param("hosts_filter");
+        auto dcs = req->get_query_param("dcs_filter");
 
-        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant);
+        std::unordered_set<sstring> hosts_vec;
+        boost::split(hosts_vec, hosts, boost::algorithm::is_any_of(","));
+        for (auto& h : hosts_vec) {
+            try {
+                locator::host_id(utils::UUID(h));
+            } catch (...) {
+                throw httpd::bad_param_exception(fmt::format("Wrong host_id format {}", h));
+            }
+        }
+        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant, hosts, dcs);
         co_return json::json_return_type(res);
 }
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -167,12 +167,14 @@ struct tablet_task_info {
     bool operator==(const tablet_task_info&) const = default;
     bool is_valid() const;
     bool is_user_repair_request() const;
-    static tablet_task_info make_user_repair_request();
-    static tablet_task_info make_auto_repair_request();
+    static tablet_task_info make_user_repair_request(sstring hosts_filter = {}, sstring dcs_filter = {});
+    static tablet_task_info make_auto_repair_request(sstring hosts_filter = {}, sstring dcs_filter = {});
     static tablet_task_info make_migration_request();
     static tablet_task_info make_intranode_migration_request();
     static tablet_task_info make_split_request();
     static tablet_task_info make_merge_request();
+    std::unordered_set<locator::host_id> get_repair_hosts_filter() const;
+    std::unordered_set<sstring> get_repair_dcs_filter() const;
 };
 
 /// Stores information about a single tablet.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2446,10 +2446,35 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     auto replicas = info.replicas;
     std::vector<locator::host_id> nodes;
     std::vector<shard_id> shards;
-    shard_id master_shard_id;
+    std::optional<shard_id> master_shard_id;
+    auto& topology = guard.get_token_metadata()->get_topology();
+    auto hosts_filter = info.repair_task_info.get_repair_hosts_filter();
+    auto dcs_filter = info.repair_task_info.get_repair_dcs_filter();
     for (auto& r : replicas) {
         auto shard = r.shard;
         if (r.host != myhostid) {
+            if (!hosts_filter.empty()) {
+                auto dc = topology.get_datacenter(r.host);
+                if (!hosts_filter.contains(r.host)) {
+                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
+                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                    continue;
+                } else {
+                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} ok",
+                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                }
+            }
+            if (!dcs_filter.empty()) {
+                auto dc = topology.get_datacenter(r.host);
+                if (!dcs_filter.contains(dc)) {
+                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
+                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                    continue;
+                } else {
+                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} ok",
+                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                }
+            }
             nodes.push_back(r.host);
             shards.push_back(shard);
         } else {
@@ -2457,10 +2482,17 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
         }
     }
 
+    if (nodes.empty() || !master_shard_id) {
+        rlogger.info("repair[{}]: Skipped tablet repair for table={}.{} range={} replicas={} global_tablet_id={} hosts_filter={} dcs_filter={}",
+                id.uuid(), keyspace_name, table_name, range, replicas, gid, hosts_filter, dcs_filter);
+        auto flush_time = gc_clock::time_point();
+        co_return flush_time;
+    }
+
     std::vector<tablet_repair_task_meta> task_metas;
     auto ranges_parallelism = std::nullopt;
     auto start = std::chrono::steady_clock::now();
-    task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, table_id, master_shard_id, range, repair_neighbors(nodes, shards), replicas});
+    task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, table_id, *master_shard_id, range, repair_neighbors(nodes, shards), replicas});
     auto task_impl_ptr = seastar::make_shared<repair::tablet_repair_task_impl>(_repair_module, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism);
     task_impl_ptr->sched_by_scheduler = true;
     auto task = co_await _repair_module->make_task(task_impl_ptr, global_tablet_repair_task_info);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -933,7 +933,7 @@ private:
     future<bool> exec_tablet_update(service::group0_guard guard, std::vector<canonical_mutation> updates, sstring reason);
 public:
     struct all_tokens_tag {};
-    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant);
+    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, sstring hosts_filter, sstring dcs_filter);
     future<> del_repair_tablet_request(table_id table, locator::tablet_task_id);
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1454,9 +1454,32 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             co_return;
                         }
                         auto sched_time = tinfo.repair_task_info.sched_time;
-                        auto primary = tmap.get_primary_replica(gid.tablet);
-                        auto dst = primary.host;
                         auto tablet = gid;
+                        auto hosts_filter = tinfo.repair_task_info.get_repair_hosts_filter();
+                        auto dcs_filter = tinfo.repair_task_info.get_repair_dcs_filter();
+                        const auto& topo = _db.get_token_metadata().get_topology();
+                        std::optional<locator::host_id> dst_opt;
+                        if (hosts_filter.empty() && dcs_filter.empty()) {
+                            auto primary = tmap.get_primary_replica(gid.tablet);
+                            dst_opt = primary.host;
+                        } else {
+                           for (auto& replica : tinfo.replicas) {
+                                if (!hosts_filter.contains(replica.host)) {
+                                    continue;
+                                }
+                                auto dc = topo.get_datacenter(replica.host);
+                                if (!dcs_filter.contains(dc)) {
+                                    continue;
+                                }
+                                dst_opt = replica.host;
+                                break;
+                           }
+                        }
+                        if (!dst_opt) {
+                            throw std::runtime_error(fmt::format("Could not find host to perform repair tablet={} replica={} hosts_filter={} dcs_filter={}",
+                                    tablet, tinfo.replicas, hosts_filter, dcs_filter));
+                        }
+                        auto dst = dst_opt.value();
                         rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);
                         auto res = co_await ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
                                 dst, _as, raft::server_id(dst.uuid()), gid);
@@ -1468,12 +1491,16 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     })) {
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);
                         bool valid = tinfo.repair_task_info.is_valid();
+                        auto hosts_filter = tinfo.repair_task_info.get_repair_hosts_filter();
+                        auto dcs_filter = tinfo.repair_task_info.get_repair_dcs_filter();
+                        bool is_filter_off = hosts_filter.empty() && dcs_filter.empty();
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::end_repair);
                         auto update = get_mutation_builder()
                                         .set_stage(last_token, locator::tablet_transition_stage::end_repair)
                                         .del_repair_task_info(last_token)
                                         .del_session(last_token);
-                        if (valid) {
+                        // Skip update repair time in case hosts filter or dcs filter is set.
+                        if (valid && is_filter_off) {
                             auto sched_time = tinfo.repair_task_info.sched_time;
                             auto time = tablet_state.repair_time;
                             rtlogger.debug("Set tablet repair time sched_time={} return_time={} set_time={}",


### PR DESCRIPTION
Currently, the tablet repair scheduler repairs all replicas of a tablet. It does not support hosts or DCs selection. It should be enough for most cases. However, users might still want to limit the repair to certain hosts or DCs in production. #21985 added the preparation work to add the config options for the selection. This patch adds the hosts or DCs selection support.

Fixes #22417

New feature. No backport is needed. 