### PR TITLE
schema: deprecate schema_extension

### DIFF
--- a/cdc/cdc_extension.hh
+++ b/cdc/cdc_extension.hh
@@ -23,6 +23,10 @@ class cdc_extension : public schema_extension {
 public:
     static constexpr auto NAME = "cdc";
 
+    // cdc_extension was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     cdc_extension() = default;
     cdc_extension(const options& opts) : _cdc_options(opts) {}
     explicit cdc_extension(std::map<sstring, sstring> tags) : _cdc_options(std::move(tags)) {}
@@ -30,6 +34,7 @@ public:
     explicit cdc_extension(const sstring& s) {
         throw std::logic_error("Cannot create cdc info from string");
     }
+#pragma clang diagnostic pop
     bytes serialize() const override {
         return ser::serialize_to_buffer<bytes>(_cdc_options.to_map());
     }

--- a/db/paxos_grace_seconds_extension.hh
+++ b/db/paxos_grace_seconds_extension.hh
@@ -36,6 +36,10 @@ class paxos_grace_seconds_extension : public schema_extension {
 public:
     static constexpr auto NAME = "paxos_grace_seconds";
 
+    // cdc_extension was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     paxos_grace_seconds_extension() = default;
     
     explicit paxos_grace_seconds_extension(int32_t seconds)
@@ -52,6 +56,7 @@ public:
     explicit paxos_grace_seconds_extension(const sstring& s)
         : _paxos_gc_sec(std::stoi(s))
     {}
+#pragma clang diagnostic pop
 
     bytes serialize() const override {
         return ser::serialize_to_buffer<bytes>(_paxos_gc_sec);

--- a/db/per_partition_rate_limit_extension.hh
+++ b/db/per_partition_rate_limit_extension.hh
@@ -19,6 +19,10 @@ class per_partition_rate_limit_extension : public schema_extension {
 public:
     static constexpr auto NAME = "per_partition_rate_limit";
 
+    // per_partition_rate_limit_extension was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     per_partition_rate_limit_extension() = default;
     per_partition_rate_limit_extension(const per_partition_rate_limit_options& opts) : _options(opts) {}
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2129,9 +2129,14 @@ static void prepare_builder_from_table_row(const schema_ctxt& ctxt, schema_build
             class placeholder : public schema_extension {
                 bytes _bytes;
             public:
+                // This support code was written before schema_extension was deprecated, so support it
+                // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                 placeholder(bytes bytes)
                                 : _bytes(std::move(bytes)) {
                 }
+#pragma clang diagnostic pop
                 bytes serialize() const override {
                     return _bytes;
                 }

--- a/db/tags/extension.hh
+++ b/db/tags/extension.hh
@@ -17,12 +17,17 @@ class tags_extension : public schema_extension {
 public:
     static constexpr auto NAME = "scylla_tags";
 
+    // tags_extension was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     tags_extension() = default;
     explicit tags_extension(const std::map<sstring, sstring>& tags) : _tags(std::move(tags)) {}
     explicit tags_extension(bytes b) : _tags(tags_extension::deserialize(b)) {}
     explicit tags_extension(const sstring& s) {
         throw std::logic_error("Cannot create tags from string");
     }
+#pragma clang diagnostic pop
     bytes serialize() const override {
         return ser::serialize_to_buffer<bytes>(_tags);
     }

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -591,11 +591,17 @@ std::ostream& operator<<(std::ostream& os, const encryption_schema_extension& ex
     return os;
 }
 
+// encryption_schema_extension was written before schema_extension was deprecated, so support it
+// without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 encryption_schema_extension::encryption_schema_extension(key_info info, shared_ptr<key_provider> provider, std::map<sstring, sstring> options)
     : _info(std::move(info))
     , _provider(std::move(provider))
     , _options(std::move(options))
 {}
+
+#pragma clang diagnostic pop
 
 ::shared_ptr<encryption_schema_extension> encryption_schema_extension::create(encryption_context_impl& ctxt, const bytes& v) {
     auto map = parse_options(v);

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -474,6 +474,9 @@ class partition_slice;
 class schema_extension {
 public:
     virtual ~schema_extension() {};
+    [[deprecated("Use dedicated columns in system_schema.scylla_tables instead")]]
+    schema_extension() = default;
+
     virtual future<> validate(const schema&) const {
         return make_ready_future<>();
     }

--- a/test/boost/extensions_test.cc
+++ b/test/boost/extensions_test.cc
@@ -31,11 +31,16 @@ BOOST_AUTO_TEST_SUITE(extensions_test)
 
 class dummy_ext : public schema_extension {
 public:
+    // dummy_ext was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     dummy_ext(bytes b) : _bytes(b) {}
     dummy_ext(const std::map<sstring, sstring>& map) : _bytes(ser::serialize_to_buffer<bytes>(map)) {}
     dummy_ext(const sstring&) {
         throw std::runtime_error("should not reach");
     }
+#pragma clang diagnostic pop
     bytes serialize() const override {
         return _bytes;
     }

--- a/tombstone_gc_extension.hh
+++ b/tombstone_gc_extension.hh
@@ -21,6 +21,10 @@ class tombstone_gc_extension : public schema_extension {
 public:
     static constexpr auto NAME = "tombstone_gc";
 
+    // tombstone_gc_extension was written before schema_extension was deprecated, so support it
+    // without warnings
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     tombstone_gc_extension() = default;
     tombstone_gc_extension(const tombstone_gc_options& opts) : _tombstone_gc_options(opts) {}
     explicit tombstone_gc_extension(std::map<seastar::sstring, seastar::sstring> tags) : _tombstone_gc_options(std::move(tags)) {}
@@ -28,6 +32,7 @@ public:
     explicit tombstone_gc_extension(const seastar::sstring& s) {
         throw std::logic_error("Cannot create tombstone_gc_extension info from string");
     }
+#pragma clang diagnostic pop
     bytes serialize() const override {
         return ser::serialize_to_buffer<bytes>(_tombstone_gc_options.to_map());
     }


### PR DESCRIPTION
schema_extension allows making invisible changes to system_schema that evade upgrade rollback tests. They appear in system_schema as an encoded blob which reduces serviceability, as they cannot be read.

Deprecate it and point users to adding explicit columns in scylla_tables.

We could probably make use of the data structure, after we teach it to encode its payload into proper named and typed columns instead of using IDL.

No backport, this just deprecates an internal feature.