### PR TITLE
repair: do not hold erm during tablet repair

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -647,7 +647,6 @@ repair::shard_repair_task_impl::shard_repair_task_impl(tasks::task_manager::modu
     , data_centers(data_centers_)
     , hosts(hosts_)
     , ignore_nodes(ignore_nodes_)
-    , total_rf(erm->get_replication_factor())
     , _hints_batchlog_flushed(std::move(hints_batchlog_flushed))
     , _small_table_optimization(small_table_optimization)
     , _user_ranges_parallelism(ranges_parallelism ? std::optional<semaphore>(semaphore(*ranges_parallelism)) : std::nullopt)

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -694,12 +694,16 @@ void repair::shard_repair_task_impl::check_in_abort_or_shutdown() {
 
 repair_neighbors repair::shard_repair_task_impl::get_repair_neighbors(const dht::token_range& range) {
     return neighbors.empty() ?
-        repair_neighbors(get_neighbors(gossiper, *erm, _status.keyspace, range, data_centers, hosts, ignore_nodes, _small_table_optimization)) :
+        repair_neighbors(get_neighbors(gossiper, *get_erm(), _status.keyspace, range, data_centers, hosts, ignore_nodes, _small_table_optimization)) :
         neighbors[range];
 }
 
 size_t repair::shard_repair_task_impl::ranges_size() const noexcept {
     return ranges.size() * table_ids.size();
+}
+
+locator::effective_replication_map_ptr repair::shard_repair_task_impl::get_erm() noexcept {
+    return erm;
 }
 
 // Repair a single local range, multiple column families.

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -702,7 +702,7 @@ size_t repair::shard_repair_task_impl::ranges_size() const noexcept {
 }
 
 locator::effective_replication_map_ptr repair::shard_repair_task_impl::get_erm() noexcept {
-    return erm;
+    return erm ? erm : db.local().get_tables_metadata().get_table(table_ids[0]).get_effective_replication_map();
 }
 
 // Repair a single local range, multiple column families.
@@ -2569,7 +2569,6 @@ future<> repair::tablet_repair_task_impl::run() {
                     rlogger.debug("repair[{}] Table {}.{} does not exist anymore", id.uuid(), m.keyspace_name, m.table_name);
                     continue;
                 }
-                auto erm = t->get_effective_replication_map();
                 if (co_await rs.get_repair_module().is_aborted(id.uuid(), parent_shard)) {
                     throw abort_requested_exception();
                 }
@@ -2588,7 +2587,7 @@ future<> repair::tablet_repair_task_impl::run() {
                 bool small_table_optimization = false;
 
                 auto task_impl_ptr = seastar::make_shared<repair::shard_repair_task_impl>(rs._repair_module, tasks::task_id::create_random_id(),
-                        m.keyspace_name, rs, erm, std::move(ranges), std::move(table_ids), id, std::move(data_centers), std::move(hosts),
+                        m.keyspace_name, rs, nullptr, std::move(ranges), std::move(table_ids), id, std::move(data_centers), std::move(hosts),
                         std::move(ignore_nodes), reason, hints_batchlog_flushed, small_table_optimization, ranges_parallelism, flush_time, sched_by_scheduler);
                 task_impl_ptr->neighbors = std::move(neighbors);
                 auto task = co_await rs._repair_module->make_task(task_impl_ptr, parent_data);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2990,9 +2990,9 @@ private:
         auto my_address = get_erm()->get_topology().my_host_id();
         // Update repair_history table only if all replicas have been repaired
         size_t repaired_replicas = _all_live_peer_nodes.size() + 1;
-        if (_shard_task.total_rf != repaired_replicas){
+        if (_shard_task.get_total_rf() != repaired_replicas){
             rlogger.debug("repair[{}]: Skipped to update system.repair_history total_rf={}, repaired_replicas={}, local={}, peers={}",
-                    _shard_task.global_repair_id.uuid(), _shard_task.total_rf, repaired_replicas, my_address, _all_live_peer_nodes);
+                    _shard_task.global_repair_id.uuid(), _shard_task.get_total_rf(), repaired_replicas, my_address, _all_live_peer_nodes);
             co_return;
         }
         // Update repair_history table only if both hints and batchlog have been flushed.
@@ -3004,7 +3004,7 @@ private:
         // system.tablet.repair_time is updated.
         if (_is_tablet && _shard_task.sched_by_scheduler) {
             rlogger.debug("repair[{}]: Skipped to update system.repair_history for tablet repair scheduled by scheduler total_rf={} repaired_replicas={} local={} peers={}",
-                    _shard_task.global_repair_id.uuid(), _shard_task.total_rf, repaired_replicas, my_address, _all_live_peer_nodes);
+                    _shard_task.global_repair_id.uuid(), _shard_task.get_total_rf(), repaired_replicas, my_address, _all_live_peer_nodes);
             co_return;
         }
 

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2977,7 +2977,7 @@ private:
 
 private:
     locator::effective_replication_map_ptr get_erm() {
-        return _shard_task.erm;
+        return _shard_task.get_erm();
     }
 
 private:

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1382,7 +1382,11 @@ public:
         } else {
             return;
         }
-        flush_rows(_schema, _working_row_buf, _repair_writer, erm, small_table_optimization, this);
+        if (small_table_optimization) {
+            flush_rows(_schema, _working_row_buf, _repair_writer, erm, small_table_optimization, this);
+        } else {
+            flush_rows(_schema, _working_row_buf, _repair_writer);
+        }
     }
 
 private:
@@ -2921,7 +2925,7 @@ private:
             throw;
           }
         }
-        master.flush_rows_in_working_row_buf(get_erm(), _small_table_optimization);
+        master.flush_rows_in_working_row_buf(_small_table_optimization ? get_erm() : nullptr, _small_table_optimization);
         return op_status::next_step;
     }
 

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -150,7 +150,9 @@ public:
     seastar::sharded<netw::messaging_service>& messaging;
     service::migration_manager& mm;
     gms::gossiper& gossiper;
+private:
     locator::effective_replication_map_ptr erm;
+public:
     dht::token_range_vector ranges;
     std::vector<sstring> cfs;
     std::vector<table_id> table_ids;
@@ -215,6 +217,8 @@ public:
     bool hints_batchlog_flushed() const {
         return _hints_batchlog_flushed;
     }
+
+    locator::effective_replication_map_ptr get_erm() noexcept;
 
     future<> repair_range(const dht::token_range& range, table_info table);
 

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -161,7 +161,6 @@ public:
     std::vector<sstring> hosts;
     std::unordered_set<locator::host_id> ignore_nodes;
     std::unordered_map<dht::token_range, repair_neighbors> neighbors;
-    size_t total_rf;
     uint64_t nr_ranges_finished = 0;
     size_t nr_failed_ranges = 0;
     int ranges_index = 0;
@@ -219,6 +218,10 @@ public:
     }
 
     locator::effective_replication_map_ptr get_erm() noexcept;
+
+    size_t get_total_rf() {
+        return get_erm()->get_replication_factor();
+    }
 
     future<> repair_range(const dht::token_range& range, table_info table);
 


### PR DESCRIPTION
Do not hold erm during repair of a tablet that is started with tablet 
repair scheduler. This way two different tablets can be repaired 
and migrated concurrently. The same tablet won't be migrated while 
being repaired as it is provided by topology coordinator.

Refs: https://github.com/scylladb/scylladb/issues/22408.

Needs backport to 2025.1 that introduces the tablet repair scheduler.