### PR TITLE
test.py: test_random_failures: improve handling of hung node

### DIFF
--- a/test/topology_custom/random_failures/error_injections.py
+++ b/test/topology_custom/random_failures/error_injections.py
@@ -33,5 +33,6 @@ ERROR_INJECTIONS_NODE_MAY_HANG = (
     "stop_after_sending_join_node_request",
     "stop_after_updating_cdc_generation",
     "stop_before_streaming",
+    "stop_after_streaming",
     "stop_after_bootstrapping_initial_raft_configuration",
 )

--- a/test/topology_custom/random_failures/test_random_failures.py
+++ b/test/topology_custom/random_failures/test_random_failures.py
@@ -39,8 +39,6 @@ TESTS_SHUFFLE_SEED = random.randrange(sys.maxsize)  # seed for the tests order r
 ERROR_INJECTIONS_COUNT = len(ERROR_INJECTIONS)  # change it to limit number of error injections
 CLUSTER_EVENTS_COUNT = len(CLUSTER_EVENTS)  # change it to limit number of cluster events
 
-WAIT_FOR_IP_TIMEOUT = 30  # seconds
-
 LOGGER = logging.getLogger(__name__)
 
 
@@ -149,7 +147,7 @@ async def test_random_failures(manager: ManagerClient,
 
     server_log = await manager.server_open_log(server_id=s_info.server_id)
 
-    if cluster_event_duration + 1 >= WAIT_FOR_IP_TIMEOUT and error_injection in ERROR_INJECTIONS_NODE_MAY_HANG:
+    if error_injection in ERROR_INJECTIONS_NODE_MAY_HANG:
         LOGGER.info("Expecting the added node can hang and we'll have a message in the coordinator's log.  See #18638.")
         coordinator = await get_coordinator_host(manager=manager)
         coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)


### PR DESCRIPTION
In some cases the paused/unpaused node can hang not after 30s timeout. This make the test flaky.  Change the condition to always check the coordinator's log if there is a hung node.

Add `stop_after_streaming` to the list of error injections which can cause a node's hang.

Also add a wait for a new coordinator election in cluster events which cause such elections.

Fixes #21872