### PR TITLE
generic_server: throttle and shed incoming connections according to semaphore limit

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -610,6 +610,10 @@ perf_tests = set([
     'test/perf/perf_sort_by_proximity',
 ])
 
+perf_standalone_tests = set([
+     'test/perf/perf_generic_server',
+])
+
 raft_tests = set([
     'test/raft/replication_test',
     'test/raft/randomized_nemesis_test',
@@ -644,7 +648,7 @@ lto_binaries = set([
     'scylla'
 ])
 
-tests = scylla_tests | perf_tests | raft_tests
+tests = scylla_tests | perf_tests | perf_standalone_tests | raft_tests
 
 other = set([
     'iotune',
@@ -1474,13 +1478,16 @@ for t in sorted(scylla_tests):
     else:
         deps[t] += scylla_core + alternator + idls + scylla_tests_generic_dependencies
 
+for t in sorted(perf_tests | perf_standalone_tests):
+    deps[t] = [t + '.cc'] + scylla_tests_dependencies
+    deps[t] += ['test/perf/perf.cc', 'seastar/tests/perf/linux_perf_event.cc']
+
 perf_tests_seastar_deps = [
     'seastar/tests/perf/perf_tests.cc'
 ]
 
 for t in sorted(perf_tests):
-    deps[t] = [t + '.cc'] + scylla_tests_dependencies + perf_tests_seastar_deps
-    deps[t] += ['test/perf/perf.cc', 'seastar/tests/perf/linux_perf_event.cc']
+    deps[t] += perf_tests_seastar_deps
 
 deps['test/boost/combined_tests'] += [
     'test/boost/aggregate_fcts_test.cc',

--- a/db/config.cc
+++ b/db/config.cc
@@ -1254,6 +1254,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Time period in seconds after which unused schema versions will be evicted from the local schema registry cache. Default is 1 second.")
     , max_concurrent_requests_per_shard(this, "max_concurrent_requests_per_shard", liveness::LiveUpdate, value_status::Used, std::numeric_limits<uint32_t>::max(),
         "Maximum number of concurrent requests a single shard can handle before it starts shedding extra load. By default, no requests will be shed.")
+    , uninitialized_connections_semaphore_cpu_concurrency(this, "uninitialized_connections_semaphore_cpu_concurrency", liveness::LiveUpdate, value_status::Used, 8,
+        "Maximum number of new concurrent connections from drivers that a single shard can be processing before it starts throttling incomming connections. This limit applies only to new connections excluding the ones blocked on network IO; connections that are ready to serve requests are not affected. By default the limit is 8.")
     , cdc_dont_rewrite_streams(this, "cdc_dont_rewrite_streams", value_status::Used, false,
             "Disable rewriting streams from cdc_streams_descriptions to cdc_streams_descriptions_v2. Should not be necessary, but the procedure is expensive and prone to failures; this config option is left as a backdoor in case some user requires manual intervention.")
     , strict_allow_filtering(this, "strict_allow_filtering", liveness::LiveUpdate, value_status::Used, strict_allow_filtering_default(), "Match Cassandra in requiring ALLOW FILTERING on slow queries. Can be true, false, or warn. When false, Scylla accepts some slow queries even without ALLOW FILTERING that Cassandra rejects. Warn is same as false, but with warning.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -432,6 +432,7 @@ public:
     named_value<unsigned> user_defined_function_contiguous_allocation_limit_bytes;
     named_value<uint32_t> schema_registry_grace_period;
     named_value<uint32_t> max_concurrent_requests_per_shard;
+    named_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
     named_value<bool> cdc_dont_rewrite_streams;
     named_value<tri_mode_restriction> strict_allow_filtering;
     named_value<tri_mode_restriction> strict_is_not_null_in_views;

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -15,6 +15,8 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
 
+#include "db/config.hh"
+
 namespace generic_server {
 
 connection::connection(server& server, connected_socket&& fd)
@@ -147,7 +149,16 @@ future<> connection::shutdown()
     return make_ready_future<>();
 }
 
-server::server(const sstring& server_name, logging::logger& logger)
+config::config(const db::config& cfg)
+{
+}
+
+config::config(uint32_t uninitialized_connections_semaphore_cpu_concurrency)
+    : uninitialized_connections_semaphore_cpu_concurrency(
+            uninitialized_connections_semaphore_cpu_concurrency) {
+}
+
+server::server(const sstring& server_name, logging::logger& logger, config cfg)
     : _server_name{server_name}
     , _logger{logger}
 {

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -129,6 +129,10 @@ future<> connection::process()
     });
 }
 
+void connection::on_connection_ready()
+{
+}
+
 void connection::on_connection_close()
 {
 }

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -363,6 +363,7 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 if (u) {
                     units = std::move(*u);
                 } else {
+                    _blocked_connections++;
                     try {
                         units = co_await get_units(_conns_cpu_concurrency_semaphore, 1, std::chrono::minutes(1));
                     } catch (const semaphore_timed_out&) {
@@ -381,6 +382,7 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
             auto conn = make_connection(server_addr, std::move(fd), std::move(addr),
                     _conns_cpu_concurrency_semaphore, std::move(units));
             if (shed) {
+                _shed_connections++;
                 static thread_local logger::rate_limit rate_limit{std::chrono::seconds(10)};
                 _logger.log(log_level::warn, rate_limit,
                         "too many in-flight connection attempts: {}, connection dropped",

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -14,10 +14,99 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
+#include <utility>
 
 #include "db/config.hh"
 
 namespace generic_server {
+
+class counted_data_source_impl : public data_source_impl {
+    data_source _ds;
+    connection::cpu_concurrency_t& _cpu_concurrency;
+
+    template <typename F>
+    future<temporary_buffer<char>> invoke_with_counting(F&& fun) {
+        if (_cpu_concurrency.stopped) {
+            return fun();
+        }
+        return futurize_invoke([this] () {
+            _cpu_concurrency.units.return_all();
+        }).then([fun = std::move(fun)] () {
+            return fun();
+        }).finally([this] () {
+            _cpu_concurrency.units.adopt(consume_units(_cpu_concurrency.semaphore, 1));
+        });
+    };
+public:
+    counted_data_source_impl(data_source ds, connection::cpu_concurrency_t& cpu_concurrency) : _ds(std::move(ds)), _cpu_concurrency(cpu_concurrency) {};
+    virtual ~counted_data_source_impl() = default;
+    virtual future<temporary_buffer<char>> get() override {
+        return invoke_with_counting([this] {return _ds.get();});
+    };
+    virtual future<temporary_buffer<char>> skip(uint64_t n) override {
+        return invoke_with_counting([this, n] {return _ds.skip(n);});
+    };
+    virtual future<> close() override {
+        return _ds.close();
+    };
+};
+
+class counted_data_sink_impl : public data_sink_impl {
+    data_sink _ds;
+    connection::cpu_concurrency_t& _cpu_concurrency;
+
+    template <typename F>
+    future<> invoke_with_counting(F&& fun) {
+        if (_cpu_concurrency.stopped) {
+            return fun();
+        }
+        return futurize_invoke([this] () {
+            _cpu_concurrency.units.return_all();
+        }).then([fun = std::move(fun)] () mutable {
+            return fun();
+        }).finally([this] () {
+            _cpu_concurrency.units.adopt(consume_units(_cpu_concurrency.semaphore, 1));
+        });
+    };
+public:
+    counted_data_sink_impl(data_sink ds, connection::cpu_concurrency_t& cpu_concurrency) : _ds(std::move(ds)), _cpu_concurrency(cpu_concurrency) {};
+    virtual ~counted_data_sink_impl() = default;
+    virtual temporary_buffer<char> allocate_buffer(size_t size) override {
+        return _ds.allocate_buffer(size);
+    }
+    virtual future<> put(net::packet data) override {
+        return invoke_with_counting([this, data = std::move(data)] () mutable {
+            return _ds.put(std::move(data));
+        });
+    }
+    virtual future<> put(std::vector<temporary_buffer<char>> data)  override {
+        return invoke_with_counting([this, data = std::move(data)] () mutable {
+            return _ds.put(std::move(data));
+        });
+    }
+    virtual future<> put(temporary_buffer<char> buf) override {
+        return invoke_with_counting([this, buf = std::move(buf)] () mutable {
+            return _ds.put(std::move(buf));
+        });
+    }
+    virtual future<> flush() override {
+        return invoke_with_counting([this] (void) mutable {
+            return _ds.flush();
+        });
+    }
+    virtual future<> close() override {
+        return _ds.close();
+    }
+    virtual size_t buffer_size() const noexcept override {
+        return _ds.buffer_size();
+    }
+    virtual bool can_batch_flushes() const noexcept override {
+        return _ds.can_batch_flushes();
+    }
+    virtual void on_batch_flush_error() noexcept override {
+        _ds.on_batch_flush_error();
+    }
+};
 
 connection::connection(server& server, connected_socket&& fd, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units)
     : _conns_cpu_concurrency{sem, std::move(initial_sem_units), false}

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -62,6 +62,8 @@ public:
 
     virtual future<> process_request() = 0;
 
+    virtual void on_connection_ready();
+
     virtual void on_connection_close();
 
     virtual future<> shutdown();

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "db/config.hh"
 #include "utils/log.hh"
 
 #include "seastarx.hh"
@@ -73,6 +74,13 @@ public:
     static execute_under_tenant_type no_tenant();
 };
 
+struct config {
+    utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
+
+    explicit config(const db::config& cfg);
+    explicit config(uint32_t uninitialized_connections_semaphore_cpu_concurrency);
+};
+
 // A generic TCP socket server.
 //
 // This class can be used as a base for a protocol specific TCP socket server
@@ -109,7 +117,7 @@ protected:
     shared_ptr<seastar::tls::server_credentials> _credentials;
 
 public:
-    server(const sstring& server_name, logging::logger& logger);
+    server(const sstring& server_name, logging::logger& logger, config cfg);
 
     virtual ~server();
 

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -23,6 +23,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
+#include <seastar/core/semaphore.hh>
 
 #include <boost/intrusive/list.hpp>
 

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -74,8 +74,6 @@ public:
 
     virtual void on_connection_ready();
 
-    virtual void on_connection_close();
-
     virtual future<> shutdown();
 
     void switch_tenant(execute_under_tenant_type execute);

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -112,6 +112,8 @@ protected:
     seastar::gate _gate;
     future<> _all_connections_stopped = make_ready_future<>();
     uint64_t _total_connections = 0;
+    uint64_t _shed_connections = 0;
+    uint64_t _blocked_connections = 0;
     future<> _listeners_stopped = make_ready_future<>();
     using connections_list_t = boost::intrusive::list<connection>;
     connections_list_t _connections_list;

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -12,7 +12,9 @@
 #include "utils/log.hh"
 
 #include "seastarx.hh"
+#include "utils/updateable_value.hh"
 
+#include <cstdint>
 #include <list>
 
 #include <seastar/core/file-types.hh>
@@ -41,6 +43,12 @@ public:
     using connection_process_loop = noncopyable_function<future<> ()>;
     using execute_under_tenant_type = noncopyable_function<future<> (connection_process_loop)>;
     bool _tenant_switch = false;
+    struct cpu_concurrency_t {
+        named_semaphore& semaphore;
+        semaphore_units<named_semaphore_exception_factory> units;
+        bool stopped;
+    };
+    cpu_concurrency_t _conns_cpu_concurrency;
     execute_under_tenant_type _execute_under_current_tenant = no_tenant();
 protected:
     server& _server;
@@ -54,7 +62,7 @@ protected:
 private:
     future<> process_until_tenant_switch();
 public:
-    connection(server& server, connected_socket&& fd);
+    connection(server& server, connected_socket&& fd, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units);
     virtual ~connection();
 
     virtual future<> process();
@@ -115,7 +123,10 @@ protected:
     std::list<gentle_iterator> _gentle_iterators;
     std::vector<server_socket> _listeners;
     shared_ptr<seastar::tls::server_credentials> _credentials;
-
+private:
+    utils::updateable_value<uint32_t> _conns_cpu_concurrency;
+    uint32_t _prev_conns_cpu_concurrency;
+    named_semaphore _conns_cpu_concurrency_semaphore;
 public:
     server(const sstring& server_name, logging::logger& logger, config cfg);
 
@@ -140,7 +151,7 @@ public:
     future<> do_accepts(int which, bool keepalive, socket_address server_addr);
 
 protected:
-    virtual seastar::shared_ptr<connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) = 0;
+    virtual seastar::shared_ptr<connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) = 0;
 
     virtual future<> advertise_new_connection(shared_ptr<connection> conn);
 

--- a/redis/controller.cc
+++ b/redis/controller.cc
@@ -39,7 +39,7 @@ controller::~controller()
 {
 }
 
-future<> controller::listen(seastar::sharded<auth::service>& auth_service, db::config& cfg)
+future<> controller::listen(seastar::sharded<auth::service>& auth_service, const db::config& cfg)
 {
     if (_server) {
         return make_ready_future<>();
@@ -61,7 +61,7 @@ future<> controller::listen(seastar::sharded<auth::service>& auth_service, db::c
                 ._total_redis_db_count = cfg.redis_database_count(),
             };
         });
-        return server->start(std::ref(_query_processor), std::ref(auth_service), std::move(get_config)).then([this, server, &cfg, ip, ceo, keepalive]() {
+        return server->start(std::ref(_query_processor), std::ref(auth_service), std::ref(cfg), std::move(get_config)).then([this, server, &cfg, ip, ceo, keepalive]() {
             auto f = make_ready_future();
             struct listen_cfg {
                 socket_address addr;

--- a/redis/controller.hh
+++ b/redis/controller.hh
@@ -61,7 +61,7 @@ class controller : public protocol_server {
     seastar::sharded<gms::gossiper>& _gossiper;
     std::vector<socket_address> _listen_addresses;
 private:
-    seastar::future<> listen(seastar::sharded<auth::service>& auth_service, db::config& cfg);
+    seastar::future<> listen(seastar::sharded<auth::service>& auth_service, const db::config& cfg);
 public:
     controller(seastar::sharded<service::storage_proxy>& proxy, seastar::sharded<auth::service>& auth_service,
             seastar::sharded<service::migration_manager>& mm, db::config& cfg, seastar::sharded<gms::gossiper>& gossiper,

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -8,6 +8,7 @@
 
 #include "redis/server.hh"
 
+#include "generic_server.hh"
 #include "redis/request.hh"
 #include "redis/reply.hh"
 
@@ -26,8 +27,8 @@ namespace redis_transport {
 
 static logging::logger logging("redis_server");
 
-redis_server::redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config)
-    : server("Redis", logging)
+redis_server::redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, const db::config& cfg, redis_server_config config)
+    : server("Redis", logging, generic_server::config(cfg))
     , _query_processor(qp)
     , _config(std::move(config))
     , _max_request_size(_config._max_request_size)

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -108,6 +108,7 @@ future<> redis_server::connection::process_request() {
         _pending_requests_gate.enter();
         utils::latency_counter lc;
         lc.start();
+        on_connection_ready();
         auto leave = defer([this] () noexcept { _pending_requests_gate.leave(); });
         return process_request_internal().then([this, leave = std::move(leave), lc = std::move(lc)] (auto&& result) mutable {
             --_server._stats._requests_serving;

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -88,7 +88,7 @@ private:
         >;
         static thread_local execution_stage_type _process_request_stage;
     public:
-        connection(redis_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr);
+        connection(redis_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units);
         virtual ~connection();
         future<> process_request() override;
         void handle_error(future<>&& f) override;
@@ -99,7 +99,7 @@ private:
         future<result> process_request_internal();
     };
 
-    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) override;
+    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
     future<> unadvertise_connection(shared_ptr<generic_server::connection> conn) override;
 };
 }

--- a/redis/server.hh
+++ b/redis/server.hh
@@ -61,7 +61,7 @@ class redis_server : public generic_server::server {
     size_t _total_redis_db_count;
 
 public:
-    redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, redis_server_config config);
+    redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, const db::config& cfg, redis_server_config config);
 
     struct result {
         result(redis::redis_message&& m) : _data(make_foreign(std::make_unique<redis::redis_message>(std::move(m)))) {}

--- a/test/boost/generic_server_test.cc
+++ b/test/boost/generic_server_test.cc
@@ -24,14 +24,16 @@ static logger test_logger("test_server");
 
 class test_server : public server {
 public:
-    test_server() : server("test_server", test_logger) {};
+    test_server(const db::config& cfg) : server("test_server", test_logger, config(cfg)) {};
 protected:
-    [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address) {
+    [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address) override {
         SCYLLA_ASSERT(false);
     }
 };
 
 SEASTAR_TEST_CASE(stop_without_listening) {
-    test_server srv;
+    db::config cfg;
+    test_server srv(cfg);
     co_await with_timeout(lowres_clock::now() + 5min, srv.stop());
+    co_return;
 }

--- a/test/boost/generic_server_test.cc
+++ b/test/boost/generic_server_test.cc
@@ -26,7 +26,7 @@ class test_server : public server {
 public:
     test_server(const db::config& cfg) : server("test_server", test_logger, config(cfg)) {};
 protected:
-    [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address) override {
+    [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override {
         SCYLLA_ASSERT(false);
     }
 };

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -91,5 +91,6 @@ add_perf_test(perf_mutation_readers
 add_perf_test(perf_mutation_fragment)
 add_perf_test(perf_vint)
 add_perf_test(perf_row_cache_reads)
+add_perf_test(perf_generic_server)
 add_perf_test(perf_s3_client)
 add_perf_test(perf_sort_by_proximity)

--- a/test/perf/perf.cc
+++ b/test/perf/perf.cc
@@ -103,7 +103,7 @@ std::ostream&
 operator<<(std::ostream& os, const aggregated_perf_results& result) {
     for (const auto& s : {"throughput", "instructions_per_op", "cpu_cycles_per_op"}) {
         auto& t = result.stats.at(s);
-        fmt::print(os, "\n{:>19}: mean={:.2f} standard-deviation={:.2f} median={:.2f} median-absolute-deviation={:.2f} maximum={:.2f} minimum={:.2f}",
+        fmt::print(os, "{}:\n\tmean=   {:.2f} standard-deviation={:.2f}\n\tmedian= {:.2f} median-absolute-deviation={:.2f}\n\tmaximum={:.2f} minimum={:.2f}\n",
                 s, t.mean, t.stdev, t.median, t.median_absolute_deviation, t.max, t.min);
     }
     return os;

--- a/test/perf/perf_generic_server.cc
+++ b/test/perf/perf_generic_server.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include <cstdint>
+#include <seastar/core/app-template.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/core/temporary_buffer.hh>
+#include <seastar/net/socket_defs.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/thread.hh>
+
+#include "db/config.hh"
+#include "generic_server.hh"
+#include "test/perf/perf.hh"
+
+seastar::logger plog("perf");
+
+struct test_config {
+    unsigned duration;
+    unsigned concurrency;
+    uint64_t requests_per_connection;
+    unsigned request_size;
+    unsigned response_size;
+    std::string server_host;
+    uint16_t server_port;
+};
+
+class test_connection : public generic_server::connection {
+    const test_config& _conf;
+    uint64_t _requests;
+
+public:
+    test_connection(generic_server::server& server, connected_socket&& fd, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units, const test_config& conf)
+            : generic_server::connection(server, std::move(fd), sem, std::move(initial_sem_units))
+            , _conf(conf)
+            , _requests(0) {
+    }
+
+    virtual void handle_error(future<>&& f) override {
+        try {
+            f.get();
+        } catch (const std::exception& ex) {
+            plog.error("Error during processing request: {}", ex);
+        }
+    }
+
+    virtual future<> process_request() override {
+        co_await _read_buf.read_exactly(_conf.request_size);
+        co_await _write_buf.write(temporary_buffer<char>(_conf.response_size));
+        co_await _write_buf.flush();
+    // simulate that it take 2 exchanges to establish logical connection
+    // this is important for performance as server disables cpu concurrency
+    // limiting code after that
+        if (++_requests == 1) {
+        on_connection_ready();
+        }
+    }
+};
+
+class test_server : public generic_server::server {
+    const test_config& _conf;
+public:
+    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override {
+        return make_shared<test_connection>(*this, std::move(fd), sem, std::move(initial_sem_units), _conf);
+    }
+
+
+    test_server(const test_config& conf)
+    : generic_server::server("test_server", plog,
+            generic_server::config(std::numeric_limits<uint32_t>::max()))
+    , _conf(conf) {}
+};
+
+struct tester {
+    test_config conf;
+    test_server server;
+
+    tester(const test_config& cfg) : conf(cfg) , server(conf) {}
+
+    socket_address addr() {
+        return socket_address(net::inet_address(conf.server_host), conf.server_port);
+    }
+
+    future<> start() {
+        return server.listen(addr(), nullptr, false, false, {});
+    }
+
+    future<> run() {
+        return seastar::async([&] {
+            auto results = time_parallel([&] -> future<> {
+                connected_socket sock = co_await seastar::connect(addr());
+                auto out = sock.output();
+                auto in = sock.input();
+                for (uint64_t i = 0; i <= conf.requests_per_connection; i++) {
+                    co_await out.write(temporary_buffer<char>(conf.request_size));
+                    co_await out.flush();
+                    co_await in.read_exactly(conf.response_size);
+                }
+                co_await out.close();
+                co_await in.close();
+            }, conf.concurrency, conf.duration, 0 ,true, conf.requests_per_connection);
+
+            // Technically, we're measuring the client side here,
+            // but since it's a single process with the server, both sides are included.
+            std::cout << aggregated_perf_results(results) << std::endl;
+        }).or_terminate();
+    }
+
+    future<> stop() {
+        co_await server.stop();
+    }
+};
+
+int main(int argc, char** argv) {
+    namespace bpo = boost::program_options;
+    app_template app;
+    app.add_options()
+        ("duration", bpo::value<unsigned>()->default_value(10), "seconds to run")
+        ("concurrency", bpo::value<unsigned>()->default_value(200), "clients per shard")
+        ("requests-per-connection", bpo::value<uint64_t>()->default_value(1024), "number of requests issued before closing the connection and making new one")
+        ("request-size", bpo::value<unsigned>()->default_value(1024), "request size")
+        ("response-size", bpo::value<unsigned>()->default_value(1024), "response size")
+        ("server-host", bpo::value<std::string>()->default_value("127.0.0.1"), "server address, defaults to localhost")
+        ("server-port", bpo::value<uint16_t>()->default_value(1234), "server port")
+    ;
+    return app.run(argc, argv, [&app] () -> future<> {
+        test_config conf;
+        conf.duration = app.configuration()["duration"].as<unsigned>();
+        conf.concurrency = app.configuration()["concurrency"].as<unsigned>();
+        conf.requests_per_connection = app.configuration()["requests-per-connection"].as<uint64_t>();
+        conf.request_size = app.configuration()["request-size"].as<unsigned>();
+        conf.response_size = app.configuration()["response-size"].as<unsigned>();
+        conf.server_host = app.configuration()["server-host"].as<std::string>();
+        conf.server_port = app.configuration()["server-port"].as<uint16_t>();
+
+        sharded<tester> test;
+        plog.info("Starting");
+        co_await test.start(std::cref(conf));
+        co_await test.invoke_on_all(&tester::start);
+        try {
+            plog.info("Running");
+            co_await test.invoke_on_all(&tester::run);
+        } catch (...) {
+            plog.error("Error running: {}", std::current_exception());
+        }
+        co_await test.stop();
+    });
+}

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -934,6 +934,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
         }
     } else {
         _ready = true;
+        on_connection_ready();
         res = make_ready(stream, trace_state);
     }
 
@@ -967,6 +968,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_au
                 return f.then([this, stream, challenge = std::move(challenge), trace_state]() mutable {
                     _authenticating = false;
                     _ready = true;
+                    on_connection_ready();
                     return make_ready_future<std::unique_ptr<cql_server::response>>(make_auth_success(stream, std::move(challenge), trace_state));
                 });
             });
@@ -1324,6 +1326,7 @@ cql_server::connection::process_register(uint16_t stream, request_reader in, ser
         _server._notifier->register_event(et, this);
     }
     _ready = true;
+    on_connection_ready();
     return make_ready_future<std::unique_ptr<cql_server::response>>(make_ready(stream, std::move(trace_state)));
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -290,6 +290,12 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         sm::make_counter("requests_shed", _stats.requests_shed,
                         sm::description("Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). "
                                             "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component."))(basic_level),
+        sm::make_counter("connections_shed", _shed_connections,
+            sm::description("Holds an incrementing counter with the CQL connections that were shed due to concurrency semaphore timeout (threshold configured via uninitialized_connections_semaphore_cpu_concurrency). "
+                                            "This typically can happen during connection storm. ")),
+        sm::make_counter("connections_blocked", _blocked_connections,
+            sm::description("Holds an incrementing counter with the CQL connections that were blocked before being processed due to threshold configured via uninitialized_connections_semaphore_cpu_concurrency. "
+                                            "Blocks are normal when we have multiple connections initialized at once. If connections are timing out and this value is high it indicates either connections storm or unusually slow processing.")),
         sm::make_gauge("requests_memory_available", [this] { return _memory_available.current(); },
                         sm::description(
                             seastar::format("Holds the amount of available memory for admitting new requests (max is {}B)."

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -246,7 +246,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
-    : server("CQLServer", clogger)
+    : server("CQLServer", clogger, generic_server::config(db_cfg))
     , _query_processor(qp)
     , _config(std::move(config))
     , _max_request_size(_config.max_request_size)

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -630,10 +630,6 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
 }
 
 cql_server::connection::~connection() {
-}
-
-void cql_server::connection::on_connection_close()
-{
     _server._notifier->unregister_connection(this);
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -11,6 +11,7 @@
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include <seastar/core/scheduling.hh>
+#include <seastar/core/semaphore.hh>
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"
@@ -318,8 +319,8 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
 cql_server::~cql_server() = default;
 
 shared_ptr<generic_server::connection>
-cql_server::make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) {
-    auto conn = make_shared<connection>(*this, server_addr, std::move(fd), std::move(addr));
+cql_server::make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) {
+    auto conn = make_shared<connection>(*this, server_addr, std::move(fd), std::move(addr),sem, std::move(initial_sem_units));
     ++_stats.connects;
     ++_stats.connections;
     return conn;
@@ -609,8 +610,8 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
     });
 }
 
-cql_server::connection::connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr)
-    : generic_server::connection{server, std::move(fd)}
+cql_server::connection::connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units)
+    : generic_server::connection{server, std::move(fd), sem, std::move(initial_sem_units)}
     , _server(server)
     , _server_addr(server_addr)
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr)

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -249,7 +249,6 @@ private:
         virtual ~connection();
         future<> process_request() override;
         void handle_error(future<>&& f) override;
-        void on_connection_close() override;
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }
         void update_scheduling_group();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -245,7 +245,7 @@ private:
                 service_permit>;
         static thread_local execution_stage_type _process_request_stage;
     public:
-        connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr);
+        connection(cql_server& server, socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units);
         virtual ~connection();
         future<> process_request() override;
         void handle_error(future<>&& f) override;
@@ -336,7 +336,7 @@ private:
     friend class type_codec;
 
 private:
-    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr) override;
+    virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
     future<> advertise_new_connection(shared_ptr<generic_server::connection> conn) override;
     future<> unadvertise_connection(shared_ptr<generic_server::connection> conn) override;
 


### PR DESCRIPTION
Adds new live updatable config: uninitialized_connections_semaphore_cpu_concurrency.

It should help to reduce cpu usage by limiting cpu concurrency for new connections.  As a last resort when those connections are waiting for initial processing too long (over 1m) they are shed.

New connections_shed and connections_blocked metrics are added for tracking.

Testing:
 - manually via simple program creating high number of connection and constantly re-connecting
 - added benchmark

Following are benchmark results:

Before:
```
> build/release/test/perf/perf_generic_server --smp=1
170101.41 tps ( 13.1 allocs/op,   0.0 logallocs/op,   7.0 tasks/op,    4695 insns/op,    3178 cycles/op,        0 errors)
[...]
throughput: mean=173850.06 standard-deviation=1844.48 median=174509.66 median-absolute-deviation=874.23 maximum=175087.49 minimum=170588.54
instructions_per_op: mean=4725.59 standard-deviation=13.35 median=4729.38 median-absolute-deviation=12.49 maximum=4738.61 minimum=4709.96
  cpu_cycles_per_op: mean=3135.08 standard-deviation=32.13 median=3122.68 median-absolute-deviation=22.29 maximum=3179.38 minimum=3103.15
```

After:
```
> build/release/test/perf/perf_generic_server --smp=1
167373.19 tps ( 13.1 allocs/op,   0.0 logallocs/op,   7.0 tasks/op,    4821 insns/op,    3371 cycles/op,        0 errors)
[...]
throughput:
  mean=   171199.55 standard-deviation=2484.58
  median= 171667.06 median-absolute-deviation=2087.63
  maximum=173689.11 minimum=167904.76
instructions_per_op:
  mean=   4801.90 standard-deviation=16.54
  median= 4796.78 median-absolute-deviation=9.32
  maximum=4830.71 minimum=4789.81
cpu_cycles_per_op:
  mean=   3245.26 standard-deviation=32.28
  median= 3230.44 median-absolute-deviation=16.52
  maximum=3297.39 minimum=3215.62
```

The patch adds around 67 insns/op so it's effect on performance should be negligible.

Fixes: https://github.com/scylladb/scylladb/issues/22844