### PR TITLE
service: Don't use new tablet_resize_finalization state until supported

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -750,6 +750,8 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
                     [[fallthrough]];
                 case topology::transition_state::tablet_migration:
                     [[fallthrough]];
+                case topology::transition_state::tablet_split_finalization:
+                    [[fallthrough]];
                 case topology::transition_state::tablet_resize_finalization:
                     [[fallthrough]];
                 case topology::transition_state::commit_cdc_generation:

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -148,6 +148,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::write_both_read_old, "write both read old"},
     {topology::transition_state::write_both_read_new, "write both read new"},
     {topology::transition_state::tablet_migration, "tablet migration"},
+    {topology::transition_state::tablet_split_finalization, "tablet split finalization"},
     {topology::transition_state::tablet_resize_finalization, "tablet resize finalization"},
     {topology::transition_state::tablet_draining, "tablet draining"},
     {topology::transition_state::left_token_ring, "left token ring"},
@@ -156,20 +157,11 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::lock, "lock"},
 };
 
-// Allows old deprecated names to be recognized and point to the correct transition.
-static std::unordered_map<sstring, topology::transition_state> deprecated_name_to_transition_state = {
-    {"tablet split finalization", topology::transition_state::tablet_resize_finalization},
-};
-
 topology::transition_state transition_state_from_string(const sstring& s) {
     for (auto&& e : transition_state_to_name_map) {
         if (e.second == s) {
             return e.first;
         }
-    }
-    auto it = deprecated_name_to_transition_state.find(s);
-    if (it != deprecated_name_to_transition_state.end()) {
-        return it->second;
     }
     on_internal_error(tsmlogger, format("cannot map name {} to transition_state", s));
 }

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -117,6 +117,7 @@ struct topology {
         write_both_read_new,
         tablet_migration,
         tablet_resize_finalization,
+        tablet_split_finalization, // deprecated in favor of tablet_resize_finalization, kept for backward compatibility.
         left_token_ring,
         rollback_to_normal,
         truncate_table,

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3490,7 +3490,7 @@ SEASTAR_TEST_CASE(test_explicit_tablets_disable) {
 
 SEASTAR_TEST_CASE(test_recognition_of_deprecated_name_for_resize_transition) {
     using transition_state = service::topology::transition_state;
-    BOOST_REQUIRE_EQUAL(service::transition_state_from_string("tablet split finalization"), transition_state::tablet_resize_finalization);
+    BOOST_REQUIRE_EQUAL(service::transition_state_from_string("tablet split finalization"), transition_state::tablet_split_finalization);
     BOOST_REQUIRE_EQUAL(service::transition_state_from_string("tablet resize finalization"), transition_state::tablet_resize_finalization);
     return make_ready_future<>();
 }


### PR DESCRIPTION
In a rolling upgrade, nodes that weren't upgraded yet will not recognize the new tablet_resize_finalization state, that serves both split and merges, leading to a crash. To fix that, coordinator will pick the old tablet_split_finalization state for serving split finalization, until the cluster agrees on merge, so it can start using the new generic state for resize finalization introduced in merge series. Regression was introduced in e00798f.

Fixes #22840.

2025.1 is affected, we should backport to it too