### PR TITLE
tablets: rebuild: use repair for tablet rebuild

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -242,6 +242,8 @@ globally driven by the topology change coordinator and serialized per-tablet. Tr
 
 - rebuild - new tablet replica is rebuilt from existing ones, possibly dropping old replica afterwards (on node removal or replace)
 
+- rebuild_v2 - same as rebuild, but repairs a tablet and streams data from one replica, instead of streaming data from all replicas
+
 - repair - tablet replicas are repaired
 
 Each tablet has its own state machine for keeping state of transition stored in group0 which is part of the tablet state. It involves

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -166,6 +166,7 @@ public:
     gms::feature tablet_options { *this, "TABLET_OPTIONS"sv };
     gms::feature tablet_load_stats_v2 { *this, "TABLET_LOAD_STATS_V2"sv };
     gms::feature sstable_compression_dicts { *this, "SSTABLE_COMPRESSION_DICTS"sv };
+    gms::feature repair_based_tablet_rebuild { *this, "REPAIR_BASED_TABLET_REBUILD"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -553,6 +553,10 @@ static const std::unordered_map<sstring, tablet_transition_stage> tablet_transit
     return result;
 });
 
+tablet_transition_kind choose_rebuild_transition_kind(const gms::feature_service& features) {
+    return features.repair_based_tablet_rebuild ? tablet_transition_kind::rebuild_v2 : tablet_transition_kind::rebuild;
+}
+
 sstring tablet_transition_stage_to_string(tablet_transition_stage stage) {
     auto i = tablet_transition_stage_to_name.find(stage);
     if (i == tablet_transition_stage_to_name.end()) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -50,6 +50,8 @@ write_replica_set_selector get_selector_for_writes(tablet_transition_stage stage
             return write_replica_set_selector::both;
         case tablet_transition_stage::streaming:
             return write_replica_set_selector::both;
+        case tablet_transition_stage::rebuild_repair:
+            return write_replica_set_selector::both;
         case tablet_transition_stage::repair:
             return write_replica_set_selector::previous;
         case tablet_transition_stage::end_repair:
@@ -78,6 +80,8 @@ read_replica_set_selector get_selector_for_reads(tablet_transition_stage stage) 
         case tablet_transition_stage::write_both_read_old:
             return read_replica_set_selector::previous;
         case tablet_transition_stage::streaming:
+            return read_replica_set_selector::previous;
+        case tablet_transition_stage::rebuild_repair:
             return read_replica_set_selector::previous;
         case tablet_transition_stage::repair:
             return read_replica_set_selector::previous;
@@ -531,6 +535,7 @@ static const std::unordered_map<tablet_transition_stage, sstring> tablet_transit
     {tablet_transition_stage::write_both_read_old, "write_both_read_old"},
     {tablet_transition_stage::write_both_read_new, "write_both_read_new"},
     {tablet_transition_stage::streaming, "streaming"},
+    {tablet_transition_stage::rebuild_repair, "rebuild_repair"},
     {tablet_transition_stage::repair, "repair"},
     {tablet_transition_stage::end_repair, "end_repair"},
     {tablet_transition_stage::use_new, "use_new"},

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -242,6 +242,10 @@ enum class tablet_transition_kind {
     // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).
     rebuild,
 
+    // Like rebuild, but instead of streaming data from all tablet replicas,
+    // it repairs the tablet and streams data from one replica.
+    rebuild_v2,
+
     // Repair the tablet replicas
     repair,
 };

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -27,6 +27,10 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+namespace gms {
+class feature_service;
+}
+
 namespace locator {
 
 class topology;
@@ -250,6 +254,8 @@ enum class tablet_transition_kind {
     // Repair the tablet replicas
     repair,
 };
+
+tablet_transition_kind choose_rebuild_transition_kind(const gms::feature_service& features);
 
 sstring tablet_transition_stage_to_string(tablet_transition_stage);
 tablet_transition_stage tablet_transition_stage_from_string(const sstring&);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -218,6 +218,7 @@ enum class tablet_transition_stage {
     allow_write_both_read_old,
     write_both_read_old,
     streaming,
+    rebuild_repair,
     write_both_read_new,
     use_new,
     cleanup,

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -649,6 +649,8 @@ public:
 // Check that all tablets which have replicas on this host, have a valid replica shard (< smp::count).
 future<bool> check_tablet_replica_shards(const tablet_metadata& tm, host_id this_host);
 
+std::optional<tablet_replica> maybe_get_primary_replica(tablet_id id, const tablet_replica_set& replica_set, std::function<bool(const tablet_replica&)> filter);
+
 struct tablet_routing_info {
     tablet_replica_set tablet_replicas;
     std::pair<dht::token, dht::token> token_range;

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -180,7 +180,7 @@ private:
 public:
     future<> repair_tablets(repair_uniq_id id, sstring keyspace_name, std::vector<sstring> table_names, bool primary_replica_only = true, dht::token_range_vector ranges_specified = {}, std::vector<sstring> dcs = {}, std::unordered_set<locator::host_id> hosts = {}, std::unordered_set<locator::host_id> ignore_nodes = {}, std::optional<int> ranges_parallelism = std::nullopt);
 
-    future<gc_clock::time_point> repair_tablet(gms::gossip_address_map& addr_map, locator::tablet_metadata_guard& guard, locator::global_tablet_id gid, tasks::task_info global_tablet_repair_task_info, service::frozen_topology_guard topo_guard);
+    future<gc_clock::time_point> repair_tablet(gms::gossip_address_map& addr_map, locator::tablet_metadata_guard& guard, locator::global_tablet_id gid, tasks::task_info global_tablet_repair_task_info, service::frozen_topology_guard topo_guard, std::optional<locator::tablet_replica_set> rebuild_replicas);
 private:
 
     future<repair_update_system_table_response> repair_update_system_table_handler(

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -116,16 +116,18 @@ private:
     size_t _metas_size = 0;
     gc_clock::time_point _flush_time;
     service::frozen_topology_guard _topo_guard;
+    bool _skip_flush;
 public:
     bool sched_by_scheduler = false;
 public:
-    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, tasks::task_id parent_id, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard)
+    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, tasks::task_id parent_id, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, bool skip_flush = false)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", parent_id, reason)
         , _keyspace(std::move(keyspace))
         , _tables(std::move(tables))
         , _metas(std::move(metas))
         , _ranges_parallelism(ranges_parallelism)
         , _topo_guard(topo_guard)
+        , _skip_flush(skip_flush)
     {
     }
 

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -362,6 +362,8 @@ tablet_colors = {
     (Tablet.STATE_LEAVING, 'write_both_read_old'): dark_red,
     (Tablet.STATE_JOINING, 'streaming'): light_green,
     (Tablet.STATE_LEAVING, 'streaming'): light_red,
+    (Tablet.STATE_JOINING, 'rebuild_repair'): light_green,
+    (Tablet.STATE_LEAVING, 'rebuild_repair'): light_red,
     (Tablet.STATE_JOINING, 'write_both_read_new'): light_yellow,
     (Tablet.STATE_LEAVING, 'write_both_read_new'): even_darker_purple,
     (Tablet.STATE_JOINING, 'use_new'): light_yellow,
@@ -487,7 +489,7 @@ def update_from_cql(initial=False):
                 stage_change = True
                 changed = True
                 if not initial and t.streaming:
-                    if tablet.stage != "streaming" and tablet.stage != "write_both_read_old":
+                    if tablet.stage != "streaming" and tablet.stage != "rebuild_repair" and tablet.stage != "write_both_read_old":
                         dst = t.streaming
                         t.streaming = None
                         fire_tracer(id, replica, dst, light_purple, light_yellow, tablet_h * 0.7,

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6102,14 +6102,13 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
         slogger.debug("Executing repair for tablet={}", tablet);
         auto& tmap = guard.get_tablet_map();
         auto* trinfo = tmap.get_tablet_transition_info(tablet.tablet);
-        tasks::task_info global_tablet_repair_task_info{tasks::task_id{tmap.get_tablet_info(tablet.tablet).repair_task_info.tablet_task_id.uuid()}, 0};
 
         // Check if the request is still valid.
         // If there is mismatch, it means this repair was canceled and the coordinator moved on.
         if (!trinfo) {
             throw std::runtime_error(fmt::format("No transition info for tablet {}", tablet));
         }
-        if (trinfo->stage != locator::tablet_transition_stage::repair) {
+        if (trinfo->stage != locator::tablet_transition_stage::repair && trinfo->stage != locator::tablet_transition_stage::rebuild_repair) {
             throw std::runtime_error(fmt::format("Tablet {} stage is not at repair", tablet));
         }
         if (trinfo->session_id) {
@@ -6118,9 +6117,18 @@ future<service::tablet_operation_repair_result> storage_service::repair_tablet(l
             throw std::runtime_error(fmt::format("Tablet {} session is not set", tablet));
         }
 
+        tasks::task_info global_tablet_repair_task_info;
+        std::optional<locator::tablet_replica_set> replicas = std::nullopt;
+        if (trinfo->stage == locator::tablet_transition_stage::repair) {
+            global_tablet_repair_task_info = {tasks::task_id{tmap.get_tablet_info(tablet.tablet).repair_task_info.tablet_task_id.uuid()}, 0};
+        } else {
+            auto migration_streaming_info = get_migration_streaming_info(get_token_metadata_ptr()->get_topology(), tmap.get_tablet_info(tablet.tablet), *trinfo);
+            replicas = locator::tablet_replica_set{migration_streaming_info.read_from.begin(), migration_streaming_info.read_from.end()};
+        }
+
         utils::get_local_injector().inject("repair_tablet_fail_on_rpc_call",
             [] { throw std::runtime_error("repair_tablet failed due to error injection"); });
-        auto time = co_await _repair.local().repair_tablet(_address_map, guard, tablet, global_tablet_repair_task_info, trinfo->session_id);
+        auto time = co_await _repair.local().repair_tablet(_address_map, guard, tablet, global_tablet_repair_task_info, trinfo->session_id, std::move(replicas));
         co_return service::tablet_operation_repair_result{time};
     });
     if (std::holds_alternative<service::tablet_operation_repair_result>(result)) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6209,6 +6209,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                 case locator::tablet_transition_kind::migration: return streaming::stream_reason::tablet_migration;
                 case locator::tablet_transition_kind::intranode_migration: return streaming::stream_reason::tablet_migration;
                 case locator::tablet_transition_kind::rebuild: return streaming::stream_reason::rebuild;
+                case locator::tablet_transition_kind::rebuild_v2: return streaming::stream_reason::rebuild;
                 default:
                     throw std::runtime_error(fmt::format("stream_tablet(): Invalid tablet transition: {}", trinfo->transition));
             }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6681,7 +6681,7 @@ future<> storage_service::add_tablet_replica(table_id table, dht::token token, l
         updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-            .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+            .set_transition(last_token, locator::choose_rebuild_transition_kind(_db.local().features()))
             .build());
 
         sstring reason = format("Adding replica to tablet {}, node {}", gid, dst);
@@ -6726,7 +6726,7 @@ future<> storage_service::del_tablet_replica(table_id table, dht::token token, l
         updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
             .set_new_replicas(last_token, new_replicas)
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-            .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+            .set_transition(last_token, locator::choose_rebuild_transition_kind(_db.local().features()))
             .build());
 
         sstring reason = format("Removing replica from tablet {}, node {}", gid, dst);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6211,6 +6211,23 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         auto range = tmap.get_token_range(tablet.tablet);
         std::optional<locator::tablet_replica> leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
         locator::tablet_migration_streaming_info streaming_info = get_migration_streaming_info(tm->get_topology(), tinfo, *trinfo);
+        locator::tablet_replica_set read_from{streaming_info.read_from.begin(), streaming_info.read_from.end()};
+        if (trinfo->transition == locator::tablet_transition_kind::rebuild_v2) {
+            auto nearest_hosts = read_from | std::views::transform([] (const auto& tr) {
+                return tr.host;
+            }) | std::ranges::to<host_id_vector_replica_set>();
+            tm->get_topology().sort_by_proximity(trinfo->pending_replica->host, nearest_hosts);
+
+            if (!nearest_hosts.empty()) {
+                auto it = std::find_if(read_from.begin(), read_from.end(), [nearest_host = nearest_hosts[0]] (const auto& tr) { return tr.host == nearest_host; });
+                if (it == read_from.end()) {
+                    on_internal_error(slogger, "Nearest replica not found");
+                }
+                read_from = { *it };
+            } else {
+                read_from = {};
+            }
+        }
 
         streaming::stream_reason reason = std::invoke([&] {
             switch (trinfo->transition) {
@@ -6245,7 +6262,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                 slogger.info("stream_sstable_files: released");
             });
 
-            for (auto src : streaming_info.read_from) {
+            for (auto src : read_from) {
                 // Use file stream for tablet to stream data
                 auto ops_id = streaming::file_stream_id::create_random_id();
                 auto start_time = std::chrono::steady_clock::now();
@@ -6311,7 +6328,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                     _gossiper.get_unreachable_members()));
 
             std::unordered_map<locator::host_id, dht::token_range_vector> ranges_per_endpoint;
-            for (auto r: streaming_info.read_from) {
+            for (auto r: read_from) {
                 ranges_per_endpoint[r.host].emplace_back(range);
             }
             streamer->add_rx_ranges(table.schema()->ks_name(), std::move(ranges_per_endpoint));

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -663,6 +663,8 @@ private:
                 return true;
             case tablet_transition_stage::streaming:
                 return true;
+            case tablet_transition_stage::rebuild_repair:
+                return true;
             case tablet_transition_stage::repair:
                 return true;
             case tablet_transition_stage::end_repair:

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2651,7 +2651,7 @@ public:
 
             tablet_transition_kind kind = (src_node_info.state() == locator::node::state::being_removed
                                            || src_node_info.state() == locator::node::state::left)
-                       ? tablet_transition_kind::rebuild : tablet_transition_kind::migration;
+                       ? locator::choose_rebuild_transition_kind(_db.features()) : tablet_transition_kind::migration;
             auto mig = get_migration_info(source_tablets, kind, src, dst);
             auto mig_streaming_info = get_migration_streaming_infos(topo, tmap, mig);
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1297,7 +1297,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             break;
                         }
                     }
-                    transition_to_with_barrier(locator::tablet_transition_stage::streaming);
+                    if (trinfo.transition == locator::tablet_transition_kind::rebuild_v2) {
+                        transition_to_with_barrier(locator::tablet_transition_stage::rebuild_repair);
+                    } else {
+                        transition_to_with_barrier(locator::tablet_transition_stage::streaming);
+                    }
                     break;
                 case locator::tablet_transition_stage::rebuild_repair: {
                     if (action_failed(tablet_state.rebuild_repair)) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1044,6 +1044,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     // Next migration of the same tablet is guaranteed to use a different instance.
     struct tablet_migration_state {
         background_action_holder streaming;
+        background_action_holder rebuild_repair;
         background_action_holder cleanup;
         background_action_holder repair;
         std::unordered_map<locator::tablet_transition_stage, background_action_holder> barriers;
@@ -1297,6 +1298,42 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                     }
                     transition_to_with_barrier(locator::tablet_transition_stage::streaming);
+                    break;
+                case locator::tablet_transition_stage::rebuild_repair: {
+                    if (action_failed(tablet_state.rebuild_repair)) {
+                        if (check_excluded_replicas()) {
+                            if (do_barrier()) {
+                                rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::cleanup_target);
+                                updates.emplace_back(get_mutation_builder()
+                                        .set_stage(last_token, locator::tablet_transition_stage::cleanup_target)
+                                        .del_session(last_token)
+                                        .build());
+                            }
+                            break;
+                        }
+                    }
+
+                    if (advance_in_background(gid, tablet_state.rebuild_repair, "rebuild_repair", [&] {
+                        if (!trinfo.pending_replica) {
+                            rtlogger.info("Skipped tablet rebuild repair of {} as no pending replica found", gid);
+                            return make_ready_future<>();
+                        }
+                        auto tsi = get_migration_streaming_info(get_token_metadata().get_topology(), tmap.get_tablet_info(gid.tablet), trinfo);
+                        if (tsi.read_from.empty()) {
+                            rtlogger.info("Skipped tablet rebuild repair of {} as no tablet replica was found", gid);
+                            return make_ready_future<>();
+                        }
+                        auto dst = locator::maybe_get_primary_replica(gid.tablet, {tsi.read_from.begin(), tsi.read_from.end()}, [] (const auto& tr) { return true; }).value().host;
+                        rtlogger.info("Initiating repair phase of tablet rebuild host={} tablet={}", dst, gid);
+                        return ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
+                                dst, _as, raft::server_id(dst.uuid()), gid).discard_result();
+                    })) {
+                        rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::streaming);
+                        updates.emplace_back(get_mutation_builder()
+                            .set_stage(last_token, locator::tablet_transition_stage::streaming)
+                            .build());
+                    }
+                }
                     break;
                 // The state "streaming" is needed to ensure that stale stream_tablet() RPC doesn't
                 // get admitted before global_tablet_token_metadata_barrier() is finished for earlier

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -892,7 +892,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                 replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
                                         .set_new_replicas(last_token, tablet_info.replicas)
                                         .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                        .set_transition(last_token, locator::tablet_transition_kind::rebuild)
+                                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_db.features()))
                                         .build()
                         ));
                         co_await coroutine::maybe_yield();


### PR DESCRIPTION
Currently, when we rebuild a tablet, we stream data from all 
replicas. This creates a lot of redundancy, wastes bandwidth 
and CPU resources.

In this series, we split the streaming stage of tablet rebuild into 
two phases: first we stream tablet's data from only one replica 
and then repair the tablet.

Fixes: https://github.com/scylladb/scylladb/issues/17174.

Needs backport to 2025.1 to prevent out of space during streaming