### PR TITLE
replica: database.hh: drop dependency on boost ranges

### DIFF
--- a/node_ops/node_ops_ctl.cc
+++ b/node_ops/node_ops_ctl.cc
@@ -18,6 +18,8 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "idl/node_ops.dist.hh"
 
+#include <boost/range/algorithm/find.hpp>
+
 static logging::logger nlogger("node_ops");
 
 node_ops_ctl::node_ops_ctl(const service::storage_service& ss_, node_ops_cmd cmd, locator::host_id id, gms::inet_address ep, node_ops_id uuid)

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -25,7 +25,6 @@
 #include <unordered_map>
 #include <set>
 #include <boost/functional/hash.hpp>
-#include <boost/range/algorithm/find.hpp>
 #include <optional>
 #include <string.h>
 #include "types/types.hh"
@@ -240,7 +239,7 @@ public:
     // # 8904 - this method is akin to std::set::erase(key_type), not
     // erase(iterator). Should be tolerant against non-existing.
     void erase(const shared_memtable& element) noexcept {
-        auto i = boost::range::find(_memtables, element);
+        auto i = std::ranges::find(_memtables, element);
         if (i != _memtables.end()) {
             _memtables.erase(i);
         }


### PR DESCRIPTION
Reduces dependency load.

Small compile time improvement, no backport needed.