### PR TITLE
test.py: topology: allow to run tests with bare pytest command

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,9 +3,33 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
+
 import os
 from pathlib import Path
 
+__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "path_to"]
+
+
 TEST_RUNNER = os.environ.get("SCYLLA_TEST_RUNNER", "pytest")
-TOP_SRC_DIR = Path(__file__).parent.parent # ScyllaDB's source code root directory
+
+TOP_SRC_DIR = Path(__file__).parent.parent  # ScyllaDB's source code root directory
+TEST_DIR = TOP_SRC_DIR / "test"
 BUILD_DIR = TOP_SRC_DIR / "build"
+
+ALL_MODES = {
+    "debug": "Debug",
+    'release': "RelWithDebInfo",
+    "dev": "Dev",
+    "sanitize": "Sanitize",
+    "coverage": "Coverage",
+}
+DEBUG_MODES = {"debug", "sanitize"}
+
+
+def path_to(mode: str, *components: str) -> str:
+    """Resolve path to built executable."""
+
+    if BUILD_DIR.joinpath("build.ninja").exists():
+        *dir_components, basename = components
+        return str(BUILD_DIR.joinpath(*dir_components, ALL_MODES[mode], basename))
+    return str(BUILD_DIR.joinpath(mode, *components))

--- a/test/boost/conftest.py
+++ b/test/boost/conftest.py
@@ -19,4 +19,4 @@ def pytest_collect_file(file_path: PosixPath, parent: Collector):
     # One of the files in the directory has additional extensions .inc. It's not a test and will not have a binary for
     # execution, so it should be excluded from collecting
     if file_path.suffix == '.cc' and '.inc' not in file_path.suffixes and file_path.stem != COMBINED_TESTS.stem:
-        return collect_items(file_path, parent, facade=BoostTestFacade(parent.config, get_combined_tests(parent.session)))
+        return collect_items(file_path, parent, facade=BoostTestFacade(parent.config, get_combined_tests()))

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -8,15 +8,18 @@
 
 from __future__ import annotations
 
+import asyncio
 import ssl
+import tempfile
 import platform
 import urllib.parse
-from functools import partial
+from multiprocessing import Event, Process
 from typing import TYPE_CHECKING
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
-from test.pylib.async_cql import event_loop, run_async
+from test.pylib.async_cql import run_async
+from test.pylib.scylla_cluster import ScyllaClusterManager
 import logging
 import pytest
 from cassandra.auth import PlainTextAuthProvider                         # type: ignore # pylint: disable=no-name-in-module
@@ -31,9 +34,13 @@ from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disa
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+    from typing import Callable
+
     from cassandra.connection import EndPoint
 
     from test.pylib.internal_types import IPAddress
+    from test.pylib.suite.base import Test
 
 
 Session.run_async = run_async     # patch Session for convenience
@@ -45,7 +52,7 @@ print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 
 
 def pytest_addoption(parser):
