### PR TITLE
Add REST API for exposing object storage endpoints

### DIFF
--- a/api/api-doc/config.json
+++ b/api/api-doc/config.json
@@ -27,4 +27,33 @@
           }
         }
       }
+},
+"/v2/config/object_store_endpoints": {
+      "get": {
+        "description": "Returns the list of configured object storage endpoints",
+        "operationId": "get_object_store_endpoints",
+        "produces": [
+          "application/json"
+        ],
+        "tags": ["config"],
+        "parameters": [ ],
+        "responses": {
+          "200": {
+            "schema": {
+              "type":"array",
+              "items":{
+                  "$ref":"#/definitions/object_store_endpoint",
+                  "description":"object store endpoint"
+              }
+            },
+            "description": "the list of configured object storage endpoints"
+          },
+          "default": {
+            "description": "unexpected error",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
 }

--- a/main.cc
+++ b/main.cc
@@ -223,6 +223,11 @@ static future<> read_object_storage_config(db::config& db_cfg) {
 
     std::unordered_map<sstring, s3::endpoint_config> cfg;
     YAML::Node doc = YAML::Load(data.c_str());
+    if (doc.size() == 0) {
+        co_await coroutine::return_exception(
+            std::runtime_error("While parsing object_storage config: a minimum of one endpoint is required."));
+    }
+
     for (auto&& section : doc) {
         auto sec_name = section.first.as<std::string>();
         if (sec_name != "endpoints") {

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -165,6 +165,21 @@ class MinioServer:
                         }
             yaml.dump({'endpoints': [endpoint]}, config_file)
 
+    @staticmethod
+    def append_endpoint_to_conf(address: str, port: int, region: str, conf: str):
+        with open(conf, 'r+', encoding='ascii') as config_file:
+            new_endpoint = {'name': address,
+                        'port': port,
+                        'aws_region': region,
+                        }
+            existing_cfg = yaml.load(config_file, Loader=yaml.Loader)
+            existing_cfg['endpoints'].append(new_endpoint)
+
+            config_file.seek(0)
+            yaml.dump(existing_cfg, config_file)
+
+
+
     async def _run_server(self, port):
         self.logger.info(f'Starting minio server at {self.address}:{port}')
         cmd = await asyncio.create_subprocess_exec(

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -460,6 +460,9 @@ class ScyllaRESTAPIClient():
 
     async def get_config(self, node_ip: str, id: str):
         return await self.client.get_json(f'/v2/config/{id}', host=node_ip)
+        
+    async def get_object_store_endpoints(self, node_ip: str):
+        return await self.client.get_json(f'/v2/config/object_store_endpoints', host=node_ip)
 
 class ScyllaMetrics:
     def __init__(self, lines: list[str]):


### PR DESCRIPTION
Currently there are multiple places where one can configure the object storage endpoints increasing the chance of misconfigurations. Scylla needs to become the source of truth so we need an API which provides the list of available endpoints.

This change exposes the `/storage_service/object_store_endpoints` REST API which provides the list of all the endpoints specified in the `object_storage.yaml` file.

The change also adds a patch and tests to enforce that the user needs to specify at least one endpoint in the `object_storage.yaml file` (i.e. can't be empty).

The validation that an endpoint belongs to the list of supported endpoints during backup/restore ops was fixed in https://github.com/scylladb/scylladb/issues/15074.

Refs #22428