### PR TITLE
db/hints: Cancel draining when stopping node

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -146,6 +146,10 @@ future<> hint_endpoint_manager::stop(drain should_drain) noexcept {
     });
 }
 
+void hint_endpoint_manager::cancel_draining() noexcept {
+    _sender.cancel_draining();
+}
+
 hint_endpoint_manager::hint_endpoint_manager(const endpoint_id& key, fs::path hint_directory, manager& shard_manager)
     : _key(key)
     , _shard_manager(shard_manager)

--- a/db/hints/internal/hint_endpoint_manager.hh
+++ b/db/hints/internal/hint_endpoint_manager.hh
@@ -102,6 +102,8 @@ public:
     /// \return Ready future when all operations are complete
     future<> stop(drain should_drain = drain::no) noexcept;
 
+    void cancel_draining() noexcept;
+
     /// \brief Start the timer.
     void start();
 
@@ -142,6 +144,10 @@ public:
 
     bool stopped() const noexcept {
         return _state.contains(state::stopped);
+    }
+
+    bool canceled_draining() const noexcept {
+        return _sender.canceled_draining();
     }
 
     /// \brief Returns replay position of the most recently written hint.

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -382,6 +382,12 @@ private:
     /// ALL requested sync points will be canceled, i.e. an exception will be issued
     /// in the corresponding futures.
     future<> perform_migration();
+
+public:
+    /// Performs draining for all nodes that have already left the cluster.
+    /// This should only be called when the hint endpoint managers have been initialized
+    /// and the hint manager has started.
+    future<> drain_left_nodes();
 };
 
 } // namespace db::hints

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -237,6 +237,15 @@ future<> resource_manager::stop() noexcept {
     });
 }
 
