### PR TITLE
tools/scylla-nodetool: refactor to use std::tie() for cleaner code

### DIFF
--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1976,10 +1976,8 @@ void snapshot_operation(scylla_rest_client& client, const bpo::variables_map& vm
         kn_msg = "all keyspaces";
     } else {
         if (kt_list.size() == 1 && split_kt(kt_list.front())) {
-            auto res = split_kt(kt_list.front());
-            params["kn"] = std::move(res->first);
-            params["cf"] = std::move(res->second);
             kn_msg = kt_list.front();
+            std::tie(params["kn"], params["cf"]) = *split_kt(kn_msg);
         } else {
             params["kn"] = fmt::to_string(fmt::join(kt_list.begin(), kt_list.end(), ","));
             if (vm.contains("table")) {


### PR DESCRIPTION
Replace explicit pair member access with std::tie() throughout scylla-nodetool. This simplifies the code by eliminating repetitive pair.first/pair.second references and makes the codebase more maintainable and readable.

---

it's a cleanup, hence no need to backport.