### PR TITLE
doc: fix product names in the 2025.1 upgrade guides

### DIFF
--- a/docs/upgrade/upgrade-guides/index.rst
+++ b/docs/upgrade/upgrade-guides/index.rst
@@ -4,8 +4,8 @@ Upgrade ScyllaDB
 
 .. toctree::
    
-   ScyllaDB 6.2 to 2025.1 <upgrade-guide-from-6.2-to-2025.1/index>
-   ScyllaDB 2024.x to 2025.1 <upgrade-guide-from-2024.x-to-2025.1/index>
+   ScyllaDB Open Source 6.2 to ScyllaDB 2025.1 <upgrade-guide-from-6.2-to-2025.1/index>
+   ScyllaDB Enterprise 2024.x to ScyllaDB 2025.1 <upgrade-guide-from-2024.x-to-2025.1/index>
    ScyllaDB Image <ami-upgrade>
 
 

--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-2024.x-to-2025.1/index.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-2024.x-to-2025.1/index.rst
@@ -1,5 +1,5 @@
 ==========================================================
-Upgrade - ScyllaDB 2024.x to ScyllaDB Enterprise 2025.1
+Upgrade - ScyllaDB Enterprise 2024.x to ScyllaDB 2025.1
 ==========================================================
 
 
@@ -10,6 +10,6 @@ Upgrade - ScyllaDB 2024.x to ScyllaDB Enterprise 2025.1
    ScyllaDB <upgrade-guide-from-2024.x-to-2025.1>
    Metrics <metric-update-2024.x-to-2025.1>
 
-* :doc:`Upgrade ScyllaDB from 2024.x.y to 2025.1.y <upgrade-guide-from-2024.x-to-2025.1>`
+* :doc:`Upgrade from ScyllaDB Enterprise 2024.x.y to ScyllaDB 2025.1.y <upgrade-guide-from-2024.x-to-2025.1>`
 * :doc:`Metrics Update Between 2024.x and 2025.1 <metric-update-2024.x-to-2025.1>`
 

--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-2024.x-to-2025.1/upgrade-guide-from-2024.x-to-2025.1.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-2024.x-to-2025.1/upgrade-guide-from-2024.x-to-2025.1.rst
@@ -9,9 +9,9 @@
 .. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - ScyllaDB 2024.x to 2025.1
 .. _SCYLLA_METRICS: ../metric-update-2024.x-to-2025.1
 
-=============================================================================
-Upgrade |SCYLLA_NAME| from |SRC_VERSION| to |NEW_VERSION|
-=============================================================================
+=======================================================================================
+Upgrade from |SCYLLA_NAME| Enterprise |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|
+=======================================================================================
 
 This document is a step-by-step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| 
 to |NEW_VERSION|, and rollback to version |SRC_VERSION| if required.

--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-6.2-to-2025.1/index.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-6.2-to-2025.1/index.rst
@@ -1,6 +1,6 @@
-=====================================
-ScyllaDB 6.2 to 2025.1 Upgrade Guide
-=====================================
+==========================================================
+Upgrade - ScyllaDB Open Source 6.2 to ScyllaDB 2025.1 
+==========================================================
 
 .. toctree::
    :maxdepth: 2
@@ -9,5 +9,5 @@ ScyllaDB 6.2 to 2025.1 Upgrade Guide
    Upgrade ScyllaDB <upgrade-guide-from-6.2-to-2025.1>
    Metrics Update <metric-update-6.2-to-2025.1>
 
-* :doc:`Upgrade ScyllaDB from 6.2 .x to 2025.1.y <upgrade-guide-from-6.2-to-2025.1>`
+* :doc:`Upgrade from ScyllaDB Open Source 6.2 .x to ScyllaDB 2025.1.y <upgrade-guide-from-6.2-to-2025.1>`
 * :doc:`Metrics Update Between 6.2 and 2025.1 <metric-update-6.2-to-2025.1>`

--- a/docs/upgrade/upgrade-guides/upgrade-guide-from-6.2-to-2025.1/upgrade-guide-from-6.2-to-2025.1.rst
+++ b/docs/upgrade/upgrade-guides/upgrade-guide-from-6.2-to-2025.1/upgrade-guide-from-6.2-to-2025.1.rst
@@ -9,9 +9,9 @@
 .. |SCYLLA_METRICS| replace:: ScyllaDB Metrics Update - ScyllaDB 6.2 to 2025.1
 .. _SCYLLA_METRICS: ../metric-update-6.2-to-2025.1
 
-=============================================================================
-Upgrade |SCYLLA_NAME| from |SRC_VERSION| to |NEW_VERSION|
-=============================================================================
+=======================================================================================
+Upgrade from |SCYLLA_NAME| Open Source |SRC_VERSION| to |SCYLLA_NAME| |NEW_VERSION|
+=======================================================================================
 
 This document describes a step-by-step procedure for upgrading from |SCYLLA_NAME| |SRC_VERSION| 
 to |SCYLLA_NAME| |NEW_VERSION| and rollback to version |SRC_VERSION| if necessary.


### PR DESCRIPTION
This PR fixes the product names in the upgrade 2025.1 guides so that:

- 6.2 is preceded with "ScyllaDB Open Source"
- 2024.x is preceded with "ScyllaDB Enterprise"
- 2025.1 is preceded with "ScyllaDB"

Fixes https://github.com/scylladb/scylladb/issues/23154

This PR should be backported to branch-2025.1 as it fixes the 2025.1 upgrade guides.