### PR TITLE
doc: add information about tablets limitation to the CQL page

### DIFF
--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -143,6 +143,8 @@ You can create a keyspace with tablets enabled with the ``tablets = {'enabled': 
     the keyspace schema with ``tablets = { 'enabled': false }`` or 
     ``tablets = { 'enabled': true }``.
 
+.. _tablets-limitations:
+
 Limitations and Unsupported Features
 --------------------------------------
 

--- a/docs/cql/_common/tablets-default.rst
+++ b/docs/cql/_common/tablets-default.rst
@@ -1,3 +1,0 @@
-By default, a keyspace is created with tablets enabled. The ``tablets`` option 
-is used to opt out a keyspace from tablets-based distribution; see :ref:`Enabling Tablets <tablets-enable-tablets>`
-for details.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -202,14 +202,6 @@ An example that excludes a datacenter while using ``replication_factor``::
 
     DESCRIBE KEYSPACE excalibur
         CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
-  
-Keyspace storage options :label-caution:`Experimental`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-By default, SStables of a keyspace are stored locally.
-As an alternative, you can configure your keyspace to be stored
-on Amazon S3 or another S3-compatible object store.
-See :ref:`Keyspace storage options <admin-keyspace-storage-options>` for details.
 
 .. _tablets:
 
@@ -228,7 +220,14 @@ sub-option                             type  description
 ``'initial'``                          int   The number of tablets to start with (deprecated)
 ===================================== ====== =============================================
 
-.. scylladb_include_flag:: tablets-default.rst
+By default, a keyspace is created with tablets enabled. You can use the ``tablets`` option 
+to opt out a keyspace from tablets-based distribution.
+
+You may want to opt out if you plan to use features that are not supported for keyspaces
+with tablets enabled. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
+for details.
+
+**The ``initial`` sub-option (deprecated)**
 
 A good rule of thumb to calculate initial tablets is to divide the expected total storage used
 by tables in this keyspace by (``replication_factor`` * 5GB). For example, if you expect a 30TB
@@ -250,6 +249,14 @@ Note that the ``initial`` tablets option was deprecated.
 Please use :ref:`Per-table tablet options <cql-per-table-tablet-options>` instead.
 
 See :doc:`Data Distribution with Tablets </architecture/tablets>` for more information about tablets.
+
+Keyspace storage options :label-caution:`Experimental`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, SStables of a keyspace are stored locally.
+As an alternative, you can configure your keyspace to be stored
+on Amazon S3 or another S3-compatible object store.
+See :ref:`Keyspace storage options <admin-keyspace-storage-options>` for details.
 
 .. _use-statement:        
         


### PR DESCRIPTION
This PR adds a link to the Limitations section on the Tablets page to the CQL pag, the tablets option.
This is actually the place where the user will need the information: when creating a keyspace.

In addition, I've reorganized the section for better readability (otherwise, the section about limitations was easy to miss) and moved the tablets section up on the page.

Note that I've removed the updated content from the  `_common` folder (which I deleted) to the .rst page - we no longer split OSS and Enterprise, so there's no need to keep using the `scylladb_include_flag` directive to include OSS- and Ent-specific content.

Fixes https://github.com/scylladb/scylladb/issues/22892

Fixes https://github.com/scylladb/scylladb/issues/22940

This PR should be backported to branch-2025.1 as it includes an update useful for 2025.1 users.