### PR TITLE
WIP: audit: enable tablets by default

### DIFF
--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -105,9 +105,10 @@ future<> audit_cf_storage_helper::start(const db::config &cfg) {
         if (ks = _qp.db().try_find_keyspace(KEYSPACE_NAME); !ks) {
             // releasing, because table_helper::setup_keyspace creates a raft guard of its own
             service::release_guard(std::move(group0_guard));
+            std::optional<unsigned int> init_tablets = 0; // 0 means let the system decide
             co_return co_await table_helper::setup_keyspace(_qp, _mm, KEYSPACE_NAME,
                                                             "org.apache.cassandra.locator.NetworkTopologyStrategy",
-                                                            "3", _dummy_query_state, {&_table});
+                                                            "3", _dummy_query_state, {&_table}, init_tablets);
         } else if (ks->metadata()->strategy_name() == "org.apache.cassandra.locator.SimpleStrategy") {
             // We want to migrate the old (pre-Scylla 6.0) SimpleStrategy to a newer one.
             // The migrate_audit_table() function will do nothing if it races with another strategy change:

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -141,7 +141,7 @@ future<> table_helper::insert(cql3::query_processor& qp, service::migration_mana
 }
 
 future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migration_manager& mm, std::string_view keyspace_name, sstring replication_strategy_name,
-                                      sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables) {
+                                      sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables, std::optional<unsigned int> init_tablets) {
     if (this_shard_id() != 0) {
         co_return;
     }
@@ -175,7 +175,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
             else {
                 opts["replication_factor"] = replication_factor;
             }
-            auto ksm = keyspace_metadata::new_keyspace(keyspace_name, replication_strategy_name, std::move(opts), std::nullopt, true);
+            auto ksm = keyspace_metadata::new_keyspace(keyspace_name, replication_strategy_name, std::move(opts), init_tablets, true);
             try {
                 co_await mm.announce(service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts),
                         std::move(group0_guard), seastar::format("table_helper: create {} keyspace", keyspace_name));

--- a/table_helper.hh
+++ b/table_helper.hh
@@ -100,7 +100,7 @@ public:
     future<> insert(cql3::query_processor& qp, service::migration_manager& mm, service::query_state& qs, noncopyable_function<cql3::query_options ()> opt_maker);
 
     static future<> setup_keyspace(cql3::query_processor& qp, service::migration_manager& mm, std::string_view keyspace_name, sstring replication_strategy_name,
-                                   sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables);
+                                   sstring replication_factor, service::query_state& qs, std::vector<table_helper*> tables, std::optional<unsigned int> init_tablets);
 
     /**
      * Makes a monotonically increasing value in 100ns ("nanos") based on the given time

--- a/tracing/trace_keyspace_helper.cc
+++ b/tracing/trace_keyspace_helper.cc
@@ -212,7 +212,8 @@ trace_keyspace_helper::trace_keyspace_helper(tracing& tr)
 future<> trace_keyspace_helper::start(cql3::query_processor& qp, service::migration_manager& mm) {
     _qp_anchor = &qp;
     _mm_anchor = &mm;
-    return table_helper::setup_keyspace(qp, mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state, { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx });
+    return table_helper::setup_keyspace(qp, mm, KEYSPACE_NAME, "org.apache.cassandra.locator.SimpleStrategy", "2", _dummy_query_state,
+            { &_sessions, &_sessions_time_idx, &_events, &_slow_query_log, &_slow_query_log_time_idx }, std::nullopt);
 }
 
 gms::inet_address trace_keyspace_helper::my_address() const noexcept {


### PR DESCRIPTION
For new clusters, create audit keyspace with tablets enabled.

Fixes: scylladb/scylla-enterprise#3884

No need to backport, this is a minor enhancement. 