### PR TITLE
test.py: reuse clusters in Python suite

### DIFF
--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -215,8 +215,8 @@ class PythonTest(Test):
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
             status = await run_test(self, options, env=self.suite.scylla_env)
-            # if self.shortname in self.suite.dirties_cluster:
-            cluster.is_dirty = True
+            if self.shortname in self.suite.dirties_cluster:
+                cluster.is_dirty = True
             cluster.after_test(self.uname, status)
             self.is_after_test_ok = True
             self.success = status


### PR DESCRIPTION
PR https://github.com/scylladb/scylladb/pull/22274 was introduced due to CI instability and want to mark the cluster dirty after each test for topology But in fact, affects only Python suites that are quite stable, and CI was Stabilized by PR https://github.com/scylladb/scylladb/pull/22252

This PR get back cluster reusage in Python test suites

**Please replace this line with justification for the backport/\* labels added to this PR**