### PR TITLE
build: cmake: remove trailing comma in db/CMakeLists.txt source list

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -38,7 +38,7 @@ target_sources(db
     snapshot/backup_task.cc
     rate_limiter.cc
     per_partition_rate_limit_options.cc
-    row_cache.cc,
+    row_cache.cc
     tablet_options.cc)
 target_include_directories(db
   PUBLIC


### PR DESCRIPTION
In c5668d99, a new source file row_cache.cc was added to the `db` target, but with an extraneous trailing comma. In CMake's target_sources(), source files should be space-separated - any comma is interpreted as part of the filename, causing build failures like:
```
  CMake Error at db/CMakeLists.txt:2 (target_sources):
    Cannot find source file:
      row_cache.cc,
```
Fix the issue by removing the trailing comma.

---

this is a cmake related  change, hence no need to backport.