### PR TITLE
transport: storage_proxy: release ERM when waiting for query timeout

### DIFF
--- a/exceptions/coordinator_result.hh
+++ b/exceptions/coordinator_result.hh
@@ -33,7 +33,8 @@ using coordinator_exception_container = utils::exception_container<
     read_timeout_exception,
     read_failure_exception,
     rate_limit_exception,
-    overloaded_exception
+    overloaded_exception,
+    read_failure_exception_with_timeout
 >;
 
 template<typename T = void>

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -297,6 +297,7 @@ future<> server::shutdown() {
         _logger.debug("shutdown connection {} out of {} done", ++nr_conn, nr_conn_total);
     });
     co_await std::move(_listeners_stopped);
+    _abort_source.request_abort();
 }
 
 future<>

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -124,6 +124,7 @@ protected:
     std::list<gentle_iterator> _gentle_iterators;
     std::vector<server_socket> _listeners;
     shared_ptr<seastar::tls::server_credentials> _credentials;
+    seastar::abort_source _abort_source;
 private:
     utils::updateable_value<uint32_t> _conns_cpu_concurrency;
     uint32_t _prev_conns_cpu_concurrency;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -4617,6 +4617,7 @@ private:
             // if the error is because of a connection disconnect and there is no targets to speculate
             // wait for timeout in hope that the client will issue speculative read
             // FIXME: resolver should have access to all replicas and try another one in this case
