### PR TITLE
repair: Fix return type for storage_service/tablets/repair API

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2844,7 +2844,7 @@
                "nickname":"repair_tablet",
                "method":"POST",
                "summary":"Repair a tablet",
-               "type":"void",
+               "type":"tablet_repair_result",
                "produces":[
                   "application/json"
                ],
@@ -3317,6 +3317,15 @@
                 "items":{
                     "$ref":"sstable"
                 }
+            }
+        }
+      },
+      "tablet_repair_result":{
+        "id":"tablet_repair_result",
+        "description":"Tablet repair result",
+        "properties":{
+            "tablet_task_id":{
+                "type":"string"
             }
         }
       }


### PR DESCRIPTION
The API returns string which contains the repair task UUID.

{"tablet_task_id":"3597e990-dc4f-11ef-b961-95d5ead302a7"}

Fixes #23032

Backport to 2025.1