### PR TITLE
network_topology_strategy/alter ks: Remove dc:s from options once rf=0

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -26,6 +26,8 @@
 #include "gms/feature_service.hh"
 #include "replica/database.hh"
 
+using namespace std::string_literals;
+
 static logging::logger mylogger("alter_keyspace");
 
 bool is_system_keyspace(std::string_view keyspace);
@@ -205,6 +207,25 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
 
         auto ts = mc.write_timestamp();
         auto global_request_id = mc.new_group0_state_id();
+
+        // #22688 - filter out any dc*:0 entries - consider these
+        // null and void (removed). Migration planning will treat it
+        // as dc*=0 still.
+        std::erase_if(ks_options, [](const auto& i) {
+            static constexpr std::string replication_prefix = ks_prop_defs::KW_REPLICATION + ":"s;
+            // Flattened map, replication entries starts with "replication:".
+            // Only valid options are replication_factor, class and per-dc rf:s. We want to
+            // filter out any dcN=0 entries.
+            auto& [key, val] = i;
+            if (key.starts_with(replication_prefix) && val == "0") {
+                std::string_view v(key);
+                v.remove_prefix(replication_prefix.size());
+                return v != ks_prop_defs::REPLICATION_FACTOR_KEY 
+                    && v != ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY
+                    ;
+            }
+            return false;
+        });
 
         // we only want to run the tablets path if there are actually any tablets changes, not only schema changes
         // TODO: the current `if (changes_tablets(qp))` is insufficient: someone may set the same RFs as before,

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -70,6 +70,16 @@ static std::map<sstring, sstring> prepare_options(
         }
     }
 
+    // #22688 / #20039 - check for illegal, empty options (after above expand)
+    // moved to here. We want to be able to remove dc:s once rf=0, 
+    // in which case, the options actually serialized in result mutations
+    // will in extreme cases in fact be empty -> cannot do this check in 
+    // verify_options. We only want to apply this constraint on the input
+    // provided by the user
+    if (options.empty() && !tm.get_topology().get_datacenters().empty()) {
+        throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
+    }
+
     return options;
 }
 

--- a/docs/operating-scylla/procedures/cluster-management/decommissioning-data-center.rst
+++ b/docs/operating-scylla/procedures/cluster-management/decommissioning-data-center.rst
@@ -55,7 +55,7 @@ Procedure
       cqlsh> DESCRIBE <KEYSPACE_NAME>
       cqlsh> CREATE KEYSPACE <KEYSPACE_NAME> WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '<DC_NAME1>' : 3, '<DC_NAME2>' : 3, '<DC_NAME3>' : 3};
 
-      cqlsh> ALTER KEYSPACE <KEYSPACE_NAME> WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '<DC_NAME1>' : 3, '<DC_NAME2>' : 3};
+      cqlsh> ALTER KEYSPACE <KEYSPACE_NAME> WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '<DC_NAME1>' : 3, '<DC_NAME2>' : 3, '<DC_NAME3>' : 0};
 
    For example:
 
@@ -71,7 +71,7 @@ Procedure
 
    .. code-block:: shell
 
-      cqlsh> ALTER KEYSPACE nba WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : 3, 'EUROPE-DC' : 3};
+      cqlsh> ALTER KEYSPACE nba WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'US-DC' : 3, 'ASIA-DC' : 0, 'EUROPE-DC' : 3};
 
 #. Run :doc:`nodetool decommission </operating-scylla/nodetool-commands/decommission>` on every node in the data center that is to be removed.
    Refer to :doc:`Remove a Node from a ScyllaDB Cluster - Down Scale </operating-scylla/procedures/cluster-management/remove-node>` for further information.

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -271,9 +271,9 @@ network_topology_strategy::calculate_natural_endpoints(
 }
 
 void network_topology_strategy::validate_options(const gms::feature_service& fs, const locator::topology& topology) const {
-    if(_config_options.empty()) {
-        throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
-    }
+    // #22688 / #20039 - we want to remove dc:s once rf=0, and we
+    // also want to allow fully setting rf=0 in _all_ dc:s (hello data loss)
+    // so empty options here are in fact ok. Removed check for it
     auto dcs = topology.get_datacenters();
     validate_tablet_options(*this, fs, _config_options);
     for (auto& c : _config_options) {
@@ -387,7 +387,10 @@ future<tablet_replica_set> network_topology_strategy::reallocate_tablets(schema_
         ++nodes_per_dc[node.dc_rack().dc];
     }
 
-    for (const auto& [dc, dc_rf] : _dc_rep_factor) {
+    // #22688 - take all dcs in topology into account when determining migration.
+    // Any change should still have been pre-checked to never exceed rf factor one.
+    for (const auto& dc : tm->get_topology().get_datacenters()) {
+        auto dc_rf = get_replication_factor(dc);
         auto dc_node_count = nodes_per_dc[dc];
         if (dc_rf == dc_node_count) {
             continue;


### PR DESCRIPTION
Fixes #22688

If we set a dc rf to zero, the options map will still retain a dc=0 entry. If this dc is decommissioned, any further alters of keyspace will fail, because the union of new/old options will now contained an unknown keyword.

Change alter ks options processing to simply remove any dc with rf=0 on alter, and treat this as an implicit dc=0 in nw-topo strategy. This means we change the reallocate_tablets routine to not rely on the strategy objects dc mapping, but the full replica topology info for dc:s to consider for reallocation. Since we verify the input on attribute processing, the amount of rf/tablets moved should still be legal.
