### PR TITLE
cql3/select_statement: require LIMIT and PER PARTITION LIMIT to be strictly positive

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -301,42 +301,40 @@ select_statement::make_partition_slice(const query_options& options) const
         ++_stats.reverse_queries;
     }
 
-    const uint64_t per_partition_limit = get_inner_loop_limit(get_limit(options, _per_partition_limit),
+    const uint64_t per_partition_limit = get_inner_loop_limit(get_limit(options, _per_partition_limit, true),
         _selection->is_aggregate());
     return query::partition_slice(std::move(bounds),
         std::move(static_columns), std::move(regular_columns), _opts, nullptr, per_partition_limit);
 }
 
-select_statement::get_limit_result select_statement::get_limit(
-    const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit) const
+uint64_t select_statement::get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit) const
 {
-    if (!limit.has_value()) {
-        return bo::success(query::max_rows);
+    const auto& unset_guard = is_per_partition_limit ? _per_partition_limit_unset_guard : _limit_unset_guard;
+    if (!limit.has_value() || unset_guard.is_unset(options)) {
+        return query::max_rows;
     }
     try {
         auto val = expr::evaluate(*limit, options);
         if (val.is_null()) {
-            return bo::failure(exceptions::invalid_request_exception("Invalid null value of limit"));
+            throw exceptions::invalid_request_exception("Invalid null value of limit");
         }
         auto l = val.view().validate_and_deserialize<int32_t>(*int32_type);
         if (l <= 0) {
             auto msg = is_per_partition_limit ? "PER PARTITION LIMIT must be strictly positive" : "LIMIT must be strictly positive";
-            return bo::failure(exceptions::invalid_request_exception(msg));
+            throw exceptions::invalid_request_exception(msg);
         }
-        return bo::success(l);
+        return l;
     } catch (const marshal_exception& e) {
-        return bo::failure(exceptions::invalid_request_exception("Invalid limit value"));
-    } catch (const exceptions::invalid_request_exception& e) {
-        return bo::failure(e);
+        throw exceptions::invalid_request_exception("Invalid limit value");
     }
 }
 
-uint64_t select_statement::get_inner_loop_limit(const select_statement::get_limit_result& limit, bool is_aggregate)
+uint64_t select_statement::get_inner_loop_limit(uint64_t limit, bool is_aggregate)
 {
-    if (!limit.has_value() || is_aggregate) {
+    if (is_aggregate) {
         return query::max_rows;
     }
-    return limit.value();
+    return limit;
 }
 
 bool select_statement::needs_post_query_ordering() const {
@@ -472,7 +470,7 @@ select_statement::do_execute(query_processor& qp,
     } else {
         f = execute_without_checking_exception_message_aggregate_or_paged(qp, command,
             std::move(key_ranges), state, options, now, page_size, aggregate,
-            nonpaged_filtering, parsed_limit.has_value() ? parsed_limit.value() : query::max_rows);
+            nonpaged_filtering, parsed_limit);
     }
 
     if (!tablet_info.has_value()) {
@@ -499,7 +497,7 @@ select_statement::execute_without_checking_exception_message_aggregate_or_paged(
     auto per_partition_limit = get_limit(options, _per_partition_limit, true);
 
     if (aggregate || nonpaged_filtering) {
-        auto builder = cql3::selection::result_set_builder(*_selection, now, &options, *_group_by_cell_indices, limit, per_partition_limit.value());
+        auto builder = cql3::selection::result_set_builder(*_selection, now, &options, *_group_by_cell_indices, limit, per_partition_limit);
         coordinator_result<void> result_void = co_await utils::result_do_until(
                 [&p, &builder, limit] {
                     return p->is_exhausted() || (limit < builder.result_set_size());

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -153,9 +153,8 @@ public:
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 
 protected:
-    using get_limit_result = bo::result<uint64_t, exceptions::invalid_request_exception>;
-    get_limit_result get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
-    static uint64_t get_inner_loop_limit(const select_statement::get_limit_result& limit, bool is_aggregate);
+    uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
+    static uint64_t get_inner_loop_limit(uint64_t limit, bool is_aggregate);
 
     bool needs_post_query_ordering() const;
     virtual void update_stats_rows_read(int64_t rows_read) const {


### PR DESCRIPTION
LIMIT and PER PARTITION LIMIT limit the number of rows returned or taken into consideration by a query. It makes no logical sense to have this value at less than 1. Cassandra also has this requirement.

This patch ensures that the limit value is strictly positive and adds an explicit test for it - it was only tested in a test ported from Cassandra, that is disabled due to other issues.

backports: no, there's no active issue for this bug and it's a minor correctness change - it only affects already incorrect queries.