### PR TITLE
pgo: run secondary index training with vnodes

### DIFF
--- a/pgo/conf/si.yaml
+++ b/pgo/conf/si.yaml
@@ -2,7 +2,7 @@ keyspace: sec_index
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS sec_index WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+  CREATE KEYSPACE IF NOT EXISTS sec_index WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND TABLETS = {'enabled': false};
 
 table: users
 


### PR DESCRIPTION
As of right now, materialized views, and consequently secondary indexes, are experimental with tablets. As such, most users should have materialized views only on vnodes, so when training Scylla during PGO, we should also train it using vnodes.
We do that in this patch by using a vnode-based keyspace in the cassandra-stress YAML file used for training on secondary indexes.

Fixes https://github.com/scylladb/scylladb/issues/22638

The views with tablets feature is being backported to 2025.1, so this should too