### PR TITLE
sstables: Avoid using storage->prefix() when cloning

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -880,7 +880,7 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
 }
 
 future<entry_descriptor> sstable::clone(generation_type new_generation) const {
-    co_await _storage->snapshot(*this, _storage->prefix(), storage::absolute_path::yes, new_generation);
+    co_await _storage->snapshot(*this, "", storage::absolute_path::no, new_generation);
     co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
 }
 


### PR DESCRIPTION
The sstable::clone() calls

  storage->snapshot(storage->prefix(), abs_path::yes)

which is redundant. With abd_path::no it's possible to make snapshot() method pick up the prefix() on its own.

Other than that, it's not nice to use storage->prefix() as sstable path, because it's not necessarily a filename.

**Please replace this line with justification for the backport/\* labels added to this PR**