### PR TITLE
test/perf/s3: Don't forget to stop sharded<tester> on error

### DIFF
--- a/test/perf/perf_s3_client.cc
+++ b/test/perf/perf_s3_client.cc
@@ -158,9 +158,9 @@ int main(int argc, char** argv) {
         sharded<tester> test;
         plog.info("Creating");
         co_await test.start(dur, sks, part_size, oname, osz);
-        plog.info("Starting");
-        co_await test.invoke_on_all(&tester::start);
         try {
+            plog.info("Starting");
+            co_await test.invoke_on_all(&tester::start);
             plog.info("Running");
             if (upload) {
                 co_await test.invoke_on_all(&tester::run_upload);


### PR DESCRIPTION
In case invoke_on_all(tester::start) throws, the sharded<tester> instance remains non-stopped and calltrace is reported on test stop. Not nice, fix it so that sharded<> thing is stopped in any case.
