### PR TITLE
Untangle sstable-directory vs sstable in pending log creation code

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -626,21 +626,17 @@ bool sstable_directory::compare_sstable_storage_prefix(const sstring& prefix_a, 
     return size_a == size_b && sstring::traits_type::compare(prefix_a.begin(), prefix_b.begin(), size_a) == 0;
 }
 
-future<sstable_directory::pending_delete_result> sstable_directory::create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts) {
+future<sstring> sstable_directory::create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts) {
     return seastar::async([&] {
         min_max_tracker<generation_type> gen_tracker;
         sstring pending_delete_log;
-        pending_delete_result res;
 
         for (const auto& sst : ssts) {
-            auto prefix = sst->_storage->prefix();
-            res.prefixes.insert(prefix);
             gen_tracker.update(sst->generation());
         }
 
         sstring pending_delete_dir = (base_dir.path() / sstables::pending_delete_dir).native();
         pending_delete_log = format("{}/sstables-{}-{}.log", pending_delete_dir, gen_tracker.min(), gen_tracker.max());
-        res.pending_delete_log = pending_delete_log;
         sstring tmp_pending_delete_log = pending_delete_log + ".tmp";
         dirlog.trace("Writing {}", tmp_pending_delete_log);
 
@@ -677,7 +673,7 @@ future<sstable_directory::pending_delete_result> sstable_directory::create_pendi
             base_dir.sync(general_disk_error_handler).get();
             dirlog.debug("{} written successfully.", pending_delete_log);
 
-      return res;
+        return pending_delete_log;
     });
 }
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -312,7 +312,7 @@ public:
     // Creates the deletion log for atomic deletion of sstables at `base_dir` (helper for the
     // above function that's also used by tests)
     // Returns the name of the pending_delete_log and an unordered_set of sstable prefixes.
-    static future<pending_delete_result> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
+    static future<sstring> create_pending_deletion_log(opened_directory& base_dir, const std::vector<shared_sstable>& ssts);
 
     static bool compare_sstable_storage_prefix(const sstring& a, const sstring& b) noexcept;
     sstable_state state() const noexcept { return _state; }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -291,11 +291,6 @@ public:
     using can_be_remote = bool_class<struct can_be_remote_tag>;
     future<> collect_output_unshared_sstables(std::vector<sstables::shared_sstable> resharded_sstables, can_be_remote);
 
-    struct pending_delete_result {
-        sstring pending_delete_log;
-        std::unordered_set<sstring> prefixes;
-    };
-
     // When we compact sstables, we have to atomically instantiate the new
     // sstable and delete the old ones.  Otherwise, if we compact A+B into C,
     // and if A contained some data that was tombstoned by B, and if B was

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -526,7 +526,6 @@ private:
     }
 
     friend class sstable_stream_sink_impl;
-    friend class sstable_directory;
     friend class filesystem_storage;
     friend class s3_storage;
     friend class tiered_storage;

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -480,7 +480,7 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
 }
 
 future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    sstable_directory::pending_delete_result res;
+    atomic_delete_context res;
 
     for (const auto& sst : ssts) {
         auto prefix = sst->_storage->prefix();

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -480,7 +480,15 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
 }
 
 future<atomic_delete_context> filesystem_storage::atomic_delete_prepare(const std::vector<shared_sstable>& ssts) const {
-    co_return co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
+    sstable_directory::pending_delete_result res;
+
+    for (const auto& sst : ssts) {
+        auto prefix = sst->_storage->prefix();
+        res.prefixes.insert(prefix);
+    }
+
+    res.pending_delete_log = co_await sstable_directory::create_pending_deletion_log(_base_dir, ssts);
+    co_return std::move(res);
 }
 
 future<> filesystem_storage::atomic_delete_complete(atomic_delete_context ctx) const {

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -23,7 +23,6 @@
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 #include "utils/disk-error-handler.hh"
-#include "sstables/sstable_directory.hh"
 
 class schema;
 
@@ -41,7 +40,10 @@ class sstable;
 class sstables_manager;
 class entry_descriptor;
 
-using atomic_delete_context = sstable_directory::pending_delete_result;
+struct atomic_delete_context {
+    sstring pending_delete_log;
+    std::unordered_set<sstring> prefixes;
+};
 
 class opened_directory final {
     std::filesystem::path _pathname;


### PR DESCRIPTION
There's a sstable_directory::create_pending_deletion_log() helper method that's called by sstable's filesystem_storage atomic-delete methods and that prepares the deletion log for a bunch of sstables. For that method to do its job it needs to get private sstable->_storage field (which is always the filesystem_storage one), also the atomic-delete transparent context object is leaked into the sstable_directory code and low-level sstable storage code needs to include higher-level sstable_directory header.

This patch unties these knots. As the result:
- friendship between sstable and sstable_directory is removed
- transparent atomic_delete_context is encapsulated in storage.(cc|hh) code
- less code for create_pending_deletion_log() to dump TOC filename into log