### PR TITLE
raft/test: adjust the "raft_ignore_nodes" test for limited voters

### DIFF
--- a/test/topology_custom/test_raft_ignore_nodes.py
+++ b/test/topology_custom/test_raft_ignore_nodes.py
@@ -4,16 +4,59 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 import time
+from typing import Optional, List, Any
 import pytest
 import logging
 
 from test.pylib.internal_types import IPAddress, HostID
 from test.pylib.scylla_cluster import ReplaceConfig
-from test.pylib.manager_client import ManagerClient
-from test.topology.util import wait_for_token_ring_and_group0_consistency
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.topology.util import get_current_group0_config, wait_for_token_ring_and_group0_consistency
 
 
 logger = logging.getLogger(__name__)
+
+
+async def make_servers(manager: ManagerClient, servers_num: int,
+                       config: Optional[dict[str, Any]] = None) -> List[ServerInfo]:
+    """ Create servers with the given configuration.
+
+        It is expected that the first 3 servers returned can be stopped without losing the majority of voters.
+        This requires that the number of servers requested is greater or equal to 7.
+    """
+    assert servers_num >= 7
+
+    servers = await manager.servers_add(servers_num, config=config)
+
+    servers_by_host_id = {await manager.get_host_id(s.server_id): s for s in servers}
+
+    # voters vs non-voters: we cannot stop 3 random nodes because some nodes might be non-voters
+    # - therefore we detect the number of voters to keep the majority
+    group0_members = await get_current_group0_config(manager, servers[0])
+
+    is_voter_by_id = {servers_by_host_id[HostID(
+        member[0])].server_id: member[1] for member in group0_members}
+
+    # keeping the order of the servers
+    voters: List[ServerInfo] = []
+    non_voters: List[ServerInfo] = []
+    for s in servers:
+        (voters if is_voter_by_id[s.server_id] else non_voters).append(s)
+
+    # we need to keep the voters majority
+    # odd number of voters is expected, but the following should also work for even number of voters (> 0)
+    assert len(voters) > 0
+    num_voters_allowed_to_stop = (len(voters) - 1) // 2
+
+    servers_ordered = (
+        voters[:num_voters_allowed_to_stop] +
+        non_voters +
+        voters[num_voters_allowed_to_stop:]
+    )
+
+    assert len(servers_ordered) == len(servers)
+
+    return servers_ordered
 
 
 @pytest.mark.asyncio
@@ -23,8 +66,9 @@ async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
        This is a slow test with a 7 node cluster and 3 replace operations,
        we want to run it only in dev mode.
     """
-    logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(7, config={'failure_detector_timeout_in_ms': 2000})
+    logger.info("Booting initial cluster")
+    servers = await make_servers(manager, 7, config={'failure_detector_timeout_in_ms': 2000})
+
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
@@ -59,8 +103,9 @@ async def test_raft_remove_ignore_nodes(manager: ManagerClient) -> None:
        This is a slow test with a 7 node cluster and 3 removenode operations,
        we want to run it only in dev mode.
     """
-    logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(7)
+    logger.info("Booting initial cluster")
+    servers = await make_servers(manager, 7)
+
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
     logger.info(f"Stopping servers {servers[:3]}")


### PR DESCRIPTION
Before the limited voters feature, the "raft_ignore_nodes" test was relying upon the fact that all nodes will become voters.

With the limited voters feature, the test needs to be adjusted to ensure that we do not lose the majority of the cluster. This could happen when there are 7 nodes, but only 5 of them are voters - then if we kill 3 nodes randomly we might end up with only 2 voters left.

Therefore we need to ensure that we only stop the appropriate number of voter nodes. So we need to determine which nodes became voters and which ones are non-voters, and select the nodes to be stopped based on that.

That means with 7 nodes and 5 voters, we can stop up to 2 voter nodes, but at least one of the stopped nodes must be a non-voter.

Fixes: scylladb/scylladb#22902

Refs: scylladb/scylladb#18793
Refs: scylladb/scylladb#21969

No backport: This is only needed for the new "limited voters" feature, so there is no need to backport.