### PR TITLE
.github/workflows/make-pr-ready-for-review: add missing permissions

### DIFF
--- a/.github/workflows/make-pr-ready-for-review.yaml
+++ b/.github/workflows/make-pr-ready-for-review.yaml
@@ -11,6 +11,8 @@ env:
 jobs:
   mark-ready:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Check if specific label was removed


### PR DESCRIPTION
Following the work done in ed4bfad5c3, the action is failing with the following error:
```
Error: Input required and not supplied: token
```

It is due to missing permissions in the workflow, adding it

**automation bug fix, no need for backport**