### PR TITLE
service: topology coordinator: demote log message about refreshing stats

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2936,7 +2936,7 @@ future<locator::load_stats> topology_coordinator::refresh_tablet_load_stats() {
 
     for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
         locator::load_stats dc_stats;
-        rtlogger.info("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
+        rtlogger.debug("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
             auto dst = node.get().host_id();
 


### PR DESCRIPTION
This repeats every minute and isn't very interesting. Demote to debug to reduce log clutter.

Small UX improvement, doesn't merit a backport.