### PR TITLE
utils/sorting: Fix VerticesContainer concept constraints

### DIFF
--- a/utils/sorting.hh
+++ b/utils/sorting.hh
@@ -22,8 +22,7 @@ concept VerticiesContainer = requires(const Container& c) {
     c.begin();
     c.end();
     c.size();
-    std::same_as<typename Container::value_type, T>;
-};
+} && std::same_as<typename Container::value_type, T>;
 
 /**
  * Topological sort a DAG using Kahn's algorithm.


### PR DESCRIPTION
Fix a bug where std::same_as<...> constraint was incorrectly used as a simple requirement instead of a nested requirement or part of a conjunction. This caused the constraint to be always satisfied regardless of the actual types involved.

This change promotes std::same_as<...> to a top-level constraint, ensuring proper type checking while improving code readability.

---

since the code compiles before and after this change, this fix should be considered as a cleanup, hence no need to backport.