### PR TITLE
raft_rpc::send_append_entries: limit memory usage

### DIFF
--- a/raft/raft.cc
+++ b/raft/raft.cc
@@ -12,6 +12,27 @@ namespace raft {
 
 seastar::logger logger("raft");
 
+size_t log_entry::get_size() const {
+    struct overloaded {
+        size_t operator()(const command& c) {
+            return c.size();
+        }
+        size_t operator()(const configuration& c) {
+            size_t size = 0;
+            for (auto& s : c.current) {
+                size += sizeof(s.addr.id);
+                size += s.addr.info.size();
+                size += sizeof(s.can_vote);
+            }
+            return size;
+        }
+        size_t operator()(const log_entry::dummy& d) {
+            return 0;
+        }
+    };
+    return std::visit(overloaded{}, this->data) + sizeof(*this);
+}
+
 } // end of namespace raft
 
 auto fmt::formatter<raft::server_address>::format(const raft::server_address& addr,

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -239,6 +239,8 @@ struct log_entry {
     term_t term;
     index_t idx;
     std::variant<command, configuration, dummy> data;
+
+    size_t get_size() const;
 };
 
 using log_entry_ptr = seastar::lw_shared_ptr<const log_entry>;

--- a/service/raft/raft_rpc.hh
+++ b/service/raft/raft_rpc.hh
@@ -31,6 +31,9 @@ protected:
     shared_ptr<raft::failure_detector> _failure_detector;
     seastar::gate _shutdown_gate;
 
+    // Limits the total memory usage of raft::append_request messages that are currently being sent
+    seastar::semaphore _append_entries_semaphore;
+
     explicit raft_rpc(raft_state_machine& sm, netw::messaging_service& ms,
              shared_ptr<raft::failure_detector> failure_detector, raft::group_id gid, raft::server_id my_id);
 


### PR DESCRIPTION
Serializing `raft::append_request` for transmission requires approximately the same amount of memory as its size. This means when the Raft library replicates a log item to M servers, the log item is effectively copied M times. To prevent excessive memory usage and potential out-of-memory issues, we limit the total memory consumption of in-flight `raft::append_request` messages.

Fixes scylladb/scylladb#14411