### PR TITLE
locator: network_topology_strategy: Fix SIGSEGV when creating a table when there is a rack with no normal nodes

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -430,8 +430,8 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             continue;
         }
         const auto& existing = replicas_per_rack[rack];
-        auto& candidate = existing.empty() ?
-                new_racks.emplace_back(rack) : existing_racks.emplace_back(rack);
+        candidates_list& rack_list = existing.empty() ? new_racks : existing_racks;
+        auto& candidate = rack_list.emplace_back(rack);
         for (const auto& node : nodes) {
             if (!node.get().is_normal()) {
                 continue;
@@ -442,7 +442,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             }
         }
         if (candidate.nodes.empty()) {
-            existing_racks.pop_back();
+            rack_list.pop_back();
             tablet_logger.trace("allocate_replica {}.{}: no candidate nodes left on rack={}", s->ks_name(), s->cf_name(), rack);
             // Note that this rack can't be in new_racks since
             // those had no existing replicas and if current rack has no nodes

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1830,6 +1830,70 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
     }, tablet_cql_test_config()).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_table_creation_during_rack_decommission) {
+    // Reproduces #22625
+    // The problematic scenario happens when allocating tablets for a new table
+    // when there is a rack with only non-normal nodes.
+    do_with_cql_env_thread([](auto& e) {
+        inet_address ip1("192.168.0.1");
+        inet_address ip2("192.168.0.2");
+        inet_address ip3("192.168.0.3");
+        inet_address ip4("192.168.0.4");
+
+        auto host1 = host_id(next_uuid());
+        auto host2 = host_id(next_uuid());
+        auto host3 = host_id(next_uuid());
+        auto host4 = host_id(next_uuid());
+
+        auto dc = "datacenter1";
+        locator::endpoint_dc_rack dcrack  = { dc, "rack1" };
+        locator::endpoint_dc_rack dcrack2 = { dc, "rack2" };
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
+            locator::topology::config {
+                .this_endpoint = ip1,
+                .this_host_id = host1,
+                .local_dc_rack = dcrack
+            }
+        });
+
+        const unsigned shard_count = 1;
+
+        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+            tm.update_topology(host1, dcrack, node::state::normal, shard_count);
+            tm.update_topology(host2, dcrack, node::state::normal, shard_count);
+            tm.update_topology(host3, dcrack2, node::state::being_decommissioned, shard_count);
+            tm.update_topology(host4, dcrack2, node::state::left, shard_count);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
+            co_return;
+        }).get();
+
+        sstring ks_name = "test_ks";
+        sstring table_name = "table1";
+        e.execute_cql(format("create keyspace {} with replication = "
+                             "{{'class': 'NetworkTopologyStrategy', '{}': 1}} "
+                             "and tablets = {{'enabled': true, 'initial': 8}}", ks_name, dcrack.dc)).get();
+        e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
+        auto s = e.local_db().find_schema(ks_name, table_name);
+
+        auto* rs = e.local_db().find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
+        BOOST_REQUIRE(rs);
+        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 8).get();
+
+        tmap.for_each_tablet([&](auto tid, auto& tinfo) {
+            for (auto& replica : tinfo.replicas) {
+                BOOST_REQUIRE_NE(replica.host, host3);
+                BOOST_REQUIRE_NE(replica.host, host4);
+            }
+            return make_ready_future<>();
+        }).get();
+    }, tablet_cql_test_config()).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that replication constraints of tablets can be satisfied after decommission.


### PR DESCRIPTION
In that case, the `new_racks` vector will be used, but when we discover no candidates, we try to pop from `existing_racks`.

Fixes #22625
