### PR TITLE
cql3: Introduce RF-rack-valid keyspaces

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -837,3 +837,6 @@ maintenance_socket: ignore
 # Note that creating keyspaces with tablets enabled or disabled is irreversible.
 # The `tablets` option cannot be changed using `ALTER KEYSPACE`.
 enable_tablets: true
+
+# Enforce RF-rack-valid keyspaces.
+rf_rack_valid_keyspaces: false

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -11,6 +11,8 @@
 #include <seastar/core/coroutine.hh>
 #include "cql3/statements/create_keyspace_statement.hh"
 #include "cql3/statements/ks_prop_defs.hh"
+#include "exceptions/exceptions.hh"
+#include "locator/tablets.hh"
 #include "prepared_statement.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "data_dictionary/keyspace_metadata.hh"
@@ -90,14 +92,14 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>> create_keyspace_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
     using namespace cql_transport;
-    const auto& tm = *qp.proxy().get_token_metadata_ptr();
+    const auto tmptr = qp.proxy().get_token_metadata_ptr();
     const auto& feat = qp.proxy().features();
     const auto& cfg = qp.db().get_config();
     std::vector<mutation> m;
     std::vector<sstring> warnings;
 
     try {
-        auto ksm = _attrs->as_ks_metadata(_name, tm, feat, cfg);
+        auto ksm = _attrs->as_ks_metadata(_name, *tmptr, feat, cfg);
         m = service::prepare_new_keyspace_announcement(qp.db().real_database(), ksm, ts);
         // If the new keyspace uses tablets, as long as there are features
         // which aren't supported by tablets we want to warn the user that
@@ -117,6 +119,21 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
                 "to the CREATE KEYSPACE statement.");
             if (ksm->initial_tablets().value()) {
                 warnings.push_back("Keyspace `initial` tablets option is deprecated.  Use per-table tablet options instead.");
+            }
+        }
+
+        // If `rf_rack_valid_keyspaces` is enabled, it's forbidden to create an RF-rack-invalid keyspace.
+        // Verify that it's RF-rack-valid.
+        // For more context, see: scylladb/scylladb#23071.
+        if (cfg.rf_rack_valid_keyspaces()) {
+            try {
+                // We hold a group0_guard, so it's correct to check this here.
+                // The topology or schema cannot change while we're performing this query.
+                locator::assert_rf_rack_valid_keyspace(_name, tmptr, *rs);
+            } catch (const std::exception& e) {
+                // There's no guarantee what the type of the exception will be, so we need to
+                // wrap it manually here in a type that can be passed to the user.
+                throw exceptions::invalid_request_exception(e.what());
             }
         }
     } catch (const exceptions::already_exists_exception& e) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -1381,6 +1381,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , disk_space_monitor_high_polling_interval_in_seconds(this, "disk_space_monitor_high_polling_interval_in_seconds", value_status::Used, 1, "Disk-space polling interval at or above polling threshold")
     , disk_space_monitor_polling_interval_threshold(this, "disk_space_monitor_polling_interval_threshold", value_status::Used, 0.9, "Disk-space polling threshold. Polling interval is increased when disk utilization is greater than or equal to this threshold")
     , enable_create_table_with_compact_storage(this, "enable_create_table_with_compact_storage", liveness::LiveUpdate, value_status::Used, false, "Enable the deprecated feature of CREATE TABLE WITH COMPACT STORAGE.  This feature will eventually be removed in a future version.")
