### PR TITLE
db/config: reader_concurrency_semaphore_cpu_concurrency: bump default to 2

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1208,7 +1208,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Start serializing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , reader_concurrency_semaphore_kill_limit_multiplier(this, "reader_concurrency_semaphore_kill_limit_multiplier", liveness::LiveUpdate, value_status::Used, 4,
             "Start killing reads after their collective memory consumption goes above $normal_limit * $multiplier.")
-    , reader_concurrency_semaphore_cpu_concurrency(this, "reader_concurrency_semaphore_cpu_concurrency", liveness::LiveUpdate, value_status::Used, 1,
+    , reader_concurrency_semaphore_cpu_concurrency(this, "reader_concurrency_semaphore_cpu_concurrency", liveness::LiveUpdate, value_status::Used, 2,
             "Admit new reads while there are less than this number of requests that need CPU.")
     , view_update_reader_concurrency_semaphore_serialize_limit_multiplier(this, "view_update_reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
             "Start serializing view update reads after their collective memory consumption goes above $normal_limit * $multiplier.")


### PR DESCRIPTION
This config item controls how many CPU-bound reads are allowed to run in parallel. The effective concurrency of a single CPU core is 1, so allowing more than one CPU-bound reads to run concurrently will just result in time-sharing and both reads having higher latency. However, restricting concurrency to 1 means that a CPU bound read that takes a lot of time to complete can block other quick reads while it is running. Increase this default setting to 2 as a compromise between not over-using time-sharing, while not allowing such slow reads to block the queue behind them.

Fixes: #22450

We want to change the default in the 2025.1 release, so this needs a backport to said release.