### PR TITLE
.github: improve license header check workflow

### DIFF
--- a/.github/workflows/check-license-header.yaml
+++ b/.github/workflows/check-license-header.yaml
@@ -14,6 +14,8 @@ jobs:
   check-license-headers:
     name: Check License Headers
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Checkout code

--- a/.github/workflows/check-license-header.yaml
+++ b/.github/workflows/check-license-header.yaml
@@ -28,6 +28,7 @@ jobs:
           echo "files=$(git diff --name-only --diff-filter=A ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr '\n' ' ')" >> $GITHUB_OUTPUT
 
       - name: Check license headers
+        if: steps.changed-files.outputs.files != ''
         run: |
           .github/scripts/check-license.py \
             --files ${{ steps.changed-files.outputs.files }} \


### PR DESCRIPTION
This patch series contains improvements to our GitHub license header check workflow.
The first patch grants necessary write permissions to the workflow, allowing it to comment directly on pull requests when license header issues are found. This addresses a permissions-related error that previously prevented the workflow from creating comments.
The second patch optimizes the workflow by skipping the license check step when no relevant files have been modified in the pull request. This prevents unnecessary workflow failures that occurred when the check was run without any files to analyze.
Together, these changes make the license header checking process more robust and efficient. The workflow now properly communicates findings through PR comments and avoids running unnecessary checks.

---

no need to backport, as the workflow updated by this change only exists in master.