### PR TITLE
install-dependencies.sh: install pytest-asyncio as a pip package

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -85,7 +85,6 @@ fedora_packages=(
     python3-tabulate
     python3-boto3
     python3-pytest
-    python3-pytest-asyncio
     python3-redis
     python3-unidiff
     python3-humanfriendly
@@ -162,6 +161,7 @@ declare -A pip_packages=(
     [treelib]=""
     [allure-pytest]=""
     [pytest-xdist]=""
+    [pytest-asyncio]=""
     [pykmip]=""
     [universalasync]=""
     [boto3-stubs[dynamodb]]=""


### PR DESCRIPTION
The version of pytest-asyncio in Fedora 41 (0.23.6) contains a bug related to loop_scope=module.  It is not a problem for test.py test runner because it starts Python tests file-by-file and scopes session, package, and module effectively are the same.  But it's not true for bare pytest, and it's became a problem during development of #22960

Fedora 42 contains the fixed version of pytest-asyncio (0.24.0), but it'll be released by the end of April (planned.)

Current version in PyPI is 0.25.3

Ref: https://github.com/pytest-dev/pytest-asyncio/issues/862