+    , rf_rack_valid_keyspaces(this, "rf_rack_valid_keyspaces", liveness::MustRestart, value_status::Used, false,
+        "Enforce RF-rack-valid keyspaces. Additionally, if there are existing RF-rack-invalid "
+        "keyspaces, attempting to start a node with this option ON will fail.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -545,6 +545,8 @@ public:
 
     named_value<bool> enable_create_table_with_compact_storage;
 
+    named_value<bool> rf_rack_valid_keyspaces;
+
     static const sstring default_tls_priority;
 private:
     template<typename T>

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -140,6 +140,12 @@ You can create a keyspace with tablets enabled with the ``tablets = {'enabled': 
 Limitations and Unsupported Features
 --------------------------------------
 
+.. warning::
+
+    If a keyspace has tablets enabled, it must remain :term:`RF-rack-valid <RF-rack-valid keyspace>`
+    throughout its lifetime. Failing to keep that invariant satisfied may result in data inconsistencies,
+    performance problems, or other issues.
+
 The following ScyllaDB features are not supported if a keyspace has tablets
 enabled:
 

--- a/docs/architecture/zero-token-nodes.rst
+++ b/docs/architecture/zero-token-nodes.rst
@@ -21,3 +21,8 @@ Note that:
 * Zero-token nodes never store replicated data, so running ``nodetool rebuild``,
   ``nodetool repair``, and ``nodetool cleanup`` can be skipped as it does not
   affect zero-token nodes.
+* Racks consisting solely of zero-token nodes are not taken into consideration
+  when deciding whether a keyspace is :term:`RF-rack-valid <RF-rack-valid keyspace>`.
+  However, an RF-rack-valid keyspace must have the replication factor equal to 0
+  in an :doc:`arbiter DC </operating-scylla/procedures/cluster-management/arbiter-dc>`.
+  Otherwise, it is RF-rack-invalid.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -224,7 +224,8 @@ By default, a keyspace is created with tablets enabled. You can use the ``tablet
 to opt out a keyspace from tablets-based distribution.
 
 You may want to opt out if you plan to use features that are not supported for keyspaces
-with tablets enabled. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
+with tablets enabled. Keyspaces using tablets must also remain :term:`RF-rack-valid <RF-rack-valid keyspace>`
+throughout their lifetime. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
 for details.
 
 **The ``initial`` sub-option (deprecated)**
@@ -300,6 +301,7 @@ Modifying a keyspace with tablets enabled is possible and doesn't require any sp
 - If there's any other ongoing global topology operation, executing the ``ALTER`` statement will fail (with an explicit and specific error) and needs to be repeated.
 - The ``ALTER`` statement may take longer than the regular query timeout, and even if it times out, it will continue to execute in the background.
 - The replication strategy cannot be modified, as keyspaces with tablets only support ``NetworkTopologyStrategy``.
+- The ``ALTER`` statement will fail if it would make the keyspace :term:`RF-rack-invalid <RF-rack-valid keyspace>`.
 
 .. _drop-keyspace-statement:
 

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -127,6 +127,12 @@ Glossary
       RBNO is enabled by default for a subset node operations. 
       See :doc:`Repair Based Node Operations </operating-scylla/procedures/cluster-management/repair-based-node-operation>` for details.
 
+    RF-rack-valid keyspace
+      A keyspace with :doc:`tablets </architecture/tablets>` enabled is RF-rack-valid if all of its data centers
+      have the :term:`Replication Factor (RF) <Replication Factor (RF)>` of 0, 1, or the number of racks in that data center.
+
+      Keyspaces with tablets disabled are always deemed RF-rack-valid, even if they do not satisfy the aforementioned condition.
+
     Shard
       Each ScyllaDB node is internally split into *shards*, an independent thread bound to a dedicated core.
       Each shard of data is allotted CPU, RAM, persistent storage, and networking resources which it uses as efficiently as possible.

--- a/main.cc
+++ b/main.cc
@@ -13,6 +13,7 @@
 
 #include <seastar/util/closeable.hh>
 #include <seastar/core/abort_source.hh>
+#include "exceptions/exceptions.hh"
 #include "gms/inet_address.hh"
 #include "auth/allow_all_authenticator.hh"
 #include "auth/allow_all_authorizer.hh"
@@ -2175,6 +2176,14 @@ sharded<locator::shared_token_metadata> token_metadata;
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();
+
+            // At this point, `locator::topology` should be stable, i.e. we should have complete information
+            // about the layout of the cluster (= list of nodes along with the racks/DCs).
+            if (cfg->rf_rack_valid_keyspaces()) {
+                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                db.local().check_rf_rack_validity(token_metadata.local().get());
+                startlog.info("All keyspaces are RF-rack-valid");
+            }
 
             dictionary_service dict_service(
                 dict_sampler,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -10,6 +10,9 @@
 
 #include <fmt/ranges.h>
 #include <fmt/std.h>
+#include "locator/network_topology_strategy.hh"
+#include "locator/tablets.hh"
+#include "locator/token_metadata_fwd.hh"
 #include "utils/log.hh"
 #include "replica/database_fwd.hh"
 #include "utils/assert.hh"
@@ -3182,6 +3185,14 @@ future<> database::on_before_service_level_change(qos::service_level_options slo
 future<>
 database::on_effective_service_levels_cache_reloaded() {
     co_return;
+}
+
+void database::check_rf_rack_validity(const locator::token_metadata_ptr tmptr) const {
+    SCYLLA_ASSERT(get_config().rf_rack_valid_keyspaces());
+
+    for (const auto& [name, info] : get_keyspaces()) {
+        locator::assert_rf_rack_valid_keyspace(name, tmptr, info.get_replication_strategy());
+    }
 }
 
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1951,6 +1951,14 @@ public:
     /** This callback is going to be called just before the service level is changed **/
     virtual future<> on_before_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) override;
     virtual future<> on_effective_service_levels_cache_reloaded() override;
+
+    // Verify that the existing keyspaces are all RF-rack-valid.
+    //
+    // Preconditions:
+    // * the option `rf_rack_valid_keyspaces` in enabled,
+    // * the `locator::topology` instance corresponding to the passed `locator::token_metadata_ptr`
+    //   must contain a complete list of racks and data centers in the cluster.
+    void check_rf_rack_validity(const locator::token_metadata_ptr) const;
 };
 
 // A helper function to parse the directory name back

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -3,14 +3,18 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
+import asyncio
 import logging
 import sys
+
+from typing import List, Union
 
 import pytest
 from cassandra.policies import WhiteListRoundRobinPolicy
 
 from test.cqlpy import nodetool
 from cassandra import ConsistencyLevel
+from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables, TextType, Column
@@ -143,3 +147,240 @@ async def test_query_dc_with_rf_0_does_not_crash_db(request: pytest.FixtureReque
         f"Expected {expected} from {select_query.query_string}, but got {first_node_results}"
     assert second_node_result is None, \
         f"Expected no results from {select_query.query_string}, but got {second_node_result}"
+
+@pytest.mark.asyncio
+async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: ManagerClient):
+    """
+    This test verifies that creating and altering a keyspace keeps it RF-rack-valid.
+    If an operation would make it RF-rack-invalid, it should fail.
+    We can add a new rack or a data center and the existing keyspaces must still work fine.
+
+    For context, see: scylladb/scylladb#23276.
+    """
+
+    cql = None
+    cfg = {"rf_rack_valid_keyspaces": "true"}
+    cfg_zero_token = {"rf_rack_valid_keyspaces": "true", "join_ring": "false"}
+
+    async def create_aux(ks: str, rfs: Union[List[int], int]):
+        if type(rfs) is int:
+            rep_opts = f"'replication_factor': {rfs}"
+        else:
+            rep_opts = ", ".join([f"'dc{i + 1}': {rf}" for i, rf in enumerate(rfs)])
+        opts = f"replication = {{'class': 'NetworkTopologyStrategy', {rep_opts}}} AND tablets = {{'enabled': true}}"
+        print("CREATING KEYSPACE!")
+        await cql.run_async(f"CREATE KEYSPACE {ks} WITH {opts}")
+
+    async def create_ok(rfs: Union[List[int], int]) -> str:
+        ks = unique_name()
+        await create_aux(ks, rfs)
+        return ks
+
+    async def create_fail(rfs: Union[List[int], int], failed_dc: int, rf: int, rack_count: int):
+        ks = unique_name()
+        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+              f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
+        with pytest.raises(InvalidRequest, match=err):
+            await create_aux(ks, rfs)
+
+    async def create_fail(rfs: List[int], failed_dc: int, rf: int, rack_count: int) -> None:
+        ks = unique_name()
+        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+              f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
+
+        with pytest.raises(InvalidRequest, match=err):
+            await create_aux(ks, rfs)
+
+    async def alter_ok(ks: str, rfs: List[int]) -> None:
+        dcs = ", ".join([f"'dc{i + 1}': {rf}" for i, rf in enumerate(rfs)])
+        print("ALTERING KEYSPACE!")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', {dcs}}}")
+
+    async def alter_fail(ks: str, rfs: List[int], failed_dc: int, rack_count: int) -> None:
+        rf = rfs[failed_dc - 1]
+        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+              f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
+
+        with pytest.raises(InvalidRequest, match=err):
+            await alter_ok(ks, rfs)
+
+    # Step 1.
+    # -------
+    # dc1: r1=1, rzerotoken=1 (Note: zero-token nodes have NO impact. In this case, this rack should behave as if it never existed).
+    _ = await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}, config=cfg)
+    _ = await manager.server_add(property_file={"dc": "dc1", "rack": "rzerotoken"}, config=cfg_zero_token)
+    cql = manager.get_cql()
+
+    ks1 = await create_ok([1])
+    await create_ok([0])
+    await create_ok(0)
+    await create_ok(1)
+    await create_fail([2], 1, 2, 1)
+    await create_fail(2, 1, 2, 1)
+
+    await alter_ok(ks1, [0])
+    await alter_ok(ks1, [1])
+    # Check if it works if the RF doesn't change.
+    await alter_ok(ks1, [1])
+
+    await alter_fail(ks1, [2], 1, 1)
+
+    # Step 2.
+    # -------
+    # dc1: r1=1, rzerotoken=1.
+    # dc2: r1=1.
+    _ = await manager.server_add(property_file={"dc": "dc2", "rack": "r1"}, config=cfg)
+
+    ks2 = await create_ok([1, 1])
+
+    tasks = [
+        create_ok([0, 1]),
+        create_ok([0, 0]),
+        create_ok([1, 0]),
+        create_ok(0),
+        create_ok(1),
+        create_fail([2, 1], 1, 2, 1),
+        create_fail([1, 2], 2, 2, 1),
+        create_fail([2, 0], 1, 2, 1)
+    ]
+
+    # To reduce the latency.
+    async with asyncio.TaskGroup() as tg:
+        for task in tasks:
+            _ = tg.create_task(task)
+
+    # Edge case: global RF = 0.
+    await alter_ok(ks1, [0, 0])
+    await alter_ok(ks1, [1, 0])
+    # Check if it works if the RF doesn't change.
+    await alter_ok(ks1, [1, 0])
+
+    # Edge case: global RF = 0.
+    await alter_ok(ks1, [0])
+    await alter_ok(ks1, [1])
+    # Check if it works if the RF doesn't change.
+    await alter_ok(ks1, [1])
+
+    await alter_fail(ks1, [2, 0], 1, 1)
+    await alter_fail(ks1, [2], 1, 1)
+
+    await alter_ok(ks1, [1, 1])
+    await alter_ok(ks2, [0, 1])
+    await alter_ok(ks2, [1, 1])
+    await alter_ok(ks2, [1, 0])
+    await alter_ok(ks2, [1, 1])
+
+    await alter_fail(ks2, [2, 1], 1, 1)
+    await alter_fail(ks2, [1, 2], 2, 1)
+
+    # Step 3.
+    # -------
+    # dc1: r1=1, r2=1, rzerotoken=1.
+    # dc2: r1=1.
+    _ = await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}, config=cfg)
+
+    ks3 = await create_ok([2, 1])
+    # RF = 1 is always OK!
+    ks4 = await create_ok([1, 1])
+
+    tasks = [
+        create_ok([2, 0]),
+        create_ok([0, 1]),
+        create_ok(0),
+        create_ok(1),
+        create_fail([1, 2], 2, 2, 1),
+        create_fail([2, 2], 2, 2, 1),
+        create_fail(2, 2, 2, 1)
+    ]
+
+    # To reduce the latency.
+    async with asyncio.TaskGroup() as tg:
+        for task in tasks:
+            _ = tg.create_task(task)
+
+    await alter_ok(ks1, [2, 1])
+    await alter_fail(ks1, [2, 2], 2, 1)
+
+    await alter_ok(ks2, [2, 1])
+    await alter_ok(ks3, [2, 1])
+    await alter_ok(ks4, [2, 1])
+    # RF = 1 is always OK!
+    await alter_ok(ks3, [1, 1])
+
+@pytest.mark.asyncio
+async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
+    """
+    This test verifies that Scylla rejects RF-rack-invalid keyspaces
+    in presence of an arbiter data center.
+
+    For context, see: scylladb/scylladb#23276 and scylladb/scylladb#20356.
+    """
+
+    cfg = {"rf_rack_valid_keyspaces": "true"}
+    zero_token_cfg = {"rf_rack_valid_keyspaces": "true", "join_ring": "false"}
+
+    # Regular DC.
+    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"})
+    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r2"})
+    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r3"})
+    # Zero-token node. This rack should behave as if it didn't exist.
+    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc1", "rack": "r4"})
+
+    # Arbiter DC.
+    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r1"})
+    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r2"})
+    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r3"})
+
+    cql = manager.get_cql()
+
+    async def create_aux(ks: str, rfs: Union[List[int], int]):
+        if type(rfs) is int:
+            rep_opts = f"'replication_factor': {rfs}"
+        else:
+            rep_opts = f"'dc1': {rfs[0]}, 'dc2': {rfs[1]}"
+        opts = f"replication = {{'class': 'NetworkTopologyStrategy', {rep_opts}}} AND tablets = {{'enabled': true}}"
+        try:
+            print("CREATING KEYSPACE!")
+            await cql.run_async(f"CREATE KEYSPACE {ks} WITH {opts}")
+        finally:
+            await cql.run_async(f"DROP KEYSPACE IF EXISTS {ks}")
+
+    async def create_ok(rfs: Union[List[int], int]):
+        ks = unique_name()
+        await create_aux(ks, rfs)
+
+    async def create_fail(rfs: Union[List[int], int], failed_dc: int, rf: int, rack_count: int):
+        ks = unique_name()
+        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+              f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
+        with pytest.raises(InvalidRequest, match=err):
+            await create_aux(ks, rfs)
+
+    valid_keyspaces = [
+        create_ok([0, 0]),
+        create_ok([1, 0]),
+        create_ok([3, 0]),
+        create_ok(0)
+    ]
+
+    # We don't consider cases where the RF for dc1 is 2 and the RF for dc2 is a positive number
+    # because then we can't predict what error will say.
+    invalid_keyspaces = [
+        create_fail([4, 0], 1, 4, 3),
+        create_fail([2, 0], 1, 2, 3),
+        create_fail([0, 1], 2, 1, 0),
+        create_fail([0, 2], 2, 2, 0),
+        create_fail([0, 3], 2, 3, 0),
+        create_fail([1, 1], 2, 1, 0),
+        create_fail([1, 2], 2, 2, 0),
+        create_fail([1, 3], 2, 3, 0),
+        create_fail([3, 1], 2, 1, 0),
+        create_fail([3, 2], 2, 2, 0),
+        create_fail([3, 3], 2, 3, 0),
+        create_fail(1, 2, 1, 0),
+        create_fail(3, 2, 3, 0)
+    ]
+
+    async with asyncio.TaskGroup() as tg:
+        for task in [*valid_keyspaces, *invalid_keyspaces]:
+            _ = tg.create_task(task)

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1050,6 +1050,12 @@ private:
                 throw;
             }
 
