### PR TITLE
utils: fix integer narrowing warnings in compression algorithm code

### DIFF
--- a/utils/advanced_rpc_compressor.hh
+++ b/utils/advanced_rpc_compressor.hh
@@ -81,7 +81,7 @@ struct compression_algorithm {
 class compression_algorithm_set {
     uint8_t _bitset;
     static_assert(std::numeric_limits<decltype(_bitset)>::digits > compression_algorithm::count());
-    constexpr compression_algorithm_set(uint8_t v) noexcept : _bitset(v) {}
+    constexpr compression_algorithm_set(int v) noexcept : _bitset(static_cast<uint8_t>(v)) {}
 public:
     // Returns a set containing the given algorithm and all algorithms weaker (smaller in the enum order)
     // than it.
@@ -91,7 +91,7 @@ public:
     }
     // Returns the strongest (greatest in the enum order) algorithm in the set.
     constexpr compression_algorithm heaviest() const {
-        return {std::bit_width(_bitset) - 1};
+        return {static_cast<uint8_t>(std::bit_width(_bitset) - 1)};
     }
     // The usual set operations.
     constexpr static compression_algorithm_set singleton(compression_algorithm algo) noexcept {


### PR DESCRIPTION
Fix multiple narrowing conversion warnings that appeared when compiling with GCC-14. These warnings occur in utils/advanced_rpc_compressor.hh where arithmetic operations promote uint8_t values to int, and then the results are implicitly narrowed back to uint8_t.

The specific issues include:
- Narrowing from integer expressions like `x + (x - 1)` to uint8_t
- Conversion of bit manipulation operations (`<<`, `&`, `|`) results to uint8_t
- Using std::bit_width() results (which return int) in uint8_t context

This change adds explicit static_cast<uint8_t>() in appropriate places to make the narrowing conversions explicit and intentional. The casts don't change the behavior as our values are guaranteed to fit within uint8_t range, but they properly document our intent and satisfy the compiler's type safety requirements.

The error message looks like:

```
/usr/lib64/ccache/g++ -DDEVEL -DSCYLLA_BUILD_MODE=dev -DSCYLLA_ENABLE_ERROR_INJECTION -DSCYLLA_ENABLE_PREEMPTION_SOURCE -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"Dev\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build -I/home/kefu/dev/scylladb/build/gen -isystem /home/kefu/dev/scylladb/build/rust -isystem /home/kefu/dev/scylladb/seastar/include -isystem /home/kefu/dev/scylladb/build/Dev/seastar/gen/include -isystem /home/kefu/dev/scylladb/abseil -I/usr/include/p11-kit-1  -O2 -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unused-parameter -Wno-changes-meaning -Wno-ignored-attributes -ffile-prefix-map=/home/kefu/dev/scylladb/= -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -ffile-prefix-map=/home/kefu/dev/scylladb/build/=build -march=westmere -Wstack-usage=21504 -std=gnu++23 -Wno-maybe-uninitialized -Werror=unused-result -fstack-clash-protection -DSEASTAR_P2581R1 -DSEASTAR_API_LEVEL=7 -DSEASTAR_BUILD_SHARED_LIBS -DSEASTAR_SSTRING -DSEASTAR_ENABLE_ALLOC_FAILURE_INJECTION -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=19 -DSEASTAR_LOGGER_TYPE_STDOUT -DSEASTAR_TYPE_ERASE_MORE -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_DYN_LINK -DFMT_SHARED -MD -MT cql3/CMakeFiles/cql3.dir/Dev/statements/ks_prop_defs.cc.o -MF cql3/CMakeFiles/cql3.dir/Dev/statements/ks_prop_defs.cc.o.d -o cql3/CMakeFiles/cql3.dir/Dev/statements/ks_prop_defs.cc.o -c /home/kefu/dev/scylladb/cql3/statements/ks_prop_defs.cc
In file included from /home/kefu/dev/scylladb/db/config.hh:28,
                 from /home/kefu/dev/scylladb/cql3/statements/ks_prop_defs.cc:19:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In static member function ‘static constexpr utils::compression_algorithm_set utils::compression_algorithm_set::this_or_lighter(utils::compression_algorithm)’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:91:19: error: narrowing conversion of ‘(x + (x - 1))’ from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} [-Werror=narrowing]
   91 |         return {x + (x - 1)};
      |                 ~~^~~~~~~~~
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In member function ‘constexpr utils::compression_algorithm utils::compression_algorithm_set::heaviest() const’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:95:41: error: narrowing conversion of ‘(std::bit_width<unsigned char>(((int)((uint8_t)((const utils::compression_algorithm_set*)this)->utils::compression_algorithm_set::_bitset))) - 1)’ from ‘int’ to ‘utils::compression_algorithm::underlying’ {aka ‘unsigned char’} [-Werror=narrowing]
   95 |         return {std::bit_width(_bitset) - 1};
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~^~~
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In static member function ‘static constexpr utils::compression_algorithm_set utils::compression_algorithm_set::singleton(utils::compression_algorithm)’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:99:19: error: narrowing conversion of ‘(1, (1 << ((int)algo.utils::compression_algorithm::idx())))’ from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} [-Werror=narrowing]
   99 |         return {1 << algo.idx()};
      |                 ~~^~~~~~~~~~~~~
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In member function ‘constexpr utils::compression_algorithm_set utils::compression_algorithm_set::intersection(utils::compression_algorithm_set) const’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:102:25: error: narrowing conversion of ‘(int)(((unsigned char)((int)((const utils::compression_algorithm_set*)this)->utils::compression_algorithm_set::_bitset)) & ((unsigned char)((int)o.utils::compression_algorithm_set::_bitset)))’ from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} [-Werror=narrowing]
  102 |         return {_bitset & o._bitset};
      |                 ~~~~~~~~^~~~~~~~~~~
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In member function ‘constexpr utils::compression_algorithm_set utils::compression_algorithm_set::difference(utils::compression_algorithm_set) const’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:105:25: error: narrowing conversion of ‘(((int)((const utils::compression_algorithm_set*)this)->utils::compression_algorithm_set::_bitset) & (~(int)o.utils::compression_algorithm_set::_bitset))’ from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} [-Werror=narrowing]
  105 |         return {_bitset &~ o._bitset};
      |                 ~~~~~~~~^~~~~~~~~~~~
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh: In member function ‘constexpr utils::compression_algorithm_set utils::compression_algorithm_set::sum(utils::compression_algorithm_set) const’:
/home/kefu/dev/scylladb/utils/advanced_rpc_compressor.hh:108:25: error: narrowing conversion of ‘(int)(((unsigned char)((int)((const utils::compression_algorithm_set*)this)->utils::compression_algorithm_set::_bitset)) | ((unsigned char)((int)o.utils::compression_algorithm_set::_bitset)))’ from ‘int’ to ‘uint8_t’ {aka ‘unsigned char’} [-Werror=narrowing]
  108 |         return {_bitset | o._bitset};
      |                 ~~~~~~~~^~~~~~~~~~~
```

---

it's a cleanup, hence no need to backport.