### PR TITLE
[Backport 6.2] Improve compation on read of expired tombstones

### DIFF
--- a/cache_mutation_reader.hh
+++ b/cache_mutation_reader.hh
@@ -200,7 +200,7 @@ class cache_mutation_reader final : public mutation_reader::impl {
     gc_clock::time_point get_gc_before(const schema& schema, dht::decorated_key dk, const gc_clock::time_point query_time) {
         auto gc_state = _read_context.tombstone_gc_state();
         if (gc_state) {
-            return gc_state->get_gc_before_for_key(schema.shared_from_this(), dk, query_time);
+            return gc_state->with_commitlog_check_disabled().get_gc_before_for_key(schema.shared_from_this(), dk, query_time);
         }
 
         return gc_clock::time_point::min();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2555,7 +2555,7 @@ table::sstables_as_snapshot_source() {
                 std::move(reader),
                 gc_clock::now(),
                 get_max_purgeable_fn_for_cache_underlying_reader(),
-                _compaction_manager.get_tombstone_gc_state(),
+                _compaction_manager.get_tombstone_gc_state().with_commitlog_check_disabled(),
                 fwd);
         }, [this, sst_set] {
             return make_partition_presence_checker(sst_set);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4377,19 +4377,28 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
         replica::table& t = env.local_db().find_column_family(ks_name, table_name);
         schema_ptr s = t.schema();
 
+        // emulate commitlog behaivor
+        t.get_compaction_manager().get_tombstone_gc_state().set_gc_time_min_source([s](const table_id& id) {
+            return gc_clock::now() - (std::chrono::seconds(s->gc_grace_seconds().count() + 600));
+        });
+
         dht::decorated_key dk = tests::generate_partition_key(s);
 
         auto ck1 = clustering_key::from_deeply_exploded(*s, {1});
         auto ck1_prefix = clustering_key_prefix::from_deeply_exploded(*s, {1});
         auto ck2 = clustering_key::from_deeply_exploded(*s, {2});
         auto ck2_prefix = clustering_key_prefix::from_deeply_exploded(*s, {2});
+        auto ck3 = clustering_key::from_deeply_exploded(*s, {3});
+        auto ck3_prefix = clustering_key_prefix::from_deeply_exploded(*s, {3});
 
         auto dt_noexp = gc_clock::now();
-        auto dt_exp = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 1);
+        auto dt_exp = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 700);
+        auto dt_hold = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 1);
 
         mutation m(s, dk);
         m.partition().apply_delete(*s, ck1_prefix, tombstone(1, dt_noexp)); // create non-expired tombstone
         m.partition().apply_delete(*s, ck2_prefix, tombstone(2, dt_exp)); // create expired tombstone
+        m.partition().apply_delete(*s, ck3_prefix, tombstone(3, dt_hold)); // create held by commit log tombstone
         t.apply(m);
         t.flush().get();
 
@@ -4408,6 +4417,7 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
 
         BOOST_REQUIRE_EQUAL(cp.clustered_row(*s, ck1).deleted_at(), row_tombstone(tombstone(1, dt_noexp))); // non-expired tombstone is in cache
         BOOST_REQUIRE(cp.find_row(*s, ck2) == nullptr); // expired tombstone isn't in cache
+        BOOST_REQUIRE(cp.find_row(*s, ck3) == nullptr); // held tombstone isn't in cache
 
         const auto rows = cp.non_dummy_rows();
         BOOST_REQUIRE(std::distance(rows.begin(), rows.end()) == 1); // cache contains non-expired row only
@@ -4541,8 +4551,10 @@ SEASTAR_TEST_CASE(test_cache_compacts_expired_tombstones_on_read) {
         auto ck1 = make_ck(1);
         auto ck2 = make_ck(2);
         auto ck3 = make_ck(3);
+        auto ck4 = make_ck(4);
         auto dt_noexp = gc_clock::now();
-        auto dt_exp = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 1);
+        auto dt_exp = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 700);
+        auto dt_held = gc_clock::now() - std::chrono::seconds(s->gc_grace_seconds().count() + 1);
 
         auto mt = make_lw_shared<replica::memtable>(s);
         cache_tracker tracker;
@@ -4553,10 +4565,17 @@ SEASTAR_TEST_CASE(test_cache_compacts_expired_tombstones_on_read) {
             m.set_clustered_cell(ck1, "v", data_value(101), 1);
             m.partition().apply_delete(*s, make_prefix(2), tombstone(1, dt_noexp)); // create non-expired tombstone
             m.partition().apply_delete(*s, make_prefix(3), tombstone(2, dt_exp)); // create expired tombstone
+            m.partition().apply_delete(*s, make_prefix(4), tombstone(3, dt_held)); // create expired but held by commit log tombstone
             cache.populate(m);
         }
 
         tombstone_gc_state gc_state(nullptr);
+
+        // emulate commitlog behaivor
+        gc_state.set_gc_time_min_source([&s](const table_id& id) {
+                return gc_clock::now() - (std::chrono::seconds(s->gc_grace_seconds().count() + 600));
+        });
+
         auto rd1 = cache.make_reader(s, semaphore.make_permit(), query::full_partition_range, &gc_state);
         auto close_rd = deferred_close(rd1);
         rd1.fill_buffer().get(); // cache_mutation_reader compacts cache on fill buffer
@@ -4567,11 +4586,12 @@ SEASTAR_TEST_CASE(test_cache_compacts_expired_tombstones_on_read) {
         BOOST_REQUIRE(cp.find_row(*s, ck1) != nullptr); // live row is in cache
         BOOST_REQUIRE_EQUAL(cp.clustered_row(*s, ck2).deleted_at(), row_tombstone(tombstone(1, dt_noexp))); // non-expired tombstone is in cache
         BOOST_REQUIRE(cp.find_row(*s, ck3) == nullptr); // expired tombstone isn't in cache
+        BOOST_REQUIRE(cp.find_row(*s, ck4) == nullptr); // held tombstone isn't in cache
 
         // check tracker stats
         auto &tracker_stats = tracker.get_stats();
-        BOOST_REQUIRE(tracker_stats.rows_compacted == 1);
-        BOOST_REQUIRE(tracker_stats.rows_compacted_away == 1);
+        BOOST_REQUIRE(tracker_stats.rows_compacted == 2);
+        BOOST_REQUIRE(tracker_stats.rows_compacted_away == 2);
     });
 }
 


### PR DESCRIPTION
Compact expired tombstones in cache even if they are blocked by commitlog

Fixes #16781
Fixes backport request issue #22977

- (cherry picked from commit 9a085cffe67a7affe60f88cd594415c0cdab3caf)

Parent PR #21613