### PR TITLE
doc: remove the reference to the 6.2 version

### DIFF
--- a/docs/operating-scylla/admin-tools/sstableloader.rst
+++ b/docs/operating-scylla/admin-tools/sstableloader.rst
@@ -5,7 +5,7 @@ Bulk loads SSTables from a directory to a ScyllaDB cluster via the **CQL API**.
 
 .. warning::
 
-    SSTableLoader is deprecated since ScyllaDB 6.2 and will be removed in the next release.
+    SSTableLoader is deprecated and will be removed in a future release.
     Please consider switching to :doc:`nodetool refresh --load-and-stream </operating-scylla/nodetool-commands/refresh>`.
 
 .. note::


### PR DESCRIPTION
This commit removes the OSS version name, which is irrelevant and confusing for 2025.1 and later users.
Also, it updates the warning to avoid specifying the release when the deprecated feature will be removed.

Fixes https://github.com/scylladb/scylladb/issues/22839

This update is relevant for 2025.1 users and should be backported to branch-2025.1.