### PR TITLE
Main: stop system_keyspace

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -32,6 +32,7 @@
 #include "seastarx.hh"
 #include "sstables/exceptions.hh"
 #include "tombstone_gc.hh"
+#include "utils/pluggable.hh"
 
 namespace db {
 class system_keyspace;
@@ -138,7 +139,7 @@ private:
     // being picked more than once.
     seastar::named_semaphore _off_strategy_sem = {1, named_semaphore_exception_factory{"off-strategy compaction"}};
 
-    seastar::shared_ptr<db::system_keyspace> _sys_ks;
+    utils::pluggable<db::system_keyspace> _sys_ks;
 
     std::function<void()> compaction_submission_callback();
     // all registered tables are reevaluated at a constant interval.
@@ -391,7 +392,7 @@ public:
     future<> run_with_compaction_disabled(compaction::table_state& t, std::function<future<> ()> func);
 
     void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
-    void unplug_system_keyspace() noexcept;
+    future<> unplug_system_keyspace() noexcept;
 
     // Adds a table to the compaction manager.
     // Creates a compaction_state structure that can be used for submitting

--- a/configure.py
+++ b/configure.py
@@ -1513,6 +1513,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/mutation_writer_test.cc',
     'test/boost/network_topology_strategy_test.cc',
     'test/boost/per_partition_rate_limit_test.cc',
+    'test/boost/pluggable_test.cc',
     'test/boost/querier_cache_test.cc',
     'test/boost/query_processor_test.cc',
     'test/boost/reader_concurrency_semaphore_test.cc',

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -14,6 +14,7 @@
 #include "sstables/shared_sstable.hh"
 #include "utils/assert.hh"
 #include "utils/updateable_value.hh"
+#include "utils/pluggable.hh"
 
 namespace sstables {
 class sstable;
@@ -66,7 +67,7 @@ private:
     mutable large_data_handler::stats _stats;
 
 protected:
-    seastar::shared_ptr<db::system_keyspace> _sys_ks;
+    mutable utils::pluggable<db::system_keyspace> _sys_ks;
 
 public:
     explicit large_data_handler(uint64_t partition_threshold_bytes, uint64_t row_threshold_bytes, uint64_t cell_threshold_bytes, uint64_t rows_count_threshold, uint64_t collection_elements_count_threshold);
@@ -133,7 +134,7 @@ public:
     static sstring sst_filename(const sstables::sstable& sst);
 
     void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
-    void unplug_system_keyspace() noexcept;
+    future<> unplug_system_keyspace() noexcept;
 
 protected:
     virtual future<> record_large_cells(const sstables::sstable& sst, const sstables::key& partition_key,

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3520,8 +3520,7 @@ system_keyspace::~system_keyspace() {
 }
 
 future<> system_keyspace::shutdown() {
-    _db.unplug_system_keyspace();
-    co_return;
+    co_await _db.unplug_system_keyspace();
 }
 
 future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const data_value_list& values) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3520,7 +3520,10 @@ system_keyspace::~system_keyspace() {
 }
 
 future<> system_keyspace::shutdown() {
-    co_await _db.unplug_system_keyspace();
+    if (!_shutdown) {
+        _shutdown = true;
+        co_await _db.unplug_system_keyspace();
+    }
 }
 
 future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const data_value_list& values) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3526,6 +3526,10 @@ future<> system_keyspace::shutdown() {
     }
 }
 
+future<> system_keyspace::stop() {
+    co_await shutdown();
+}
+
 future<::shared_ptr<cql3::untyped_result_set>> system_keyspace::execute_cql(const sstring& query_string, const data_value_list& values) {
     return _qp.execute_internal(query_string, values, cql3::query_processor::cache_internal::yes);
 }

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -129,6 +129,7 @@ class system_keyspace : public seastar::peering_sharded_service<system_keyspace>
     std::unique_ptr<local_cache> _cache;
     virtual_tables_registry _virtual_tables_registry;
     bool _peers_table_read_fixup_done = false;