+            fail_request(read_failure_exception_with_timeout(_schema->ks_name(), _schema->cf_name(), _cl, _cl_responses, _failed, _block_for, _data_result, _timeout.get_timeout()));
             return;
         }
         if (_block_for + _failed > _target_count_for_cl) {

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -1,0 +1,125 @@
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+from cassandra.policies import WhiteListRoundRobinPolicy
+from test.cluster.conftest import skip_mode
+from test.pylib.manager_client import ManagerClient
+from test.pylib.random_tables import RandomTables, Column, IntType
+from test.pylib.rest_client import inject_error_one_shot
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+import asyncio
+from datetime import datetime, timedelta
+import pytest
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query,should_wait_for_timeout,shutdown_nodes", [
+    ("SELECT * FROM {}", True, False),
+    ("SELECT * FROM {}", True, True),
+    ("SELECT COUNT(*) FROM {}", False, False),
+    ("SELECT * FROM {} WHERE key = 0", True, False),
+    ("SELECT COUNT(*) FROM {} WHERE key = 0", True, False),
+])
+async def test_long_query_timeout_erm(request, manager: ManagerClient, query, should_wait_for_timeout, shutdown_nodes):
+    """
+    Test verifies that a query with long timeout doesn't block ERM on failure.
+
+    The test is parametrized ("SELECT * ..." and "SELECT COUNT(*) ...") to verify both
+    regular query execution and aggregate query that goes through mapreduce service.
+
+    After an initial preparation, the test kills a node during the execution of
+    a query with long timeout. The expectation is that:
+      1) Due to scylladb#21831 fix, ERM will not be blocked for the timeout period.
+      2) For non-mapreduce queries, due to scylladb#3699 fix, the query will not finish
+         before the timeout passes.
+      3) For mapreduce query, the query will fail promptly with "Operation failed for ..." error,
+         because waiting with a hope for driver-side speculative retry (scylladb#3699 fix)
+         is not needed for an aggregate query.
+
+    Please note that "SELECT COUNT(*) FROM {} WHERE key = 0" is not a mapreduce query.
+
+    One of the test scenarios sets shutdown_nodes=True, to verify that we are able to
+    quickly shutdown nodes, even if query timeout is extremely long.
+    """
+    logger.info("Start four nodes cluster")
+    servers = await manager.servers_add(4)
+
+    selected_server = servers[0]
+    logger.info(f"Creating a client with selected_server: {selected_server}")
+    cql = await manager.get_cql_exclusive(selected_server)
+
+    logger.info("Create a table")
+    random_tables = RandomTables(request.node.name, manager, "ks", replication_factor=3, enable_tablets=True)
+    table = await random_tables.add_table(pks=1, columns=[
+        Column(name="key", ctype=IntType),
+        Column(name="value", ctype=IntType)
+    ])
+
+    if "WHERE" in query:
+        # For non-ranged queries, Scylladb-side speculative retries are disabled to enforce
+        # conditions of scylladb#3699 fix.
+        logger.info("Disabling speculative retries")
+        cql.execute(f"ALTER TABLE {table} WITH speculative_retry = 'NONE'")
+
+    logger.info(f"Created {table}, write some rows")
+    await asyncio.gather(*[cql.run_async(f"INSERT INTO {table} (key, value) VALUES ({i}, {i})") for i in range(256)])
+
+    logger.info("Enable injected errors that stop reads")
+    injected_handlers = {}
+    for server in servers:
+        injected_handlers[server.ip_addr] = await inject_error_one_shot(
+            manager.api, server.ip_addr, 'storage_proxy::handle_read', parameters={'cf_name': table.name})
+
+    query_timeout = 60
+    if shutdown_nodes:
+        query_timeout *= 100 # Will end test by shutting down nodes instead of finishing the query
+    before_query = datetime.now()
+
+    final_query = query.format(table)
+    logger.info("Starting to execute query={final_query} with query_timeout={query_timeout}")
+    query_future = cql.run_async(f"{final_query} USING TIMEOUT {query_timeout}s", timeout=2*query_timeout)
+
+    logger.info("Confirm reads are waiting on the injected error")
+    server_to_kill = None
+    for server in servers:
+        if server != selected_server:
+            server_log = await manager.server_open_log(server.server_id)
+            try:
+                await server_log.wait_for("storage_proxy::handle_read injection hit", timeout=5)
+                server_to_kill = server
+            except TimeoutError:
+                # Some nodes might not receive any reads
+                logger.info(f"Node not handling any reads: {server.ip_addr}")
+
+    logger.info(f"Kill a node: {server_to_kill.ip_addr}")
+    await manager.server_stop(server_to_kill.server_id)
+
+    logger.info("Unblock reads")
+    for server in servers:
+        if server != server_to_kill:
+            await injected_handlers[server.ip_addr].message()
+
+    logger.info("Remove the killed node, add a new one - ERM should not be blocked")
+    await manager.server_not_sees_other_server(selected_server.ip_addr, server_to_kill.ip_addr)
+    await manager.remove_node(selected_server.server_id, server_to_kill.server_id)
+
+    expected_timeout_time = before_query + timedelta(seconds=query_timeout)
+    if datetime.now() > expected_timeout_time:
+        logger.warning("Too much time passed and query already might be timed-out")
+
+    if shutdown_nodes:
+        for server in servers:
+            await manager.server_stop_gracefully(server.server_id)
+    else:
+        if should_wait_for_timeout:
+            with pytest.raises(Exception, match="Operation time"):
+                await query_future
+            assert datetime.now() > expected_timeout_time
+        else:
+            with pytest.raises(Exception, match="Operation failed for"):
+                await query_future
+

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -539,91 +539,91 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             return response;
         }).handle_exception([this, stream, &client_state, trace_state] (std::exception_ptr eptr) {
             if (auto* exp = try_catch<exceptions::unavailable_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in unavailable_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in unavailable_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state));
             } else if (auto* exp = try_catch<exceptions::read_timeout_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in read_timeout_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in read_timeout_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state));
             } else if (auto* exp = try_catch<exceptions::read_failure_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in read_failure_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in read_failure_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state));
             } else if (auto* exp = try_catch<exceptions::mutation_write_timeout_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in mutation_write_timeout_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in mutation_write_timeout_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state));
             } else if (auto* exp = try_catch<exceptions::mutation_write_failure_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in mutation_write_failure_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in mutation_write_failure_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state));
             } else if (auto* exp = try_catch<exceptions::already_exists_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in already_exists_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in already_exists_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state));
             } else if (auto* exp = try_catch<exceptions::prepared_query_not_found_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in unprepared_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in unprepared_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state));
             } else if (auto* exp = try_catch<exceptions::function_execution_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in function_failure_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in function_failure_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state));
             } else if (auto* exp = try_catch<exceptions::rate_limit_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in rate_limit_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in rate_limit_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state));
             } else if (auto* exp = try_catch<exceptions::cassandra_exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in cassandra_error, stream {}, code {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.code(), ex.what());
-            // Note: the CQL protocol specifies that many types of errors have
-            // mandatory parameters. These cassandra_exception subclasses MUST
-            // be handled above. This default "cassandra_exception" case is
-            // only appropriate for the specific types of errors which do not have
-            // additional information, such as invalid_request_exception.
-            // TODO: consider listing those types explicitly, instead of the
-            // catch-all type cassandra_exception.
-            try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, ex.code(), ex.what(), trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in cassandra_error, stream {}, code {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                // Note: the CQL protocol specifies that many types of errors have
+                // mandatory parameters. These cassandra_exception subclasses MUST
+                // be handled above. This default "cassandra_exception" case is
+                // only appropriate for the specific types of errors which do not have
+                // additional information, such as invalid_request_exception.
+                // TODO: consider listing those types explicitly, instead of the
+                // catch-all type cassandra_exception.
+                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, ex.code(), ex.what(), trace_state));
             } else if (auto* exp = try_catch<std::exception>(eptr)) {
-            const auto& ex = *exp;
-            clogger.debug("{}: request resulted in error, stream {}, message [{}]",
-                _client_state.get_remote_address(), stream, ex.what());
-            try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
-            sstring msg = ex.what();
-            try {
-                std::rethrow_if_nested(ex);
-            } catch (...) {
-                std::ostringstream ss;
-                ss << msg << ": " << std::current_exception();
-                msg = ss.str();
-            }
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state));
+                const auto& ex = *exp;
+                clogger.debug("{}: request resulted in error, stream {}, message [{}]",
+                    _client_state.get_remote_address(), stream, ex.what());
+                try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
+                sstring msg = ex.what();
+                try {
+                    std::rethrow_if_nested(ex);
+                } catch (...) {
+                    std::ostringstream ss;
+                    ss << msg << ": " << std::current_exception();
+                    msg = ss.str();
+                }
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state));
             } else {
-            clogger.debug("{}: request resulted in unknown error, stream {}",
-                _client_state.get_remote_address(), stream);
-            try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
-            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state));
+                clogger.debug("{}: request resulted in unknown error, stream {}",
+                    _client_state.get_remote_address(), stream);
+                try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state));
             }
         });
     });

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -539,63 +539,53 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             return response;
         }).handle_exception([this, stream, &client_state, trace_state] (std::exception_ptr eptr) {
             if (auto* exp = try_catch<exceptions::unavailable_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in unavailable_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_unavailable_error(stream, exp->code(), exp->what(), exp->consistency, exp->required, exp->alive, trace_state));
             } else if (auto* exp = try_catch<exceptions::read_timeout_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in read_timeout_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_timeout_error(stream, exp->code(), exp->what(), exp->consistency, exp->received, exp->block_for, exp->data_present, trace_state));
             } else if (auto* exp = try_catch<exceptions::read_failure_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in read_failure_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_read_failure_error(stream, exp->code(), exp->what(), exp->consistency, exp->received, exp->failures, exp->block_for, exp->data_present, trace_state));
             } else if (auto* exp = try_catch<exceptions::mutation_write_timeout_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in mutation_write_timeout_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_timeout_error(stream, exp->code(), exp->what(), exp->consistency, exp->received, exp->block_for, exp->type, trace_state));
             } else if (auto* exp = try_catch<exceptions::mutation_write_failure_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in mutation_write_failure_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_failure_error(stream, exp->code(), exp->what(), exp->consistency, exp->received, exp->failures, exp->block_for, exp->type, trace_state));
             } else if (auto* exp = try_catch<exceptions::already_exists_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in already_exists_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_already_exists_error(stream, exp->code(), exp->what(), exp->ks_name, exp->cf_name, trace_state));
             } else if (auto* exp = try_catch<exceptions::prepared_query_not_found_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in unprepared_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_unprepared_error(stream, exp->code(), exp->what(), exp->id, trace_state));
             } else if (auto* exp = try_catch<exceptions::function_execution_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in function_failure_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_function_failure_error(stream, exp->code(), exp->what(), exp->ks_name, exp->func_name, exp->args, trace_state));
             } else if (auto* exp = try_catch<exceptions::rate_limit_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in rate_limit_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state));
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_rate_limit_error(stream, exp->code(), exp->what(), exp->op_type, exp->rejected_by_coordinator, trace_state, client_state));
             } else if (auto* exp = try_catch<exceptions::cassandra_exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in cassandra_error, stream {}, code {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.code(), ex.what());
+                    _client_state.get_remote_address(), stream, exp->code(), exp->what());
                 // Note: the CQL protocol specifies that many types of errors have
                 // mandatory parameters. These cassandra_exception subclasses MUST
                 // be handled above. This default "cassandra_exception" case is
