### PR TITLE
gms: Fix fmt formatter for gossip_digest_sync

### DIFF
--- a/gms/gossip_digest_syn.cc
+++ b/gms/gossip_digest_syn.cc
@@ -13,8 +13,8 @@
 auto fmt::formatter<gms::gossip_digest_syn>::format(const gms::gossip_digest_syn& syn, fmt::format_context& ctx) const
         -> decltype(ctx.out()) {
     auto out = ctx.out();
-    // out = fmt::format_to(out, "cluster_id:{},partioner:{},group0_id{},"
-    //                      syn._cluster_id, syn._partioner, syn._group0_id);
+    out = fmt::format_to(out, "cluster_id:{},partioner:{},group0_id{},",
+                         syn._cluster_id, syn._partioner, syn._group0_id);
     out = fmt::format_to(out, "digests:{{");
     for (auto& d : syn._digests) {
         out = fmt::format_to(out, "{} ", d);


### PR DESCRIPTION
Previously, the fmt-based formatter for gossip_digest_sync (migrated in commit 4812a57f) had formatting code for cluster_id, partitioner, and group0_id fields commented out accidentally, effectively preventing these fields from being formatted.

This commit uncomments the formatting code to restore full field formatting in the gossip_digest_sync formatter.

Fixes #23142
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this change addresses a regression introduced by 4812a57f. the regression prevented us from seeing the cluster_id, partitioner, and group0_id fields of a gossip message -- `gossip_digest_syn`. so better off backporting it, so we have better visibility of this message as long as the logging level allows.