### PR TITLE
dist/docker: drop hostname package, use Python API

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -108,7 +108,7 @@ run apt-get -y update
 run apt-get -y upgrade
 run apt-get -y --no-install-suggests install dialog apt-utils
 run bash -ec "echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections"
-run apt-get -y --no-install-suggests install hostname supervisor python3 python3-yaml curl sudo systemd
+run apt-get -y --no-install-suggests install supervisor python3 python3-yaml curl sudo systemd
 run bash -ec "echo LANG=C.UTF-8 > /etc/default/locale"
 run bash -ec "dpkg -i packages/*.deb"
 run apt-get -y clean all

--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -2,6 +2,7 @@ import subprocess
 import logging
 import yaml
 import os
+import socket
 
 
 class ScyllaSetup:
@@ -74,7 +75,7 @@ class ScyllaSetup:
         elif self._listenAddress:
             hostname = self._listenAddress
         else:
-            hostname = subprocess.check_output(['hostname', '-i']).decode('ascii').strip()
+            hostname = socket.gethostbyname(socket.gethostname())
         self._run(["mkdir", "-p",  "%s/.cassandra" % home])
         with open("%s/.cassandra/cqlshrc" % home, "w") as cqlshrc:
             cqlshrc.write("[connection]\nhostname = %s\n" % hostname)
@@ -102,7 +103,7 @@ class ScyllaSetup:
             args += ["--overprovisioned"]
 
         if self._listenAddress is None:
-            self._listenAddress = subprocess.check_output(['hostname', '-i']).decode('ascii').strip()
+            self._listenAddress = socket.gethostbyname(socket.gethostname())
 
         if self._rpcAddress is None:
             self._rpcAddress = self._listenAddress


### PR DESCRIPTION
We currently depends on hostname command to get local IP, but we can do this on Python API.
After the change, we can drop the package.