-    parser.addoption('--manager-api', action='store', required=True,
+    parser.addoption('--manager-api', action='store',
                      help='Manager unix socket path')
     parser.addoption('--host', action='store', default='localhost',
                      help='CQL server host to connect to')
@@ -158,8 +165,40 @@ def cluster_con(hosts: list[IPAddress | EndPoint], port: int, use_ssl: bool, aut
                    )
 
 
-@pytest.fixture(scope="session")
-async def manager_internal(event_loop, request):
+@pytest.fixture(scope="module")
+async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Test) -> AsyncGenerator[str]:
+    if manager_api := request.config.getoption("--manager-api"):
+        yield manager_api
+    else:
+        test_uname = testpy_test.uname
+        clusters = testpy_test.suite.clusters
+        base_dir = str(testpy_test.suite.log_dir)
+        sock_path = f"{tempfile.mkdtemp(prefix='manager-', dir='/tmp')}/api"
+
+        start_event = Event()
+        stop_event = Event()
+
+        async def run_manager() -> None:
+            mgr = ScyllaClusterManager(test_uname=test_uname, clusters=clusters, base_dir=base_dir, sock_path=sock_path)
+            await mgr.start()
+            start_event.set()
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, stop_event.wait)
+            finally:
+                await mgr.stop()
+
+        manager_process = Process(target=lambda: asyncio.run(run_manager()))
+        manager_process.start()
+        start_event.wait()
+
+        yield sock_path
+
+        stop_event.set()
+        manager_process.join()
+
+
+@pytest.fixture(scope="module")
+async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path: str) -> Callable[[], ManagerClient]:
     """Session fixture to prepare client object for communicating with the Cluster API.
        Pass the Unix socket path where the Manager server API is listening.
        Pass a function to create driver connections.
@@ -173,14 +212,22 @@ async def manager_internal(event_loop, request):
         auth_provider = PlainTextAuthProvider(username=auth_username, password=auth_password)
     else:
         auth_provider = None
-    manager_int = partial(ManagerClient, request.config.getoption('manager_api'), port, use_ssl, auth_provider, cluster_con)
-    yield manager_int
+    return lambda: ManagerClient(
+        sock_path=manager_api_sock_path,
+        port=port,
+        use_ssl=use_ssl,
+        auth_provider=auth_provider,
+        con_gen=cluster_con,
+    )
 
 
 @pytest.fixture(scope="function")
-async def manager(request, manager_internal, record_property, testpy_test):
-    """Per test fixture to notify Manager client object when tests begin so it can
-    perform checks for cluster state.
+async def manager(request: pytest.FixtureRequest,
+                  manager_internal: Callable[[], ManagerClient],
+                  record_property: Callable[[str, object], None],
+                  testpy_test: Test) -> AsyncGenerator[ManagerClient]:
+    """
+    Per test fixture to notify Manager client object when tests begin so it can perform checks for cluster state.
     """
     test_case_name = request.node.name
     suite_testpy_log = testpy_test.log_filename
@@ -205,7 +252,7 @@ async def manager(request, manager_internal, record_property, testpy_test):
             failed_test_dir_path,
             {'pytest.log': test_log, 'test_py.log': test_py_log_test}
         )
-        with open(failed_test_dir_path / f"stacktrace", 'w') as f:
+        with open(failed_test_dir_path / "stacktrace", "w") as f:
             f.write(report.longreprtext)
         if request.config.getoption('artifacts_dir_url') is not None:
             # get the relative path to the tmpdir for the failed directory
@@ -217,7 +264,11 @@ async def manager(request, manager_internal, record_property, testpy_test):
     cluster_status = await manager_client.after_test(test_case_name, not failed)
     await manager_client.stop()  # Stop client session and close driver after each test
     if cluster_status["server_broken"]:
-        pytest.fail(f"test case {test_case_name} leave unfinished tasks on Scylla server. Server marked as broken, server_broken_reason: {cluster_status["message"]}")
+        pytest.fail(
+            f"test case {test_case_name} leave unfinished tasks on Scylla server. Server marked as broken,"
+            f" server_broken_reason: {cluster_status["message"]}"
+        )
+
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # Since connection is managed by manager just return that object

--- a/test/cluster/random_failures/conftest.py
+++ b/test/cluster/random_failures/conftest.py
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+from __future__ import annotations
+
+import os
+import random
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest import Session
+
+
+def pytest_sessionstart(session: Session) -> None:
+    if not session.config.getoption("collectonly") and "xdist" in sys.modules:
+        if sys.modules["xdist"].is_xdist_controller(request_or_session=session):
+            os.environ["TOPOLOGY_RANDOM_FAILURES_TEST_SHUFFLE_SEED"] = str(random.randrange(sys.maxsize))

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import time
 import random
@@ -35,7 +36,10 @@ TESTS_COUNT = 1  # number of tests from the whole matrix to run, None to run the
 
 # Following parameters can be adjusted to run same sequence of tests from a previous run.  Look at logs for the values.
 # Also see `pytest_generate_tests()` below for details.
-TESTS_SHUFFLE_SEED = random.randrange(sys.maxsize)  # seed for the tests order randomization
+
+# Seed for the tests order randomization.
+TESTS_SHUFFLE_SEED = int(os.environ.get("TOPOLOGY_RANDOM_FAILURES_TEST_SHUFFLE_SEED", random.randrange(sys.maxsize)))
+
 ERROR_INJECTIONS_COUNT = len(ERROR_INJECTIONS)  # change it to limit number of error injections
 CLUSTER_EVENTS_COUNT = len(CLUSTER_EVENTS)  # change it to limit number of cluster events
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -26,6 +26,7 @@ from test.pylib.suite.base import (
 
 if TYPE_CHECKING:
     from asyncio import AbstractEventLoop
+
     from test.pylib.cpp.item import CppTestFunction
     from test.pylib.suite.base import Test
 
@@ -49,6 +50,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                      help='Run pytest session in test.py-compatible mode.  I.e., start all required services, etc.')
 
     # Options for compatibility with test.py
