### PR TITLE
replica: Fix race of some operations like cleanup with snapshot

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -71,11 +71,10 @@ private:
     // Update compaction backlog tracker with the same changes applied to the underlying sstable set.
     void backlog_tracker_adjust_charges(const std::vector<sstables::shared_sstable>& old_sstables, const std::vector<sstables::shared_sstable>& new_sstables);
 
-    future<> delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove);
     // Input SSTables that weren't added to any SSTable set, are considered unused and can be unlinked.
     // An input SSTable remains linked if it wasn't actually compacted, yet compaction manager wants
     // it to be moved from its original sstable set (e.g. maintenance) into a new one (e.g. main).
-    future<> delete_unused_sstables(sstables::compaction_completion_desc desc);
+    std::vector<sstables::shared_sstable> unused_sstables_for_deletion(sstables::compaction_completion_desc desc) const;
     // Tracks the maximum timestamp observed across all SSTables in this group.
     // This is used by the compacting reader to determine if a memtable contains entries
     // with timestamps that overlap with those in the SSTables of the compaction group.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -355,6 +355,8 @@ struct table_stats {
     int64_t live_sstable_count = 0;
     /** Estimated number of compactions pending for this column family */
     int64_t pending_compactions = 0;
+    /** Number of pending tasks that will potentially perform deletions */
+    int64_t pending_sstable_deletions = 0;
     int64_t memtable_partition_insertions = 0;
     int64_t memtable_partition_hits = 0;
     int64_t memtable_range_tombstone_reads = 0;
@@ -462,11 +464,13 @@ private:
     lw_shared_ptr<const sstables::sstable_set> _sstables;
     // Control background fibers waiting for sstables to be deleted
     seastar::gate _sstable_deletion_gate;
-    // This semaphore ensures that an operation like snapshot won't have its selected
-    // sstables deleted by compaction in parallel, a race condition which could
-    // easily result in failure.
-    seastar::named_semaphore _sstable_deletion_sem = {1, named_semaphore_exception_factory{"sstable deletion"}};
-    // Ensures that concurrent updates to sstable set will work correctly
+    // This semaphore ensures that any operation updating the SSTable list and deleting unused
+    // SSTables will be atomic to other concurrent operations.
+    // That means snapshot, for example, won't have its selected sstables deleted by compaction
+    // in parallel, a race condition which could easily result in failure.
+    // Another example is snapshot not being able to see SSTables deleted by tablet cleanup,
+    // while cleanup is in the middle of the list update.
+    // TODO: find a better name for this semaphore.
     seastar::named_semaphore _sstable_set_mutation_sem = {1, named_semaphore_exception_factory{"sstable set mutation"}};
     mutable row_cache _cache; // Cache covers only sstables.
     // Initialized when the table is populated via update_sstables_known_generation.
@@ -563,11 +567,23 @@ public:
     // Ensures that concurrent preemptible mutations to sstable lists will produce correct results.
     // User will hold this permit until done with all updates. As soon as it's released, another concurrent
     // attempt to update the lists will be able to proceed.
-    struct sstable_list_builder {
+    struct sstable_list_permit {
         using permit_t = semaphore_units<seastar::named_semaphore_exception_factory>;
         permit_t permit;
 
-        explicit sstable_list_builder(permit_t p) : permit(std::move(p)) {}
+        sstable_list_permit(permit_t p) : permit(std::move(p)) {}
+    };
+    // This permit ensures that the observer won't be able to find the intermediate state left by any
+    // process updating the sstable list. It guarantees atomicity of list updates. That being said,
+    // an iteration over the list should always acquire this permit in order to guarantee stability
+    // during the traversal. For example, that none of the SSTables will be found unlinked.
+    future<sstable_list_permit> get_sstable_list_permit();
+
+    class sstable_list_builder {
+        lw_shared_ptr<table> _t;
+        sstable_list_permit _permit;
+    public:
+        explicit sstable_list_builder(table& t, sstable_list_permit p) : _t(t.shared_from_this()), _permit(std::move(p)) {}
         sstable_list_builder& operator=(const sstable_list_builder&) = delete;
         sstable_list_builder(const sstable_list_builder&) = delete;
 
@@ -584,7 +600,12 @@ public:
                        sstables::sstable_set new_sstable_list,
                        const std::vector<sstables::shared_sstable>& new_sstables,
                        const std::vector<sstables::shared_sstable>& old_sstables);
+
+        future<> delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove);
     };
