### PR TITLE
[Backport 2025.1] repair: Enable small table optimization for system_replicated_keys

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1508,6 +1508,7 @@ future<> repair::data_sync_repair_task_impl::run() {
         static const std::unordered_set<sstring> small_table_optimization_enabled_ks = {
             "system_distributed",
             "system_distributed_everywhere",
+            "system_replicated_keys",
             "system_auth",
             "system_traces"
         };


### PR DESCRIPTION
This enterprise-only system table is replicated and small. It should be included for small table optimization.

Fixes https://github.com/scylladb/scylla-enterprise/issues/5256
Fixes https://github.com/scylladb/scylladb/issues/23148

Should be backported because it fixes a regression in bootstrap speed.

Backported from https://github.com/scylladb/scylladb/pull/23135