### PR TITLE
sstables: writer.hh: drop unneeded boost depedencies

### DIFF
--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -10,7 +10,6 @@
 
 #include <seastar/core/iostream.hh>
 #include <seastar/core/fstream.hh>
-#include <boost/range/numeric.hpp>
 #include "sstables/types.hh"
 #include "checksum_utils.hh"
 #include "vint-serialization.hh"


### PR DESCRIPTION
Code cleanup, no backport.