### PR TITLE
topology_coordinator: handle_table_migration: do not continue after executing metadata barrier

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1547,6 +1547,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             guard = co_await global_tablet_token_metadata_barrier(std::move(guard));
             barrier.set_value();
             fail_barrier.cancel();
+            co_return;
         }
 
         if (has_updates) {


### PR DESCRIPTION
Return after executing the global metadata barrier to allow the topology handler to handle any transitions that might have started by a concurrect transaction.

Fixes #22792

Requires backport to 6.1, 6.2 and 2025.1 as it fixes a bug related to topology transaction atomicity.