### PR TITLE
test_compaction_stats_after_major_compaction: reduce tablet count 

### DIFF
--- a/test/cqlpy/test_compaction.py
+++ b/test/cqlpy/test_compaction.py
@@ -159,7 +159,7 @@ def get_compaction_stats(cql, table):
             tasks += int(s['task'])
     return tasks, stats
 
-@pytest.mark.parametrize("compaction_strategy", ["LeveledCompactionStrategy", "SizeTieredCompactionStrategy", "TimeWindowCompactionStrategy"])
+@pytest.mark.parametrize("compaction_strategy", ["IncrementalCompactionStrategy", "LeveledCompactionStrategy", "SizeTieredCompactionStrategy", "TimeWindowCompactionStrategy"])
 def test_compactionstats_after_major_compaction(scylla_only, cql, test_keyspace, compaction_strategy):
     """
     Test that compactionstats show no pending compaction after major compaction


### PR DESCRIPTION
Fixes #23116

* Backport would be required if and when 2463e524ed6a92468bf67d6362f85102d80955d9 is backported
