### PR TITLE
backup: Optimize S3 throughput with shard-based upload

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -145,7 +145,6 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
     }
 
     co_await coroutine::switch_to(_config.backup_sched_group);
-    auto cln = _storage_manager.get_endpoint_client(endpoint);
     snap_log.info("Backup sstables from {}({}) to {}", keyspace, snapshot_name, endpoint);
     auto global_table = co_await get_table_on_all_shards(_db, keyspace, table);
     auto& storage_options = global_table->get_storage_options();
@@ -175,7 +174,7 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
                 sstables::snapshots_dir /
                 std::string_view(snapshot_name));
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
+        {}, *this, std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
     co_return task->id();
 }
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -111,6 +111,7 @@ public:
 
     future<int64_t> true_snapshots_size();
     future<int64_t> true_snapshots_size(sstring ks, sstring cf);
+    sstables::storage_manager& storage_manager() { return _storage_manager; }
 private:
     config _config;
     sharded<replica::database>& _db;

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -56,9 +56,11 @@ tasks::is_abortable backup_task_impl::is_abortable() const noexcept {
 }
 
 future<tasks::task_manager::task::progress> backup_task_impl::get_progress() const {
-    co_return tasks::task_manager::task::progress {
-        .completed = _progress.uploaded,
-        .total = _progress.total,
+    auto p =
+        co_await _snap_ctl.container().map_reduce0([this](const auto&) { return _progress_per_shard[this_shard_id()]; }, s3::upload_progress(), std::plus<s3::upload_progress>());
+    co_return tasks::task_manager::task::progress{
+        .completed = p.uploaded,
+        .total = p.total,
     };
 }
 
@@ -66,7 +68,7 @@ tasks::is_user_task backup_task_impl::is_user_task() const noexcept {
     return tasks::is_user_task::yes;
 }
 
-future<> backup_task_impl::upload_component(shared_ptr<s3::client> client, sstring name) {
+future<> backup_task_impl::upload_component(shared_ptr<s3::client> client, abort_source& as, s3::upload_progress& progress, sstring name) {
     auto component_name = _snapshot_dir / name;
     auto destination = fmt::format("/{}/{}/{}", _bucket, _prefix, name);
     snap_log.trace("Upload {} to {}", component_name.native(), destination);
@@ -77,7 +79,7 @@ future<> backup_task_impl::upload_component(shared_ptr<s3::client> client, sstri
     //  - s3::client::claim_memory semaphore
     //  - http::client::max_connections limitation
     try {
-        co_await client->upload_file(component_name, destination, _progress, &_as);
+        co_await client->upload_file(component_name, destination, progress, &as);
     } catch (const abort_requested_exception&) {
         snap_log.info("Upload aborted per requested: {}", component_name.native());
         throw;
@@ -103,52 +105,139 @@ future<> backup_task_impl::upload_component(shared_ptr<s3::client> client, sstri
     }
 }
 
+namespace {
+
+future<std::vector<std::tuple<size_t, sstring>>> get_backup_files(const std::filesystem::path& snapshot_dir) {
+    std::exception_ptr ex;
+    auto snapshot_dir_lister = directory_lister(snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
+    std::vector<std::tuple<size_t, sstring>> backup_files;
+    std::optional<directory_entry> component_ent;
+
+    do {
+        try {
+            component_ent = co_await snapshot_dir_lister.get();
+            if (component_ent) {
+                auto component_name = snapshot_dir / component_ent->name;
+                auto size = co_await file_size(component_name.native());
+                backup_files.emplace_back(size, std::move(component_ent->name));
+            }
+        } catch (...) {
+            ex = std::current_exception();
+            break;
+        }
+    } while (component_ent);
+    co_await snapshot_dir_lister.close();
+    if (ex)
+        co_await coroutine::return_exception_ptr(std::move(ex));
+
+    std::ranges::sort(backup_files, std::greater());
+    co_return backup_files;
+}
+} // namespace
+
 future<> backup_task_impl::do_backup() {
     if (!co_await file_exists(_snapshot_dir.native())) {
         throw std::invalid_argument(fmt::format("snapshot does not exist at {}", _snapshot_dir.native()));
     }
 
-    std::exception_ptr ex;
-    gate uploads;
-    auto snapshot_dir_lister = directory_lister(_snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
-    auto cln = _snap_ctl.storage_manager().container().local().get_endpoint_client(_endpoint);
+    auto backup_files = co_await get_backup_files(_snapshot_dir);
+    std::atomic_size_t counter = 0;
 
-    for (;;) {
-        std::optional<directory_entry> component_ent;
+    sharded<abort_source> sharded_aborter;
+    co_await sharded_aborter.start();
+    gate as_gate;
+
+    // Subscribe to the task's main abort source (_as). When aborted, the subscription triggers an abort on every shard via the sharded aborter.
+    auto s = std::make_unique<optimized_optional<abort_source::subscription>>(_as.subscribe([&]() noexcept {
         try {
-            component_ent = co_await snapshot_dir_lister.get();
+            auto h = as_gate.hold();
+            std::ignore = sharded_aborter.invoke_on_all([ex = _as.abort_requested_exception_ptr()](abort_source& aborter) {
+                aborter.request_abort_ex(ex);
+            }).finally([h = std::move(h)] {});
         } catch (...) {
-            if (!ex) {
+        }
+    }));
+
+    // This will capture any exception from the backup process.
+    std::exception_ptr ret_ex;
+    co_await sharded_aborter
+        .invoke_on_all([this, &backup_files, &counter, &sharded_aborter](abort_source& aborter) -> future<> {
+            auto shard_id = this_shard_id();
+            gate uploads;
+            std::exception_ptr ex;
+            auto sharded_aborter_fn = [&sharded_aborter, &aborter, &ex]() -> future<> {
+                // If the `aborter` was requested to abort the backup, no need to propagate the exception to other shards since it can be initiated by two ways:
+                // 1. The task's abort source requested to abort the backup on all shards (see the subscription creation).
+                // 2. Another shard requested to abort the backup since it got an exception.
+                if (ex && !aborter.abort_requested()) {
+                    // On the contrary, if we have the `ex` set, we need to propagate it to other shards to abort the backup since the only reason it was filled
+                    // it is any failure except the abortion from the `abort_source` (any of them).
+                    co_await sharded_aborter.invoke_on_all([&ex](abort_source& abort_service) -> future<> {
+                        abort_service.request_abort_ex(ex);
+                        co_return;
+                    });
+                }
+            };
+            try {
+                auto cln = _snap_ctl.storage_manager().container().local().get_endpoint_client(_endpoint);
+
+                // Process backup files continuously until:
+                //   1. There are no more files.
+                //   2. An exception is thrown.
+                //   3. An abort is requested.
+                while (true) {
+                    // One of two things happened: the `upload_component` threw an exception, `aborter`'s exception was set.
+                    // The later can happen if the `aborter` was requested to abort the backup by task's abort source or another shard requested to abort since
+                    // it got an exception
+                    if (ex || aborter.abort_requested()) {
+                        break;
+                    }
+
+                    // Fetching files sequentially within each shard allows less loaded shards to take on more work, compensating for those that are lagging behind.
+                    auto name_idx = counter++;
+                    if (name_idx >= backup_files.size()) {
+                        break;
+                    }
+                    auto gh = uploads.hold();
+                    // Pre-upload break point. For testing abort in actual s3 client usage.
+                    co_await utils::get_local_injector().inject("backup_task_pre_upload", utils::wait_for_message(std::chrono::minutes(2)));
+
+                    // Start uploading the component asynchronously.
+                    // Future is ignored here because:
+                    // - The client (cln) is maintained via shared ownership.
+                    // - Filenames are passed by value.
+                    // - The abort source remains valid for the duration of the function.
+                    // - The gate ensures that execution remains until completion.
+                    std::ignore = upload_component(cln, aborter, _progress_per_shard[shard_id], std::get<1>(backup_files[name_idx]))
+                                      .handle_exception([&ex, &sharded_aborter_fn](std::exception_ptr e)->future<> {
+                                          // Record the exception to eventually abort the rest of the backup.
+                                          ex = std::move(e);
+                                          co_await sharded_aborter_fn();
+                                      }).finally([gh = std::move(gh)] {});
+
+                    co_await coroutine::maybe_yield();
+                    co_await utils::get_local_injector().inject("backup_task_pause", utils::wait_for_message(std::chrono::minutes(2)));
+                }
+            } catch (...) {
+                // Catch any exception thrown during backup processing.
                 ex = std::current_exception();
-                break;
             }
-        }
-        if (!component_ent.has_value()) {
-            break;
-        }
-        auto gh = uploads.hold();
-
-        // Pre-upload break point. For testing abort in actual s3 client usage.
-        co_await utils::get_local_injector().inject("backup_task_pre_upload", utils::wait_for_message(std::chrono::minutes(2)));
-
-        std::ignore = upload_component(cln, component_ent->name).handle_exception([&ex] (std::exception_ptr e) {
-            // keep the first exception
-            if (!ex) {
-                ex = std::move(e);
+            co_await sharded_aborter_fn();
+            co_await uploads.close();
+            if (ex) {
+                // Rethrow to allow the outer handler to catch and propagate the exception.
+                std::rethrow_exception(std::move(ex));
             }
-        }).finally([gh = std::move(gh)] {});
-        co_await coroutine::maybe_yield();
-        co_await utils::get_local_injector().inject("backup_task_pause", utils::wait_for_message(std::chrono::minutes(2)));
-        if (impl::_as.abort_requested()) {
-            ex = impl::_as.abort_requested_exception_ptr();
-            break;
-        }
-    }
-
-    co_await snapshot_dir_lister.close();
-    co_await uploads.close();
-    if (ex) {
-        co_await coroutine::return_exception_ptr(std::move(ex));
+        }).handle_exception([&ret_ex](std::exception_ptr e) {
+            // Capture any exception rethrown from the shard operations.
+            ret_ex = std::move(e);
+        });
+    co_await as_gate.close();
+    s.reset();
+    co_await sharded_aborter.stop();
+    if (ret_ex || _as.abort_requested()) {
+        // Either the sharded backup ended with an exception or the task's abort source requested to abort the backup.
+        co_await coroutine::return_exception_ptr(ret_ex ? ret_ex : _as.abort_requested_exception_ptr());
     }
 }
 

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -20,7 +20,7 @@ namespace snapshot {
 
 class backup_task_impl : public tasks::task_manager::task::impl {
     snapshot_ctl& _snap_ctl;
-    shared_ptr<s3::client> _client;
+    sstring _endpoint;
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
@@ -28,7 +28,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     s3::upload_progress _progress = {};
 
     future<> do_backup();
-    future<> upload_component(sstring name);
+    future<> upload_component(shared_ptr<s3::client> client, sstring name);
 
 protected:
     virtual future<> run() override;
@@ -36,7 +36,7 @@ protected:
 public:
     backup_task_impl(tasks::task_manager::module_ptr module,
                      snapshot_ctl& ctl,
-                     shared_ptr<s3::client> cln,
+                     sstring endpoint,
                      sstring bucket,
                      sstring prefix,
                      sstring ks,

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -24,11 +24,11 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
+    std::vector<s3::upload_progress> _progress_per_shard{smp::count};
     bool _remove_on_uploaded;
-    s3::upload_progress _progress = {};
 
     future<> do_backup();
-    future<> upload_component(shared_ptr<s3::client> client, sstring name);
+    future<> upload_component(shared_ptr<s3::client> client, abort_source& as, s3::upload_progress& progress, sstring name);
 
 protected:
     virtual future<> run() override;

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -144,7 +144,32 @@ async def test_backup_to_non_existent_bucket(manager: ManagerClient, s3_server):
     status = await manager.api.wait_task(server.ip_addr, tid)
     assert status is not None
     assert status['state'] == 'failed'
+    assert 'S3 request failed. Code: 15. Reason: Access Denied.' in status['error']
 
+
+async def test_backup_to_non_existent_endpoint(manager: ManagerClient, s3_server):
+    '''backup should fail if the endpoint is invalid/inaccessible'''
+
+    cfg = {'enable_user_defined_functions': False,
+           'object_storage_config_file': str(s3_server.config_file),
+           'experimental_features': ['keyspace-storage-options'],
+           'task_ttl_in_seconds': 300
+           }
+    cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace']
+    server = await manager.server_add(config=cfg, cmdline=cmd)
+    ks, cf = await prepare_snapshot_for_backup(manager, server)
+
+    workdir = await manager.server_get_workdir(server.server_id)
+    cf_dir = os.listdir(f'{workdir}/data/{ks}')[0]
+    files = set(os.listdir(f'{workdir}/data/{ks}/{cf_dir}/snapshots/backup'))
+    assert len(files) > 0
+
+    prefix = f'{cf}/backup'
+    tid = await manager.api.backup(server.ip_addr, ks, cf, 'backup', "does_not_exist", s3_server.bucket_name, prefix)
+    status = await manager.api.wait_task(server.ip_addr, tid)
+    assert status is not None
+    assert status['state'] == 'failed'
+    assert status['error'] == 'std::invalid_argument (endpoint does_not_exist not found)'
 
 async def do_test_backup_abort(manager: ManagerClient, s3_server,
                                breakpoint_name, min_files, max_files = None):
@@ -182,6 +207,7 @@ async def do_test_backup_abort(manager: ManagerClient, s3_server,
     status = await manager.api.wait_task(server.ip_addr, tid)
     print(f'Status: {status}')
     assert (status is not None) and (status['state'] == 'failed')
+    assert "seastar::abort_requested_exception (abort requested)" in status['error']
 
     objects = set(o.key for o in get_s3_resource(s3_server).Bucket(s3_server.bucket_name).objects.all())
     uploaded_count = 0

--- a/utils/s3/client_fwd.hh
+++ b/utils/s3/client_fwd.hh
@@ -15,5 +15,6 @@ class client;
 struct upload_progress {
     size_t total;
     size_t uploaded;
+    upload_progress operator+(const upload_progress& other) const { return {total + other.total, uploaded + other.uploaded}; }
 };
 }


### PR DESCRIPTION
Use all shards to upload backup files to enhance S3 throughput by distributing the load across multiple shards.

ref: https://github.com/scylladb/scylladb/issues/22460

## Perf comaparison
[Non-sharded native backup (100GiB)](https://argus.scylladb.com/tests/scylla-cluster-tests/e49444d1-63ab-4001-8d96-afa008e62217) (14 shards)

```
+---------------+-----------+---------+------------+
|               | Size      | Time [s]| Throughput |
+---------------+-----------+---------+------------+
| Native backup | 105.42 GiB| 00:28:33| 62 MiB/s   |
+---------------+-----------+---------+------------+
```


[Sharded native backup (200GiB)](https://argus.scylladb.com/tests/scylla-cluster-tests/76240aa1-06a1-417d-b248-2b0cede6ecbd) (14 shards)
```
+---------------+-----------+---------+------------+
|               | Size      | Time [s]| Throughput |
+---------------+-----------+---------+------------+
| Native backup | 208.84 GiB| 00:04:46| 730 MiB/s  |
+---------------+-----------+---------+------------+
```
fixes: https://github.com/scylladb/scylladb/issues/22520
