### PR TITLE
Alternator: add error checks for item count in BatchWriteItem (see #5057)

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -840,3 +840,10 @@ enable_tablets: true
 
 # Enforce RF-rack-valid keyspaces.
 rf_rack_valid_keyspaces: false
+
+#
+# Alternator options
+#
+# Maximum number of items in single BatchWriteItem command. Default is 100.
+# Note: DynamoDB has a hard-coded limit of 25.
+# alternator_max_items_in_batch_write: 100

--- a/db/config.cc
+++ b/db/config.cc
@@ -1282,6 +1282,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "the same endpoint used in the request. The string 'disabled' "
         "disables the DescribeEndpoints operation. Any other string is the "
         "fixed value that will be returned by DescribeEndpoints operations.")
+    // alternator_max_items_in_batch_write matches DynamoDB behaviour of size limit, but with different value - for DynamoDB it's 25
+    // (see DynamoDB's documentation for BatchWriteItem command)
+    , alternator_max_items_in_batch_write(this, "alternator_max_items_in_batch_write", value_status::Used, 100, "Maximum amount of items in single BatchItemWrite call.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -442,6 +442,7 @@ public:
     named_value<uint32_t> alternator_timeout_in_ms;
     named_value<double> alternator_ttl_period_in_seconds;
     named_value<sstring> alternator_describe_endpoints;
+    named_value<uint32_t> alternator_max_items_in_batch_write;
 
     named_value<bool> abort_on_ebadf;
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -231,6 +231,14 @@ in DynamoDB and Scylla - determined by the _sort key_ defined for that table.
 
 ---
 
+## Configurable or different limits
+
+Some features have fixed limits in DynamoDB, but the limit does not exist,
+is different, or can be configured in Alternator:
+
+* DynamoDB limits each BatchWriteItem request to 25 items. In Alternator,
+  this limit defaults to 100 but can be changed with 
+  the alternator_max_items_in_batch_write configuration parameter.
 
 ## Experimental API features
 

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -443,17 +443,17 @@ def test_batch_write_item_large_broken_connection(test_table_sn, request, dynamo
 # DynamoDB limits the number of items written by a BatchWriteItem operation
 # to 25, even if they are small. Exceeding this limit results in a
 # ValidationException error - and none of the items in the batch are written.
+# Default limit for ScyllaDB is set to 100, hence we check against 105.
 # Reproduces #5057
-@pytest.mark.xfail(reason="Issue #5057")
 def test_batch_write_item_too_many(test_table_sn):
     p = random_string()
     with pytest.raises(ClientError, match='ValidationException.*length'):
         test_table_sn.meta.client.batch_write_item(RequestItems = {
-            test_table_sn.name: [{'PutRequest': {'Item': {'p': p, 'c': i}}} for i in range(30)]
+            test_table_sn.name: [{'PutRequest': {'Item': {'p': p, 'c': i}}} for i in range(105)]
     })
     with pytest.raises(ClientError, match='ValidationException.*length'):
         test_table_sn.meta.client.batch_write_item(RequestItems = {
-            test_table_sn.name: [{'DeleteRequest': {'Key': {'p': p, 'c': i}}} for i in range(30)]
+            test_table_sn.name: [{'DeleteRequest': {'Key': {'p': p, 'c': i}}} for i in range(105)]
     })
 
 # According to the DynamoDB documentation, a single BatchGetItem operation is


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/5057