### PR TITLE
cql3: fix false-positive "used-after-move" warning in clang-tidy

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -419,8 +419,8 @@ select_statement::do_execute(query_processor& qp,
             options.get_timestamp(state));
     command->allow_limit = db::allow_per_partition_rate_limit::yes;
     logger.trace("Executing read query (reversed {}): table schema {}, query schema {}",
-        slice.is_reversed(), _schema->version(), _query_schema->version());
-    tracing::trace(state.get_trace_state(), "Executing read query (reversed {})", slice.is_reversed());
+        command->slice.is_reversed(), _schema->version(), _query_schema->version());
+    tracing::trace(state.get_trace_state(), "Executing read query (reversed {})", command->slice.is_reversed());
 
     int32_t page_size = options.get_page_size();
 


### PR DESCRIPTION
`slice.is_reversed()` was falsely flagged as accessing moved data, since the underlying enum_set remains valid after move. However, to improve code clarity and silence the warning, now reference `command->slice` directly instead, which is guaranteed to be valid as the move target.

---

it's a cleanup, hence no need to backport.