### PR TITLE
test/s3: Increase boost/s3_test log levels

### DIFF
--- a/test/boost/suite.yaml
+++ b/test/boost/suite.yaml
@@ -48,5 +48,7 @@ custom_args:
         - '-c1 -m2G'
     bloom_filter_test:
         - '-c1'
+    s3_test:
+        - '-c2 -m2G --logger-log-level s3=trace --logger-log-level http=trace'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test


### PR DESCRIPTION
When something goes wrong, it's impossible to find anyting out without s3 and http logs, so increase them for boost tests.
