### PR TITLE
Co-locate tablets of different tables

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -223,6 +223,7 @@ Schema:
 CREATE TABLE system.tablets (
     table_id uuid,
     last_token bigint,
+    base_table uuid STATIC,
     keyspace_name text STATIC,
     repair_scheduler_config frozen<repair_scheduler_config> STATIC,
     resize_seq_number bigint STATIC,
@@ -263,6 +264,9 @@ Only tables which use tablet-based replication strategy have an entry here.
 
 `tablet_count` is the number of tablets in the map.
 `table_name` is the name of the table, provided for convenience.
+
+`base_table` is optionally set with the table_id of another table that this table is co-located with, meaning they always have the same tablet count and tablet replicas, and are migrated and resized together as a group.
+ When base_table is set then the rest of the tablet map is empty, and the tablet map of base_table should be read instead.
 
 `resize_type` is the resize decision type that spans all tablets of a given table, which can be one of: `merge`, `split` or `none`.
 

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -221,21 +221,24 @@ Holds information about all tablets in the cluster.
 Schema:
 ~~~
 CREATE TABLE system.tablets (
-    keyspace_name text,
     table_id uuid,
     last_token bigint,
+    keyspace_name text STATIC,
+    repair_scheduler_config frozen<repair_scheduler_config> STATIC,
+    resize_seq_number bigint STATIC,
+    resize_task_info frozen<tablet_task_info> STATIC,
+    resize_type text STATIC,
+    table_name text STATIC,
+    tablet_count int STATIC,
+    migration_task_info frozen<tablet_task_info>,
     new_replicas frozen<list<frozen<tuple<uuid, int>>>>,
-    replicas frozen<list<frozen<tuple<uuid, int>>>>,
-    stage text,
-    transition text,
-    table_name text static,
-    tablet_count int static,
-    resize_type text static,
-    resize_seq_number bigint static,
-    repair_scheduler_config frozen<repair_scheduler_config> static,
     repair_task_info frozen<tablet_task_info>,
     repair_time timestamp,
-    PRIMARY KEY ((keyspace_name, table_id), last_token)
+    replicas frozen<list<frozen<tuple<uuid, int>>>>,
+    session uuid,
+    stage text,
+    transition text,
+    PRIMARY KEY (table_id, last_token)
 )
 
 CREATE TYPE system.repair_scheduler_config (
@@ -254,7 +257,7 @@ CREATE TYPE system.tablet_task_info (
 )
 ~~~
 
-Each partition (keyspace_name, table_id) represents a tablet map of a given table.
+Each partition (table_id) represents a tablet map of a given table.
 
 Only tables which use tablet-based replication strategy have an entry here.
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -163,6 +163,7 @@ public:
 
     gms::feature in_memory_tables { *this, "IN_MEMORY_TABLES"sv };
     gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
+    gms::feature colocated_tablets { *this, "COLOCATED_TABLETS"sv };
     gms::feature file_stream { *this, "FILE_STREAM"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
     gms::feature tablet_options { *this, "TABLET_OPTIONS"sv };

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -77,6 +77,7 @@ verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tab
 verb [[cancellable]] table_load_stats_v1 (raft::server_id dst_id) -> locator::load_stats_v1;
 verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
 verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id) -> service::tablet_operation_repair_result;
+verb [[cancellable]] tablet_repair_colocated(raft::server_id dst_id, locator::global_tablet_id, std::vector<locator::global_tablet_id>) -> service::tablet_operation_repair_result;
 verb [[]] estimate_sstable_volume(table_id table) -> uint64_t;
 verb [[]] sample_sstables(table_id table, uint64_t chunk_size, uint64_t n_chunks) -> utils::chunked_vector<temporary_buffer<char>>;
 

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -125,7 +125,7 @@ public:
                 co_await populate_table(tmap, host, only_dc);
             }
         } else {
-            for (auto&& [table, tmap]: _tm->tablets().all_tables()) {
+            for (const auto& [table, tmap] : _tm->tablets().all_tables_ungrouped()) {
                 co_await populate_table(*tmap, host, only_dc);
             }
         }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -896,7 +896,7 @@ bool tablet_metadata::has_replica_on(host_id host) const {
 
 future<bool> check_tablet_replica_shards(const tablet_metadata& tm, host_id this_host) {
     bool valid = true;
-    for (const auto& [table_id, tmap] : tm.all_tables()) {
+    for (const auto& [table, tmap] : tm.all_tables_ungrouped()) {
         co_await tmap->for_each_tablet([this_host, &valid] (locator::tablet_id tid, const tablet_info& tinfo) -> future<> {
             for (const auto& replica : tinfo.replicas) {
                 if (replica.host == this_host) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -644,7 +644,6 @@ public:
     bool balancing_enabled() const { return _balancing_enabled; }
     const tablet_map& get_tablet_map(table_id id) const;
     bool has_tablet_map(table_id id) const;
-    const table_to_tablet_map& all_tables() const { return _tablets; }
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -606,6 +606,8 @@ private:
     void check_tablet_id(tablet_id) const;
 };
 
+using table_group_set = utils::small_vector<table_id, 2>;
+
 /// Holds information about all tablets in the cluster.
 ///
 /// When this instance is obtained via token_metadata_ptr, it is immutable
@@ -624,8 +626,17 @@ public:
     // See storage_service::replicate_to_all_cores().
     using tablet_map_ptr = foreign_ptr<lw_shared_ptr<const tablet_map>>;
     using table_to_tablet_map = std::unordered_map<table_id, tablet_map_ptr>;
+    using table_group_map = std::unordered_map<table_id, table_group_set>;
 private:
     table_to_tablet_map _tablets;
+
+    // This map contains all tables by co-location groups. The key is the base table and the value
+    // is a list all co-located tables in the co-location group, including the base table.
+    table_group_map _table_groups;
+
+    // This maps a co-located table to its base table. It contains only non-trivial relations, i.e. a base table is
+    // not mapped to itself.
+    std::unordered_map<table_id, table_id> _base_table;
 
     // When false, tablet load balancer will not try to rebalance tablets.
     bool _balancing_enabled = true;
@@ -636,6 +647,18 @@ public:
     const table_to_tablet_map& all_tables() const { return _tablets; }
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;
+
+    // get all tables with their tablet maps, including both base and children tables.
+    // for a child table we get the tablet map of the base table.
+    const table_to_tablet_map& all_tables_ungrouped() const { return _tablets; }
+
+    // get all tables by co-location groups. the key is the base table and the value
+    // is the set of all co-located tables in the group (including the base table).
+    const table_group_map& all_table_groups() const { return _table_groups; }
+
+    table_id get_base_table(table_id id) const;
+    bool is_base_table(table_id id) const;
+
 public:
     tablet_metadata() = default;
     // No implicit copy, use copy()
@@ -648,6 +671,7 @@ public:
 
     void set_balancing_enabled(bool value) { _balancing_enabled = value; }
     void set_tablet_map(table_id, tablet_map);
+    future<> set_colocated_table(table_id id, table_id base_id);
     void drop_tablet_map(table_id);
 
     // Allow mutating a tablet_map

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -710,6 +710,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
     case messaging_verb::TABLET_REPAIR:
+    case messaging_verb::TABLET_REPAIR_COLOCATED:
     case messaging_verb::TABLE_LOAD_STATS_V1:
     case messaging_verb::TABLE_LOAD_STATS:
         return 1;

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -206,7 +206,8 @@ enum class messaging_verb : int32_t {
     TABLE_LOAD_STATS = 77,
     ESTIMATE_SSTABLE_VOLUME = 78,
     SAMPLE_SSTABLES = 79,
-    LAST = 80,
+    TABLET_REPAIR_COLOCATED = 80,
+    LAST = 81,
 };
 
 } // namespace netw

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -935,6 +935,10 @@ void database::init_schema_commitlog() {
     }).release();
 }
 
+std::optional<table_id> database::get_base_table_for_tablet_colocation(const schema& s) {
+    return std::nullopt;
+}
+
 future<> database::create_local_system_table(
         schema_ptr table, bool write_in_user_memory, locator::effective_replication_map_factory& erm_factory) {
     auto ks_name = table->ks_name();

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -935,7 +935,7 @@ void database::init_schema_commitlog() {
     }).release();
 }
 
-std::optional<table_id> database::get_base_table_for_tablet_colocation(const schema& s) {
+std::optional<table_id> database::get_base_table_for_tablet_colocation(const schema& s, const std::unordered_map<table_id, schema_ptr>& new_cfms) {
     return std::nullopt;
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -936,6 +936,42 @@ void database::init_schema_commitlog() {
 }
 
 std::optional<table_id> database::get_base_table_for_tablet_colocation(const schema& s, const std::unordered_map<table_id, schema_ptr>& new_cfms) {
+    auto find_schema_from_db_or_new = [this, &new_cfms] (table_id table_id) -> schema_ptr {
+        auto it = new_cfms.find(table_id);
+        if (it != new_cfms.end()) {
+            return it->second;
+        }
+        return find_schema(table_id);
+    };
+
+    // Co-locate a view table with its base table when it has exactly the same partition key - the same columns
+    // in the same order. In this case the tokens of corresponding partitions are equal and we can benefit from
+    // locality of view updates.
+    bool is_colocated_view = std::invoke([&] {
+        if (!s.is_view()) {
+            return false;
+        }
+
+        auto base_schema_ptr = find_schema_from_db_or_new(s.view_info()->base_id());
+
+        if (s.partition_key_size() != base_schema_ptr->partition_key_size()) {
+            return false;
+        }
+
+        auto&& view_pk = s.partition_key_columns();
+        auto&& base_pk = base_schema_ptr->partition_key_columns();
+        for (const auto& [a,b] : std::views::zip(view_pk, base_pk)) {
+            if (a.name() != b.name()) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    if (is_colocated_view) {
+        return s.view_info()->base_id();
+    }
+
     return std::nullopt;
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1726,6 +1726,8 @@ public:
     lang::manager& lang() noexcept { return _lang_manager; }
     const lang::manager& lang() const noexcept { return _lang_manager; }
 
+    std::optional<table_id> get_base_table_for_tablet_colocation(const schema& s);
+
     service::migration_notifier& get_notifier() { return _mnotifier; }
     const service::migration_notifier& get_notifier() const { return _mnotifier; }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1726,7 +1726,7 @@ public:
     lang::manager& lang() noexcept { return _lang_manager; }
     const lang::manager& lang() const noexcept { return _lang_manager; }
 
-    std::optional<table_id> get_base_table_for_tablet_colocation(const schema& s);
+    std::optional<table_id> get_base_table_for_tablet_colocation(const schema& s, const std::unordered_map<table_id, schema_ptr>& new_cfms = {});
 
     service::migration_notifier& get_notifier() { return _mnotifier; }
     const service::migration_notifier& get_notifier() const { return _mnotifier; }

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -48,6 +48,7 @@ public:
     tablet_mutation_builder& del_migration_task_info(dht::token last_token, const gms::feature_service& features);
     tablet_mutation_builder& set_resize_task_info(locator::tablet_task_info info, const gms::feature_service& features);
     tablet_mutation_builder& del_resize_task_info(const gms::feature_service& features);
+    tablet_mutation_builder& set_base_table(table_id base_table);
 
     mutation build() {
         return std::move(_m);

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -77,6 +77,7 @@ schema_ptr make_tablets_schema() {
             .with_column("repair_scheduler_config", repair_scheduler_config_type, column_kind::static_column)
             .with_column("migration_task_info", tablet_task_info_type)
             .with_column("resize_task_info", tablet_task_info_type, column_kind::static_column)
+            .with_column("base_table", uuid_type, column_kind::static_column)
             .with_hash_version()
             .build();
 }
@@ -291,6 +292,12 @@ tablet_mutation_builder::del_resize_task_info(const gms::feature_service& featur
         auto col = _s->get_column_definition("resize_task_info");
         _m.set_static_cell(*col, atomic_cell::make_dead(_ts, gc_clock::now()));
     }
+    return *this;
+}
+
+tablet_mutation_builder&
+tablet_mutation_builder::set_base_table(table_id base_table) {
+    _m.set_static_cell("base_table", data_value(base_table.uuid()), _ts);
     return *this;
 }
 

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -456,6 +456,10 @@ static void do_validate_tablet_metadata_change(const locator::tablet_metadata& t
         return;
     }
 
+    if (mp.row_count() && !tm.is_base_table(table_id)) {
+        throw std::runtime_error(fmt::format("Table {} is a co-located table, it cannot have clustering rows.", table_id));
+    }
+
     auto& r_cdef = *s.get_column_definition("replicas");
     auto& nr_cdef = *s.get_column_definition("new_replicas");
 

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -168,6 +168,23 @@ tablet_map_to_mutation(const tablet_map& tablets, table_id id, const sstring& ke
     co_return std::move(m);
 }
 
+mutation
+colocated_tablet_map_to_mutation(table_id id, const sstring& keyspace_name, const sstring& table_name, table_id base_table, api::timestamp_type ts) {
+    auto s = db::system_keyspace::tablets();
+    auto gc_now = gc_clock::now();
+    auto tombstone_ts = ts - 1;
+
+    mutation m(s, partition_key::from_single_value(*s,
+        data_value(id.uuid()).serialize_nonnull()
+    ));
+    m.partition().apply(tombstone(tombstone_ts, gc_now));
+    m.set_static_cell("keyspace_name", data_value(keyspace_name), ts);
+    m.set_static_cell("table_name", data_value(table_name), ts);
+    m.set_static_cell("base_table", data_value(base_table.uuid()), ts);
+
+    return m;
+}
+
 tablet_mutation_builder&
 tablet_mutation_builder::set_new_replicas(dht::token last_token, locator::tablet_replica_set replicas) {
     _m.set_clustered_cell(get_ck(last_token), "new_replicas", make_list_value(replica_set_type, replicas_to_data_value(replicas)), _ts);
@@ -368,12 +385,20 @@ locator::repair_scheduler_config deserialize_repair_scheduler_config(cql3::untyp
 future<> save_tablet_metadata(replica::database& db, const tablet_metadata& tm, api::timestamp_type ts) {
     tablet_logger.trace("Saving tablet metadata: {}", tm);
     std::vector<mutation> muts;
-    muts.reserve(tm.all_tables().size());
-    for (auto&& [id, tablets] : tm.all_tables()) {
+    muts.reserve(tm.all_tables_ungrouped().size());
+    for (auto&& [base_id, tables] : tm.all_table_groups()) {
         // FIXME: Should we ignore missing tables? Currently doesn't matter because this is only used in tests.
-        auto s = db.find_schema(id);
+        const auto& tablets = tm.get_tablet_map(base_id);
+        auto s = db.find_schema(base_id);
         muts.emplace_back(
-                co_await tablet_map_to_mutation(*tablets, id, s->ks_name(), s->cf_name(), ts, db.features()));
+                co_await tablet_map_to_mutation(tablets, base_id, s->ks_name(), s->cf_name(), ts, db.features()));
+        for (auto id : tables) {
+            if (id != base_id) {
+                auto s = db.find_schema(id);
+                muts.emplace_back(
+                        colocated_tablet_map_to_mutation(id, s->ks_name(), s->cf_name(), base_id, ts));
+            }
+        }
     }
     co_await db.apply(freeze(muts), db::no_timeout);
 }
@@ -587,6 +612,12 @@ struct tablet_metadata_builder {
     };
     std::optional<active_tablet_map> current;
 
+    // maps a co-located table to its base table.
+    // when reading the tablet metadata of a co-located table, we store it in the map, and we apply
+    // all co-located tables in on_end_of_stream. This is because we want to apply all normal tables first,
+    // to ensure the base table tablet map is already present when we apply the co-located tables.
+    std::unordered_map<table_id, table_id> base_tables;
+
     void process_row(const cql3::untyped_result_set_row& row, replica::database* db) {
         auto table = table_id(row.get_as<utils::UUID>("table_id"));
 
@@ -594,9 +625,15 @@ struct tablet_metadata_builder {
             if (current) {
                 tm.set_tablet_map(current->table, std::move(current->map));
             }
-            auto tablet_count = row.get_as<int>("tablet_count");
-            auto tmap = tablet_map(tablet_count);
-            current = active_tablet_map{table, tmap, tmap.first_tablet()};
+            if (row.has("base_table")) {
+                auto base_table = table_id(row.get_as<utils::UUID>("base_table"));
+                base_tables[table] = base_table;
+                current = {};
+            } else {
+                auto tablet_count = row.get_as<int>("tablet_count");
+                auto tmap = tablet_map(tablet_count);
+                current = active_tablet_map{table, tmap, tmap.first_tablet()};
+            }
 
             // Resize decision fields are static columns, so set them only once per table.
             if (row.has("resize_type") && row.has("resize_seq_number")) {
@@ -616,12 +653,19 @@ struct tablet_metadata_builder {
             }
         }
 
-        current->tid = process_one_row(db, current->table, current->map, current->tid, row);
+        if (row.has("last_token")) {
+            current->tid = process_one_row(db, current->table, current->map, current->tid, row);
+        }
     }
 
-    void on_end_of_stream() {
+    future<> on_end_of_stream() {
         if (current) {
             tm.set_tablet_map(current->table, std::move(current->map));
+        }
+        // Set co-located tables after setting all other tablet maps to ensure the tablet map
+        // of the base table is found.
+        for (auto&& [table, base_table] : base_tables) {
+            co_await tm.set_colocated_table(table, base_table);
         }
     }
 };
@@ -645,7 +689,7 @@ future<tablet_metadata> read_tablet_metadata(cql3::query_processor& qp) {
             std::throw_with_nested(std::runtime_error("Failed to read tablet metadata"));
         }
     }
-    builder.on_end_of_stream();
+    co_await builder.on_end_of_stream();
     tablet_logger.trace("Read tablet metadata: {}", tm);
     co_return std::move(tm);
 }
@@ -686,8 +730,7 @@ future<std::unordered_set<locator::host_id>> read_required_hosts(cql3::query_pro
 }
 
 static future<>
-do_update_tablet_metadata_partition(cql3::query_processor& qp, tablet_metadata& tm, const tablet_metadata_change_hint::table_hint& hint) {
-    tablet_metadata_builder builder{tm};
+do_update_tablet_metadata_partition(cql3::query_processor& qp, tablet_metadata& tm, const tablet_metadata_change_hint::table_hint& hint, tablet_metadata_builder& builder) {
     co_await qp.query_internal(
             "select * from system.tablets where table_id = ?",
             db::consistency_level::ONE,
@@ -699,6 +742,9 @@ do_update_tablet_metadata_partition(cql3::query_processor& qp, tablet_metadata& 
             });
     if (builder.current) {
         tm.set_tablet_map(builder.current->table, std::move(builder.current->map));
+        builder.current = {};
+    } else if (builder.base_tables.contains(hint.table_id)) {
+        // it's a co-located table. we handle it later, after processing all tables, by builder.on_end_of_stream().
     } else {
         tm.drop_tablet_map(hint.table_id);
     }
@@ -723,10 +769,12 @@ do_update_tablet_metadata_rows(replica::database& db, cql3::query_processor& qp,
 }
 
 future<> update_tablet_metadata(replica::database& db, cql3::query_processor& qp, tablet_metadata& tm, const locator::tablet_metadata_change_hint& hint) {
+    tablet_metadata_builder builder{tm};
+
     try {
         for (const auto& [_, table_hint] : hint.tables) {
             if (table_hint.tokens.empty()) {
-                co_await do_update_tablet_metadata_partition(qp, tm, table_hint);
+                co_await do_update_tablet_metadata_partition(qp, tm, table_hint, builder);
             } else {
                 co_await tm.mutate_tablet_map_async(table_hint.table_id, [&] (tablet_map& tmap) -> future<> {
                     co_await do_update_tablet_metadata_rows(db, qp, tmap, table_hint);
@@ -736,6 +784,7 @@ future<> update_tablet_metadata(replica::database& db, cql3::query_processor& qp
     } catch (...) {
         std::throw_with_nested(std::runtime_error("Failed to read tablet metadata"));
     }
+    co_await builder.on_end_of_stream();
     tablet_logger.trace("Updated tablet metadata: {}", tm);
 }
 

--- a/replica/tablets.hh
+++ b/replica/tablets.hh
@@ -57,6 +57,12 @@ future<mutation> tablet_map_to_mutation(const locator::tablet_map&,
                                         api::timestamp_type,
                                         const gms::feature_service& features);
 
+mutation colocated_tablet_map_to_mutation(table_id,
+                                        const sstring& keyspace_name,
+                                        const sstring& table_name,
+                                        table_id base_table,
+                                        api::timestamp_type);
+
 mutation make_drop_tablet_map_mutation(table_id, api::timestamp_type);
 
 /// Stores a given tablet_metadata in system.tablets.

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -86,7 +86,19 @@ class Shard(object):
         self.tablets = {}
 
     def ordered_tablets(self):
-        return sorted(self.tablets.values(), key=lambda t: t.id)
+        return sorted(self.tablets.values(), key=lambda t: (t.base_id, t.seq))
+
+    def ordered_tablets_by_groups(self):
+        ts = self.ordered_tablets()
+        gs = []
+        while len(ts) > 0:
+            cur_group = (ts[0].base_id, ts[0].seq)
+            i = 1
+            while i < len(ts) and (ts[i].base_id, ts[i].seq) == cur_group:
+                i += 1
+            gs.append(ts[:i])
+            ts = ts[i:]
+        return gs
 
 
 class Tablet(object):
@@ -94,8 +106,9 @@ class Tablet(object):
     STATE_JOINING = 1
     STATE_LEAVING = 2
 
-    def __init__(self, id, node, state, initial):
+    def __init__(self, id, node, state, initial, base_id):
         self.id = id
+        self.base_id = base_id
         self.state = state
         self.insert_time = pygame.time.get_ticks()
         self.streaming = False
@@ -495,7 +508,7 @@ def update_from_cql(initial=False):
         tablet_id_by_table[table_id] += 1
         return ret
 
-    def process_tablet(table_id, tablet):
+    def process_tablet(table_id, tablet, base_id):
         tablet_seq = tablet_id_for_table(table_id)
         id = (table_id, tablet.last_token)
         replicas = set(tablet.replicas)
@@ -525,7 +538,7 @@ def update_from_cql(initial=False):
             node = nodes_by_id[host]
             s = node.shards[shard]
             if id not in s.tablets:
-                s.tablets[id] = Tablet(id, node, state, initial=initial)
+                s.tablets[id] = Tablet(id, node, state, initial=initial, base_id=base_id)
                 stage_change = True
                 inserted = True
                 changed = True
@@ -565,7 +578,7 @@ def update_from_cql(initial=False):
             pass
 
         for t in all_tablets[base_id]:
-            process_tablet(table_id, t)
+            process_tablet(table_id, t, base_id)
 
     for n in nodes:
         for s_idx, s in enumerate(n.shards):
@@ -729,9 +742,22 @@ def redraw():
         node_x += node_frame_size
 
         for shard in node.shards:
-            for tablet in shard.ordered_tablets():
-                tablet_y = bottom_line - node_frame_size - tablet.pos
-                draw_tablet(tablet, node_x, tablet_y)
+            for tablet_group in shard.ordered_tablets_by_groups():
+                g_min_y = None
+                g_total_h = 0
+
+                for tablet in tablet_group:
+                    tablet_y = bottom_line - node_frame_size - tablet.pos
+                    draw_tablet(tablet, node_x, tablet_y)
+
+                    g_min_y = min(g_min_y or tablet_y, tablet_y)
+                    g_total_h += tablet.h
+
+                if len(tablet_group) > 1:
+                    pygame.draw.rect(window, BLACK, (node_x + tablet_frame_size,
+                                                     g_min_y + tablet_frame_size,
+                                                     tablet_w // 10,
+                                                     g_total_h - 2 * tablet_frame_size))
 
             node_x += tablet_frame_size * 2 + tablet_w
 

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -81,6 +81,7 @@ public:
     // and its column families together. Therefore, listeners can't load the keyspace from the
     // database. Instead, they should use the `ksm` parameter if needed.
     virtual void on_before_create_column_family(const keyspace_metadata& ksm, const schema&, std::vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& mutations, api::timestamp_type timestamp);
     virtual void on_before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_column_family(const schema&, std::vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_keyspace(const sstring& keyspace_name, std::vector<mutation>&, api::timestamp_type) {}
@@ -147,6 +148,7 @@ public:
     future<> drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
 
     void before_create_column_family(const keyspace_metadata& ksm, const schema&, std::vector<mutation>&, api::timestamp_type);
+    void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, std::vector<mutation>&, api::timestamp_type);
     void before_update_column_family(const schema& new_schema, const schema& old_schema, std::vector<mutation>&, api::timestamp_type);
     void before_drop_column_family(const schema&, std::vector<mutation>&, api::timestamp_type);
     void before_drop_keyspace(const sstring& keyspace_name, std::vector<mutation>&, api::timestamp_type);

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -588,6 +588,14 @@ void migration_notifier::before_create_column_family(const keyspace_metadata& ks
     });
 }
 
+void migration_notifier::before_create_column_families(const keyspace_metadata& ksm,
+        const std::vector<schema_ptr>& schemas, std::vector<mutation>& mutations, api::timestamp_type timestamp) {
+    _listeners.thread_for_each([&ksm, &schemas, &mutations, timestamp] (migration_listener* listener) {
+        // allow exceptions. so a listener can effectively kill a create-table
+        listener->on_before_create_column_families(ksm, schemas, mutations, timestamp);
+    });
+}
+
 void migration_notifier::before_update_column_family(const schema& new_schema,
         const schema& old_schema, std::vector<mutation>& mutations, api::timestamp_type ts) {
     _listeners.thread_for_each([&mutations, &new_schema, &old_schema, ts] (migration_listener* listener) {
@@ -638,25 +646,38 @@ static future<std::vector<mutation>> include_keyspace(
     co_return std::move(mutations);
 }
 
-static future<std::vector<mutation>> do_prepare_new_column_family_announcement(storage_proxy& sp,
-        const keyspace_metadata& ksm, schema_ptr cfm, api::timestamp_type timestamp) {
+static future<std::vector<mutation>> do_prepare_new_column_families_announcement(storage_proxy& sp,
+        const keyspace_metadata& ksm, std::vector<schema_ptr> cfms, api::timestamp_type timestamp) {
     auto& db = sp.local_db();
-    if (db.has_schema(cfm->ks_name(), cfm->cf_name())) {
-        throw exceptions::already_exists_exception(cfm->ks_name(), cfm->cf_name());
-    }
-    if (db.column_family_exists(cfm->id())) {
-        throw exceptions::invalid_request_exception(format("Table with ID {} already exists: {}", cfm->id(), db.find_schema(cfm->id())));
+    for (auto cfm : cfms) {
+        if (db.has_schema(cfm->ks_name(), cfm->cf_name())) {
+            throw exceptions::already_exists_exception(cfm->ks_name(), cfm->cf_name());
+        }
+        if (db.column_family_exists(cfm->id())) {
+            throw exceptions::invalid_request_exception(format("Table with ID {} already exists: {}", cfm->id(), db.find_schema(cfm->id())));
+        }
     }
 
-    mlogger.info("Create new ColumnFamily: {}", cfm);
+    for (auto cfm : cfms) {
+        mlogger.info("Create new ColumnFamily: {}", cfm);
+    }
 
-    return seastar::async([&db, &ksm, cfm, timestamp] {
-        auto mutations = db::schema_tables::make_create_table_mutations(cfm, timestamp);
-        db.get_notifier().before_create_column_family(ksm, *cfm, mutations, timestamp);
+    return seastar::async([&db, &ksm, timestamp, cfms = std::move(cfms)] {
+        std::vector<mutation> mutations;
+        for (schema_ptr cfm : cfms) {
+            auto table_muts = db::schema_tables::make_create_table_mutations(cfm, timestamp);
+            mutations.insert(mutations.end(), std::make_move_iterator(table_muts.begin()), std::make_move_iterator(table_muts.end()));
+        }
+        db.get_notifier().before_create_column_families(ksm, cfms, mutations, timestamp);
         return mutations;
     }).then([&sp, &ksm](std::vector<mutation> mutations) {
         return include_keyspace(sp, ksm, std::move(mutations));
     });
+}
+
+static future<std::vector<mutation>> do_prepare_new_column_family_announcement(storage_proxy& sp,
+        const keyspace_metadata& ksm, schema_ptr cfm, api::timestamp_type timestamp) {
+    return do_prepare_new_column_families_announcement(sp, ksm, std::vector<schema_ptr>{std::move(cfm)}, timestamp);
 }
 
 future<std::vector<mutation>> prepare_new_column_family_announcement(storage_proxy& sp, schema_ptr cfm, api::timestamp_type timestamp) {
@@ -673,10 +694,15 @@ future<std::vector<mutation>> prepare_new_column_family_announcement(storage_pro
 
 future<> prepare_new_column_family_announcement(std::vector<mutation>& mutations,
         storage_proxy& sp, const keyspace_metadata& ksm, schema_ptr cfm, api::timestamp_type timestamp) {
+    return prepare_new_column_families_announcement(mutations, sp, ksm, std::vector<schema_ptr>{std::move(cfm)}, timestamp);
+}
+
+future<> prepare_new_column_families_announcement(std::vector<mutation>& mutations,
+        storage_proxy& sp, const keyspace_metadata& ksm, std::vector<schema_ptr> cfms, api::timestamp_type timestamp) {
     auto& db = sp.local_db();
     // If the keyspace exists, ensure that we use the current metadata.
     const auto& current_ksm = db.has_keyspace(ksm.name()) ? *db.find_keyspace(ksm.name()).metadata() : ksm;
-    auto new_mutations = co_await do_prepare_new_column_family_announcement(sp, current_ksm, cfm, timestamp);
+    auto new_mutations = co_await do_prepare_new_column_families_announcement(sp, current_ksm, cfms, timestamp);
     std::move(new_mutations.begin(), new_mutations.end(), std::back_inserter(mutations));
 }
 
@@ -1180,6 +1206,12 @@ future<> migration_manager::on_alive(gms::inet_address endpoint, locator::host_i
 
 void migration_manager::set_concurrent_ddl_retries(size_t n) {
     _concurrent_ddl_retries = n;
+}
+
+void migration_listener::on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& mutations, api::timestamp_type timestamp) {
+    for (auto cfm : cfms) {
+        on_before_create_column_family(ksm, *cfm, mutations, timestamp);
+    }
 }
 
 }

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -219,6 +219,9 @@ future<std::vector<mutation>> prepare_new_column_family_announcement(storage_pro
 // This function allows announcing a new keyspace together with its tables at once.
 future<> prepare_new_column_family_announcement(std::vector<mutation>& mutations,
         storage_proxy& sp, const keyspace_metadata& ksm, schema_ptr cfm, api::timestamp_type timestamp);
+// Announce multiple tables in one operation
+future<> prepare_new_column_families_announcement(std::vector<mutation>& mutations,
+        storage_proxy& sp, const keyspace_metadata& ksm, std::vector<schema_ptr> cfms, api::timestamp_type timestamp);
 
 future<std::vector<mutation>> prepare_new_type_announcement(storage_proxy& sp, user_type new_type, api::timestamp_type ts);
 

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -317,7 +317,9 @@ future<group0_guard> raft_group0_client::start_operation(seastar::abort_source& 
     }
 }
 
-void raft_group0_client::validate_change(const topology_change& change) {
+template<typename Command>
+requires std::same_as<Command, topology_change> || std::same_as<Command, mixed_change>
+void raft_group0_client::validate_change(const Command& change) {
     replica::validate_tablet_metadata_change(_token_metadata.get()->tablets(), change.mutations);
 }
 
@@ -514,6 +516,9 @@ void raft_group0_client::set_query_result(utils::UUID query_id, service::broadca
         it->second = std::move(qr);
     }
 }
+
+template void raft_group0_client::validate_change(const topology_change& change);
+template void raft_group0_client::validate_change(const mixed_change& change);
 
 template group0_command raft_group0_client::prepare_command(schema_change change, group0_guard& guard, std::string_view description);
 template group0_command raft_group0_client::prepare_command(topology_change change, group0_guard& guard, std::string_view description);

--- a/service/raft/raft_group0_client.hh
+++ b/service/raft/raft_group0_client.hh
@@ -120,7 +120,9 @@ class raft_group0_client {
 
     template <typename Command>
     void validate_change(const Command& change) {}
-    void validate_change(const topology_change& change);
+    template<typename Command>
+    requires std::same_as<Command, topology_change> || std::same_as<Command, mixed_change>
+    void validate_change(const Command& change);
 
 public:
     raft_group0_client(service::raft_group_registry&, db::system_keyspace&, locator::shared_token_metadata&, maintenance_mode_enabled);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6578,6 +6578,11 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
     while (true) {
         auto guard = co_await get_guard_for_tablet_update();
 
+        // Currently tablet repair works only on base tables.
+        if (!get_token_metadata().tablets().is_base_table(table)) {
+            throw std::runtime_error("Can't set repair request on a co-located table");
+        }
+
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         std::vector<canonical_mutation> updates;
 
@@ -6652,6 +6657,11 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
     slogger.info("Deleting tablet repair request by API request table_id={} tablet_task_id={}", table, tablet_task_id);
     while (true) {
         auto guard = co_await get_guard_for_tablet_update();
+
+        // Currently tablet repair requests can be set only on base tables.
+        if (!get_token_metadata().tablets().is_base_table(table)) {
+            throw std::runtime_error("Can't set repair request on a co-located table");
+        }
 
         auto& tmap = get_token_metadata().tablets().get_tablet_map(table);
         std::vector<canonical_mutation> updates;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6540,6 +6540,11 @@ future<bool> storage_service::exec_tablet_update(service::group0_guard guard, st
     co_return false;
 }
 
+replica::tablet_mutation_builder storage_service::tablet_mutation_builder_for_base_table(api::timestamp_type ts, table_id table) {
+    auto base_table = get_token_metadata_ptr()->tablets().get_base_table(table);
+    return replica::tablet_mutation_builder(ts, base_table);
+}
+
 // Repair the tablets contain the tokens and wait for the repair to finish
 // This is used to run a manual repair requested by user from the restful API.
 future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant,
@@ -6595,7 +6600,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
             }
             auto last_token = tmap.get_last_token(tid);
             updates.emplace_back(
-                replica::tablet_mutation_builder(guard.write_timestamp(), table)
+                tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
                     .set_repair_task_info(last_token, repair_task_info)
                     .build());
         }
@@ -6659,7 +6664,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
             }
             auto last_token = tmap.get_last_token(tid);
             auto* trinfo = tmap.get_tablet_transition_info(tid);
-            auto update = replica::tablet_mutation_builder(guard.write_timestamp(), table)
+            auto update = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
                             .del_repair_task_info(last_token);
             if (trinfo && trinfo->transition == locator::tablet_transition_kind::repair) {
                 update.del_session(last_token);
@@ -6732,7 +6737,7 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
             : locator::tablet_task_info::make_migration_request();
         migration_task_info.sched_nr++;
         migration_task_info.sched_time = db_clock::now();
-        updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
+        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, src.host == dst.host ? locator::tablet_transition_kind::intranode_migration
@@ -6778,7 +6783,7 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
         locator::tablet_replica_set new_replicas(tinfo.replicas);
         new_replicas.push_back(dst);
 
-        updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
+        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
@@ -6823,7 +6828,7 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
         new_replicas.reserve(tinfo.replicas.size() - 1);
         std::copy_if(tinfo.replicas.begin(), tinfo.replicas.end(), std::back_inserter(new_replicas), [&dst] (auto r) { return r != dst; });
 
-        updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
+        updates.emplace_back(tablet_mutation_builder_for_base_table(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
             .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6216,6 +6216,26 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
     on_internal_error(slogger, "Got wrong tablet_operation_repair_result");
 }
 
+future<service::tablet_operation_repair_result> storage_service::repair_colocated_tablets(locator::global_tablet_id base_tablet, std::vector<locator::global_tablet_id> tablets) {
+    auto base_repair_result = co_await repair_tablet(base_tablet);
+    gc_clock::time_point min_repair_time = base_repair_result.repair_time;
+
+    // repair derived co-located tablets
+    for (auto tablet : tablets) {
+        if (tablet == base_tablet) {
+            continue;
+        }
+
+        auto tablet_repair_result = co_await repair_tablet(tablet);
+
+        min_repair_time = std::min(min_repair_time, tablet_repair_result.repair_time);
+    }
+
+    co_return tablet_operation_repair_result {
+        min_repair_time
+    };
+}
+
 future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id tablet, locator::tablet_replica leaving, locator::tablet_replica pending) {
     if (leaving.host != pending.host) {
         throw std::runtime_error(fmt::format("Leaving and pending tablet replicas belong to different nodes, {} and {} respectively",
@@ -7447,6 +7467,12 @@ void storage_service::init_messaging_service() {
     ser::storage_service_rpc_verbs::register_tablet_repair(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id tablet) {
         return handle_raft_rpc(dst_id, [tablet] (auto& ss) -> future<service::tablet_operation_repair_result> {
             auto res = co_await ss.repair_tablet(tablet);
+            co_return res;
+        });
+    });
+    ser::storage_service_rpc_verbs::register_tablet_repair_colocated(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, locator::global_tablet_id base_tablet, std::vector<locator::global_tablet_id> tablets) {
+        return handle_raft_rpc(dst_id, [base_tablet, tablets = std::move(tablets)] (auto& ss) -> future<service::tablet_operation_repair_result> {
+            auto res = co_await ss.repair_colocated_tablets(base_tablet, std::move(tablets));
             co_return res;
         });
     });

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3133,8 +3133,9 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
             open_sessions.insert(session);
         }
 
-        for (auto&& [table_id, tmap]: tmptr->tablets().all_tables()) {
-            for (auto&& [tid, trinfo]: tmap->transitions()) {
+        for (auto&& [table, tables] : tmptr->tablets().all_table_groups()) {
+            const auto& tmap = tmptr->tablets().get_tablet_map(table);
+            for (auto&& [tid, trinfo]: tmap.transitions()) {
                 if (trinfo.session_id) {
                     auto id = session_id(trinfo.session_id);
                     open_sessions.insert(id);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -102,6 +102,10 @@ namespace tasks {
 class task_manager;
 }
 
+namespace replica {
+class tablet_mutation_builder;
+}
+
 namespace utils {
 class disk_space_monitor;
 }
@@ -355,6 +359,14 @@ private:
     bool is_me(locator::host_id id) const noexcept {
         return get_token_metadata_ptr()->get_topology().is_me(id);
     }
+
+    // When we create a tablet mutation, usually we want to write it to the base table.
+    // In a group of co-located tables, the tablet info is stored on the base table partition only.
+    // Other tables which are co-located with the base table have only a static row that points to the base table.
+    // So if for example a tablet migration is requested for a co-located table, we need to write the
+    // tablet mutation with the transition stage to the base table, and then the entire co-location group
+    // will be migrated.
+    replica::tablet_mutation_builder tablet_mutation_builder_for_base_table(api::timestamp_type ts, table_id table);
 
     /* This abstraction maintains the token/endpoint metadata information */
     shared_token_metadata& _shared_token_metadata;

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -205,6 +205,7 @@ private:
                                  sstring op_name,
                                  std::function<future<service::tablet_operation_result>(locator::tablet_metadata_guard&)> op);
     future<service::tablet_operation_repair_result> repair_tablet(locator::global_tablet_id);
+    future<service::tablet_operation_repair_result> repair_colocated_tablets(locator::global_tablet_id, std::vector<locator::global_tablet_id>);
     future<> stream_tablet(locator::global_tablet_id);
     // Clones storage of leaving tablet into pending one. Done in the context of intra-node migration,
     // when both of which sit on the same node. So all the movement is local.

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -951,8 +951,8 @@ public:
             return tmap.needs_merge() && _db.column_family_exists(tid) && _db.find_column_family(tid).views().empty();
         };
 
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
             if (!can_proceed_with_colocation(table, tmap)) {
                 continue;
             }
@@ -2846,8 +2846,8 @@ public:
 
         // Compute tablet load on nodes.
 
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
 
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
                 auto trinfo = tmap.get_tablet_transition_info(tid);
@@ -2981,8 +2981,8 @@ public:
         co_await _load_sketch->populate_dc(dc);
         _tablet_count_per_table.clear();
 
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
             uint64_t total_load = 0;
 
             auto get_replicas = [this] (std::optional<tablet_desc> t) -> tablet_replica_set {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3201,22 +3201,58 @@ public:
         return map;
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
+    // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
+    void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& muts, api::timestamp_type ts) {
         locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
         auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
             auto tm = _db.get_shared_token_metadata().get();
 
-            if (auto base_table_opt = _db.get_base_table_for_tablet_colocation(s); base_table_opt && _db.features().colocated_tablets) {
-                auto base_table = *base_table_opt;
-                lblogger.debug("Creating tablets for {}.{} id={} with base={}", s.ks_name(), s.cf_name(), s.id(), base_table);
-                muts.emplace_back(colocated_tablet_map_to_mutation(s.id(), s.ks_name(), s.cf_name(), base_table, ts));
-            } else {
-                lblogger.debug("Creating tablets for {}.{} id={}", s.ks_name(), s.cf_name(), s.id());
-                tablet_map map = allocate_tablets_for_new_base_table(tablet_rs, s);
-                muts.emplace_back(tablet_map_to_mutation(std::move(map), s.id(), s.ks_name(), s.cf_name(), ts, _db.features()).get());
+            std::unordered_map<table_id, schema_ptr> new_cfms_map;
+            for (auto s : cfms) {
+                new_cfms_map[s->id()] = s;
+            }
+
+            // Group the new tables by co-location groups.
+            // The key is the base table id, which may be a new table or an existing table.
+            const bool colocated_tablets_enabled = _db.features().colocated_tablets;
+            std::unordered_map<table_id, std::vector<schema_ptr>> table_groups;
+            for (auto s : cfms) {
+                std::optional<table_id> base_id;
+                if (colocated_tablets_enabled) {
+                    base_id = _db.get_base_table_for_tablet_colocation(*s, new_cfms_map);
+                }
+                table_groups[base_id.value_or(s->id())].push_back(s);
+            }
+
+            // allocate tablets for each co-location group.
+            // if the base is a new table, allocate new tablets for it.
+            // for the other tables in the group, create a co-located tablet map.
+            for (const auto& [base_id, group_schemas] : table_groups) {
+                if (auto it = new_cfms_map.find(base_id); it != new_cfms_map.end()) {
+                    const auto& s = *it->second;
+                    lblogger.debug("Creating tablets for {}.{} id={}", s.ks_name(), s.cf_name(), s.id());
+                    auto base_map = allocate_tablets_for_new_base_table(tablet_rs, s);
+                    muts.emplace_back(tablet_map_to_mutation(std::move(base_map), s.id(), s.ks_name(), s.cf_name(), ts, _db.features()).get());
+                }
+
+                for (auto sp : group_schemas) {
+                    const auto& s = *sp;
+                    if (s.id() != base_id) {
+                        lblogger.debug("Creating tablets for {}.{} id={} with base={}", s.ks_name(), s.cf_name(), s.id(), base_id);
+                        muts.emplace_back(colocated_tablet_map_to_mutation(s.id(), s.ks_name(), s.cf_name(), base_id, ts));
+                    }
+                }
             }
         }
+    }
+
+    void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, std::vector<mutation>& muts, api::timestamp_type ts) override {
+        allocate_tablets_for_new_tables(ksm, cfms, muts, ts);
+    }
+
+    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {
+        allocate_tablets_for_new_tables(ksm, {s.shared_from_this()}, muts, ts);
     }
 
     void on_before_drop_column_family(const schema& s, std::vector<mutation>& muts, api::timestamp_type ts) override {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1559,11 +1559,7 @@ public:
             }
 
             auto& tmap = _tm->tablets().get_tablet_map(table);
-
-            const auto* table_stats = load_stats_for_table(table);
-            if (!table_stats) {
-                continue;
-            }
+            const auto& table_groups = _tm->tablets().all_table_groups();
 
             auto finalize_decision = [&] {
                 _stats.for_cluster().resizes_finalized++;
@@ -1572,10 +1568,16 @@ public:
 
             // If all replicas have completed split work for the current sequence number, it means that
             // load balancer can emit finalize decision, for split to be completed.
-            if (tmap.needs_split() && table_stats->split_ready_seq_number == tmap.resize_decision().sequence_number) {
-                finalize_decision();
-                lblogger.info("Finalizing resize decision for table {} as all replicas agree on sequence number {}",
-                              table, table_stats->split_ready_seq_number);
+            if (tmap.needs_split()) {
+                bool all_tables_ready = std::ranges::all_of(table_groups.at(table), [&, seq_num = tmap.resize_decision().sequence_number] (table_id table) {
+                    const auto* table_stats = load_stats_for_table(table);
+                    return table_stats && table_stats->split_ready_seq_number == seq_num;
+                });
+                if (all_tables_ready) {
+                    finalize_decision();
+                    lblogger.info("Finalizing resize decision for table {} as all replicas agree on sequence number {}",
+                                  table, tmap.resize_decision().sequence_number);
+                }
             // If all sibling tablets are co-located across all DCs, then merge can be finalized.
             } else if (tmap.needs_merge() && co_await all_sibling_tablet_replicas_colocated(table, tmap) && !bypass_merge_completion()) {
                 finalize_decision();

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -106,6 +106,35 @@ void load_balancer_stats_manager::unregister() {
     _metrics.clear();
 }
 
+template <std::ranges::range R>
+requires std::convertible_to<std::ranges::range_value_t<R>, db::tablet_options>
+db::tablet_options combine_tablet_options(R&& opts) {
+    db::tablet_options combined_opts;
+
+    using data_size_type = decltype(db::tablet_options::expected_data_size_in_gb)::value_type;
+    data_size_type total_expected_data_size_in_gb = 0;
+    size_t total_expected_data_size_in_gb_count = 0;
+
+    for (const auto& opt : opts) {
+        if (opt.min_tablet_count) {
+            combined_opts.min_tablet_count = std::max(combined_opts.min_tablet_count.value_or(0), *opt.min_tablet_count);
+        }
+        if (opt.min_per_shard_tablet_count) {
+            combined_opts.min_per_shard_tablet_count = std::max(combined_opts.min_per_shard_tablet_count.value_or(0), *opt.min_per_shard_tablet_count);
+        }
+        if (opt.expected_data_size_in_gb) {
+            total_expected_data_size_in_gb += *opt.expected_data_size_in_gb;
+            total_expected_data_size_in_gb_count++;
+        }
+    }
+
+    if (total_expected_data_size_in_gb_count) {
+        combined_opts.expected_data_size_in_gb = total_expected_data_size_in_gb / total_expected_data_size_in_gb_count;
+    }
+
+    return combined_opts;
+}
+
 // Used to compare different migration choices in regard to impact on load imbalance.
 // There is a total order on migration_badness such that better migrations are ordered before worse ones.
 struct migration_badness {
@@ -519,12 +548,12 @@ class load_balancer {
 
     const unsigned _tablets_per_shard_goal;
 
-    uint64_t target_max_tablet_size() const noexcept {
-        return _target_tablet_size * 2;
+    uint64_t target_max_tablet_size(uint64_t target_tablet_size) const noexcept {
+        return target_tablet_size * 2;
     }
 
-    uint64_t target_min_tablet_size() const noexcept {
-        return _target_tablet_size / 2;
+    uint64_t target_min_tablet_size(uint64_t target_tablet_size) const noexcept {
+        return target_tablet_size / 2;
     }
 
     struct table_size_desc {
@@ -1220,10 +1249,15 @@ public:
             }
         });
 
-        auto process_table = [&] (table_id table, schema_ptr s, const tablet_aware_replication_strategy* rs, size_t tablet_count) {
+        auto process_table = [&] (table_id table, const locator::table_group_set& tables, schema_ptr s, db::tablet_options tablet_options, const tablet_aware_replication_strategy* rs, size_t tablet_count) {
             table_sizing& table_plan = plan.tables[table];
             table_plan.current_tablet_count = tablet_count;
             rs_by_table[table] = rs;
+
+            // for a group of co-located tablets of size g with average tablet size t, the migration unit
+            // size is g*t. in order to keep the migration unit size reasonable, we set a lower target tablet size
+            // as the group size increases.
+            auto target_tablet_size = _target_tablet_size / tables.size();
 
             tablet_count_and_reason target_tablet_count = {1, ""};
             auto maybe_apply = [&] (tablet_count_and_reason candidate) {
@@ -1236,13 +1270,12 @@ public:
 
             maybe_apply({rs->get_initial_tablets(), "initial"});
 
-            const auto& tablet_options = s->tablet_options();
             if (tablet_options.min_tablet_count) {
                 maybe_apply({tablet_options.min_tablet_count.value(), "min_tablet_count"});
             }
 
             if (tablet_options.expected_data_size_in_gb) {
-                maybe_apply({(tablet_options.expected_data_size_in_gb.value() << 30) / _target_tablet_size,
+                maybe_apply({(tablet_options.expected_data_size_in_gb.value() << 30) / target_tablet_size,
                         format("expected_data_size_in_gb={}", tablet_options.expected_data_size_in_gb.value())});
             }
 
@@ -1254,23 +1287,36 @@ public:
                 maybe_apply(tablet_count_from_min_per_shard_tablet_count(*s, shards_per_dc, *rs, min_per_shard_tablet_count));
             }
 
-            const auto* table_stats = load_stats_for_table(table);
-            if (table_stats) {
+            auto total_size_opt = std::invoke([&] -> std::optional<size_t> {
+                size_t total_size = 0;
+                for (auto table : tables) {
+                    const auto* table_stats = load_stats_for_table(table);
+                    if (!table_stats) {
+                        return std::nullopt;
+                    }
+                    total_size += table_stats->size_in_bytes;
+                }
+                return total_size;
+            });
+
+            if (total_size_opt) {
+                auto total_size = *total_size_opt;
+
                 auto cur_decision = _tm->tablets().get_tablet_map(table).resize_decision();
-                auto avg_tablet_size = table_stats->size_in_bytes / std::max<size_t>(table_plan.current_tablet_count, 1);
+                auto avg_tablet_size = total_size / std::max<size_t>(table_plan.current_tablet_count * tables.size(), 1);
                 auto tablet_count_from_size = table_plan.current_tablet_count;
 
                 // Split based on avg_tablet_size, or if the current resize_decision is split, apply hysteresis,
                 // so it would get cancelled only when crossing back the half-way point.
-                if (avg_tablet_size > target_max_tablet_size() ||
-                    (cur_decision.is_split() && avg_tablet_size >= _target_tablet_size)) {
+                if (avg_tablet_size > target_max_tablet_size(target_tablet_size) ||
+                    (cur_decision.is_split() && avg_tablet_size >= target_tablet_size)) {
                     // TODO: extend to n-way split when needed
                     tablet_count_from_size *= 2;
                 } else {
                     // Consider merge. If the current resize_decision is merge, apply hysteresis,
                     // so it would get cancelled only when crossing back the half-way point.
-                    if (avg_tablet_size < target_min_tablet_size() ||
-                        (cur_decision.is_merge() && avg_tablet_size <= _target_tablet_size)) {
+                    if (avg_tablet_size < target_min_tablet_size(target_tablet_size) ||
+                        (cur_decision.is_merge() && avg_tablet_size <= target_tablet_size)) {
                         tablet_count_from_size /= 2;
                     }
                 }
@@ -1292,14 +1338,22 @@ public:
                     table_plan.target_tablet_count, table_plan.target_tablet_count_reason);
         };
 
-        for (auto&& [table, tmap] : _tm->tablets().all_tables()) {
+        for (const auto& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
             auto [s, rs] = get_schema_and_rs(table);
-            process_table(table, s, rs, tmap->tablet_count());
+
+            auto tablet_options = combine_tablet_options(
+                    tables | std::views::transform([&] (table_id table) { return _db.get_tables_metadata().get_table_if_exists(table); })
+                           | std::views::filter([] (auto t) { return t != nullptr; })
+                           | std::views::transform([] (auto t) { return t->schema()->tablet_options(); })
+            );
+
+            process_table(table, tables, s, tablet_options, rs, tmap.tablet_count());
             co_await coroutine::maybe_yield();
         }
 
         if (new_table) {
-            process_table(new_table->id(), new_table, new_rs, 0);
+            process_table(new_table->id(), {new_table->id()}, new_table, new_table->tablet_options(), new_rs, 0);
         }
 
         // Below section ensures we respect the _tablets_per_shard_goal.
@@ -1419,10 +1473,9 @@ public:
 
         cluster_resize_load resize_load;
 
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, table_plan] : table_sizing_plan.tables) {
+            auto& tmap = _tm->tablets().get_tablet_map(table);
 
-            table_sizing& table_plan = table_sizing_plan.tables[table];
             if (!table_plan.avg_tablet_size) {
                 continue;
             }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -842,8 +842,8 @@ public:
         });
 
         // Consider load that is already scheduled
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
             for (auto&& [tid, trinfo]: tmap.transitions()) {
                 co_await coroutine::maybe_yield();
                 if (is_streaming(&trinfo)) {
@@ -873,8 +873,8 @@ public:
 
         std::vector<repair_plan> plans;
         auto migration_tablet_ids = co_await mplan.get_migration_tablet_ids();
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = *tmap_;
+        for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            const auto& tmap = _tm->tablets().get_tablet_map(table);
             co_await coroutine::maybe_yield();
             auto& config = tmap.repair_scheduler_config();
             auto now = db_clock::now();

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -218,7 +218,7 @@ future<std::vector<tasks::task_stats>> tablet_virtual_task::get_stats() {
 }
 
 std::vector<table_id> tablet_virtual_task::get_table_ids() const {
-    return _ss.get_token_metadata().tablets().all_tables() | std::views::transform([] (const auto& table_to_tablets) { return table_to_tablets.first; }) | std::ranges::to<std::vector<table_id>>();
+    return _ss.get_token_metadata().tablets().all_table_groups() | std::views::transform([] (const auto& table_to_tablets) { return table_to_tablets.first; }) | std::ranges::to<std::vector<table_id>>();
 }
 
 static void update_status(const locator::tablet_task_info& task_info, tasks::task_status& status, size_t& sched_nr) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -942,6 +942,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
                 for (const auto& table_or_mv : tables_with_mvs) {
                     try {
+                        if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
+                            // Apply the transition only on base tables.
+                            // If this table has a base table then the transition will be applied on the base table, and
+                            // the base table will coordinate the transition for the entire group.
+                            continue;
+                        }
                         locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1171,18 +1171,18 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         return true;
     }
 
-    future<> for_each_tablet_transition(std::function<void(const locator::tablet_map&,
-                                                           schema_ptr,
-                                                           locator::global_tablet_id,
+    future<> for_each_tablet_group_transition(std::function<void(const locator::tablet_map&,
+                                                           table_id,
+                                                           const locator::table_group_set&,
+                                                           locator::tablet_id,
                                                            const locator::tablet_transition_info&)> func) {
         auto tm = get_token_metadata_ptr();
-        for (auto&& [table, tmap] : tm->tablets().all_tables()) {
+        for (auto&& [base_table, tables] : tm->tablets().all_table_groups()) {
             co_await coroutine::maybe_yield();
-            auto s = _db.find_schema(table);
-            for (auto&& [tablet, trinfo]: tmap->transitions()) {
+            const auto& tmap = tm->tablets().get_tablet_map(base_table);
+            for (auto&& [tablet, trinfo]: tmap.transitions()) {
                 co_await coroutine::maybe_yield();
-                auto gid = locator::global_tablet_id {table, tablet};
-                func(*tmap, s, gid, trinfo);
+                func(tmap, base_table, tables, tablet, trinfo);
             }
         }
     }
@@ -1293,17 +1293,29 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         });
 
         _tablets_ready = false;
-        co_await for_each_tablet_transition([&] (const locator::tablet_map& tmap,
-                                                 schema_ptr s,
-                                                 locator::global_tablet_id gid,
+        // We operate here on groups of co-located tablets.
+        // The tablets of several tables may be co-located and share the same tablet map, and in
+        // particular their transitions are shared. Therefore, each transition must be handled for
+        // all tablets in a co-location group at once.
+        co_await for_each_tablet_group_transition([&] (const locator::tablet_map& tmap,
+                                                 table_id base_table,
+                                                 const locator::table_group_set& tables,
+                                                 locator::tablet_id tid,
                                                  const locator::tablet_transition_info& trinfo) {
+            // we have `gid` which is the tablet id of the base table of the tablet group, which we use as a
+            // representative of the group for some of the operations - such as logging, and as the key in the _tablets
+            // map where we store the migration state.
+            // `gids` is all the tablet ids of tablets in the co-location group. When we execute some operation such as
+            // streaming, cleanup, etc, we do it for each tablet in `gids`.
+            locator::global_tablet_id gid { base_table, tid };
+            auto gids = tables | std::views::transform([tid] (table_id table) { return locator::global_tablet_id{table, tid}; }) | std::ranges::to<std::vector>();
+
             has_transitions = true;
             auto last_token = tmap.get_last_token(gid.tablet);
             auto& tablet_state = _tablets[gid];
-            table_id table = s->id();
 
             auto get_mutation_builder = [&] () {
-                return replica::tablet_mutation_builder(guard.write_timestamp(), table);
+                return replica::tablet_mutation_builder(guard.write_timestamp(), base_table);
             };
 
             auto transition_to = [&] (locator::tablet_transition_stage stage) {
@@ -1403,8 +1415,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         auto dst = locator::maybe_get_primary_replica(gid.tablet, {tsi.read_from.begin(), tsi.read_from.end()}, [] (const auto& tr) { return true; }).value().host;
                         rtlogger.info("Initiating repair phase of tablet rebuild host={} tablet={}", dst, gid);
-                        return ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
-                                dst, _as, raft::server_id(dst.uuid()), gid).discard_result();
+                        return do_with(gids, [this, dst] (const auto& gids) {
+                            return do_for_each(gids, [this, dst] (locator::global_tablet_id gid) {
+                                return ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
+                                        dst, _as, raft::server_id(dst.uuid()), gid).discard_result();
+                            });
+                        });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::streaming);
                         updates.emplace_back(get_mutation_builder()
@@ -1447,8 +1463,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         rtlogger.info("Initiating tablet streaming ({}) of {} to {}", trinfo.transition, gid, *trinfo.pending_replica);
                         auto dst = trinfo.pending_replica->host;
-                        return ser::storage_service_rpc_verbs::send_tablet_stream_data(&_messaging,
-                                   dst, _as, raft::server_id(dst.uuid()), gid);
+                        return do_with(gids, [this, dst] (const auto& gids) {
+                            return do_for_each(gids, [this, dst] (locator::global_tablet_id gid) {
+                                return ser::storage_service_rpc_verbs::send_tablet_stream_data(&_messaging,
+                                           dst, _as, raft::server_id(dst.uuid()), gid);
+                            });
+                        });
                     })) {
                         rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::write_both_read_new);
                         updates.emplace_back(get_mutation_builder()
@@ -1509,8 +1529,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             return make_ready_future<>();
                         }
                         rtlogger.info("Initiating tablet cleanup of {} on {}", gid, dst);
-                        return ser::storage_service_rpc_verbs::send_tablet_cleanup(&_messaging,
-                                                                                   dst.host, _as, raft::server_id(dst.host.uuid()), gid);
+                        return do_with(gids, [this, dst] (const auto& gids) {
+                            return do_for_each(gids, [this, dst] (locator::global_tablet_id gid) {
+                                return ser::storage_service_rpc_verbs::send_tablet_cleanup(&_messaging,
+                                                                                           dst.host, _as, raft::server_id(dst.host.uuid()), gid);
+                            });
+                        });
                     })) {
                         transition_to(locator::tablet_transition_stage::end_migration);
                     }
@@ -1528,8 +1552,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             return make_ready_future<>();
                         }
                         rtlogger.info("Initiating tablet cleanup of {} on {} to revert migration", gid, dst);
-                        return ser::storage_service_rpc_verbs::send_tablet_cleanup(&_messaging,
-                                                                                   dst.host, _as, raft::server_id(dst.host.uuid()), gid);
+                        return do_with(gids, [this, dst] (const auto& gids) {
+                            return do_for_each(gids, [this, dst] (locator::global_tablet_id gid) {
+                                return ser::storage_service_rpc_verbs::send_tablet_cleanup(&_messaging,
+                                                                                           dst.host, _as, raft::server_id(dst.host.uuid()), gid);
+                            });
+                        });
                     })) {
                         transition_to(locator::tablet_transition_stage::revert_migration);
                     }
@@ -1594,8 +1622,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             dst = dst_opt.value().host;
                         }
                         rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);
-                        auto res = co_await ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
-                                dst, _as, raft::server_id(dst.uuid()), gid);
+                        auto res = gids.size() > 1 ?
+                                co_await ser::storage_service_rpc_verbs::send_tablet_repair_colocated(&_messaging,
+                                    dst, _as, raft::server_id(dst.uuid()), gid, gids)
+                                : co_await ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
+                                    dst, _as, raft::server_id(dst.uuid()), gid);
                         auto duration = std::chrono::duration<float>(db_clock::now() - sched_time);
                         auto& tablet_state = _tablets[tablet];
                         tablet_state.repair_time = db_clock::from_time_t(gc_clock::to_time_t(res.repair_time));

--- a/test/boost/view_schema_test.cc
+++ b/test/boost/view_schema_test.cc
@@ -3056,14 +3056,17 @@ SEASTAR_TEST_CASE(test_view_update_generating_writetime) {
 
     return do_with_cql_env_thread([] (cql_test_env& e) {
 
+        auto f1 = e.local_view_builder().wait_until_built("ks", "mv1");
+        auto f2 = e.local_view_builder().wait_until_built("ks", "mv2");
+
         e.execute_cql("CREATE TABLE t (k int, c int, a int, b int, e int, f int, g int, primary key(k, c))").get();
         e.execute_cql("CREATE MATERIALIZED VIEW mv1 AS SELECT k,c,a,b FROM t "
                          "WHERE k IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, k)").get();
         e.execute_cql("CREATE MATERIALIZED VIEW mv2 AS SELECT k,c,a,b FROM t "
                          "WHERE k IS NOT NULL AND c IS NOT NULL AND a IS NOT NULL PRIMARY KEY (c, k, a)").get();
 
-        e.local_view_builder().wait_until_built("ks", "mv1").get();
-        e.local_view_builder().wait_until_built("ks", "mv2").get();
+        f1.get();
+        f2.get();
 
         auto total_t_view_updates = [&] {
             return e.db().map_reduce0([] (replica::database& local_db) {

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -1,0 +1,438 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from contextlib import asynccontextmanager
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot
+from test.pylib.tablets import get_tablet_replica, get_base_table, get_tablet_count, get_tablet_info
+from test.pylib.util import wait_for
+from test.cluster.conftest import skip_mode
+from test.cluster.util import new_test_keyspace
+import time
+import pytest
+import logging
+import asyncio
+import random
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+logger = logging.getLogger(__name__)
+
+async def inject_error_one_shot_on(manager, error_name, servers):
+    errs = [inject_error_one_shot(manager.api, s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+async def inject_error_on(manager, error_name, servers):
+    errs = [manager.api.enable_injection(s.ip_addr, error_name, False) for s in servers]
+    await asyncio.gather(*errs)
+
+async def disable_injection_on(manager, error_name, servers):
+    errs = [manager.api.disable_injection(s.ip_addr, error_name) for s in servers]
+    await asyncio.gather(*errs)
+
+async def disable_tablet_balancing(manager, servers):
+    await asyncio.gather(*[manager.api.disable_tablet_balancing(s.ip_addr) for s in servers])
+
+async def enable_tablet_balancing(manager, servers):
+    await asyncio.gather(*[manager.api.enable_tablet_balancing(s.ip_addr) for s in servers])
+
+@asynccontextmanager
+async def no_tablet_balancing(manager, servers):
+    await disable_tablet_balancing(manager, servers)
+    try:
+        yield
+    finally:
+        await enable_tablet_balancing(manager, servers)
+
+async def wait_for_tablet_stage(manager, server, keyspace_name, table_name, token, stage):
+    async def tablet_is_in_stage():
+        ti = await get_tablet_info(manager, server, keyspace_name, table_name, token)
+        if ti.stage == stage:
+            return True
+    await wait_for(tablet_is_in_stage, time.time() + 60)
+
+# Test the when creating MVs that have the same partition key as the base table
+# they are co-located with the base table.
+# We create multiple views, some with the same partition key and some not, and
+# check that those views with the same partition key are co-located by reading
+# their tablet map from system.tablets and checking they have base_table set.
+@pytest.mark.asyncio
+async def test_base_view_colocation(manager: ManagerClient):
+    cfg = {'enable_tablets': True}
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'raft_topology=debug',
+        '--logger-log-level', 'load_balancer=debug',
+    ]
+    servers = await manager.servers_add(1, config=cfg, cmdline=cmdline)
+
+    cql = manager.get_cql()
+
+    min_tablet_count = 8
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } AND tablets = {'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int, c int, v int, PRIMARY KEY(pk, c)) WITH tablets={{'min_tablet_count':{min_tablet_count}}};")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv1 AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c)")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv2 AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL AND v IS NOT NULL PRIMARY KEY (pk, v, c)")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv3 AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")
+
+        base_id = await manager.get_table_id(ks, 'test')
+        tv1_id = await manager.get_view_id(ks, 'tv1')
+        tv2_id = await manager.get_view_id(ks, 'tv2')
+        tv3_id = await manager.get_view_id(ks, 'tv3')
+
+        # tv1 and tv2 are co-located with the base table because they have the same partition key
+        assert base_id == (await get_base_table(manager, tv1_id))
+        assert base_id == (await get_base_table(manager, tv2_id))
+
+        # tv3 is not co-located with the base table because it has a different partition key
+        assert tv3_id == (await get_base_table(manager, tv3_id))
+
+        base_tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+        assert base_tablet_count == (await get_tablet_count(manager, servers[0], ks, 'tv1'))
+        assert base_tablet_count == (await get_tablet_count(manager, servers[0], ks, 'tv2'))
+
+        await cql.run_async(f"DROP MATERIALIZED VIEW {ks}.tv1")
+        await cql.run_async(f"DROP MATERIALIZED VIEW {ks}.tv2")
+        await cql.run_async(f"DROP MATERIALIZED VIEW {ks}.tv3")
+
+# Create co-located base and view tables with a single tablet each in a 2 node
+# cluster, and request to move the tablet of some table (either base or view,
+# according to the parameter) to the other node. It should succeed and move
+# both tablets to be co-located on the other node.  After they are moved we
+# stop the other node, remaining only with the one node that should hold the
+# base and view tablets, and verify we can read both tables from this node.
+@pytest.mark.parametrize("move_table", ["base", "child"])
+@pytest.mark.asyncio
+async def test_move_tablet(manager: ManagerClient, move_table: str):
+    cfg = {'enable_tablets': True}
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'raft_topology=debug',
+    ]
+    servers = await manager.servers_add(2, config=cfg, cmdline=cmdline)
+    await asyncio.gather(*[manager.api.disable_tablet_balancing(s.ip_addr) for s in servers])
+
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        # The base and view table should be co-located on one of the nodes with a single tablet each.
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c)")
+
+        row_count = 100
+        insert = cql.prepare(f"INSERT INTO {ks}.test(pk, c) VALUES(?, ?)")
+        for pk in range(row_count):
+            cql.execute(insert, [pk, pk+1])
+
+        if move_table == 'base':
+            table = 'test'
+        else:
+            table = 'tv'
+
+        s0_host_id = await manager.get_host_id(servers[0].server_id)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+        # Request to move one of the tablets to the other node. it should move
+        # both tablets because they must remain co-located.
+
+        tablet_token = 0 # Doesn't matter since there is one tablet
+        replica = await get_tablet_replica(manager, servers[0], ks, table, tablet_token)
+        if replica[0] == s0_host_id:
+            src_server = 0
+            dst_host_id = s1_host_id
+        else:
+            src_server = 1
+            dst_host_id = s0_host_id
+
+        logger.info(f"Migrate the tablet to {dst_host_id}")
+        await manager.api.move_tablet(servers[0].ip_addr, ks, table, replica[0], replica[1], dst_host_id, 0, tablet_token)
+        logger.info("Migration done")
+
+        new_replica = await get_tablet_replica(manager, servers[0], ks, table, tablet_token)
+        assert new_replica[0] == dst_host_id
+
+        # Now the dst node should hold both tablets. Stop the other node and
+        # verify we can read from both tables.
+        await manager.server_stop(servers[src_server].server_id)
+
+        rows = await cql.run_async(f"SELECT * FROM {ks}.test")
+        assert len(rows) == row_count
+
+        rows = await cql.run_async(f"SELECT * FROM {ks}.tv")
+        assert len(rows) == row_count
+
+        # Start the server back because we need quorom when dropping the keyspace
+        await manager.server_start(servers[src_server].server_id)
+
+# Basic test of tablet split and merge of co-located tablets.
+# Create co-located base and view tablets and populate the base table with enough data to trigger tablet splits.
+# The view table has a filter so it's empty and wouldn't be a candidate for tablet split normally, but it should
+# be split because it's co-located with the base table and their combined sizes are large enough.
+# We verify that the tablets of both tables are split, and the tables have the same tablet count.
+# Then delete some keys and verify the tablets of both tables are merged.
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.parametrize(
+    "with_merge",
+    [
+        pytest.param(False, id="no_merge"),
+        pytest.param(True, id="with_merge", marks=pytest.mark.xfail(reason="issue #17265")),
+    ],
+)
+async def test_tablet_split_and_merge(manager: ManagerClient, with_merge: bool):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'table=debug',
+        '--logger-log-level', 'load_balancer=debug',
+        '--target-tablet-size-in-bytes', '30000',
+    ]
+    servers = [await manager.server_add(config={
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
+    }, cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=1 AND bloom_filter_fp_chance=1;")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL AND pk > 1000000 PRIMARY KEY (pk, c)")
+
+        # Initial average table size of 400k (1 tablet), so triggers some splits.
+        total_keys = 200
+        keys = range(total_keys)
+        def populate(keys):
+            insert = cql.prepare(f"INSERT INTO {ks}.test(pk, c) VALUES(?, ?)")
+            for pk in keys:
+                value = random.randbytes(2000)
+                cql.execute(insert, [pk, value])
+        populate(keys)
+
+        async def check():
+            logger.info("Checking table")
+            cql = manager.get_cql()
+            rows = await cql.run_async(f"SELECT * FROM {ks}.test BYPASS CACHE;")
+            assert len(rows) == len(keys)
+
+        await check()
+
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+        assert tablet_count == 1
+
+        logger.info("Adding new server")
+        servers.append(await manager.server_add(cmdline=cmdline))
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+        # Increases the chance of tablet migration concurrent with split
+        await inject_error_one_shot_on(manager, "tablet_allocator_shuffle", servers)
+        await inject_error_on(manager, "tablet_load_stats_refresh_before_rebalancing", servers)
+
+        s1_log = await manager.server_open_log(servers[0].server_id)
+        s1_mark = await s1_log.mark()
+
+        # Now there's a split and migration need, so they'll potentially run concurrently.
+        await manager.api.enable_tablet_balancing(servers[0].ip_addr)
+
+        await check()
+        await asyncio.sleep(2) # Give load balancer some time to do work
+
+        await s1_log.wait_for(f"Detected tablet split for table {ks}.test", from_mark=s1_mark, timeout=60)
+        await s1_log.wait_for(f"Detected tablet split for table {ks}.tv", from_mark=s1_mark, timeout=60)
+
+        await check()
+
+        async with no_tablet_balancing(manager, servers):
+            tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+            assert tablet_count > 1
+            other_tablet_count = await get_tablet_count(manager, servers[0], ks, 'tv')
+            assert tablet_count == other_tablet_count
+
+        if not with_merge:
+            return
+
+        # Allow shuffling of tablet replicas to make co-location work harder
+        async def shuffle():
+            await inject_error_on(manager, "tablet_allocator_shuffle", servers)
+            await asyncio.sleep(2)
+            await disable_injection_on(manager, "tablet_allocator_shuffle", servers)
+
+        await shuffle()
+
+        # This will allow us to simulate some balancing after co-location with shuffling, to make sure that
+        # balancer won't break co-location.
+        await inject_error_on(manager, "tablet_merge_completion_bypass", servers)
+
+        # Shrinks table significantly, forcing merge.
+        delete_keys = range(total_keys - 1)
+        await asyncio.gather(*[cql.run_async(f"DELETE FROM {ks}.test WHERE pk={k};") for k in delete_keys])
+        keys = range(total_keys - 1, total_keys)
+
+        # To avoid race of major with migration
+        async with no_tablet_balancing(manager, servers):
+            for server in servers:
+                await manager.api.flush_keyspace(server.ip_addr, ks)
+                await manager.api.keyspace_compaction(server.ip_addr, ks)
+
+        await s1_log.wait_for("Emitting resize decision of type merge", from_mark=s1_mark, timeout=60)
+        # Waits for balancer to co-locate sibling tablets
+        await s1_log.wait_for("All sibling tablets are co-located", timeout=60)
+        # Do some shuffling to make sure balancer works with co-located tablets
+        await shuffle()
+
+        old_tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+        s1_mark = await s1_log.mark()
+
+        await inject_error_on(manager, "replica_merge_completion_wait", servers)
+        await disable_injection_on(manager, "tablet_merge_completion_bypass", servers)
+
+        await s1_log.wait_for(f"Detected tablet merge for table {ks}.test", from_mark=s1_mark, timeout=60)
+        await s1_log.wait_for(f"Detected tablet merge for table {ks}.tv", from_mark=s1_mark, timeout=60)
+
+        async with no_tablet_balancing(manager, servers):
+            tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
+            assert tablet_count < old_tablet_count
+            other_tablet_count = await get_tablet_count(manager, servers[0], ks, 'tv')
+            assert tablet_count == other_tablet_count
+
+            await check()
+
+# Test creating a co-located table while the base table is migrating.  We
+# create a table with a single tablet and start migrating it to the other node.
+# While it's in some transition stage, we hold it and create a co-located view.
+# We verify we can continue read and write to both tables. Then we complete the
+# migration and verify everything continues to work as expected.
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.parametrize("wait_stage", [("streaming", "stream_tablet_wait"), ("cleanup", "cleanup_tablet_wait")])
+async def test_create_colocated_table_while_base_is_migrating(manager: ManagerClient, wait_stage):
+    cfg = {'enable_tablets': True, 'error_injections_at_startup': ['short_tablet_stats_refresh_interval'] }
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'raft_topology=debug',
+    ]
+    servers = await manager.servers_add(2, config=cfg, cmdline=cmdline)
+    await asyncio.gather(*[manager.api.disable_tablet_balancing(s.ip_addr) for s in servers])
+
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+
+        total_keys = 100
+        keys = range(total_keys)
+        def populate(table, keys):
+            insert = cql.prepare(f"INSERT INTO {ks}.{table}(pk, c) VALUES(?, ?)")
+            for pk in keys:
+                cql.execute(insert, [pk, pk+1])
+
+        populate('test', keys)
+
+        s0_host_id = await manager.get_host_id(servers[0].server_id)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+        tablet_token = 0
+        replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+        if replica[0] == s0_host_id:
+            replica_ip = servers[0].ip_addr
+            dst_host_id = s1_host_id
+        else:
+            replica_ip = servers[1].ip_addr
+            dst_host_id = s0_host_id
+
+        wait_injection = wait_stage[1]
+        await inject_error_on(manager, wait_injection, servers)
+        move_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, 'test', replica[0], replica[1], dst_host_id, 0, tablet_token))
+        await wait_for_tablet_stage(manager, servers[0], ks, 'test', tablet_token, wait_stage[0])
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (pk, c) WITH synchronous_updates = true")
+        await asyncio.sleep(2)
+
+        # check we can write and read from the base table during the migration, and
+        # that the view is also updated
+        cql.execute(f"INSERT INTO {ks}.test(pk, c) VALUES(200, 201)")
+        rows = await cql.run_async(f"SELECT * FROM {ks}.test WHERE pk=200")
+        assert len(rows) == 1 and rows[0].c == 201
+
+        await cql.run_async(f"SELECT * FROM {ks}.tv WHERE pk=200 BYPASS CACHE")
+        assert len(rows) == 1 and rows[0].c == 201
+
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        await disable_injection_on(manager, wait_injection, servers)
+        await move_task
+
+        base_id = await manager.get_table_id(ks, 'test')
+        tv_id = await manager.get_view_id(ks, 'tv')
+
+        new_replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+        assert new_replica[0] == dst_host_id
+
+        rows = await cql.run_async(f"SELECT * FROM {ks}.tv")
+        assert len(rows) == total_keys+1
+
+        cql.execute(f"INSERT INTO {ks}.test(pk, c) VALUES(300, 301)")
+        rows = await cql.run_async(f"SELECT * FROM {ks}.tv WHERE pk=300 BYPASS CACHE")
+        assert len(rows) == 1 and rows[0].c == 301
+
+        src_host_id, dst_host_id = dst_host_id, replica[0]
+        await manager.api.move_tablet(servers[0].ip_addr, ks, 'test', src_host_id, 0, dst_host_id, 0, tablet_token)
+
+        cql.execute(f"INSERT INTO {ks}.test(pk, c) VALUES(400, 401)")
+        rows = await cql.run_async(f"SELECT * FROM {ks}.tv WHERE pk=400 BYPASS CACHE")
+        assert len(rows) == 1 and rows[0].c == 401
+
+# Test basic tablet repair of a co-located base and view table.
+# 1. start 2 nodes
+# 1. Create a base table and a co-located view table with a single tablet and RF=2 (replica on each node)
+# 2. write data to the base table while one node is down
+# 3. bring the node back up - it is now missing some data
+# 4. run tablet repair on the base table
+# 5. verify both the base table and the view contain the missing data on the node that was down
+@pytest.mark.asyncio
+async def test_repair_colocated_base_and_view(manager: ManagerClient):
+    cfg = {'enable_tablets': True}
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'repair=debug',
+    ]
+    servers = await manager.servers_add(2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
+    await asyncio.gather(*[manager.api.disable_tablet_balancing(s.ip_addr) for s in servers])
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c)")
+
+        cql.execute(SimpleStatement(f"INSERT INTO {ks}.test(pk, c) VALUES(1, 10)", consistency_level=ConsistencyLevel.ONE))
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+        await manager.api.flush_keyspace(servers[1].ip_addr, ks)
+
+        # Stop node 2 and write data while it is down
+        await manager.server_stop(servers[1].server_id)
+
+        cql.execute(SimpleStatement(f"INSERT INTO {ks}.test(pk, c) VALUES(2, 20)", consistency_level=ConsistencyLevel.ONE))
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        # Start node 2 back up
+        await manager.server_start(servers[1].server_id)
+
+        # At this point, node 2 is missing pk=2
+        # Verify that pk=2 is missing on node 2 before repair
+        # Connect directly to server 2 to check its data
+        cql_server2 = await manager.get_cql_exclusive(servers[1])
+        rows = await cql_server2.run_async(SimpleStatement(f"SELECT * FROM {ks}.test", consistency_level=ConsistencyLevel.ONE))
+        pks = set(row.pk for row in rows)
+        assert 1 in pks and 2 not in pks
+
+        # Trigger repair of the single tablet
+        tablet_token = 0
+        await manager.api.tablet_repair(servers[0].ip_addr, ks, 'test', tablet_token)
+
+        # Verify the view is repaired on server 2
+        rows = await cql_server2.run_async(SimpleStatement(f"SELECT * FROM {ks}.tv", consistency_level=ConsistencyLevel.ONE))
+        pks = set(row.pk for row in rows)
+        assert 1 in pks and 2 in pks

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -81,7 +81,7 @@ sstring add_keyspace(cql_test_env& e, std::unordered_map<sstring, int> dc_rf, in
 static
 size_t get_tablet_count(const tablet_metadata& tm) {
     size_t count = 0;
-    for (auto& [table, tmap] : tm.all_tables()) {
+    for (const auto& [table, tmap] : tm.all_tables_ungrouped()) {
         count += std::accumulate(tmap->tablets().begin(), tmap->tablets().end(), size_t(0),
                                  [] (size_t accumulator, const locator::tablet_info& info) {
                                      return accumulator + info.replicas.size();

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -599,6 +599,13 @@ class ManagerClient:
         rows = await self.cql.run_async(f"select id from system_schema.views where keyspace_name = '{keyspace}' and view_name = '{view}'")
         return rows[0].id
 
+    async def get_table_or_view_id(self, keyspace: str, table: str):
+        rows = await self.cql.run_async(f"select id from system_schema.tables where keyspace_name = '{keyspace}' and table_name = '{table}'")
+        if len(rows) > 0:
+            return rows[0].id
+        rows = await self.cql.run_async(f"select id from system_schema.views where keyspace_name = '{keyspace}' and view_name = '{table}'")
+        return rows[0].id
+
     async def server_sees_others(self, server_id: ServerNum, count: int, interval: float = 45.):
         """Wait till a server sees a minimum given count of other servers"""
         if count < 1:


### PR DESCRIPTION
Add the option to co-locate tablets of different tables. For example, a base table and its CDC table, or a local index.

main changes and ideas:
* "table group" - a set of one or more tables that should be co-located. (Example: base table and CDC table). A group consists of one base table and zero or more children tables.
* new column `base_table` in `system.tablets`: when creating a new table, it can be set to point to a base table, which the new table's tablets will be co-located with. when it's set, the tablet map information should be retrieved from the base table map. the child map doesn't contain per-tablet information.
* co-located tables always have the same tablet count and the same tablet replicas. each tablet operation - migration, resize, repair - is applied on all tablets in a synchronized manner by the topology coordinator.
* resize decision for a group is made by combining the per-table hints and comparing the average tablet size (over all tablets in the group) with the target tablet size.
* the tablets load balancer works with the base table as a representative of the group. it represents a single migration unit with some `group_size` that is taken into account.
* view tablets are co-located with base tablets when the partition keys match.

Fixes https://github.com/scylladb/scylladb/issues/17043

backport is not needed. this is preliminary work for support of MVs and CDC with tablets.