### PR TITLE
tree: Remove redundant std::move() calls

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -149,7 +149,7 @@ struct intersection_visitor {
         value_list common;
         common.reserve(std::max(a.size(), b.size()));
         boost::set_intersection(a, b, back_inserter(common), type->as_less_comparator());
-        return std::move(common);
+        return common;
     }
 
     value_set operator()(const interval<managed_bytes>& a, const value_list& b) const {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -197,7 +197,7 @@ ring_position_range_sharder::next(const schema& s) {
         auto end = interval_bound<ring_position>(shard_boundary, false);
         _range = dht::partition_range(
                 interval_bound<ring_position>(std::move(shard_boundary), true),
-                std::move(_range.end()));
+                _range.end());
         return ring_position_range_and_shard{dht::partition_range(std::move(start), std::move(end)), shard};
     }
     _done = true;


### PR DESCRIPTION
These redundant `std::move()` calls were identified by GCC-14. In general, copy elision applies to these places, so adding `std::move()` is not only unnecessary but can actually prevent the compiler from performing copy elision, as it causes the return statement to fail to satisfy the requirements for copy elision optimization.

---

it's a cleanup, hence no need to backport.