### PR TITLE
github: Skip clang-tidy when not explicitly requested

### DIFF
--- a/.github/workflows/clang-tidy.yaml
+++ b/.github/workflows/clang-tidy.yaml
@@ -34,6 +34,7 @@ jobs:
     name: Run clang-tidy
     needs:
       - read-toolchain
+    if: "${{ needs.read-toolchain.result == 'success' }}"
     runs-on: ubuntu-latest
     container: ${{ needs.read-toolchain.outputs.image }}
     steps:


### PR DESCRIPTION
Previously, the clang-tidy.yaml workflow would cancel the clang-tidy job when a comment wasn't prefixed with "/clang-tidy", instead of skipping it. This cancellation triggered unnecessary email notifications for developers with GitHub action notifications enabled.

This change modifies the workflow to only run clang-tidy when the read-toolchain job succeeds, reducing notification noise by properly skipping the job rather than cancelling it.

---

this change improves developers' experience, hence no need to backport.