### PR TITLE
test: remove spammy deprecation warnings

### DIFF
--- a/test/cqlpy/test_virtual_tables.py
+++ b/test/cqlpy/test_virtual_tables.py
@@ -132,24 +132,24 @@ def test_system_config_read(scylla_only, cql):
 # representation (true/false). #19791.
 def test_system_config_update_boolean(scylla_only, cql):
     var = 'compaction_enforce_min_threshold'
-    value = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'")[0].value
+    value = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'").one().value
     assert value in ('true', 'false')
     other = 'true' if value == 'false' else 'false'
     cql.execute(f"UPDATE system.config SET value = '{other}' WHERE name = '{var}'")
-    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'")[0].value
+    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'").one().value
     assert readback == other
 
     # just for completeness, check that writing 0/1 works too
     cql.execute(f"UPDATE system.config SET value = '0' WHERE name = '{var}'")
-    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'")[0].value
+    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'").one().value
     assert readback == 'false'
     cql.execute(f"UPDATE system.config SET value = '1' WHERE name = '{var}'")
-    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'")[0].value
+    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'").one().value
     assert readback == 'true'
 
     # restore original
     cql.execute(f"UPDATE system.config SET value = '{value}' WHERE name = '{var}'")
-    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'")[0].value
+    readback = cql.execute(f"SELECT value FROM system.config WHERE name = '{var}'").one().value
     assert readback == value
 
 def test_token_ring_vnodes(scylla_only, cql, test_keyspace_vnodes):

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -28,6 +28,8 @@ filterwarnings =
     ignore::urllib3.exceptions.InsecureRequestWarning
     ignore:record_property is incompatible with junit_family:pytest.PytestWarning
     ignore::DeprecationWarning:importlib._bootstrap
+    ignore::DeprecationWarning:botocore
+    ignore::DeprecationWarning:pytest_elk_reporter
 
 tmp_path_retention_count = 1
 tmp_path_retention_policy = failed


### PR DESCRIPTION
Recently, when running Alternator tests we get hundreds of warnings like the following from basically all test files:

    /usr/lib/python3.12/site-packages/botocore/crt/auth.py:59:
    DeprecationWarning: datetime.datetime.utcnow() is deprecated and
    scheduled for removal in a future version. Use timezone-aware objects
    to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

    /usr/local/lib/python3.12/site-packages/pytest_elk_reporter.py:299:
    DeprecationWarning: datetime.datetime.utcnow() is deprecated and
    scheduled for removal in a future version. Use timezone-aware objects
    to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).

These warnings all come from two libraries that we use in the tests - botocore is used by Alternator tests, and elk reporter is a plugin that we don't actually use, but it is installed by dtest and we often see it in our runs as well. These warnings have zero interest to us - not only do we not care if botocore uses some deprecated Python APIs and will need to be updated in the future, all these warnings are hiding *real* warnings about deprecated things we actually use in our own test code.

The patch modifies test/pytest.ini (used by all our Python tests, including but not limited to Alternator tests) to ignore deprecation warnings from *inside* these two libraries, botocore and elk_reporter.

After this patch, test/alternator/run finishes without any warnings at all. test/cqlpy does still have a few warnings left, which earlier were hidden by the thousands of spammy warning eliminated in this patch.

We fix one of these warnings in this patch:

    ResultSet indexing support will be removed in 4.0.
    Consider using ResultSet.one()

by doing exactly what the warning recommended.

Some deprecation warnings in test/cqlpy remain in calls to get_query_trace(). The "blame" for these warning is misplaced - this function is part of the cassandra driver, but Python seems to think it's part of our test code so I can't avoid them with the pytest.ini trick, I'm not sure why. So I don't know yet how to eliminate these last warnings.

This patch just improves developer experience while running tests, which almost always happens on master, so no backport necessary.