### PR TITLE
Respect per-shard tablet goal and 10x default per-shard tablet count

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1336,6 +1336,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , maximum_replication_factor_fail_threshold(this, "maximum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 10,
          "Minimum average number of tablet replicas per shard per table. Suppressed by tablet options in table's schema: min_per_shard_tablet_count and min_tablet_count")
+    , tablets_per_shard_goal(this, "tablets_per_shard_goal", liveness::LiveUpdate, value_status::Used, 100,
+         "The goal for the maximum number of tablet replicas per shard. Tablet allocator tries to keep this goal.")
     , target_tablet_size_in_bytes(this, "target_tablet_size_in_bytes", liveness::LiveUpdate, value_status::Used, service::default_target_tablet_size,
          "Allows target tablet size to be configured. Defaults to 5G (in bytes). Maintaining tablets at reasonable sizes is important to be able to " \
          "redistribute load. A higher value means tablet migration throughput can be reduced. A lower value may cause number of tablets to increase significantly, " \

--- a/db/config.cc
+++ b/db/config.cc
@@ -1334,7 +1334,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , minimum_replication_factor_warn_threshold(this, "minimum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used,  3, "")
     , maximum_replication_factor_warn_threshold(this, "maximum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , maximum_replication_factor_fail_threshold(this, "maximum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
-    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 10, "Calculated initial tablets are multiplied by this number")
+    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 10,
+         "Minimum average number of tablet replicas per shard per table. Suppressed by tablet options in table's schema: min_per_shard_tablet_count and min_tablet_count")
     , target_tablet_size_in_bytes(this, "target_tablet_size_in_bytes", liveness::LiveUpdate, value_status::Used, service::default_target_tablet_size,
          "Allows target tablet size to be configured. Defaults to 5G (in bytes). Maintaining tablets at reasonable sizes is important to be able to " \
          "redistribute load. A higher value means tablet migration throughput can be reduced. A lower value may cause number of tablets to increase significantly, " \

--- a/db/config.cc
+++ b/db/config.cc
@@ -1334,7 +1334,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , minimum_replication_factor_warn_threshold(this, "minimum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used,  3, "")
     , maximum_replication_factor_warn_threshold(this, "maximum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , maximum_replication_factor_fail_threshold(this, "maximum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
-    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 1, "Calculated initial tablets are multiplied by this number")
+    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 10, "Calculated initial tablets are multiplied by this number")
     , target_tablet_size_in_bytes(this, "target_tablet_size_in_bytes", liveness::LiveUpdate, value_status::Used, service::default_target_tablet_size,
          "Allows target tablet size to be configured. Defaults to 5G (in bytes). Maintaining tablets at reasonable sizes is important to be able to " \
          "redistribute load. A higher value means tablet migration throughput can be reduced. A lower value may cause number of tablets to increase significantly, " \

--- a/db/config.cc
+++ b/db/config.cc
@@ -1334,7 +1334,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , minimum_replication_factor_warn_threshold(this, "minimum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used,  3, "")
     , maximum_replication_factor_warn_threshold(this, "maximum_replication_factor_warn_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
     , maximum_replication_factor_fail_threshold(this, "maximum_replication_factor_fail_threshold", liveness::LiveUpdate, value_status::Used, -1, "")
-    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", value_status::Used, 10,
+    , tablets_initial_scale_factor(this, "tablets_initial_scale_factor", liveness::LiveUpdate, value_status::Used, 10,
          "Minimum average number of tablet replicas per shard per table. Suppressed by tablet options in table's schema: min_per_shard_tablet_count and min_tablet_count")
     , tablets_per_shard_goal(this, "tablets_per_shard_goal", liveness::LiveUpdate, value_status::Used, 100,
          "The goal for the maximum number of tablet replicas per shard. Tablet allocator tries to keep this goal.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -502,7 +502,7 @@ public:
     named_value<int> maximum_replication_factor_warn_threshold;
     named_value<int> maximum_replication_factor_fail_threshold;
 
-    named_value<int> tablets_initial_scale_factor;
+    named_value<double> tablets_initial_scale_factor;
     named_value<unsigned> tablets_per_shard_goal;
     named_value<uint64_t> target_tablet_size_in_bytes;
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -503,6 +503,7 @@ public:
     named_value<int> maximum_replication_factor_fail_threshold;
 
     named_value<int> tablets_initial_scale_factor;
+    named_value<unsigned> tablets_per_shard_goal;
     named_value<uint64_t> target_tablet_size_in_bytes;
 
     named_value<std::vector<enum_option<replication_strategy_restriction_t>>> replication_strategy_warn_list;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -311,16 +311,13 @@ static future<unsigned> calculate_initial_tablets_from_topology(const schema& s,
             shards_per_dc_map[node.dc_rack().dc] += node.get_shard_count();
         }
     });
+    min_per_shard_tablet_count = std::max(1.0, min_per_shard_tablet_count);
     for (const auto& [dc, rf_in_dc] : rf) {
         if (!rf_in_dc) {
             continue;
         }
         unsigned shards_in_dc = shards_per_dc_map[dc];
-        unsigned tablets_in_dc = (shards_in_dc + rf_in_dc - 1) / rf_in_dc;
-        if (min_per_shard_tablet_count) {
-            auto min_tablets_in_dc = std::ceil((double)(min_per_shard_tablet_count * shards_in_dc) / rf_in_dc);
-            tablets_in_dc = std::max<unsigned>(tablets_in_dc, min_tablets_in_dc);
-        }
+        unsigned tablets_in_dc = std::ceil((double)(min_per_shard_tablet_count * shards_in_dc) / rf_in_dc);
         initial_tablets = std::max(initial_tablets, tablets_in_dc);
     }
     rslogger.debug("Estimated {} initial tablets for table {}.{}", initial_tablets, s.ks_name(), s.cf_name());

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -344,14 +344,12 @@ future<size_t> network_topology_strategy::calculate_min_tablet_count(schema_ptr 
     co_return tablet_count;
 }
 
-future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const {
-    size_t tablet_count = co_await calculate_min_tablet_count(s, tm, target_tablet_size, initial_scale);
+future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(schema_ptr s, token_metadata_ptr tm, size_t tablet_count) const {
     auto aligned_tablet_count = 1ul << log2ceil(tablet_count);
     if (tablet_count != aligned_tablet_count) {
         rslogger.info("Rounding up tablet count from {} to {} for table {}.{}", tablet_count, aligned_tablet_count, s->ks_name(), s->cf_name());
         tablet_count = aligned_tablet_count;
     }
-
     co_return co_await reallocate_tablets(std::move(s), std::move(tm), tablet_map(tablet_count));
 }
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -296,54 +296,6 @@ effective_replication_map_ptr network_topology_strategy::make_replication_map(ta
     return do_make_replication_map(table, shared_from_this(), std::move(tm), _rep_factor);
 }
 
-//
-// Try to use as many tablets initially, so that all shards in the current topology
-// are covered with at least `min_per_shard_tablet_count` tablets. In other words, the value is
-//
-//    initial_tablets = max(nr_shards_in(dc) / RF_in(dc) for dc in datacenters)
-//
-
-static future<unsigned> calculate_initial_tablets_from_topology(const schema& s, token_metadata_ptr tm, const std::unordered_map<sstring, size_t>& rf, double min_per_shard_tablet_count = 0) {
-    unsigned initial_tablets = std::numeric_limits<unsigned>::min();
-    std::unordered_map<sstring, unsigned> shards_per_dc_map;
-    tm->for_each_token_owner([&] (const node& node) {
-        if (node.is_normal()) {
-            shards_per_dc_map[node.dc_rack().dc] += node.get_shard_count();
-        }
-    });
-    min_per_shard_tablet_count = std::max(1.0, min_per_shard_tablet_count);
-    for (const auto& [dc, rf_in_dc] : rf) {
-        if (!rf_in_dc) {
-            continue;
-        }
-        unsigned shards_in_dc = shards_per_dc_map[dc];
-        unsigned tablets_in_dc = std::ceil((double)(min_per_shard_tablet_count * shards_in_dc) / rf_in_dc);
-        initial_tablets = std::max(initial_tablets, tablets_in_dc);
-    }
-    rslogger.debug("Estimated {} initial tablets for table {}.{}", initial_tablets, s.ks_name(), s.cf_name());
-    co_return initial_tablets;
-}
-
-future<size_t> network_topology_strategy::calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const {
-    size_t tablet_count = get_initial_tablets();
-    const auto& tablet_options = s->tablet_options();
-    if (tablet_options.min_tablet_count) {
-        tablet_count = std::max<size_t>(tablet_count, tablet_options.min_tablet_count.value());
-    }
-    if (tablet_options.expected_data_size_in_gb) {
-        tablet_count = std::max<size_t>(tablet_count, (tablet_options.expected_data_size_in_gb.value() << 30) / target_tablet_size);
-    }
-    auto min_per_shard_tablet_count = tablet_options.min_per_shard_tablet_count.value_or(
-            // If min_tablet_count is set, initial_scale should not be effective for
-            // compatibility with the deprecated "initial" tablet count.
-            (get_initial_tablets() || tablet_options.min_tablet_count) ? 0 : initial_scale.value_or(1));
-    if (min_per_shard_tablet_count) {
-        tablet_count = std::max<size_t>(tablet_count, co_await calculate_initial_tablets_from_topology(*s, tm, _dc_rep_factor,
-                                                              min_per_shard_tablet_count));
-    }
-    co_return tablet_count;
-}
-
 future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(schema_ptr s, token_metadata_ptr tm, size_t tablet_count) const {
     auto aligned_tablet_count = 1ul << log2ceil(tablet_count);
     if (tablet_count != aligned_tablet_count) {

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -47,7 +47,7 @@ public:
 public: // tablet_aware_replication_strategy
     virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const override;
     virtual future<size_t> calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const override;
-    virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, uint64_t target_tablet_size, std::optional<unsigned> initial_scale = std::nullopt) const override;
+    virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, size_t tablet_count) const override;
     virtual future<tablet_map> reallocate_tablets(schema_ptr, token_metadata_ptr, tablet_map cur_tablets) const override;
 protected:
     /**

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -29,7 +29,7 @@ public:
         return _rep_factor;
     }
 
-    size_t get_replication_factor(const sstring& dc) const {
+    size_t get_replication_factor(const sstring& dc) const override {
         auto dc_factor = _dc_rep_factor.find(dc);
         return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second;
     }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -46,7 +46,6 @@ public:
 
 public: // tablet_aware_replication_strategy
     virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const override;
-    virtual future<size_t> calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const override;
     virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, size_t tablet_count) const override;
     virtual future<tablet_map> reallocate_tablets(schema_ptr, token_metadata_ptr, tablet_map cur_tablets) const override;
 protected:

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -46,7 +46,7 @@ public:
 
 public: // tablet_aware_replication_strategy
     virtual effective_replication_map_ptr make_replication_map(table_id, token_metadata_ptr) const override;
-    virtual size_t calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const override;
+    virtual future<size_t> calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const override;
     virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, uint64_t target_tablet_size, std::optional<unsigned> initial_scale = std::nullopt) const override;
     virtual future<tablet_map> reallocate_tablets(schema_ptr, token_metadata_ptr, tablet_map cur_tablets) const override;
 protected:

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -38,7 +38,7 @@ protected:
 public:
     /// Calculate the minimum tablet_count for a table, given the target_tablet_size, the per-table hints,
     /// the network topology, and the configured replication factors.
-    virtual size_t calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const = 0;
+    virtual future<size_t> calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const = 0;
 
     /// Generates tablet_map for a new table.
     /// Runs under group0 guard.

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -49,6 +49,12 @@ public:
     /// otherwise, cur_tablets is a copy of the current tablet_map.
     /// Runs under group0 guard.
     virtual future<tablet_map> reallocate_tablets(schema_ptr, token_metadata_ptr, tablet_map cur_tablets) const = 0;
+
+    /// Returns replication factor in a given DC.
+    /// Note that individual tablets may lag behind desired replication factor in their
+    /// current replica list, as replication factor changes involve table rebuilding transitions
+    /// which are not instantaneous.
+    virtual size_t get_replication_factor(const sstring& dc) const = 0;
 };
 
 } // namespace locator

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -29,16 +29,13 @@ private:
 protected:
     void validate_tablet_options(const abstract_replication_strategy&, const gms::feature_service&, const replication_strategy_config_options&) const;
     void process_tablet_options(abstract_replication_strategy&, replication_strategy_config_options&, replication_strategy_params);
-    size_t get_initial_tablets() const { return _initial_tablets; }
     effective_replication_map_ptr do_make_replication_map(table_id,
                                                           replication_strategy_ptr,
                                                           token_metadata_ptr,
                                                           size_t replication_factor) const;
 
 public:
-    /// Calculate the minimum tablet_count for a table, given the target_tablet_size, the per-table hints,
-    /// the network topology, and the configured replication factors.
-    virtual future<size_t> calculate_min_tablet_count(schema_ptr s, token_metadata_ptr tm, uint64_t target_tablet_size, std::optional<unsigned> initial_scale) const = 0;
+    size_t get_initial_tablets() const { return _initial_tablets; }
 
     /// Generates tablet_map for a new table.
     /// Runs under group0 guard.

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -42,7 +42,7 @@ public:
 
     /// Generates tablet_map for a new table.
     /// Runs under group0 guard.
-    virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, uint64_t target_tablet_size, std::optional<unsigned> initial_scale = std::nullopt) const = 0;
+    virtual future<tablet_map> allocate_tablets_for_new_table(schema_ptr, token_metadata_ptr, size_t tablet_count) const = 0;
 
     /// Generates tablet_map for a new table or when increasing replication factor.
     /// For a new table, cur_tablets is initialized with the tablet_count,

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -633,13 +633,7 @@ resize_decision::resize_decision(sstring decision, uint64_t seq_number)
 }
 
 sstring resize_decision::type_name() const {
-    static const std::array<sstring, 3> index_to_string = {
-        "none",
-        "split",
-        "merge",
-    };
-    static_assert(std::variant_size_v<decltype(way)> == index_to_string.size());
-    return index_to_string[way.index()];
+    return fmt::format("{}", way);
 }
 
 resize_decision::seq_number_t resize_decision::next_sequence_number() const {
@@ -1029,6 +1023,17 @@ void tablet_metadata_guard::subscribe() {
     });
 }
 
+}
+
+auto fmt::formatter<locator::resize_decision_way>::format(const locator::resize_decision_way& way, fmt::format_context& ctx) const
+        -> decltype(ctx.out()) {
+    static const std::array<sstring, 3> index_to_string = {
+        "none",
+        "split",
+        "merge",
+    };
+    static_assert(std::variant_size_v<locator::resize_decision_way> == index_to_string.size());
+    return fmt::format_to(ctx.out(), "{}", index_to_string[way.index()]);
 }
 
 auto fmt::formatter<locator::global_tablet_id>::format(const locator::global_tablet_id& id, fmt::format_context& ctx) const

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -325,10 +325,12 @@ struct resize_decision {
     struct merge {
         auto operator<=>(const merge&) const = default;
     };
+    using way_type = std::variant<none, split, merge>;
 
     using seq_number_t = int64_t;
 
-    std::variant<none, split, merge> way;
+    way_type way;
+
     // The sequence number globally identifies a resize decision.
     // It's monotonically increasing, globally.
     // Needed to distinguish stale decision from latest one, in case coordinator

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -354,6 +354,8 @@ struct resize_decision {
     seq_number_t next_sequence_number() const;
 };
 
+using resize_decision_way = resize_decision::way_type;
+
 struct table_load_stats {
     uint64_t size_in_bytes = 0;
     // Stores the minimum seq number among all replicas, as coordinator wants to know if
@@ -667,6 +669,11 @@ struct tablet_metadata_change_hint {
 };
 
 }
+
+template <>
+struct fmt::formatter<locator::resize_decision_way> : fmt::formatter<string_view> {
+    auto format(const locator::resize_decision_way&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
 
 template <>
 struct fmt::formatter<locator::tablet_transition_stage> : fmt::formatter<string_view> {

--- a/main.cc
+++ b/main.cc
@@ -1658,7 +1658,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     gossiper.local(), feature_service.local(), sys_ks.local(), group0_client, dbcfg.gossip_scheduling_group};
 
             service::tablet_allocator::config tacfg;
-            tacfg.initial_tablets_scale = cfg->tablets_initial_scale_factor();
             distributed<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();
             auto stop_tablet_allocator = defer_verbose_shutdown("tablet allocator", [&tablet_allocator] {

--- a/main.cc
+++ b/main.cc
@@ -1693,6 +1693,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_tsm = defer_verbose_shutdown("topology_state_machine", [&tsm] {
                 tsm.stop().get();
             });
+            auto tablets_per_shard_goal_observer = cfg->tablets_per_shard_goal.observe([&tsm] (unsigned goal) {
+                tsm.local().event.broadcast();
+            });
 
             auto compression_dict_updated_callback = [] () -> future<> {
                 auto dict = co_await sys_ks.local().query_dict();

--- a/main.cc
+++ b/main.cc
@@ -1692,9 +1692,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto stop_tsm = defer_verbose_shutdown("topology_state_machine", [&tsm] {
                 tsm.stop().get();
             });
-            auto tablets_per_shard_goal_observer = cfg->tablets_per_shard_goal.observe([&tsm] (unsigned goal) {
+            auto notify_topology = [&tsm] (auto) {
                 tsm.local().event.broadcast();
-            });
+            };
+            auto tablets_per_shard_goal_observer = cfg->tablets_per_shard_goal.observe(notify_topology);
+            auto tablets_initial_scale_factor_observer = cfg->tablets_initial_scale_factor.observe(notify_topology);
 
             auto compression_dict_updated_callback = [] () -> future<> {
                 auto dict = co_await sys_ks.local().query_dict();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -480,6 +480,8 @@ class load_balancer {
     // due to the average size dropping below the merge threshold, as tablet count doubles.
     const uint64_t _target_tablet_size = default_target_tablet_size;
 
+    const unsigned _tablets_per_shard_goal;
+
     uint64_t target_max_tablet_size() const noexcept {
         return _target_tablet_size * 2;
     }
@@ -662,8 +664,13 @@ private:
         return streaming_infos;
     }
 public:
-    load_balancer(replica::database& db, token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, load_balancer_stats_manager& stats, uint64_t target_tablet_size, std::unordered_set<host_id> skiplist)
+    load_balancer(replica::database& db, token_metadata_ptr tm, locator::load_stats_ptr table_load_stats,
+            load_balancer_stats_manager& stats,
+            uint64_t target_tablet_size,
+            unsigned tablets_per_shard_goal,
+            std::unordered_set<host_id> skiplist)
         : _target_tablet_size(target_tablet_size)
+        , _tablets_per_shard_goal(tablets_per_shard_goal)
         , _db(db)
         , _tm(std::move(tm))
         , _table_load_stats(std::move(table_load_stats))
@@ -1068,11 +1075,13 @@ public:
     };
 
     future<sizing_plan> make_sizing_plan(schema_ptr new_table = nullptr, const tablet_aware_replication_strategy* new_rs = nullptr) {
+        std::unordered_map<table_id, const tablet_aware_replication_strategy*> rs_by_table;
         sizing_plan plan;
 
         auto process_table = [&] (table_id table, schema_ptr s, const tablet_aware_replication_strategy* rs, size_t tablet_count) -> future<> {
             table_sizing& table_plan = plan.tables[table];
             table_plan.current_tablet_count = tablet_count;
+            rs_by_table[table] = rs;
 
             size_t target_tablet_count = 1;
 
@@ -1111,16 +1120,6 @@ public:
             }
 
             table_plan.target_tablet_count = target_tablet_count;
-            table_plan.target_tablet_count_aligned = 1u << log2ceil(table_plan.target_tablet_count);
-
-            if (table_plan.target_tablet_count_aligned > table_plan.current_tablet_count) {
-                table_plan.resize_decision = locator::resize_decision::split();
-            } else if (table_plan.target_tablet_count_aligned < table_plan.current_tablet_count) {
-                table_plan.resize_decision = locator::resize_decision::merge();
-            }
-
-            lblogger.debug("make_sizing_plan: table={}.{}, id={}, tablet_count={}, avg_tablet_size={}, min_tablet_count={}, target_tablet_count={}: decision={}",
-                           s->ks_name(), s->cf_name(), s->id(), tablet_count, table_plan.avg_tablet_size, min_tablet_count, target_tablet_count, table_plan.resize_decision);
         };
 
         for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
@@ -1130,6 +1129,114 @@ public:
 
         if (new_table) {
             co_await process_table(new_table->id(), new_table, new_rs, 0);
+        }
+
+        // Below section ensures we respect the _tablets_per_shard_goal.
+        //
+        // It will scale down target_tablet_count for all tables so that
+        // the average number of tablets per shard in each DC does not exceed _tablets_per_shard_goal.
+        //
+        // The impact of table's tablet count on average per-shard tablet replica count
+        // is different in each DC because replication factors are different in each DC.
+        //
+        // The algorithm works like this:
+        // Compute average tablet replica count per-shard in each DC,
+        // determine if per-shard goal is exceeded in that DC,
+        // compute scale factor by which tablet count should be multiplied so that the goal
+        // is not exceeded in that DC.
+        // Take the smallest scale factor among all DCs, which ensures that no DC is overloaded.
+        //
+        // We align tablet counts to the nearest power of 2 post-scaling, which
+        // means that scaling may not be effective and in the worst case we may overshoot the goal by
+        // a factor of 2. This is acceptable since the goal is a soft limit and not a hard constraint.
+        // Scaling post-alignment would be problematic. If we scale down all tables fairly, we undershoot the goal
+        // by a factor of 2 in the worst case. If we choose a subset of tables to scale down by a factor of 2 then
+        // we have a problem of making sure that the choice is stable across scheduler invocations to avoid
+        // oscillations of decisions.
+
+        std::unordered_map<table_id, double> table_scaling;
+
+        std::unordered_map<sstring, unsigned> shards_per_dc;
+        _tm->for_each_token_owner([&] (const node& n) {
+            if (n.is_normal()) {
+                shards_per_dc[n.dc_rack().dc] += n.get_shard_count();
+            }
+        });
+
+        for (auto&& [dc, shard_count] : shards_per_dc) {
+            double cur_avg_tablets_per_shard = 0;
+            double new_avg_tablets_per_shard = 0;
+
+            for (auto&& [table, table_plan] : plan.tables) {
+                auto* rs = rs_by_table[table];
+                auto rf = rs->get_replication_factor(dc);
+                auto get_avg_tablets_per_shard = [&] (size_t tablet_count) {
+                    return double(tablet_count) * rf / shard_count;
+                };
+
+                auto cur_tablets_per_shard = get_avg_tablets_per_shard(table_plan.current_tablet_count);
+                cur_avg_tablets_per_shard += cur_tablets_per_shard;
+                lblogger.debug("cur_avg_tablets_per_shard [dc={}, table={}]: {:.3f}", dc, table, cur_tablets_per_shard);
+
+                auto new_tablets_per_shard = get_avg_tablets_per_shard(table_plan.target_tablet_count);
+                new_avg_tablets_per_shard += new_tablets_per_shard;
+                lblogger.debug("new_avg_tablets_per_shard [dc={}, table={}]: {:.3f}", dc, table, new_tablets_per_shard);
+            }
+
+            {
+                bool overloaded = cur_avg_tablets_per_shard > _tablets_per_shard_goal;
+                lblogger.debug("cur_avg_tablets_per_shard[dc={}]: {:.3f}{}", dc, cur_avg_tablets_per_shard,
+                    overloaded ? " (overloaded!)" : "");
+            }
+
+            bool overloaded = new_avg_tablets_per_shard > _tablets_per_shard_goal;
+            lblogger.debug("new_avg_tablets_per_shard[dc={}]: {:.3f}{}", dc, new_avg_tablets_per_shard,
+                overloaded ? " (overloaded!)" : "");
+
+            if (overloaded) {
+                auto scale = _tablets_per_shard_goal / new_avg_tablets_per_shard;
+
+                for (auto&& [table, table_plan]: plan.tables) {
+                    auto* rs = rs_by_table[table];
+                    auto rf = rs->get_replication_factor(dc);
+
+                    // If table has no replicas in this DC, scaling it won't help and is harmful to its distribution
+                    // in other DCs.
+                    if (rf) {
+                        auto [i, inserted] = table_scaling.try_emplace(table, scale);
+                        if (!inserted) {
+                            i->second = std::min(i->second, scale);
+                        }
+                    }
+                }
+            }
+        }
+
+        for (auto&& [table, scale] : table_scaling) {
+            auto& table_plan = plan.tables[table];
+            auto new_count = std::max<size_t>(1, table_plan.target_tablet_count * scale);
+            lblogger.debug("Scaling down table {} by a factor of {:.3f}: {} => {}", table, scale, table_plan.target_tablet_count, new_count);
+            table_plan.target_tablet_count = new_count;
+        }
+
+        // Generate:
+        //   table_plan.target_tablet_count_aligned
+        //   table_plan.resize_decision
+
+        for (auto&& [table, table_plan] : plan.tables) {
+            table_plan.target_tablet_count_aligned = 1u << log2ceil(table_plan.target_tablet_count);
+
+            if (table_plan.target_tablet_count_aligned > table_plan.current_tablet_count) {
+                table_plan.resize_decision = locator::resize_decision::split();
+            } else if (table_plan.target_tablet_count_aligned < table_plan.current_tablet_count) {
+                table_plan.resize_decision = locator::resize_decision::merge();
+            }
+
+            lblogger.debug("Table {}, {} => {} ({}), resize: {}", table,
+                           table_plan.current_tablet_count,
+                           table_plan.target_tablet_count_aligned,
+                           table_plan.target_tablet_count,
+                           table_plan.resize_decision);
         }
 
         co_return std::move(plan);
@@ -2486,7 +2593,8 @@ public:
         auto shuffle = in_shuffle_mode();
 
         _stats.for_dc(dc).calls++;
-        lblogger.debug("Examining DC {} (shuffle={}, balancing={})", dc, shuffle, _tm->tablets().balancing_enabled());
+        lblogger.debug("Examining DC {} (shuffle={}, balancing={}, tablets_per_shard_goal={})",
+                dc, shuffle, _tm->tablets().balancing_enabled(), _tablets_per_shard_goal);
 
         const locator::topology& topo = _tm->get_topology();
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2944,7 +2944,6 @@ public:
 
 class tablet_allocator_impl : public tablet_allocator::impl
                             , public service::migration_listener::empty_listener {
-    const tablet_allocator::config _config;
     service::migration_notifier& _migration_notifier;
     replica::database& _db;
     load_balancer_stats_manager _load_balancer_stats;
@@ -2959,18 +2958,14 @@ private:
             _db.get_config().tablets_per_shard_goal(),
             std::move(skiplist));
         lb.set_use_table_aware_balancing(_use_tablet_aware_balancing);
-        lb.set_initial_scale(_config.initial_tablets_scale);
+        lb.set_initial_scale(_db.get_config().tablets_initial_scale_factor());
         return lb;
     }
 public:
     tablet_allocator_impl(tablet_allocator::config cfg, service::migration_notifier& mn, replica::database& db)
-            : _config(std::move(cfg))
-            , _migration_notifier(mn)
+            : _migration_notifier(mn)
             , _db(db)
             , _load_balancer_stats("load_balancer") {
-        if (_config.initial_tablets_scale == 0) {
-            throw std::runtime_error("Initial tablets scale must be positive");
-        }
         _migration_notifier.register_listener(this);
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -565,7 +565,7 @@ class load_balancer {
             return [] (const table_id_and_size_desc& a, const table_id_and_size_desc& b) {
                 auto urgency = [] (const table_size_desc& d) -> double {
                     // FIXME: only takes into account split today.
-                    return double(d.avg_tablet_size) / d.target_max_tablet_size();
+                    return double(d.avg_tablet_size);
                 };
                 return urgency(a.second) < urgency(b.second);
             };

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -618,6 +618,7 @@ class load_balancer {
     load_balancer_stats_manager& _stats;
     std::unordered_set<host_id> _skiplist;
     bool _use_table_aware_balancing = true;
+    int _initial_scale = 1;
 private:
     tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
         // We reflect migrations in the load as if they already happened,
@@ -694,13 +695,13 @@ public:
         , _skiplist(std::move(skiplist))
     { }
 
-    future<migration_plan> make_plan(std::optional<unsigned> initial_scale) {
+    future<migration_plan> make_plan() {
         const locator::topology& topo = _tm->get_topology();
         migration_plan plan;
 
         // Prepare plans for each DC separately and combine them to be executed in parallel.
         for (auto&& dc : topo.get_datacenters()) {
-            auto dc_plan = co_await make_plan(dc, initial_scale);
+            auto dc_plan = co_await make_plan(dc);
             auto level = dc_plan.size() > 0 ? seastar::log_level::info : seastar::log_level::debug;
             lblogger.log(level, "Prepared {} migrations in DC {}", dc_plan.size(), dc);
             plan.merge(std::move(dc_plan));
@@ -710,7 +711,7 @@ public:
         plan.set_repair_plan(co_await make_repair_plan(plan));
 
         // Merge table-wide resize decisions, may emit new decisions, revoke or finalize ongoing ones.
-        plan.merge_resize_plan(co_await make_resize_plan(plan, initial_scale));
+        plan.merge_resize_plan(co_await make_resize_plan(plan));
 
         auto level = plan.size() > 0 ? seastar::log_level::info : seastar::log_level::debug;
         lblogger.log(level, "Prepared {} migration plans, out of which there were {} tablet migration(s) and {} resize decision(s) and {} tablet repair(s)",
@@ -720,6 +721,10 @@ public:
 
     void set_use_table_aware_balancing(bool use_table_aware_balancing) {
         _use_table_aware_balancing = use_table_aware_balancing;
+    }
+
+    void set_initial_scale(int initial_scale) {
+        _initial_scale = initial_scale;
     }
 
     const locator::table_load_stats* load_stats_for_table(table_id id) const {
@@ -1073,7 +1078,7 @@ public:
         return {s, rs};
     }
 
-    future<table_resize_plan> make_resize_plan(const migration_plan& plan, std::optional<unsigned> initial_scale) {
+    future<table_resize_plan> make_resize_plan(const migration_plan& plan) {
         table_resize_plan resize_plan;
 
         if (!_tm->tablets().balancing_enabled()) {
@@ -1108,7 +1113,7 @@ public:
 
             auto [s, rs] = get_schema_and_rs(table);
             size_desc.min_tablet_count = std::max<size_t>(size_desc.min_tablet_count,
-                co_await rs->calculate_min_tablet_count(s, _tm, size_desc.target_tablet_size, initial_scale));
+                co_await rs->calculate_min_tablet_count(s, _tm, size_desc.target_tablet_size, _initial_scale));
 
             resize_load.update(table, std::move(size_desc));
             lblogger.debug("Table {} with tablet_count={} has an average tablet size of {}", table, tmap.tablet_count(), avg_tablet_size);
@@ -2415,7 +2420,7 @@ public:
         }
     };
 
-    future<migration_plan> make_plan(dc_name dc, std::optional<unsigned> initial_scale) {
+    future<migration_plan> make_plan(dc_name dc) {
         migration_plan plan;
 
         _dc = dc;
@@ -2733,7 +2738,8 @@ public:
     future<migration_plan> balance_tablets(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, std::unordered_set<host_id> skiplist) {
         load_balancer lb(_db, tm, std::move(table_load_stats), _load_balancer_stats, _db.get_config().target_tablet_size_in_bytes(), std::move(skiplist));
         lb.set_use_table_aware_balancing(_use_tablet_aware_balancing);
-        co_return co_await lb.make_plan(_config.initial_tablets_scale);
+        lb.set_initial_scale(_config.initial_tablets_scale);
+        co_return co_await lb.make_plan();
     }
 
     void set_use_tablet_aware_balancing(bool use_tablet_aware_balancing) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -597,7 +597,7 @@ class load_balancer {
     load_balancer_stats_manager& _stats;
     std::unordered_set<host_id> _skiplist;
     bool _use_table_aware_balancing = true;
-    int _initial_scale = 1;
+    double _initial_scale = 1;
 private:
     tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
         // We reflect migrations in the load as if they already happened,
@@ -707,7 +707,7 @@ public:
         _use_table_aware_balancing = use_table_aware_balancing;
     }
 
-    void set_initial_scale(int initial_scale) {
+    void set_initial_scale(double initial_scale) {
         _initial_scale = initial_scale;
     }
 
@@ -1092,7 +1092,6 @@ public:
         size_t tablet_count = 0;
         const sstring* winning_dc = nullptr;
 
-        min_per_shard_tablet_count = std::max(1.0, min_per_shard_tablet_count);
         for (auto&& [dc, shards_in_dc] : shards_per_dc) {
             auto rf_in_dc = rs.get_replication_factor(dc);
             if (!rf_in_dc) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1108,7 +1108,7 @@ public:
 
             auto [s, rs] = get_schema_and_rs(table);
             size_desc.min_tablet_count = std::max<size_t>(size_desc.min_tablet_count,
-                rs->calculate_min_tablet_count(s, _tm, size_desc.target_tablet_size, initial_scale));
+                co_await rs->calculate_min_tablet_count(s, _tm, size_desc.target_tablet_size, initial_scale));
 
             resize_load.update(table, std::move(size_desc));
             lblogger.debug("Table {} with tablet_count={} has an average tablet size of {}", table, tmap.tablet_count(), avg_tablet_size);

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -191,7 +191,6 @@ class migration_notifier;
 class tablet_allocator {
 public:
     struct config {
-        unsigned initial_tablets_scale = 1;
     };
     class impl {
     public:

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -229,7 +229,7 @@ public:
     ///
     /// The algorithm takes care of limiting the streaming load on the system, also by taking active migrations into account.
     ///
-    future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {}, std::unordered_set<locator::host_id> = {}, bool test_mode = false);
+    future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {}, std::unordered_set<locator::host_id> = {});
 
     load_balancer_stats_manager& stats();
 

--- a/test.py
+++ b/test.py
@@ -542,6 +542,7 @@ class PythonTestSuite(TestSuite):
             default_config_options = \
                     {"authenticator": "PasswordAuthenticator",
                      "authorizer": "CassandraAuthorizer"}
+            default_config_options["tablets_initial_scale_factor"] = 4 if self.mode == "release" else 2
             config_options = default_config_options | \
                              self.cfg.get("extra_scylla_config_options", {}) | \
                              create_cfg.config_from_test

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -519,7 +519,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
                 "NetworkTopologyStrategy", params);
         auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(tab_awr_ptr);
-        auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), service::default_target_tablet_size).get();
+        auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), tablet_count).get();
         full_ring_check(tmap, ars_ptr, stm.get());
 
         // Test reallocate_tablets after randomizing a different set of options
@@ -611,7 +611,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
     auto nts_ptr = dynamic_cast<const network_topology_strategy*>(ars_ptr.get());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
-    auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, tmptr, 1).get();
+    auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, tmptr, tablet_count).get();
     full_ring_check(tmap, ars_ptr, stm.get());
     check_tablets_balance(tmap, nts_ptr, topo);
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3096,7 +3096,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
         return make_ready_future<>();
     }).get();
 
-    auto allocated_map = tablet_aware_ptr->allocate_tablets_for_new_table(s, stm.get(), 0).get();
+    auto allocated_map = tablet_aware_ptr->allocate_tablets_for_new_table(s, stm.get(), tablet_count).get();
 
     BOOST_REQUIRE_EQUAL(allocated_map.tablet_count(), tablet_count);
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1487,7 +1487,7 @@ void do_rebalance_tablets(cql_test_env& e,
     auto max_iterations = 1 + get_tablet_count(stm.get()->tablets()) * 10;
 
     for (size_t i = 0; i < max_iterations; ++i) {
-        auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist, true).get();
+        auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist).get();
         if (plan.empty()) {
             return;
         }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2678,6 +2678,12 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_option_and_config_changes) {
         cfg.tablets_per_shard_goal(100);
         rebalance_tablets(e, &load_stats);
         BOOST_REQUIRE_EQUAL(get_tablet_count(), 16);
+
+        // initial scale can be smaller than 1.
+        // 0.5 tablet/shard * 3 shards = 1.5 tablets =~ 2 tablets.
+        cfg.tablets_initial_scale_factor(0.5);
+        rebalance_tablets(e, &load_stats);
+        BOOST_REQUIRE_EQUAL(get_tablet_count(), 2);
     }, cfg).get();
 }
 

--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -7,3 +7,4 @@ extra_scylla_cmdline_options:
   - '--experimental-features=keyspace-storage-options'
   - '--experimental-features=views-with-tablets'
   - '--enable-tablets=true'
+  - '--tablets-initial-scale-factor=1'

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -168,6 +168,7 @@ private:
     sharded<gms::gossip_address_map> _gossip_address_map;
     sharded<service::direct_fd_pinger> _fd_pinger;
     sharded<cdc::cdc_service> _cdc;
+    db::config* _db_config;
 
     service::raft_group0_client* _group0_client;
 
@@ -651,6 +652,7 @@ private:
             _lang_manager.invoke_on_all(&lang::manager::start).get();
 
 
+            _db_config = &*cfg;
             _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), std::ref(abort_sources), utils::cross_shard_barrier()).get();
             auto stop_db = defer_verbose_shutdown("database", [this] {
                 _db.stop().get();
@@ -1151,6 +1153,10 @@ public:
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() override {
         return _sl_controller;
+    }
+
+    db::config& db_config() override {
+        return *_db_config;
     }
 };
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -194,6 +194,8 @@ public:
     data_dictionary::database data_dictionary();
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;
+
+    virtual db::config& db_config() = 0;
 };
 
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -300,7 +300,7 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
             opts[rack1.dc] = format("{}", rf);
             network_topology_strategy tablet_rs(replication_strategy_params(opts, initial_tablets));
             stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-                auto map = co_await tablet_rs.allocate_tablets_for_new_table(s, stm.get(), service::default_target_tablet_size);
+                auto map = co_await tablet_rs.allocate_tablets_for_new_table(s, stm.get(), initial_tablets.value_or(1));
                 tm.tablets().set_tablet_map(s->id(), std::move(map));
             }).get();
         };

--- a/test/rest_api/suite.yaml
+++ b/test/rest_api/suite.yaml
@@ -9,3 +9,4 @@ extra_scylla_cmdline_options:
   - '--experimental-features=udf'
   - '--enable-tablets=true'
   - '--experimental-features=views-with-tablets'
+  - '--tablets-initial-scale-factor=1'

--- a/test/topology_custom/test_major_compaction.py
+++ b/test/topology_custom/test_major_compaction.py
@@ -39,7 +39,10 @@ async def test_major_compaction_consider_only_existing_data(manager: ManagerClie
        - If consider_only_existing_data is True, the tombstones should be purged and the backdated rows should be visible
     """
     logger.info("Bootstrapping cluster")
-    server = (await manager.servers_add(1))[0]
+    cmdline = [
+        '--tablets-initial-scale-factor=1' # The test assumes 1 compaction group per shard because of injection point trap
+    ]
+    server = (await manager.servers_add(1, cmdline=cmdline))[0]
 
     logger.info("Creating table")
     ks = "test_consider_only_existing_data"


### PR DESCRIPTION
This series achieves two things:

1) changes default number of tablet replicas per shard to be 10 in order to reduce load imbalance between shards

    This will result in new tables having at least 10 tablet replicas per
    shard by default.
    
    We want this to reduce tablet load imbalance due to differences in
    tablet count per shard, where some shards have 1 tablet and some
    shards have 2 tablets. With higher tablet count per shard, this
    difference-by-one is less relevant.
  
    Fixes https://github.com/scylladb/scylladb/issues/21967

2) introduces a global goal for tablet replica count per shard and adds logic to tablet scheduler to respect it by controlling per-table tablet count 
    
    The per-shard goal is enforced by controlling average per-shard tablet replica
    count in a given DC, which is controlled by per-table tablet
    count. This is effective in respecting the limit on individual shards
    as long as tablet replicas are distributed evenly between shards.
    There is no attempt to move tablets around in order to enforce limits
    on individual shards in case of imbalance between shards.
    
    If the average per-shard tablet count exceeds the limit, all tables
    which contribute to it (have replicas in the DC) are scaled down
    by the same factor. Due to rounding up to the nearest power of 2,
    we may overshoot the per-shard goal by at most a factor of 2.

    The scaling is applied after computing desired tablet count due to
    all other factors: per-table tablet count hints, defaults, average tablet size. 
    
    If different DCs want different scale factors of a given table, the
    lowest scale factor is chosen for a given table.

    When creating a new table, its tablet count is determined by tablet
    scheduler using the scheduler logic, as if the table was already created.
    So any scaling due to per-shard tablet count goal is reflected immediately
    when creating a table. It may however still take some time for the system
    to shrink existing tables. We don't reject requests to create new tables.  

    Fixes #21458    
