### PR TITLE
[Out-of-space prevention] db: backup: prioritize sstables that were deleted from the table

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -171,7 +171,7 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
                 sstables::snapshots_dir /
                 std::string_view(snapshot_name));
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir, move_files);
+        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir, global_table->schema()->id(), move_files);
     co_return task->id();
 }
 

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -63,6 +63,8 @@ public:
 
     future<> stop();
 
+    sharded<replica::database>& db() { return _db; };
+
     /**
      * Takes the snapshot for all keyspaces. A snapshot name must be specified.
      *

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -170,12 +170,15 @@ future<> backup_task_impl::uploads_worker() {
 }
 
 future<> backup_task_impl::backup_file(sstring name, upload_permit permit) {
-    return upload_component(name).handle_exception([this] (std::exception_ptr e) {
+    try {
+        co_await upload_component(name);
+    } catch (...) {
+        snap_log.debug("backup_file {} failed: {}", name, std::current_exception());
         // keep the first exception
         if (!_ex) {
-            _ex = std::move(e);
+            _ex = std::current_exception();
         }
-    }).finally([permit = std::move(permit)] {});
+    }
 }
 
 future<> backup_task_impl::run() {

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -33,6 +33,7 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
                                    sstring prefix,
                                    sstring ks,
                                    std::filesystem::path snapshot_dir,
+                                   table_id tid,
                                    bool move_files) noexcept
     : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
     , _snap_ctl(ctl)
@@ -40,6 +41,7 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
     , _bucket(std::move(bucket))
     , _prefix(std::move(prefix))
     , _snapshot_dir(std::move(snapshot_dir))
+    , _table_id(tid)
     , _remove_on_uploaded(move_files) {
     _status.progress_units = "bytes";
 }

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -37,6 +37,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     future<> do_backup();
     future<> upload_component(sstring name);
     future<> process_snapshot_dir();
+    future<> uploads_worker();
 
 protected:
     virtual future<> run() override;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -15,6 +15,7 @@
 #include <unordered_map>
 
 #include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
 
 #include "utils/s3/client_fwd.hh"
 #include "utils/small_vector.hh"
@@ -71,6 +72,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     future<> uploads_worker();
     struct upload_permit {
         gate::holder gh;
+        semaphore_units<> units;
     };
     future<> backup_file(sstring name, upload_permit permit);
     // Returns a disengaged optional when done

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -28,6 +28,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
     bool _remove_on_uploaded;
+    tasks::task_manager::task::progress _total_progress;
     s3::upload_progress _progress;
 
     std::exception_ptr _ex;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -43,6 +43,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     using comps_vector = utils::small_vector<std::string, sstables::num_component_types>;
     using comps_map = std::unordered_map<sstables::generation_type, comps_vector>;
     comps_map _sstable_comps;
+    std::vector<sstables::generation_type> _deleted_sstables;
 
     future<> do_backup();
     future<> upload_component(sstring name);

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -22,6 +22,14 @@
 #include "sstables/component_type.hh"
 #include "sstables/generation_type.hh"
 
+namespace replica {
+    class database;
+}
+
+namespace sstables {
+class sstables_manager;
+}
+
 namespace db {
 class snapshot_ctl;
 
@@ -44,6 +52,18 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     using comps_map = std::unordered_map<sstables::generation_type, comps_vector>;
     comps_map _sstable_comps;
     std::vector<sstables::generation_type> _deleted_sstables;
+
+    class worker {
+        sstables::sstables_manager& _manager;
+
+    public:
+        worker(const replica::database& db, table_id t);
+
+        sstables::sstables_manager& manager() const noexcept {
+            return _manager;
+        }
+    };
+    sharded<worker> _sharded_worker;
 
     future<> do_backup();
     future<> upload_component(sstring name);

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -11,6 +11,7 @@
 
 #include <filesystem>
 #include <exception>
+#include <vector>
 
 #include "utils/s3/client_fwd.hh"
 #include "tasks/task_manager.hh"
@@ -30,9 +31,11 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     s3::upload_progress _progress = {};
 
     std::exception_ptr _ex;
+    std::vector<sstring> _files;
 
     future<> do_backup();
     future<> upload_component(sstring name);
+    future<> process_snapshot_dir();
 
 protected:
     virtual future<> run() override;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -13,6 +13,8 @@
 #include <exception>
 #include <vector>
 
+#include <seastar/core/gate.hh>
+
 #include "utils/s3/client_fwd.hh"
 #include "tasks/task_manager.hh"
 
@@ -38,6 +40,10 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     future<> upload_component(sstring name);
     future<> process_snapshot_dir();
     future<> uploads_worker();
+    struct upload_permit {
+        gate::holder gh;
+    };
+    future<> backup_file(sstring name, upload_permit permit);
 
 protected:
     virtual future<> run() override;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -10,6 +10,8 @@
 #pragma once
 
 #include <filesystem>
+#include <exception>
+
 #include "utils/s3/client_fwd.hh"
 #include "tasks/task_manager.hh"
 
@@ -26,6 +28,8 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     std::filesystem::path _snapshot_dir;
     bool _remove_on_uploaded;
     s3::upload_progress _progress = {};
+
+    std::exception_ptr _ex;
 
     future<> do_backup();
     future<> upload_component(sstring name);

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -33,6 +33,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _bucket;
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
+    table_id _table_id;
     bool _remove_on_uploaded;
     tasks::task_manager::task::progress _total_progress;
     s3::upload_progress _progress;
@@ -66,6 +67,7 @@ public:
                      sstring prefix,
                      sstring ks,
                      std::filesystem::path snapshot_dir,
+                     table_id tid,
                      bool move_files) noexcept;
 
     virtual std::string type() const override;

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -28,7 +28,7 @@ class backup_task_impl : public tasks::task_manager::task::impl {
     sstring _prefix;
     std::filesystem::path _snapshot_dir;
     bool _remove_on_uploaded;
-    s3::upload_progress _progress = {};
+    s3::upload_progress _progress;
 
     std::exception_ptr _ex;
     std::vector<sstring> _files;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -895,6 +895,10 @@ static bool is_system_table(const schema& s) {
         k == db::system_distributed_keyspace::NAME_EVERYWHERE;
 }
 
+sstables::sstables_manager& database::get_sstables_manager(const schema& s) const {
+    return get_sstables_manager(system_keyspace(is_system_table(s)));
+}
+
 void database::init_schema_commitlog() {
     SCYLLA_ASSERT(this_shard_id() == 0);
 
@@ -976,7 +980,7 @@ future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_fam
         erm = ks.get_vnode_effective_replication_map();
     }
     // avoid self-reporting
-    auto& sst_manager = get_sstables_manager(system_keyspace(is_system_table(*schema)));
+    auto& sst_manager = get_sstables_manager(*schema);
     auto cf = make_lw_shared<column_family>(schema, std::move(cfg), ks.metadata()->get_storage_options_ptr(), _compaction_manager, sst_manager, *_cl_stats, _row_cache_tracker, erm);
     cf->set_durable_writes(ks.metadata()->durable_writes());
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1845,6 +1845,8 @@ public:
         return is_sys_ks ? get_system_sstables_manager() : get_user_sstables_manager();
     }
 
+    sstables::sstables_manager& get_sstables_manager(const schema& s) const;
+
     // Returns the list of ranges held by this endpoint
     // The returned list is sorted, and its elements are non overlapping and non wrap-around.
     future<dht::token_range_vector> get_keyspace_local_ranges(locator::vnode_effective_replication_map_ptr erm);

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -30,6 +30,8 @@ enum class component_type {
     Unknown,
 };
 
+constexpr size_t num_component_types = size_t(component_type::Unknown);
+
 struct sstable;
 struct component_name {
     const sstable& sst;

--- a/sstables/sstables_manager_subscription.hh
+++ b/sstables/sstables_manager_subscription.hh
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <boost/signals2/dummy_mutex.hpp>
+#include <boost/signals2/signal_type.hpp>
+
+#include "sstables/generation_type.hh"
+
+namespace bs2 = boost::signals2;
+
+namespace sstables {
+
+class sstables_manager;
+
+class sstables_manager_event_handler {
+    std::optional<boost::signals2::scoped_connection> _connection;
+public:
+    void subscribe(boost::signals2::scoped_connection&& c) {
+        assert(!_connection);
+        _connection.emplace(std::move(c));
+    }
+
+    void unsubscribe() {
+        _connection.reset();
+    }
+
+    // Note: other notifications like "added_sstables" may be needed in the future
+    virtual future<> deleted_sstable(sstables::generation_type) const { return make_ready_future(); }
+};
+
+} // namespace sstables

--- a/utils/s3/client_fwd.hh
+++ b/utils/s3/client_fwd.hh
@@ -13,7 +13,7 @@ namespace s3 {
 class client;
 
 struct upload_progress {
-    size_t total;
-    size_t uploaded;
+    size_t total = 0;
+    size_t uploaded = 0;
 };
 }


### PR DESCRIPTION
The motivation behind this change to free up disk space as early as possible.
The reason is that snapshot locks the space of all SSTables in the snapshot,
and deleting form the table, for example, by compaction, or tablet migration,
won't free-up their capacity until they are uploaded to object storage and deleted from the snapshot.

This series adds prioritization of deleted sstables in two cases:
First, after the snapshot dir is processed, the list of SSTable generation is cross-referenced with the
list of SSTables presently in the table and any generation that is not in the table is prioritized to
be uploaded earlier.
In addition, a subscription mechanism was added to sstables_manager
and it is used in backup to prioritize SSTables that get deleted from the table directory
during backup.

This is particularly important when backup happens during high disk utilization (e.g. 90%).
Without it, even if the cluster is scaled up and tablets are migrated away from the full nodes
to new nodes, tablet cleanup might not free any space if all the tablet sstables are hardlinked to the
snapshot taken for backup.

* Enhancement, no backport needed
