### PR TITLE
install.sh: simplify check_usermode_support()

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -220,8 +220,7 @@ installconfig() {
 }
 
 check_usermode_support() {
-    user=$(systemctl --help|grep -e '--user')
-    [ -n "$user" ]
+    systemctl --help | grep -q -e '--user'
 }
 
 . /etc/os-release


### PR DESCRIPTION
because we don't care about the exact output of grep, let's silence its output. also, no need to check for the string is empty, so let's just use the status code of the grep for the return value of the function, more idiomatic this way.

---

it's a cleanup, hence no need to backport.