### PR TITLE
test: sstable_test: use `auto` instead of `statistics` to avoid name collision

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -222,8 +222,8 @@ SEASTAR_TEST_CASE(check_statistics_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_statistics().get();
-        const statistics& sst1_s = sst1->get_statistics();
-        const statistics& sst2_s = sst2->get_statistics();
+        const auto& sst1_s = sst1->get_statistics();
+        const auto& sst2_s = sst2->get_statistics();
 
         BOOST_REQUIRE(sst1_s.offsets.elements.size() == sst2_s.offsets.elements.size());
         BOOST_REQUIRE(sst1_s.contents.size() == sst2_s.contents.size());


### PR DESCRIPTION
Replace explicit `statistics` type with `auto` in sstable_test to resolve name collision. This addresses ambiguity introduced by commit 87c221cb which added `struct statistics` in
`seastar/include/seastar/net/api.hh`, conflicting with the existing definition in `scylladb/sstables/types.hh` when the `seastar` namespace is opened.

The `auto` keyword avoids the need to explicitly reference either type, cleanly resolving the collision while maintaining functionality. This change prepares for the upcoming change to bump up seastar submodule.

---

change change prepares us for a change bumping up seastar, which in turn does not include critical fixes. so no need to backport.