### PR TITLE
querier: demote tombstone warning for range-scans to debug level

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -854,7 +854,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
       Related information: Cassandra anti-patterns: Queues and queue-like datasets.
     */
     , tombstone_warn_threshold(this, "tombstone_warn_threshold", value_status::Used, 1000,
-        "The maximum number of tombstones a query can scan before warning.")
+        "The maximum number of tombstones a query can scan before warning. Tombstone warnings are only logged for single-partition queries."
+        " Tombstone logs for range-scans are logged with debug level (querier logger), as it is normal for range-scans to go through many tombstones.")
     , tombstone_failure_threshold(this, "tombstone_failure_threshold", value_status::Unused, 100000,
         "The maximum number of tombstones a query can scan before aborting.")
     , query_tombstone_page_limit(this, "query_tombstone_page_limit", liveness::LiveUpdate, value_status::Used, 10000,

--- a/querier.cc
+++ b/querier.cc
@@ -452,7 +452,7 @@ void querier::maybe_log_tombstone_warning(std::string_view what, uint64_t live, 
         qrlogger.log(log_level::warn, rl, "Read {} live {} and {} dead {}/tombstones for {}.{} partition key \"{}\" {} (see tombstone_warn_threshold)",
                       live, what, dead, what, _schema->ks_name(), _schema->cf_name(), _range->start()->value().key()->with_schema(*_schema), (*_range));
     } else {
-        qrlogger.log(log_level::warn, rl, "Read {} live {} and {} dead {}/tombstones for {}.{} <partition-range-scan> {} (see tombstone_warn_threshold)",
+        qrlogger.log(log_level::debug, rl, "Read {} live {} and {} dead {}/tombstones for {}.{} <partition-range-scan> {} (see tombstone_warn_threshold)",
                       live, what, dead, what, _schema->ks_name(), _schema->cf_name(), (*_range));
     }
 }


### PR DESCRIPTION
Range scans are expected to go though lots of tombstones, no need to spam the logs about this. The tombstone warning log is demoted to debug level, if somebody wants to see it they can bump the logger to debug level.

Fixes: https://github.com/scylladb/scylladb/issues/23093

Improvement, no backport needed.