### PR TITLE
tree: replace boost::min_element() with std::ranges::min_element()

### DIFF
--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -441,8 +441,8 @@ void incremental_compaction_strategy::sort_run_bucket_by_first_key(size_bucket_t
         auto sst_first_key_less = [&schema] (const shared_sstable& sst_a, const shared_sstable& sst_b) {
             return sst_a->get_first_decorated_key().tri_compare(*schema, sst_b->get_first_decorated_key()) <= 0;
         };
-        auto& a_first = *boost::min_element(a->all(), sst_first_key_less);
-        auto& b_first = *boost::min_element(b->all(), sst_first_key_less);
+        auto& a_first = *std::ranges::min_element(a->all(), sst_first_key_less);
+        auto& b_first = *std::ranges::min_element(b->all(), sst_first_key_less);
         return a_first->get_first_decorated_key().tri_compare(*schema, b_first->get_first_decorated_key()) <= 0;
     });
 }

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/algorithm/min_element.hpp>
 #include <boost/range/numeric.hpp>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -109,7 +108,7 @@ distribute_reshard_jobs(sstables::sstable_directory::sstable_open_info_vector so
         // Choose the stable shard owner with the smallest amount of accumulated work.
         // Note that for sstables that need cleanup via resharding, owners may contain
         // a single shard.
-        auto shard_it = boost::min_element(info.owners, [&] (const shard_id& lhs, const shard_id& rhs) {
+        auto shard_it = std::ranges::min_element(info.owners, [&] (const shard_id& lhs, const shard_id& rhs) {
             return destinations[lhs].total_size_smaller(destinations[rhs]);
         });
         auto& dest = destinations[*shard_it];

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -15,7 +15,6 @@
 
 #include <boost/range/algorithm/find.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
-#include <boost/range/algorithm/min_element.hpp>
 
 #include <ranges>
 
@@ -407,7 +406,7 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
     if (non_expiring_sstables.empty()) {
         return {};
     }
-    auto it = boost::min_element(non_expiring_sstables, [] (auto& i, auto& j) {
+    auto it = std::ranges::min_element(non_expiring_sstables, [] (auto& i, auto& j) {
         return i->get_stats_metadata().min_timestamp < j->get_stats_metadata().min_timestamp;
     });
     return { *it };

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -34,7 +34,6 @@
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
 #include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/min_element.hpp>
 #include <boost/container/static_vector.hpp>
 #include "mutation/frozen_mutation.hh"
 #include "mutation/async_utils.hh"
@@ -182,7 +181,7 @@ phased_barrier_top_10_counts(const database::tables_metadata& tables_metadata, s
 
         // If we are here, min_element->first < count
         *min_element = {count, table_list({table.get()})};
-        min_element = &*boost::min_element(res, less);
+        min_element = &*std::ranges::min_element(res, less);
     });
 
     std::ranges::sort(res, less);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -38,7 +38,6 @@
 #include "utils/throttle.hh"
 
 #include <fmt/ranges.h>
-#include <boost/range/algorithm/min_element.hpp>
 #include "readers/from_mutations_v2.hh"
 #include "readers/delegating_v2.hh"
 #include "readers/empty_v2.hh"
@@ -3375,7 +3374,7 @@ SEASTAR_TEST_CASE(test_concurrent_reads_and_eviction) {
         const int n_readers = 3;
         std::vector<size_t> generations(n_readers);
         auto gc_versions = [&] {
-            auto n_live = last_generation - *boost::min_element(generations) + 1;
+            auto n_live = last_generation - *std::ranges::min_element(generations) + 1;
             while (versions.size() > n_live) {
                 versions.pop_front();
             }


### PR DESCRIPTION
in order to reduce the external header dependency, let's switch to the standardlized std::ranges::min_element().

---

it's a cleanup, hence no need to backport.