### PR TITLE
tree: migrate from boost::remove_if() to the standard library based alternatives

### DIFF
--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -11,8 +11,6 @@
 #include "compaction_strategy_state.hh"
 #include <algorithm>
 
-#include <boost/range/algorithm/remove_if.hpp>
-
 namespace sstables {
 
 leveled_compaction_strategy_state& leveled_compaction_strategy::get_state(table_state& table_s) const {
@@ -50,10 +48,9 @@ compaction_descriptor leveled_compaction_strategy::get_sstables_for_compaction(t
     for (auto level = int(manifest.get_level_count()); level >= 0; level--) {
         auto& sstables = manifest.get_level(level);
         // filter out sstables which droppable tombstone ratio isn't greater than the defined threshold.
-        auto e = boost::range::remove_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
+        std::erase_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
             return !worth_dropping_tombstones(sst, compaction_time, table_s);
         });
-        sstables.erase(e, sstables.end());
         if (sstables.empty()) {
             continue;
         }

--- a/compaction/size_tiered_compaction_strategy.cc
+++ b/compaction/size_tiered_compaction_strategy.cc
@@ -11,8 +11,6 @@
 #include "size_tiered_compaction_strategy.hh"
 #include "cql3/statements/property_definitions.hh"
 
-#include <boost/range/algorithm.hpp>
-
 namespace sstables {
 
 static long validate_sstable_size(const std::map<sstring, sstring>& options) {
@@ -242,10 +240,9 @@ size_tiered_compaction_strategy::get_sstables_for_compaction(table_state& table_
     // tombstone purge, i.e. less likely to shadow even older data.
     for (auto&& sstables : buckets | std::views::reverse) {
         // filter out sstables which droppable tombstone ratio isn't greater than the defined threshold.
-        auto e = boost::range::remove_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
+        std::erase_if(sstables, [this, compaction_time, &table_s] (const sstables::shared_sstable& sst) -> bool {
             return !worth_dropping_tombstones(sst, compaction_time, table_s);
         });
-        sstables.erase(e, sstables.end());
         if (sstables.empty()) {
             continue;
         }

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -14,7 +14,6 @@
 #include "compaction_strategy_state.hh"
 
 #include <boost/range/algorithm/find.hpp>
-#include <boost/range/algorithm/remove_if.hpp>
 
 #include <ranges>
 
@@ -399,10 +398,9 @@ time_window_compaction_strategy::get_next_non_expired_sstables(table_state& tabl
 
     // if there is no sstable to compact in standard way, try compacting single sstable whose droppable tombstone
     // ratio is greater than threshold.
-    auto e = boost::range::remove_if(non_expiring_sstables, [this, compaction_time, &table_s] (const shared_sstable& sst) -> bool {
+    std::erase_if(non_expiring_sstables, [this, compaction_time, &table_s] (const shared_sstable& sst) -> bool {
         return !worth_dropping_tombstones(sst, compaction_time, table_s);
     });
-    non_expiring_sstables.erase(e, non_expiring_sstables.end());
     if (non_expiring_sstables.empty()) {
         return {};
     }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -10,7 +10,6 @@
 #include "locator/tablet_replication_strategy.hh"
 #include "utils/class_registrator.hh"
 #include "exceptions/exceptions.hh"
-#include <boost/range/algorithm/remove_if.hpp>
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -53,7 +53,6 @@
 #include "replica/global_table_ptr.hh"
 #include "locator/tablets.hh"
 
-#include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm.hpp>
 #include <boost/range/numeric.hpp>
 #include "utils/error_injection.hh"
@@ -1970,10 +1969,9 @@ compaction_group::update_sstable_sets_on_compaction_completion(sstables::compact
     // or they could stay forever in the set, resulting in deleted files remaining
     // opened and disk space not being released until shutdown.
     auto undo_compacted_but_not_deleted = defer([&] {
-        auto e = boost::range::remove_if(sstables_compacted_but_not_deleted, [&] (sstables::shared_sstable sst) {
+        std::erase_if(sstables_compacted_but_not_deleted, [&] (sstables::shared_sstable sst) {
             return s.contains(sst);
         });
-        sstables_compacted_but_not_deleted.erase(e, sstables_compacted_but_not_deleted.end());
         _t.rebuild_statistics();
     });
 

--- a/service/mapreduce_service.cc
+++ b/service/mapreduce_service.cc
@@ -8,7 +8,6 @@
 
 #include "service/mapreduce_service.hh"
 
-#include <boost/range/algorithm/remove_if.hpp>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -197,8 +196,8 @@ static const dht::token& end_token(const dht::partition_range& r) {
 }
 
 static void retain_local_endpoints(const locator::topology& topo, host_id_vector_replica_set& eps) {
-    auto itend = boost::range::remove_if(eps, std::not_fn(topo.get_local_dc_filter()));
-    eps.erase(itend, eps.end());
+    auto [b, e] = std::ranges::remove_if(eps, std::not_fn(topo.get_local_dc_filter()));
+    eps.erase(b, e);
 }
 
 // Given an initial partition range vector, iterate through ranges owned by

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -12,8 +12,6 @@
 #include <seastar/util/defer.hh>
 
 #include <boost/icl/interval_map.hpp>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/remove_if.hpp>
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/numeric.hpp>
 
@@ -890,7 +888,7 @@ make_sstable_filter(const dht::ring_position& pos, const schema& schema, const s
 static std::vector<shared_sstable>
 filter_sstable_for_reader(std::vector<shared_sstable>&& sstables, const schema& schema, const dht::ring_position& pos, const sstable_predicate& predicate) {
     auto filter = [_filter = make_sstable_filter(pos, schema, predicate)] (const shared_sstable& sst) { return !_filter(*sst); };
-    sstables.erase(boost::remove_if(sstables, filter), sstables.end());
+    std::erase_if(sstables, filter);
     return std::move(sstables);
 }
 


### PR DESCRIPTION
Replace boost::remove_if() with the standard library's std::erase_if() or std::ranges::remove_if() to reduce external dependencies and simplify the codebase. This change eliminates the requirement for boost::range and makes the implementation more maintainable.

---

it's a cleanup, hence no need to backport.