### PR TITLE
.github: Make "make-pr-ready-for-review" workflow run in base repo

### DIFF
--- a/.github/workflows/make-pr-ready-for-review.yaml
+++ b/.github/workflows/make-pr-ready-for-review.yaml
@@ -1,7 +1,7 @@
-name: PR Ready for Review on Label Removal
+name: Mark PR as Ready When Conflicts Label is Removed
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - unlabeled
 
@@ -10,29 +10,13 @@ env:
 
 jobs:
   mark-ready:
+    if: github.event.label.name == 'conflicts'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
 
     steps:
-      - name: Check if specific label was removed
-        id: check-label
-        run: |
-          if [[ "${{ github.event.label.name }}" == "conflicts" ]]; then
-            echo "The removed label is conflicts."
-            echo "removed_conflicts=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: ${{ github.repository }}
-          ref: ${{ env.DEFAULT_BRANCH }}
-          token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
-          fetch-depth: 1
-
       - name: Mark pull request as ready for review
-        if: steps.check-label.outputs.removed_conflicts == 'true'
         run:  gh pr ready "${{ github.event.pull_request.number }}"
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}


### PR DESCRIPTION
The "make-pr-ready-for-review" workflow was failing with an "Input required and not supplied: token" error.  This was due to GitHub Actions security restrictions preventing access to the token when the workflow is triggered in a fork:
```
    Error: Input required and not supplied: token
```

This commit addresses the issue by:

- Running the workflow in the base repository instead of the fork. This grants the workflow access to the required token with write permissions.
- Simplifying the workflow by using a job-level `if` condition to controlexecution, as recommended in the GitHub Actions documentation (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution). This is cleaner than conditional steps.
- Removing the repository checkout step, as the source code is not required for this workflow.

This change resolves the token error and ensures the "make-pr-ready-for-review" workflow functions correctly.

Fixes scylladb/scylladb#22765

---

this is a fix for improving a relatively new workflow which only exists in master, hence no need to backport.