+future<> resource_manager::drain_hints_for_left_nodes() {
+    for (manager& m : _shard_managers) {
+        // It's safe to discard the future here. It's awaited in `manager::stop()`.
+        (void) m.drain_left_nodes();
+    }
+
+    co_return;
+}
+
 future<> resource_manager::register_manager(manager& m) {
     return with_semaphore(_operation_lock, 1, [this, &m] () {
         return with_semaphore(_space_watchdog.update_lock(), 1, [this, &m] {

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -188,6 +188,8 @@ public:
     /// \brief Allows replaying hints for managers which are registered now or will be in the future.
     void allow_replaying() noexcept;
 
+    future<> drain_hints_for_left_nodes();
+
     /// \brief Registers the hints::manager in resource_manager, and starts it, if resource_manager is already running.
     ///
     /// The hints::managers can be added either before or after resource_manager starts.

--- a/main.cc
+++ b/main.cc
@@ -2307,6 +2307,24 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             checkpoint(stop_signal, "allow replaying hints");
             proxy.invoke_on_all(&service::storage_proxy::allow_replaying_hints).get();
 
+            // Note: This is here because we can only start draining after we allow for replaying hints.
+            //
+            //       We want the draining to be started before exposing the API of hinted handoff to
+            //       the user (note it happens in the following step in this file). That's a preventive
+            //       measure to avoid situations when e.g. the user decides to change the host filter
+            //       and effectively disable sending hints towards some nodes. Since we only drain hints
+            //       for nodes that have left the cluster, we want to perform that before the user has
+            //       the means to interrupt it in any way.
+            //
+            //       Lastly, note that this call does NOT await the draining. It only starts the draining
+            //       process that will be taking place in the background. Thus, it does not slow down
+            //       the initialization of the node.
+            //
+            //       See the logic of draining in `db::hints::internal::hint_sender` for more details
+            //       of the semantics of the process of draining hints.
+            supervisor::notify("Drain hints for nodes that have already left the cluster");
+            proxy.invoke_on_all(&service::storage_proxy::drain_hints_for_left_nodes).get();
+
             api::set_hinted_handoff(ctx, proxy, gossiper).get();
             auto stop_hinted_handoff_api = defer_verbose_shutdown("hinted handoff API", [&ctx] {
                 api::unset_hinted_handoff(ctx).get();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6797,6 +6797,10 @@ void storage_proxy::allow_replaying_hints() noexcept {
     return _hints_resource_manager.allow_replaying();
 }
 
+future<> storage_proxy::drain_hints_for_left_nodes() {
+    return _hints_resource_manager.drain_hints_for_left_nodes();
+}
+
 future<> storage_proxy::change_hints_host_filter(db::hints::host_filter new_filter) {
     if (new_filter == _hints_manager.get_host_filter()) {
         co_return;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -704,6 +704,7 @@ public:
     future<> stop();
     future<> start_hints_manager();
     void allow_replaying_hints() noexcept;
+    future<> drain_hints_for_left_nodes();
     future<> abort_view_writes();
 
     future<> change_hints_host_filter(db::hints::host_filter new_filter);

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -245,3 +245,79 @@ async def test_hints_consistency_during_decommission(manager: ManagerClient):
         logger.info("Verify that no data stored in hints have been lost")
         for i in range(100):
             assert list(await cql.run_async(f"SELECT v FROM {table} WHERE pk = {i}")) == [(i + 1,)]
+
+@pytest.mark.asyncio
+async def test_draining_hints(manager: ManagerClient):
+    """
+    This test verifies that all hints are drained when a node is being decommissioned.
+    """
+
+    s1, s2, _ = await manager.servers_add(3)
+    cql = manager.get_cql()
+
+    await manager.api.set_logger_level(s1.ip_addr, "hints_manager", "trace")
+
+    await cql.run_async("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 3}")
+    await cql.run_async("CREATE TABLE ks.t (pk int PRIMARY KEY, v int)")
+
+    await manager.server_stop_gracefully(s2.server_id)
+
+    # Generate hints towards s2 on s1 with probability 1 - ((#nodes - 1) / #nodes)^1000 ~= 1.
+    for i in range(1000):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i + 1})", consistency_level=ConsistencyLevel.ANY))
+
+    sync_point = create_sync_point(s1)
+    await manager.server_start(s2.server_id)
+
+
+    async def wait():
+        assert await_sync_point(s1, sync_point, 60)
+
+    async with asyncio.TaskGroup() as tg:
+        _ = tg.create_task(manager.decommission_node(s1.server_id, timeout=60))
+        _ = tg.create_task(wait())
+
+@pytest.mark.asyncio
+@skip_mode("release", "error injections are not supported in release mode")
+async def test_canceling_hint_draining(manager: ManagerClient):
+    """
+    This test verifies that draining hints is canceled as soon as we issue a shutdown,
+    but it's resumed after starting the node again.
+    """
+
+    s1, s2, _ = await manager.servers_add(3)
+    cql = manager.get_cql()
+
+    host_id2 = await manager.get_host_id(s2.server_id)
+
+    await manager.api.set_logger_level(s1.ip_addr, "hints_manager", "trace")
+
+    await cql.run_async("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 3}")
+    await cql.run_async("CREATE TABLE ks.t (pk int PRIMARY KEY, v int)")
+
+    await manager.server_stop_gracefully(s2.server_id)
+
+    # Generate hints towards s2 on s1 with probability 1 - ((#nodes - 1) / #nodes)^1000 ~= 1.
+    for i in range(1000):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i + 1})", consistency_level=ConsistencyLevel.ANY))
+
+    sync_point = create_sync_point(s1)
+
+    await manager.api.enable_injection(s1.ip_addr, "hinted_handoff_pause_hint_replay", False, {})
+    await manager.remove_node(s1.server_id, s2.server_id)
+    await manager.server_stop_gracefully(s1.server_id)
+
+    s1_log = await manager.server_open_log(s1.server_id)
+    s1_mark = await s1_log.mark()
+
+    await manager.server_update_cmdline(s1.server_id, ["--logger-log-level", "hints_manager=trace"])
+    await manager.server_start(s1.server_id)
+
+    s1_log = await manager.server_open_log(s1.server_id)
+
+    # Make sure the node still knows about the decommissioned node and does start draining for it.
+    await s1_log.wait_for(f"Draining starts for {host_id2}", s1_mark)
+
+    # Make sure draining finishes successfully.
+    assert await_sync_point(s1, sync_point, 60)
+    await s1_log.wait_for(f"Removed hint directory for {host_id2}")


### PR DESCRIPTION
Draining hints may occur in one of the two scenarios:

* a node leaves the cluster and the local node drains all of the hints saved for that node,
* the local node is being decommissioned.

Draining may take some time and the hint manager won't stop until it finishes. It's not a problem when decommissioning a node, especially because we want the cluster to retain the data stored in the hints. However, it may become a problem when the local node started draining hints saved for another node and now it's being shut down.

There are two reasons for that:

* Generally, in situations like that, we'd like to be able to shut down nodes as fast as possible. The data stored in the hints won't disappear from the cluster yet since we can restart the local node.
* Draining hints may introduce flakiness in tests. Replaying hints doesn't have the highest priority and it's reflected in the scheduling groups we use as well as the explicitly enforced throughput. If there are a large number of hints to be replayed, it might affect our tests. It's already happened, see: scylladb/scylladb#21949.

To solve those problems, we change the semantics of draining. It will behave as before when the local node is being decommissioned. However, when the local node is only being stopped, we will immediately cancel all ongoing draining processes and stop the hint manager. To amend for that, when we start a node and it initializes a hint endpoint manager corresponding to a node that's already left the cluster, we will begin the draining process of that endpoint manager right away.

That should ensure all data is retained, while possibly speeding up the shutdown process.

There's a small trade-off to it, though. If we stop a node, we can then remove it. It won't have a chance to replay hints it might've before these changes, but that's an edge case. We expect this commit to bring more benefit than harm.

We also provide tests verifying that the implementation works as intended.

Fixes scylladb/scylladb#21949

Backport: not needed. This is an enhancement.