### PR TITLE
Allow to use memtable_flush_period_in_ms schema option for system tables

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -675,7 +675,8 @@ future<permission_set> get_permissions(const service& ser, const authenticated_u
 }
 
 bool is_protected(const service& ser, command_desc cmd) noexcept {
-    if (cmd.type_ == command_desc::type::ALTER_WITH_OPTS) {
+    if (cmd.type_ == command_desc::type::ALTER_WITH_OPTS ||
+        cmd.type_ == command_desc::type::ALTER_SYSTEM_WITH_ALLOWED_OPTS) {
         return false; // Table attributes are OK to modify; see #7057.
     }
     return ser.underlying_role_manager().protected_resources().contains(cmd.resource)

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -224,6 +224,7 @@ struct command_desc {
     const ::auth::resource& resource; ///< Resource impacted by this command.
     enum class type {
         ALTER_WITH_OPTS, ///< Command is ALTER ... WITH ...
+        ALTER_SYSTEM_WITH_ALLOWED_OPTS,
         OTHER
     } type_ = type::OTHER;
 };

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -70,6 +70,10 @@ public:
     static int32_t to_int(sstring key, std::optional<sstring> value, int32_t default_value);
 
     static long to_long(sstring key, std::optional<sstring> value, long default_value);
+
+    size_t count() const {
+        return _properties.size();
+    }
 };
 
 }

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -125,7 +125,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         // prevent system keyspace modification
         auto name = ks;
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
-        if (is_system_keyspace(name)) {
+        if (is_system_keyspace(name) && cmd.type_ != auth::command_desc::type::ALTER_SYSTEM_WITH_ALLOWED_OPTS) {
             return make_exception_future<>(exceptions::unauthorized_exception(ks + " keyspace is not user-modifiable."));
         }
 


### PR DESCRIPTION
It's possible to modify 'memtable_flush_period_in_ms' option only and as single option, not with any other options together.
This is the simplest solution, we also discussed to introduce new ALTER TABLE PROPERTY construction (see #21223 and #20999 comments)

Refs #20999
Fixes #21223

No backport needed