### PR TITLE
test/cqlpy, alternator: allow downloading 2025 releases

### DIFF
--- a/test/cqlpy/fetch_scylla.py
+++ b/test/cqlpy/fetch_scylla.py
@@ -65,7 +65,9 @@ def download_scylla(release, dir):
     major = f'{v[0]}.{v[1]}'
     bucket = f'downloads.scylladb.com'
     scylla_arch_string = '.' + scylla_arch + '.'
-    if int(v[0]) >= 2023: # Enterprise release (new organization)
+    if int(v[0]) >= 2025: # New single release stream (no separate Enterprise)
+        prefix = f'downloads/scylla/relocatable/scylladb-{major}/scylla-{release}'
+    elif int(v[0]) >= 2023: # Enterprise release (new organization)
         prefix = f'downloads/scylla-enterprise/relocatable/scylladb-{major}/scylla-enterprise-{release}'
     elif int(v[0]) > 2000: # Enterprise release (old organization)
         prefix = f'downloads/scylla-enterprise/relocatable/scylladb-{major}/scylla-enterprise-{scylla_arch}-package-{release}'


### PR DESCRIPTION
This patch adds to the fetch_scylla.py script, used by the "--release" option of test/{cqlpy,alternator}/run, the ability to download the new 2025.1 releases.

In the new single-stream releases, the number looks like the old Scylla Enterprise releases, but the location of the artifacts in the S3 bucket look like the old open-source releases (without the word "-enterprise" in the paths). So this patch introduces a new "if" for the (major >= 2025) case.

No need to backport - this is only a convenience for developers who would be running tests on the master branch only.