### PR TITLE
Don't export string filenames from sstable

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1054,7 +1054,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
 
         return ctx.db.map_reduce0([key, uuid] (replica::database& db) -> future<std::unordered_set<sstring>> {
             auto sstables = co_await db.find_column_family(uuid).get_sstables_by_partition_key(key);
-            co_return sstables | std::views::transform([] (auto s) { return s->get_filename(); }) | std::ranges::to<std::unordered_set>();
+            co_return sstables | std::views::transform([] (auto s) -> sstring { return fmt::to_string(s->get_filename()); }) | std::ranges::to<std::unordered_set>();
         }, std::unordered_set<sstring>(),
         [](std::unordered_set<sstring> a, std::unordered_set<sstring>&& b) mutable {
             a.merge(b);

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <seastar/core/sstring.hh>
 #include <fmt/format.h>
 
 namespace sstables {
@@ -27,6 +28,13 @@ enum class component_type {
     TemporaryStatistics,
     Scylla,
     Unknown,
+};
+
+struct sstable;
+struct component_name {
+    const sstable& sst;
+    component_type component;
+    seastar::sstring format() const;
 };
 
 }
@@ -66,5 +74,13 @@ struct fmt::formatter<sstables::component_type> : fmt::formatter<string_view> {
         case Unknown:
             return formatter<string_view>::format("Unknown", ctx);
         }
+    }
+};
+
+template <>
+struct fmt::formatter<sstables::component_name> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const sstables::component_name& name, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{}", name.format());
     }
 };

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -12,6 +12,7 @@
 #include <concepts>
 #include <seastar/core/format.hh>
 
