### PR TITLE
db: do not include unused headers

### DIFF
--- a/db/partition_snapshot_row_cursor.hh
+++ b/db/partition_snapshot_row_cursor.hh
@@ -12,8 +12,8 @@
 #include "db/row_cache.hh"
 #include "utils/assert.hh"
 #include "utils/small_vector.hh"
+#include <algorithm>
 #include <fmt/core.h>
-#include <ranges>
 
 class partition_snapshot_row_cursor;
 

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -8,24 +8,18 @@
 
 #pragma once
 
-#include <boost/intrusive/list.hpp>
-#include <boost/intrusive/set.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
 
-#include <seastar/core/memory.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include "mutation/mutation_partition.hh"
 #include "utils/phased_barrier.hh"
 #include "utils/histogram.hh"
 #include "mutation/partition_version.hh"
-#include <seastar/core/metrics_registration.hh>
 #include "utils/double-decker.hh"
 #include "db/cache_tracker.hh"
 #include "readers/empty_v2.hh"
 #include "readers/mutation_source.hh"
-
-namespace bi = boost::intrusive;
 
 class row_cache;
 class cache_tracker;


### PR DESCRIPTION
these unused includes were identified by clang-include-cleaner. after auditing these source files, all of the reports have been confirmed.

also, took this opportunity to remove an unused namespace alias. and add an include which is used actually. please note, `std::ranges::pop_heap()` and friends are actually provided by `<algorithm>` not `<ranges>`.

---

it's a cleanup, hence no need to backport.