### PR TITLE
doc: Remove "experimental" from ALTER KEYSPACE with Tablets

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -290,8 +290,8 @@ For instance::
 
 The supported options are the same as :ref:`creating a keyspace <create-keyspace-statement>`.
 
-ALTER KEYSPACE with Tablets :label-caution:`Experimental`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ALTER KEYSPACE with Tablets 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Modifying a keyspace with tablets enabled is possible and doesn't require any special CQL syntax. However, there are some limitations:
 


### PR DESCRIPTION
Altering a keyspace with tablets is no longer experimental. This PR removes the "Experimental" label from the feature.

Fixes https://github.com/scylladb/scylladb/issues/23166

This PR should be backported to branch-2025.1 as the feature is not experimental in version 2025.1.