### PR TITLE
[backport 2025.1] test: Use linux-aio backend again on seastar-based tests

### DIFF
--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -1,4 +1,6 @@
 type: boost
+extra_scylla_cmdline_options:
+    - '--reactor-backend linux-aio'
 # A list of long tests, which should be started early
 run_first:
     - index_with_paging_test

--- a/test/raft/suite.yaml
+++ b/test/raft/suite.yaml
@@ -1,1 +1,3 @@
 type: boost
+extra_scylla_cmdline_options:
+  - '--reactor-backend linux-aio'


### PR DESCRIPTION
Since mid December, tests started failing with ENOMEM while submitting I/O requests.

Logs of failed tests show IO uring was used as backend, but we never deliberately switched to IO uring. Investigation pointed to it happening accidentaly in commit 1bac6b75dcf3a85c9d3, which turned on IO uring for allowing native tool in production, and picked linux-aio backend explicitly when initializing Scylla. But it missed that seastar-based tests would pick the default backend, which is io_uring once enabled.

There's a reason we never made io_uring the default, which is that it's not stable enough, and turns out we made the right choice back then and it apparently continue to be unstable causing flakiness in the tests.

Let's undo that accidental change in tests by explicitly picking the linux-aio backend for seastar-based tests. This should hopefully bring back stability.

Refs #21968.



Closes scylladb/scylladb#22695

(cherry picked from commit ce651643150867ec2d1c80f3a37d2126acdcd93b)