+#include "sstables/component_type.hh"
 #include "seastarx.hh"
 
 namespace sstables {
@@ -19,6 +20,9 @@ class malformed_sstable_exception : public std::exception {
     sstring _msg;
 public:
     malformed_sstable_exception(sstring msg, sstring filename)
+        : malformed_sstable_exception{format("{} in sstable {}", msg, filename)}
+    {}
+    malformed_sstable_exception(sstring msg, component_name filename)
         : malformed_sstable_exception{format("{} in sstable {}", msg, filename)}
     {}
     malformed_sstable_exception(sstring s) : _msg(s) {}

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -19,9 +19,6 @@ namespace sstables {
 class malformed_sstable_exception : public std::exception {
     sstring _msg;
 public:
-    malformed_sstable_exception(sstring msg, sstring filename)
-        : malformed_sstable_exception{format("{} in sstable {}", msg, filename)}
-    {}
     malformed_sstable_exception(sstring msg, component_name filename)
         : malformed_sstable_exception{format("{} in sstable {}", msg, filename)}
     {}

--- a/sstables/file_writer.hh
+++ b/sstables/file_writer.hh
@@ -15,6 +15,7 @@
 #include <seastar/core/iostream.hh>
 
 #include "sstables/progress_monitor.hh"
+#include "sstables/component_type.hh"
 #include "bytes.hh"
 #include "seastarx.hh"
 
@@ -23,12 +24,12 @@ namespace sstables {
 class file_writer {
     output_stream<char> _out;
     writer_offset_tracker _offset;
-    std::optional<sstring> _filename;
+    std::optional<component_name> _component;
     bool _closed = false;
 public:
-    file_writer(output_stream<char>&& out, sstring filename) noexcept
+    file_writer(output_stream<char>&& out, component_name component) noexcept
         : _out(std::move(out))
-        , _filename(std::move(filename))
+        , _component(std::move(component))
     {}
 
     file_writer(output_stream<char>&& out) noexcept
@@ -41,7 +42,7 @@ public:
     file_writer(file_writer&& x) noexcept
         : _out(std::move(x._out))
         , _offset(std::move(x._offset))
-        , _filename(std::move(x._filename))
+        , _component(std::move(x._component))
         , _closed(x._closed)
     {
         x._closed = true;   // don't auto-close in destructor
@@ -66,9 +67,6 @@ public:
     const writer_offset_tracker& offset_tracker() const {
         return _offset;
     }
-
-private:
-    const char* get_filename() const noexcept;
 };
 
 }

--- a/sstables/metadata_collector.hh
+++ b/sstables/metadata_collector.hh
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "sstables/types.hh"
+#include "sstables/component_type.hh"
 #include "timestamp.hh"
 #include "utils/extremum_tracking.hh"
 #include "utils/murmur_hash.hh"
@@ -125,7 +126,7 @@ public:
     }
 private:
     const schema& _schema;
-    sstring _name;
+    component_name _name;
     locator::host_id _host_id;
     // EH of 150 can track a max value of 1697806495183, i.e., > 1.5PB
     utils::estimated_histogram _estimated_partition_size{150};
@@ -156,7 +157,7 @@ private:
 private:
     void convert(disk_array<uint32_t, disk_string<uint16_t>>&to, const std::optional<position_in_partition>& from);
 public:
-    explicit metadata_collector(const schema& schema, sstring name, const locator::host_id& host_id)
+    explicit metadata_collector(const schema& schema, component_name name, const locator::host_id& host_id)
         : _schema(schema)
         , _name(name)
         , _host_id(host_id)

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -884,17 +884,17 @@ void writer::init_file_writers() {
     auto out = _sst._storage->make_data_or_index_sink(_sst, component_type::Data).get();
 
     if (!_compression_enabled) {
-        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.filename(component_type::Data));
+        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.get_filename());
     } else {
         _data_writer = std::make_unique<file_writer>(
             make_compressed_file_m_format_output_stream(
                 output_stream<char>(std::move(out)),
                 &_sst._components->compression,
-                _sst._schema->get_compressor_params()), _sst.filename(component_type::Data));
+                _sst._schema->get_compressor_params()), _sst.get_filename());
     }
 
     out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();
-    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.filename(component_type::Index));
+    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.index_filename());
 }
 
 std::unique_ptr<file_writer> writer::close_writer(std::unique_ptr<file_writer>& w) {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -894,7 +894,7 @@ void writer::init_file_writers() {
     }
 
     out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();
-    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.index_filename());
+    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), fmt::to_string(_sst.index_filename()));
 }
 
 std::unique_ptr<file_writer> writer::close_writer(std::unique_ptr<file_writer>& w) {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -884,17 +884,17 @@ void writer::init_file_writers() {
     auto out = _sst._storage->make_data_or_index_sink(_sst, component_type::Data).get();
 
     if (!_compression_enabled) {
-        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, fmt::to_string(_sst.get_filename()));
+        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.get_filename());
     } else {
         _data_writer = std::make_unique<file_writer>(
             make_compressed_file_m_format_output_stream(
                 output_stream<char>(std::move(out)),
                 &_sst._components->compression,
-                _sst._schema->get_compressor_params()), fmt::to_string(_sst.get_filename()));
+                _sst._schema->get_compressor_params()), _sst.get_filename());
     }
 
     out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();
