### PR TITLE
raft topology: drop changing the raft voters config via storage_service

### DIFF
--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -980,7 +980,7 @@ future<bool> raft_group0::wait_for_raft() {
 
 future<> raft_group0::modify_raft_voter_status(const std::unordered_set<raft::server_id>& voters_add, const std::unordered_set<raft::server_id>& voters_del,
         abort_source& as, std::optional<raft_timeout> timeout) {
-    co_await run_op_with_retry(as, [this, &voters_add, &voters_del, timeout, &as] -> future<operation_result> {
+    return run_op_with_retry(as, [this, &voters_add, &voters_del, timeout, &as] -> future<operation_result> {
         std::vector<raft::config_member> add;
         add.reserve(voters_add.size() + voters_del.size());
 
@@ -1000,11 +1000,10 @@ future<> raft_group0::modify_raft_voter_status(const std::unordered_set<raft::se
         }
         co_return operation_result::success;
     }, "modify_raft_voter_status->modify_config");
-    co_return;
 }
 
 future<> raft_group0::remove_from_raft_config(raft::server_id id) {
-    co_await run_op_with_retry(_abort_source, [this, id]() -> future<operation_result> {
+    return run_op_with_retry(_abort_source, [this, id] -> future<operation_result> {
         try {
             co_await _raft_gr.group0_with_timeouts().modify_config({}, {id}, &_abort_source, raft_timeout{});
         } catch (const raft::commit_status_unknown& e) {
@@ -1013,7 +1012,6 @@ future<> raft_group0::remove_from_raft_config(raft::server_id id) {
         }
         co_return operation_result::success;
     }, "remove_from_raft_config->modify_config");
-    co_return;
 }
 
 bool raft_group0::joined_group0() const {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -225,17 +225,22 @@ public:
     // `wait_for_raft` must've also been called earlier and returned `true`.
     future<> become_nonvoter(abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
-    // Set the voter status of the given server, other than us, in group 0.
+    // Make the given server, other than us, a non-voter in group 0.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> set_voter_status(raft::server_id, can_vote, abort_source&, std::optional<raft_timeout> timeout = std::nullopt);
+    future<> make_nonvoter(raft::server_id, abort_source&, std::optional<raft_timeout> timeout = std::nullopt);
 
-    // Set the voter status of the given servers, other than us, in group 0.
+    // Modify the voter status of the given servers in group 0.
+    //
+    // The `voters_add` are changed to voters, the `voters_del` are changed to non-voters.
+    //
+    // The `voters_add` and `voters_del` sets must not intersect.
     //
     // Assumes we've finished the startup procedure (`setup_group0()` finished earlier).
     // `wait_for_raft` must've also been called earlier and returned `true`.
-    future<> set_voters_status(const std::unordered_set<raft::server_id>&, can_vote, abort_source&, std::optional<raft_timeout> timeout = std::nullopt);
+    future<> modify_voters(const std::unordered_set<raft::server_id>& voters_add, const std::unordered_set<raft::server_id>& voters_del, abort_source& as,
+            std::optional<raft_timeout> timeout = std::nullopt);
 
     // Remove ourselves from group 0.
     //
@@ -383,8 +388,8 @@ private:
 
     // Modify the given server voter status in Raft group 0 configuration.
     // Retries on raft::commit_status_unknown.
-    future<> modify_raft_voter_status(
-            const std::unordered_set<raft::server_id>&, can_vote, abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
+    future<> modify_raft_voter_status(const std::unordered_set<raft::server_id>& voters_add, const std::unordered_set<raft::server_id>& voters_del,
+            abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
 
     // Returns true if raft is enabled
     future<bool> use_raft();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4100,8 +4100,6 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
             throw std::runtime_error("Removenode failed. Concurrent request for removal already in progress");
         }
         try {
-            // Make non voter during request submission for better HA
-            co_await _group0->set_voters_status(ignored_ids, can_vote::no, _group0_as, raft_timeout{});
             co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
         } catch (group0_concurrent_modification&) {
             rtlogger.info("removenode: concurrent operation is detected, retrying.");
@@ -6918,8 +6916,6 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
         co_await utils::get_local_injector().inject("join-node-before-add-entry", utils::wait_for_message(5min));
 
         try {
-            // Make replaced node and ignored nodes non voters earlier for better HA
-            co_await _group0->set_voters_status(ignored_nodes_from_join_params(params), can_vote::no, _group0_as, raft_timeout{});
             co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
             break;
         } catch (group0_concurrent_modification&) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4114,19 +4114,13 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
     // Wait until request completes
     auto error = co_await wait_for_topology_request_completion(request_id);
 
-    if (error.empty()) {
-        rtlogger.info("removenode: successfully removed from topology (request ID: {}), removing from group 0 configuration", request_id);
-        try {
-            co_await _group0->remove_from_raft_config(id);
-        } catch (raft::not_a_member&) {
-            rtlogger.info("removenode: already removed from the raft config by the topology coordinator");
-        }
-        rtlogger.info("Removenode succeeded. Request ID: {}", request_id);
-    } else {
+    if (!error.empty()) {
         auto err = fmt::format("Removenode failed. See earlier errors ({}). Request ID: {}", error, request_id);
         rtlogger.error("{}", err);
         throw std::runtime_error(err);
     }
+
+    rtlogger.info("Removenode succeeded. Request ID: {}", request_id);
 }
 
 future<> storage_service::removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4176,7 +4176,7 @@ future<> storage_service::removenode(locator::host_id host_id, locator::host_id_
                 // but before removing it group 0, group 0's availability won't be reduced.
                 if (is_group0_member && ss._group0->is_member(raft_id, true)) {
                     slogger.info("removenode[{}]: making node {} a non-voter in group 0", uuid, raft_id);
-                    ss._group0->set_voter_status(raft_id, can_vote::no, ss._group0_as).get();
+                    ss._group0->make_nonvoter(raft_id, ss._group0_as).get();
                     slogger.info("removenode[{}]: made node {} a non-voter in group 0", uuid, raft_id);
                 }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2169,7 +2169,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // FIXME: removenode may be aborted and the already dead node can be resurrected. We should consider
                     // restoring its voter state on the recovery path.
                     if (node.rs->state == node_state::removing) {
-                        co_await _group0.set_voter_status(node.id, can_vote::no, _as);
+                        co_await _group0.make_nonvoter(node.id, _as);
                     }
 
                     // If we decommission a node when the number of nodes is even, we make it a non-voter early.
@@ -2186,7 +2186,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                          "giving up leadership");
                             co_await step_down_as_nonvoter();
                         } else {
-                            co_await _group0.set_voter_status(node.id, can_vote::no, _as);
+                            co_await _group0.make_nonvoter(node.id, _as);
                         }
                     }
                 }
@@ -2194,7 +2194,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     // We make a replaced node a non-voter early, just like a removed node.
                     auto replaced_node_id = parse_replaced_node(node.req_param);
                     if (_group0.is_member(replaced_node_id, true)) {
-                        co_await _group0.set_voter_status(replaced_node_id, can_vote::no, _as);
+                        co_await _group0.make_nonvoter(replaced_node_id, _as);
                     }
                 }
                 utils::get_local_injector().inject("crash_coordinator_before_stream", [] { abort(); });

--- a/test/topology_custom/test_tablets_migration.py
+++ b/test/topology_custom/test_tablets_migration.py
@@ -127,19 +127,17 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
         await make_server()
 
         if fail_stage in ["cleanup_target", "revert_migration"]:
-            # we'll stop 2 servers, group0 quorum should be there
+            # we'll stop 2 servers, group0 quorum should be there - we need five
+            # nodes to have three remaining
             #
-            # it seems that we need five nodes to have three remaining, but
-            # when removing the 1st node it will be marked as non-voter so to
-            # remove the 2nd node just two remaining will be enough
-            #
-            # also this extra node will be used to call removenode on
+            # also one of the extra nodes will be used to call removenode on
             # removing the 1st node will wait for the operation to go through
             # raft log, and it will not finish before tablet migration. An
             # attempt to remove the 2nd node, to make cleanup_target stage
             # go ahead, will step on the legacy API lock on storage_service,
             # so we need to ask some other node to do it
-            await make_server()
+            for _ in range(2):
+                await make_server()
 
         logger.info(f"Cluster is [{host_ids}]")
 


### PR DESCRIPTION
For the limited voters feature to work properly we need to make sure that we are only managing the voter status through the topology coordinator. This means that we should not change the node votership from the storage_service module for the raft topology directly.

We can drop the voter status changes from the storage_service module because the topology coordinator will handle the votership changes eventually. The calls in the storage_service module were not essential and were only used for optimization (improving the HA under certain conditions).
Furthermore, the other bundled commit improves the reaction again by reacting to the node `on_up()` and `on_down()` events, which again shortens the reaction time and improves the HA.

The change has effect on the timing in the tablets migration test though, as it previously relied on the node being made non-voter from the service_storage `raft_removenode()` function. The fix is to add another server to the topology to make sure we will keep the quorum.

Previously the test worked because the test waits for an injection to be reached and it was ensured that the injection (log line) has only been triggered after the node has been made non-voter from the `raft_removenode()`. This is not the case anymore. An alternative fix would be to wait for the first node to be made non-voter before stopping the second server, but this would make the test more complex (and it is not strictly required to only use 4 servers in the test, it has been only done for optimization purposes).

Fixes: scylladb/scylladb#22860

Refs: scylladb/scylladb#18793
Refs: scylladb/scylladb#21969

No backport: Part of the limited voters new feature, so this shouldn't to be backported.