### PR TITLE
scylla-sstable: make abortable by SIGINT/SIGTERM

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -119,6 +119,7 @@
 #include "utils/shared_dict.hh"
 #include "message/dictionary_service.hh"
 #include "utils/disk_space_monitor.hh"
+#include "utils/stop_signal.hh"
 
 
 #define P11_KIT_FUTURE_UNSTABLE_API
@@ -135,46 +136,6 @@ using namespace std::chrono_literals;
 namespace bpo = boost::program_options;
 
 logging::logger diaglog("diagnostics");
-
-// Must live in a seastar::thread
-class stop_signal {
-    bool _caught = false;
-    condition_variable _cond;
-    sharded<abort_source> _abort_sources;
-    future<> _broadcasts_to_abort_sources_done = make_ready_future<>();
-private:
-    void signaled() {
-        if (_caught) {
-            return;
-        }
-        _caught = true;
-        _cond.broadcast();
-        _broadcasts_to_abort_sources_done = _broadcasts_to_abort_sources_done.then([this] {
-            return _abort_sources.invoke_on_all(&abort_source::request_abort);
-        });
-    }
-public:
-    stop_signal() {
-        _abort_sources.start().get();
-        handle_signal(SIGINT, [this] { signaled(); });
-        handle_signal(SIGTERM, [this] { signaled(); });
-    }
-    ~stop_signal() {
-        // There's no way to unregister a handler yet, so register a no-op handler instead.
-        handle_signal(SIGINT, [] {});
-        handle_signal(SIGTERM, [] {});
-        _broadcasts_to_abort_sources_done.get();
-        _abort_sources.stop().get();
-    }
-    future<> wait() {
-        return _cond.wait([this] { return _caught; });
-    }
-    bool stopping() const {
-        return _caught;
-    }
-    abort_source& as_local_abort_source() { return _abort_sources.local(); }
-    sharded<abort_source>& as_sharded_abort_source() { return _abort_sources; }
-};
 
 struct object_storage_endpoint_param {
     sstring endpoint;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -49,7 +49,7 @@ namespace bpo = boost::program_options;
 
 using namespace tools::utils;
 
-using operation_func = void(*)(schema_ptr, reader_permit, const std::vector<sstables::shared_sstable>&, sstables::sstables_manager&, const bpo::variables_map&);
+using operation_func = void(*)(schema_ptr, reader_permit, const std::vector<sstables::shared_sstable>&, sstables::sstables_manager&, const bpo::variables_map&, abort_source& as);
 
 namespace std {
 // required by boost::lexical_cast<std::string>(vector<string>), which is in turn used
@@ -972,7 +972,7 @@ void validate_output_dir(std::filesystem::path output_dir, bool accept_nonempty_
 }
 
 void validate_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map& vm) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map& vm, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -998,7 +998,7 @@ void validate_operation(schema_ptr schema, reader_permit permit, const std::vect
 }
 
 void scrub_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map& vm) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map& vm, abort_source& as) {
     static const std::vector<std::pair<std::string, compaction_type_options::scrub::mode>> scrub_modes{
         {"abort", compaction_type_options::scrub::mode::abort},
         {"skip", compaction_type_options::scrub::mode::skip},
@@ -1042,7 +1042,7 @@ void scrub_operation(schema_ptr schema, reader_permit permit, const std::vector<
 }
 
 void dump_index_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1081,7 +1081,7 @@ sstring disk_string_to_string(const sstables::disk_string<Integer>& ds) {
 }
 
 void dump_compression_info_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1119,7 +1119,7 @@ void dump_compression_info_operation(schema_ptr schema, reader_permit permit, co
 }
 
 void dump_summary_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1409,7 +1409,7 @@ void dump_serialization_header(json_writer& writer, sstables::sstable_version_ty
 }
 
 void dump_statistics_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1604,7 +1604,7 @@ public:
 };
 
 void dump_scylla_metadata_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1628,7 +1628,7 @@ void dump_scylla_metadata_operation(schema_ptr schema, reader_permit permit, con
 }
 
 void validate_checksums_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map&) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map&, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -1671,7 +1671,7 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
 }
 
 void decompress_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map& vm) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map& vm, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -2575,7 +2575,7 @@ public:
 };
 
 void write_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& manager, const bpo::variables_map& vm) {
+        sstables::sstables_manager& manager, const bpo::variables_map& vm, abort_source& as) {
     static const std::vector<std::pair<std::string, mutation_fragment_stream_validation_level>> valid_validation_levels{
         {"none", mutation_fragment_stream_validation_level::none},
         {"partition_region", mutation_fragment_stream_validation_level::partition_region},
@@ -2629,7 +2629,7 @@ void write_operation(schema_ptr schema, reader_permit permit, const std::vector<
 }
 
 void script_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& manager, const bpo::variables_map& vm) {
+        sstables::sstables_manager& manager, const bpo::variables_map& vm, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -2650,7 +2650,7 @@ void script_operation(schema_ptr schema, reader_permit permit, const std::vector
 
 template <typename SstableConsumer>
 void sstable_consumer_operation(schema_ptr schema, reader_permit permit, const std::vector<sstables::shared_sstable>& sstables,
-        sstables::sstables_manager& sst_man, const bpo::variables_map& vm) {
+        sstables::sstables_manager& sst_man, const bpo::variables_map& vm, abort_source& as) {
     if (sstables.empty()) {
         throw std::invalid_argument("no sstables specified on the command line");
     }
@@ -2749,7 +2749,8 @@ void shard_of_with_tablets(schema_ptr schema,
 void shard_of_operation(schema_ptr schema, reader_permit permit,
                         const std::vector<sstables::shared_sstable>& sstables,
                         sstables::sstables_manager& sstable_manager,
-                        const bpo::variables_map& vm) {
+                        const bpo::variables_map& vm,
+                        abort_source& as) {
     // uses "tablets" by default. as new scylla installations enable "tablet" by
     // default
     if (vm.count("tablets") && vm.count("vnodes")) {
@@ -3177,6 +3178,8 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
     tool_app_template app(std::move(app_cfg));
 
     return app.run_async(argc, argv, [&app] (const operation& operation, const bpo::variables_map& app_config) {
+        abort_source as;
+
         schema_ptr schema;
         std::optional<schema_with_source> schema_with_source;
 
@@ -3275,7 +3278,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         const auto permit = rcs_sem.make_tracking_only_permit(schema, app_name, db::no_timeout, {});
 
         try {
-            operations_with_func.at(operation)(schema, permit, sstables, sst_man, app_config);
+            operations_with_func.at(operation)(schema, permit, sstables, sst_man, app_config, as);
         } catch (std::invalid_argument& e) {
             fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
             return 1;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -39,6 +39,7 @@
 #include "tools/sstable_consumer.hh"
 #include "tools/utils.hh"
 #include "locator/host_id.hh"
+#include "utils/stop_signal.hh"
 
 using namespace seastar;
 using namespace sstables;
@@ -3236,7 +3237,8 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
     tool_app_template app(std::move(app_cfg));
 
     return app.run_async(argc, argv, [&app] (const operation& operation, const bpo::variables_map& app_config) {
-        abort_source as;
+        ::stop_signal stop_signal;
+        abort_source& as = stop_signal.as_local_abort_source();
 
         schema_ptr schema;
         std::optional<schema_with_source> schema_with_source;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3279,6 +3279,9 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
 
         try {
             operations_with_func.at(operation)(schema, permit, sstables, sst_man, app_config, as);
+        } catch (abort_requested_exception&) {
+            fmt::print(std::cerr, "abort requested\n");
+            return 0;
         } catch (std::invalid_argument& e) {
             fmt::print(std::cerr, "error processing arguments: {}\n", e.what());
             return 1;

--- a/utils/stop_signal.hh
+++ b/utils/stop_signal.hh
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/signal.hh>
+
+#include "seastarx.hh"
+
+// Must live in a seastar::thread
+class stop_signal {
+    bool _caught = false;
+    condition_variable _cond;
+    sharded<abort_source> _abort_sources;
+    future<> _broadcasts_to_abort_sources_done = make_ready_future<>();
+private:
+    void signaled() {
+        if (_caught) {
+            return;
+        }
+        _caught = true;
+        _cond.broadcast();
+        _broadcasts_to_abort_sources_done = _broadcasts_to_abort_sources_done.then([this] {
+            return _abort_sources.invoke_on_all(&abort_source::request_abort);
+        });
+    }
+public:
+    stop_signal() {
+        _abort_sources.start().get();
+        handle_signal(SIGINT, [this] { signaled(); });
+        handle_signal(SIGTERM, [this] { signaled(); });
+    }
+    ~stop_signal() {
+        // There's no way to unregister a handler yet, so register a no-op handler instead.
+        handle_signal(SIGINT, [] {});
+        handle_signal(SIGTERM, [] {});
+        _broadcasts_to_abort_sources_done.get();
+        _abort_sources.stop().get();
+    }
+    future<> wait() {
+        return _cond.wait([this] { return _caught; });
+    }
+    bool stopping() const {
+        return _caught;
+    }
+    abort_source& as_local_abort_source() { return _abort_sources.local(); }
+    sharded<abort_source>& as_sharded_abort_source() { return _abort_sources; }
+};


### PR DESCRIPTION
Catch SIGINT and SIGTERM and propagate an `abort_source` wired into the signal handler to all consume loops.
The tool will now respond to these signals by interrupting the in-progress operations and exiting.
Note that this has limitations: as in the case of all such mechanisms in ScyllaDB, this is base on polling an `abort_source`. If the tool is stuck deep in some method which doesn't poll this, using `kill -9` might still be required.

Fixes: scylladb/scylladb#16954

New feature, no backport required