-    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), fmt::to_string(_sst.index_filename()));
+    _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.index_filename());
 }
 
 std::unique_ptr<file_writer> writer::close_writer(std::unique_ptr<file_writer>& w) {

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -884,13 +884,13 @@ void writer::init_file_writers() {
     auto out = _sst._storage->make_data_or_index_sink(_sst, component_type::Data).get();
 
     if (!_compression_enabled) {
-        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.get_filename());
+        _data_writer = std::make_unique<crc32_checksummed_file_writer>(std::move(out), _sst.sstable_buffer_size, fmt::to_string(_sst.get_filename()));
     } else {
         _data_writer = std::make_unique<file_writer>(
             make_compressed_file_m_format_output_stream(
                 output_stream<char>(std::move(out)),
                 &_sst._components->compression,
-                _sst._schema->get_compressor_params()), _sst.get_filename());
+                _sst._schema->get_compressor_params()), fmt::to_string(_sst.get_filename()));
     }
 
     out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -651,7 +651,7 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
         try {
             auto trim_size = base_dir.native().size() + 1; // Account for the '/' delimiter
             for (const auto& sst : ssts) {
-                auto toc = sst->toc_filename();
+                sstring toc = seastar::to_sstring(sst->toc_filename());
                 if (toc.size() <= trim_size) {
                     on_internal_error(dirlog, fmt::format("Sstable {} outside of basedir {} is scheduled for deletion", toc, base_dir.native()));
                 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -982,8 +982,8 @@ thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> dow
 
 future<> sstable::do_read_simple(component_type type,
                                  noncopyable_function<future<> (version_types, file&&, uint64_t sz)> read_component) {
-    auto file_path = filename(type);
-    sstlog.debug("Reading {} file {}", sstable_version_constants::get_component_map(_version).at(type), file_path);
+    auto component_name = filename(type);
+    sstlog.debug("Reading {} file {}", sstable_version_constants::get_component_map(_version).at(type), component_name);
     try {
         file fi = co_await new_sstable_component_file(_read_error_handler, type, open_flags::ro);
         uint64_t size = co_await fi.size();
@@ -992,11 +992,11 @@ future<> sstable::do_read_simple(component_type type,
         _metadata_size_on_disk += size;
     }  catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(file_path + ": file not found");
+            throw malformed_sstable_exception(component_name + ": file not found");
         }
         throw;
     } catch (malformed_sstable_exception& e) {
-        throw malformed_sstable_exception(e.what(), file_path);
+        throw malformed_sstable_exception(e.what(), component_name);
     }
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3627,6 +3627,10 @@ generation_type::from_string(const std::string& s) {
     }
 }
 
+sstring component_name::format() const {
+    return sst._storage->prefix() + "/" + sst.component_basename(component);
+}
+
 } // namespace sstables
 
 namespace seastar {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2235,16 +2235,6 @@ void sstable::validate_originating_host_id() const {
     }
 }
 
-std::vector<sstring> sstable::component_filenames() const {
-    std::vector<sstring> res;
-    for (auto c : sstable_version_constants::get_component_map(_version) | std::views::keys) {
-        if (has_component(c)) {
-            res.emplace_back(filename(c));
-        }
-    }
-    return res;
-}
-
 sstring sstable::component_basename(const sstring& ks, const sstring& cf, version_types version, generation_type generation,
                                     format_types format, sstring component) {
     sstring v = fmt::to_string(version);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1288,7 +1288,6 @@ void sstable::write_statistics() {
 }
 
 void sstable::rewrite_statistics() {
-    auto file_path = filename(component_type::TemporaryStatistics);
     sstlog.debug("Rewriting statistics component of sstable {}", get_filename());
 
     file_output_stream_options options;
@@ -1298,7 +1297,7 @@ void sstable::rewrite_statistics() {
     write(_version, w, _components->statistics);
     w.close();
     // rename() guarantees atomicity when renaming a file into place.
-    sstable_write_io_check(rename_file, file_path, filename(component_type::Statistics)).get();
+    sstable_write_io_check(rename_file, fmt::to_string(filename(component_type::TemporaryStatistics)), fmt::to_string(filename(component_type::Statistics))).get();
 }
 
 future<> sstable::read_summary() noexcept {
@@ -3516,7 +3515,7 @@ public:
 private:
     future<> load_metadata() const {
         auto metafile = _sst->filename(sstables::component_type::Scylla);
-        if (!co_await file_exists(metafile)) {
+        if (!co_await file_exists(fmt::to_string(metafile))) {
             // for compatibility with streaming a non-scylla table (no scylla component)
             co_return;
         }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -838,16 +838,16 @@ future<> sstable::read_toc() noexcept {
                     _recognized_components.insert(reverse_map(c, sstable_version_constants::get_component_map(_version)));
                 } catch (std::out_of_range& oor) {
                     _unrecognized_components.push_back(c);
-                    sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, filename(component_type::TOC));
+                    sstlog.info("Unrecognized TOC component was found: {} in sstable {}", c, toc_filename());
                 }
             }
             if (!_recognized_components.size()) {
-                throw malformed_sstable_exception("Empty TOC", filename(component_type::TOC));
+                throw malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
     } catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(filename(component_type::TOC) + ": file not found");
+            throw malformed_sstable_exception(toc_filename() + ": file not found");
         }
         throw;
     }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3027,7 +3027,7 @@ future<bool> sstable::has_partition_key(const utils::hashed_key& hk, const dht::
             reader_concurrency_semaphore::register_metrics::no);
     std::unique_ptr<sstables::index_reader> lh_index_ptr = nullptr;
     try {
-        lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema, s->get_filename(), db::no_timeout, {}));
+        lh_index_ptr = std::make_unique<sstables::index_reader>(s, sem.make_tracking_only_permit(_schema, fmt::to_string(s->get_filename()), db::no_timeout, {}));
         present = co_await lh_index_ptr->advance_lower_and_check_if_present(dk);
     } catch (...) {
         ex = std::current_exception();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -847,7 +847,7 @@ future<> sstable::read_toc() noexcept {
         });
     } catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(toc_filename() + ": file not found");
