### PR TITLE
ent/encryption: Replace manual string suffix checks with ends_with()

### DIFF
--- a/ent/encryption/symmetric_key.cc
+++ b/ent/encryption/symmetric_key.cc
@@ -94,8 +94,8 @@ encryption::parse_key_spec(const sstring& alg) {
     std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
     std::transform(padd.begin(), padd.end(), padd.begin(), ::tolower);
 
-    static const std::string padding = "padding";
-    if (padd.size() > padding.size() && std::equal(padding.rbegin(), padding.rend(), padd.rbegin())) {
+    static constexpr std::string_view padding = "padding";
+    if (padd.ends_with(padding)) {
         padd.resize(padd.size() - padding.size());
     }
 


### PR DESCRIPTION
Replace manual string suffix comparison (length check + std::equal) with std::string::ends_with() introduced in C++20 for better readability.

---

it's a cleanup, hence no need to backport.