### PR TITLE
tree: migrate from boost::find to std::ranges algorithms

### DIFF
--- a/node_ops/node_ops_ctl.cc
+++ b/node_ops/node_ops_ctl.cc
@@ -18,8 +18,6 @@
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "idl/node_ops.dist.hh"
 
-#include <boost/range/algorithm/find.hpp>
-
 static logging::logger nlogger("node_ops");
 
 node_ops_ctl::node_ops_ctl(const service::storage_service& ss_, node_ops_cmd cmd, locator::host_id id, gms::inet_address ep, node_ops_id uuid)
@@ -109,7 +107,7 @@ future<> node_ops_ctl::query_pending_op() {
     co_await coroutine::parallel_for_each(sync_nodes, [this] (const locator::host_id& node) -> future<> {
         auto resp = co_await ser::node_ops_rpc_verbs::send_node_ops_cmd(&ss._messaging.local(), node, req);
         nlogger.debug("{}[{}]: Got query_pending_ops response from node={}, resp.pending_ops={}", desc, uuid(), node, resp.pending_ops);
-        if (boost::find(resp.pending_ops, uuid()) == resp.pending_ops.end()) {
+        if (std::ranges::find(resp.pending_ops, uuid()) == resp.pending_ops.end()) {
             throw std::runtime_error(::format("{}[{}]: Node {} no longer tracks the operation", desc, uuid(), node));
         }
     });

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -53,8 +53,6 @@
 #include "replica/global_table_ptr.hh"
 #include "locator/tablets.hh"
 
-#include <boost/range/algorithm.hpp>
-#include <boost/range/numeric.hpp>
 #include "utils/error_injection.hh"
 #include "readers/reversing_v2.hh"
 #include "readers/empty_v2.hh"
@@ -473,7 +471,7 @@ table::for_all_partitions_slow(schema_ptr s, reader_permit permit, std::function
 }
 
 static bool belongs_to_current_shard(const std::vector<shard_id>& shards) {
-    return boost::find(shards, this_shard_id()) != shards.end();
+    return std::ranges::contains(shards, this_shard_id());
 }
 
 static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {

--- a/test/lib/dummy_sharder.cc
+++ b/test/lib/dummy_sharder.cc
@@ -6,11 +6,10 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/algorithm/find.hpp>
 #include "test/lib/dummy_sharder.hh"
 
 unsigned dummy_sharder::shard_of(const dht::token& t) const {
-    auto it = boost::find(_tokens, t);
+    auto it = std::ranges::find(_tokens, t);
     // Unknown tokens are assigned to shard 0
     return it == _tokens.end() ? 0 : std::distance(_tokens.begin(), it) % sharder::shard_count();
 }


### PR DESCRIPTION
Replace boost::find() calls with std::ranges::find() and std::ranges::contains() to leverage modern C++ standard library features. This change reduces external dependencies and modernizes the codebase.

The following changes were made:
- Replaced boost::find() with std::ranges::find() where index/iterator is needed
- Used std::ranges::contains() for simple element presence checks

---

it's a cleanup, hence no need to backport.