### PR TITLE
Introduce s3 data_source_impl for optimized object streaming

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -987,6 +987,102 @@ data_sink client::make_upload_jumbo_sink(sstring object_name, std::optional<unsi
     return data_sink(std::make_unique<upload_jumbo_sink>(shared_from_this(), std::move(object_name), max_parts_per_piece, as));
 }
 
+class client::download_source final : public seastar::data_source_impl {
+    shared_ptr<client> _client;
+    sstring _object_name;
+    seastar::abort_source* _as;
+    range _range;
+
+    struct external_body {
+        input_stream<char>& b;
+        promise<> done;
+        external_body(input_stream<char>& b_) noexcept : b(b_), done() {}
+    };
+
+    std::optional<external_body> _body;
+    gate _bg;
+
+    future<external_body> request_body();
+
+public:
+    download_source(shared_ptr<client> cln, sstring object_name, std::optional<range> range, seastar::abort_source* as)
+        : _client(std::move(cln))
+        , _object_name(std::move(object_name))
+        , _as(as)
+        , _range(range.value_or(s3::range{0, std::numeric_limits<uint64_t>::max()}))
+    {
+    }
+
+    virtual future<temporary_buffer<char>> get() override;
+    virtual future<> close() override {
+        if (_body.has_value()) {
+            _body->done.set_value();
+            _body.reset();
+        }
+        return _bg.close();
+    }
+};
+
+data_source client::make_download_source(sstring object_name, std::optional<range> range, seastar::abort_source* as) {
+    return data_source(std::make_unique<download_source>(shared_from_this(), std::move(object_name), range, as));
+}
+
+auto client::download_source::request_body() -> future<external_body> {
+    auto req = http::request::make("GET", _client->_host, _object_name);
+    auto range_header = format_range_header(_range);
+    s3l.trace("GET {} download range {}:{}", _object_name, _range.off, _range.len);
+    req._headers["Range"] = std::move(range_header);
+
+    auto bp = std::make_unique<std::optional<promise<external_body>>>(std::in_place);
+    auto& p = *bp;
+    future<external_body> f = p->get_future();
+
+    (void)_client->make_request(std::move(req), [this, &p] (group_client& gc, const http::reply& rep, input_stream<char>&& in_) mutable -> future<> {
+        s3l.trace("GET {} got the body ({} {} bytes)", _object_name, rep._status, rep.content_length);
+        if (rep._status != http::reply::status_type::partial_content && rep._status != http::reply::status_type::ok) {
+            co_await coroutine::return_exception(httpd::unexpected_status_error(rep._status));
+        }
+
+        auto in = std::move(in_);
+        external_body xb(in);
+        auto f = xb.done.get_future();
+        p->set_value(std::move(xb));
+        p.reset();
+        co_await std::move(f);
+    }, {}, _as).handle_exception([&p] (auto ex) {
+        if (p.has_value()) {
+            p->set_exception(std::move(ex));
+        }
+    }).finally([bp = std::move(bp), h = _bg.hold()] {});
+
+    return f;
+}
+
+future<temporary_buffer<char>> client::download_source::get() {
+    while (true) {
+        if (_body.has_value()) {
+            try {
+                auto buf = co_await _body->b.read_up_to(_range.len);
+                _range.off += buf.size();
+                _range.len -= buf.size();
+                s3l.trace("GET {} got the {}-bytes buffer", _object_name, buf.size());
+                if (buf.empty()) {
+                    _body->done.set_value();
+                    _body.reset();
+                }
+                co_return std::move(buf);
+            } catch (...) {
+                s3l.trace("GET {} error reading body, completing it and re-trying", _object_name);
+                _body->done.set_exception(std::current_exception());
+                _body.reset();
+            }
+        }
+
+        auto xb = co_await request_body();
+        _body.emplace(std::move(xb));
+    }
+}
+
 // unlike upload_sink and upload_jumbo_sink, do_upload_file reads from the
 // specified file, and sends the data read from disk right away to the wire,
 // without accumulating them first.

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -55,6 +55,7 @@ class client : public enable_shared_from_this<client> {
     class upload_sink_base;
     class upload_sink;
     class upload_jumbo_sink;
+    class download_source;
     class do_upload_file;
     class readable_file;
     std::string _host;
@@ -119,6 +120,7 @@ public:
     file make_readable_file(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_sink(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {}, seastar::abort_source* = nullptr);
+    data_source make_download_source(sstring object_name, std::optional<range> range = {}, seastar::abort_source* = nullptr);
     /// upload a file with specified path to s3
     ///
     /// @param path the path to the file


### PR DESCRIPTION
Currently, to stream data from sstable component the sstables code uses file_data_source_impl. In case the component is on S3, the s3::readable_file is put into that data source. The data source is configured with 128k buffers and at most 4 read-ahead-s. With that configuration, downloading full object from S3 becomes too slow -- GET-ing file with 128k requests is not nice even with 4 parallel read-ahead-s.

Better solution for S3 downloading is to request way larger chunk with one GET and then produce smaller, 128k or alike, buffers upon data arrival. This is what the newly introduced data source impl does -- it spawns a background GET and lets the upper input stream read buffers directly from the arriving body.

This PR doesn't yet make sstable layer use the new sink, just introduces it and adds unit and perf tests.

Testing

|Test|Download speed, MB/s|
|-|-|
|file_input_stream (*), 1 socket | 4.996|
|file_input_stream (*), 2 sockets | 9.403|
|s3_data_source (**) | 93.164|

(*) The file_input_stream test renders 128k GETs and is configured to issue at most 4 read-ahead-s
(**) The s3_data_source uses at most 1 socket regardless of what perf-test configures it to

refs: #22458 