### PR TITLE
test_rpc_compression.py: fix an overly-short timeout

### DIFF
--- a/test/topology_custom/test_rpc_compression.py
+++ b/test/topology_custom/test_rpc_compression.py
@@ -215,7 +215,7 @@ async def test_external_dicts(manager: ManagerClient) -> None:
     await asyncio.gather(*[manager.server_stop_gracefully(s.server_id) for s in servers])
     await asyncio.gather(*[manager.server_update_config(s.server_id, 'rpc_dict_training_when', 'never') for s in servers])
     await asyncio.gather(*[manager.server_start(s.server_id) for s in servers])
-    await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=10)
+    await with_retries(functools.partial(test_once, "lz4", 0.5), timeout=600)
 
 # Similar to test_external_dicts, but simpler.
 @pytest.mark.asyncio


### PR DESCRIPTION
The timeout of 10 seconds is too small for CI.
I didn't mean to make it so short, it was an accident.

Fix that by changing the timeout to 10 minutes.

Fixes scylladb/scylladb#22832

It should be backported to 2025.1, but the test fixed by this commit hasn't been backported yet itself. So I'll just squash the fix into https://github.com/scylladb/scylladb/pull/22807 manually.