### PR TITLE
db: cmake: fix row_cache.cc entry

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -38,7 +38,7 @@ target_sources(db
     snapshot/backup_task.cc
     rate_limiter.cc
     per_partition_rate_limit_options.cc
-    row_cache.cc,
+    row_cache.cc
     tablet_options.cc)
 target_include_directories(db
   PUBLIC


### PR DESCRIPTION
Lists in cmake don't have commas, but row_cache.cc does.

Broken in edd56a2c1cba3cecefa6cf9fbc11f9e68038c39b

The broken commit isn't in any branches, so no backports are needed.