### PR TITLE
ent/encryption: correct misspellings

### DIFF
--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -1004,7 +1004,7 @@ future<encryption::kms_host::impl::key_and_id_type> encryption::kms_host::impl::
      * "GenerateDataKey" API. This creates a new (epiphermal) key, encrypts it 
      * using a named (internal) key, and gives us both raw and encrypted blobs
      * for usage as a local key.
-     * To be able to actually re-use this key again, on decryption of data,
+     * To be able to actually reuse this key again, on decryption of data,
      * we employ the strategy recommended (https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKey.html)
      * namely actually embedding the encrypted key in the key ID associated with 
      * the locally encrypted data. So ID:s become pretty big.
@@ -1027,7 +1027,7 @@ future<encryption::kms_host::impl::key_and_id_type> encryption::kms_host::impl::
      *
      * (last colon is separator) 
      *
-     * The actual data key can be retreived by doing a KMS "Decrypt" of the data blob part
+     * The actual data key can be retrieved by doing a KMS "Decrypt" of the data blob part
      * using the KMS key referenced by the key ID. This gives back actual key data that can
      * be used to create a symmetric_key with algo, length etc as specified by metadata.
      *

--- a/ent/encryption/replicated_key_provider.cc
+++ b/ent/encryption/replicated_key_provider.cc
@@ -114,7 +114,7 @@ public:
         // c.) System table/commit log write, with either first use of this provider,
         //     in which case we're creating the table (here at least) - thus fine,
         //     or again, we've waited through "ensure_populated", so keys are
-        //     readble. At worst, we create a few extra keys.
+        //     readable. At worst, we create a few extra keys.
         // Note: currently c.) is not relevant, as we don't support system/commitlog
         //       encryption using repl_prov.
         return !qp.local_is_initialized();


### PR DESCRIPTION
these misspellings were flagged by codespell.

---

it's a cleanup, hence no need to backport.