### PR TITLE
encryption_at_rest_test/encryption: Add some verbosity etc to help diagnose test run issues

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -930,107 +930,108 @@ future<seastar::shared_ptr<encryption_context>> register_extensions(const db::co
         return encryption_schema_extension::parse(*ctxt, std::move(v));
     });
     exts.add_sstable_file_io_extension(encryption_attribute, std::make_unique<encryption_file_io_extension>(ctxt));
-    
-    auto maybe_get_options = [&](const utils::config_file::string_map& map, const sstring& what) -> std::optional<options> {
-        options opts(map.begin(), map.end());
-        opt_wrapper get_opt(opts);
-        if (!::strcasecmp(get_opt("enabled").value_or("false").c_str(), "false")) {
-            return std::nullopt;
-        }
-        // commitlog/system table encryption/global user encryption should not use replicated keys,
-        // We default to local keys, but KMIP/KMS is ok as well (better in fact).
-        opts[KEY_PROVIDER] = get_opt(KEY_PROVIDER).value_or(LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY);
-        if (opts[KEY_PROVIDER] == LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY && !get_opt(SECRET_KEY_FILE)) {
-            // system encryption uses different key folder than user tables.
-            // explicitly set the key file path
-            opts[SECRET_KEY_FILE] = (bfs::path(cfg.system_key_directory()) / bfs::path("system") / bfs::path(get_opt("key_name").value_or("system_table_keytab"))).string();
-        }
-        // forbid replicated. we cannot guarantee being able to open sstables on populate
-        if (opts[KEY_PROVIDER] == REPLICATED_KEY_PROVIDER_FACTORY) {
-            throw std::invalid_argument("Replicated provider is not allowed for " + what);
-        }
-        return opts;
-    };
+    std::exception_ptr p;
+    try {
+        auto maybe_get_options = [&](const utils::config_file::string_map& map, const sstring& what) -> std::optional<options> {
+            options opts(map.begin(), map.end());
+            opt_wrapper get_opt(opts);
+            if (!::strcasecmp(get_opt("enabled").value_or("false").c_str(), "false")) {
+                return std::nullopt;
+            }
+            // commitlog/system table encryption/global user encryption should not use replicated keys,
+            // We default to local keys, but KMIP/KMS is ok as well (better in fact).
+            opts[KEY_PROVIDER] = get_opt(KEY_PROVIDER).value_or(LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY);
+            if (opts[KEY_PROVIDER] == LOCAL_FILE_SYSTEM_KEY_PROVIDER_FACTORY && !get_opt(SECRET_KEY_FILE)) {
+                // system encryption uses different key folder than user tables.
+                // explicitly set the key file path
+                opts[SECRET_KEY_FILE] = (bfs::path(cfg.system_key_directory()) / bfs::path("system") / bfs::path(get_opt("key_name").value_or("system_table_keytab"))).string();
+            }
+            // forbid replicated. we cannot guarantee being able to open sstables on populate
+            if (opts[KEY_PROVIDER] == REPLICATED_KEY_PROVIDER_FACTORY) {
+                throw std::invalid_argument("Replicated provider is not allowed for " + what);
+            }
+            return opts;
+        };
 
-    future<> f = make_ready_future<>();
+        auto opts = maybe_get_options(cfg.system_info_encryption(), "system table encryption");
 
-    auto opts = maybe_get_options(cfg.system_info_encryption(), "system table encryption");
-    
-    if (opts) {
-        logg.info("Adding system info encryption using {}", *opts);
+        if (opts) {
+            logg.info("Adding system info encryption using {}", *opts);
 
-        exts.add_commitlog_file_extension(encryption_attribute, std::make_unique<encryption_commitlog_file_extension>(ctxt, *opts));
+            exts.add_commitlog_file_extension(encryption_attribute, std::make_unique<encryption_commitlog_file_extension>(ctxt, *opts));
 
-        // modify schemas for tables holding sensitive data to use encryption w. key described
-        // by the opts.
-        // since schemas are duplicated across shards, we must call to each shard and augment
-        // them all.
-        // Since we are in pre-init phase, this should be safe.
-        f = f.then([opts = *opts, &exts] {
-            return smp::invoke_on_all([opts = make_lw_shared<options>(opts), &exts] () mutable {
+            // modify schemas for tables holding sensitive data to use encryption w. key described
+            // by the opts.
+            // since schemas are duplicated across shards, we must call to each shard and augment
+            // them all.
+            // Since we are in pre-init phase, this should be safe.
+            co_await smp::invoke_on_all([&opts, &exts] () mutable {
                 auto& f = exts.schema_extensions().at(encryption_attribute);
                 for (auto& s : { db::system_keyspace::paxos(), db::system_keyspace::batchlog(), db::system_keyspace::dicts() }) {
                     exts.add_extension_to_schema(s, encryption_attribute, f(*opts));
                 }
             });
-        });
-    }
+        }
 
-    if (cfg.config_encryption_active()) {
-        f = f.then([&cfg, ctxt] {
-           return ctxt->load_config_encryption_key(cfg.config_encryption_key_name());
-        });
-    }
+        if (cfg.config_encryption_active()) {
+            co_await ctxt->load_config_encryption_key(cfg.config_encryption_key_name());
+        }
 
 
-    if (!cfg.kmip_hosts().empty()) {
-        // only pre-create on shard 0.
-        f = f.then([&cfg, ctxt] {
-            return parallel_for_each(cfg.kmip_hosts(), [ctxt](auto& p) {
+        if (!cfg.kmip_hosts().empty()) {
+            // only pre-create on shard 0.
+            co_await parallel_for_each(cfg.kmip_hosts(), [ctxt](auto& p) {
                 auto host = ctxt->get_kmip_host(p.first);
                 return host->connect();
             });
-        });
-    }
+        }
 
-    if (!cfg.kms_hosts().empty()) {
-        // only pre-create on shard 0.
-        f = f.then([&cfg, ctxt] {
-            return parallel_for_each(cfg.kms_hosts(), [ctxt](auto& p) {
+        if (!cfg.kms_hosts().empty()) {
+            // only pre-create on shard 0.
+            co_await parallel_for_each(cfg.kms_hosts(), [ctxt](auto& p) {
                 auto host = ctxt->get_kms_host(p.first);
                 return host->init();
             });
-        });
-    }
+        }
 
-    if (!cfg.gcp_hosts().empty()) {
-        // only pre-create on shard 0.
-        f = f.then([&cfg, ctxt] {
-            return parallel_for_each(cfg.gcp_hosts(), [ctxt](auto& p) {
+        if (!cfg.gcp_hosts().empty()) {
+            // only pre-create on shard 0.
+            co_await parallel_for_each(cfg.gcp_hosts(), [ctxt](auto& p) {
                 auto host = ctxt->get_gcp_host(p.first);
                 return host->init();
             });
-        });
-    }
+        }
 
-    replicated_key_provider_factory::init(exts);
+        replicated_key_provider_factory::init(exts);
 
-    auto user_opts = maybe_get_options(cfg.user_info_encryption(), "user table encryption");
-    
-    if (user_opts) {
-        logg.info("Adding user info encryption using {}", *user_opts);
+        auto user_opts = maybe_get_options(cfg.user_info_encryption(), "user table encryption");
 
-        f = f.then([user_opts = *user_opts, ctxt] {
-            return smp::invoke_on_all([user_opts = make_lw_shared<options>(user_opts), ctxt]()  {
+        if (user_opts) {
+            logg.info("Adding user info encryption using {}", *user_opts);
+            co_await smp::invoke_on_all([&user_opts, ctxt]()  {
                 auto ext = encryption_schema_extension::create(*ctxt, *user_opts);
                 ctxt->add_global_user_encryption(std::move(ext));
             });
-        });
+        }
+
+        co_return ctxt;
+    } catch (...) {
+        p = std::current_exception();
     }
 
-    return f.then([ctxt]() -> ::shared_ptr<encryption_context> {
-        return ctxt;
-    });
+    /**
+     * This only really affects tests, but in the case where we
+     * have a bad config/env vars (hint minio), we could fail even
+     * setting up the context. In a "normal" run, this is ok. We will
+     * report the exception, and the do a exit(1).
+     * In tests however, we don't and active context will instead be
+     * freed quite proper, in which case we need to call stop to ensure
+     * we don't crash on shared pointer destruction on wrong shard.
+     * Doing so will hide the real issue from whomever runs the test.
+     */
+    assert(p);
+    co_await ctxt->stop();
+    std::rethrow_exception(p);
 }
 
 }

--- a/ent/encryption/encryption_exceptions.hh
+++ b/ent/encryption/encryption_exceptions.hh
@@ -27,15 +27,15 @@ public:
     using mybase::mybase;
 };
 
-class service_error : public base_error {
-public:
-    using base_error::base_error;
-};
-
-class missing_resource_error : public db::extension_storage_resource_unavailable {
+class service_error : public db::extension_storage_resource_unavailable {
 public:
     using mybase = db::extension_storage_resource_unavailable;
     using mybase::mybase;
+};
+
+class missing_resource_error : public service_error {
+public:
+    using service_error::service_error;
 };
 
 // #4970 - not 100% correct, but network errors are 

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -295,6 +295,8 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::gcp_host::i
         throw;
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_or_create_key: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_or_create_key: {}", std::current_exception())));
     }
@@ -318,6 +320,8 @@ future<shared_ptr<encryption::symmetric_key>> encryption::gcp_host::impl::get_ke
         throw;
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_key_by_id: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -431,6 +431,8 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::kms_host::i
         throw;
     } catch (std::system_error& e) {
         std::throw_with_nested(network_error(e.what()));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }
@@ -455,6 +457,8 @@ future<shared_ptr<encryption::symmetric_key>> encryption::kms_host::impl::get_ke
         std::throw_with_nested(network_error(e.what()));
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_key_by_id: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -29,6 +29,7 @@
 #include "test/lib/random_utils.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
+#include "test/lib/log.hh"
 #include "db/config.hh"
 #include "db/extensions.hh"
 #include "db/commitlog/commitlog.hh"
@@ -63,6 +64,7 @@ struct test_provider_args {
 static void do_create_and_insert(cql_test_env& env, const test_provider_args& args, const std::string& pk, const std::string& v) {
     for (auto i = 0u; i < args.n_tables; ++i) {
         if (args.before_create_table) {
+            testlog.debug("Calling before create table");
             args.before_create_table(env);
         }
         if (args.options.empty()) {
@@ -72,11 +74,13 @@ static void do_create_and_insert(cql_test_env& env, const test_provider_args& ar
         }
 
         if (args.after_create_table) {
+            testlog.debug("Calling after create table");
             args.after_create_table(env);
         }
         try {
             env.execute_cql(fmt::format("insert into ks.t{} (pk, v) values ('{}', '{}')", i, pk, v)).get();
         } catch (...) {
+            testlog.info("Insert error {}. Notifying.", std::current_exception());
             args.on_insert_exception(env);
             throw;
         }
@@ -439,15 +443,15 @@ class fake_proxy {
     bool _do_proxy = true;
     future<> _f;
 
-    future<> run(std::string s) {
+    future<> run(std::string dst_addr) {
         uint16_t port = 443u;
-        auto i = s.find_last_of(':');
-        if (i != std::string::npos && i > 0 && s[i - 1] != ':') { // just check against ipv6...
-            port = std::stoul(s.substr(i + 1));
-            s = s.substr(0, i);
+        auto i = dst_addr.find_last_of(':');
+        if (i != std::string::npos && i > 0 && dst_addr[i - 1] != ':') { // just check against ipv6...
+            port = std::stoul(dst_addr.substr(i + 1));
+            dst_addr = dst_addr.substr(0, i);
         }
 
-        auto addr = co_await seastar::net::dns::resolve_name(s);
+        auto addr = co_await seastar::net::dns::resolve_name(dst_addr);
         std::vector<future<>> work;
 
         while (_go_on) {
@@ -455,11 +459,14 @@ class fake_proxy {
                 auto client = co_await _socket.accept();
                 auto dst = co_await seastar::connect(socket_address(addr, port));
 
-                auto f = [&]() -> future<> {      
+                testlog.debug("Got proxy connection: {}->{}:{} ({})", client.remote_address, dst_addr, port, _do_proxy);
+
+                auto f = [&]() -> future<> {
                     auto& s = client.connection;
                     auto& ldst = dst;
+                    auto addr = client.remote_address;
 
-                    auto do_io = [this](connected_socket& src, connected_socket& dst) -> future<> {
+                    auto do_io = [this, &addr, &dst_addr, port](connected_socket& src, connected_socket& dst) -> future<> {
                         auto sin = src.input();
                         auto dout = dst.output();
                         // note: have to have differing conditions for proxying
@@ -467,24 +474,36 @@ class fake_proxy {
                         // kmip connector caches connection -> not new socket.
                         while (_go_on && _do_proxy && !sin.eof()) {
                             auto buf = co_await sin.read();
+                            auto n = buf.size();
+                            testlog.trace("Read {} bytes: {}->{}:{}", n, addr, dst_addr, port);
                             if (_do_proxy) {
                                 co_await dout.write(std::move(buf));
                                 co_await dout.flush();
+                                testlog.trace("Wrote {} bytes: {}->{}:{}", n, addr, dst_addr, port);
                             }
                         }
                         co_await dout.close();
+                        co_await sin.close();
                     };
-
-                    co_await when_all(do_io(s, ldst), do_io(ldst, s));
+                    try {
+                        co_await when_all(do_io(s, ldst), do_io(ldst, s));
+                    } catch (...) {
+                        testlog.warn("Exception running proxy {}:{}->{}: {}", dst_addr, port, _address, std::current_exception());
+                        throw;
+                    }
                 }();
 
                 work.emplace_back(std::move(f));
             } catch (...) {
+                testlog.warn("Exception running proxy {}: {}", _address, std::current_exception());
             }
         }
 
         for (auto&& f : work) {
-            co_await std::move(f);
+            try {
+                co_await std::move(f);
+            } catch (...) {
+            }
         }
     }
 public:
@@ -499,9 +518,11 @@ public:
     }
     void enable(bool b) {
         _do_proxy = b;
+        testlog.info("Set proxy {} enabled = {}", _address, b);
     }
     future<> stop() {
         if (std::exchange(_go_on, false)) {
+            testlog.info("Stopping proxy {}", _address);
             _socket.abort_accept();
             co_await std::move(_f);
         }
@@ -569,6 +590,18 @@ Simple test of KMS provider. Still has some caveats:
     * ENABLE_KMS_TEST - set to non-zero (1/true) to run
     * KMS_KEY_ALIAS - default "alias/kms_encryption_test" - set to key alias you have access to.
     * KMS_AWS_REGION - default us-east-1 - set to whatever region your key is in.
+
+    NOTE: When run via test.py, the minio server used there will, unless already set,
+    put AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY into the inherited process env, with
+    values purely fictional, and only usable by itself. This _will_ screw up credentials
+    resolution in the KMS connector, and will lead to errors not intended.
+
+    In CI, we provide the vars from jenkins, with working values, and the minio
+    respects this.
+
+    As a workaround, try setting the vars yourself to something that actually works (i.e. 
+    values from your .awscredentials). Or complain until we find a way to make the minio
+    server optional for tests.
 
 */
 static future<> kms_test_helper(std::function<future<>(const tmpdir&, std::string_view, std::string_view, std::string_view)> f) {


### PR DESCRIPTION
Refs #22628

Adds exception handler + cleanup for the case where we have a bad config/env vars (hint minio) or similar, such that we fail with exception during setting up the EAR context. In a normal startup, this is ok. We will report the exception, and the do a exit(1).
    
In tests however, we don't and active context will instead be freed quite proper, in which case we need to call stop to ensure we don't crash on shared pointer destruction on wrong shard. Doing so will hide the real issue from whomever runs the test.

Adds some verbosity to track issues with the network proxy used to test EAR connector difficulties. Also adds an earlier close in input stream to help network usage.
    
Note: This is a diagnostic helper. Still cannot repro the issue above.