### PR TITLE
treewide: include build_mode.hh for SCYLLA_BUILD_MODE_RELEASE where i…

### DIFF
--- a/api/cql_server_test.cc
+++ b/api/cql_server_test.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "build_mode.hh"
+
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
 #include <seastar/core/coroutine.hh>

--- a/api/task_manager_test.cc
+++ b/api/task_manager_test.cc
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+
+#include "build_mode.hh"
+
 #ifndef SCYLLA_BUILD_MODE_RELEASE
 
 #include <seastar/core/coroutine.hh>

--- a/gms/generation-number.hh
+++ b/gms/generation-number.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "build_mode.hh"
 #include "utils/tagged_integer.hh"
 
 namespace gms {

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -46,6 +46,7 @@
 #include "utils/error_injection.hh"
 #include "idl/gossip.dist.hh"
 #include <csignal>
+#include "build_mode.hh"
 
 namespace gms {
 

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -47,6 +47,7 @@
 #include "service/raft/group0_state_machine_merger.hh"
 #include "gms/feature_service.hh"
 #include "idl/migration_manager.dist.hh"
+#include "build_mode.hh"
 
 namespace service {
 
@@ -216,6 +217,7 @@ future<> group0_state_machine::merge_and_apply(group0_state_machine_merger& merg
     co_await _sp.mutate_locally({std::move(history)}, nullptr);
 }
 
+#ifndef SCYLLA_BUILD_MODE_RELEASE
 static void ensure_group0_schema(const group0_command& cmd, const replica::database& db) {
     auto validate_schema = [&db](const std::vector<canonical_mutation>& mutations) {
         for (const auto& mut : mutations) {
@@ -249,6 +251,7 @@ static void ensure_group0_schema(const group0_command& cmd, const replica::datab
             },
         }, cmd.change);
 }
+#endif
 
 future<> group0_state_machine::apply(std::vector<raft::command_cref> command) {
     slogger.trace("apply() is called with {} commands", command.size());


### PR DESCRIPTION
…t is missing

This causes some debug only code, that slows down the execution, to be compiled in. I also causes some debug only REST apis to be compiled in, but this is less of a problem.

Fixes: #22914

