### PR TITLE
sstable_loader: fix cross-shard resource cleanup in download_task_impl 

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -15,6 +15,7 @@
 #include "sstables/sstables_manager.hh"
 #include <memory>
 #include <fmt/ranges.h>
+#include <seastar/core/future.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/switch_to.hh>
@@ -503,7 +504,7 @@ public:
 
     virtual ~sstables_task_executor() = default;
 
-    virtual void release_resources() noexcept override;
+    virtual future<> release_resources() noexcept override;
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         return compaction_task_impl::get_progress(_compaction_data, _progress_monitor);
@@ -788,9 +789,10 @@ compaction::compaction_state::~compaction_state() {
     compaction_done.broken();
 }
 
-void sstables_task_executor::release_resources() noexcept {
+future<> sstables_task_executor::release_resources() noexcept {
     _cm._stats.pending_tasks -= _sstables.size() - (_state == state::pending);
     _sstables = {};
+    return make_ready_future();
 }
 
 future<compaction_manager::compaction_stats_opt> compaction_task_executor::run_compaction() noexcept {
@@ -1565,10 +1567,10 @@ public:
         , _can_purge(can_purge)
     {}
 
-    virtual void release_resources() noexcept override {
+    virtual future<> release_resources() noexcept override {
         _compacting.release_all();
         _owned_ranges_ptr = nullptr;
-        sstables_task_executor::release_resources();
+        co_await sstables_task_executor::release_resources();
     }
 
 protected:
@@ -1846,11 +1848,12 @@ public:
 
     virtual ~cleanup_sstables_compaction_task_executor() = default;
 
-    virtual void release_resources() noexcept override {
+    virtual future<> release_resources() noexcept override {
         _cm._stats.pending_tasks -= _pending_cleanup_jobs.size();
         _pending_cleanup_jobs = {};
         _compacting.release_all();
         _owned_ranges_ptr = nullptr;
+        return make_ready_future();
     }
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1021,7 +1021,7 @@ private:
     }
 };
 
-void repair::shard_repair_task_impl::release_resources() noexcept {
+future<> repair::shard_repair_task_impl::release_resources() noexcept {
     erm = {};
     cfs = {};
     data_centers = {};
@@ -1030,6 +1030,7 @@ void repair::shard_repair_task_impl::release_resources() noexcept {
     neighbors = {};
     dropped_tables = {};
     nodes_down = {};
+    return make_ready_future();
 }
 
 future<> repair::shard_repair_task_impl::do_repair_ranges() {
@@ -2482,10 +2483,11 @@ tasks::is_user_task repair::tablet_repair_task_impl::is_user_task() const noexce
     return tasks::is_user_task::yes;
 }
 
-void repair::tablet_repair_task_impl::release_resources() noexcept {
+future<> repair::tablet_repair_task_impl::release_resources() noexcept {
     _metas_size = _metas.size();
     _metas = {};
     _tables = {};
+    return make_ready_future();
 }
 
 size_t repair::tablet_repair_task_impl::get_metas_size() const noexcept {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -133,7 +133,7 @@ public:
     gc_clock::time_point get_flush_time() const { return _flush_time; }
 
     tasks::is_user_task is_user_task() const noexcept override;
-    virtual void release_resources() noexcept override;
+    virtual future<> release_resources() noexcept override;
 private:
     size_t get_metas_size() const noexcept;
 protected:
@@ -220,7 +220,7 @@ public:
 
     size_t ranges_size() const noexcept;
 
-    virtual void release_resources() noexcept override;
+    virtual future<> release_resources() noexcept override;
 protected:
     future<> do_repair_ranges();
     virtual future<tasks::task_manager::task::progress> get_progress() const override;

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -34,7 +34,11 @@ struct stream_progress {
     float completed = 0.;
 
     virtual ~stream_progress() = default;
-
+    stream_progress& operator+=(const stream_progress& p) {
+        total += p.total;
+        completed += p.completed;
+        return *this;
+    }
     void start(float amount) {
         assert(amount >= 0);
         total = amount;

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -254,7 +254,7 @@ future<> task_manager::task::impl::finish() noexcept {
         _status.state = task_manager::task_state::done;
         co_await maybe_fold_into_parent();
         _done.set_value();
-        release_resources();
+        co_await release_resources();
     }
 }
 
@@ -265,7 +265,7 @@ future<> task_manager::task::impl::finish_failed(std::exception_ptr ex, std::str
         _status.error = std::move(error);
         co_await maybe_fold_into_parent();
         _done.set_exception(ex);
-        release_resources();
+        co_await release_resources();
     }
 }
 

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -213,7 +213,9 @@ public:
             virtual void abort() noexcept;
             bool is_complete() const noexcept;
             bool is_done() const noexcept;
-            virtual void release_resources() noexcept {}
+            virtual future<> release_resources() noexcept {
+                return make_ready_future();
+            }
             future<std::vector<task_essentials>> get_failed_children() const;
             void set_virtual_parent() noexcept;
         protected:


### PR DESCRIPTION
This PR addresses two related issues in our task system:

1. Prepares for asynchronous resource cleanup by converting release_resources() to a coroutine. This refactoring enables future improvements in how we handle resource cleanup.

2. Fixes a cross-shard resource cleanup issue in the SSTable loader where destruction of per-shard progress elements could trigger "shared_ptr accessed on non-owner cpu" errors in multi-shard environments. The fix uses coroutines to ensure resources are released on their owner shards.

Fixes #22759

---

this change addresses a regression introduced by d815d7013cb7c74dfb265f3fe920a3c5b2226646, which is contained by 2025.1 and master branches. so it should be backported to 2025.1 branch.