+            throw malformed_sstable_exception(fmt::format("{}: file not found", toc_filename()));
         }
         throw;
     }
@@ -992,7 +992,7 @@ future<> sstable::do_read_simple(component_type type,
         _metadata_size_on_disk += size;
     }  catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(component_name + ": file not found");
+            throw malformed_sstable_exception(fmt::format("{}: file not found", component_name));
         }
         throw;
     } catch (malformed_sstable_exception& e) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -416,8 +416,8 @@ public:
         return filename(component_type::Data);
     }
 
-    sstring toc_filename() const {
-        return filename(component_type::TOC);
+    component_name toc_filename() const {
+        return component_name(*this, component_type::TOC);
     }
 
     component_name index_filename() const {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -516,21 +516,16 @@ public:
 
 private:
     friend struct component_name;
-    sstring filename(component_type f) const {
-        auto dir = _storage->prefix();
-        return filename(f, std::move(dir));
-    }
-
-    sstring filename(component_type f, sstring dir) const {
-        return filename(dir, _schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
-    }
-
     friend class sstable_stream_sink_impl;
     friend class filesystem_storage;
     friend class s3_storage;
     friend class tiered_storage;
 
     const size_t sstable_buffer_size;
+
+    component_name filename(component_type f) const {
+        return component_name(*this, f);
+    }
 
     std::unordered_set<component_type, enum_hash<component_type>> _recognized_components;
     std::vector<sstring> _unrecognized_components;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -515,6 +515,7 @@ public:
     }
 
 private:
+    friend struct component_name;
     sstring filename(component_type f) const {
         auto dir = _storage->prefix();
         return filename(f, std::move(dir));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -454,7 +454,6 @@ public:
     gc_clock::time_point max_data_age() const {
         return _now;
     }
-    std::vector<sstring> component_filenames() const;
 
     utils::observer<sstable&> add_on_closed_handler(std::function<void (sstable&)> on_closed_handler) noexcept {
         return _on_closed.observe(on_closed_handler);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -412,8 +412,8 @@ public:
         return component_basename(_schema->ks_name(), _schema->cf_name(), _version, _generation, _format, f);
     }
 
-    sstring get_filename() const {
-        return filename(component_type::Data);
+    component_name get_filename() const {
+        return component_name(*this, component_type::Data);
     }
 
     component_name toc_filename() const {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -420,8 +420,8 @@ public:
         return filename(component_type::TOC);
     }
 
-    sstring index_filename() const {
-        return filename(component_type::Index);
+    component_name index_filename() const {
+        return component_name(*this, component_type::Index);
     }
 
     bool requires_view_building() const noexcept { return _state == sstable_state::staging; }

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -256,12 +256,12 @@ future<> filesystem_storage::check_create_links_replay(const sstable& sst, const
         auto comp = p.second;
         auto src = sstable::filename(_dir.native(), sst._schema->ks_name(), sst._schema->cf_name(), sst._version, sst._generation, sst._format, comp);
         auto dst = sstable::filename(dst_dir, sst._schema->ks_name(), sst._schema->cf_name(), sst._version, dst_gen, sst._format, comp);
-        return do_with(std::move(src), std::move(dst), [this] (const sstring& src, const sstring& dst) mutable {
-            return file_exists(dst).then([&, this] (bool exists) mutable {
+        return do_with(std::move(src), std::move(dst), [] (const sstring& src, const sstring& dst) mutable {
+            return file_exists(dst).then([&] (bool exists) mutable {
                 if (!exists) {
                     return make_ready_future<>();
                 }
-                return same_file(src, dst).then_wrapped([&, this] (future<bool> fut) {
+                return same_file(src, dst).then_wrapped([&] (future<bool> fut) {
                     if (fut.failed()) {
                         auto eptr = fut.get_exception();
                         sstlog.error("Error while linking SSTable: {} to {}: {}", src, dst, eptr);
@@ -271,7 +271,7 @@ future<> filesystem_storage::check_create_links_replay(const sstable& sst, const
                     if (!same) {
                         auto msg = format("Error while linking SSTable: {} to {}: File exists", src, dst);
                         sstlog.error("{}", msg);
-                        return make_exception_future<>(malformed_sstable_exception(msg, _dir.native()));
+                        return make_exception_future<>(malformed_sstable_exception(msg));
                     }
                     return make_ready_future<>();
                 });

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -146,7 +146,6 @@ future<file> filesystem_storage::open_component(const sstable& sst, component_ty
 
 void filesystem_storage::open(sstable& sst) {
     touch_temp_dir(sst).get();
-    auto file_path = sst.filename(component_type::TemporaryTOC);
 
     // Writing TOC content to temporary file.
     // If creation of temporary TOC failed, it implies that that boot failed to
@@ -159,7 +158,7 @@ void filesystem_storage::open(sstable& sst) {
                                     open_flags::create |
                                     open_flags::exclusive,
                                     options).get();
-    auto w = file_writer(output_stream<char>(std::move(sink)), std::move(file_path));
+    auto w = file_writer(output_stream<char>(std::move(sink)), component_name(sst, component_type::TemporaryTOC));
 
     bool toc_exists = file_exists(sst.filename(component_type::TOC)).get();
     if (toc_exists) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -570,7 +570,7 @@ sstring s3_storage::make_s3_object_name(const sstable& sst, component_type type)
 
     return std::visit(overloaded_functor {
         [&] (const sstring& prefix) -> sstring {
-            return format("/{}/{}", _bucket, sst.filename(type, prefix));
+            return format("/{}/{}/{}", _bucket, prefix, sst.component_basename(type));
         },
         [&] (const table_id& owner) -> sstring {
             return format("/{}/{}/{}", _bucket, sst.generation(), sstable_version_constants::get_component_map(sst.get_version()).at(type));

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -431,7 +431,7 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
     // Running out of memory here will terminate.
     auto name = [&sst] () noexcept {
         memory::scoped_critical_alloc_section _;
-        return sst.toc_filename();
+        return fmt::to_string(sst.toc_filename());
     }();
 
     try {

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -11,6 +11,7 @@
 #include <seastar/core/iostream.hh>
 #include <seastar/core/fstream.hh>
 #include "sstables/types.hh"
+#include "sstables/component_type.hh"
 #include "checksum_utils.hh"
 #include "vint-serialization.hh"
 #include <seastar/core/byteorder.hh>
@@ -138,8 +139,8 @@ class checksummed_file_writer : public file_writer {
     checksum _c;
     uint32_t _full_checksum;
 public:
-    checksummed_file_writer(data_sink out, size_t buffer_size, sstring filename)
-            : file_writer(make_checksummed_file_output_stream<ChecksumType>(std::move(out), _c, _full_checksum), std::move(filename))
+    checksummed_file_writer(data_sink out, size_t buffer_size, component_name c)
+            : file_writer(make_checksummed_file_output_stream<ChecksumType>(std::move(out), _c, _full_checksum), std::move(c))
             , _c(uint32_t(std::min(size_t(DEFAULT_CHUNK_SIZE), buffer_size)), {})
             , _full_checksum(ChecksumType::init_checksum()) {}
 

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -478,7 +478,7 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
         try {
             co_await coroutine::parallel_for_each(sstables, [&] (sstables::shared_sstable& sst) {
                 llog.debug("load_and_stream: ops_uuid={}, ks={}, table={}, remove sst={}",
-                        ops_uuid, s->ks_name(), s->cf_name(), sst->component_filenames());
+                        ops_uuid, s->ks_name(), s->cf_name(), sst->toc_filename());
                 return sst->unlink();
             });
         } catch (...) {

--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -252,7 +252,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reload_after_unlink) {
         // manager's reclaimed set has the sst now
         auto& reclaimed_set = sst_mgr.get_reclaimed_set();
         BOOST_REQUIRE_EQUAL(reclaimed_set.size(), 1);
-        BOOST_REQUIRE_EQUAL(reclaimed_set.begin()->get_filename(), sst->get_filename());
+        BOOST_REQUIRE_EQUAL(fmt::to_string(reclaimed_set.begin()->get_filename()), fmt::to_string(sst->get_filename()));
 
         // hold a copy of shared sst object in async thread to test reload after unlink
         utils::get_local_injector().enable("test_bloom_filter_reload_after_unlink");
@@ -330,7 +330,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         // hold sst1 as the async thread still has a reference.
         auto& active_list = sst_mgr.get_active_list();
         BOOST_REQUIRE_EQUAL(active_list.size(), 1);
-        BOOST_REQUIRE_EQUAL(active_list.front().get_filename(), sst1_filename);
+        BOOST_REQUIRE_EQUAL(fmt::to_string(active_list.front().get_filename()), fmt::to_string(sst1_filename));
 
         // create another sst and unlink it to trigger reload of components.
         // the reload should not attempt to load sst'1 bloom filter into memory depsite its presence in the _active list.

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -329,7 +329,7 @@ SEASTAR_TEST_CASE(test_load_schema_from_sstable) {
 
             // Do the check in a separate method to ensure we don't accidentally
             // re-use the original schema.
-            check_sstable_schema(env, std::filesystem::path(sst->get_filename()), mutations);
+            check_sstable_schema(env, std::filesystem::path(fmt::to_string(sst->get_filename())), mutations);
         }
     });
 }

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5921,7 +5921,7 @@ SEASTAR_TEST_CASE(cleanup_during_offstrategy_incremental_compaction_test) {
                 }));
                 observers.push_back(sst->add_on_delete_handler([&] (sstable& sst) mutable {
                     // ATTN -- the _on_delete callback is not necessarily running in thread
-                    auto missing = (::access(sst.get_filename().c_str(), F_OK) != 0);
+                    auto missing = (::access(fmt::to_string(sst.get_filename()).c_str(), F_OK) != 0);
                     testlog.info("Deleting sstable of generation {}: missing={}", sst.generation(), missing);
                     sstables_missing_on_delete += missing;
                 }));

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -155,7 +155,7 @@ public:
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
         _sst->_recognized_components.erase(component);
-        remove_file(_sst->toc_filename()).get();
+        remove_file(fmt::to_string(_sst->toc_filename())).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
     }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -161,11 +161,11 @@ public:
     }
 
     future<> remove_component(component_type c) {
-        return remove_file(_sst->filename(c));
+        return remove_file(fmt::to_string(_sst->filename(c)));
     }
 
     fs::path filename(component_type c) const {
-        return fs::path(_sst->filename(c));
+        return fs::path(fmt::to_string(_sst->filename(c)));
     }
 
     void set_shards(std::vector<unsigned> shards) {

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -155,7 +155,7 @@ public:
     void rewrite_toc_without_component(component_type component) {
         SCYLLA_ASSERT(component != component_type::TOC);
         _sst->_recognized_components.erase(component);
-        remove_file(_sst->filename(component_type::TOC)).get();
+        remove_file(_sst->toc_filename()).get();
         _sst->_storage->open(*_sst);
         _sst->seal_sstable(false).get();
     }

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -444,7 +444,7 @@ int sstable_index_l(lua_State* l) {
     auto& sst = pop_userdata_ref<const sstables::sstable>(l, 1);
     lua_pop(l, 2);
     if (strcmp(field, "filename") == 0) {
-        lua::push_sstring(l, sst.get_filename());
+        lua::push_sstring(l, fmt::to_string(sst.get_filename()));
         return 1;
     }
     return 0;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -473,7 +473,7 @@ void mutation_fragment_stream_json_writer::start_stream() {
 
 void mutation_fragment_stream_json_writer::start_sstable(const sstables::sstable* const sst) {
     if (sst) {
-        writer().Key(sst->get_filename());
+        writer().Key(fmt::to_string(sst->get_filename()));
     } else {
         writer().Key("anonymous");
     }
@@ -1004,7 +1004,7 @@ void validate_operation(schema_ptr schema, reader_permit permit, const std::vect
     writer.StartStream();
     for (const auto& sst : sstables) {
         const auto errors = sst->validate(permit, abort, [] (sstring what) { sst_log.info("{}", what); }).get();
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         writer.Key("errors");
         writer.Uint64(errors);
@@ -1072,7 +1072,7 @@ void dump_index_operation(schema_ptr schema, reader_permit permit, const std::ve
         sstables::index_reader idx_reader(sst, permit);
         auto close_idx_reader = deferred_close(idx_reader);
 
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartArray();
 
         while (!idx_reader.eof()) {
@@ -1111,7 +1111,7 @@ void dump_compression_info_operation(schema_ptr schema, reader_permit permit, co
     for (auto& sst : sstables) {
         const auto& compression = sst->get_compression();
 
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         writer.Key("name");
         writer.String(disk_string_to_string(compression.name));
@@ -1149,7 +1149,7 @@ void dump_summary_operation(schema_ptr schema, reader_permit permit, const std::
     for (auto& sst : sstables) {
         auto& summary = sst->get_summary();
 
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
 
         writer.Key("header");
@@ -1448,7 +1448,7 @@ void dump_statistics_operation(schema_ptr schema, reader_permit permit, const st
     for (auto& sst : sstables) {
         auto& statistics = sst->get_statistics();
 
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
 
         writer.Key("offsets");
@@ -1631,7 +1631,7 @@ void dump_scylla_metadata_operation(schema_ptr schema, reader_permit permit, con
     json_writer writer;
     writer.StartStream();
     for (auto& sst : sstables) {
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         auto m = sst->get_scylla_metadata();
         if (!m) {
@@ -1659,7 +1659,7 @@ void validate_checksums_operation(schema_ptr schema, reader_permit permit, const
     writer.StartStream();
     for (auto& sst : sstables) {
         const auto res = sstables::validate_checksums(sst, permit).get();
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartObject();
         writer.Key("has_checksums");
         switch (res.status) {
@@ -1702,6 +1702,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
         }
 
         auto output_filename = fmt::format("{}.decompressed", sst->get_filename());
+
         auto ofile = open_file_dma(output_filename, open_flags::wo | open_flags::create).get();
         file_output_stream_options options;
         options.buffer_size = 4096;
@@ -2708,7 +2709,7 @@ void shard_of_with_vnodes(const std::vector<sstables::shared_sstable>& sstables,
             sst->get_version());
         new_sst->load_owner_shards(schema->get_sharder()).get();
 
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartArray();
         for (unsigned shard_id : new_sst->get_shards_for_this_sstable()) {
             writer.Uint(shard_id);
@@ -2730,7 +2731,7 @@ void shard_of_with_tablets(schema_ptr schema,
     json_writer writer;
     writer.StartStream();
     for (auto& sst : sstables) {
-        writer.Key(sst->get_filename());
+        writer.Key(fmt::to_string(sst->get_filename()));
         writer.StartArray();
 
         // token ranges are distributed across tablets, so we just check for

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1701,9 +1701,7 @@ void decompress_operation(schema_ptr schema, reader_permit permit, const std::ve
             continue;
         }
 
-        auto output_filename = sst->get_filename();
-        output_filename += ".decompressed";
-
+        auto output_filename = fmt::format("{}.decompressed", sst->get_filename());
         auto ofile = open_file_dma(output_filename, open_flags::wo | open_flags::create).get();
         file_output_stream_options options;
         options.buffer_size = 4096;


### PR DESCRIPTION
There are several sstring-returning methods on class sstable that return paths to files. Mostly these are used to print them into logs, sometimes are used to be put into exception messages. And there are places that use these strings as file names. Since now sstables can also be stored on S3, generic code shouldn't consider those strings as on disk file names.

Other than that, even when the methods are used to put component names into logs, in many cases these log messages come with debug or trace level, so generated strings are immediately dropped on the floor, but generating it is not extremely cheap. Code would benefit from using lazily-printed names.

This change introduces the component_name struct that wraps sstable reference and component ID (which is a numerical enum of several items). When printed, the component_name formatter calls the aforementioned filename generation, thus implementing lazy printing. And since there's no automatic conversion of component_name-s into strings, all the code that treats them as file paths, becomes explicit.

refs: #14122 (previous ugly attempt to achieve the same goal)