### PR TITLE
auth: Remove unused client member variables from authenticator classes

### DIFF
--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -88,7 +88,7 @@ static const class_registrator<
 ldap_role_manager::ldap_role_manager(
         std::string_view query_template, std::string_view target_attr, std::string_view bind_name, std::string_view bind_password,
         cql3::query_processor& qp, ::service::raft_group0_client& rg0c, ::service::migration_manager& mm)
-        : _std_mgr(qp, rg0c, mm), _group0_client(rg0c), _query_template(query_template), _target_attr(target_attr), _bind_name(bind_name)
+        : _std_mgr(qp, mm), _group0_client(rg0c), _query_template(query_template), _target_attr(target_attr), _bind_name(bind_name)
         , _bind_password(bind_password)
         , _connection_factory(bind(std::mem_fn(&ldap_role_manager::reconnect), std::ref(*this))) {
 }

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -47,7 +47,6 @@ static const class_registrator<
         authenticator,
         password_authenticator,
         cql3::query_processor&,
-        ::service::raft_group0_client&,
         ::service::migration_manager&> password_auth_reg("org.apache.cassandra.auth.PasswordAuthenticator");
 
 static thread_local auto rng_for_salt = std::default_random_engine(std::random_device{}());
@@ -63,9 +62,8 @@ std::string password_authenticator::default_superuser(const db::config& cfg) {
 password_authenticator::~password_authenticator() {
 }
 
-password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
+password_authenticator::password_authenticator(cql3::query_processor& qp, ::service::migration_manager& mm)
     : _qp(qp)
-    , _group0_client(g0)
     , _migration_manager(mm)
     , _stopped(make_ready_future<>()) 
     , _superuser(default_superuser(qp.db().get_config()))

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -37,7 +37,6 @@ extern const std::string_view password_authenticator_name;
 
 class password_authenticator : public authenticator {
     cql3::query_processor& _qp;
-    ::service::raft_group0_client& _group0_client;
     ::service::migration_manager& _migration_manager;
     future<> _stopped;
     abort_source _as;
@@ -48,7 +47,7 @@ public:
     static db::consistency_level consistency_for_user(std::string_view role_name);
     static std::string default_superuser(const db::config&);
 
-    password_authenticator(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
+    password_authenticator(cql3::query_processor&, ::service::migration_manager&);
 
     ~password_authenticator();
 

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -71,7 +71,6 @@ static const class_registrator<
         role_manager,
         standard_role_manager,
         cql3::query_processor&,
-        ::service::raft_group0_client&,
         ::service::migration_manager&> registration("org.apache.cassandra.auth.CassandraRoleManager");
 
 struct record final {
@@ -129,9 +128,8 @@ static bool has_can_login(const cql3::untyped_result_set_row& row) {
     return row.has("can_login") && !(boolean_type->deserialize(row.get_blob("can_login")).is_null());
 }
 
-standard_role_manager::standard_role_manager(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
+standard_role_manager::standard_role_manager(cql3::query_processor& qp, ::service::migration_manager& mm)
     : _qp(qp)
-    , _group0_client(g0)
     , _migration_manager(mm)
     , _stopped(make_ready_future<>())
     , _superuser(password_authenticator::default_superuser(qp.db().get_config()))

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -34,7 +34,6 @@ namespace auth {
 
 class standard_role_manager final : public role_manager {
     cql3::query_processor& _qp;
-    ::service::raft_group0_client& _group0_client;
     ::service::migration_manager& _migration_manager;
     future<> _stopped;
     abort_source _as;
@@ -42,7 +41,7 @@ class standard_role_manager final : public role_manager {
     shared_promise<> _superuser_created_promise;
 
 public:
-    standard_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);
+    standard_role_manager(cql3::query_processor&, ::service::migration_manager&);
 
     virtual std::string_view qualified_java_name() const noexcept override;
 

--- a/auth/transitional.cc
+++ b/auth/transitional.cc
@@ -37,8 +37,8 @@ class transitional_authenticator : public authenticator {
 public:
     static const sstring PASSWORD_AUTHENTICATOR_NAME;
 
-    transitional_authenticator(cql3::query_processor& qp, ::service::raft_group0_client& g0, ::service::migration_manager& mm)
-            : transitional_authenticator(std::make_unique<password_authenticator>(qp, g0, mm)) {
+    transitional_authenticator(cql3::query_processor& qp, ::service::migration_manager& mm)
+            : transitional_authenticator(std::make_unique<password_authenticator>(qp, mm)) {
     }
     transitional_authenticator(std::unique_ptr<authenticator> a)
             : _authenticator(std::move(a)) {
@@ -238,7 +238,6 @@ static const class_registrator<
         auth::authenticator,
         auth::transitional_authenticator,
         cql3::query_processor&,
-        ::service::raft_group0_client&,
         ::service::migration_manager&> transitional_authenticator_reg(auth::PACKAGE_NAME + "TransitionalAuthenticator");
 
 static const class_registrator<

--- a/test/boost/role_manager_test.cc
+++ b/test/boost/role_manager_test.cc
@@ -24,7 +24,7 @@ auto make_manager(cql_test_env& env) {
         std::default_delete<auth::standard_role_manager>()(m);
     };
     return std::unique_ptr<auth::standard_role_manager, decltype(stop_role_manager)>(
-            new auth::standard_role_manager(env.local_qp(), env.get_raft_group0_client(), env.migration_manager().local()),
+            new auth::standard_role_manager(env.local_qp(), env.migration_manager().local()),
             std::move(stop_role_manager));
 }
 


### PR DESCRIPTION
GCC warned that `password_authenticator::_group0_client` and `standard_role_manager::_group0_client` are unused throughout the codebase.

This commit:
- Removes both redundant member variables
- Eliminates associated parameters from function signatures in their respective initialization call chains
- Simplifies related code paths in both classes

These changes reduce code complexity and resolve static analyzer warnings without affecting functionality.

The warning from GCC looks like:
```
FAILED: auth/CMakeFiles/scylla_auth.dir/RelWithDebInfo/password_authenticator.cc.o
/home/kefu/.local/bin/clang++ -DSCYLLA_BUILD_MODE=release -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build -I/home/kefu/dev/scylladb/build/gen -isystem /home/kefu/dev/scylladb/seastar/include -isystem /home/kefu/dev/scylladb/build/RelWithDebInfo/seastar/gen/include -isystem /home/kefu/dev/scylladb/abseil -isystem /home/kefu/dev/scylladb/build/rust -I/usr/include/p11-kit-1 -ffunction-sections -fdata-sections -O3 -g -gz -std=gnu++23 -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/= -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -ffile-prefix-map=/home/kefu/dev/scylladb/build/=build -march=westmere -mllvm -inline-threshold=2500 -fno-slp-vectorize -std=gnu++23 -Werror=unused-result -DSEASTAR_API_LEVEL=7 -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=19 -DSEASTAR_LOGGER_TYPE_STDOUT -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_DYN_LINK -DFMT_SHARED -MD -MT auth/CMakeFiles/scylla_auth.dir/RelWithDebInfo/password_authenticator.cc.o -MF auth/CMakeFiles/scylla_auth.dir/RelWithDebInfo/password_authenticator.cc.o.d -o auth/CMakeFiles/scylla_auth.dir/RelWithDebInfo/password_authenticator.cc.o -c /home/kefu/dev/scylladb/auth/password_authenticator.cc
In file included from /home/kefu/dev/scylladb/auth/password_authenticator.cc:11:
/home/kefu/dev/scylladb/auth/password_authenticator.hh:40:36: error: private field '_group0_client' is not used [-Werror,-Wunused-private-field]
   40 |     ::service::raft_group0_client& _group0_client;
      |                                    ^
1 error generated.
```

---

it's a cleanup, hence no need to backport.