### PR TITLE
treewide: Reduce db/config.hh header fanout

### DIFF
--- a/lang/lua.cc
+++ b/lang/lua.cc
@@ -19,7 +19,6 @@
 #include <seastar/core/align.hh>
 #include <lua.hpp>
 #include "seastarx.hh"
-#include "db/config.hh"
 
 // Lua 5.4 added an extra parameter to lua_resume
 

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "db/config.hh"
 #include "messaging_service_fwd.hh"
 #include "msg_addr.hh"
 #include <seastar/core/sharded.hh>
@@ -50,15 +49,6 @@ namespace gms {
     class gossip_get_endpoint_states_request;
     class gossip_get_endpoint_states_response;
     class feature_service;
-}
-
-namespace db {
-class seed_provider_type;
-class config;
-}
-
-namespace db::view {
-class update_backlog;
 }
 
 namespace locator {

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -10,7 +10,6 @@
 #include "multishard_mutation_query.hh"
 #include "mutation_query.hh"
 #include "replica/database.hh"
-#include "db/config.hh"
 #include "query-result-writer.hh"
 #include "query_result_merger.hh"
 #include "readers/multishard.hh"

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "db/config.hh"
 #include "repair.hh"
 #include "gms/gossip_address_map.hh"
 #include "repair/row_level.hh"

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -14,7 +14,6 @@
 #include "vint-serialization.hh"
 #include "sstables/types.hh"
 #include "sstables/mx/types.hh"
-#include "db/config.hh"
 #include "mutation/atomic_cell.hh"
 #include "utils/assert.hh"
 #include "utils/exceptions.hh"

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/rpc/rpc_types.hh>
 #include <seastar/util/closeable.hh>
+#include "db/config.hh"
 #include "gms/feature_service.hh"
 #include "message/messaging_service.hh"
 #include "gms/gossip_digest_syn.hh"

--- a/transport/controller.hh
+++ b/transport/controller.hh
@@ -13,7 +13,6 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/future.hh>
 
-#include "db/config.hh"
 #include "protocol_server.hh"
 #include "service/maintenance_mode.hh"
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -36,13 +36,16 @@
 #include "utils/chunked_vector.hh"
 #include "exceptions/coordinator_result.hh"
 #include "db/operation_type.hh"
-#include "db/config.hh"
 #include "service/maintenance_mode.hh"
 
 namespace cql3 {
 
 class query_processor;
 
+}
+
+namespace db {
+class config;
 }
 
 namespace scollectd {


### PR DESCRIPTION
Drop it from files that obviously don't need it. Also kill some forward declarations while at it.
