### PR TITLE
tree: Make values mutable to enable move semantics

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -345,7 +345,7 @@ static value_set possible_lhs_values(const column_definition* cdef,
                             if (cdef) {
                                 return unbounded_value_set;
                             }
-                            const auto val = evaluate(oper.rhs, options).to_managed_bytes_opt();
+                            auto val = evaluate(oper.rhs, options).to_managed_bytes_opt();
                             if (!val) {
                                 return empty_value_set; // All NULL comparisons fail; no token values match.
                             }

--- a/test/boost/cql_auth_query_test.cc
+++ b/test/boost/cql_auth_query_test.cc
@@ -63,7 +63,7 @@ static void with_user(cql_test_env& env, std::string_view user_name, noncopyable
     create_user_if_not_exists(env, user_name);
     cs.set_login(auth::authenticated_user(sstring(user_name)));
 
-    const auto reset = defer([&cs, old_user = std::move(old_user)] {
+    const auto reset = defer([&cs, old_user = std::move(old_user)] mutable {
         cs.set_login(std::move(*old_user));
     });
 

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -824,19 +824,19 @@ schema_ptr build_random_schema(uint32_t seed, random_schema_specification& spec)
         builder.with_column(to_bytes(format("pk{}", pk)), std::move(pk_columns[pk]), column_kind::partition_key);
     }
 
-    const auto ck_columns = spec.clustering_key_columns(engine);
+    auto ck_columns = spec.clustering_key_columns(engine);
     for (size_t ck = 0; ck < ck_columns.size(); ++ck) {
         builder.with_column(to_bytes(format("ck{}", ck)), std::move(ck_columns[ck]), column_kind::clustering_key);
     }
 
     if (!ck_columns.empty()) {
-        const auto static_columns = spec.static_columns(engine);
+        auto static_columns = spec.static_columns(engine);
         for (size_t s = 0; s < static_columns.size(); ++s) {
             builder.with_column(to_bytes(format("s{}", s)), std::move(static_columns[s]), column_kind::static_column);
         }
     }
 
-    const auto regular_columns = spec.regular_columns(engine);
+    auto regular_columns = spec.regular_columns(engine);
     for (size_t r = 0; r < regular_columns.size(); ++r) {
         builder.with_column(to_bytes(format("v{}", r)), std::move(regular_columns[r]), column_kind::regular_column);
     }

--- a/validation.cc
+++ b/validation.cc
@@ -43,7 +43,7 @@ std::optional<sstring> is_cql_key_invalid(const schema& schema, partition_key_vi
 
 void
 validate_cql_key(const schema& schema, partition_key_view key) {
-    if (const auto err = is_cql_key_invalid(schema, key); err) {
+    if (auto err = is_cql_key_invalid(schema, key); err) {
         throw exceptions::invalid_request_exception(std::move(*err));
     }
 }


### PR DESCRIPTION
Previously, variables were marked as const, causing std::move() calls to be redundant as reported by GCC warnings. This change either removes const qualifiers or marks related lambdas as mutable, allowing the compiler to properly utilize move constructors for better performance.

---

it's a cleanup, hence no need to backport.