### PR TITLE
test/cqlpy,alternator: "--release" should not require AWS credentials

### DIFF
--- a/test/cqlpy/fetch_scylla.py
+++ b/test/cqlpy/fetch_scylla.py
@@ -16,6 +16,7 @@
 #   * 2023.1 (latest in this branch, Enterprise release)
 
 import boto3
+import botocore
 import sys
 import os
 import subprocess
@@ -81,7 +82,11 @@ def download_scylla(release, dir):
     # This prefix has many different packages belonging to all releases in
     # the same major version. We need to look only for those matching the
     # minor version, and take the highest minor number.
-    s3 = boto3.resource('s3')
+
+    # We set region_name and use unsigned (anonymous) requests to avoid
+    # the need of the user to have to set up a valid $HOME/.aws/config
+    # or $HOME/.aws/credentails.
+    s3 = boto3.resource('s3', region_name='us-east-1', config=botocore.client.Config(signature_version=botocore.UNSIGNED))
     bucket = s3.Bucket(bucket)
     matches = bucket.objects.filter(Prefix=prefix)
     candidates = [o.key.removeprefix(prefix) for o in matches if scylla_arch_string in o.key]


### PR DESCRIPTION
The script fetch_scylla.py is used by the "--release" option of test/cqlpy/run and test/alternator/run to fetch a given release of Scylla. The release is fetched from S3, and the script assumed that the user properly set up $HOME/.aws/config and $HOME/.aws/credentials to determine the source of that download and the credentials to do this.

But this is unnecessary - Scylla's "downloads.scylladb.com" bucket actually allows **anonymous** downloads, and this is what we should use.

After this patch, fetch_scylla.py (and the "--release" option of the run scripts) work correctly even for a user that doesn't have $HOME/.aws set up at all.

This fix is especially important to new developers, who might not even have AWS credentials to put into these files.

This patch is a convenience feature for tests developers who would be running tests on the master branch anyway, so no need to backport.