### PR TITLE
[Backport 6.1] dist: systemd: use default KillMode

### DIFF
--- a/dist/common/systemd/scylla-server.service
+++ b/dist/common/systemd/scylla-server.service
@@ -20,7 +20,6 @@ ExecStart=/usr/bin/scylla $SCYLLA_ARGS $SEASTAR_IO $DEV_MODE $CPUSET $MEM_CONF
 ExecStopPost=+/opt/scylladb/scripts/scylla_stop
 TimeoutStartSec=1y
 TimeoutStopSec=900
-KillMode=process
 Restart=on-abnormal
 User=scylla
 OOMScoreAdjust=-950


### PR DESCRIPTION
before this change, we specify the KillMode of the scylla-service service unit explicitly to "process". according to according to
https://www.freedesktop.org/software/systemd/man/latest/systemd.kill.html,

> If set to process, only the main process itself is killed (not recommended!).

and the document suggests use "control-group" over "process". but scylla server is not a multi-process server, it is a multi-threaded server. so it should not make any difference even if we switch to the recommended "control-group".

in the light that we've been seeing "defunct" scylla process after stopping the scylla service using systemd. we are wondering if we should try to change the `KillMode` to "control-group", which is the default value of this setting.

in this change, we just drop the setting so that the systemd stops the service by stopping all processes in the control group of this unit are stopped.

Fixes scylladb/scylladb#21507

---

This commit addresses an issue that was introduced in all LTS branches. The fix should be backported to all LTS branches to maintain consistency.

(cherry picked from commit 961a53f716182b3e6160de12d153a9da7434cb21)

Parent PR: https://github.com/scylladb/scylladb/pull/21508