### PR TITLE
sstables, test:  migrate from boost::copy() to std::ranges::copy()

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -12,9 +12,7 @@
 #include <seastar/util/defer.hh>
 
 #include <boost/icl/interval_map.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/remove_if.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/range/numeric.hpp>
 
 #include "sstables.hh"
@@ -325,12 +323,9 @@ std::unique_ptr<sstable_set_impl> partitioned_sstable_set::clone() const {
 }
 
 std::vector<shared_sstable> partitioned_sstable_set::select(const dht::partition_range& range) const {
-    auto ipair = query(range);
-    auto b = std::move(ipair.first);
-    auto e = std::move(ipair.second);
     value_set result;
-    while (b != e) {
-        boost::copy(b++->second, std::inserter(result, result.end()));
+    for (auto [b, e] = query(range); b != e; ++b) {
+        std::ranges::copy(b->second, std::inserter(result, result.end()));
     }
     auto r = _unleveled_sstables;
     r.insert(r.end(), result.begin(), result.end());

--- a/test/boost/schema_change_test.cc
+++ b/test/boost/schema_change_test.cc
@@ -14,8 +14,6 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/util/defer.hh>
 
-#include <boost/range/algorithm/copy.hpp>
-
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
 #include "service/migration_manager.hh"
@@ -514,7 +512,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
                 auto group0_guard = mm.start_group0_operation().get();
                 const auto ts = group0_guard.write_timestamp();
                 auto muts = service::prepare_keyspace_drop_announcement(e.local_db(), "ks", ts).get();
-                boost::copy(muts, std::back_inserter(all_muts));
+                std::ranges::copy(muts, std::back_inserter(all_muts));
                 mm.announce(muts, std::move(group0_guard), "").get();
             }
 
@@ -524,7 +522,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
 
                 // all_muts contains keyspace drop.
                 auto muts = service::prepare_new_keyspace_announcement(e.db().local(), keyspace, ts);
-                boost::copy(muts, std::back_inserter(all_muts));
+                std::ranges::copy(muts, std::back_inserter(all_muts));
                 mm.announce(muts, std::move(group0_guard), "").get();
             }
 
@@ -533,7 +531,7 @@ SEASTAR_TEST_CASE(test_merging_creates_a_table_even_if_keyspace_was_recreated) {
                 const auto ts = group0_guard.write_timestamp();
 
                 auto muts = service::prepare_new_column_family_announcement(mm.get_storage_proxy(), s0, ts).get();
-                boost::copy(muts, std::back_inserter(all_muts));
+                std::ranges::copy(muts, std::back_inserter(all_muts));
 
                 mm.announce(all_muts, std::move(group0_guard), "").get();
             }


### PR DESCRIPTION
Replace boost::copy() with the standard library's std::ranges::copy() to reduce external dependencies and simplify the codebase. This change eliminates the requirement for boost::range and makes the implementation more maintainable.

---

it's a cleanup, hence no need to backport.