### PR TITLE
dist: fix upgrade error from 2024.1

### DIFF
--- a/dist/debian/control.template
+++ b/dist/debian/control.template
@@ -19,8 +19,8 @@ Breaks: scylla-enterprise-conf (<< 2025.1.0~)
 Package: %{product}-server
 Architecture: any
 Depends: ${misc:Depends}, %{product}-conf (= ${binary:Version}), %{product}-python3 (= ${binary:Version})
-Replaces: %{product}-tools (<<5.5), scylla-enterprise-server (<< 2025.1.0~)
-Breaks: %{product}-tools (<<5.5), scylla-enterprise-server (<< 2025.1.0~)
+Replaces: %{product}-tools (<<5.5), scylla-enterprise-tools (<< 2024.2.0~), scylla-enterprise-server (<< 2025.1.0~)
+Breaks: %{product}-tools (<<5.5), scylla-enterprise-tools (<< 2024.2.0~), scylla-enterprise-server (<< 2025.1.0~)
 Description: Scylla database server binaries
  Scylla is a highly scalable, eventually consistent, distributed,
  partitioned row DB.

--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -74,6 +74,8 @@ Requires:       %{product}-python3 = %{version}-%{release}
 AutoReqProv:    no
 Provides:       %{product}-tools:%{_bindir}/nodetool
 Provides:       %{product}-tools:%{_sysconfigdir}/bash_completion.d/nodetool-completion
+Provides:       scylla-enterprise-tools:%{_bindir}/nodetool
+Provides:       scylla-enterprise-tools:%{_sysconfigdir}/bash_completion.d/nodetool-completion
 Provides:       scylla-enterprise-server = %{version}-%{release}
 Obsoletes:      scylla-enterprise-server < 2025.1.0
 


### PR DESCRIPTION
We need to allow replacing nodetool from scylla-enterprise-tools < 2024.2, just like we did for scylla-tools < 5.5.
This is required to make packages able to upgrade from 2024.1.

Fixes #22820