### PR TITLE
transport/server.cc: set default timestamp info in EXECUTE and BATCH tracing

### DIFF
--- a/tracing/trace_state.hh
+++ b/tracing/trace_state.hh
@@ -483,11 +483,10 @@ private:
     friend void set_request_size(const trace_state_ptr& p, size_t s) noexcept;
     friend void set_response_size(const trace_state_ptr& p, size_t s) noexcept;
     friend void set_batchlog_endpoints(const trace_state_ptr& p, const host_id_vector_replica_set& val);
-    friend void set_consistency_level(const trace_state_ptr& p, db::consistency_level val);
-    friend void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>&val);
     friend void add_query(const trace_state_ptr& p, std::string_view val);
     friend void add_session_param(const trace_state_ptr& p, std::string_view key, std::string_view val);
-    friend void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val);
+    friend void set_common_query_parameters(const trace_state_ptr& p, db::consistency_level consistency,
+        const std::optional<db::consistency_level>& serial_consistency, api::timestamp_type timestamp);
     friend void add_prepared_statement(const trace_state_ptr& p, prepared_checked_weak_ptr& prepared);
     friend void set_username(const trace_state_ptr& p, const std::optional<auth::authenticated_user>& user);
     friend void add_table_name(const trace_state_ptr& p, const sstring& ks_name, const sstring& cf_name);
@@ -609,18 +608,6 @@ inline void set_batchlog_endpoints(const trace_state_ptr& p, const host_id_vecto
     }
 }
 
-inline void set_consistency_level(const trace_state_ptr& p, db::consistency_level val) {
-    if (p) {
-        p->set_consistency_level(val);
-    }
-}
-
-inline void set_optional_serial_consistency_level(const trace_state_ptr& p, const std::optional<db::consistency_level>& val) {
-    if (p) {
-        p->set_optional_serial_consistency_level(val);
-    }
-}
-
 inline void add_query(const trace_state_ptr& p, std::string_view val) {
     if (p) {
         p->add_query(std::move(val));
@@ -633,9 +620,25 @@ inline void add_session_param(const trace_state_ptr& p, std::string_view key, st
     }
 }
 
-inline void set_user_timestamp(const trace_state_ptr& p, api::timestamp_type val) {
+/**
+ * This function sets parameters present in the binary payload of QUERY, EXECUTE and BATCH operations that we always
+ * want to see in the Tracing state.
+ * For more details see CQL Binary protocol description.
+ *
+ * @param p Trace state object
+ * @param consistency Consistency Level
+ * @param serial_consistency Serial Consistency Level
+ * @param timestamp default or user defined timestamp
+ */
+inline void set_common_query_parameters(
+        const trace_state_ptr& p,
+        db::consistency_level consistency,
+        const std::optional<db::consistency_level>& serial_consistency,
+        api::timestamp_type timestamp) {
     if (p) {
-        p->set_user_timestamp(val);
+        p->set_consistency_level(consistency);
+        p->set_optional_serial_consistency_level(serial_consistency);
+        p->set_user_timestamp(timestamp);
     }
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1150,6 +1150,7 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
         tracing::set_optional_serial_consistency_level(trace_state, options.get_serial_consistency());
         tracing::add_query(trace_state, prepared->statement->raw_cql_statement);
         tracing::add_prepared_statement(trace_state, prepared);
+        tracing::set_user_timestamp(trace_state, options.get_specific_options().timestamp);
 
         tracing::begin(trace_state, seastar::value_of([&id] { return seastar::format("Execute CQL3 prepared query [{}]", id); }),
                 client_state.get_client_address());
@@ -1287,6 +1288,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     if (init_trace) {
         tracing::set_consistency_level(trace_state, options.get_consistency());
         tracing::set_optional_serial_consistency_level(trace_state, options.get_serial_consistency());
+        tracing::set_user_timestamp(trace_state, options.get_specific_options().timestamp);
         tracing::add_prepared_query_options(trace_state, options);
         tracing::trace(trace_state, "Creating a batch statement");
     }

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1067,10 +1067,9 @@ process_query_internal(service::client_state& client_state, distributed<cql3::qu
 
     if (init_trace) {
         tracing::set_page_size(trace_state, options.get_page_size());
-        tracing::set_consistency_level(trace_state, options.get_consistency());
-        tracing::set_optional_serial_consistency_level(trace_state, options.get_serial_consistency());
         tracing::add_query(trace_state, query);
-        tracing::set_user_timestamp(trace_state, options.get_specific_options().timestamp);
+        tracing::set_common_query_parameters(trace_state, options.get_consistency(),
+            options.get_serial_consistency(), options.get_specific_options().timestamp);
 
         tracing::begin(trace_state, "Execute CQL3 query", client_state.get_client_address());
     }
@@ -1146,11 +1145,10 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
 
     if (init_trace) {
         tracing::set_page_size(trace_state, options.get_page_size());
-        tracing::set_consistency_level(trace_state, options.get_consistency());
-        tracing::set_optional_serial_consistency_level(trace_state, options.get_serial_consistency());
         tracing::add_query(trace_state, prepared->statement->raw_cql_statement);
         tracing::add_prepared_statement(trace_state, prepared);
-        tracing::set_user_timestamp(trace_state, options.get_specific_options().timestamp);
+        tracing::set_common_query_parameters(trace_state, options.get_consistency(),
+            options.get_serial_consistency(), options.get_specific_options().timestamp);
 
         tracing::begin(trace_state, seastar::value_of([&id] { return seastar::format("Execute CQL3 prepared query [{}]", id); }),
                 client_state.get_client_address());
@@ -1286,10 +1284,10 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     }
 
     if (init_trace) {
-        tracing::set_consistency_level(trace_state, options.get_consistency());
-        tracing::set_optional_serial_consistency_level(trace_state, options.get_serial_consistency());
-        tracing::set_user_timestamp(trace_state, options.get_specific_options().timestamp);
         tracing::add_prepared_query_options(trace_state, options);
+        tracing::set_common_query_parameters(trace_state, options.get_consistency(),
+            options.get_serial_consistency(), options.get_specific_options().timestamp);
+
         tracing::trace(trace_state, "Creating a batch statement");
     }
 


### PR DESCRIPTION
A default timestamp (not to confuse with the timestamp passed via 'USING TIMESTAMP' query clause) can be set using 0x20 flag and the <timestamp> field in the binary CQL frame payload of QUERY, EXECUTE and BATCH ops. It also happens to be a default of a Java CQL Driver.

However, we were only setting the corresponding info in the CQL Tracing context of a QUERY operation. For an unknown reason we were not setting this for an EXECUTE and for a BATCH traces (I guess I simply forgot to set it back then).

This patch fixes this.

Fixes #23173

The issue fixed by this PR is not critical but the fix is simple and safe enough so we should backport it to all live releases.