### PR TITLE
B+tree: Clean const_iterator->iterator conversion

### DIFF
--- a/utils/bptree.hh
+++ b/utils/bptree.hh
@@ -664,7 +664,7 @@ public:
         iterator(data* d, kid_index idx) noexcept : super(d, idx) {}
 
     public:
-        iterator(const const_iterator&& other) noexcept {
+        explicit iterator(const_iterator&& other) noexcept {
             if (other.is_end()) {
                 super::_idx = super::npos;
                 super::_tree = const_cast<tree *>(other._tree);

--- a/utils/double-decker.hh
+++ b/utils/double-decker.hh
@@ -98,7 +98,7 @@ public:
         friend class double_decker;
         using super = iterator_base<false>;
 
-        iterator(const const_iterator&& other) noexcept : super(std::move(other._bucket), other._idx) {}
+        explicit iterator(const_iterator&& other) noexcept : super(outer_iterator(std::move(other._bucket)), other._idx) {}
 
     public:
         iterator() noexcept : super() {}


### PR DESCRIPTION
The tree code have const and non-const overloads for searching methods like find(), lower_bound(), etc. Not to implement them twice, it's coded like

   const_iterator find() const {
       ... // the implementation itself
   }

   iterator find() {
       return iterator(const_cast<const *>(this)->find());
   }

i.e. -- const overload is called, and returned by it const_iterator is converted into a non-const iterator. For that the latter has dedicated constructor with two inaccuracies: it's not marked as explicit and it accepts const rvalue reference.

This patch fixes both.

Although this disables implicit const -> non-const conversion of iterators, the constructor in question is public, which still opens a way for conversion (without const_cast<>). This constructor is better be marked private, but there's double_decker class that uses bptree and exploits the same hacks in its finding methods, so it needs this constructor to be callable. Alas.