### PR TITLE
tablets: repair: fix hosts and dcs filters behavior for tablet repair

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1148,6 +1148,17 @@ bool locator::tablet_task_info::is_user_repair_request() const {
     return request_type == locator::tablet_task_type::user_repair;
 }
 
+bool locator::tablet_task_info::selected_by_filters(const tablet_replica& replica, const topology& topo) const {
+    if (!repair_hosts_filter.empty() && !repair_hosts_filter.contains(replica.host)) {
+        return false;
+    }
+    auto dc = topo.get_datacenter(replica.host);
+    if (!repair_dcs_filter.empty() && !repair_dcs_filter.contains(dc)) {
+        return false;
+    }
+    return true;
+}
+
 locator::tablet_task_info locator::tablet_task_info::make_auto_repair_request(std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter) {
     long sched_nr = 0;
     auto tablet_task_id = locator::tablet_task_id(utils::UUID_gen::get_time_UUID());

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -404,6 +404,13 @@ tablet_replica tablet_map::get_primary_replica_within_dc(tablet_id id, const top
     return replicas.at(size_t(id) % replicas.size());
 }
 
+std::optional<tablet_replica> tablet_map::maybe_get_selected_replica(tablet_id id, const topology& topo, const tablet_task_info& tablet_task_info) const {
+    const auto replicas = get_tablet_info(id).replicas | std::views::filter([&] (const auto& tr) {
+        return tablet_task_info.selected_by_filters(tr, topo);
+    }) | std::ranges::to<tablet_replica_set>();
+    return !replicas.empty() ? std::make_optional(replicas.at(size_t(id) % replicas.size())) : std::nullopt;
+}
+
 future<std::vector<token>> tablet_map::get_sorted_tokens() const {
     std::vector<token> tokens;
     tokens.reserve(tablet_count());

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -475,6 +475,9 @@ public:
     tablet_replica get_primary_replica(tablet_id id) const;
     tablet_replica get_primary_replica_within_dc(tablet_id id, const topology& topo, sstring dc) const;
 
+    // Returns the replica that matches hosts and dcs filters for tablet_task_info.
+    std::optional<tablet_replica> maybe_get_selected_replica(tablet_id id, const topology& topo, const tablet_task_info& tablet_task_info) const;
+
     /// Returns a vector of sorted last tokens for tablets.
     future<std::vector<token>> get_sorted_tokens() const;
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -167,6 +167,7 @@ struct tablet_task_info {
     bool operator==(const tablet_task_info&) const = default;
     bool is_valid() const;
     bool is_user_repair_request() const;
+    bool selected_by_filters(const tablet_replica& replica, const topology& topo) const;
     static tablet_task_info make_user_repair_request(std::unordered_set<locator::host_id> hosts_filter = {}, std::unordered_set<sstring> dcs_filter = {});
     static tablet_task_info make_auto_repair_request(std::unordered_set<locator::host_id> hosts_filter = {}, std::unordered_set<sstring> dcs_filter = {});
     static tablet_task_info make_migration_request();

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2455,26 +2455,15 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     for (auto& r : replicas) {
         auto shard = r.shard;
         if (r.host != myhostid) {
-            if (!hosts_filter.empty()) {
+            if (!hosts_filter.empty() || !dcs_filter.empty()) {
                 auto dc = topology.get_datacenter(r.host);
-                if (!hosts_filter.contains(r.host)) {
+                if (!info.repair_task_info.selected_by_filters(r, topology)) {
                     rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
-                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                        id.uuid(), r.host, dc, hosts_filter, dcs_filter);
                     continue;
                 } else {
                     rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} ok",
-                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
-                }
-            }
-            if (!dcs_filter.empty()) {
-                auto dc = topology.get_datacenter(r.host);
-                if (!dcs_filter.contains(dc)) {
-                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} skipped",
-                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
-                    continue;
-                } else {
-                    rlogger.debug("repair[{}]: Check node={} from dc={} hosts_filter={} dcs_filter={} ok",
-                            id.uuid(), r.host, dc, hosts_filter, dcs_filter);
+                        id.uuid(), r.host, dc, hosts_filter, dcs_filter);
                 }
             }
             nodes.push_back(r.host);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1465,11 +1465,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             dst_opt = primary.host;
                         } else {
                            for (auto& replica : tinfo.replicas) {
-                                if (!hosts_filter.empty() && !hosts_filter.contains(replica.host)) {
-                                    continue;
-                                }
-                                auto dc = topo.get_datacenter(replica.host);
-                                if (!dcs_filter.empty() && !dcs_filter.contains(dc)) {
+                                if (!tinfo.repair_task_info.selected_by_filters(replica, topo)) {
                                     continue;
                                 }
                                 dst_opt = replica.host;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1477,8 +1477,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                            }
                         }
                         if (!dst_opt) {
-                            throw std::runtime_error(fmt::format("Could not find host to perform repair tablet={} replica={} hosts_filter={} dcs_filter={}",
-                                    tablet, tinfo.replicas, hosts_filter, dcs_filter));
+                            co_return;
                         }
                         auto dst = dst_opt.value();
                         rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);

--- a/test/topology_custom/test_tablet_repair_scheduler.py
+++ b/test/topology_custom/test_tablet_repair_scheduler.py
@@ -230,9 +230,14 @@ def check_repairs(row_num_before: list[int], row_num_after: list[int], expected_
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-async def test_tablet_repair_hosts_filter(manager: ManagerClient):
+@pytest.mark.parametrize("included_host_count", [2, 1, 0])
+async def test_tablet_repair_hosts_filter(manager: ManagerClient, included_host_count):
     servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
-    hosts_filter = f"{hosts[0].host_id},{hosts[1].host_id}"
+    hosts_filter = "00000000-0000-0000-0000-000000000000"
+    if included_host_count == 1:
+        hosts_filter = f"{hosts[0].host_id}"
+    elif included_host_count == 2:
+        hosts_filter = f"{hosts[0].host_id},{hosts[1].host_id}"
 
     row_num_before = [get_repair_row_from_disk(server) for server in servers]
 
@@ -255,7 +260,7 @@ async def test_tablet_repair_hosts_filter(manager: ManagerClient):
     await asyncio.gather(repair_task(), check_filter())
 
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
-    check_repairs(row_num_before, row_num_after, [0, 1])
+    check_repairs(row_num_before, row_num_after, [0, 1] if included_host_count == 2 else [])
 
 async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraSession, list[Host], str, str]:
     servers = [await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}),
@@ -273,9 +278,10 @@ async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraS
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-async def test_tablet_repair_dcs_filter(manager: ManagerClient):
+@pytest.mark.parametrize("dcs_filter_and_res", [("DC1", [0, 1]), ("DC2", []), ("DC3", [])])
+async def test_tablet_repair_dcs_filter(manager: ManagerClient, dcs_filter_and_res):
+    dcs_filter, expected_repairs = dcs_filter_and_res
     servers, cql, hosts, ks, table_id = await prepare_multi_dc_repair(manager)
-    dcs_filter = "DC1"
 
     row_num_before = [get_repair_row_from_disk(server) for server in servers]
 
@@ -298,7 +304,7 @@ async def test_tablet_repair_dcs_filter(manager: ManagerClient):
     await asyncio.gather(repair_task(), check_filter())
 
     row_num_after = [get_repair_row_from_disk(server) for server in servers]
-    check_repairs(row_num_before, row_num_after, [0, 1])
+    check_repairs(row_num_before, row_num_after, expected_repairs)
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')


### PR DESCRIPTION
If hosts and/or dcs filters are specified for tablet repair and
some replicas match these filters, choose the replica that will 
be the repair master according to round-robin principle
(currently it's always the first replica).

If hosts and/or dcs filters are specified for tablet repair and
no replica matches these filters, the repair succeeds and 
the repair request is removed (currently an exception is thrown
and tablet repair scheduler reschedules the repair forever).

Fixes: https://github.com/scylladb/scylladb/issues/23100.

Needs backport to 2025.1 that introduces hosts and dcs filters for tablet repair