### PR TITLE
pgo: disable tablets for training with secondary index, lwt and counters

### DIFF
--- a/pgo/conf/counters.yaml
+++ b/pgo/conf/counters.yaml
@@ -1,7 +1,7 @@
 DROP KEYSPACE IF EXISTS counters;
 
 CREATE KEYSPACE IF NOT EXISTS counters
-WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3'};
+WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3'} AND TABLETS = {'enabled': false};
 
 CREATE TABLE IF NOT EXISTS counters.counter1 (
                 key blob PRIMARY KEY,

--- a/pgo/conf/lwt.yaml
+++ b/pgo/conf/lwt.yaml
@@ -3,7 +3,7 @@ keyspace: ks
 
 # The CQL for creating a keyspace (optional if it already exists)
 keyspace_definition: |
-  CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+  CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND TABLETS = {'enabled': false};
 
 # Table name
 table: targettable

--- a/pgo/conf/si.yaml
+++ b/pgo/conf/si.yaml
@@ -2,7 +2,7 @@ keyspace: sec_index
 
 keyspace_definition: |
 
-  CREATE KEYSPACE IF NOT EXISTS sec_index WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};
+  CREATE KEYSPACE IF NOT EXISTS sec_index WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND TABLETS = {'enabled': false};
 
 table: users
 


### PR DESCRIPTION
As of right now, materialized views (and consequently secondary indexes), lwt and counters are unsupported or experimental with tablets. Since by defaults tablets are enabled, training cases using those features are currently broken.

The right thing to do here is to disable tablets in those cases.

Fixes https://github.com/scylladb/scylladb/issues/22638

This affects branch 2025.1 as well, so it should be backported there.