### PR TITLE
install-dependencies.sh: Make script capable of updating pip packages

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -360,7 +360,7 @@ elif [ "$ID" = "fedora" ]; then
     do
         pip_constrained_packages="${pip_constrained_packages} ${package}${pip_packages[$package]}"
     done
-    pip3 install "$PIP_DEFAULT_ARGS" $pip_constrained_packages
+    pip3 install --upgrade "$PIP_DEFAULT_ARGS" $pip_constrained_packages
 
     if [ -f "$(node_exporter_fullpath)" ] && node_exporter_checksum; then
         echo "$(node_exporter_filename) already exists, skipping download"


### PR DESCRIPTION
Before these changes, the script didn't update the listed pip packages if they were already installed. If the latest version of Scylla started using new features and required an updated Python driver, for example, the developers (and possibly the user) were forced to update it manually.

In this commit, we modify the script so that it updates the installed packages when run. This should make things easier for everyone.

Backport: not necessary, this is an enhancement.