### PR TITLE
tools: toolchain: prepare: fix optimized_clang archive printout

### DIFF
--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -191,5 +191,5 @@ echo "    podman manifest push --all $(<tools/toolchain/image) docker://$(<tools
 if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
     echo ""
     echo "Optimized clang archive saved at:"
-    echo "    ${CLANG_ARCHIVES[$current_arch_name}]}"
+    echo "    ${CLANG_ARCHIVES[${current_arch_uname}]}"
 fi


### PR DESCRIPTION
prepare helpfully prints out the path where optimized clang is stored, but a couple of typos mean it prints out an empty string. Fix that.

Minor bug encountered by a maintainer twice a year, so no need to backport.