+    bool _shutdown = false;
 
     static schema_ptr raft_snapshot_config();
     static schema_ptr local();

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -673,6 +673,7 @@ public:
     system_keyspace(cql3::query_processor& qp, replica::database& db) noexcept;
     ~system_keyspace();
     future<> shutdown();
+    future<> stop();
 
     virtual_tables_registry& get_virtual_tables_registry() { return _virtual_tables_registry; }
 private:

--- a/main.cc
+++ b/main.cc
@@ -1385,7 +1385,9 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             supervisor::notify("starting system keyspace");
             sys_ks.start(std::ref(qp), std::ref(db)).get();
-            // TODO: stop()?
+            auto stop_sys_ks = defer_verbose_shutdown("system keyspace", [] {
+                sys_ks.stop().get();
+            });
 
             // Initialization of a keyspace is done by shard 0 only. For system
             // keyspace, the procedure  will go through the hardcoded column

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3012,10 +3012,10 @@ void database::plug_system_keyspace(db::system_keyspace& sys_ks) noexcept {
     _user_sstables_manager->plug_sstables_registry(std::make_unique<db::system_keyspace_sstables_registry>(sys_ks));
 }
 
-void database::unplug_system_keyspace() noexcept {
+future<> database::unplug_system_keyspace() noexcept {
     _user_sstables_manager->unplug_sstables_registry();
-    _compaction_manager.unplug_system_keyspace();
-    _large_data_handler->unplug_system_keyspace();
+    co_await _compaction_manager.unplug_system_keyspace();
+    co_await _large_data_handler->unplug_system_keyspace();
 }
 
 void database::plug_view_update_generator(db::view::view_update_generator& generator) noexcept {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1578,7 +1578,7 @@ public:
     future<> drain();
 
     void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
-    void unplug_system_keyspace() noexcept;
+    future<> unplug_system_keyspace() noexcept;
 
     void plug_view_update_generator(db::view::view_update_generator& generator) noexcept;
     void unplug_view_update_generator() noexcept;

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -321,6 +321,7 @@ add_scylla_test(combined_tests
     mutation_writer_test.cc
     network_topology_strategy_test.cc
     per_partition_rate_limit_test.cc
+    pluggable_test.cc
     querier_cache_test.cc
     query_processor_test.cc
     reader_concurrency_semaphore_test.cc

--- a/test/boost/pluggable_test.cc
+++ b/test/boost/pluggable_test.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+#include <stdexcept>
+
+#include "seastar/core/on_internal_error.hh"
+#include "seastar/core/shared_ptr.hh"
+#include "utils/pluggable.hh"
+
+BOOST_AUTO_TEST_SUITE(pluggable_test)
+
+class test_service {
+    int& _counter;
+public:
+    test_service(int& counter) : _counter(counter) { counter = 0; }
+
+    void called() {
+        ++_counter;
+    }
+};
+
+SEASTAR_TEST_CASE(test_pluggable) {
+    int counter;
+    auto service = make_shared<test_service>(counter);
+    utils::pluggable<test_service> plugin;
+
+    auto check_unplugged = [&] {
+        BOOST_REQUIRE(!plugin);
+        BOOST_REQUIRE(!plugin.plugged());
+  
+        auto permit = plugin.get_permit();
+        BOOST_REQUIRE(!permit);
+        BOOST_REQUIRE_EQUAL(permit.get(), nullptr);
+    };
+
+    auto check_plugged = [&] {
+        BOOST_REQUIRE(plugin);
+        BOOST_REQUIRE(plugin.plugged());
+  
+        auto permit = plugin.get_permit();
+        BOOST_REQUIRE(permit);
+        BOOST_REQUIRE_EQUAL(permit.get(), service.get());
+        auto prev = counter;
+        permit->called();
+        BOOST_REQUIRE_EQUAL(counter, prev + 1);
+    };
+
+    check_unplugged();
+    co_await plugin.unplug();
+    check_unplugged();
+
+    plugin.plug(service);
+    check_plugged();
+
+    co_await plugin.unplug();
+    check_unplugged();
+
+    plugin.plug(service);
+    check_plugged();
+
+    co_await plugin.close();
+    check_unplugged();
+
+    set_abort_on_internal_error(false);
+    BOOST_REQUIRE_THROW(plugin.plug(service), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -699,7 +699,6 @@ private:
 
             _sys_ks.start(std::ref(_qp), std::ref(_db)).get();
             auto stop_sys_kd = defer_verbose_shutdown("system keyspace", [this] {
-                _sys_ks.invoke_on_all(&db::system_keyspace::shutdown).get();
                 _sys_ks.stop().get();
             });
 

--- a/utils/pluggable.hh
+++ b/utils/pluggable.hh
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <stdexcept>
+#include <optional>
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include "seastarx.hh"
+#include "utils/phased_barrier.hh"
+#include "utils/on_internal_error.hh"
+
+namespace utils {
+
+/// This class provides plug-in interface for accessing async services.
+///
+/// The user calls \c get_permit() to access the service.
+/// The returned \c permit evaluates to `true` iff the service is plugged in.
+/// The permit ensures that the service is kept alive using RAII,
+/// so it has to be kept as a guard until the service async operation is resolved.
+///
+/// On the service side, \c plug() is used to plug-in the service,
+/// and \c unplug() is used to, well, unplug it, while awaiting for all
+/// outstanding permits to be destroyed.  After \c unplug resolves, the service
+/// can be safely destroyed.
+/// Note that \c plug and \c unplug can be used repeatedly, for example, for going
+/// in and out of maintenance mode, until \c pluggable is closed.
+///
+/// \c close() must be called exactly once.  It unplugs the service if needed,
+/// and puts \c pluggable in a terminal state, disallowing further plug-ins.
+template <typename T>
+class pluggable {
+    shared_ptr<T> _service;
+    utils::phased_barrier _phaser;
+
+public:
+    class permit {
+        utils::phased_barrier::operation _op;
+        T* _service = nullptr;
+    public:
+        permit() = default;
+        permit(permit&&) = default;
+        permit(utils::phased_barrier::operation op, T* s) noexcept
+            : _op(std::move(op))
+            , _service(s)
+        {}
+
+        permit& operator=(permit&&) = default;
+
+        operator bool() const noexcept {
+            return _service != nullptr;
+        }
+    
+        T* get() noexcept {
+            return _service;
+        }
+    
+        T* operator->() noexcept {
+            return get();
+        }
+    
+        T& operator*() noexcept {
+            return *get();
+        }
+    };
+
+    operator bool() const noexcept {
+        return plugged();
+    }
+
+    bool plugged() const noexcept {
+        return bool(_service);
+    }
+
+    permit get_permit() {
+        if (auto* p = _service.get()) {
+            return permit(_phaser.start(), p);
+        }
+        return permit();
+    }
+
+    void plug(shared_ptr<T> service) {
+        if (plugged()) {
+            on_internal_error("service is already plugged-in");
+        }
+        if (_phaser.is_closed()) {
+            on_internal_error("service plugin is closed");
+        }
+        _service = std::move(service);
+    }
+
+    future<> unplug() {
+        if (plugged()) {
+            auto s = std::move(_service);
+            co_await _phaser.advance_and_await();
+        }
+    }
+
+    future<> close() {
+        if (plugged()) {
+            auto s = std::move(_service);
+            co_await _phaser.close();
+        }
+    }
+};
+
+} // namespace utils


### PR DESCRIPTION
This series adds an async guard to system_keyspace operations
and adds a deferred action to stop the system_keyspace in main() before destroying the service.

This helps to make sure that sys_ks is unplugged from its users and that all async operations using it are drained once it's stopped.

* Enhancement, no backport needed