+            if (cfg->rf_rack_valid_keyspaces()) {
+                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                _db.local().check_rf_rack_validity(_token_metadata.local().get());
+                startlog.info("All keyspaces are RF-rack-valid");
+            }
+
             utils::loading_cache_config perm_cache_config;
             perm_cache_config.max_size = cfg->permissions_cache_max_entries();
             perm_cache_config.expiry = std::chrono::milliseconds(cfg->permissions_validity_in_ms());


### PR DESCRIPTION
This PR is an introductory step towards enforcing
RF-rack-valid keyspaces in Scylla.

The scope of changes:
* defining RF-rack-valid keyspaces,
* introducing a configuration option enforcing RF-rack-valid
  keyspaces,
* restricting the CREATE and ALTER KEYSPACE statements
  so that they never lead to RF-rack invalid keyspaces,
* during the initialization of a node, it verifies that all existing
  keyspaces are RF-rack-valid. If not, the initialization fails.

We provide tests verifying that the changes behave as intended.

---

Note that there are a number of things that still need to be implemented.
That includes, for instance, restricting topology operations too.

---

Implementation strategy (going beyond the scope of this PR):

1. Introduce the new configuration option `rf_rack_valid_keyspaces`.
2. Start enforcing RF-rack-validity in keyspaces if the option is enabled.
3. Adjust the tests: in the tree and out of it. Explicitly enable the option in all tests.
4. Once the tests have been adjusted, change the default value of the option to enabled.
5. Stop explicitly enabling the option in tests.
6. Get rid of the option.

---

Fixes scylladb/scylladb#20356
Fixes scylladb/scylladb#23276
Fixes scylladb/scylladb#23300

---

Backport: this is part of the requirements for releasing 2025.1.