### PR TITLE
Speed up (and generalize) the way API calculates sstable disk usage

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -251,16 +251,15 @@ static integral_ratio_holder mean_partition_size(replica::column_family& cf) {
 }
 
 static future<json::json_return_type>  sum_sstable(http_context& ctx, const sstring name, bool total) {
-    auto uuid = parse_table_info(name, ctx.db.local()).id;
-    return ctx.db.map_reduce0([uuid, total](replica::database& db) {
+    return map_reduce_cf_raw(ctx, name, uint64_t(0), [total](replica::column_family& cf) {
         uint64_t bytes_on_disk = 0;
-        auto sstables = (total) ? db.find_column_family(uuid).get_sstables_including_compacted_undeleted() :
-                db.find_column_family(uuid).get_sstables();
+        auto sstables = (total) ? cf.get_sstables_including_compacted_undeleted() :
+                cf.get_sstables();
         for (auto t : *sstables) {
             bytes_on_disk += t->bytes_on_disk();
         }
         return bytes_on_disk;
-    }, uint64_t(0), std::plus<>()).then([] (uint64_t val) {
+    }, std::plus<>()).then([] (uint64_t val) {
         return make_ready_future<json::json_return_type>(val);
     });
 }

--- a/test/rest_api/test_column_family.py
+++ b/test/rest_api/test_column_family.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 
+import os
 import pytest
 import sys
 import requests
@@ -146,3 +147,44 @@ def test_column_family_compaction_strategy(cql, this_dc, rest_api):
                 resp = rest_api.send("POST", f"column_family/compaction_strategy/{table_name}", params={"class_name": strategy})
                 resp.raise_for_status()
                 check_strategy(strategy)
+
+
+# Test that get_live|total_disk_space_used returns sane values
+def test_sstables_total_disk_space_sanity(cql, this_dc, rest_api):
+    ksdef = f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : '1' }}"
+    with new_test_keyspace(cql, ksdef) as test_keyspace:
+        with new_test_table(cql, test_keyspace, "a int, PRIMARY KEY (a)") as t:
+            test_table = t.split('.')[1]
+            cql.execute(f"INSERT INTO {test_keyspace}.{test_table} (a) VALUES (1)")
+            resp = rest_api.send("POST", f"storage_service/keyspace_flush/{test_keyspace}")
+            resp.raise_for_status()
+            resp = rest_api.send("GET", f"column_family/sstables/by_key/{test_keyspace}:{test_table}?key=1")
+            resp.raise_for_status()
+
+            sstables = resp.json()
+            assert len(sstables) > 0, "no sstables generated for a table"
+
+            total_real_size = 0
+            for sst in sstables:
+                sstname = os.path.basename(sst).removesuffix('-big-Data.db')
+                dirname = os.path.dirname(sst)
+                print(f'Collecting {sstname}')
+                for f in os.listdir(dirname):
+                    if f.startswith(sstname):
+                        size = os.stat(f'{dirname}/{f}').st_size
+                        print(f'Add {f}, {size} bytes')
+                        total_real_size += size
+
+            print(f'Total real size : {total_real_size}')
+
+            resp = rest_api.send("GET", f"column_family/metrics/total_disk_space_used/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            total_size = int(resp.json())
+            print(f'Reported total size : {total_size}')
+            assert total_size == total_real_size
+
+            resp = rest_api.send("GET", f"column_family/metrics/live_disk_space_used/{test_keyspace}:{test_table}")
+            resp.raise_for_status()
+            live_size = int(resp.json())
+            print(f'Reported live size : {live_size}')
+            assert live_size <= total_real_size


### PR DESCRIPTION
There are several API endpoints that walk a specific list of sstables and sums up their bytes_on_disk() values. All those endpoints accumulate a map of sstable names to their sizes, then squashes the maps together and, finally, sums up the values to report it back. Maintaining these intermediate collections is the waste of CPU and memory, the usage values can be summed up instantly.

Also add a test for per-cf endpoints to validate the change, and generalize the helper functions while at it.