### PR TITLE
reader_concurrency_semaphore: foreach_permit(): include _inactive_reads

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1684,6 +1684,7 @@ void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(cons
     boost::for_each(_wait_list._admission_queue, std::ref(func));
     boost::for_each(_wait_list._memory_queue, std::ref(func));
     boost::for_each(_ready_list, std::ref(func));
+    boost::for_each(_inactive_reads, std::ref(func));
 }
 
 void reader_concurrency_semaphore::foreach_permit(noncopyable_function<void(const reader_permit&)> func) const {


### PR DESCRIPTION
So inactive reads show up in semaphore diagnostics dumps (currently the only non-test user of this method).

Fixes: #22574

Minor bug, but present in all supported versions.