### PR TITLE
conf: scylla.yaml: correct a misspelling

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -747,7 +747,7 @@ maintenance_socket: ignore
 #
 # Actual connection can be either an explicit endpoint (<host>:<port>), or selected automatic via aws_region.
 # 
-# Authentication can be explicit with aws_access_key_id and aws_secret_access_key. Either secret or both can be ommitted
+# Authentication can be explicit with aws_access_key_id and aws_secret_access_key. Either secret or both can be omitted
 # in which case the provider will try to read them from AWS credentials in ~/.aws/credentials. If aws_profile is set, the
 # credentials in this section is used.
 #


### PR DESCRIPTION
s/ommitted/omitted/

---

this misspelling was introduced in 1ef0a48bbe1650aa45d161d96c3404cebae768e9, which is only contained by master, hence no need to backport.