### PR TITLE
Resolve race between tablet cleanup and take snapshot

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3971,12 +3971,12 @@ future<> compaction_group::cleanup() {
             set->for_each_sstable([&all_sstables] (const sstables::shared_sstable& sst) mutable {
                 all_sstables.push_back(sst);
             });
+            co_await _cg.delete_sstables_atomically(std::move(all_sstables));
             if (utils::get_local_injector().enter("tablet_cleanup_failure")) {
                 co_await sleep(std::chrono::seconds(1));
                 tlogger.info("Cleanup failed for tablet {}", _cg.group_id());
                 throw std::runtime_error("tablet cleanup failure");
             }
-            co_await _cg.delete_sstables_atomically(std::move(all_sstables));
         }
 
         virtual void execute() override {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1887,7 +1887,7 @@ compaction_group::delete_sstables_atomically(std::vector<sstables::shared_sstabl
     } catch (...) {
         // There is nothing more we can do here.
         // Any remaining SSTables will eventually be re-compacted and re-deleted.
-        tlogger.error("Compacted SSTables deletion failed: {}. Ignored.", std::current_exception());
+        tlogger.error("Atomic SSTables deletion failed: {}. Ignored.", std::current_exception());
     }
 }
 

--- a/test/topology_custom/test_tablets2.py
+++ b/test/topology_custom/test_tablets2.py
@@ -1800,3 +1800,38 @@ async def test_decommission_not_enough_racks(manager: ManagerClient):
         expected_replicas_per_server = get_expected_replicas_per_server(live_servers.values(), dead_servers.values(), ctx.initial_tablets, ctx.rf)
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
+    cmdline = ['--smp=1']
+
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    cql = manager.get_cql()
+    n_tablets = 1
+    n_partitions = 1000
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await manager.servers_see_each_other(servers)
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
+
+        await inject_error_one_shot_on(manager, "tablet_cleanup_failure", servers)
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+
+        servers.append(await manager.server_add())
+
+        tablet_token = 0
+        replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+        dst_shard = 0
+        migration_task = asyncio.create_task(
+            manager.api.move_tablet(servers[0].ip_addr, ks, "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
+
+        logger.info("Waiting for injected cleanup failure...")
+        await s0_log.wait_for('Cleanup failed for tablet', from_mark=s0_mark)
+
+        await manager.api.take_snapshot(servers[0].ip_addr, ks, "test_snapshot")


### PR DESCRIPTION
Like in `update_sstable_sets_on_compaction_completion`,
the sstable files should be deleted as the last step,
after the compaction group is updated to avoid a case
where the sstable sets do not reflect the sstables
state on disk.

Fixes #23049

* Although the issue exists in he code base in all live OSS versions, it is rare enough and benign enough (just snapshot api failing) to not require backport
