### PR TITLE
doc: Update system.sstables table schema description

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -177,13 +177,13 @@ The "ownership" table for non-local sstables
 Schema:
 ~~~
 CREATE TABLE system.sstables (
-    location text,
+    owner uuid,
     generation timeuuid,
     format text,
     status text,
     uuid uuid,
     version text,
-    PRIMARY KEY (location, generation)
+    PRIMARY KEY (owner, generation)
 )
 ~~~
 


### PR DESCRIPTION
The partition key had been renamed and its type changed some time ago, but the doc wasn't updated. Fix it.

refs: #20998

no backport, 6.2 still has "string location" in it