### PR TITLE
truncate: create session during request handling

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1093,7 +1093,6 @@ private:
             updates.emplace_back(topology_mutation_builder(guard.write_timestamp())
                                     .set_global_topology_request(global_topology_request::truncate_table)
                                     .set_global_topology_request_id(global_request_id)
-                                    .set_session(session_id(global_request_id))
                                     .build());
 
             updates.emplace_back(topology_request_tracking_mutation_builder(global_request_id)

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -933,6 +933,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             std::vector<canonical_mutation> updates;
             updates.push_back(topology_mutation_builder(guard.write_timestamp())
                                 .set_transition_state(topology::transition_state::truncate_table)
+                                .set_session(session_id(_topo_sm._topology.global_request_id.value()))
                                 .build());
             co_await update_topology_state(std::move(guard), std::move(updates), "TRUNCATE TABLE requested");
         }


### PR DESCRIPTION
Currently, the session ID under which the truncate for tablets request is running is created during the request creation and queuing. This is a problem because this could overwrite the session ID of any ongoing operation on system.topology#session

This change moves the creation of the session ID for truncate from the request creation to the request handling.

Fixes #22613

This is a bugfix and needs to be backported to 2025.1