### PR TITLE
main: fix typo in tablet allocator checkpoint message

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1687,7 +1687,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     stop_signal.as_local_abort_source(), raft_gr.local(), messaging,
                     gossiper.local(), feature_service.local(), sys_ks.local(), group0_client, dbcfg.gossip_scheduling_group};
 
-            checkpoint(stop_signal, "starting talet allocator");
+            checkpoint(stop_signal, "starting tablet allocator");
             service::tablet_allocator::config tacfg;
             distributed<service::tablet_allocator> tablet_allocator;
             tablet_allocator.start(tacfg, std::ref(mm_notifier), std::ref(db)).get();


### PR DESCRIPTION
Inroduced in b6705ad48bc3aebb0a6b8fed495bbc8e30906535

* cosmetic fix, no backport needed