### PR TITLE
build: fix broken CMake

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -38,7 +38,7 @@ target_sources(db
     snapshot/backup_task.cc
     rate_limiter.cc
     per_partition_rate_limit_options.cc
-    row_cache.cc,
+    row_cache.cc
     tablet_options.cc)
 target_include_directories(db
   PUBLIC


### PR DESCRIPTION
Somehow an unnecessary comma crawled into db/CMakeLists.txt file.

Hopefully no backport needed