### PR TITLE
test: test_mv_topology_change: increase timeout for removenode

### DIFF
--- a/test/topology_custom/mv/test_mv_topology_change.py
+++ b/test/topology_custom/mv/test_mv_topology_change.py
@@ -194,4 +194,4 @@ async def test_mv_write_to_dead_node(manager: ManagerClient):
         # If the MV write is not completed, as in issue #19529, the topology change
         # will be held for long time until the write timeouts.
         # Otherwise, it is expected to complete in short time.
-        await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=30)
+        await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=60)


### PR DESCRIPTION
The test `test_mv_topology_change` is a regression test for scylladb/scylladb#19529. The problem was that CL=ANY writes issued when all replicas were down would be kept in memory until the timeout. In particular, MV updates are CL=ANY writes and have a 5 minute timeout. When doing topology operations for vnodes or when migrating tablet replicas, the cluster goes through stages where the replica sets for writes undergo changes, and the writes started with the old replica set need to be drained first.

Because of the aforementioned MV updates, the removenode operation could be delayed by 5 minutes or more. Therefore, the
`test_mv_topology_change` test uses a short timeout for the removenode operation, i.e. 30s. Apparently, this is too low for the debug mode and the test has been observed to time out even though the removenode operation is progressing fine.

Increase the timeout to 60s. This is the lowest timeout for the removenode operation that we currently use among the in-repo tests, and is lower than 5 minutes so the test will still serve its purpose.

Fixes: scylladb/scylladb#22953

The flaky test was introduced back in 6.1 (https://github.com/scylladb/scylladb/commit/ed33e59714b9af956c536f22b3e2eb9af2ec24f9), so this fix should be backported to all live releases.