+    // NOTE: Always use this interface for deleting SSTables in the table, since it guarantees
+    // synchronization with concurrent iterations.
+    future<> delete_sstables_atomically(const sstable_list_permit&, std::vector<sstables::shared_sstable> sstables_to_remove);
 
     // Precondition: table needs tablet splitting.
     // Returns true if all storage of table is ready for splitting.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1249,7 +1249,7 @@ const storage_group_map& table::storage_groups() const {
 }
 
 future<> table::safe_foreach_sstable(const sstables::sstable_set& set, noncopyable_function<future<>(const sstables::shared_sstable&)> action) {
-    auto deletion_guard = co_await get_units(_sstable_deletion_sem, 1);
+    auto deletion_guard = co_await get_sstable_list_permit();
 
     co_await set.for_each_sstable_gently([&] (const sstables::shared_sstable& sst) -> future<> {
         return action(sst);
@@ -1735,7 +1735,7 @@ void table::set_metrics() {
                 ms::make_gauge("pending_compaction", ms::description("Estimated number of compactions pending for this column family"), _stats.pending_compactions)(cf)(ks),
                 ms::make_gauge("pending_sstable_deletions",
                         ms::description("Number of tasks waiting to delete sstables from a table"),
-                        [this] { return _sstable_deletion_sem.waiters(); })(cf)(ks)
+                        [this] { return _stats.pending_sstable_deletions; })(cf)(ks)
         });
 
         // Metrics related to row locking
@@ -1852,6 +1852,11 @@ void table::subtract_compaction_group_from_stats(const compaction_group& cg) noe
     _stats.live_sstable_count -= cg.live_sstable_count();
 }
 