+    parser.addoption('--save-log-on-success', default=False,
+                        dest="save_log_on_success", action="store_true",
+                        help="Save test log output on success.")
     parser.addoption('--coverage', action='store_true', default=False,
                       help="When running code instrumented with coverage support"
                            "Will route the profiles to `tmpdir`/mode/coverage/`suite` and post process them in order to generate "
@@ -57,6 +61,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--cluster-pool-size", type=int,
                      help="Set the pool_size for PythonTest and its descendants.  Alternatively environment variable "
                           "CLUSTER_POOL_SIZE can be used to achieve the same")
+    parser.addoption("--extra-scylla-cmdline-options", default=[],
+                     help="Passing extra scylla cmdline options for all tests.  Options should be space separated:"
+                          " '--logger-log-level raft=trace --default-log-level error'")
 
 
 @pytest.fixture(scope="session")

--- a/test/pylib/async_cql.py
+++ b/test/pylib/async_cql.py
@@ -10,7 +10,7 @@ from asyncio loop.
 
 Example usage:
     from cassandra.cluster import Session, Cluster
-    from test.pylib.async_cql import event_loop, run_async
+    from test.pylib.async_cql import run_async
 
     Session.run_async = run_async
     ccluster = Cluster(...)
@@ -20,22 +20,11 @@ Example usage:
 
 import asyncio
 import logging
-from typing import List
-import pytest
+
 from cassandra.cluster import ResponseFuture     # type: ignore # pylint: disable=no-name-in-module
 
 
 logger = logging.getLogger(__name__)
-
-
-@pytest.fixture(scope="session")
-def event_loop(request):
-    """Change default pytest-asyncio event_loop fixture scope to session to
-       allow async fixtures with scope larger than function. (e.g. manager fixture)
-       See https://github.com/pytest-dev/pytest-asyncio/issues/68"""
-    loop = asyncio.get_event_loop_policy().new_event_loop()
-    yield loop
-    loop.close()
 
 
 def _wrap_future(driver_response_future: ResponseFuture, all_pages: bool = False) -> asyncio.Future:

--- a/test/pylib/cpp/common_cpp_conftest.py
+++ b/test/pylib/cpp/common_cpp_conftest.py
@@ -12,22 +12,13 @@ from pathlib import Path, PosixPath
 import yaml
 from pytest import Collector
 
+from test import ALL_MODES, DEBUG_MODES, TOP_SRC_DIR
 from test.pylib.cpp.boost.boost_facade import COMBINED_TESTS
 from test.pylib.cpp.facade import CppTestFacade
 from test.pylib.cpp.item import CppFile
 from test.pylib.util import get_modes_to_run
 
