### PR TITLE
De-duplicate API's table name to table ID conversion

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -664,9 +664,8 @@ rest_get_range_to_endpoint_map(http_context& ctx, sharded<service::storage_servi
                 ensure_tablets_disabled(ctx, keyspace, "storage_service/range_to_endpoint_map");
                 return ks.get_vnode_effective_replication_map();
             } else {
-                validate_table(ctx.db.local(), keyspace, table);
-
-                auto& cf = ctx.db.local().find_column_family(keyspace, table);
+                auto table_id = validate_table(ctx.db.local(), keyspace, table);
+                auto& cf = ctx.db.local().find_column_family(table_id);
                 return cf.get_effective_replication_map();
             }
         });
@@ -1621,8 +1620,7 @@ rest_move_tablet(http_context& ctx, sharded<service::storage_service>& ss, std::
         auto token = dht::token::from_int64(validate_int(req->get_query_param("token")));
         auto ks = req->get_query_param("ks");
         auto table = req->get_query_param("table");
-        validate_table(ctx.db.local(), ks, table);
-        auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
+        auto table_id = validate_table(ctx.db.local(), ks, table);
         auto force_str = req->get_query_param("force");
         auto force = service::loosen_constraints(force_str == "" ? false : validate_bool(force_str));
 
@@ -1692,8 +1690,7 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
         if (!await.empty()) {
             await_completion = validate_bool(await);
         }
-        validate_table(ctx.db.local(), ks, table);
-        auto table_id = ctx.db.local().find_column_family(ks, table).schema()->id();
+        auto table_id = validate_table(ctx.db.local(), ks, table);
         std::variant<utils::chunked_vector<dht::token>, service::storage_service::all_tokens_tag> tokens_variant;
         if (all_tokens) {
             tokens_variant = service::storage_service::all_tokens_tag();

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -83,9 +83,9 @@ sstring validate_keyspace(const http_context& ctx, const http::request& req) {
     return validate_keyspace(ctx, req.get_path_param("keyspace"));
 }
 
-static void validate_table(const replica::database& db, sstring ks_name, sstring table_name) {
+table_id validate_table(const replica::database& db, sstring ks_name, sstring table_name) {
     try {
-        db.find_column_family(ks_name, table_name);
+        return db.find_uuid(ks_name, table_name);
     } catch (replica::no_such_column_family& e) {
         throw bad_param_exception(e.what());
     }

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -43,6 +43,10 @@ sstring validate_keyspace(const http_context& ctx, sstring ks_name);
 // containing the description of the respective keyspace error.
 sstring validate_keyspace(const http_context& ctx, const std::unique_ptr<http::request>& req);
 
+// verify that the keyspace:table is found, otherwise a bad_param_exception exception is thrown
+// returns the table_id of the table if found
+table_id validate_table(const replica::database& db, sstring ks_name, sstring table_name);
+
 // splits a request parameter assumed to hold a comma-separated list of table names
 // verify that the tables are found, otherwise a bad_param_exception exception is thrown
 // containing the description of the respective no_such_column_family error.


### PR DESCRIPTION
This is continuation of #21533 

There are two almost identical helpers in api/ -- validate_table(ks, cf) and get_uuid(ks, cf). Both check if the ks:cf table exists, throwing bad_param_exception if it doesn't. There's slight difference in their usage, namely -- callers of the latter one get the table_id found and make use of it, while the former helper is void and its callers need to re-search for the uuid again if the need (spoiler: they do).

This PR merges two helpers together, so there's less code to maintain. As a nice side effect, the existing validate_table() callers save one re-lookup of the ks:cf pair in database mappings.

Affected endpoints are validated by existing tests:
* column_family/{autocompation|tombstone_gc|compaction_strategy}, validated by the tests described in #21533 
* /storage_service/{range_to_endpoint_map|describe_ring|ownership}, validated by nodetool tests
* /storage_service/tablets/{move|repair}, validated by tablets move and repair tests