### PR TITLE
raft/group0_state_machine: load current RPC compression dict on startup

### DIFF
--- a/service/raft/group0_state_machine.hh
+++ b/service/raft/group0_state_machine.hh
@@ -106,6 +106,7 @@ class group0_state_machine : public raft_state_machine {
     abort_source _abort_source;
     bool _topology_change_enabled;
     group0_state_id_handler _state_id_handler;
+    gms::feature_service& _feature_service;
     gms::feature::listener_registration _topology_on_raft_support_listener;
 
     modules_to_reload get_modules_to_reload(const std::vector<canonical_mutation>& mutations);

--- a/test/topology_custom/test_rpc_compression.py
+++ b/test/topology_custom/test_rpc_compression.py
@@ -208,10 +208,14 @@ async def test_external_dicts(manager: ManagerClient) -> None:
         assert approximately_equal(compressed, expected_ratio * volume, 0.8)
 
     await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=600)
-
     await live_update_config(manager, servers, "internode_compression_zstd_max_cpu_fraction", "1.0"),
-
     await with_retries(functools.partial(test_once, "zstd", 0.25), timeout=600)
+
+    # Test that the dicts are loaded on startup.
+    await asyncio.gather(*[manager.server_stop_gracefully(s.server_id) for s in servers])
+    await asyncio.gather(*[manager.server_update_config(s.server_id, 'rpc_dict_training_when', 'never') for s in servers])
+    await asyncio.gather(*[manager.server_start(s.server_id) for s in servers])
+    await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=10)
 
 # Similar to test_external_dicts, but simpler.
 @pytest.mark.asyncio


### PR DESCRIPTION
We are supposed to be loading the most recent RPC compression dictionary
on startup, but we forgot to port the relevant piece of logic during
the source-available port. This causes a restarted node not to use the
dictionary for RPC compression until the next dictionary update.

Fix that.

Fixes scylladb/scylladb#22738

This is more of a bugfix than an improvement, so it should be backported to 2025.1.