### PR TITLE
install-dependencies.sh: harden pip_packages against shellcheck

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -155,14 +155,14 @@ fedora_python3_packages=(
 
 # an associative array from packages to constrains
 declare -A pip_packages=(
-    [scylla-driver]=
+    [scylla-driver]=""
     [geomet]="<0.3,>=0.1"
-    [traceback-with-variables]=
-    [scylla-api-client]=
-    [treelib]=
-    [allure-pytest]=
-    [pytest-xdist]=
-    [pykmip]=
+    [traceback-with-variables]=""
+    [scylla-api-client]=""
+    [treelib]=""
+    [allure-pytest]=""
+    [pytest-xdist]=""
+    [pykmip]=""
     [universalasync]=""
     [boto3-stubs[dynamodb]]=""
 )


### PR DESCRIPTION
pip_packages is an associative array, which in bash is constructed as ([key]=value...). In our case the value is often empty (indicating no version constraint). Shellcheck warns against it, since `[key]= x` could be a mistype of `[key]=x`. It's not in our case, but shellcheck doesn't know that.

Make shellcheck happier by specifying the empty values explicitly.

Small cleanup with no code effect, so no backport is needed.