### PR TITLE
tablets: Make load balancing capacity-aware

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -543,6 +543,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The directory where the schema commit log is stored. This is a special commitlog instance used for schema and system tables. For optimal write performance, it is recommended the commit log be on a separate disk partition (ideally, a separate physical device) from the data file directories.")
     , data_file_directories(this, "data_file_directories", "datadir", value_status::Used, { },
         "The directory location where table data (SSTables) is stored.")
+    , data_file_capacity(this, "data_file_capacity", liveness::LiveUpdate, value_status::Used, 0,
+        "Total capacity in bytes for storing data files. Used by tablet load balancer to compute storage utilization."
+        " If not set, will use file system's capacity.")
     , hints_directory(this, "hints_directory", value_status::Used, "",
         "The directory where hints files are stored if hinted handoff is enabled.")
     , view_hints_directory(this, "view_hints_directory", value_status::Used, "",

--- a/db/config.hh
+++ b/db/config.hh
@@ -191,6 +191,7 @@ public:
     named_value<sstring> commitlog_directory;
     named_value<sstring> schema_commitlog_directory;
     named_value<string_list> data_file_directories;
+    named_value<uint64_t> data_file_capacity;
     named_value<sstring> hints_directory;
     named_value<sstring> view_hints_directory;
     named_value<sstring> saved_caches_directory;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -164,6 +164,7 @@ public:
     gms::feature file_stream { *this, "FILE_STREAM"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
     gms::feature tablet_options { *this, "TABLET_OPTIONS"sv };
+    gms::feature tablet_load_stats_v2 { *this, "TABLET_LOAD_STATS_V2"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -24,8 +24,13 @@ struct table_load_stats final {
     int64_t split_ready_seq_number;
 };
 
-struct load_stats final {
+struct load_stats_v1 final {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
+};
+
+struct load_stats {
+    std::unordered_map<::table_id, locator::table_load_stats> tables;
+    std::unordered_map<locator::host_id, uint64_t> capacity;
 };
 
 }
@@ -69,6 +74,7 @@ verb raft_topology_cmd (raft::server_id dst_id, raft::term_t term, uint64_t cmd_
 verb [[cancellable]] raft_pull_snapshot (raft::server_id dst_id, service::raft_snapshot_pull_params) -> service::raft_snapshot;
 verb [[cancellable]] tablet_stream_data (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tablet_id);
+verb [[cancellable]] table_load_stats_v1 (raft::server_id dst_id) -> locator::load_stats_v1;
 verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
 verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id) -> service::tablet_operation_repair_result;
 }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -236,6 +236,19 @@ public:
         }
         return minmax;
     }
+
+    // Returns nullopt if capacity is not known.
+    std::optional<double> get_allocated_utilization(host_id node, const locator::load_stats& stats, uint64_t target_tablet_size) const {
+        if (!_nodes.contains(node)) {
+            return std::nullopt;
+        }
+        auto& n = _nodes.at(node);
+        if (!stats.capacity.contains(node)) {
+            return std::nullopt;
+        }
+        auto capacity = stats.capacity.at(node);
+        return capacity > 0 ? double(n.load() * target_tablet_size) / capacity : 0;
+    }
 };
 
 } // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -662,9 +662,16 @@ table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexce
     return *this;
 }
 
+load_stats load_stats::from_v1(load_stats_v1&& stats) {
+    return { .tables = std::move(stats.tables) };
+}
+
 load_stats& load_stats::operator+=(const load_stats& s) {
     for (auto& [id, stats] : s.tables) {
         tables[id] += stats;
+    }
+    for (auto& [host, cap] : s.capacity) {
+        capacity[host] = cap;
     }
     return *this;
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -372,14 +372,26 @@ struct table_load_stats {
     }
 };
 
+// Deprecated, use load_stats instead.
+struct load_stats_v1 {
+    std::unordered_map<table_id, table_load_stats> tables;
+};
+
 struct load_stats {
     std::unordered_map<table_id, table_load_stats> tables;
+
+    // Capacity in bytes for data file storage.
+    std::unordered_map<host_id, uint64_t> capacity;
+
+    static load_stats from_v1(load_stats_v1&&);
 
     load_stats& operator+=(const load_stats& s);
     friend load_stats operator+(load_stats a, const load_stats& b) {
         return a += b;
     }
 };
+
+using load_stats_v2 = load_stats;
 
 struct repair_scheduler_config {
     bool auto_repair_enabled = false;

--- a/main.cc
+++ b/main.cc
@@ -24,6 +24,7 @@
 #include "tasks/task_manager.hh"
 #include "utils/assert.hh"
 #include "utils/build_id.hh"
+#include "utils/only_on_shard0.hh"
 #include "supervisor.hh"
 #include "replica/database.hh"
 #include <seastar/core/reactor.hh>
@@ -1745,7 +1746,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
                 std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller),
                 std::ref(tsm), std::ref(task_manager), std::ref(gossip_address_map),
