### PR TITLE
cql3,test: replace boost::range::adjacent_find with std::ranges

### DIFF
--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -13,7 +13,6 @@
 #include <inttypes.h>
 #include <boost/regex.hpp>
 
-#include <boost/range/algorithm/adjacent_find.hpp>
 #include <seastar/core/coroutine.hh>
 
 #include "cql3/statements/create_table_statement.hh"
@@ -173,7 +172,7 @@ std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepa
     }
 
     // Check for duplicate column names
-    auto i = boost::range::adjacent_find(_defined_names, [] (auto&& e1, auto&& e2) {
+    auto i = std::ranges::adjacent_find(_defined_names, [] (auto&& e1, auto&& e2) {
         return e1->text() == e2->text();
     });
     if (i != _defined_names.end()) {

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -35,7 +35,6 @@
 #include <sstream>
 #include <compare>
 #include <ranges>
-#include <boost/range/algorithm/adjacent_find.hpp>
 #include <boost/algorithm/cxx11/iota.hpp>
 #include "test/lib/log.hh"
 #include "test/lib/cql_test_env.hh"
@@ -72,7 +71,7 @@ static void verify_sorted(const dht::token_range_vector& trv) {
                 || a.end()->value() > b.start()->value()
                 || (a.end()->value() == b.start()->value() && a.end()->is_inclusive() && b.start()->is_inclusive());
     };
-    BOOST_CHECK(boost::adjacent_find(trv, not_strictly_before) == trv.end());
+    BOOST_CHECK(std::ranges::adjacent_find(trv, not_strictly_before) == trv.end());
 }
 
 static future<> check_ranges_are_sorted(vnode_effective_replication_map_ptr erm, locator::host_id ep) {


### PR DESCRIPTION
to reduce third-party dependencies and modernize the codebase.

---

it's a cleanup, hence no need to backport.