### PR TITLE
Remove some excessive ks:cf -> table_id conversions in API and schema_tables

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -916,8 +916,7 @@ rest_force_keyspace_flush(http_context& ctx, std::unique_ptr<http::request> req)
         auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
         apilog.info("perform_keyspace_flush: keyspace={} tables={}", keyspace, table_infos);
         auto& db = ctx.db;
-        auto column_families = table_infos | std::views::transform([] (auto ti) { return ti.name; }) | std::ranges::to<std::vector>();
-        co_await replica::database::flush_tables_on_all_shards(db, keyspace, std::move(column_families));
+        co_await replica::database::flush_tables_on_all_shards(db, keyspace, std::move(table_infos));
         co_return json_void();
 }
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -916,7 +916,7 @@ rest_force_keyspace_flush(http_context& ctx, std::unique_ptr<http::request> req)
         auto table_infos = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
         apilog.info("perform_keyspace_flush: keyspace={} tables={}", keyspace, table_infos);
         auto& db = ctx.db;
-        co_await replica::database::flush_tables_on_all_shards(db, keyspace, std::move(table_infos));
+        co_await replica::database::flush_tables_on_all_shards(db, std::move(table_infos));
         co_return json_void();
 }
 

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -561,7 +561,7 @@ public:
 
     future<> flush_schemas() {
         auto& db = _qp.db().real_database().container();
-        return replica::database::flush_tables_on_all_shards(db, db::schema_tables::NAME, db::schema_tables::all_table_infos(schema_features::full()));
+        return replica::database::flush_tables_on_all_shards(db, db::schema_tables::all_table_infos(schema_features::full()));
     }
 
     future<> migrate() {

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -561,7 +561,7 @@ public:
 
     future<> flush_schemas() {
         auto& db = _qp.db().real_database().container();
-        return replica::database::flush_tables_on_all_shards(db, db::schema_tables::NAME, db::schema_tables::all_table_names(schema_features::full()));
+        return replica::database::flush_tables_on_all_shards(db, db::schema_tables::NAME, db::schema_tables::all_table_infos(schema_features::full()));
     }
 
     future<> migrate() {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2670,12 +2670,6 @@ std::vector<schema_ptr> all_tables(schema_features features) {
     return result;
 }
 
-std::vector<sstring> all_table_names(schema_features features) {
-    return all_tables(features)
-        | std::views::transform([] (auto schema) { return schema->cf_name(); })
-        | std::ranges::to<std::vector>();
-}
-
 std::vector<table_info> all_table_infos(schema_features features) {
     return all_tables(features)
         | std::views::transform([] (auto schema) { return table_info{ schema->cf_name(), schema->id() }; })

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -714,10 +714,10 @@ future<table_schema_version> calculate_schema_digest(distributed<service::storag
 {
     using mutations_generator = coroutine::experimental::generator<mutation>;
 
-    auto map = [&proxy, features, accept_keyspace = std::move(accept_keyspace)] (sstring table) mutable -> mutations_generator {
+    auto map = [&proxy, features, accept_keyspace = std::move(accept_keyspace)] (table_info table) mutable -> mutations_generator {
         auto& db = proxy.local().get_db();
-        auto rs = co_await db::system_keyspace::query_mutations(db, NAME, table);
-        auto s = db.local().find_schema(NAME, table);
+        auto s = db.local().find_schema(table.id);
+        auto rs = co_await db::system_keyspace::query_mutations(db, s);
         for (auto&& p : rs->partitions()) {
             auto partition_key = value_cast<sstring>(utf8_type->deserialize(::partition_key(p.mut().key()).get_component(*s, 0)));
             if (!accept_keyspace(partition_key)) {
@@ -728,7 +728,7 @@ future<table_schema_version> calculate_schema_digest(distributed<service::storag
         }
     };
     auto hash = md5_hasher();
-    auto tables = all_table_names(features);
+    auto tables = all_table_infos(features);
     {
         for (auto& table: tables) {
             auto gen_mutations = map(table);
@@ -816,10 +816,10 @@ future<> recalculate_schema_version(sharded<db::system_keyspace>& sys_ks, distri
 
 future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<service::storage_proxy>& proxy, schema_features features)
 {
-    auto map = [&proxy, features] (sstring table) -> future<std::vector<canonical_mutation>> {
+    auto map = [&proxy, features] (table_info table) -> future<std::vector<canonical_mutation>> {
         auto& db = proxy.local().get_db();
-        auto rs = co_await db::system_keyspace::query_mutations(db, NAME, table);
-        auto s = db.local().find_schema(NAME, table);
+        auto s = db.local().find_schema(table.id);
+        auto rs = co_await db::system_keyspace::query_mutations(db, s);
         std::vector<canonical_mutation> results;
         results.reserve(rs->partitions().size());
         for (auto&& p : rs->partitions()) {
@@ -837,7 +837,7 @@ future<std::vector<canonical_mutation>> convert_schema_to_mutations(distributed<
         std::move(mutations.begin(), mutations.end(), std::back_inserter(result));
         return std::move(result);
     };
-    co_return co_await map_reduce(all_table_names(features), map, std::vector<canonical_mutation>{}, reduce);
+    co_return co_await map_reduce(all_table_infos(features), map, std::vector<canonical_mutation>{}, reduce);
 }
 
 std::vector<mutation>

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -187,9 +187,9 @@ static future<> save_system_schema_to_keyspace(cql3::query_processor& qp, const 
     auto ksm = ks.metadata();
 
     // delete old, possibly obsolete entries in schema tables
-    co_await coroutine::parallel_for_each(all_table_names(schema_features::full()), [&qp, ksm] (sstring cf) -> future<> {
+    co_await coroutine::parallel_for_each(all_table_infos(schema_features::full()), [&qp, ksm] (table_info ti) -> future<> {
         auto deletion_timestamp = system_keyspace::schema_creation_timestamp() - 1;
-        co_await qp.execute_internal(format("DELETE FROM {}.{} USING TIMESTAMP {} WHERE keyspace_name = ?", NAME, cf,
+        co_await qp.execute_internal(format("DELETE FROM {}.{} USING TIMESTAMP {} WHERE keyspace_name = ?", NAME, ti.name,
             deletion_timestamp), { ksm->name() }, cql3::query_processor::cache_internal::yes).discard_result();
     });
     {

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2676,6 +2676,12 @@ std::vector<sstring> all_table_names(schema_features features) {
         | std::ranges::to<std::vector>();
 }
 
+std::vector<table_info> all_table_infos(schema_features features) {
+    return all_tables(features)
+        | std::views::transform([] (auto schema) { return table_info{ schema->cf_name(), schema->id() }; })
+        | std::ranges::to<std::vector>();
+}
+
 void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema) {
     // Legacy format for a secondary index used a hardcoded "token" column, which ensured a proper
     // order for indexed queries. This "token" column is has been implemented as a computed column

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -203,6 +203,9 @@ std::vector<schema_ptr> all_tables(schema_features);
 // Like all_tables(), but returns schema::cf_name() of each table.
 std::vector<sstring> all_table_names(schema_features);
 
+// Like all_tables(), but returns table_info of each table.
+std::vector<table_info> all_table_infos(schema_features);
+
 // saves/creates all the system objects in the appropriate keyspaces;
 // deletes them first, so they will be effectively overwritten.
 future<> save_system_schema(cql3::query_processor& qp);

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -200,9 +200,6 @@ extern const sstring version;
 // Returns schema_ptrs for all schema tables supported by given schema_features.
 std::vector<schema_ptr> all_tables(schema_features);
 
-// Like all_tables(), but returns schema::cf_name() of each table.
-std::vector<sstring> all_table_names(schema_features);
-
 // Like all_tables(), but returns table_info of each table.
 std::vector<table_info> all_table_infos(schema_features);
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2405,7 +2405,7 @@ static future<> force_new_commitlog_segments(std::unique_ptr<db::commitlog>& cl1
     }
 }
 
-future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<table_info> table_names) {
+future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std::vector<table_info> tables) {
     /**
      * #14870 
      * To ensure tests which use nodetool flush to force data
@@ -2416,9 +2416,8 @@ future<> database::flush_tables_on_all_shards(sharded<database>& sharded_db, std
     */
     return sharded_db.invoke_on_all([] (replica::database& db) {
         return force_new_commitlog_segments(db._commitlog, db._schema_commitlog);
-    }).then([&, ks_name, table_names = std::move(table_names)] {
-        return parallel_for_each(table_names, [&, ks_name] (const auto& ti) {
-            (void)ks_name;
+    }).then([&, tables = std::move(tables)] {
+        return parallel_for_each(tables, [&] (const auto& ti) {
             return flush_table_on_all_shards(sharded_db, ti.id);
         });
     });

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1857,7 +1857,7 @@ public:
     // flush a single table in a keyspace on all shards.
     static future<> flush_table_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::string_view table_name);
     // flush a list of tables in a keyspace on all shards.
-    static future<> flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<sstring> table_names);
+    static future<> flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<table_info> table_infos);
     // flush all tables in a keyspace on all shards.
     static future<> flush_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name);
     // flush all tables on this shard.

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1857,7 +1857,7 @@ public:
     // flush a single table in a keyspace on all shards.
     static future<> flush_table_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::string_view table_name);
     // flush a list of tables in a keyspace on all shards.
-    static future<> flush_tables_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, std::vector<table_info> table_infos);
+    static future<> flush_tables_on_all_shards(sharded<database>& sharded_db, std::vector<table_info> tables);
     // flush all tables in a keyspace on all shards.
     static future<> flush_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name);
     // flush all tables on this shard.

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -151,8 +151,8 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         for (auto cf : { db::system_keyspace::LOCAL, db::system_keyspace::PEERS }) {
             tmp.insert(auth::make_data_resource(db::system_keyspace::NAME, cf));
         }
-        for (const auto& cf : db::schema_tables::all_table_names(db::schema_features::full())) {
-            tmp.insert(auth::make_data_resource(db::schema_tables::NAME, cf));
+        for (const auto& cf : db::schema_tables::all_table_infos(db::schema_features::full())) {
+            tmp.insert(auth::make_data_resource(db::schema_tables::NAME, cf.name));
         }
         return tmp;
     }();


### PR DESCRIPTION
Actually, the main goal of this PR was to remove parse_tables() helpers from api/ in favor of more flexible (yet same complex) parse_table_infos(), but it turned out that it also saves some lookups in database maps.

There are several places in API and schema_tables that have table_id at hand, but at some point drop it and carry keyspace and table names over to a place that maps ks:cf back to table_id and then uses it to find the table object. This PR keeps the table_id with the help of table_info struct in those places. This change allows removing the aforementioned parse_table() helpers from api/ and also saves few lookups in database maps.

Removing the parse_tables() from api/ is the continuation of previous effort that reduces the set of helpers in api/ code that help handlers "parse" keyspaces and tables names see #22742 #21533