@@ -603,16 +593,15 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
                 // additional information, such as invalid_request_exception.
                 // TODO: consider listing those types explicitly, instead of the
                 // catch-all type cassandra_exception.
-                try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-                return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, ex.code(), ex.what(), trace_state));
+                try { ++_server._stats.errors[exp->code()]; } catch(...) {}
+                return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exp->code(), exp->what(), trace_state));
             } else if (auto* exp = try_catch<std::exception>(eptr)) {
-                const auto& ex = *exp;
                 clogger.debug("{}: request resulted in error, stream {}, message [{}]",
-                    _client_state.get_remote_address(), stream, ex.what());
+                    _client_state.get_remote_address(), stream, exp->what());
                 try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
-                sstring msg = ex.what();
+                sstring msg = exp->what();
                 try {
-                    std::rethrow_if_nested(ex);
+                    std::rethrow_if_nested(*exp);
                 } catch (...) {
                     std::ostringstream ss;
                     ss << msg << ": " << std::current_exception();

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -500,10 +500,10 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
         });
         --_server._stats.requests_serving;
 
-        return utils::result_into_future<result_with_foreign_response_ptr>(utils::result_try([&] () -> result_with_foreign_response_ptr {
+        return seastar::futurize_invoke([&] () {
             result_with_foreign_response_ptr res = f.get();
             if (!res) {
-                return res;
+                res.assume_error().throw_me();
             }
 
             auto response = std::move(res).assume_value();
@@ -537,52 +537,63 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             tracing::set_response_size(trace_state, response->size());
             cql_stats.response_size += response->size();
             return response;
-        },  utils::result_catch<exceptions::unavailable_exception>([&] (const auto& ex) {
+        }).handle_exception([this, stream, &client_state, trace_state] (std::exception_ptr eptr) {
+            if (auto* exp = try_catch<exceptions::unavailable_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in unavailable_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state);
-        }), utils::result_catch<exceptions::read_timeout_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_unavailable_error(stream, ex.code(), ex.what(), ex.consistency, ex.required, ex.alive, trace_state));
+            } else if (auto* exp = try_catch<exceptions::read_timeout_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in read_timeout_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state);
-        }), utils::result_catch<exceptions::read_failure_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_read_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.data_present, trace_state));
+            } else if (auto* exp = try_catch<exceptions::read_failure_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in read_failure_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state);
-        }), utils::result_catch<exceptions::mutation_write_timeout_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_read_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.data_present, trace_state));
+            } else if (auto* exp = try_catch<exceptions::mutation_write_timeout_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in mutation_write_timeout_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state);
-        }), utils::result_catch<exceptions::mutation_write_failure_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_timeout_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.block_for, ex.type, trace_state));
+            } else if (auto* exp = try_catch<exceptions::mutation_write_failure_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in mutation_write_failure_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state);
-        }), utils::result_catch<exceptions::already_exists_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_mutation_write_failure_error(stream, ex.code(), ex.what(), ex.consistency, ex.received, ex.failures, ex.block_for, ex.type, trace_state));
+            } else if (auto* exp = try_catch<exceptions::already_exists_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in already_exists_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state);
-        }), utils::result_catch<exceptions::prepared_query_not_found_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_already_exists_error(stream, ex.code(), ex.what(), ex.ks_name, ex.cf_name, trace_state));
+            } else if (auto* exp = try_catch<exceptions::prepared_query_not_found_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in unprepared_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state);
-        }), utils::result_catch<exceptions::function_execution_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_unprepared_error(stream, ex.code(), ex.what(), ex.id, trace_state));
+            } else if (auto* exp = try_catch<exceptions::function_execution_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in function_failure_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state);
-        }), utils::result_catch<exceptions::rate_limit_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_function_failure_error(stream, ex.code(), ex.what(), ex.ks_name, ex.func_name, ex.args, trace_state));
+            } else if (auto* exp = try_catch<exceptions::rate_limit_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in rate_limit_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state);
-        }), utils::result_catch<exceptions::cassandra_exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_rate_limit_error(stream, ex.code(), ex.what(), ex.op_type, ex.rejected_by_coordinator, trace_state, client_state));
+            } else if (auto* exp = try_catch<exceptions::cassandra_exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in cassandra_error, stream {}, code {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.code(), ex.what());
             // Note: the CQL protocol specifies that many types of errors have
@@ -593,8 +604,9 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
             // TODO: consider listing those types explicitly, instead of the
             // catch-all type cassandra_exception.
             try { ++_server._stats.errors[ex.code()]; } catch(...) {}
-            return make_error(stream, ex.code(), ex.what(), trace_state);
-        }), utils::result_catch<std::exception>([&] (const auto& ex) {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, ex.code(), ex.what(), trace_state));
+            } else if (auto* exp = try_catch<std::exception>(eptr)) {
+            const auto& ex = *exp;
             clogger.debug("{}: request resulted in error, stream {}, message [{}]",
                 _client_state.get_remote_address(), stream, ex.what());
             try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
@@ -606,13 +618,14 @@ future<foreign_ptr<std::unique_ptr<cql_server::response>>>
                 ss << msg << ": " << std::current_exception();
                 msg = ss.str();
             }
