### PR TITLE
doc: remove references to Enterprise

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -187,8 +187,8 @@ ATTACH SERVICE_LEVEL oltp TO bob;
 Note that `alternator_enforce_authorization` has to be enabled in Scylla configuration.
 
 See [Authorization](##Authorization) section to learn more about roles and authorization.
-See <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>
-to read about **Workload Prioritization** in detail.
+See [Workload Prioritization](../features/workload-prioritization)
+to read about Workload Prioritization in detail.
 
 ## Metrics
 
@@ -313,7 +313,7 @@ they should be easy to detect. Here is a list of these unimplemented features:
   RestoreTableToPointInTime
 
 * DynamoDB's encryption-at-rest settings are not supported. The Encryption-
-  at-rest feature is available in Scylla Enterprise, but needs to be
+  at-rest feature is available in ScyllaDB, but needs to be
   enabled and configured separately, not through the DynamoDB API.
 
 * No support for throughput accounting or capping. As mentioned above, the

--- a/docs/architecture/compaction/compaction-strategies.rst
+++ b/docs/architecture/compaction/compaction-strategies.rst
@@ -70,8 +70,6 @@ Set the parameters for :ref:`Leveled Compaction <leveled-compaction-strategy-lcs
 Incremental Compaction Strategy (ICS)
 =====================================
 
-.. versionadded:: 2019.1.4 Scylla Enterprise
-
 ICS principles of operation are similar to those of STCS, merely replacing the increasingly larger SSTables in each tier, by increasingly longer SSTable runs, modeled after LCS runs, but using larger fragment size of 1 GB, by default.
 
 Compaction is triggered when there are two or more runs of roughly the same size. These runs are incrementally compacted with each other, producing a new SSTable run, while incrementally releasing space as soon as each SSTable in the input run is processed and compacted. This method eliminates the high temporary space amplification problem of STCS by limiting the overhead to twice the (constant) fragment size, per shard.

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -75,15 +75,7 @@ to a new node.
 File-based Streaming
 ========================
 
-:label-tip:`ScyllaDB Enterprise`
-
-File-based streaming is a ScyllaDB Enterprise-only feature that optimizes
-tablet migration.
-
-In ScyllaDB Open Source, migrating tablets is performed by streaming mutation
-fragments, which involves deserializing SSTable files into mutation fragments
-and re-serializing them back into SSTables on the other node.
-In ScyllaDB Enterprise, migrating tablets is performed by streaming entire
+Migrating tablets is performed by streaming entire
 SStables, which does not require (de)serializing or processing mutation fragments.
 As a result, less data is streamed over the network, and less CPU is consumed,
 especially for data models that contain small cells.

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -170,8 +170,6 @@ LCS options
 Incremental Compaction Strategy (ICS)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 2019.1.4 Scylla Enterprise
-
 When using ICS, SSTable runs are put in different buckets depending on their size.
 When an SSTable run is bucketed, the average size of the runs in the bucket is compared to the new run, as well as the ``bucket_high`` and ``bucket_low`` levels.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -193,6 +193,8 @@ ScyllaDB comes with its own version of the Apache Cassandra client tools, in the
 
 We recommend uninstalling Apache Cassandra before installing :code:`scylla-tools`.
 
+ .. TODO Update the example below then a patch release for 2025.1 is available
+
 .. _faq-pinning:
 
 Can I install or upgrade to a patch release other than latest on Debian or Ubuntu?

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -18,7 +18,7 @@ For example, consider the following two workloads:
   - Slow queries 
   - In essence - Latency agnostic
 
-Using Service Level CQL commands, database administrators (working on Scylla Enterprise) can set different workload prioritization levels (levels of service) for each workload without sacrificing latency or throughput.
+Using Service Level CQL commands, database administrators (working on ScyllaDB) can set different workload prioritization levels (levels of service) for each workload without sacrificing latency or throughput.
 By assigning each service level to the different roles within your organization, DBAs ensure that each role_ receives the level of service the role requires.
 
 .. _`role` : /operating-scylla/security/rbac_usecase/
@@ -425,7 +425,7 @@ In order for workload prioritization to take effect, application users need to b
 
 Limits
 ======
-Scylla Enterprise is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
+ScyllaDB is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
 
 
 Additional References

--- a/docs/getting-started/cloud-instance-recommendations.rst
+++ b/docs/getting-started/cloud-instance-recommendations.rst
@@ -110,7 +110,7 @@ Google Compute Engine (GCE)
 -----------------------------------
 
 Pick a zone where Haswell CPUs are found. Local SSD performance offers, according to Google, less than 1 ms of latency and up to 680,000 read IOPS and 360,000 write IOPS.
-Image with NVMe disk interface is recommended, CentOS 7 for ScyllaDB Enterprise 2020.1 and older, and Ubuntu 20 for 2021.1 and later.  
+Image with NVMe disk interface is recommended.
 (`More info <https://cloud.google.com/compute/docs/disks/local-ssd>`_)
 
 Recommended instances types are `n1-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n1_machines>`_ and `n2-highmem <https://cloud.google.com/compute/docs/general-purpose-machines#n2_machines>`_

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -325,8 +325,6 @@ ScyllaDB uses experimental flags to expose non-production-ready features safely.
 In recent ScyllaDB versions, these features are controlled by the ``experimental_features`` list in scylla.yaml, allowing one to choose which experimental to enable.
 Use ``scylla --help`` to get the list of experimental features.
 
-ScyllaDB Enterprise and ScyllaDB Cloud do not officially support experimental Features.
-
 .. _admin-keyspace-storage-options:
 
 Keyspace storage options

--- a/docs/operating-scylla/procedures/backup-restore/backup.rst
+++ b/docs/operating-scylla/procedures/backup-restore/backup.rst
@@ -7,8 +7,8 @@ Even though ScyllaDB is a fault-tolerant system, it is recommended to regularly 
 * Backup is a per-node procedure. Make sure to back up each node in your 
   cluster. For cluster-wide backup and restore, see `ScyllaDB Manager <https://manager.docs.scylladb.com/stable/restore/>`_.
 * Backup works the same for non-encrypted and encrypted SStables. You can use 
-  `Encryption at Rest <https://enterprise.docs.scylladb.com/stable/operating-scylla/security/encryption-at-rest.html>`_ 
-  available in ScyllaDB Enterprise without affecting the backup procedure.
+  :doc:`Encryption at Rest </operating-scylla/security/encryption-at-rest>` 
+  without affecting the backup procedure.
 
 You can choose one of the following:
 

--- a/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
+++ b/docs/operating-scylla/procedures/cassandra-to-scylla-migration-process.rst
@@ -77,7 +77,7 @@ Procedure
 
 .. note::
 
-   ScyllaDB Open Source 3.0 and later and ScyllaDB Enterprise 2019.1 and later support :doc:`Materialized View(MV) </features/materialized-views>` and :doc:`Secondary Index(SI) </features/secondary-indexes>`.
+   ScyllaDB supports :doc:`Materialized View(MV) </features/materialized-views>` and :doc:`Secondary Index(SI) </features/secondary-indexes>`.
 
    When migrating data from Apache Cassandra with MV or SI, you can either:
 

--- a/docs/operating-scylla/procedures/cluster-management/_common/match_version.rst
+++ b/docs/operating-scylla/procedures/cluster-management/_common/match_version.rst
@@ -1,10 +1,13 @@
 .. Note:: 
 
    Make sure to use the same ScyllaDB **patch release** on the new/replaced node, to match the rest of the cluster. It is not recommended to add a new node with a different release to the cluster.
-   For example, use the following for installing ScyllaDB patch release (use your deployed version)
+   For example, use the following for installing ScyllaDB patch release (use your deployed version):
 
-   * ScyllaDB Enterprise - ``sudo yum install scylla-enterprise-2018.1.9``
+   .. code::
+
+      sudo yum install scylla-2025.1.0
+
    
-   * ScyllaDB open source - ``sudo yum install scylla-3.0.3``
+
 
 

--- a/docs/operating-scylla/procedures/config-change/advanced-internode-compression.rst
+++ b/docs/operating-scylla/procedures/config-change/advanced-internode-compression.rst
@@ -5,7 +5,7 @@ Advanced Internode (RPC) Compression
 Internode (RPC) compression controls whether traffic between nodes is
 compressed. If enabled, it reduces network bandwidth usage.
 
-To further reduce network traffic, you can configure ScyllaDB Enterprise to use
+To further reduce network traffic, you can configure ScyllaDB to use
 ZSTD-based compression and shared dictionary compression. You can enable one or
 both of these features to limit network throughput and reduce network transfer costs.
 

--- a/docs/operating-scylla/procedures/tips/benchmark-tips.rst
+++ b/docs/operating-scylla/procedures/tips/benchmark-tips.rst
@@ -181,7 +181,7 @@ Use Workload Prioritization
 In a typical application there are operational workloads that require low latency.
 Sometimes these run in parallel with analytic workloads that process high volumes of data and do not require low latency.
 With workload prioritization, one can prevent that the analytic workloads lead to an unwanted high latency on operational workload.
-`Workload prioritization <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>`_ is only available with `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_.
+See :doc:`Workload prioritization </operating-scylla/security/encryption-at-rest>`.
 
 Bypass Cache
 ============
@@ -330,7 +330,7 @@ When records get updated or deleted, the old data eventually needs to be deleted
 The compaction settings can make a huge difference.
 
 * Use the following :ref:`Compaction Strategy Matrix <CSM1>` to use the correct compaction strategy for your workload.
-* ICS is an incremental compaction strategy that combines the low space amplification of LCS with the low write amplification of STCS. It is **only** available with ScyllaDB Enterprise.
+* ICS is an incremental compaction strategy that combines the low space amplification of LCS with the low write amplification of STCS.
 * If you have time series data, the TWCS should be used.
 
 Read more about :doc:`Compaction Strategies </architecture/compaction/compaction-strategies>`

--- a/docs/operating-scylla/procedures/tips/production-readiness.rst
+++ b/docs/operating-scylla/procedures/tips/production-readiness.rst
@@ -28,7 +28,7 @@ Incremental Compaction Strategy (ICS)
 We highly recommend using ICS (the default setting) for any table that you have.
 You will have much less Space Amplification with ICS as it only requires 25% additional storage, as opposed to STCS which requires 50% more.
 
-.. note:: ICS is the default compaction strategy setting for Scylla Enterprise versions 2020.1 and higher.
+.. note:: ICS is the default compaction strategy.
 
 * Refer to :ref:`Incremental Compaction Strategy <ICS1>` for an overview of the benefits.
 * Refer to :ref:`Incremental Compaction Strategy Overview <incremental-compaction-strategy-ics>` for a description of how it works.

--- a/docs/operating-scylla/security/auditing.rst
+++ b/docs/operating-scylla/security/auditing.rst
@@ -61,7 +61,7 @@ QUERY      Logs all queries
 ---------  -----------------------------------------------------------------------------------------
 ADMIN      Logs service level operations: create, alter, drop, attach, detach, list.
            For :ref:`service level <workload-priorization-service-level-management>`
-           auditing, this parameter is available in Scylla Enterprise 2019.1 and later.
+           auditing.
 =========  =========================================================================================
 
 Note that audit for every DML or QUERY might impact performance and consume a lot of storage.

--- a/docs/operating-scylla/security/encryption-at-rest.rst
+++ b/docs/operating-scylla/security/encryption-at-rest.rst
@@ -5,11 +5,11 @@ Encryption at Rest
 Introduction
 ----------------------
 
-ScyllaDB Enterprise protects your sensitive data with data-at-rest encryption. 
+ScyllaDB protects your sensitive data with data-at-rest encryption. 
 It protects the privacy of your user's data, reduces the risk of data breaches, and helps meet regulatory requirements. 
 In particular, it provides an additional level of protection for your data persisted in storage or its backups.
 
-When ScyllaDB Enterprise Encryption at Rest is used together with Encryption in Transit (:doc:`Node to Node </operating-scylla/security/node-node-encryption>`  and :doc:`Client to Node </operating-scylla/security/client-node-encryption>`), you benefit from end to end data encryption.
+When ScyllaDB's Encryption at Rest is used together with Encryption in Transit (:doc:`Node to Node </operating-scylla/security/node-node-encryption>`  and :doc:`Client to Node </operating-scylla/security/client-node-encryption>`), you benefit from end to end data encryption.
 
 About Encryption at Rest
 -----------------------------
@@ -280,8 +280,6 @@ If you are using :term:`KMIP <Key Management Interoperability Protocol (KMIP)>` 
 Set the KMS Host
 ----------------------
 
-.. note:: KMS support is available since ScyllaDB Enterprise **2023.1.1**.
-
 If you are using AWS KMS to encrypt tables or system information, add the KMS information to the ``scylla.yaml`` configuration file. 
 
 #. Edit the ``scylla.yaml`` file located in ``/etc/scylla/`` to add the following in KMS host(s) section:
@@ -405,10 +403,6 @@ If you are using Google GCP KMS to encrypt tables or system information, add the
 
 Encrypt Tables
 -----------------------------
-
-.. note::
-
-   This feature is available since ScyllaDB Enterprise 2023.1.2.
 
 ScyllaDB allows you to enable or disable default encryption of tables. 
 When enabled, tables will be encrypted by default using the configuration 

--- a/docs/operating-scylla/security/ldap-authorization.rst
+++ b/docs/operating-scylla/security/ldap-authorization.rst
@@ -2,7 +2,7 @@
 LDAP Authorization (Role Management)
 =====================================
 
-Scylla Enterprise customers can manage and authorize users’ privileges via an :abbr:`LDAP (Lightweight Directory Access Protocol)` server.
+Scylla customers can manage and authorize users’ privileges via an :abbr:`LDAP (Lightweight Directory Access Protocol)` server.
 LDAP is an open, vendor-neutral, industry-standard protocol for accessing and maintaining distributed user access control over a standard IP network.
 If your users are already stored in an LDAP directory, you can now use the same LDAP server to regulate their roles in Scylla.
 

--- a/docs/operating-scylla/security/rbac-usecase.rst
+++ b/docs/operating-scylla/security/rbac-usecase.rst
@@ -22,7 +22,7 @@ In the same manner, should someone leave the organization, all you would have to
 Should someone change positions at the company, just assign the new employee to the new role and revoke roles no longer required for the new position.
    
 To build an RBAC environment, you need to create the roles and their associated permissions and then assign or grant the roles to the individual users. Roles inherit the permissions of any other roles that they are granted. The hierarchy of roles can be either simple or extremely complex. This gives great flexibility to database administrators, where they can  create specific permission conditions without incurring a huge administrative burden.
-In addition to standard roles, ScyllaDB Enterprise users can implement :doc:`Workload Prioritization </features/workload-prioritization/>`, which allows you to attach roles to Service Levels, thus granting resources to roles as the role demands.
+In addition to standard roles, ScyllaDB users can implement :doc:`Workload Prioritization </features/workload-prioritization/>`, which allows you to attach roles to Service Levels, thus granting resources to roles as the role demands.
 
 .. _rbac-usecase-grant-roles-and-permissions:
 

--- a/docs/operating-scylla/security/security-checklist.rst
+++ b/docs/operating-scylla/security/security-checklist.rst
@@ -41,7 +41,6 @@ kernel in FIPS mode.
 
 Encryption at Rest
 ~~~~~~~~~~~~~~~~~~
-Encryption at Rest is available in a Scylla Enterprise 2019.1.1.
 
 Encryption at Rest protects the privacy of your user's data, reduces the risk of data breaches, and helps meet regulatory requirements. 
 In particular, it provides an additional level of protection for your data persisted in storage or backup.

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -187,8 +187,8 @@ Glossary
        Cache dummy rows are entries in the row set, which have a clustering position, although they do not represent CQL rows written by users.  ScyllaDB cache uses them to mark boundaries of population ranges, to represent the information that the whole range is complete, and there is no need to go to sstables to read the gaps between existing row entries when scanning.
       
     Workload
-      A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By defining workloads, you can specify how ScyllaDB will process those activities. For example, `ScyllaDB Enterprise <https://enterprise.docs.scylladb.com/>`_
-      ships with a feature that allows you to prioritize one workload over another (e.g., user requests over administrative activities). See `Workload Prioritization <https://enterprise.docs.scylladb.com/stable/using-scylla/workload-prioritization.html>`_.
+      A database category that allows you to manage different sources of database activities, such as requests or administrative activities. By defining workloads, you can specify how ScyllaDB will process those activities. For example, ScyllaDB
+      ships with a feature that allows you to prioritize one workload over another (e.g., user requests over administrative activities). See :doc:`Workload Prioritization </features/workload-prioritization/>`.
 
     MurmurHash3
        A hash function `created by Austin Appleby <https://en.wikipedia.org/wiki/MurmurHash>`_, and used by the :term:`Partitioner` to distribute the partitions between nodes.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -15,4 +15,3 @@ Reference
 * :doc:`Limits </reference/limits>`
 * :doc:`API Reference </reference/api-reference>`
 * :doc:`Metrics </reference/metrics>`
-* .. scylladb_include_flag:: enterprise-vs-oss-matrix-link.rst

--- a/docs/using-scylla/cassandra-compatibility.rst
+++ b/docs/using-scylla/cassandra-compatibility.rst
@@ -5,8 +5,8 @@ ScyllaDB and Apache Cassandra Compatibility
 ScyllaDB is a drop-in replacement for Apache Cassandra 3.11, with additional features from Apache Cassandra 4.0.
 This page contains information about ScyllaDB compatibility with Apache Cassandra. 
 
-The tables on this page include information about ScyllaDB Open Source support for Apache Cassandra features. 
-They do not include the ScyllaDB Enterprise-only features or ScyllaDB-specific features with no match in 
+The tables on this page include information about ScyllaDB support for Apache Cassandra features. 
+They do not include the ScyllaDB-specific features with no match in 
 Apache Cassandra.  See :doc:`ScyllaDB Features </features/index>` for more information about ScyllaDB features.
 
 How to Read the Tables on This Page
@@ -36,8 +36,8 @@ Interfaces
        | deprecated in ScyllaDB 5.2 and got dropped in 6.0
    * - SSTable format (all versions)
      - 3.11(mc / md / me), 2.2(la), 2.1.8 (ka)
-     - | ``me`` - supported in ScyllaDB Open Source 5.1 and ScyllaDB Enterprise 2022.2.0 (and later)
-       | ``md`` - supported in ScyllaDB Open Source 4.3 and ScyllaDB Enterprise 2021.1.0 (and later)
+     - | ``me`` - supported in ScyllaDB 2022.2.0 and later
+       | ``md`` - supported in ScyllaDB 2021.1.0 and later
        
 
    * - JMX   


### PR DESCRIPTION
This PR removes the redundant references to Enterprise, which are no longer valid.
Also, it replaces the links to Enterprise with those to the same pages but in the core docs at docs.scylladb.com.

Fixes https://github.com/scylladb/scylladb/issues/22927


This PR must be backported to 2025.1 as it's a 2025.1-related update.
