### PR TITLE
sstables: explicitly call parent's default constructor in copy constr…

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -126,7 +126,8 @@ sstable_set::sstable_set(std::unique_ptr<sstable_set_impl> impl)
 {}
 
 sstable_set::sstable_set(const sstable_set& x)
-        : _impl(x._impl->clone())
+        : enable_lw_shared_from_this<sstable_set>()
+        , _impl(x._impl->clone())
 {}
 
 sstable_set::sstable_set(sstable_set&&) noexcept = default;


### PR DESCRIPTION
…uctor

When implementing the copy constructor for `sstable_set` (derived from `enable_lw_shared_from_this`), we intentionally need the parent's default constructor rather than its copy constructor. This is because each new `sstable_set` instance maintains its own reference count and owns a clone of the source object's implementation (`x._impl->clone()`).

Although this behavior is correct, GCC warns about not calling the parent's copy constructor. This change explicitly calls the parent's default constructor to:

1. Silence GCC warnings
2. Clearly document our intention to use the default constructor
3. Follow best practices for constructor initialization

The functionality remains unchanged, but the code is now more explicit about its design and free of compiler warnings.

---

it's a cleanup, hence no need to backport.