### PR TITLE
remove redundant std::move() from position_in_partition::key()

### DIFF
--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -487,7 +487,7 @@ public:
             if (is_static) {
                 _in_progress = mutation_fragment(*_schema, permit(), static_row());
             } else {
-                _in_progress = mutation_fragment(*_schema, permit(), clustering_row(std::move(pos.key())));
+                _in_progress = mutation_fragment(*_schema, permit(), clustering_row(pos.key()));
             }
             if (_out_of_range) {
                 ret = push_ready_fragments_out_of_range();


### PR DESCRIPTION
Fix GCC warning about moving from a const reference in mp_row_consumer_k_l::flush_if_needed. Since position_in_partition::key() returns a const reference, std::move has no effect.

Considered adding an rvalue reference overload (clustering_key_prefix&& key() &&) but since the "me" sstable format is mandatory since 63b266e9, this approach offers no benefit.

This change simply removes the redundant std::move() call to silence the warning and improve code clarity.

---

it's a cleanup, hence no need to backport.