-                compression_dict_updated_callback
+                compression_dict_updated_callback,
+                only_on_shard0(&*disk_space_monitor_shard0)
             ).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {

--- a/main.cc
+++ b/main.cc
@@ -1187,6 +1187,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 .normal_polling_interval = cfg->disk_space_monitor_normal_polling_interval_in_seconds,
                 .high_polling_interval = cfg->disk_space_monitor_high_polling_interval_in_seconds,
                 .polling_interval_threshold = cfg->disk_space_monitor_polling_interval_threshold,
+                .capacity_override = cfg->data_file_capacity
             };
             if (data_dir_set.get_paths().empty()) {
                 throw std::runtime_error("data_dir_set must be non-empty");

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -690,6 +690,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
     case messaging_verb::TABLET_REPAIR:
+    case messaging_verb::TABLE_LOAD_STATS_V1:
     case messaging_verb::TABLE_LOAD_STATS:
         return 1;
     case messaging_verb::CLIENT_ID:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -197,12 +197,13 @@ enum class messaging_verb : int32_t {
     JOIN_NODE_RESPONSE = 69,
     TABLET_STREAM_FILES = 70,
     STREAM_BLOB = 71,
-    TABLE_LOAD_STATS = 72,
+    TABLE_LOAD_STATS_V1 = 72,
     JOIN_NODE_QUERY = 73,
     TASKS_GET_CHILDREN = 74,
     TABLET_REPAIR = 75,
     TRUNCATE_WITH_TABLETS = 76,
-    LAST = 77,
+    TABLE_LOAD_STATS = 77,
+    LAST = 78,
 };
 
 } // namespace netw

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -10,6 +10,7 @@
  */
 
 #include "storage_service.hh"
+#include "utils/disk_space_monitor.hh"
 #include "compaction/task_manager_module.hh"
 #include "gc_clock.hh"
 #include "raft/raft.hh"
@@ -183,7 +184,8 @@ storage_service::storage_service(abort_source& abort_source,
     topology_state_machine& topology_state_machine,
     tasks::task_manager& tm,
     gms::gossip_address_map& address_map,
-    std::function<future<void>()> compression_dictionary_updated_callback
+    std::function<future<void>()> compression_dictionary_updated_callback,
+    utils::disk_space_monitor* disk_space_monitor
     )
         : _abort_source(abort_source)
         , _feature_service(feature_service)
@@ -217,6 +219,7 @@ storage_service::storage_service(abort_source& abort_source,
         , _view_builder(view_builder)
         , _topology_state_machine(topology_state_machine)
         , _compression_dictionary_updated_callback(std::move(compression_dictionary_updated_callback))
+        , _disk_space_monitor(disk_space_monitor)
 {
     tm.register_module(_node_ops_module->get_name(), _node_ops_module);
     tm.register_module(_tablets_module->get_name(), _tablets_module);
@@ -6621,6 +6624,9 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
         co_return std::move(load_stats);
     }, locator::load_stats{}, std::plus<locator::load_stats>());
 
+    auto this_host = _db.local().get_token_metadata().get_my_id();
+    load_stats.capacity[this_host] = _disk_space_monitor->space().capacity;
+
     co_return std::move(load_stats);
 }
 
@@ -7184,6 +7190,13 @@ void storage_service::init_messaging_service() {
     ser::storage_service_rpc_verbs::register_table_load_stats(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id) {
         return handle_raft_rpc(dst_id, [] (auto& ss) mutable {
             return ss.load_stats_for_tablet_based_tables();
+        });
+    });
+    ser::storage_service_rpc_verbs::register_table_load_stats_v1(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id) {
+        return handle_raft_rpc(dst_id, [] (auto& ss) mutable {
+            return ss.load_stats_for_tablet_based_tables().then([] (auto stats) {
+                return locator::load_stats_v1{ .tables = std::move(stats.tables) };
+            });
         });
     });
     ser::join_node_rpc_verbs::register_join_node_request(&_messaging.local(), [handle_raft_rpc] (raft::server_id dst_id, service::join_node_request_params params) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -105,6 +105,10 @@ namespace tasks {
 class task_manager;
 }
 
+namespace utils {
+class disk_space_monitor;
+}
+
 namespace service {
 
 class storage_service;
@@ -238,7 +242,8 @@ public:
         topology_state_machine& topology_state_machine,
         tasks::task_manager& tm,
         gms::gossip_address_map& address_map,
-        std::function<future<void>()> compression_dictionary_updated_callback);
+        std::function<future<void>()> compression_dictionary_updated_callback,
+        utils::disk_space_monitor* disk_space_minitor);
     ~storage_service();
 
     node_ops::task_manager_module& get_node_ops_module() noexcept;
@@ -993,6 +998,8 @@ private:
     abort_source _group0_as;
 
     std::function<future<void>()> _compression_dictionary_updated_callback;