-            return make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state);
-        }), utils::result_catch_dots([&] () {
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, msg, trace_state));
+            } else {
             clogger.debug("{}: request resulted in unknown error, stream {}",
                 _client_state.get_remote_address(), stream);
             try { ++_server._stats.errors[exceptions::exception_code::SERVER_ERROR]; } catch(...) {}
-            return make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state);
-        })));
+            return utils::result_into_future<result_with_foreign_response_ptr>(make_error(stream, exceptions::exception_code::SERVER_ERROR, "unknown error", trace_state));
+            }
+        });
     });
 }
 

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -256,6 +256,8 @@ private:
         scheduling_group get_scheduling_group() const { return _current_scheduling_group; }
     private:
         friend class process_request_executor;
+
+        future<foreign_ptr<std::unique_ptr<cql_server::response>>> sleep_until_timeout_passes(const seastar::lowres_clock::time_point& timeout, std::unique_ptr<cql_server::response>&& resp) const;
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);
         unsigned frame_size() const;
         unsigned pick_request_cpu();


### PR DESCRIPTION
Before this change, if a read executor had just enough targets to
achieve query's CL, and there was a connection drop (e.g. node failure),
the read executor waited for the entire request timeout to give drivers
time to execute a speculative read in a meantime. Such behavior don't
work well when a very long query timeout (e.g. 1800s) is set, because
the unfinished request blocks topology changes.

This change implements a mechanism to thrown a new
read_failure_exception_with_timeout in the aforementioned scenario.
The exception is caught by CQL server which conducts the waiting, after
ERM is released. The new exception inherits from read_failure_exception,
because layers that don't catch the exception (such as mapreduce
service) should handle the exception just a regular read_failure.
However, when CQL server catch the exception, it returns
read_timeout_exception to the client because after additional waiting
such an error message is more appropriate (read_timeout_exception was
also returned before this change was introduced).

This change:
- Rewrite cql_server::connection::process_request_one to use
  seastar::futurize_invoke and try_catch<> instead of utils::result_try
- Add new read_failure_exception_with_timeout and throws it in storage_proxy
- Add sleep in CQL server when the new exception is caught
- Catch local exceptions in Mapreduce Service and convert them
   to std::runtime_error.
- Add get_cql_exclusive to manager_client.py
- Add test_long_query_timeout_erm

No backport needed - minor issue fix.