-ALL_MODES = {
-    'debug': 'Debug',
-    'release': 'RelWithDebInfo',
-    'dev': 'Dev',
-    'sanitize': 'Sanitize',
-    'coverage': 'Coverage',
-}
-DEBUG_MODES = {
-    'debug': 'Debug',
-    'sanitize': 'Sanitize',
-}
+
 DEFAULT_ARGS = [
     '--overprovisioned',
     '--unsafe-bypass-fsync 1',
@@ -79,8 +70,6 @@ def read_suite_config(directory: Path) -> dict[str, str]:
             raise RuntimeError('Failed to load tests: suite.yaml is empty')
         return cfg
 
-def get_root_path(session) -> Path:
-    return Path(session.config.rootpath).parent
 
 def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade) -> object:
     """
@@ -110,9 +99,9 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
 
 
 @cache
-def get_combined_tests(session):
+def get_combined_tests():
     suites = collections.defaultdict()
-    executable = get_root_path(session) / COMBINED_TESTS
+    executable = TOP_SRC_DIR / COMBINED_TESTS
     args = [executable, '--list_content']
 
     output = subprocess.check_output(

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -41,7 +41,7 @@ class ManagerClient():
     # pylint: disable=too-many-public-methods
 
     def __init__(self, sock_path: str, port: int, use_ssl: bool, auth_provider: Any|None,
-                 con_gen: Callable[[List[IPAddress], int, bool, Any], CassandraSession]) \
+                 con_gen: Callable[[List[IPAddress], int, bool, Any], CassandraCluster]) \
                          -> None:
         self.test_log_fh: Optional[logging.FileHandler] = None
         self.port = port

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -34,7 +34,7 @@ from test.pylib.minio_server import MinioServer
 from test.pylib.resource_gather import get_resource_gather
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
-from test.pylib.util import LogPrefixAdapter
+from test.pylib.util import LogPrefixAdapter, get_xdist_worker_id
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
@@ -308,7 +308,9 @@ class Test:
         self.suite = suite
         self.allure_dir = self.suite.log_dir / 'allure'
         # Unique file name, which is also readable by human, as filename prefix
-        self.uname = "{}.{}.{}".format(self.suite.name, self.shortname.replace("/", "_"), self.id)
+        self.uname = f"{self.suite.name}.{self.shortname.replace('/', '_')}.{self.id}"
+        if xdist_worker_id := get_xdist_worker_id():
+            self.uname = f"{xdist_worker_id}.{self.uname}"
         self.log_filename = self.suite.log_dir / f"{self.uname}.log"
         self.log_filename.parent.mkdir(parents=True, exist_ok=True)
         self.is_flaky = self.shortname in suite.flaky_tests

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -14,33 +14,31 @@ import logging
 import os
 import pathlib
 import re
-import shlex
+import shutil
 import sys
 import time
-import traceback
 import xml.etree.ElementTree as ET
 from abc import ABC, abstractmethod
 from importlib import import_module
 from typing import TYPE_CHECKING
 
 import colorama
+import universalasync
 import yaml
 
+from test import ALL_MODES, DEBUG_MODES, TOP_SRC_DIR, TEST_RUNNER
 from test.pylib.artifact_registry import ArtifactRegistry
 from test.pylib.host_registry import HostRegistry
+from test.pylib.ldap_server import start_ldap
+from test.pylib.minio_server import MinioServer
 from test.pylib.resource_gather import get_resource_gather
+from test.pylib.s3_proxy import S3ProxyServer
+from test.pylib.s3_server_mock import MockS3Server
+from test.pylib.util import LogPrefixAdapter
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from typing import Any, Dict, List
-
-
-all_modes = {'debug': 'Debug',
-             'release': 'RelWithDebInfo',
-             'dev': 'Dev',
-             'sanitize': 'Sanitize',
-             'coverage': 'Coverage'}
-debug_modes = {'debug', 'sanitize'}
 
 
 output_is_a_tty = sys.stdout.isatty()
@@ -75,15 +73,6 @@ class palette:
         return palette.ansi_escape.sub('', text)
 
 
-def path_to(mode, *components):
-    """Resolve path to built executable"""
-    build_dir = 'build'
-    if os.path.exists(os.path.join(build_dir, 'build.ninja')):
-        *dir_components, basename = components
-        return os.path.join(build_dir, *dir_components, all_modes[mode], basename)
-    return os.path.join(build_dir, mode, *components)
-
-
 class TestSuite(ABC):
     """A test suite is a folder with tests of the same type.
     E.g. it can be unit tests, boost tests, or CQL tests."""
@@ -97,6 +86,7 @@ class TestSuite(ABC):
 
     def __init__(self, path: str, cfg: dict, options: argparse.Namespace, mode: str) -> None:
         self.suite_path = pathlib.Path(path)
+        self.log_dir = pathlib.Path(options.tmpdir) / mode
         self.name = str(self.suite_path.name)
         self.cfg = cfg
         self.options = options
@@ -116,7 +106,7 @@ class TestSuite(ABC):
         self.flaky_tests = set(self.cfg.get("flaky", []))
         # If this mode is one of the debug modes, and there are
         # tests disabled in a debug mode, add these tests to the skip list.
-        if mode in debug_modes:
+        if mode in DEBUG_MODES:
             self.disabled_tests.update(self.cfg.get("skip_in_debug_modes", []))
         # If a test is listed in run_in_<mode>, it should only be enabled in
         # this mode. Tests not listed in any run_in_<mode> directive should
@@ -125,7 +115,7 @@ class TestSuite(ABC):
         # This of course may create ambiguity with skip_* settings,
         # since the priority of the two is undefined, but oh well.
         run_in_m = set(self.cfg.get("run_in_" + mode, []))
-        for a in all_modes:
+        for a in ALL_MODES:
             if a == mode:
                 continue
             skip_in_m = set(self.cfg.get("run_in_" + a, []))
@@ -138,7 +128,7 @@ class TestSuite(ABC):
             # this way is that the storage will not be bloated with coverage files (each can weigh 10s of MBs so for several
             # thousands of tests it can easily reach 10 of GBs)
             # ref: https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#running-the-instrumented-program
-            self.base_env["LLVM_PROFILE_FILE"] = os.path.join(options.tmpdir,self.mode, "coverage", self.name, "%m.profraw")
+            self.base_env["LLVM_PROFILE_FILE"] = str(self.log_dir / "coverage" / self.name / "%m.profraw")
     # Generate a unique ID for `--repeat`ed tests
     # We want these tests to have different XML IDs so test result
     # processors (Jenkins) don't merge results for different iterations of
@@ -308,10 +298,10 @@ class Test:
         self.shortname = shortname
         self.mode = suite.mode
         self.suite = suite
-        self.allure_dir = pathlib.Path(suite.options.tmpdir) / self.mode / 'allure'
+        self.allure_dir = self.suite.log_dir / 'allure'
         # Unique file name, which is also readable by human, as filename prefix
-        self.uname = "{}.{}.{}".format(self.suite.name, self.shortname.replace("/","."), self.id)
-        self.log_filename = pathlib.Path(suite.options.tmpdir) / self.mode / (self.uname + ".log")
+        self.uname = "{}.{}.{}".format(self.suite.name, self.shortname.replace("/", "_"), self.id)
+        self.log_filename = self.suite.log_dir / f"{self.uname}.log"
         self.log_filename.parent.mkdir(parents=True, exist_ok=True)
         self.is_flaky = self.shortname in suite.flaky_tests
         # True if the test was retried after it failed
@@ -403,7 +393,6 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
     """Run test program, return True if success else False"""
 
     with test.log_filename.open("wb") as log:
-        cleanup_fn = None
         def report_error(error, failure_injection_desc = None):
             msg = "=== TEST.PY SUMMARY START ===\n"
             msg += "{}\n".format(error)
@@ -413,12 +402,12 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             log.write(msg.encode(encoding="UTF-8"))
 
         process = None
-        stdout = None
+
         logging.info("Starting test %s: %s %s", test.uname, test.path, " ".join(test.args))
         UBSAN_OPTIONS = [
             "halt_on_error=1",
             "abort_on_error=1",
-            f"suppressions={os.getcwd()}/ubsan-suppressions.supp",
+            f"suppressions={TOP_SRC_DIR / 'ubsan-suppressions.supp'}",
             os.getenv("UBSAN_OPTIONS"),
         ]
         ASAN_OPTIONS = [
@@ -428,7 +417,7 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             os.getenv("ASAN_OPTIONS"),
         ]
         try:
-            resource_gather = get_resource_gather(options.gather_metrics, test, options.tmpdir)
+            resource_gather = get_resource_gather(is_switched_on=options.gather_metrics, test=test)
             resource_gather.make_cgroup()
             log.write("=== TEST.PY STARTING TEST {} ===\n".format(test.uname).encode(encoding="UTF-8"))
             log.write("export UBSAN_OPTIONS='{}'\n".format(
@@ -450,16 +439,18 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
             test_running_event = asyncio.Event()
             test_resource_watcher = resource_gather.cgroup_monitor(test_event=test_running_event)
 
-            test_env = dict(os.environ,
-                            UBSAN_OPTIONS=":".join(filter(None, UBSAN_OPTIONS)),
-                            ASAN_OPTIONS=":".join(filter(None, ASAN_OPTIONS)),
-                            # TMPDIR env variable is used by any seastar/scylla
-                            # test for directory to store test temporary data.
-                            TMPDIR=os.path.join(options.tmpdir, test.mode),
-                            SCYLLA_TEST_ENV='yes',
-                            SCYLLA_TEST_RUNNER="test.py",
-                            **env,
-                            )
+            test_env = dict(
+                os.environ,
+                UBSAN_OPTIONS=":".join(filter(None, UBSAN_OPTIONS)),
+                ASAN_OPTIONS=":".join(filter(None, ASAN_OPTIONS)),
+
+                # TMPDIR env variable is used by any seastar/scylla test for directory to store test temporary data.
+                TMPDIR=str(test.suite.log_dir),
+
+                SCYLLA_TEST_ENV="yes",
+                SCYLLA_TEST_RUNNER="test.py",
+                **env,
+            )
             process = await asyncio.create_subprocess_exec(
                 path, *args,
                 stderr=log,
@@ -508,7 +499,73 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
                 report_error("Test was cancelled: the parent process is exiting")
         except Exception as e:
             report_error("Failed to run the test:\n{e}".format(e=e))
-        finally:
-            if cleanup_fn is not None:
-                cleanup_fn()
     return False
+
+
+def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
+    # Ensure the dir exists.
+    dirname.mkdir(parents=True, exist_ok=True)
+
+    # Remove old artifacts.
+    for p in dirname.rglob(pattern):
+        p.unlink()
+
+
+def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str]) -> None:
+    prepare_dir(tempdir_base, "*.log")
+    shutil.rmtree(tempdir_base / "ldap_instances", ignore_errors=True)
+    prepare_dir(tempdir_base / "ldap_instances", "*")
+    for mode in modes:
+        prepare_dir(tempdir_base / mode, "*.log")
+        prepare_dir(tempdir_base / mode, "*.reject")
+        prepare_dir(tempdir_base / mode / "xml", "*.xml")
+        shutil.rmtree(tempdir_base / mode / "failed_test", ignore_errors=True)
+        prepare_dir(tempdir_base / mode / "failed_test", "*")
+        prepare_dir(tempdir_base / mode / "allure", "*.xml")
+        if TEST_RUNNER != "pytest":
+            shutil.rmtree(tempdir_base / mode / "pytest", ignore_errors=True)
+            prepare_dir(tempdir_base / mode / "pytest", "*")
+
+
+@universalasync.async_to_sync_wraps
+async def start_3rd_party_services(tempdir_base: pathlib.Path, toxyproxy_byte_limit: int):
+    hosts = HostRegistry()
+
+    finalize = start_ldap(
+        host=await hosts.lease_host(),
+        port=5000,
+        instance_root=tempdir_base / 'ldap_instances',
+        toxyproxy_byte_limit=toxyproxy_byte_limit)
+    async def make_async_finalize():
+        finalize()
+
+    TestSuite.artifacts.add_exit_artifact(None, make_async_finalize)
+    ms = MinioServer(
+        tempdir_base=str(tempdir_base),
+        address="127.0.0.1",
+        logger=LogPrefixAdapter(logger=logging.getLogger("minio"), extra={"prefix": "minio"}),
+    )
+    await ms.start()
+    TestSuite.artifacts.add_exit_artifact(None, ms.stop)
+
+    TestSuite.artifacts.add_exit_artifact(None, hosts.cleanup)
+
+    mock_s3_server = MockS3Server(
+        host=await hosts.lease_host(),
+        port=2012,
+        logger=LogPrefixAdapter(logger=logging.getLogger("s3_mock"), extra={"prefix": "s3_mock"}),
+    )
+    await mock_s3_server.start()
+    TestSuite.artifacts.add_exit_artifact(None, mock_s3_server.stop)
+
+    minio_uri = f"http://{os.environ[ms.ENV_ADDRESS]}:{os.environ[ms.ENV_PORT]}"
+    proxy_s3_server = S3ProxyServer(
+        host=await hosts.lease_host(),
+        port=9002,
+        minio_uri=minio_uri,
+        max_retries=3,
+        seed=int(time.time()),
+        logger=LogPrefixAdapter(logger=logging.getLogger("s3_proxy"), extra={"prefix": "s3_proxy"}),
+    )
+    await proxy_s3_server.start()
+    TestSuite.artifacts.add_exit_artifact(None, proxy_s3_server.stop)

--- a/test/pylib/suite/boost.py
+++ b/test/pylib/suite/boost.py
@@ -16,8 +16,9 @@ import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
 from scripts import coverage
+from test import path_to
 from test.pylib.scylla_cluster import merge_cmdline_options
-from test.pylib.suite.base import Test, palette, path_to, read_log, run_test
+from test.pylib.suite.base import Test, palette, read_log, run_test
 from test.pylib.suite.unit import UnitTest, UnitTestSuite
 
 if TYPE_CHECKING:
@@ -181,9 +182,9 @@ class BoostTest(Test):
         if self.mode == "coverage":
             self.env.update(coverage.env(self.path))
 
-        self.xmlout = os.path.join(suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
+        self.xmlout = self.suite.log_dir / "xml" / f"{self.uname}.xunit.xml"
         boost_args += ['--report_level=no',
-                       '--logger=HRF,test_suite:XML,test_suite,' + self.xmlout]
+                       f'--logger=HRF,test_suite:XML,test_suite,{self.xmlout}']
         boost_args += ['--catch_system_errors=no']  # causes undebuggable cores
         boost_args += ['--color_output=false']
         boost_args += ['--']

--- a/test/pylib/suite/cql_approval.py
+++ b/test/pylib/suite/cql_approval.py
@@ -48,10 +48,10 @@ class CQLApprovalTest(Test):
         super().__init__(test_no, shortname, suite)
         # Path to cql_repl driver, in the given build mode
         self.path = "pytest"
-        self.cql = suite.suite_path / (self.shortname + ".cql")
-        self.result = suite.suite_path / (self.shortname + ".result")
-        self.tmpfile = os.path.join(suite.options.tmpdir, self.mode, self.uname + ".reject")
-        self.reject = suite.suite_path / (self.shortname + ".reject")
+        self.cql = self.suite.suite_path / f"{self.shortname}.cql"
+        self.result = self.suite.suite_path / f"{self.shortname}.result"
+        self.tmpfile = self.suite.log_dir / f"{self.uname}.reject"
+        self.reject = self.suite.suite_path / f"{self.shortname}.reject"
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None
         self.is_before_test_ok = False
@@ -64,7 +64,7 @@ class CQLApprovalTest(Test):
         self.server_log = None
         self.server_log_filename = None
         self.env: Dict[str, str] = dict()
-        self._prepare_args(suite.options)
+        self._prepare_args(self.suite.options)
 
     def reset(self) -> None:
         """Reset the test before a retry, if it is retried as flaky"""

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -14,9 +14,10 @@ import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
 from scripts import coverage
+from test import path_to
 from test.pylib.pool import Pool
 from test.pylib.scylla_cluster import ScyllaCluster, ScyllaServer, merge_cmdline_options
-from test.pylib.suite.base import Test, TestSuite, path_to, read_log, run_test
+from test.pylib.suite.base import Test, TestSuite, read_log, run_test
 from test.pylib.util import LogPrefixAdapter
 
 if TYPE_CHECKING:
@@ -85,7 +86,7 @@ class PythonTestSuite(TestSuite):
             server = ScyllaServer(
                 mode=self.mode,
                 exe=self.scylla_exe,
-                vardir=os.path.join(self.options.tmpdir, self.mode),
+                vardir=self.log_dir,
                 logger=create_cfg.logger,
                 cluster_name=create_cfg.cluster_name,
                 ip_addr=create_cfg.ip_addr,
@@ -144,7 +145,7 @@ class PythonTest(Test):
         self.path = "python"
         self.core_args = ["-m", "pytest"]
         self.casename = casename
-        self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
+        self.xmlout = self.suite.log_dir / "xml" / f"{self.uname}.xunit.xml"
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None
         self.is_before_test_ok = False

--- a/test/pylib/suite/run.py
+++ b/test/pylib/suite/run.py
@@ -7,11 +7,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import TYPE_CHECKING
 
 from scripts import coverage
-from test.pylib.suite.base import Test, TestSuite, path_to, read_log, run_test
+from test import path_to
+from test.pylib.suite.base import Test, TestSuite, read_log, run_test
 
 if TYPE_CHECKING:
     import argparse
@@ -44,7 +44,7 @@ class RunTest(Test):
     def __init__(self, test_no: int, shortname: str, suite) -> None:
         super().__init__(test_no, shortname, suite)
         self.path = suite.suite_path / shortname
-        self.xmlout = os.path.join(suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
+        self.xmlout = self.suite.log_dir / "xml" / f"{self.uname}.xunit.xml"
         self.args = [
             "--junit-xml={}".format(self.xmlout),
             "-vv",

--- a/test/pylib/suite/tool.py
+++ b/test/pylib/suite/tool.py
@@ -7,11 +7,10 @@
 from __future__ import annotations
 
 import logging
-import os
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
-from test.pylib.suite.base import  Test, TestSuite,run_test
+from test.pylib.suite.base import Test, TestSuite, run_test
 from test.pylib.util import LogPrefixAdapter
 
 if TYPE_CHECKING:
@@ -46,7 +45,7 @@ class ToolTest(Test):
         super().__init__(test_no, shortname, suite)
         launcher = self.suite.cfg.get("launcher", "pytest")
         self.path = launcher.split(maxsplit=1)[0]
-        self.xmlout = os.path.join(self.suite.options.tmpdir, self.mode, "xml", self.uname + ".xunit.xml")
+        self.xmlout = self.suite.log_dir / "xml" / f"{self.uname}.xunit.xml"
 
     def _prepare_pytest_params(self, options: argparse.Namespace):
         launcher = self.suite.cfg.get("launcher", "pytest")

--- a/test/pylib/suite/topology.py
+++ b/test/pylib/suite/topology.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 from test.pylib.scylla_cluster import get_cluster_manager
@@ -46,8 +45,7 @@ class TopologyTest(PythonTest):
 
         self._prepare_pytest_params(options)
 
-        test_path = os.path.join(self.suite.options.tmpdir, self.mode)
-        async with get_cluster_manager(self.uname, self.suite.clusters, test_path) as manager:
+        async with get_cluster_manager(self.uname, self.suite.clusters, str(self.suite.log_dir)) as manager:
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
             if options.artifacts_dir_url:

--- a/test/pylib/suite/unit.py
+++ b/test/pylib/suite/unit.py
@@ -12,8 +12,9 @@ import shlex
 from typing import TYPE_CHECKING
 
 from scripts import coverage
+from test import path_to
 from test.pylib.scylla_cluster import merge_cmdline_options
-from test.pylib.suite.base import Test, TestSuite, palette, path_to, read_log, run_test
+from test.pylib.suite.base import Test, TestSuite, palette, read_log, run_test
 
 if TYPE_CHECKING:
     import argparse

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -305,3 +305,7 @@ async def gather_safely(*awaitables: Awaitable):
         if isinstance(result, BaseException):
             raise result from None
     return results
+
+
+def get_xdist_worker_id() -> str | None:
+    return os.environ.get("PYTEST_XDIST_WORKER")

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = module
 
 log_format = %(asctime)s.%(msecs)03d %(levelname)s>  %(message)s
 log_date_format = %H:%M:%S


### PR DESCRIPTION
Add possibility to run topology tests using bare pytest command.

To achieve this goal the following changes were made:

- Add fixtures `testpy_testsuite` and `testpy_test` to `test/conftest.py`.
- To build `TestSuite` object we need to discover a corresponding `suite.xml` file.  Do this by walking up thru the fs tree starting from the current test file.
- Run ScyllaClusterManager using pytest fixture if `--manager-api` option is not provided.

And made some refactoring:

- Add path constants to `test` module and use them in different test suites instead of own dups of the same code:
  - TOP_SRC_DIR : ScyllaDB's source code root directory
  - TEST_DIR : the directory with test.py tests and libs
  - BUILD_DIR : directory with ScyllaDB's build artifacts
- Add TestSuite.log_dir attribute as a ScyllaDB's build mode subdir of a path provided using `--tmpdir` CLI argument. Don't use `tmpdir` name because it mixed up with pytest's built-in fixture and `--tmpdir` option itself.
- Change default value for `--tmdir` from `./testlog` to `TOP_SRC_DIR/testlog`
- Refactor `ResourceGather*` classes to use path from a `test` object instead of providing it separately.
- Move modes constants (`all_modes`/`ALL_MODES` and `debug_modes`/`DEBUG_MODES`) to `test` module and remove duplication.
- Move `prepare_dirs()` and `start_3rd_party_services()` from `pylib.util` to`pylib.suite.base` to avoid circular imports.
- In some places refactor to use f-strings for formatting.

Also minor changes related to running with pytest-xdist:

- When run tests in parallel we need to ensure that filenames are unique by adding xdist worker ID to them.
- Pass random seed across xdist workers using env variable.
