### PR TITLE
db: cql3: add comments regarding unsafe interval<clustering_key_prefix>

### DIFF
--- a/cql3/statements/cas_request.cc
+++ b/cql3/statements/cas_request.cc
@@ -87,6 +87,7 @@ lw_shared_ptr<query::read_command> cas_request::read_command(query_processor& qp
         ranges.emplace_back(query::clustering_range::make_open_ended_both_sides());
         max_rows = 1;
     } else {
+        // WARNING: clustering_range::deoverlap can return incorrect results - refer to scylladb#22817 and scylladb#21604
         ranges = query::clustering_range::deoverlap(std::move(ranges), clustering_key::tri_compare(*_schema));
     }
     auto options = update_parameters::options;

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -319,6 +319,7 @@ size_estimates_mutation_reader::estimates_for_current_keyspace(std::vector<token
         auto rows = std::ranges::subrange(
                 virtual_row_iterator(cf_names, local_ranges),
                 virtual_row_iterator(cf_names, local_ranges, virtual_row_iterator::end_iterator_tag()));
+        // WARNING: interval<clustering_key_prefix> is unsafe - refer to scylladb#21604 and scylladb#8157
         auto rows_to_estimate = range.slice(rows, virtual_row_comparator(_schema));
         for (auto&& r : rows_to_estimate) {
             auto& cf = _db.find_column_family(*_current_partition, utf8_type->to_string(r.cf_name));

--- a/query-request.hh
+++ b/query-request.hh
@@ -48,6 +48,13 @@ using range = wrapping_interval<T>;
 
 using ring_position = dht::ring_position;
 
+// WARNING: interval<clustering_key_prefix> is unsafe - refer to scylladb#22817, scylladb#21604, and scylladb#8157.
+// Due to the note below, methods such as intersection() and deoverlap() returns unexpected (i.e. incorrect) results.
+// If only possible, do not use interval<clustering_key_prefix> in new code. Instead, use position_range,
+// which is an alternative class well-suited to keep clustering_key_prefix ranges. Also refer to
+// optional<clustering_range> intersection(const clustering_range&, const clustering_range&, const prefix_equal_tri_compare&)
+// in statement_restrictions.cc for a correct (but overcomplicated) implementation of intersection().
+//
 // Note: the bounds of a  clustering range don't necessarily satisfy `rb.end()->value() >= lb.end()->value()`,
 // where `lb`, `rb` are the left and right bound respectively, if the bounds use non-full clustering
 // key prefixes. Inclusiveness of the range's bounds must be taken into account during comparisons.


### PR DESCRIPTION
class clustering_range is a range of Clustering Key Prefixes implemented as interval<clustering_key_prefix>. However, due to the nature of Clustering Key Prefix, the ordering of clustering_range is complex and does not satisfy the invariant of interval<>. To be more specific, as a comment in interval<> implementation states: “The end bound can never be smaller than the start bound”. As a range of CKP violates the invariant, some algorithms, like intersection(), can return incorrect results. For more details refer to scylladb#8157, scylladb#21604, scylladb#22817.

This commit:
 - Add a WARNING comment to discourage usage of clustering_range
 - Add WARNING comments to potentially incorrect uses of interval<clustering_key_prefix> non-trivial methods
 - Add a FIXME comment to incorrect use of interval<clustering_key_prefix_view>::deoverlap and WARNING comments to related interval<clustering_key_prefix_view> misuse.

Only comments are changed - no need to backport