### PR TITLE
test: skip test_complex_null_values in uf_typest_test

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -32,6 +32,7 @@ def read_function_from_file(file_name, wasm_name=None, udf_name=None):
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
+@pytest.mark.skip(reason="Issue #22799")
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"


### PR DESCRIPTION
test_complex_null_values is currently flaky, causing many failures in CI. The reason for the failures is unclear, and a fix might not be simple, so because UDFs are experimental, for now let's skip this test until the corresponding issue is fixed.

We haven't seen the test fail in backport PRs, so no need to backport.