### PR TITLE
tree: Fix polymorphic exception handling by using references

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -730,7 +730,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 }
             } catch (raft::request_aborted&) {
                 rtlogger.debug("CDC generation publisher fiber aborted");
-            } catch (seastar::abort_requested_exception) {
+            } catch (seastar::abort_requested_exception&) {
                 rtlogger.debug("CDC generation publisher fiber aborted");
             } catch (group0_concurrent_modification&) {
             } catch (term_changed_error&) {
@@ -805,7 +805,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
             } catch (raft::request_aborted&) {
                 rtlogger.debug("gossiper orphan remover fiber aborted");
-            } catch (seastar::abort_requested_exception) {
+            } catch (seastar::abort_requested_exception&) {
                 rtlogger.debug("gossiper orphan remover fiber aborted");
             } catch (group0_concurrent_modification&) {
             } catch (term_changed_error&) {
@@ -3051,7 +3051,7 @@ future<> topology_coordinator::start_tablet_load_stats_refresher() {
         } catch (raft::request_aborted&) {
             rtlogger.debug("raft topology: Tablet load stats refresher aborted");
             sleep = false;
-        } catch (seastar::abort_requested_exception) {
+        } catch (seastar::abort_requested_exception&) {
             rtlogger.debug("raft topology: Tablet load stats refresher aborted");
             sleep = false;
         } catch (...) {

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -205,7 +205,7 @@ future<> stream_blob_handler(replica::database& db,
                     }
                 }
             }
-          } catch (seastar::rpc::stream_closed) {
+          } catch (seastar::rpc::stream_closed&) {
               // After we get streaming::stream_blob_cmd::end_of_stream which
               // is the last message from peer, it does not matter if the
               // source() is closed or not.
@@ -514,7 +514,7 @@ tablet_stream_files(netw::messaging_service& ms, std::list<stream_blob_info> sou
                         } else {
                             break;
                         }
-                      } catch (seastar::rpc::stream_closed) {
+                      } catch (seastar::rpc::stream_closed&) {
                           // After we get streaming::stream_blob_cmd::ok
                           // which is the last message from peer, it does not
                           // matter if the source() is closed or not.

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -169,7 +169,7 @@ future<> directories::verify_owner_and_mode_of_data_dir(directories::set dir_set
                     // like stat/lstat will load the inode/dentry into the cache.
                     auto descriptor_tuple = sstables::parse_path(path);
                     path_component_type = std::get<0>(descriptor_tuple).component;
-                } catch (sstables::malformed_sstable_exception) {
+                } catch (sstables::malformed_sstable_exception&) {
                     // path is not a SSTable component - do not filter it out
                     return true;
                 }


### PR DESCRIPTION
Replace value-based exception catching with reference-based catching to address GCC warnings about polymorphic type slicing:

```
warning: catching polymorphic type ‘class seastar::rpc::stream_closed’ by value [-Wcatch-value=]
```

When catching polymorphic exceptions by value, the C++ runtime copies the thrown exception into a new instance of the specified type, slicing the actual exception and potentially losing important information. This change ensures all polymorphic exceptions are caught by reference to preserve the complete exception state.

---

it's a cleanup, hence no need to backport.