### PR TITLE
treewide: improve bash error reporting

### DIFF
--- a/bin/cqlsh
+++ b/bin/cqlsh
@@ -1,7 +1,9 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Copyright (C) 2023-present ScyllaDB
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
 
 here=$(dirname "$0")
 exec "$here/../tools/cqlsh/bin/cqlsh.py" "$@"

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -1,10 +1,12 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2024-present ScyllaDB
 #
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
 
 SCRIPT_PATH=$(dirname $(realpath "$0"))
 

--- a/dist/common/kernel_conf/post_install.sh
+++ b/dist/common/kernel_conf/post_install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 #
 # Copyright (C) 2023-present ScyllaDB
 #
@@ -6,6 +6,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
 
 version_ge() {
     [  "$2" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]

--- a/dist/debuginfo/install.sh
+++ b/dist/debuginfo/install.sh
@@ -9,6 +9,8 @@
 
 set -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if [ -z "$BASH_VERSION" ]; then
     echo "Unsupported shell, please run this script on bash."
     exit 1

--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 product="$(<build/SCYLLA-PRODUCT-FILE)"
 version="$(sed 's/-/~/' <build/SCYLLA-VERSION-FILE)"
 release="$(<build/SCYLLA-RELEASE-FILE)"

--- a/dist/offline_installer/debian/build_offline_installer.sh
+++ b/dist/offline_installer/debian/build_offline_installer.sh
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if [ ! -e dist/offline_installer/debian/build_offline_installer.sh ]; then
     echo "run build_offline_installer.sh in top of scylla dir"
     exit 1

--- a/dist/offline_installer/debian/header
+++ b/dist/offline_installer/debian/header
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 print_usage() {
     echo "scylla_offline_installer.sh -- --skip-setup"
     echo "  --skip-setup skip running scylla_setup"

--- a/dist/offline_installer/redhat/build_offline_installer.sh
+++ b/dist/offline_installer/redhat/build_offline_installer.sh
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if [ ! -e dist/offline_installer/redhat/build_offline_installer.sh ]; then
     echo "run build_offline_installer.sh in top of scylla dir"
     exit 1

--- a/dist/offline_installer/redhat/lib/construct_offline_repo.sh
+++ b/dist/offline_installer/redhat/lib/construct_offline_repo.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 releasever=`rpm -q --provides $(rpm -q --whatprovides "system-release(releasever)") | grep "system-release(releasever)"| uniq |  cut -d ' ' -f 3`
 
 # Can ignore error since we only needed when files exists

--- a/dist/offline_installer/redhat/lib/header
+++ b/dist/offline_installer/redhat/lib/header
@@ -5,6 +5,8 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 print_usage() {
     echo "scylla_offline_installer.sh -- --skip-setup"
     echo "  --skip-setup skip running scylla_setup"

--- a/dist/offline_installer/redhat/lib/install_deps.sh
+++ b/dist/offline_installer/redhat/lib/install_deps.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/bash -e
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
 
 . /etc/os-release
 

--- a/docs/_utils/deploy.sh
+++ b/docs/_utils/deploy.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+set -e
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 # Copy contents
 mkdir gh-pages
 cp -r ./docs/_build/dirhtml/. gh-pages

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -17,6 +17,8 @@
 # under the License.
 #
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 # os-release may be missing in container environment by default.
 if [ -f "/etc/os-release" ]; then
     . /etc/os-release

--- a/pgo/train
+++ b/pgo/train
@@ -1,2 +1,5 @@
 #!/bin/bash -xue
+
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 exec python3 -u "$(dirname "$(realpath "$0")")"/pgo.py train_full "$@"

--- a/reloc/build_deb.sh
+++ b/reloc/build_deb.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 . /etc/os-release
 print_usage() {
     echo "build_deb.sh -target <codename> --dist --rebuild-dep --reloc-pkg build/release/scylla-package.tar.gz"

--- a/reloc/build_rpm.sh
+++ b/reloc/build_rpm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 . /etc/os-release
 print_usage() {
     echo "build_rpm.sh --rebuild-dep --target centos7 --reloc-pkg build/release/scylla-package.tar.gz"

--- a/scripts/open-coredump.sh
+++ b/scripts/open-coredump.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 SCRIPT_NAME=$(basename $0)
 SCYLLA_S3_RELOC_SERVER_DEFAULT_URL=http://backtrace.scylladb.com
 

--- a/scripts/pull_github_pr.sh
+++ b/scripts/pull_github_pr.sh
@@ -9,6 +9,8 @@
 
 set -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 gh_hosts=~/.config/gh/hosts.yml
 jenkins_url="https://jenkins.scylladb.com"
 FORCE=$2

--- a/scripts/refresh-pgo-profiles.sh
+++ b/scripts/refresh-pgo-profiles.sh
@@ -8,6 +8,8 @@
 
 set -eu
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 SCRIPT_PATH="$(realpath "$0")"
 PROJECT_BASE="$(realpath "$(dirname "$0")"/..)"
 WORKING_DIR="$(realpath "$PWD")"

--- a/scripts/refresh-submodules.sh
+++ b/scripts/refresh-submodules.sh
@@ -11,6 +11,8 @@
 
 set -euo pipefail
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 # The following is the default list of submodules to refresh. To only refresh
 # some of them, pass the list of modules to refresh as arguments. For example,
 # "scripts/refresh-submodules.sh seastar tools/java" only refreshes the

--- a/scripts/strip.sh
+++ b/scripts/strip.sh
@@ -2,6 +2,8 @@
 
 set -o pipefail
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 orig="$1"
 stripped="$orig.stripped"
 debuginfo="$orig.debug"

--- a/tools/testing/dist-check/dist-check.sh
+++ b/tools/testing/dist-check/dist-check.sh
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 PROGRAM=$(basename $0)
 
 print_usage() {

--- a/tools/testing/dist-check/docker.io/rockylinux-9.sh
+++ b/tools/testing/dist-check/docker.io/rockylinux-9.sh
@@ -8,6 +8,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 source "$(dirname $0)/util.sh"
 
 echo "Installing Scylla ($MODE) packages on $PRETTY_NAME..."

--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -ue
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 case "${CLANG_BUILD}" in
     "SKIP")
         echo "CLANG_BUILD: ${CLANG_BUILD}"

--- a/tools/toolchain/prepare
+++ b/tools/toolchain/prepare
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if ! command -v buildah > /dev/null; then
     echo install buildah 1.19.3 or later
     exit 1

--- a/unified/build_unified.sh
+++ b/unified/build_unified.sh
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 print_usage() {
     echo "build_unified.sh --build-dir <build_dir>"
     echo "  --build-dir specify build directory (default: build/release)"

--- a/unified/install.sh
+++ b/unified/install.sh
@@ -9,6 +9,8 @@
 
 set -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if [ -z "$BASH_VERSION" ]; then
     echo "Unsupported shell, please run this script on bash."
     exit 1

--- a/unified/uninstall.sh
+++ b/unified/uninstall.sh
@@ -9,6 +9,8 @@
 
 set -e
 
+trap 'echo "error $? in $0 line $LINENO"' ERR
+
 if [ -z "$BASH_VERSION" ]; then
     echo "Unsupported shell, please run this script on bash."
     exit 1


### PR DESCRIPTION
bash error handling and reporting is atrocious. Without -e it will just ignore errors. With -e it will stop on errors, but not report where the error happened (apart from exiting itself with an error code).

Improve that with the `trap ERR` command. Note that this won't be invoked on intentional error exit with `exit 1`.

We apply this on every bash script that contains -e or that it appears trivial to set it in. Non-trivial scripts without -e are left unmodified, since they might intentionally invoke failing scripts.

Small error handling improvement in auxiliary scripts, not worth backporting.