### PR TITLE
service: raft: drop unused dependency from group0_state_machine_merger.hh

### DIFF
--- a/service/raft/group0_state_machine_merger.hh
+++ b/service/raft/group0_state_machine_merger.hh
@@ -11,8 +11,6 @@
 #include "service/raft/group0_state_machine.hh"
 #include "service/storage_proxy.hh"
 
-#include <boost/range/algorithm/transform.hpp>
-
 namespace service {
 
 /**


### PR DESCRIPTION

Reduces dependency load.

Tiny build-time improvement, no backport needed.