### PR TITLE
config: Improve internode_compression option validation and documentation

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -904,9 +904,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Sets the receiving socket buffer size in bytes for inter-node calls.")
     , internode_compression(this, "internode_compression", value_status::Used, "none",
         "Controls whether traffic between nodes is compressed. The valid values are:\n"
-        "\tall: All traffic is compressed.\n"
-        "\tdc : Traffic between data centers is compressed.\n"
-        "\tnone : No compression.")
+        "* all: All traffic is compressed.\n"
+        "* dc : Traffic between data centers is compressed.\n"
+        "* none : No compression.")
     , internode_compression_zstd_max_cpu_fraction(this, "internode_compression_zstd_max_cpu_fraction", liveness::LiveUpdate, value_status::Used, 0.000,
         "ZSTD compression of RPC will consume at most this fraction of each internode_compression_zstd_quota_refresh_period_ms time slice.\n"
         "If you wish to try out zstd for RPC compression, 0.05 is a reasonable starting point.")

--- a/db/config.cc
+++ b/db/config.cc
@@ -906,7 +906,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Controls whether traffic between nodes is compressed. The valid values are:\n"
         "* all: All traffic is compressed.\n"
         "* dc : Traffic between data centers is compressed.\n"
-        "* none : No compression.")
+        "* none : No compression.",
+        {"all", "dc", "none"})
     , internode_compression_zstd_max_cpu_fraction(this, "internode_compression_zstd_max_cpu_fraction", liveness::LiveUpdate, value_status::Used, 0.000,
         "ZSTD compression of RPC will consume at most this fraction of each internode_compression_zstd_quota_refresh_period_ms time slice.\n"
         "If you wish to try out zstd for RPC compression, 0.05 is a reasonable starting point.")


### PR DESCRIPTION
This PR enhances the internode_compression configuration option in two ways:

1. Add validation for option values
   Previously, we silently defaulted to 'none' when given invalid values. Now we 
   explicitly validate against the three supported values (all, dc, none) and 
   reject invalid inputs. This provides better error messages when users 
   misconfigure the option.

2. Fix documentation rendering
   The help text for this option previously used C++ escape sequences which
   rendered incorrectly in Sphinx-generated HTML. We now use bullet points with
   '*' prefix to list the available values, matching our documentation style
   for other config options. This ensures consistent rendering in both CLI
   and HTML outputs.

Note: The current documentation format puts type/default/liveness information 
in the same bullet list as option values. This affects other config options 
as well and will need to be addressed in a separate change.

---

this improves the handling of invalid option values, and improves the doc rendering, neither of which is critical. hence no need to backport.