### PR TITLE
tree: Remove unused boost headers

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -16,7 +16,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/coroutine/maybe_yield.hh>
-#include <boost/multiprecision/cpp_int.hpp>
 
 #include "exceptions/exceptions.hh"
 #include "gms/gossiper.hh"

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/numeric.hpp>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -11,7 +11,6 @@
 #include "column_identifier.hh"
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
-#include <boost/iterator/transform_iterator.hpp>
 #include "types/list.hh"
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"

--- a/db/config.cc
+++ b/db/config.cc
@@ -12,7 +12,6 @@
 
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim_all.hpp>
-#include <boost/any.hpp>
 #include <boost/program_options.hpp>
 #include <yaml-cpp/yaml.h>
 

--- a/ent/encryption/encryption_config.cc
+++ b/ent/encryption/encryption_config.cc
@@ -7,8 +7,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/filesystem.hpp>
-
 #include "db/config.hh"
 #include "utils/config_file_impl.hh"
 

--- a/ent/encryption/local_file_provider.cc
+++ b/ent/encryption/local_file_provider.cc
@@ -10,8 +10,6 @@
 #include <stdexcept>
 #include <regex>
 
-#include <boost/filesystem.hpp>
-
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 

--- a/ent/encryption/replicated_key_provider.cc
+++ b/ent/encryption/replicated_key_provider.cc
@@ -11,8 +11,6 @@
 #include <regex>
 #include <tuple>
 
-#include <boost/filesystem.hpp>
-
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 

--- a/partition_slice_builder.cc
+++ b/partition_slice_builder.cc
@@ -6,9 +6,6 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include <boost/range/algorithm/copy.hpp>
-#include <boost/range/algorithm_ext/push_back.hpp>
-
 #include "partition_slice_builder.hh"
 
 partition_slice_builder::partition_slice_builder(const schema& schema, query::partition_slice slice)

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -12,7 +12,6 @@
 #include <seastar/util/defer.hh>
 
 #include <boost/icl/interval_map.hpp>
-#include <boost/range/numeric.hpp>
 
 #include "sstables.hh"
 

--- a/test/boost/bytes_ostream_test.cc
+++ b/test/boost/bytes_ostream_test.cc
@@ -9,7 +9,6 @@
 #define BOOST_TEST_MODULE core
 
 #include "utils/assert.hh"
-#include <boost/range/algorithm/for_each.hpp>
 
 #include <seastar/util/variant_utils.hh>
 

--- a/utils/config_file.cc
+++ b/utils/config_file.cc
@@ -12,7 +12,6 @@
 #include <yaml-cpp/yaml.h>
 
 #include <boost/program_options.hpp>
-#include <boost/any.hpp>
 
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>

--- a/utils/config_file_impl.hh
+++ b/utils/config_file_impl.hh
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <boost/any.hpp>
 #include <boost/regex.hpp>
 #include <boost/program_options/errors.hpp>
 #include <boost/program_options/value_semantic.hpp>

--- a/utils/uuid.cc
+++ b/utils/uuid.cc
@@ -10,8 +10,7 @@
 #include "UUID.hh"
 #include <seastar/net/byteorder.hh>
 #include <random>
-#include <boost/iterator/function_input_iterator.hpp>
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/erase.hpp>
 #include <string>
 #include <fmt/ostream.h>
 #include <seastar/core/format.hh>


### PR DESCRIPTION
This commit eliminates unused boost header includes from the tree.

Removing these unnecessary includes reduces dependencies on the external Boost.Adapters library, leading to faster compile times and a slightly cleaner codebase.

---

it's a cleanup, hence no need to backport.