### PR TITLE
mutation,test: replace boost::equal with std::ranges::equal

### DIFF
--- a/mutation/range_tombstone_list.cc
+++ b/mutation/range_tombstone_list.cc
@@ -9,7 +9,6 @@
 #include "range_tombstone_list.hh"
 #include "utils/assert.hh"
 #include "utils/allocation_strategy.hh"
-#include <boost/range/algorithm/equal.hpp>
 #include <seastar/util/variant_utils.hh>
 
 range_tombstone_list::range_tombstone_list(const range_tombstone_list& x)
@@ -425,7 +424,7 @@ void range_tombstone_list::update_undo_op::undo(const schema& s, range_tombstone
 }
 
 bool range_tombstone_list::equal(const schema& s, const range_tombstone_list& other) const {
-    return boost::equal(_tombstones, other._tombstones, [&s] (auto&& rt1, auto&& rt2) {
+    return std::ranges::equal(_tombstones, other._tombstones, [&s] (auto&& rt1, auto&& rt2) {
         return rt1.tombstone().equal(s, rt2.tombstone());
     });
 }

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -21,9 +21,7 @@
 #include "utils/chunked_vector.hh"
 #include "utils/amortized_reserve.hh"
 
-#include <boost/range/algorithm/equal.hpp>
 #include <boost/range/algorithm/reverse.hpp>
-#include <boost/range/irange.hpp>
 
 using disk_array = utils::chunked_vector<uint64_t, 1024>;
 
@@ -109,7 +107,7 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             abort();
         }
         BOOST_REQUIRE_EQUAL(c.size(), d.size());
-        BOOST_REQUIRE(boost::equal(c, d));
+        BOOST_REQUIRE(std::ranges::equal(c, d));
     }
 }
 


### PR DESCRIPTION
to reduce third-party dependencies and modernize the codebase.

---

it's a cleanup, hence no need to backport.