+
+    utils::disk_space_monitor* _disk_space_monitor; // != nullptr only on shard0.
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -346,8 +346,10 @@ class load_balancer {
     using global_shard_id = tablet_replica;
     using shard_id = seastar::shard_id;
 
-    // Represents metric for per-node load which we want to equalize between nodes.
-    // It's an average per-shard load in terms of tablet count.
+    // Represents metric for load which we want to equalize between shards or nodes.
+    // Load balancer equalizes storage utilization.
+    // It is assumed that each tablet has equal size and that shards and nodes can have different capacity.
+    // So we equalize: tablet_count * target_tablet_size / capacity_in_bytes.
     using load_type = double;
 
     using table_candidates_map = std::unordered_map<table_id, std::unordered_set<migration_tablet_set>>;
@@ -403,10 +405,12 @@ class load_balancer {
         host_id id;
         uint64_t shard_count = 0;
         uint64_t tablet_count = 0;
+        std::optional<uint64_t> capacity; // Invariant: bool(capacity) || drained.
         bool drained = false;
         const locator::node* node; // never nullptr
 
         // The average shard load on this node.
+        // Valid only when "capacity" is set.
         load_type avg_load = 0;
 
         absl::flat_hash_map<table_id, size_t> tablet_count_per_table;
@@ -418,6 +422,12 @@ class load_balancer {
         std::vector<shard_load> shards; // Indexed by shard_id to which a given shard_load corresponds.
 
         utils::chunked_vector<skipped_candidate> skipped_candidates;
+
+        std::optional<double> capacity_per_shard() const {
+            return capacity.transform([&] (auto cap) {
+                return double(cap) / shard_count;
+            });
+        }
 
         const sstring& dc() const {
             return node->dc_rack().dc;
@@ -431,13 +441,38 @@ class load_balancer {
             return node->get_state();
         }
 
-        // Call when tablet_count changes.
-        void update() {
-            avg_load = get_avg_load(tablet_count);
+        // Call when tablet_count or capacity changes.
+        void update(uint64_t target_tablet_size) {
+            if (auto load = get_avg_load(tablet_count, target_tablet_size)) {
+                avg_load = *load;
+            }
         }
 
-        load_type get_avg_load(uint64_t tablets) const {
+        // Result engaged when !drained.
+        std::optional<load_type> get_avg_load(uint64_t tablets, uint64_t target_tablet_size) const {
+            return capacity.transform([&] (auto capacity) {
+                return load_type(tablets * target_tablet_size) / capacity;
+            });
+        }
+
+        double tablets_per_shard(uint64_t tablets) const {
             return double(tablets) / shard_count;
+        }
+
+        double tablets_per_shard() const {
+            return tablets_per_shard(tablet_count);
+        }
+
+        // Result engaged for !drained nodes.
+        std::optional<load_type> shard_load(shard_id shard, uint64_t target_tablet_size) const {
+            return shard_load(shard, shards[shard].tablet_count, target_tablet_size);
+        }
+
+        // Result engaged for !drained nodes.
+        std::optional<load_type> shard_load(shard_id shard, uint64_t shard_tablet_count, uint64_t target_tablet_size) const {
+            return capacity_per_shard().transform([&] (auto cap_per_shard) {
+                return load_type(shard_tablet_count * target_tablet_size) / cap_per_shard;
+            });
         }
 
         auto shards_by_load_cmp() {
@@ -589,10 +624,12 @@ class load_balancer {
     replica::database& _db;
     token_metadata_ptr _tm;
     std::optional<locator::load_sketch> _load_sketch;
+    // Holds tablet replica count per table in the balanced node set (within a single DC).
     absl::flat_hash_map<table_id, size_t> _tablet_count_per_table;
     dc_name _dc;
     size_t _total_capacity_shards; // Total number of non-drained shards in the balanced node set.
     size_t _total_capacity_nodes; // Total number of non-drained nodes in the balanced node set.
+    uint64_t _total_capacity_storage; // Total storage of non-drained nodes in the balanced node set.
     locator::load_stats_ptr _table_load_stats;
     load_balancer_stats_manager& _stats;
     std::unordered_set<host_id> _skiplist;
@@ -1542,26 +1579,31 @@ public:
         _stats.for_dc(_dc).candidates_evaluated++;
 
         auto& node_info = nodes[dst.host];
-        size_t total_load = _tablet_count_per_table[table];
-        size_t total_shard_count = _total_capacity_shards;
 
-        // Load per shard in a perfectly balanced state.
-        // Assumes each shard has same capacity.
-        double desired_load_per_shard = double(total_load) / total_shard_count;
+        // Size of all tablet replicas of the table in bytes.
+        uint64_t table_size = _tablet_count_per_table[table] * _target_tablet_size;
+
+        if (node_info.drained) {
+            // Moving a tablet to a drained node is always bad.
+            // We may not have capacity information for the drained node, so we can't evaluate exact badness.
+            return migration_badness{0, 0, table_size, table_size};
+        }
+
+        double ideal_table_load = double(table_size) / _total_capacity_storage;
 
         // max number of tablets per shard to keep perfect distribution.
-        // Rounded up because we don't want to consider movement which is within the best possible
-        // per-shard distribution as bad.
-        double shard_balance_threshold = std::ceil(desired_load_per_shard);
-        auto new_shard_load = node_info.shards[dst.shard].tablet_count_per_table[table] + 1;
-        auto dst_shard_badness = (new_shard_load - shard_balance_threshold) / total_load;
+        double shard_balance_threshold = ideal_table_load;
+        auto new_tablet_count_per_shard = node_info.shards[dst.shard].tablet_count_per_table[table] + 1;
+        auto new_shard_load = *node_info.shard_load(dst.shard, new_tablet_count_per_shard, _target_tablet_size);
+        auto dst_shard_badness = (new_shard_load - shard_balance_threshold) / table_size;
         lblogger.trace("Table {} @{} shard balance threshold: {}, dst: {} ({:.4f})", table, dst,
                        shard_balance_threshold, new_shard_load, dst_shard_badness);
 
         // max number of tablets per node to keep perfect distribution.
-        double node_balance_threshold = std::ceil(desired_load_per_shard * node_info.shard_count);
-        size_t new_node_load = node_info.tablet_count_per_table[table] + 1;
-        auto dst_node_badness = (new_node_load - node_balance_threshold) / total_load;
+        double node_balance_threshold = ideal_table_load;
+        size_t new_tablet_count_per_node = node_info.tablet_count_per_table[table] + 1;
+        load_type new_node_load = *node_info.get_avg_load(new_tablet_count_per_node, _target_tablet_size);
+        auto dst_node_badness = (new_node_load - node_balance_threshold) / table_size;
         lblogger.trace("Table {} @{} node balance threshold: {}, dst: {} ({:.4f})", table, dst,
                        node_balance_threshold, new_node_load, dst_node_badness);
 
@@ -1573,33 +1615,29 @@ public:
         _stats.for_dc(_dc).candidates_evaluated++;
 
         auto& node_info = nodes[src.host];
-        size_t total_load = _tablet_count_per_table[table];
-        size_t total_shard_count = _total_capacity_shards;
 
-        // Load per shard in a perfectly balanced state.
-        // Assumes each shard has same capacity.
-        double desired_load_per_shard = double(total_load) / total_shard_count;
+        // Size of all tablet replicas of the table in bytes.
+        uint64_t table_size = _tablet_count_per_table[table] * _target_tablet_size;
 
-        // For determining impact on leaving, round down, because we don't want to consider movement which is within
-        // the best possible per-shard distribution as bad.
-        double leaving_shard_balance_threshold = std::floor(desired_load_per_shard);
-        auto new_shard_load = node_info.shards[src.shard].tablet_count_per_table[table] - 1;
+        if (node_info.drained) {
+            // Moving a tablet away from a drained node is always good.
+            return migration_badness{-1, -1, 0, 0};
+        }
 
-        auto src_shard_badness = node_info.drained
-                ? 0 // Moving a tablet away from a drained node is always good.
-                : (leaving_shard_balance_threshold - new_shard_load) / total_load;
+        double ideal_table_load = double(table_size) / _total_capacity_storage;
 
+        double leaving_shard_balance_threshold = ideal_table_load;
+        auto new_tablet_count_per_shard = node_info.shards[src.shard].tablet_count_per_table[table] - 1;
+        auto new_shard_load = *node_info.shard_load(src.shard, new_tablet_count_per_shard, _target_tablet_size);
+        auto src_shard_badness = (leaving_shard_balance_threshold - new_shard_load) / table_size;
         lblogger.trace("Table {} @{} shard balance threshold: {}, src: {} ({:.4f})", table, src,
                        leaving_shard_balance_threshold, new_shard_load, src_shard_badness);
 
         // max number of tablets per node to keep perfect distribution.
-        double leaving_node_balance_threshold = std::floor(desired_load_per_shard * node_info.shard_count);
-        size_t new_node_load = node_info.tablet_count_per_table[table] - 1;
-
-        auto src_node_badness = node_info.drained
-                ? 0 // Moving a tablet away from a drained node is always good.
-                : (leaving_node_balance_threshold - new_node_load) / total_load;
-
+        double leaving_node_balance_threshold = ideal_table_load;
+        size_t new_tablet_count_per_node = node_info.tablet_count_per_table[table] - 1;
+        auto new_node_load = *node_info.get_avg_load(new_tablet_count_per_node, _target_tablet_size);
+        auto src_node_badness = (leaving_node_balance_threshold - new_node_load) / table_size;
         lblogger.trace("Table {} @{} node balance threshold: {}, src: {} ({:.4f})", table, src,
                        leaving_node_balance_threshold, new_node_load, src_node_badness);
 
@@ -1714,6 +1752,13 @@ public:
     // so convergence is reached where the node we picked as source has lower load, or will have lower
     // load post-movement, than the node we picked as the destination.
     bool check_convergence(node_load& src_info, node_load& dst_info, unsigned delta = 1) {
+        if (src_info.drained) {
+            return true;
+        }
+        if (dst_info.drained) {
+            return false;
+        }
+
         // Allow migrating only from candidate nodes which have higher load than the target.
         if (src_info.avg_load <= dst_info.avg_load) {
             lblogger.trace("Load inversion: src={} (avg_load={}), dst={} (avg_load={})",
@@ -1722,8 +1767,8 @@ public:
         }
 
         // Prevent load inversion post-movement which can lead to oscillations.
-        if (src_info.get_avg_load(src_info.tablet_count - delta) <
-            dst_info.get_avg_load(dst_info.tablet_count + delta)) {
+        if (*src_info.get_avg_load(src_info.tablet_count - delta, _target_tablet_size) <
+            *dst_info.get_avg_load(dst_info.tablet_count + delta, _target_tablet_size)) {
             lblogger.trace("Load inversion post-movement: src={} (avg_load={}), dst={} (avg_load={})",
                            src_info.id, src_info.avg_load, dst_info.id, dst_info.avg_load);
             return false;
@@ -1738,12 +1783,16 @@ public:
 
     // Checks whether moving a tablet from shard A to B (intra-node) would go against convergence.
     // Returns false if the tablet should not be moved, and true if it may be moved.
-    bool check_convergence(const shard_load& src_info, const shard_load& dst_info, unsigned delta = 1) {
-        return src_info.tablet_count > dst_info.tablet_count + delta;
+    // Can be called when node_info.drained.
+    bool check_intranode_convergence(const node_load& node_info, shard_id src_shard, shard_id dst_shard,
+                                     unsigned delta = 1) {
+        return node_info.shards[src_shard].tablet_count > node_info.shards[dst_shard].tablet_count + delta;
     }
 
-    bool check_convergence(const shard_load& src_info, const shard_load& dst_info, const migration_tablet_set& tablet_set) {
-        return check_convergence(src_info, dst_info, tablet_set.tablets().size());
+    // Can be called when node_info.drained.
+    bool check_intranode_convergence(const node_load& node_info, shard_id src_shard, shard_id dst_shard,
+                                    const migration_tablet_set& tablet_set) {
+        return check_intranode_convergence(node_info, src_shard, dst_shard, tablet_set.tablets().size());
     }
 
     // Adjusts the load of the source and destination shards in the host where intra-node migration happens.
@@ -1764,7 +1813,7 @@ public:
             target_info.shards[dst.shard].tablet_count_per_table[source_tablet.table]++;
             target_info.tablet_count_per_table[source_tablet.table]++;
             target_info.tablet_count += 1;
-            target_info.update();
+            target_info.update(_target_tablet_size);
         }
 
         auto& src_node_info = nodes[src.host];
@@ -1774,7 +1823,7 @@ public:
         src_node_info.tablet_count_per_table[source_tablet.table]--;
 
         src_node_info.tablet_count -= 1;
-        src_node_info.update();
+        src_node_info.update(_target_tablet_size);
     }
 
     void update_node_load_on_migration(node_load& node_load, host_id host, shard_id src, shard_id dst, const migration_tablet_set& tablet_set) {
@@ -1857,12 +1906,11 @@ public:
             });
 
             auto& src_info = node_load.shards[src];
-            auto& dst_info = node_load.shards[dst];
 
             // Convergence check
 
             // When in shuffle mode, exit condition is guaranteed by running out of candidates or by load limit.
-            if (!shuffle && (src == dst || !check_convergence(src_info, dst_info))) {
+            if (!shuffle && (src == dst || !check_intranode_convergence(node_load, src, dst))) {
                 lblogger.debug("Node {} is balanced", host);
                 break;
             }
@@ -1879,7 +1927,7 @@ public:
             auto tablets = candidate.tablets;
 
             // Recheck convergence to avoid oscillations if co-located tablets are being migrated together.
-            if (!shuffle && (src == dst || !check_convergence(src_info, dst_info, tablets))) {
+            if (!shuffle && (src == dst || !check_intranode_convergence(node_load, src, dst, tablets))) {
                 lblogger.debug("Node {} is balanced", host);
                 break;
             }
@@ -2138,7 +2186,7 @@ public:
                 auto& new_target_info = nodes[new_target];
 
                 // Skip movements which may harm convergence.
-                if (!src_node_info.drained && !check_convergence(src_node_info, new_target_info, tablets)) {
+                if (!check_convergence(src_node_info, new_target_info, tablets)) {
                     continue;
                 }
 
@@ -2281,20 +2329,21 @@ public:
     }
 
     future<> log_table_load(node_load_map& nodes, table_id table) {
-        size_t total_load = 0;
+        load_type total_load = 0;
         size_t shard_count = 0;
-        size_t max_shard_load = 0;
+        load_type max_shard_load = 0;
 
         for (auto&& [host, node] : nodes) {
             if (node.drained) {
                 continue;
             }
             shard_count += node.shard_count;
-            size_t this_node_max_shard_load = 0;
-            size_t node_load = 0;
+            load_type this_node_max_shard_load = 0;
+            load_type node_load = 0;
             for (shard_id shard = 0; shard < node.shard_count; shard++) {
                 co_await coroutine::maybe_yield();
-                auto load = node.shards[shard].tablet_count_per_table[table];
+                load_type load = double(node.shards[shard].tablet_count_per_table[table]) * _target_tablet_size
+                        / *node.capacity_per_shard();
                 total_load += load;
                 node_load += load;
                 max_shard_load = std::max(max_shard_load, load);
@@ -2336,8 +2385,9 @@ public:
             if (lblogger.is_enabled(seastar::log_level::debug)) {
                 shard_id shard = 0;
                 for (auto&& shard_load : node_load.shards) {
-                    lblogger.debug("shard {}: all tablets: {}, candidates: {}, tables: {}", tablet_replica {host, shard},
-                                   shard_load.tablet_count, shard_load.candidate_count(), shard_load.tablet_count_per_table);
+                    lblogger.debug("shard {}: load: {}, tablets: {}, candidates: {}, tables: {}", tablet_replica {host, shard},
+                                   node_load.shard_load(shard, _target_tablet_size), shard_load.tablet_count,
+                                   shard_load.candidate_count(), shard_load.tablet_count_per_table);
                     shard++;
                 }
             }
@@ -2480,13 +2530,16 @@ public:
             // Pick best target shard.
 
             auto dst = global_shard_id {target, _load_sketch->get_least_loaded_shard(target)};
-            lblogger.trace("target shard: {}, load={}", dst.shard, target_info.shards[dst.shard].tablet_count);
+            lblogger.trace("target shard: {}, tablets={}, load={}", dst.shard,
+                           target_info.shards[dst.shard].tablet_count,
+                           target_info.shard_load(dst.shard, _target_tablet_size));
 
             if (lblogger.is_enabled(seastar::log_level::trace)) {
                 shard_id shard = 0;
                 for (auto&& shard_load : target_info.shards) {
-                    lblogger.trace("shard {}: all tablets: {}, candidates: {}, tables: {}", tablet_replica {dst.host, shard},
-                                   shard_load.tablet_count, shard_load.candidate_count(), shard_load.tablet_count_per_table);
+                    lblogger.trace("shard {}: load: {}, tablets: {}, candidates: {}, tables: {}", tablet_replica{dst.host, shard},
+                                   target_info.shard_load(shard, _target_tablet_size), shard_load.tablet_count,
+                                   shard_load.candidate_count(), shard_load.tablet_count_per_table);
                     shard++;
                 }
             }
@@ -2691,6 +2744,12 @@ public:
             if (!load.shard_count) {
                 throw std::runtime_error(format("Shard count of {} not found in topology", host));
             }
+            if (!_db.features().tablet_load_stats_v2) {
+                // This way load calculation will hold tablet count.
+                load.capacity = _target_tablet_size * load.shard_count;
+            } else if (_table_load_stats && _table_load_stats->capacity.contains(host)) {
+                load.capacity = _table_load_stats->capacity.at(host);
+            }
         };
 
         _tm->for_each_token_owner([&] (const locator::node& node) {
@@ -2785,15 +2844,27 @@ public:
 
         plan.set_has_nodes_to_drain(!nodes_to_drain.empty());
 
+        // Invariant: node.capacity || node.drained
+        for (auto& [host, node] : nodes) {
+            if (node.drained) {
+                continue;
+            }
+            if (!node.capacity) {
+                lblogger.info("Cannot balance because capacity of node {} (or more) is unknown", host);
+                co_return plan;
+            }
+        }
+
         // Compute load imbalance.
 
         _total_capacity_shards = 0;
         _total_capacity_nodes = 0;
+        _total_capacity_storage = 0;
         load_type max_load = 0;
         load_type min_load = 0;
         std::optional<host_id> min_load_node = std::nullopt;
         for (auto&& [host, load] : nodes) {
-            load.update();
+            load.update(_target_tablet_size);
             _stats.for_node(dc, host).load = load.avg_load;
 
             if (!load.drained) {
@@ -2806,6 +2877,7 @@ public:
                 }
                 _total_capacity_shards += load.shard_count;
                 _total_capacity_nodes++;
+                _total_capacity_storage += *load.capacity;
             }
         }
 
@@ -2817,8 +2889,10 @@ public:
                 write += shard_load.streaming_write_load;
             }
             auto level = (read + write) > 0 ? seastar::log_level::info : seastar::log_level::debug;
-            lblogger.log(level, "Node {}: dc={} rack={} avg_load={} tablets={} shards={} state={} stream_read={} stream_write={}",
-                          host, dc, load.rack(), load.avg_load, load.tablet_count, load.shard_count, load.state(), read, write);
+            lblogger.log(level, "Node {}: dc={} rack={} load={} tablets={} shards={} tablets/shard={} state={} cap={}"
+                                " stream_read={} stream_write={}",
+                         host, dc, load.rack(), load.avg_load, load.tablet_count, load.shard_count,
+                         load.tablets_per_shard(), load.state(), load.capacity, read, write);
         }
 
         if (!min_load_node) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2284,6 +2284,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     muts.emplace_back(rtbuilder.build());
                     co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
                                                    "bootstrap: read fence completed");
+                    // Make sure the load balancer knows the capacity for the new node immediately.
+                    (void)_tablet_load_stats_refresh.trigger().handle_exception([] (auto ep) {
+                        rtlogger.warn("Error during tablet load stats refresh: {}", ep);
+                    });
                     }
                     break;
                 case node_state::removing: {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2912,7 +2912,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     auto tm = get_token_metadata_ptr();
     auto plan = co_await _tablet_allocator.balance_tablets(tm, _tablet_load_stats, get_dead_nodes());
     if (plan.empty()) {
-        rtlogger.debug("Tablets are balanced");
+        rtlogger.debug("Tablet load balancer did not make any plan");
         co_return false;
     }
 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -51,6 +51,7 @@
 #include "db/system_keyspace.hh"
 #include "db/view/view_builder.hh"
 #include "replica/mutation_dump.hh"
+#include "utils/disk_space_monitor.hh"
 
 using namespace std::chrono_literals;
 using namespace sstables;
@@ -1610,6 +1611,56 @@ SEASTAR_TEST_CASE(mutation_dump_generated_schema_deterministic_id_version) {
     BOOST_REQUIRE_EQUAL(os1->version(), os2->version());
 
     return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_disk_space_monitor_capacity_override) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        utils::disk_space_monitor& monitor = e.disk_space_monitor();
+        std::filesystem::space_info orig_space = {
+            .capacity = 100,
+            .free = 12,
+            .available = 11,
+        };
+        monitor.set_space_source([&] { return make_ready_future<std::filesystem::space_info>(orig_space); });
+
+        utils::phased_barrier poll_barrier; // new operation started whenever monitor calls listeners.
+        auto op = poll_barrier.start();
+        auto listener_registration = monitor.listen([&] (auto& mon) mutable {
+            op = poll_barrier.start();
+            return make_ready_future<>();
+        });
+
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE(monitor.space() == orig_space);
+
+        e.db_config().data_file_capacity(90);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 90);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 1);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 2);
+
+        e.db_config().data_file_capacity(10);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 10);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 0);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 0);
+
+        e.db_config().data_file_capacity(1000);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 1000);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 911);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 912);
+
+        e.db_config().data_file_capacity(0);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE(monitor.space() == orig_space);
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -49,22 +49,6 @@ using namespace locator;
 using namespace replica;
 using namespace service;
 
-struct shared_load_stats {
-    locator::load_stats stats;
-
-    locator::load_stats_ptr get() {
-        return make_lw_shared(stats);
-    }
-
-    void set_size(table_id table, size_t size_in_bytes) {
-        stats.tables[table].size_in_bytes = size_in_bytes;
-    }
-
-    void set_split_ready_seq_number(table_id table, size_t seq_number) {
-        stats.tables[table].split_ready_seq_number = seq_number;
-    }
-};
-
 static api::timestamp_type current_timestamp(cql_test_env& e) {
     // Mutations in system.tablets got there via group0, so in order for new
     // mutations to take effect, their timestamp should be "later" than that
@@ -1546,6 +1530,15 @@ void rebalance_tablets(cql_test_env& e,
     auto guard = e.get_raft_group0_client().start_operation(as).get();
     testlog.debug("rebalance_tablets(): took group0 guard");
 
+    shared_load_stats local_stats;
+    if (!load_stats) {
+        // Provide default capacity for each node.
+        e.shared_token_metadata().local().get()->get_topology().for_each_node([&] (const auto& node) {
+            local_stats.set_capacity(node.host_id(), default_target_tablet_size * node.get_shard_count());
+        });
+        load_stats = &local_stats;
+    }
+
     do_rebalance_tablets(e, guard, load_stats, std::move(skiplist), std::move(stop), auto_split);
     testlog.debug("rebalance_tablets(): rebalanced");
 
@@ -1560,9 +1553,9 @@ void rebalance_tablets(cql_test_env& e,
 }
 
 static
-void rebalance_tablets_as_in_progress(tablet_allocator& talloc, shared_token_metadata& stm) {
+void rebalance_tablets_as_in_progress(tablet_allocator& talloc, shared_token_metadata& stm, shared_load_stats& stats) {
     while (true) {
-        auto plan = talloc.balance_tablets(stm.get()).get();
+        auto plan = talloc.balance_tablets(stm.get(), stats.get()).get();
         if (plan.empty()) {
             break;
         }
@@ -1733,7 +1726,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
     }
 
-    rebalance_tablets(e, {}, {host3});
+    rebalance_tablets(e, &topo.get_shared_load_stats(), {host3});
 
     {
         load_sketch load(stm.get());
@@ -2093,7 +2086,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
     auto guard = e.get_raft_group0_client().start_operation(as).get();
     auto& stm = e.shared_token_metadata().local();
 
-    rebalance_tablets_as_in_progress(e.get_tablet_allocator().local(), stm);
+    rebalance_tablets_as_in_progress(e.get_tablet_allocator().local(), stm, topo.get_shared_load_stats());
     execute_transitions(stm);
 
     {
@@ -2139,17 +2132,17 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
         co_return;
     });
 
-    rebalance_tablets(e);
+    rebalance_tablets(e, &topo.get_shared_load_stats());
 
     auto& stm = e.shared_token_metadata().local();
-    BOOST_REQUIRE(e.get_tablet_allocator().local().balance_tablets(stm.get()).get().empty());
+    BOOST_REQUIRE(e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get().empty());
 
     utils::get_local_injector().enable("tablet_allocator_shuffle");
     auto disable_injection = seastar::defer([&] {
         utils::get_local_injector().disable("tablet_allocator_shuffle");
     });
 
-    BOOST_REQUIRE(!e.get_tablet_allocator().local().balance_tablets(stm.get()).get().empty());
+    BOOST_REQUIRE(!e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get().empty());
   }).get();
 }
 #endif
@@ -2226,7 +2219,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
             return !plan.has_nodes_to_drain();
         };
 
-        rebalance_tablets(e, {}, {}, until_nodes_drained);
+        rebalance_tablets(e, &topo.get_shared_load_stats(), {}, until_nodes_drained);
 
         auto& stm = e.shared_token_metadata().local();
 
@@ -2272,7 +2265,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         });
 
         {
-            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
             BOOST_REQUIRE(!plan.empty());
         }
 
@@ -2283,7 +2276,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         }).get();
 
         {
-            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
             BOOST_REQUIRE(plan.empty());
         }
 
