### PR TITLE
tree: Remove unused boost headers

### DIFF
--- a/api/collectd.cc
+++ b/api/collectd.cc
@@ -10,7 +10,6 @@
 #include "api/api-doc/collectd.json.hh"
 #include <seastar/core/scollectd.hh>
 #include <seastar/core/scollectd_api.hh>
-#include <boost/range/irange.hpp>
 #include <ranges>
 #include <regex>
 #include "api/api_init.hh"

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -24,9 +24,6 @@
 #include "compaction/compaction_manager.hh"
 #include "unimplemented.hh"
 
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/numeric.hpp>
-
 extern logging::logger apilog;
 
 namespace api {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -22,7 +22,6 @@
 #include <functional>
 #include <iterator>
 #include <chrono>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/functional/hash.hpp>

--- a/auth/default_authorizer.cc
+++ b/auth/default_authorizer.cc
@@ -16,7 +16,6 @@ extern "C" {
 #include <unistd.h>
 }
 
-#include <boost/range.hpp>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
 

--- a/collection_mutation.cc
+++ b/collection_mutation.cc
@@ -16,8 +16,6 @@
 
 #include "collection_mutation.hh"
 
-#include <boost/range/numeric.hpp>
-
 bytes_view collection_mutation_input_stream::read_linearized(size_t n) {
     managed_bytes_view mbv = ::read_simple_bytes(_src, n);
     if (mbv.is_linearized()) {

--- a/compaction/incremental_backlog_tracker.cc
+++ b/compaction/incremental_backlog_tracker.cc
@@ -6,7 +6,6 @@
 
 #include "incremental_backlog_tracker.hh"
 #include "sstables/sstables.hh"
-#include <boost/range/adaptor/map.hpp>
 
 using namespace sstables;
 

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "compaction_strategy_impl.hh"
-#include <boost/range/algorithm.hpp>
 
 class incremental_backlog_tracker;
 

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -8,9 +8,6 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
  */
 
-#include <boost/range/algorithm/equal.hpp>
-#include <boost/range/algorithm/transform.hpp>
-
 #include "cql3/selection/selection.hh"
 #include "cql3/selection/raw_selector.hh"
 #include "cql3/result_set.hh"

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -18,7 +18,6 @@
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "data_dictionary/keyspace_metadata.hh"
-#include "boost/range/adaptor/map.hpp"
 #include "data_dictionary/user_types_metadata.hh"
 
 namespace cql3 {

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -13,7 +13,6 @@
 #include <inttypes.h>
 #include <boost/regex.hpp>
 
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/algorithm/adjacent_find.hpp>
 #include <seastar/core/coroutine.hh>
 

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -12,8 +12,6 @@
 #include "cql3/query_processor.hh"
 #include "cql3/functions/functions.hh"
 
-#include "boost/range/adaptor/map.hpp"
-
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "data_dictionary/data_dictionary.hh"

--- a/db/batchlog_manager.cc
+++ b/db/batchlog_manager.cc
@@ -16,8 +16,6 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/sliced.hpp>
 
 #include "batchlog_manager.hh"
 #include "mutation/canonical_mutation.hh"

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -13,7 +13,6 @@
 #include <algorithm>
 #include <unordered_map>
 #include <ranges>
-#include <boost/range/adaptor/map.hpp>
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>

--- a/db/cql_type_parser.cc
+++ b/db/cql_type_parser.cc
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
  */
 #include <unordered_map>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/adaptor/sliced.hpp>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include "replica/database.hh"

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -20,9 +20,6 @@
 #include <seastar/core/format.hh>
 #include <seastar/core/seastar.hh>
 
-// Boost features.
-#include <boost/range/algorithm/find.hpp>
-
 // Scylla includes.
 #include "db/hints/internal/common.hh"
 #include "db/hints/internal/hint_logger.hh"

--- a/db/hints/internal/hint_storage.cc
+++ b/db/hints/internal/hint_storage.cc
@@ -19,9 +19,6 @@
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 
-// Boost features.
-#include <boost/range/adaptor/map.hpp>
-
 // Scylla includes.
 #include "db/hints/internal/hint_logger.hh"
 #include <seastar/core/future.hh>

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -12,7 +12,6 @@
 #include "manager.hh"
 #include "utils/log.hh"
 #include <boost/range/algorithm/for_each.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/numeric.hpp>
 #include "utils/disk-error-handler.hh"
 #include "seastarx.hh"

--- a/db/per_partition_rate_limit_options.cc
+++ b/db/per_partition_rate_limit_options.cc
@@ -7,7 +7,6 @@
  */
 
 #include <optional>
-#include <boost/range/adaptor/map.hpp>
 #include "exceptions/exceptions.hh"
 #include "serializer.hh"
 #include "schema/schema.hh"

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -18,11 +18,6 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/on_internal_error.hh>
 
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/algorithm/transform.hpp>
-#include <boost/range/adaptor/indirected.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/range/join.hpp>
 
 #include <fmt/ranges.h>

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -10,8 +10,6 @@
 #include <seastar/core/timed_out_error.hh>
 #include "gms/inet_address.hh"
 #include <seastar/util/defer.hh>
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/numeric.hpp>
 #include "replica/database.hh"
 #include "view_update_generator.hh"
 #include "utils/error_injection.hh"

--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -8,7 +8,6 @@
 
 #include <algorithm>
 
-#include <boost/range/algorithm.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
 #include <seastar/core/coroutine.hh>

--- a/dht/murmur3_partitioner.cc
+++ b/dht/murmur3_partitioner.cc
@@ -10,8 +10,6 @@
 #include "utils/murmur_hash.hh"
 #include "sstables/key.hh"
 #include "utils/class_registrator.hh"
-#include <boost/lexical_cast.hpp>
-#include <boost/range/irange.hpp>
 
 namespace dht {
 

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -22,9 +22,6 @@
 #include <openssl/sha.h>
 #include <openssl/hmac.h>
 
-#include <boost/range/adaptor/map.hpp>
-#include <boost/filesystem.hpp>
-
 #include <seastar/core/seastar.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -20,8 +20,6 @@
 #include "concrete_types.hh"
 #include "db/tags/extension.hh"
 
-#include <boost/range/adaptor/map.hpp>
-
 namespace secondary_index {
 
 index::index(const sstring& target_column, const index_metadata& im)

--- a/querier.cc
+++ b/querier.cc
@@ -15,8 +15,6 @@
 #include "utils/log.hh"
 #include "utils/error_injection.hh"
 
-#include <boost/range/adaptor/map.hpp>
-
 namespace query {
 
 logging::logger qlogger("querier_cache");

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -11,8 +11,6 @@
 #include <unordered_map>
 #include <optional>
 #include "reader_concurrency_semaphore.hh"
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/numeric.hpp>
 
 // The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory,
 // the memory is dynamically divided between them according to a relative slice of shares each semaphore

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -33,7 +33,6 @@
 #include <seastar/core/metrics.hh>
 #include "sstables/sstables.hh"
 #include "sstables/sstables_manager.hh"
-#include <boost/range/adaptor/map.hpp>
 #include <boost/container/static_vector.hpp>
 #include "mutation/frozen_mutation.hh"
 #include "mutation/async_utils.hh"

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -30,7 +30,6 @@
 #include "tracing/trace_keyspace_helper.hh"
 #include "db/view/view_update_checks.hh"
 #include <unordered_map>
-#include <boost/range/adaptor/map.hpp>
 #include "db/view/view_builder.hh"
 
 extern logging::logger dblog;

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -40,7 +40,6 @@
 #include "timestamp.hh"
 #include "utils/overloaded_functor.hh"
 #include "utils/to_string.hh"
-#include <boost/range/algorithm/transform.hpp>
 #include <optional>
 #include "db/config.hh"
 #include "replica/database.hh"

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -11,8 +11,6 @@
 #include "utils/log.hh"
 #include "db/system_keyspace.hh"
 
-#include <boost/range/adaptor/map.hpp>
-
 namespace service {
 
 logging::logger tsmlogger("topology_state_machine");

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -12,7 +12,6 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/util/file.hh>
-#include <boost/range/adaptor/map.hpp>
 #include <boost/algorithm/string.hpp>
 #include "sstables/sstable_directory.hh"
 #include "sstables/sstables.hh"

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -25,7 +25,6 @@
 #include "mutation_writer/multishard_writer.hh"
 #include "sstables/sstable_set.hh"
 #include "db/view/view_update_checks.hh"
-#include <boost/range/adaptor/map.hpp>
 #include "replica/database.hh"
 #include "streaming/stream_mutation_fragments_cmd.hh"
 #include "consumer.hh"

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -25,7 +25,6 @@
 #include "interval.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/sharder.hh"
-#include <boost/range/irange.hpp>
 #include <boost/icl/interval.hpp>
 #include <boost/icl/interval_set.hpp>
 #include <fmt/ranges.h>

--- a/test/boost/aggregate_fcts_test.cc
+++ b/test/boost/aggregate_fcts_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -7,9 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
-#include <boost/test/unit_test.hpp>
 #include <stdint.h>
 #include <fmt/ranges.h>
 

--- a/test/boost/batchlog_manager_test.cc
+++ b/test/boost/batchlog_manager_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 

--- a/test/boost/cached_file_test.cc
+++ b/test/boost/cached_file_test.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/irange.hpp>
 #include "test/lib/scylla_test_case.hh"
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/iostream.hh>

--- a/test/boost/cartesian_product_test.cc
+++ b/test/boost/cartesian_product_test.cc
@@ -26,7 +26,6 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include "cartesian_product.hh"
 
 template<typename Range>

--- a/test/boost/castas_fcts_test.cc
+++ b/test/boost/castas_fcts_test.cc
@@ -7,10 +7,7 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include "utils/big_decimal.hh"
 #include "exceptions/exceptions.hh"

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -12,7 +12,6 @@
 #include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <string>
-#include <boost/range/adaptor/map.hpp>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptor/map.hpp>
 
 #include <stdlib.h>
 #include <iostream>

--- a/test/boost/cql_functions_test.cc
+++ b/test/boost/cql_functions_test.cc
@@ -8,8 +8,6 @@
 
 #include <algorithm>
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/cql_query_group_test.cc
+++ b/test/boost/cql_query_group_test.cc
@@ -7,10 +7,7 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include <seastar/net/inet_address.hh>
 

--- a/test/boost/cql_query_large_test.cc
+++ b/test/boost/cql_query_large_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/cql_query_like_test.cc
+++ b/test/boost/cql_query_like_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -4,9 +4,6 @@
 
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 #include <random>

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -4,9 +4,6 @@
 
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/process.hpp>
 

--- a/test/boost/filtering_test.cc
+++ b/test/boost/filtering_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/flush_queue_test.cc
+++ b/test/boost/flush_queue_test.cc
@@ -11,7 +11,6 @@
 #include <bitset>
 #include <ranges>
 #include <boost/test/unit_test.hpp>
-#include <boost/range/irange.hpp>
 #include <seastar/core/loop.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/seastar.hh>

--- a/test/boost/json_cql_query_test.cc
+++ b/test/boost/json_cql_query_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 

--- a/test/boost/keys_test.cc
+++ b/test/boost/keys_test.cc
@@ -9,7 +9,6 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include "keys.hh"
 #include "schema/schema.hh"
 #include "schema/schema_builder.hh"

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -7,9 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/adaptor/uniqued.hpp>
-
 #include <seastar/core/thread.hh>
 
 #undef SEASTAR_TESTING_MAIN

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -31,7 +31,6 @@
 #include "test/lib/log.hh"
 #include "test/lib/test_utils.hh"
 
-#include <boost/range/adaptor/map.hpp>
 #include "readers/from_mutations_v2.hh"
 #include "readers/empty_v2.hh"
 #include "readers/generating_v2.hh"

--- a/test/boost/mvcc_test.cc
+++ b/test/boost/mvcc_test.cc
@@ -8,7 +8,6 @@
 
 
 #include "utils/assert.hh"
-#include <boost/range/algorithm_ext/push_back.hpp>
 #include <boost/range/size.hpp>
 #include <seastar/core/thread.hh>
 #include <seastar/util/defer.hh>

--- a/test/boost/query_processor_test.cc
+++ b/test/boost/query_processor_test.cc
@@ -7,8 +7,6 @@
  */
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
 #include <iterator>

--- a/test/boost/symmetric_key_test.cc
+++ b/test/boost/symmetric_key_test.cc
@@ -4,9 +4,6 @@
 
 
 
-#include <boost/range/irange.hpp>
-#include <boost/range/adaptors.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/lexical_cast.hpp>
 #include <stdint.h>

--- a/test/boost/view_complex_test.cc
+++ b/test/boost/view_complex_test.cc
@@ -7,7 +7,6 @@
  */
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <fmt/ranges.h>
 
 #include "replica/database.hh"

--- a/test/boost/view_schema_ckey_test.cc
+++ b/test/boost/view_schema_ckey_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptor/map.hpp>
 
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>

--- a/test/boost/view_schema_pkey_test.cc
+++ b/test/boost/view_schema_pkey_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptor/map.hpp>
 
 #include "db/view/view_builder.hh"
 

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -8,7 +8,6 @@
 
 
 #include <boost/test/unit_test.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <fmt/ostream.h>
 #include <fmt/ranges.h>
 #include "replica/database.hh"

--- a/test/boost/virtual_reader_test.cc
+++ b/test/boost/virtual_reader_test.cc
@@ -8,8 +8,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm.hpp>
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>
 

--- a/test/lib/dummy_sharder.hh
+++ b/test/lib/dummy_sharder.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <boost/range/adaptor/map.hpp>
 #include "dht/token.hh"
 #include "dht/token-sharding.hh"
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -12,7 +12,6 @@
 #include "replica/memtable-sstable.hh"
 #include "dht/i_partitioner.hh"
 #include "dht/murmur3_partitioner.hh"
-#include <boost/range/irange.hpp>
 #include "sstables/version.hh"
 #include "test/lib/mutation_reader_assertions.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"

--- a/test/lib/test_utils.cc
+++ b/test/lib/test_utils.cc
@@ -9,7 +9,6 @@
 #include "test/lib/test_utils.hh"
 
 #include <seastar/util/file.hh>
-#include <boost/range/adaptor/map.hpp>
 #include <seastar/core/format.hh>
 #include <seastar/util/backtrace.hh>
 #include "test/lib/log.hh"

--- a/test/manual/partition_data_test.cc
+++ b/test/manual/partition_data_test.cc
@@ -11,9 +11,6 @@
 
 #include <random>
 
-#include <boost/range/irange.hpp>
-#include <boost/range/algorithm/generate.hpp>
-
 #include "test/lib/random_utils.hh"
 #include "utils/disk-error-handler.hh"
 #include "mutation/atomic_cell.hh"

--- a/test/manual/sstable_scan_footprint_test.cc
+++ b/test/manual/sstable_scan_footprint_test.cc
@@ -16,7 +16,6 @@
 #include "db/config.hh"
 #include "db/commitlog/commitlog.hh"
 
-#include <boost/range/irange.hpp>
 #include <fmt/ranges.h>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/seastar.hh>

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -7,7 +7,6 @@
  */
 
 #include "utils/assert.hh"
-#include <boost/range/irange.hpp>
 
 #include <seastar/util/defer.hh>
 #include <seastar/core/app-template.hh>

--- a/test/perf/perf.hh
+++ b/test/perf/perf.hh
@@ -23,7 +23,6 @@
 
 #include <chrono>
 #include <iosfwd>
-#include <boost/range/irange.hpp>
 #include <vector>
 
 template <typename Func>

--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/irange.hpp>
 #include <fmt/ranges.h>
 #include "seastarx.hh"
 #include "test/lib/simple_schema.hh"

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -9,7 +9,6 @@
 #include "utils/assert.hh"
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/range/irange.hpp>
 #include <json/json.h>
 #include <fmt/ranges.h>
 

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -25,7 +25,6 @@
 #include <boost/accumulators/framework/features.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
 #include <boost/accumulators/statistics/error_of_mean.hpp>
-#include <boost/range/irange.hpp>
 
 using namespace sstables;
 

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/irange.hpp>
 #include "seastarx.hh"
 #include "test/lib/simple_schema.hh"
 #include "test/lib/log.hh"

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -20,7 +20,6 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <fmt/chrono.h>
 #include <fmt/ranges.h>
 #include <seastar/core/sleep.hh>

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -7,7 +7,6 @@
  */
 
 #include <boost/algorithm/string.hpp>
-#include <boost/range/adaptor/map.hpp>
 #include <filesystem>
 #include <set>
 #include <fmt/chrono.h>

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -8,12 +8,6 @@
 
 #include "server.hh"
 
-#include <boost/bimap/unordered_set_of.hpp>
-#include <boost/range/irange.hpp>
-#include <boost/bimap.hpp>
-#include <boost/assign.hpp>
-#include <boost/range/adaptor/sliced.hpp>
-
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
 #include "seastar/core/scheduling.hh"


### PR DESCRIPTION
This commit eliminates unused boost header includes from the tree.

Removing these unnecessary includes reduces dependencies on the external Boost.Adapters library, leading to faster compile times and a slightly cleaner codebase.

---

it's a cleanup, hence no need to backport.