### PR TITLE
doc: Fix object_storage_config_file option

### DIFF
--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -144,7 +144,7 @@ in the same directory as ``scylla.yaml``. You can override this location using t
 
 .. code-block:: yaml
 
-   object-storage-config-file: object-storage-config-file.yaml
+   object_storage_config_file: object_storage.yaml
 
 Configuring AWS S3 access
 -------------------------


### PR DESCRIPTION
It needs to use underscores, not dash

Should be backported to 6.2 at least, as this is present in older versions of doc as well.