@@ -2293,7 +2286,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         }).get();
 
         {
-            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
             BOOST_REQUIRE(plan.empty());
         }
 
@@ -2304,7 +2297,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         }).get();
 
         {
-            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
             BOOST_REQUIRE(!plan.empty());
         }
 
@@ -2314,7 +2307,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         }).get();
 
         {
-            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+            auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
             BOOST_REQUIRE(!plan.empty());
         }
   }).get();
@@ -2346,7 +2339,7 @@ SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
             co_return;
         });
 
-        migration_plan plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
+        migration_plan plan = e.get_tablet_allocator().local().balance_tablets(stm.get(), topo.get_load_stats()).get();
         BOOST_REQUIRE(plan.has_nodes_to_drain());
         for (auto&& mig : plan.migrations()) {
             BOOST_REQUIRE(mig.kind != tablet_transition_kind::intranode_migration);
@@ -2376,7 +2369,7 @@ SEASTAR_THREAD_TEST_CASE(test_plan_fails_when_removing_last_replica) {
         });
 
         std::unordered_set<host_id> skiplist = {host1};
-        BOOST_REQUIRE_THROW(rebalance_tablets(e, {}, skiplist), std::runtime_error);
+        BOOST_REQUIRE_THROW(rebalance_tablets(e, &topo.get_shared_load_stats(), skiplist), std::runtime_error);
     }).get();
 }
 
