### PR TITLE
cql3: result_set: Initialize result_generator::_stats to prevent unde…

### DIFF
--- a/cql3/result_generator.hh
+++ b/cql3/result_generator.hh
@@ -20,7 +20,7 @@ class result_generator {
     foreign_ptr<lw_shared_ptr<query::result>> _result;
     lw_shared_ptr<const query::read_command> _command;
     shared_ptr<const selection::selection> _selection;
-    cql_stats* _stats;
+    cql_stats* _stats = nullptr;
 private:
     friend class untyped_result_set;
     template<typename Visitor>


### PR DESCRIPTION
…fined behavior

Previously, when result_generator's default constructor was called, the _stats member variable remained uninitialized. This could lead to undefined behavior in release builds where uninitialized values are unpredictable, making issues difficult to debug.

This change initializes the pointer to nullptr, ensuring consistent behavior across all build types and preventing potential memory-related bugs.

---

it's a cleanup, hence no need to backport.