### PR TITLE
test.py: fix failed_test collection

### DIFF
--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -310,7 +310,7 @@ class Test:
         self.suite = suite
         self.allure_dir = pathlib.Path(suite.options.tmpdir) / self.mode / 'allure'
         # Unique file name, which is also readable by human, as filename prefix
-        self.uname = "{}.{}.{}".format(self.suite.name, self.shortname, self.id)
+        self.uname = "{}.{}.{}".format(self.suite.name, self.shortname.replace("/","_"), self.id)
         self.log_filename = pathlib.Path(suite.options.tmpdir) / self.mode / (self.uname + ".log")
         self.log_filename.parent.mkdir(parents=True, exist_ok=True)
         self.is_flaky = self.shortname in suite.flaky_tests


### PR DESCRIPTION
after introducing the test.py subfolders support,
test.py start creating weird log files like
testlog/topology_custom.mv/tablets/test_mv_tablets.1

that affect failed test collection logic
this commit fixes this and test.py logs as previously in testlog directory without any subfolders: topology_custom.mv_tablets_test_mv_tablets.1