@@ -2414,7 +2407,7 @@ SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
 
         auto& stm = e.shared_token_metadata().local();
         std::unordered_set<host_id> skiplist = {host2};
-        rebalance_tablets(e, {}, skiplist);
+        rebalance_tablets(e, &topo.get_shared_load_stats(), skiplist);
 
         {
             load_sketch load(stm.get());
@@ -2639,7 +2632,7 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_option_and_config_changes) {
             return tm->tablets().get_tablet_map(table1).tablet_count();
         };
 
-        shared_load_stats load_stats;
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
         load_stats.set_size(table1, 0);
 
         rebalance_tablets(e, &load_stats);
@@ -2707,7 +2700,7 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
 
         auto ks_name1 = add_keyspace(e, {{dc, 1}});
         std::vector<table_id> tables;
-        shared_load_stats load_stats;
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
 
         const auto nr_tables = 100u;
         parallel_for_each(std::views::iota(0u, nr_tables), [&] (auto i) -> future<> {
@@ -2857,7 +2850,7 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
     auto tablet_count = [&] {
         return stm.get()->tablets().get_tablet_map(table1).tablet_count();
     };
-    shared_load_stats load_stats;
+    shared_load_stats& load_stats = topo.get_shared_load_stats();
     auto do_rebalance_tablets = [&] () {
         rebalance_tablets(e, &load_stats);
     };
@@ -3018,7 +3011,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             return stm.get()->tablets().get_tablet_map(table1).resize_decision();
         };
 
-        shared_load_stats load_stats;
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
         auto do_rebalance_tablets = [&] () {
             rebalance_tablets(e, &load_stats, {}, nullptr, false); // no auto-split
         };

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -58,6 +58,7 @@
 #include "db/sstables-format-selector.hh"
 #include "repair/row_level.hh"
 #include "utils/assert.hh"
+#include "utils/only_on_shard0.hh"
 #include "utils/class_registrator.hh"
 #include "utils/cross-shard-barrier.hh"
 #include "streaming/stream_manager.hh"
@@ -903,7 +904,8 @@ private:
                 std::ref(_topology_state_machine),
                 std::ref(_task_manager),
                 std::ref(_gossip_address_map),
-                compression_dict_updated_callback
+                compression_dict_updated_callback,
+                only_on_shard0(&*_disk_space_monitor_shard0)
             ).get();
             auto stop_storage_service = defer_verbose_shutdown("storage service", [this] { _ss.stop().get(); });
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -603,6 +603,7 @@ private:
                 .normal_polling_interval = cfg->disk_space_monitor_normal_polling_interval_in_seconds,
                 .high_polling_interval = cfg->disk_space_monitor_high_polling_interval_in_seconds,
                 .polling_interval_threshold = cfg->disk_space_monitor_polling_interval_threshold,
