### PR TITLE
./github/workflows/pr-require-backport-label: fix regex to match source available version

### DIFF
--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -17,6 +17,6 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "backport/none\nbackport/\\d.\\d"
+          labels: "backport/none\nbackport/\\d{4}\\.\\d+\nbackport/\\d+\\.\\d+"
           use_regex: true
           add_comment: false


### PR DESCRIPTION
Until now this action checked if we have a `backport/none` or `backport/x.y` label only, since we moved to the source available and the releases like 2025.1 don't match this regex this action keeps failing

**bug fix due to the source available changes, since this is only relevant for `master` there is no need for backport**

Verified this change with https://github.com/scylladb/scylladb/actions/runs/13186473604/job/36809638024?pr=22734
