### PR TITLE
metadata: Correct "DESCRIBE" output for keyspace metadata

### DIFF
--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -426,10 +426,8 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
         if (db.features().tablets) {
             if (!_initial_tablets.has_value()) {
                 os << " AND tablets = {'enabled': false}";
-            } else if (_initial_tablets.value() > 0) {
-                os << " AND tablets = {'initial': " << _initial_tablets.value() << "}";
             } else {
-                os << " AND tablets = {'enabled': true}";
+                os << format(" AND tablets = {{'enabled': true{}}}", _initial_tablets.value() ? format(", 'initial': {}", _initial_tablets.value()) : "");
             }
         }
         os << ";";


### PR DESCRIPTION
Update the "DESCRIBE" command output to accurately display `tablet` settings in keyspace metadata.

create - describe mapping
```
create keyspace cql_test_1741076609474 with replication = { 'class' : 'networktopologystrategy', 'replication_factor' : '1' } and tablets = {'enabled': true, 'initial': 0}
create keyspace cql_test_1741076609474 with replication = {'class': 'org.apache.cassandra.locator.networktopologystrategy', 'datacenter1': '1'} and durable_writes = true and tablets = {'enabled': true};

create keyspace cql_test_1741076609539 with replication = { 'class' : 'networktopologystrategy', 'replication_factor' : '1' } and tablets = {'enabled': true, 'initial': 7}
create keyspace cql_test_1741076609539 with replication = {'class': 'org.apache.cassandra.locator.networktopologystrategy', 'datacenter1': '1'} and durable_writes = true and tablets = {'enabled': true, 'initial': 7};

create keyspace cql_test_1741076609577 with replication = { 'class' : 'networktopologystrategy', 'replication_factor' : '1' } and tablets = {'enabled': true}
create keyspace cql_test_1741076609577 with replication = {'class': 'org.apache.cassandra.locator.networktopologystrategy', 'datacenter1': '1'} and durable_writes = true and tablets = {'enabled': true};

create keyspace cql_test_1741076609601 with replication = { 'class' : 'networktopologystrategy', 'replication_factor' : '1' } and tablets = {'enabled': false}
create keyspace cql_test_1741076609601 with replication = {'class': 'org.apache.cassandra.locator.networktopologystrategy', 'datacenter1': '1'} and durable_writes = true and tablets = {'enabled': false};

create keyspace cql_test_1741076609624 with replication = { 'class' : 'networktopologystrategy', 'replication_factor' : '1' }
create keyspace cql_test_1741076609624 with replication = {'class': 'org.apache.cassandra.locator.networktopologystrategy', 'datacenter1': '1'} and durable_writes = true and tablets = {'enabled': true};
```
fixes: https://github.com/scylladb/scylladb/issues/22866
@bhalevy Not sure about backport, should we?