### PR TITLE
build: cmake: restrict -Xclang options to Clang compiler only

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -122,7 +122,9 @@ if(target_arch)
   add_compile_options("-march=${target_arch}")
 endif()
 
-add_compile_options("SHELL:-Xclang -fexperimental-assignment-tracking=disabled")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_compile_options("SHELL:-Xclang -fexperimental-assignment-tracking=disabled")
+endif()
 
 function(maybe_limit_stack_usage_in_KB stack_usage_threshold_in_KB config)
   math(EXPR _stack_usage_threshold_in_bytes "${stack_usage_threshold_in_KB} * 1024")

--- a/configure.py
+++ b/configure.py
@@ -2151,13 +2151,14 @@ def get_extra_cxxflags(mode, mode_config, cxx, debuginfo):
     if debuginfo and mode_config['can_have_debug_info']:
         cxxflags += ['-g', '-gz']
 
-    # Since AssignmentTracking was enabled by default in clang
-    # (llvm/llvm-project@de6da6ad55d3ca945195d1cb109cb8efdf40a52a)
-    # coroutine frame debugging info (`coro_frame_ty`) is broken.
-    # 
-    # It seems that we aren't losing much by disabling AssigmentTracking,
-    # so for now we choose to disable it to get `coro_frame_ty` back.
-    cxxflags.append('-Xclang -fexperimental-assignment-tracking=disabled')
+    if 'clang' in cxx:
+        # Since AssignmentTracking was enabled by default in clang
+        # (llvm/llvm-project@de6da6ad55d3ca945195d1cb109cb8efdf40a52a)
+        # coroutine frame debugging info (`coro_frame_ty`) is broken.
+        #
+        # It seems that we aren't losing much by disabling AssigmentTracking,
+        # so for now we choose to disable it to get `coro_frame_ty` back.
+        cxxflags.append('-Xclang -fexperimental-assignment-tracking=disabled')
 
     return cxxflags
 


### PR DESCRIPTION
Modify CMake configuration to only apply "-Xclang" options when building with the Clang compiler. These options are Clang-specific and can cause errors or warnings when used with other compilers like g++.

This change:
- Adds compiler detection to conditionally apply Clang-specific flags
- Prevents build failures when using non-Clang compilers

Previously, the build system would apply these flags universally, which could lead to compilation errors with other compilers.

---

this change enables us to move further when building the tree with GCC, and GCC is not used in production or CI, hence no need to backport.