### PR TITLE
docs: add warning for docs.scylladb.com/manual

### DIFF
--- a/docs/_templates/version-warning.html
+++ b/docs/_templates/version-warning.html
@@ -1,0 +1,23 @@
+{% if flag == "manual" and current_version == latest_version %}
+<div class="admonition note">
+    <p class="admonition-title">Note</p>
+    <p>
+        We're updating our <a href="https://www.scylladb.com/2024/12/18/why-were-moving-to-a-source-available-license/" target="_blank">license and versioning policy</a>. 
+        The documentation for <b>ScyllaDB Enterprise 2024.2 or earlier</b> can be found <a href="https://enterprise.docs.scylladb.com/branch-2024.2/">here</a>.
+    </p>
+</div>
+{% elif versions and current_version and latest_version and current_version != latest_version %}
+    <div class="admonition caution">
+        <p class="admonition-title">Caution</p>
+        <p>
+            {% if current_version.name in theme_versions_unstable %}
+                You're viewing documentation for an unstable version of {{ project }}.
+            {% elif current_version.name in theme_versions_deprecated %}
+                You're viewing documentation for a deprecated version of {{ project }}.
+            {% else %}
+                You're viewing documentation for a previous version of {{ project }}.
+            {% endif %}
+            <a href="{{ vpathto(latest_version.name) }}">Switch to the latest stable version.</a>
+        </p>
+    </div>
+{% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,7 +196,7 @@ htmlhelp_basename = "ScyllaDocumentationdoc"
 html_baseurl = BASE_URL
 
 # Dictionary of values to pass into the template engine’s context for all pages
-html_context = {"html_baseurl": html_baseurl}
+html_context = {"html_baseurl": html_baseurl, "flag": FLAG}
 
 def setup(app):
     if 'opensource' in app.tags:


### PR DESCRIPTION
## Motivation

Adds a note at the top of each page in the docs published on `docs.scylladb.com/manual`, guiding users to the enterprise docs while they are supported.

## How to test

1. Build the docs with `make preview`.
2. Check the note renders.

Note: The note will not appear on opensource.docs.scylladb.com.