### PR TITLE
config: prevent SIGHUP from changing non-liveupdatable parameters

### DIFF
--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -451,6 +451,9 @@ class ScyllaRESTAPIClient():
     async def abort_task(self, node_ip: str, task_id: str):
         await self.client.post(f'/task_manager/abort_task/{task_id}', host=node_ip)
 
+    async def get_config(self, node_ip: str, id: str):
+        return await self.client.get_json(f'/v2/config/{id}', host=node_ip)
+
 class ScyllaMetrics:
     def __init__(self, lines: list[str]):
         self.lines: list[str] = lines

--- a/test/topology_custom/test_config.py
+++ b/test/topology_custom/test_config.py
@@ -1,0 +1,41 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import logging
+import pytest
+import requests
+import sys
+import threading
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import read_barrier
+from test.pylib.util import wait_for
+
+async def wait_for_config(manager, server, config_name, value):
+    async def config_value_equal():
+        await read_barrier(manager.api, server.ip_addr)
+        resp = await manager.api.get_config(server.ip_addr, config_name)
+        logging.info(f"Obtained config via REST api - config_name={config_name} value={value}")
+        if resp == value:
+            return True
+        return None
+    await wait_for(config_value_equal, deadline=time.time() + 60)
+
+@pytest.mark.asyncio
+async def test_non_liveupdatable_config(manager):
+
+    server = await manager.server_add()
+    not_liveupdatable_param = "auto_bootstrap"
+    liveupdatable_param = "compaction_enforce_min_threshold"
+
+    logging.info("Verify initial (default) config values")
+    await wait_for_config(manager, server, not_liveupdatable_param, True)
+    await wait_for_config(manager, server, liveupdatable_param, False)
+
+    logging.info("Change config values - verify only liveupdatable config is changed")
+    await manager.server_update_config(server.server_id, not_liveupdatable_param, False)
+    await manager.server_update_config(server.server_id, liveupdatable_param, True)
+    await wait_for_config(manager, server, liveupdatable_param, True)
+    await wait_for_config(manager, server, not_liveupdatable_param, True)

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -226,7 +226,7 @@ sstring utils::hyphenate(const std::string_view& v) {
 }
 
 utils::config_file::config_file(std::initializer_list<cfg_ref> cfgs)
-    : _cfgs(cfgs)
+    : _cfgs(cfgs), _initialization_completed(false)
 {}
 
 void utils::config_file::add(cfg_ref cfg, std::unique_ptr<any_value> value) {
@@ -331,7 +331,7 @@ void utils::config_file::read_from_yaml(const char* yaml, error_handler h) {
         }
         // Still, a syntax error is an error warning, not a fail
         try {
-            cfg.set_value(node.second);
+            cfg.set_value(node.second, this->_initialization_completed ? config_source::SettingsFile : config_source::None);
         } catch (std::exception& e) {
             h(label, e.what(), cfg.status());
         } catch (...) {
@@ -365,6 +365,11 @@ future<> utils::config_file::read_from_file(file f, error_handler h) {
         return do_with(make_file_input_stream(f), [this, s, h](input_stream<char>& in) {
             return in.read_exactly(s).then([this, h](temporary_buffer<char> buf) {
                read_from_yaml(sstring(buf.begin(), buf.end()), h);
+                if (!_initialization_completed) {
+                    // Boolean value set on only one shard, but broadcast_to_all_shards().get() called later
+                    // in main.cc will apply the required memory barriers anyway.
+                    _initialization_completed = true;
+                }
             });
         });
     });

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -147,7 +147,7 @@ public:
         }
         bool matches(std::string_view name) const;
         virtual void add_command_line_option(bpo::options_description_easy_init&) = 0;
-        virtual void set_value(const YAML::Node&) = 0;
+        virtual void set_value(const YAML::Node&, config_source) = 0;
         virtual bool set_value(sstring, config_source) = 0;
         virtual future<bool> set_value_on_all_shards(sstring, config_source) = 0;
         virtual value_status status() const noexcept = 0;