+                .capacity_override = cfg->data_file_capacity,
             };
             _disk_space_monitor_shard0.emplace(abort_sources.local(), data_dir_path, dsm_cfg);
             _disk_space_monitor_shard0->start().get();
@@ -1152,6 +1153,10 @@ public:
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() override {
         return _sl_controller;
+    }
+
+    utils::disk_space_monitor& disk_space_monitor() override {
+        return *_disk_space_monitor_shard0;
     }
 
     db::config& db_config() override {

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -49,6 +49,10 @@ namespace cql3 {
     class query_processor;
 }
 
+namespace utils {
+class disk_space_monitor;
+}
+
 namespace service {
 
 class client_state;
@@ -194,6 +198,9 @@ public:
     data_dictionary::database data_dictionary();
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;
+
+    // Call only on shard0.
+    virtual utils::disk_space_monitor& disk_space_monitor() = 0;
 
     virtual db::config& db_config() = 0;
 };

--- a/utils/only_on_shard0.hh
+++ b/utils/only_on_shard0.hh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shard_id.hh>
+
+// When passed to sharded<>::start(), translates to "val" passed to sharded instances on shard 0 and T{} on other shards.
+template <typename T>
+auto only_on_shard0(T val) {
+    return sharded_parameter([val] {
+        if (seastar::this_shard_id() == 0) {
+            return val;
+        }
+        return T{};
+    });
+}


### PR DESCRIPTION
Before this patch, the load balancer was equalizing tablet count per
shard, so it achieved balance assuming that:
 1) tablets have the same size
 2) shards have the same capacity

That can cause imbalance of utilization if shards have different
capacity, which can happen in heterogeneous clusters with different
instance types. One of the causes for capacity difference is that
larger instances run with fewer shards due to vCPUs being dedicated to
IRQ handling. This makes those shards have more disk capacity, and
more CPU power.

After this patch, the load balancer equalizes shard's storage
utilization, so it no longer assumes that shards have the same
capacity. It still assumes that each tablet has equal size. So it's a
middle step towards full size-aware balancing.

One consequence is that to be able to balance, the load balancer need
to know about every node's capacity, which is collected with the same
RPC which collects load_stats for average tablet size. This is not a
significant set back because migrations cannot proceed anyway if nodes
are down due to barriers. We could make intra-node migration
scheduling work without capacity information, but it's pointless due
to above, so not implemented.

Also, per-shard goal for tablet count is still the same for all nodes in the cluster,
so nodes with less capacity will be below limit and nodes with more capacity will
be slightly above limit. This shouldn't be a significant problem in practice, we could
compensate for this by increasing the limit.

Refs #23042 
