### PR TITLE
tree: implement boost::accumulate with std::ranges library

### DIFF
--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -12,7 +12,6 @@
 #include "manager.hh"
 #include "utils/log.hh"
 #include <boost/range/algorithm/for_each.hpp>
-#include <boost/range/numeric.hpp>
 #include "utils/disk-error-handler.hh"
 #include "seastarx.hh"
 #include <seastar/core/sleep.hh>
@@ -189,7 +188,7 @@ void space_watchdog::on_timer() {
 
         // Adjust the quota to take into account the space we guarantee to every end point manager
         size_t adjusted_quota = 0;
-        size_t delta = boost::accumulate(per_device_limits.managers, 0, [] (size_t sum, manager& shard_manager) {
+        size_t delta = std::ranges::fold_left(per_device_limits.managers, 0, [] (size_t sum, manager& shard_manager) {
             return sum + shard_manager.ep_managers_size() * resource_manager::hint_segment_size_in_mb * 1024 * 1024;
         });
         if (per_device_limits.max_shard_disk_space_size > delta) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -17,8 +17,6 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/range/numeric.hpp>
-
 #include <fmt/ranges.h>
 
 #include <seastar/core/future-util.hh>
@@ -3337,7 +3335,7 @@ update_backlog node_update_backlog::fetch() {
     auto now = clock::now();
     if (now >= _last_update.load(std::memory_order_relaxed) + _interval) {
         _last_update.store(now, std::memory_order_relaxed);
-        auto new_max = boost::accumulate(
+        auto new_max = std::ranges::fold_left(
                 _backlogs,
                 update_backlog::no_backlog(),
                 [] (const update_backlog& lhs, const per_shard_backlog& rhs) {

--- a/mutation/range_tombstone.cc
+++ b/mutation/range_tombstone.cc
@@ -9,7 +9,6 @@
 #include "range_tombstone.hh"
 
 #include <boost/range/algorithm/upper_bound.hpp>
-#include <boost/range/numeric.hpp>
 
 std::optional<range_tombstone> range_tombstone::apply(const schema& s, range_tombstone&& src)
 {
@@ -39,7 +38,7 @@ position_in_partition_view range_tombstone::end_position() const {
 }
 
 void range_tombstone_accumulator::update_current_tombstone() {
-    _current_tombstone = boost::accumulate(_range_tombstones, _partition_tombstone, [] (tombstone t, const range_tombstone& rt) {
+    _current_tombstone = std::ranges::fold_left(_range_tombstones, _partition_tombstone, [] (tombstone t, const range_tombstone& rt) {
         t.apply(rt.tomb);
         return t;
     });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -30,7 +30,6 @@
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/range/algorithm_ext.hpp>
-#include <boost/range/numeric.hpp>
 
 #include <fmt/ranges.h>
 
@@ -609,7 +608,7 @@ future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, co
             // FIXME: If sstables are shared, they will be accounted more than
             // once. However, shared sstables should exist for a short-time only.
             auto sstables = db.find_column_family(keyspace, cf).get_sstables();
-            return boost::accumulate(*sstables, uint64_t(0),
+            return std::ranges::fold_left(*sstables, uint64_t(0),
                 [&range] (uint64_t x, auto&& sst) { return x + sst->estimated_keys_for_range(range); });
         },
         uint64_t(0),

--- a/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
+++ b/test/lib/sstable_run_based_compaction_strategy_for_tests.cc
@@ -39,10 +39,10 @@ compaction_descriptor sstable_run_based_compaction_strategy_for_tests::get_sstab
         if (runs.size() < size_t(table_s.schema()->min_compaction_threshold())) {
             continue;
         }
-        auto all = boost::accumulate(runs, std::vector<shared_sstable>(), [&] (std::vector<shared_sstable>&& v, const frozen_sstable_run& run) {
-            v.insert(v.end(), run->all().begin(), run->all().end());
-            return std::move(v);
-        });
+        auto all = runs
+            | std::views::transform([] (auto& run) -> auto& { return run->all(); })
+            | std::views::join
+            | std::ranges::to<std::vector>();
         return sstables::compaction_descriptor(std::move(all), 0, static_fragment_size_for_run);
     }
     return sstables::compaction_descriptor();

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -14,7 +14,6 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/range/irange.hpp>
 #include <boost/range/algorithm_ext.hpp>
-#include <boost/range/numeric.hpp>
 #include <json/json.h>
 #include <fmt/ranges.h>
 #include "test/lib/cql_test_env.hh"
@@ -1316,7 +1315,7 @@ public:
         for (auto&& result : results) {
             print_all(result);
 
-            auto average_aio = boost::accumulate(result, 0., [&] (double a, const test_result& b) {
+            auto average_aio = std::ranges::fold_left(result, 0., [&] (double a, const test_result& b) {
                 return a + b.aio_reads() + b.aio_writes();
             }) / (result.empty() ? 1 : result.size());
 


### PR DESCRIPTION
Replace boost::accumulate() calls with std::ranges facilities. This change reduces external dependencies and modernizes the codebase.

---

it's a cleanup, hence no need to backport.