### PR TITLE
sstables_manager: trigger reclaim/reload on `components_memory_reclaim_threshold` update

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1364,7 +1364,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     _stats.on_open_for_reading();
 
     _total_reclaimable_memory.reset();
-    _manager.increment_total_reclaimable_memory_and_maybe_reclaim(this);
+    _manager.increment_total_reclaimable_memory(this);
 }
 
 future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
@@ -1608,7 +1608,7 @@ future<> sstable::load(sstables::foreign_sstable_open_info info) noexcept {
     validate_partitioner();
     co_await update_info_for_opened_data();
     _total_reclaimable_memory.reset();
-    _manager.increment_total_reclaimable_memory_and_maybe_reclaim(this);
+    _manager.increment_total_reclaimable_memory(this);
 }
 
 future<foreign_sstable_open_info> sstable::get_open_info() & {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -158,8 +158,7 @@ void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(ssta
 }
 
 void sstables_manager::maybe_reclaim_components() {
-    size_t memory_reclaim_threshold = _available_memory * _db_config.components_memory_reclaim_threshold();
-    if (_total_reclaimable_memory <= memory_reclaim_threshold) {
+    if (_total_reclaimable_memory <= get_components_memory_reclaim_threshold()) {
         // total memory used is within limit; no need to reclaim.
         return;
     }
@@ -179,9 +178,12 @@ void sstables_manager::maybe_reclaim_components() {
             memory_reclaimed, sst_with_max_memory->get_filename(), _total_memory_reclaimed);
 }
 
-size_t sstables_manager::get_memory_available_for_reclaimable_components() {
-    size_t memory_reclaim_threshold = _available_memory * _db_config.components_memory_reclaim_threshold();
-    return memory_reclaim_threshold - _total_reclaimable_memory;
+size_t sstables_manager::get_components_memory_reclaim_threshold() const {
+    return _available_memory * _db_config.components_memory_reclaim_threshold();
+}
+
+size_t sstables_manager::get_memory_available_for_reclaimable_components() const {
+    return get_components_memory_reclaim_threshold() - _total_reclaimable_memory;
 }
 
 future<> sstables_manager::components_reloader_fiber() {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -43,7 +43,7 @@ sstables_manager::sstables_manager(
     , _maintenance_sg(std::move(maintenance_sg))
     , _abort(abort)
 {
-    _components_reloader_status = components_reloader_fiber();
+    _components_reloader_status = components_reclaim_reload_fiber();
 }
 
 sstables_manager::~sstables_manager() {
@@ -184,7 +184,7 @@ size_t sstables_manager::get_memory_available_for_reclaimable_components() const
     return get_components_memory_reclaim_threshold() - _total_reclaimable_memory;
 }
 
-future<> sstables_manager::components_reloader_fiber() {
+future<> sstables_manager::components_reclaim_reload_fiber() {
     co_await coroutine::switch_to(_maintenance_sg);
 
     sstlog.trace("components_reloader_fiber start");

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -154,7 +154,10 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
 
 void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst) {
     _total_reclaimable_memory += sst->total_reclaimable_memory_size();
+    maybe_reclaim_components();
+}
 
+void sstables_manager::maybe_reclaim_components() {
     size_t memory_reclaim_threshold = _available_memory * _db_config.components_memory_reclaim_threshold();
     if (_total_reclaimable_memory <= memory_reclaim_threshold) {
         // total memory used is within limit; no need to reclaim.

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -152,7 +152,7 @@ sstable_writer_config sstables_manager::configure_writer(sstring origin) const {
     return cfg;
 }
 
-void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst) {
+void sstables_manager::increment_total_reclaimable_memory(sstable* sst) {
     _total_reclaimable_memory += sst->total_reclaimable_memory_size();
     _components_memory_change_event.signal();
 }

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -189,7 +189,7 @@ future<> sstables_manager::components_reclaim_reload_fiber() {
 
     sstlog.trace("components_reloader_fiber start");
     while (true) {
-        co_await _sstable_deleted_event.when();
+        co_await _components_memory_change_event.when();
 
         if (_closing) {
             co_return;
@@ -269,7 +269,7 @@ void sstables_manager::deactivate(sstable* sst) {
 void sstables_manager::remove(sstable* sst) {
     _undergoing_close.erase(_undergoing_close.iterator_to(*sst));
     delete sst;
-    _sstable_deleted_event.signal();
+    _components_memory_change_event.signal();
     maybe_done();
 }
 
@@ -304,7 +304,7 @@ future<> sstables_manager::close() {
     co_await _done.get_future();
     co_await _sstable_metadata_concurrency_sem.stop();
     // stop the components reload fiber
-    _sstable_deleted_event.signal();
+    _components_memory_change_event.signal();
     co_await std::move(_components_reloader_status);
 }
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -159,21 +159,21 @@ void sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(ssta
 
 void sstables_manager::maybe_reclaim_components() {
     while(_total_reclaimable_memory > get_components_memory_reclaim_threshold()) {
-    // Memory consumption is above threshold. Reclaim from the SSTable that
-    // has the most reclaimable memory to get the total consumption under limit.
-    // FIXME: Take SSTable usage into account during reclaim - see https://github.com/scylladb/scylladb/issues/21897
-    auto sst_with_max_memory = std::max_element(_active.begin(), _active.end(), [](const sstable& sst1, const sstable& sst2) {
-        return sst1.total_reclaimable_memory_size() < sst2.total_reclaimable_memory_size();
-    });
+        // Memory consumption is above threshold. Reclaim from the SSTable that
+        // has the most reclaimable memory to get the total consumption under limit.
+        // FIXME: Take SSTable usage into account during reclaim - see https://github.com/scylladb/scylladb/issues/21897
+        auto sst_with_max_memory = std::max_element(_active.begin(), _active.end(), [](const sstable& sst1, const sstable& sst2) {
+            return sst1.total_reclaimable_memory_size() < sst2.total_reclaimable_memory_size();
+        });
 
-    auto memory_reclaimed = sst_with_max_memory->reclaim_memory_from_components();
-    _total_memory_reclaimed += memory_reclaimed;
-    _total_reclaimable_memory -= memory_reclaimed;
-    _reclaimed.insert(*sst_with_max_memory);
-    // TODO: As of now only bloom filter is reclaimed. Print actual component names when adding support for more components.
-    smlogger.info("Reclaimed {} bytes of memory from components of {}. Total memory reclaimed so far is {} bytes",
-            memory_reclaimed, sst_with_max_memory->get_filename(), _total_memory_reclaimed);
-    }
+        auto memory_reclaimed = sst_with_max_memory->reclaim_memory_from_components();
+        _total_memory_reclaimed += memory_reclaimed;
+        _total_reclaimable_memory -= memory_reclaimed;
+        _reclaimed.insert(*sst_with_max_memory);
+        // TODO: As of now only bloom filter is reclaimed. Print actual component names when adding support for more components.
+        smlogger.info("Reclaimed {} bytes of memory from components of {}. Total memory reclaimed so far is {} bytes",
+                memory_reclaimed, sst_with_max_memory->get_filename(), _total_memory_reclaimed);
+        }
 }
 
 size_t sstables_manager::get_components_memory_reclaim_threshold() const {

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -192,6 +192,11 @@ future<> sstables_manager::components_reloader_fiber() {
             co_return;
         }
 
+        co_await maybe_reload_components();
+    }
+}
+
+future<> sstables_manager::maybe_reload_components() {
         // Reload bloom filters from the smallest to largest so as to maximize
         // the number of bloom filters being reloaded.
         auto memory_available = get_memory_available_for_reclaimable_components();
@@ -224,7 +229,6 @@ future<> sstables_manager::components_reloader_fiber() {
             _total_memory_reclaimed -= reclaimed_memory;
             memory_available = get_memory_available_for_reclaimable_components();
         }
-    }
 }
 
 void sstables_manager::reclaim_memory_and_stop_tracking_sstable(sstable* sst) {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -108,8 +108,8 @@ private:
     size_t _total_memory_reclaimed{0};
     // Set of sstables from which memory has been reclaimed
     set_type _reclaimed;
-    // Condition variable that gets notified when an sstable is deleted
-    seastar::condition_variable _sstable_deleted_event;
+    // Condition variable that needs to be notified when an sstable is created or deleted
+    seastar::condition_variable _components_memory_change_event;
     future<> _components_reloader_status = make_ready_future<>();
 
     bool _closing = false;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -217,7 +217,7 @@ private:
     // reclaim it from the SSTable that has the most reclaimable memory.
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
     // Fiber to reload reclaimed components back into memory when memory becomes available.
-    future<> components_reloader_fiber();
+    future<> components_reclaim_reload_fiber();
     // Reclaims components from SSTables if total memory usage exceeds the threshold.
     void maybe_reclaim_components();
     // Reloads components from reclaimed SSTables if memory is available.

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -217,7 +217,7 @@ private:
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reclaim_reload_fiber();
     // Reclaims components from SSTables if total memory usage exceeds the threshold.
-    void maybe_reclaim_components();
+    future<> maybe_reclaim_components();
     // Reloads components from reclaimed SSTables if memory is available.
     future<> maybe_reload_components();
     size_t get_components_memory_reclaim_threshold() const;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -212,10 +212,8 @@ private:
     // Allow at most 10% of memory to be filled with such reads.
     size_t max_memory_sstable_metadata_concurrent_reads(size_t available_memory) { return available_memory * 0.1; }
 
-    // Increment the _total_reclaimable_memory with the new SSTable's reclaimable
-    // memory and if the total memory usage exceeds the pre-defined threshold,
-    // reclaim it from the SSTable that has the most reclaimable memory.
-    void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
+    // Increment the _total_reclaimable_memory with the new SSTable's reclaimable memory
+    void increment_total_reclaimable_memory(sstable* sst);
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reclaim_reload_fiber();
     // Reclaims components from SSTables if total memory usage exceeds the threshold.

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -222,7 +222,8 @@ private:
     void maybe_reclaim_components();
     // Reloads components from reclaimed SSTables if memory is available.
     future<> maybe_reload_components();
-    size_t get_memory_available_for_reclaimable_components();
+    size_t get_components_memory_reclaim_threshold() const;
+    size_t get_memory_available_for_reclaimable_components() const;
     // Reclaim memory from the SSTable and remove it from the memory tracking metrics.
     // The method is idempotent and for an sstable that is deleted, it is called both
     // during unlink and during deactivation.

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -218,6 +218,8 @@ private:
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reloader_fiber();
+    // Reloads components from reclaimed SSTables if memory is available.
+    future<> maybe_reload_components();
     size_t get_memory_available_for_reclaimable_components();
     // Reclaim memory from the SSTable and remove it from the memory tracking metrics.
     // The method is idempotent and for an sstable that is deleted, it is called both

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -218,6 +218,8 @@ private:
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable* sst);
     // Fiber to reload reclaimed components back into memory when memory becomes available.
     future<> components_reloader_fiber();
+    // Reclaims components from SSTables if total memory usage exceeds the threshold.
+    void maybe_reclaim_components();
     // Reloads components from reclaimed SSTables if memory is available.
     future<> maybe_reload_components();
     size_t get_memory_available_for_reclaimable_components();

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -53,7 +53,7 @@ public:
     }
 
     void increment_total_reclaimable_memory_and_maybe_reclaim(sstable *sst) {
-        sstables_manager::increment_total_reclaimable_memory_and_maybe_reclaim(sst);
+        sstables_manager::increment_total_reclaimable_memory(sst);
     }
 
     size_t get_total_memory_reclaimed() {


### PR DESCRIPTION
The config variable `components_memory_reclaim_threshold` limits the
memory available to the sstable bloom filters. Any change to its value
is not immediately propagated to the sstable manager, despite it being
a LiveUpdate variable. The updated value takes effect only when a new
sstable is created or deleted.

This PR first refactors the reclaim and reload logic into a single              
background fiber. It then updates the sstable manager to subscribe to           
changes in the `components_memory_reclaim_threshold` configuration value        
and immediately triggers the reclaim/reload fiber when a change is              
detected.

Fixes #21947

This is an improvement and does not need to be backported.