### PR TITLE
test/cqlpy/run: reduce number of tablets

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -326,6 +326,7 @@ def run_scylla_cmd(pid, dir):
         '--shutdown-announce-in-ms', '0',
         '--maintenance-socket=workdir',
         '--service-levels-interval-ms=500',
+        '--tablets-initial-scale-factor=1',
         # Avoid unhelpful "guardrails" warnings
         '--minimum-replication-factor-warn-threshold=-1',
         ], env)
@@ -390,6 +391,8 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--max-networking-io-control-blocks=1000')
     if major == [5,4] or major == [2024,1]:
         cmd.append('--force-schema-commit-log=true')
+    if major < [2025,1]:
+        cmd.remove('--tablets-initial-scale-factor=1')
     return (cmd, env)
 
 # Get a Cluster object to connect to CQL at the given IP address (and with


### PR DESCRIPTION
In commit 2463e524ed6a92468bf67d6362f85102d80955d9, Scylla's default changed from starting with one tablet per shard to starting 10 per shard. The functional tests don't need more tablets and it can only slow down the tests, so the patch added --tablets-initial-scale-factor=1 to test/*/suite.yaml but forgot to add it to test/cqlpy/run.py (to affect test/cqlpy/run) so this patch does this now.

This patch should *only* be about making tests faster, although to be honest, I don't see any measurable improvement in test speed (10 isn't so many). But, unfortunately, this is only part of the story. Over time we allowed a few cqlpy tests to be written in a way that relies on having only a small number of tablets or even exactly one tablet per shard (!). These tests are buggy and should be fixed - see issues #23115 and #23116 as examples. But adding the option --tablets-initial-scale-factor=1 also to run.py will make these bugs not affect test/cqlpy/run in the same way as it doesn't affect test.py.

These buggy tests will still break with `pytest cqlpy` against a Scylla you ran yourself manually, so eventually will still need to fix those test bugs.

Refs #23115
Refs #23116