### PR TITLE
github: use clang-21 in clang-nightly workflow

### DIFF
--- a/.github/workflows/clang-nightly.yaml
+++ b/.github/workflows/clang-nightly.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   # use the development branch explicitly
-  CLANG_VERSION: 20
+  CLANG_VERSION: 21
   BUILD_DIR: build
 
 permissions: {}


### PR DESCRIPTION
since clang 20 has been branched. let's track the development brach, which is clang 21.

---

this change only addresses the build failure in a github workflow, and has no impacts to the production, hence no need to backport.