### PR TITLE
tools: toolchain: dbuild: don't use `which` command

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -16,9 +16,13 @@ EOF
     exit 1
 }
 
-if which podman >/dev/null 2>&1 ; then
+command_exists() {
+    type -p "$1" > /dev/null
+}
+
+if command_exists podman ; then
   tool=${DBUILD_TOOL-podman}
-elif which docker >/dev/null 2>&1 ; then
+elif command_exists docker ; then
   tool=${DBUILD_TOOL-docker}
 else
   die "Please make sure you install either podman or docker on this machine to run dbuild"


### PR DESCRIPTION
The `which` command is typically not installed on cloud OS images and so requires the user to remember to install it (or to be prompted by a failure to install it).

Replace it with the built-in `type` that is always there. Wrap it in a function to make it clear what it does.

Cosmetic change, no backport