### PR TITLE
 reader_concurrency_semaphore: set_notify_handler(): disable timeout 

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -495,7 +495,7 @@ public:
         _trace_ptr = std::move(trace_ptr);
     }
 
-    void check_abort() {
+    void check_abort() const {
         if (_ex) {
             std::rethrow_exception(_ex);
         }
@@ -644,7 +644,7 @@ void reader_permit::set_trace_state(tracing::trace_state_ptr trace_ptr) noexcept
     _impl->set_trace_state(std::move(trace_ptr));
 }
 
-void reader_permit::check_abort() {
+void reader_permit::check_abort() const {
     return _impl->check_abort();
 }
 

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1165,6 +1165,7 @@ void reader_concurrency_semaphore::set_notify_handler(inactive_read_handle& irh,
     auto& ir = *(*irh._permit)->aux_data().ir;
     ir.notify_handler = std::move(notify_handler);
     if (ttl_opt) {
+        irh._permit->set_timeout(db::no_timeout);
         ir.ttl_timer.set_callback([this, permit = *irh._permit] () mutable {
             evict(*permit, evict_reason::time);
         });

--- a/reader_permit.hh
+++ b/reader_permit.hh
@@ -174,7 +174,7 @@ public:
 
     // If the read was aborted, throw the exception the read was aborted with.
     // Otherwise no-op.
-    void check_abort();
+    void check_abort() const;
 
     query::max_result_size max_result_size() const;
     void set_max_result_size(query::max_result_size);


### PR DESCRIPTION
`set_notify_handler()` is called after a querier was inserted into the querier cache. It has two purposes: set a callback for eviction and set a TTL for the cache entry. This latter was not disabling the pre-existing timeout of the permit (if any) and this would lead to premature eviction of the cache entry if the timeout was shorter than TTL (which his typical).
Disable the timeout before setting the TTL to prevent premature eviction.

Fixes: https://github.com/scylladb/scylladb/issues/22629

Backport required to all active releases, they are all affected.