@@ -255,11 +255,12 @@ public:
         }
 
         void add_command_line_option(bpo::options_description_easy_init&) override;
-        void set_value(const YAML::Node&) override;
+        void set_value(const YAML::Node&, config_source) override;
         bool set_value(sstring, config_source) override;
         // For setting a single value on all shards,
         // without having to call broadcast_to_all_shards
         // that broadcasts all values to all shards.
+
         future<bool> set_value_on_all_shards(sstring, config_source) override;
     };
 
@@ -317,6 +318,7 @@ private:
 
     configs
         _cfgs;
+    bool _initialization_completed;
 };
 
 template <typename T>

--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -149,7 +149,6 @@ public:
         virtual void add_command_line_option(bpo::options_description_easy_init&) = 0;
         virtual void set_value(const YAML::Node&) = 0;
         virtual bool set_value(sstring, config_source) = 0;
-        virtual future<> set_value_on_all_shards(const YAML::Node&) = 0;
         virtual future<bool> set_value_on_all_shards(sstring, config_source) = 0;
         virtual value_status status() const noexcept = 0;
         virtual config_source source() const noexcept = 0;
@@ -261,7 +260,6 @@ public:
         // For setting a single value on all shards,
         // without having to call broadcast_to_all_shards
         // that broadcasts all values to all shards.
-        future<> set_value_on_all_shards(const YAML::Node&) override;
         future<bool> set_value_on_all_shards(sstring, config_source) override;
     };
 

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -225,18 +225,6 @@ bool utils::config_file::named_value<T>::set_value(sstring value, config_source 
 }
 
 template<typename T>
-future<> utils::config_file::named_value<T>::set_value_on_all_shards(const YAML::Node& node) {
-    if (_source == config_source::SettingsFile && _liveness != liveness::LiveUpdate) {
-        // FIXME: warn if different?
-        co_return;
-    }
-    co_await smp::invoke_on_all([this, value = node.as<T>()] () {
-        (*this)(value);
-    });
-    _source = config_source::SettingsFile;
-}
-
-template<typename T>
 future<bool> utils::config_file::named_value<T>::set_value_on_all_shards(sstring value, config_source src) {
     if ((_liveness != liveness::LiveUpdate) || (src == config_source::CQL && !_cf->are_live_updatable_config_params_changeable_via_cql())) {
         co_return false;

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -205,9 +205,8 @@ void utils::config_file::named_value<T>::add_command_line_option(boost::program_
 }
 
 template<typename T>
-void utils::config_file::named_value<T>::set_value(const YAML::Node& node) {
-    if (_source == config_source::SettingsFile && _liveness != liveness::LiveUpdate) {
-        // FIXME: warn if different?
+void utils::config_file::named_value<T>::set_value(const YAML::Node& node, config_source previous_src) {
+    if (previous_src == config_source::SettingsFile && _liveness != liveness::LiveUpdate) {
         return;
     }
     (*this)(node.as<T>());


### PR DESCRIPTION
Before this change, it was possible to change non-liveupdatable config
parameter without process restart. This erroneous behavior not only
contradicts the documentation but is potentially dangerous, as various
components theoretically might not be prepared for a change of
configuration parameter value without a restart. The issue came from
a fact that liveupdatability verification check was skipped for default
configuration parameters (those without its initial values
in configuration file during process start).
    
This change:
 - Introduce _initialization_completed member in config_file
 - Set _initialization_completed=true when config file is processed on
   server start
 - Verify config_file's initialization status during config update - if
   config_file was initialized, prevent from further changes of
   non-liveupdatable parameters
 - Implement ScyllaRESTAPIClient::get_config() that obtains a current
    value of given configuration parameter via /v2/config REST API
 - Implement test to confirm that only liveupdatable parameters are
    changed when SIGHUP is sent after configuration file change

Function set_initialization_completed() is called only once in main.cc,
and the effect is expected to be visible in all shards, as a side effect
of cfg->broadcast_to_all_shards() that is called shortly after. The same
technique was already used for enable_3_1_0_compatibility_mode() call.
    
Fixes scylladb/scylladb#5382


No backport - minor fix.