### PR TITLE
s3_client: Fix buffer offset reset on request retry

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -468,6 +468,7 @@ future<temporary_buffer<char>> client::get_object_contiguous(sstring object_name
     co_await make_request(std::move(req), [&off, &ret, &object_name, start = s3_clock::now()] (group_client& gc, const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
         auto in = std::move(in_);
         ret = temporary_buffer<char>(rep.content_length);
+        off = 0;
         s3l.trace("Consume {} bytes for {}", ret->size(), object_name);
         co_await in.consume([&off, &ret] (temporary_buffer<char> buf) mutable {
             if (buf.empty()) {


### PR DESCRIPTION
This patch addresses an issue where the buffer offset becomes incorrect when a request is retried. The new request uses an offset that has already been advanced, causing misalignment. This fix ensures the buffer offset is correctly reset, preventing such errors.

fixes: https://github.com/scylladb/scylladb/issues/22345

No backport needed since we dont have any s3 related activity on the scylla side been released