### PR TITLE
test/cqlpy: fix some false failures on Cassandra

### DIFF
--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -263,6 +263,11 @@ def skip_without_tablets(scylla_only, has_tablets):
     if not has_tablets:
         pytest.skip("Test needs tablets experimental feature on")
 
+# Recent versions of Scylla deprecated the "WITH COMPACT STORAGE" feature,
+# but it can be enabled temporarily for a test. So to keep our old compact
+# storage tests alive for a while longer (at least until this feature is
+# completely removed from Scylla), the "compact_storage" fixture can be
+# added to enable WITH COMPACT STORAGE for the duration of this test.
 @pytest.fixture(scope="function")
 def compact_storage(cql):
     try:
@@ -272,4 +277,4 @@ def compact_storage(cql):
         # enable_create_table_with_compact_storage is a scylla only feature
         # so the above may fail on cassandra.
         # This is fine since compact storage is enabled there by default.
-        pass
+        yield

--- a/test/cqlpy/test_compaction_strategy_validation.py
+++ b/test/cqlpy/test_compaction_strategy_validation.py
@@ -49,7 +49,7 @@ def test_time_window_compaction_strategy_options(cql, table1):
 def test_leveled_compaction_strategy_options(cql, table1):
     assert_throws(cql, table1, r"sstable_size_in_mb value \(-5\) must be positive|sstable_size_in_mb must be larger than 0, but was -5", "ALTER TABLE %s WITH compaction = { 'class' : 'LeveledCompactionStrategy', 'sstable_size_in_mb' : -5 }")
 
-def test_incremental_compaction_strategy_options(cql, table1):
+def test_incremental_compaction_strategy_options(cql, table1, scylla_only):
     assert_throws(cql, table1, r"min_sstable_size value \(-1\) must be non negative", "ALTER TABLE %s WITH compaction = { 'class' : 'IncrementalCompactionStrategy', 'min_sstable_size' : -1 }")
     assert_throws(cql, table1, r"bucket_low value \(0\) must be between 0.0 and 1.0", "ALTER TABLE %s WITH compaction = { 'class' : 'IncrementalCompactionStrategy', 'bucket_low' : 0.0 }")
     assert_throws(cql, table1, r"bucket_low value \(1.3\) must be between 0.0 and 1.0", "ALTER TABLE %s WITH compaction = { 'class' : 'IncrementalCompactionStrategy', 'bucket_low' : 1.3 }")

--- a/test/cqlpy/test_service_level_api.py
+++ b/test/cqlpy/test_service_level_api.py
@@ -12,6 +12,12 @@ from .rest_api import get_request, post_request
 from .util import new_session, unique_name
 import time
 
+# All tests in this file check the Scylla-only service levels feature,
+# so let's mark them all scylla_only with an autouse fixture:
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
 def count_opened_connections(cql, retry_unauthenticated=True):
     response = get_request(cql, "service_levels/count_connections")
     return response

--- a/test/cqlpy/test_tablets.py
+++ b/test/cqlpy/test_tablets.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
 #############################################################################
-# Some tests for the new "tablets"-based replication, replicating the old
+# Some tests for the new "tablets"-based replication, replacing the old
 # "vnodes". Eventually, ScyllaDB will use tablets by default and all tests
 # will run using tablets, but these tests are for specific issues discovered
 # while developing tablets that didn't exist for vnodes. Note that most tests
@@ -40,7 +40,7 @@ def test_keyspace_128_tablets(cql, this_dc):
 # or DROP TABLE operations in the loop.
 # Note that this test doesn't even involve any data inside the table.
 # Reproduces #16493.
-def test_create_loop_with_tablets(cql, test_keyspace_128_tablets):
+def test_create_loop_with_tablets(cql, skip_without_tablets, test_keyspace_128_tablets):
     table = test_keyspace_128_tablets + "." + unique_name()
     for i in range(100):
         cql.execute(f"CREATE TABLE {table} (p int PRIMARY KEY, v int)")
@@ -207,7 +207,7 @@ def test_tablets_are_dropped_when_dropping_table(cql, test_keyspace, skip_withou
 #
 # Reproduces https://github.com/scylladb/scylladb/issues/17627
 # with materialized views, which were not part of the original scope of this issue.
-def test_tablets_are_dropped_when_dropping_table_with_view(cql, test_keyspace):
+def test_tablets_are_dropped_when_dropping_table_with_view(cql, test_keyspace, skip_without_tablets):
     table_name = unique_name()
     schema = "pk int PRIMARY KEY, c int"
     # new_test_table is not used since we want to test a failure to drop the table
@@ -253,7 +253,7 @@ def test_tablets_are_dropped_when_dropping_table_with_view(cql, test_keyspace):
 #
 # Reproduces https://github.com/scylladb/scylladb/issues/17627
 @pytest.mark.parametrize("drop_index", [True, False])
-def test_tablets_are_dropped_when_dropping_index(cql, test_keyspace, drop_index):
+def test_tablets_are_dropped_when_dropping_index(cql, test_keyspace, drop_index, skip_without_tablets):
     table_name = unique_name()
     schema = "pk int PRIMARY KEY, c int"
     cql.execute(f"CREATE TABLE {test_keyspace}.{table_name} ({schema})")
@@ -299,7 +299,7 @@ def test_lwt_support_with_tablets(cql, test_keyspace, skip_without_tablets):
 # We want to ensure that we can only change the RF of any DC by at most 1 at a time
 # if we use tablets. That provides us with the guarantee that the old and the new QUORUM
 # overlap by at least one node.
-def test_alter_tablet_keyspace_rf(cql, this_dc):
+def test_alter_tablet_keyspace_rf(cql, this_dc, skip_without_tablets):
     with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }} "
                                 f"AND TABLETS = {{ 'enabled': true, 'initial': 128 }}") as keyspace:
         def change_opt_rf(rf_opt, new_rf):

--- a/test/cqlpy/test_tombstone_limit.py
+++ b/test/cqlpy/test_tombstone_limit.py
@@ -17,6 +17,11 @@ from .conftest import driver_bug_1
 from cassandra.query import SimpleStatement
 import pytest
 
+# All tests in this file check the Scylla-only query_tombstone_page_limit
+# feature, so let's mark them all scylla_only with an autouse fixture:
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
 
 # Tests that need a single partition can co-locate their data in a single table.
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Developers are expected to run new cqlpy tests against Cassandra - to verify that the new test itself is correct. Usually there is no need to run the entire cqlpy test suite against Cassandra, but when users do this, it isn't confidence-inspiring to see hundreds of tests failing. In this patch I fix many but not all of these failures.

Refs #11690 (which will remain open until we fix all the failures on Cassandra)

* Fixed the "compact_storage" fixture recently introduced to enable the deprecated feature in Scylla for the tests. This fixture was broken on Cassandra and caused all compact-storage related tests to fail on Cassandra.

* Marked all tests in test_tombstone_limit.py as scylla_only - as they check the Scylla-only query_tombstone_page_limit configuration option.

* Marked all tests in test_service_level_api.py as scylla_only - as they check the Scylla-only service levels feature.

* Marked a test specific to the Scylla-only IncrementalCompactionStrategy as scylla_only. Some tests mix STCS and ICS testing in one test - this is a mistake and isn't fixed in this patch.

* Various tests in test_tablets.py forgot to use skip_without_tablets to skip them on Cassandra or older Scylla that doesn't have the tablets feature.

This is only a test cleanup, with no effect even on CI, so no backports should be done.