### PR TITLE
Apply hard limit to partition range vectors in secondary index queries

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -36,6 +36,7 @@
 #include "service/pager/query_pagers.hh"
 #include "service/storage_proxy.hh"
 #include <seastar/core/execution_stage.hh>
+#include <seastar/core/on_internal_error.hh>
 #include "view_info.hh"
 #include "partition_slice_builder.hh"
 #include "cql3/untyped_result_set.hh"
@@ -1398,12 +1399,19 @@ indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
     using value_type = std::tuple<dht::partition_range_vector, lw_shared_ptr<const service::pager::paging_state>>;
     auto now = gc_clock::now();
     auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
+    bool is_paged = options.get_page_size() >= 0;
+    constexpr size_t MAX_PARTITION_RANGES = 1000;
+    // Check that `partition_range_vector` won't cause a large allocation (see #18536).
+    // If this fails, please adjust MAX_PARTITION_RANGES accordingly.
+    static_assert(MAX_PARTITION_RANGES * sizeof(dht::partition_range_vector::value_type) <= 128 * 1024,
+            "MAX_PARTITION_RANGES too high - will cause large allocations from partition_range_vector");
+    size_t max_vector_size = is_paged ? MAX_PARTITION_RANGES : std::numeric_limits<size_t>::max();
     const uint64_t limit = get_inner_loop_limit(get_limit(options, _limit), _selection->is_aggregate());
     return read_posting_list(qp, options, limit, state, now, timeout, false).then(utils::result_wrap(
-            [this, &options] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
+            [this, &options, max_vector_size] (::shared_ptr<cql_transport::messages::result_message::rows> rows) {
         auto rs = cql3::untyped_result_set(rows);
         dht::partition_range_vector partition_ranges;
-        partition_ranges.reserve(rs.size());
+        partition_ranges.reserve(std::min(rs.size(), max_vector_size));
         // We are reading the list of primary keys as rows of a single
         // partition (in the index view), so they are sorted in
         // lexicographical order (N.B. this is NOT token order!). We need
@@ -1434,6 +1442,9 @@ indexed_table_select_statement::find_index_partition_ranges(query_processor& qp,
             last_dk = dk;
             auto range = dht::partition_range::make_singular(dk);
             partition_ranges.emplace_back(range);
+            if (partition_ranges.size() >= partition_ranges.capacity()) {
+                break;
+            }
         }
         auto paging_state = rows->rs().get_metadata().paging_state();
         return make_ready_future<coordinator_result<value_type>>(value_type(std::move(partition_ranges), std::move(paging_state)));

--- a/cql3/untyped_result_set.hh
+++ b/cql3/untyped_result_set.hh
@@ -154,7 +154,7 @@ class result_set;
 class untyped_result_set {
 public:
     using row = untyped_result_set_row;
-    using rows_type = std::vector<row>;
+    using rows_type = utils::chunked_vector<row>;
     using const_iterator = rows_type::const_iterator;
     using iterator = rows_type::const_iterator;
 

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -2038,7 +2038,7 @@ SEASTAR_TEST_CASE(test_large_allocations) {
         const auto stats_after = memory::stats();
 
         assert_that(msg).is_rows().is_not_empty();
-        BOOST_REQUIRE_LT(stats_before.large_allocations(), stats_after.large_allocations());
+        BOOST_REQUIRE_EQUAL(stats_before.large_allocations(), stats_after.large_allocations());
     });
 }
 #endif


### PR DESCRIPTION
Secondary index queries fetch partition keys from the index view and store them in an `std::vector`. The vector size is currently limited by the user's page size and the page memory limit (1MiB). These are not enough to prevent large contiguous allocations (which can lead to stalls).

This series introduces a hard limit to the vector size to ensure it does not exceed the allocator's preferred max contiguous allocation size (128KiB). With the size of each element being 120 bytes, this allows for 1092 partition keys. The limit was set to 1000. Any partitions above this limit are discarded.

Discarding partitions breaks the querier cache on the replicas, causing a performance regression, as can be seen from the following measurements:
```
* Cluster: 3 nodes (local Docker containers), 1 vCPU, 4GB memory, dev mode
* Schema:
  CREATE KEYSPACE ks WITH replication = {'class': 'org.apache.cassandra.locator.NetworkTopologyStrategy', 'datacenter1': '3'} AND durable_writes = true AND tablets = {'enabled': false};
  CREATE TABLE ks.t1 (pk1 int, pk2 int, ck int, value int, PRIMARY KEY ((pk1, pk2), ck));
  CREATE INDEX t1_pk2_idx ON ks.t1(pk2); 
* Query: CONSISTENCY LOCAL_QUORUM; SELECT * FROM ks.t1 where pk2 = 1;

+------------+-------------------+-------------------+
|  Page Size |      Master       |   Vector Limit    |
+============+===================+===================+
|            |   Latency (sec)   |   Latency (sec)   |
+------------+-------------------+-------------------+
|     100    |  5.80 ± 0.13      |  5.64 ± 0.10      |
+------------+-------------------+-------------------+
|    1000    |  4.77 ± 0.07      |  4.62 ± 0.06      |
+------------+-------------------+-------------------+
|    2000    |  4.67 ± 0.07      |  5.13 ± 0.03      |
+------------+-------------------+-------------------+
|    5000    |  4.82 ± 0.09      |  6.25 ± 0.06      |
+------------+-------------------+-------------------+
|   10000    |  4.89 ± 0.36      |  7.52 ± 0.13      |
+------------+-------------------+-------------------+
|     -1     |  4.90 ± 0.67      |  4.79 ± 0.33      |
+------------+-------------------+-------------------+
```
We expect this to be fixed with adaptive paging in a future PR. Until then, users can avoid regressions by adjusting their page size.

Additionally, this series changes the `untyped_result_set` to store rows in a `chunked_vector` instead of an `std::vector`, similarly to the `result_set`. Secondary index queries use an `untyped_result_set` to store the raw result from the index view before processing. With 1MiB results, the `std::vector` would cause a large allocation of this magnitude. 

Finally, a unit test is added to reproduce the bug.

Fixes #18536.

The PR fixes stalls of up to 100ms, but there is an easy workaround: adjust the page size. No need to backport.