### PR TITLE
alter_table_statement: fix renaming multiple columns in tables with views

### DIFF
--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -377,28 +377,30 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
 
             validate_column_rename(db, *s, *from, *to);
             cfm.rename_column(from->name(), to->name());
-
-            // If the view includes a renamed column, it must be renamed in
-            // the view table and the definition.
-            for (auto&& view : cf.views()) {
+        }
+        // If the view includes a renamed column, it must be renamed in
+        // the view table and the definition.
+        for (auto&& view : cf.views()) {
+            schema_builder builder(view);
+            std::vector<std::pair<::shared_ptr<column_identifier>, ::shared_ptr<column_identifier>>> view_renames;
+            for (auto&& entry : _renames) {
+                auto from = entry.first->prepare_column_identifier(*s);
                 if (view->get_column_definition(from->name())) {
-                    schema_builder builder(view);
-
                     auto view_from = entry.first->prepare_column_identifier(*view);
                     auto view_to = entry.second->prepare_column_identifier(*view);
                     validate_column_rename(db, *view, *view_from, *view_to);
                     builder.rename_column(view_from->name(), view_to->name());
-
-                    auto new_where = util::rename_column_in_where_clause(
-                            view->view_info()->where_clause(),
-                            column_identifier::raw(view_from->text(), true),
-                            column_identifier::raw(view_to->text(), true),
-                            cql3::dialect{});
-                    builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
-                            view->view_info()->include_all_columns(), std::move(new_where));
-
-                    view_updates.push_back(view_ptr(builder.build()));
+                    view_renames.emplace_back(view_from, view_to);
                 }
+            }
+            if (!view_renames.empty()) {
+                auto new_where = util::rename_columns_in_where_clause(
+                        view->view_info()->where_clause(),
+                        view_renames,
+                        cql3::dialect{});
+                builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
+                        view->view_info()->include_all_columns(), std::move(new_where));
+                view_updates.push_back(view_ptr(builder.build()));
             }
         }
         break;

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -40,7 +40,7 @@ sstring relations_to_where_clause(const expr::expression& e);
 
 expr::expression where_clause_to_relations(const std::string_view& where_clause, dialect d);
 
-sstring rename_column_in_where_clause(const std::string_view& where_clause, column_identifier::raw from, column_identifier::raw to, dialect d);
+sstring rename_columns_in_where_clause(const std::string_view& where_clause, std::vector<std::pair<::shared_ptr<column_identifier>, ::shared_ptr<column_identifier>>> renames, dialect d);
 
 /// build a CQL "select" statement with the desired parameters.
 /// If select_all_columns==true, all columns are selected and the value of

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -1711,3 +1711,12 @@ def test_reverse_read_from_view(cql, test_keyspace):
             assert {(1,),(2,)} == set(cql.execute(f'select a from {mv} where b=1'))
             assert [(1,),(2,)] == list(cql.execute(f'select a from {mv} where b=1 order by a asc'))
             assert [(2,),(1,)] == list(cql.execute(f'select a from {mv} where b=1 order by a desc'))
+
+# Test that we can rename multiple columns in the base table at the same time
+# without causing any issues for view updates.
+# Reproduces issue https://github.com/scylladb/scylladb/issues/22194
+def test_rename_multiple_columns(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, 'pk int, ck int, PRIMARY KEY (pk, ck)') as table:
+        with new_materialized_view(cql, table, '*', 'ck, pk', 'pk IS NOT NULL AND ck IS NOT NULL'):
+            cql.execute(f'ALTER TABLE {table} RENAME pk TO pk2 AND ck TO ck2')
+            cql.execute(f'INSERT INTO {table} (pk2, ck2) VALUES (0,0)')


### PR DESCRIPTION
When we rename columns in a table which has materialized views depending on it, we need to also rename them in the materialized views' WHERE clauses.
Currently, we do that by creating a new WHERE clause after each rename, with the updated column. This is later converted to a mutation that overwrites the WHERE clause. After multiple renames, we have multiple mutations, each overwriting the WHERE clause with one column renamed. As a result, the final WHERE clause is one of the modified clauses with one column renamed.
Instead, we should prepare one new WHERE clause which includes all the renamed columns. This patch accomplishes this by processing all the column renames first, and only preparing the new view schema with the new WHERE clause afterwards.

This patch also includes a test reproducer for this scenario.

Fixes https://github.com/scylladb/scylladb/issues/22194