+future<table::sstable_list_permit>
+table::get_sstable_list_permit() {
+    co_return sstable_list_permit(co_await seastar::get_units(_sstable_set_mutation_sem, 1));
+}
+
 future<table::sstable_list_builder::result>
 table::sstable_list_builder::build_new_list(const sstables::sstable_set& current_sstables,
                               sstables::sstable_set new_sstable_list,
@@ -1879,11 +1884,10 @@ table::sstable_list_builder::build_new_list(const sstables::sstable_set& current
 }
 
 future<>
-compaction_group::delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove) {
+table::delete_sstables_atomically(const sstable_list_permit&, std::vector<sstables::shared_sstable> sstables_to_remove) {
     try {
-        auto gh = _t._sstable_deletion_gate.hold();
-        auto units = co_await get_units(_t._sstable_deletion_sem, 1);
-        co_await _t.get_sstables_manager().delete_atomically(std::move(sstables_to_remove));
+        auto gh = _sstable_deletion_gate.hold();
+        co_await get_sstables_manager().delete_atomically(std::move(sstables_to_remove));
     } catch (...) {
         // There is nothing more we can do here.
         // Any remaining SSTables will eventually be re-compacted and re-deleted.
@@ -1892,14 +1896,18 @@ compaction_group::delete_sstables_atomically(std::vector<sstables::shared_sstabl
 }
 
 future<>
-compaction_group::delete_unused_sstables(sstables::compaction_completion_desc desc) {
+table::sstable_list_builder::delete_sstables_atomically(std::vector<sstables::shared_sstable> sstables_to_remove) {
+    return _t->delete_sstables_atomically(_permit, std::move(sstables_to_remove));
+}
+
+std::vector<sstables::shared_sstable>
+compaction_group::unused_sstables_for_deletion(sstables::compaction_completion_desc desc) const {
     std::unordered_set<sstables::shared_sstable> output(desc.new_sstables.begin(), desc.new_sstables.end());
 
-    auto sstables_to_remove = std::ranges::to<std::vector<sstables::shared_sstable>>(desc.old_sstables
+    return std::ranges::to<std::vector<sstables::shared_sstable>>(desc.old_sstables
             | std::views::filter([&output] (const sstables::shared_sstable& input_sst) {
         return !output.contains(input_sst);
     }));
-    return delete_sstables_atomically(std::move(sstables_to_remove));
 }
 
 std::vector<sstables::shared_sstable> compaction_group::all_sstables() const {
@@ -1915,8 +1923,8 @@ std::vector<sstables::shared_sstable> compaction_group::all_sstables() const {
 future<>
 compaction_group::merge_sstables_from(compaction_group& group) {
     auto& cs = _t.get_compaction_strategy();
-    auto permit = co_await seastar::get_units(_t._sstable_set_mutation_sem, 1);
-    table::sstable_list_builder builder(std::move(permit));
+    auto permit = co_await _t.get_sstable_list_permit();
+    table::sstable_list_builder builder(_t, std::move(permit));
 
     auto sstables_to_merge = group.all_sstables();
     // re-build new list for this group with sstables of the group being merged.
@@ -1973,10 +1981,15 @@ compaction_group::update_sstable_sets_on_compaction_completion(sstables::compact
         _t.rebuild_statistics();
     });
 
+    _t.get_stats().pending_sstable_deletions++;
+    auto undo_stats = defer([this] {
+        _t.get_stats().pending_sstable_deletions--;
+    });
+
     class sstable_list_updater : public row_cache::external_updater_impl {
         table& _t;
         compaction_group& _cg;
-        table::sstable_list_builder _builder;
+        table::sstable_list_builder& _builder;
         const sstables::compaction_completion_desc& _desc;
         struct replacement_desc {
             sstables::compaction_completion_desc desc;
@@ -1985,8 +1998,8 @@ compaction_group::update_sstable_sets_on_compaction_completion(sstables::compact
         };
         std::unordered_map<compaction_group*, replacement_desc> _cg_desc;
     public:
-        explicit sstable_list_updater(compaction_group& cg, table::sstable_list_builder::permit_t permit, sstables::compaction_completion_desc& d)
-            : _t(cg._t), _cg(cg), _builder(std::move(permit)), _desc(d) {}
+        explicit sstable_list_updater(compaction_group& cg, table::sstable_list_builder& builder, sstables::compaction_completion_desc& d)
+            : _t(cg._t), _cg(cg), _builder(builder), _desc(d) {}
         virtual future<> prepare() override {
             // Segregate output sstables according to their owner compaction group.
             // If not in splitting mode, then all output sstables will belong to the same group.
@@ -2027,12 +2040,12 @@ compaction_group::update_sstable_sets_on_compaction_completion(sstables::compact
                 cg->backlog_tracker_adjust_charges(d.main_sstable_set_builder_result.removed_sstables, d.desc.new_sstables);
             }
         }
-        static std::unique_ptr<row_cache::external_updater_impl> make(compaction_group& cg, table::sstable_list_builder::permit_t permit, sstables::compaction_completion_desc& d) {
-            return std::make_unique<sstable_list_updater>(cg, std::move(permit), d);
+        static std::unique_ptr<row_cache::external_updater_impl> make(compaction_group& cg, table::sstable_list_builder& builder, sstables::compaction_completion_desc& d) {
+            return std::make_unique<sstable_list_updater>(cg, builder, d);
         }
     };
-    auto permit = co_await seastar::get_units(_t._sstable_set_mutation_sem, 1);
-    auto updater = row_cache::external_updater(sstable_list_updater::make(*this, std::move(permit), desc));
+    table::sstable_list_builder builder(_t, co_await _t.get_sstable_list_permit());
+    auto updater = row_cache::external_updater(sstable_list_updater::make(*this, builder, desc));
     auto& cache = _t.get_row_cache();
 
     co_await cache.invalidate(std::move(updater), std::move(desc.ranges_for_cache_invalidation));
@@ -2043,7 +2056,7 @@ compaction_group::update_sstable_sets_on_compaction_completion(sstables::compact
 
     _t.rebuild_statistics();
 
-    co_await delete_unused_sstables(std::move(desc));
+    co_await builder.delete_sstables_atomically(unused_sstables_for_deletion(std::move(desc)));
 }
 
 future<>
@@ -2906,7 +2919,7 @@ future<> table::snapshot_on_all_shards(sharded<database>& sharded_db, const glob
 future<table::snapshot_file_set> table::take_snapshot(sstring jsondir) {
     tlogger.trace("take_snapshot {}", jsondir);
 
-    auto sstable_deletion_guard = co_await get_units(_sstable_deletion_sem, 1);
+    auto sstable_deletion_guard = co_await get_sstable_list_permit();
 
     auto tables = *_sstables->all() | std::ranges::to<std::vector<sstables::shared_sstable>>();
     auto table_names = std::make_unique<std::unordered_set<sstring>>();
@@ -3134,6 +3147,13 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
     };
     std::vector<removed_sstable> remove;
 
+    _stats.pending_sstable_deletions++;
+    auto undo_stats = defer([this] {
+        _stats.pending_sstable_deletions--;
+    });
+
+    auto permit = co_await get_sstable_list_permit();
+
     co_await _cache.invalidate(row_cache::external_updater([this, &rp, &remove, truncated_at] {
         // FIXME: the following isn't exception safe.
         for_each_compaction_group([&] (compaction_group& cg) {
@@ -3176,7 +3196,7 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
         erase_sstable_cleanup_state(r.sst);
         del.emplace_back(r.sst);
     };
-    co_await get_sstables_manager().delete_atomically(std::move(del));
+    co_await delete_sstables_atomically(permit, std::move(del));
     co_return rp;
 }
 
@@ -3719,14 +3739,14 @@ table::make_reader_v2_excluding_staging(schema_ptr s,
 }
 
 future<> table::move_sstables_from_staging(std::vector<sstables::shared_sstable> sstables) {
-    auto units = co_await get_units(_sstable_deletion_sem, 1);
+    auto permit = co_await get_sstable_list_permit();
     sstables::delayed_commit_changes delay_commit;
     std::unordered_set<compaction_group*> compaction_groups_to_notify;
     for (auto sst : sstables) {
         try {
             // Off-strategy can happen in parallel to view building, so the SSTable may be deleted already if the former
             // completed first.
-            // The _sstable_deletion_sem prevents list update on off-strategy completion and move_sstables_from_staging()
+            // The sstable list permit prevents list update on off-strategy completion and move_sstables_from_staging()
             // from stepping on each other's toe.
             co_await sst->change_state(sstables::sstable_state::normal, &delay_commit);
             auto& cg = compaction_group_for_sstable(sst);
@@ -3966,17 +3986,16 @@ future<> compaction_group::cleanup() {
         virtual future<> prepare() override {
             // Capture SSTables after flush, and with compaction disabled, to avoid missing any.
             auto set = _cg.make_sstable_set();
-            std::vector<sstables::shared_sstable> all_sstables;
-            all_sstables.reserve(set->size());
-            set->for_each_sstable([&all_sstables] (const sstables::shared_sstable& sst) mutable {
-                all_sstables.push_back(sst);
+            auto& sstables_compacted_but_not_deleted = _cg._sstables_compacted_but_not_deleted;
+            sstables_compacted_but_not_deleted.reserve(set->size() + sstables_compacted_but_not_deleted.size());
+            set->for_each_sstable([&] (const sstables::shared_sstable& sst) mutable {
+                sstables_compacted_but_not_deleted.push_back(sst);
             });
             if (utils::get_local_injector().enter("tablet_cleanup_failure")) {
                 co_await sleep(std::chrono::seconds(1));
                 tlogger.info("Cleanup failed for tablet {}", _cg.group_id());
                 throw std::runtime_error("tablet cleanup failure");
             }
-            co_await _cg.delete_sstables_atomically(std::move(all_sstables));
         }
 
         virtual void execute() override {
@@ -3987,13 +4006,25 @@ future<> compaction_group::cleanup() {
         }
     };
 
+    auto permit = co_await _t.get_sstable_list_permit();
     auto updater = row_cache::external_updater(std::make_unique<compaction_group_cleaner>(*this));
 
     auto p_range = to_partition_range(token_range());
     tlogger.debug("Invalidating range {} for compaction group {} of table {} during cleanup.",
                   p_range, group_id(), _t.schema()->ks_name(), _t.schema()->cf_name());
+    // Since permit is still held, all actions below will be executed atomically:
     co_await _t._cache.invalidate(std::move(updater), p_range);
     _t._cache.refresh_snapshot();
+
+    co_await _t.delete_sstables_atomically(permit, _sstables_compacted_but_not_deleted);
+    // Clearing sstables_compacted_but_not_deleted only on success allows a retry caused
+    // by a failure during deletion to still find the sstables, despite they were removed
+    // from the sstable sets.
+    _sstables_compacted_but_not_deleted.clear();
+    if (utils::get_local_injector().enter("tablet_cleanup_failure_post_deletion")) {
+        tlogger.info("Cleanup failed for tablet {}", group_id());
+        throw std::runtime_error("tablet cleanup failure");
+    }
 }
 
 future<> table::clear_inactive_reads_for_tablet(database& db, storage_group& sg) {

--- a/test/topology_custom/test_tablets2.py
+++ b/test/topology_custom/test_tablets2.py
@@ -1800,3 +1800,38 @@ async def test_decommission_not_enough_racks(manager: ManagerClient):
         expected_replicas_per_server = get_expected_replicas_per_server(live_servers.values(), dead_servers.values(), ctx.initial_tablets, ctx.rf)
         tablet_count = await get_tablet_count_per_shard_for_hosts(manager, all_servers.values(), tables)
         verify_replicas_per_server("After decommission", expected_replicas_per_server, tablet_count, ctx.initial_tablets, ctx.rf)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
+    cmdline = ['--smp=1']
+
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    cql = manager.get_cql()
+    n_tablets = 1
+    n_partitions = 1000
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await manager.servers_see_each_other(servers)
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
+
+        await inject_error_one_shot_on(manager, "tablet_cleanup_failure_post_deletion", servers)
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+
+        servers.append(await manager.server_add())
+
+        tablet_token = 0
+        replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+        dst_shard = 0
+        migration_task = asyncio.create_task(
+            manager.api.move_tablet(servers[0].ip_addr, ks, "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
+
+        logger.info("Waiting for injected cleanup failure...")
+        await s0_log.wait_for('Cleanup failed for tablet', from_mark=s0_mark)
+
+        await manager.api.take_snapshot(servers[0].ip_addr, ks, "test_snapshot")


### PR DESCRIPTION
There are two semaphores in table for synchronizing changes to sstable list:

sstable_set_mutation_sem: used to serialize two concurrent operations updating the list, to prevent them from racing with each other.

sstable_deletion_sem: A deletion guard, used to serialize deletion and iteration over the list, to prevent iteration from finding deleted files on disk.

they're always taken in this order to avoid deadlocks: sstable_set_mutation_sem -> sstable_deletion_sem.

problem:

A = tablet cleanup
B = take_snapshot()

1) A acquires sstable_set_mutation_sem for updating list
2) A acquires sstable_deletion_sem, then delete sstable before updating list
3) A releases sstable_deletion_sem, then yield
4) B acquires sstable_deletion_sem
5) B iterates through list and bumps sstable deleted in step 2
6) B fails since it cannot find the file on disk

Initial reaction is to say that no procedure must delete sstable before updating the list, that's true.

But we want a iteration, running concurrently to cleanup, to not find sstables being removed from the system. Otherwise, e.g. snapshot works with sstables of a tablet that was just cleaned up. That's achieved by serializing iteration with list update.
Since sstable_deletion_sem is used within the scope of deletion only, it's useless for achieving this. Cleanup could acquire the deletion sem when preparing list updates, and then pass the "permit" to deletion function, but then sstable_deletion_sem would essentially become sstable_set_mutation_sem, which was created exactly to protect the list update.

That being said, it makes sense to merge both semaphores. Also things become easier to reason about, and we don't have to worry about deadlocks anymore.

The deletion goes through sstable_list_builder, which holds a permit throughout its lifetime, which guarantees that list updates and deletion are atomic to other concurrent operations. The interface becomes less error prone with that. It allowed us to find discard_sstables() was doing deletion without any permit, meaning another race could happen between truncate and snapshot.

So we're fixing race of (truncate|cleanup) with take_snapshot, as far as we know. It's possible another unknown races are fixed as well.

Fixes #23049.
