### PR TITLE
row_cache: don't garbage-collect tombstones which cover data in memtables

### DIFF
--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -1111,6 +1111,7 @@ future<> row_cache::do_update(external_updater eu, replica::memtable& m, Updater
 }
 
 future<> row_cache::update(external_updater eu, replica::memtable& m, preemption_source& preempt_src) {
+    m._merging_into_cache = true;
     return do_update(std::move(eu), m, [this] (logalloc::allocating_section& alloc,
             row_cache::partitions_type::iterator cache_i, replica::memtable_entry& mem_e, partition_presence_checker& is_present,
             real_dirty_memory_accounter& acc, const partitions_type::bound_hint& hint, preemption_source& preempt_src) mutable {

--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -776,12 +776,13 @@ row_cache::make_reader_opt(schema_ptr s,
                        const dht::partition_range& range,
                        const query::partition_slice& slice,
                        const tombstone_gc_state* gc_state,
+                       max_purgeable_fn get_max_purgeable,
                        tracing::trace_state_ptr trace_state,
                        streamed_mutation::forwarding fwd,
                        mutation_reader::forwarding fwd_mr)
 {
     auto make_context = [&] {
-        return std::make_unique<read_context>(*this, s, permit, range, slice, gc_state, trace_state, fwd_mr);
+        return std::make_unique<read_context>(*this, s, permit, range, slice, gc_state, get_max_purgeable, trace_state, fwd_mr);
     };
 
     if (query::is_single_partition(range) && !fwd_mr) {

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -20,6 +20,7 @@
 #include "db/cache_tracker.hh"
 #include "readers/empty_v2.hh"
 #include "readers/mutation_source.hh"
+#include "compaction/compaction_garbage_collector.hh"
 
 class row_cache;
 class cache_tracker;
@@ -370,8 +371,9 @@ public:
                                      tracing::trace_state_ptr trace_state = nullptr,
                                      streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
                                      mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no,
-                                     const tombstone_gc_state* gc_state = nullptr) {
-        if (auto reader_opt = make_reader_opt(s, permit, range, slice, gc_state, std::move(trace_state), fwd, fwd_mr)) {
+                                     const tombstone_gc_state* gc_state = nullptr,
+                                     max_purgeable_fn get_max_purgeable = can_never_purge) {
+        if (auto reader_opt = make_reader_opt(s, permit, range, slice, gc_state, std::move(get_max_purgeable), std::move(trace_state), fwd, fwd_mr)) {
             return std::move(*reader_opt);
         }
         [[unlikely]] return make_empty_flat_reader_v2(std::move(s), std::move(permit));
@@ -383,6 +385,7 @@ public:
                                      const dht::partition_range&,
                                      const query::partition_slice&,
                                      const tombstone_gc_state*,
+                                     max_purgeable_fn get_max_purgeable,
                                      tracing::trace_state_ptr trace_state = nullptr,
                                      streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
                                      mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::no);
@@ -390,10 +393,11 @@ public:
     mutation_reader make_reader(schema_ptr s,
                                     reader_permit permit,
                                     const dht::partition_range& range = query::full_partition_range,
-                                    const tombstone_gc_state* gc_state = nullptr) {
+                                    const tombstone_gc_state* gc_state = nullptr,
+                                    max_purgeable_fn get_max_purgeable = can_never_purge) {
         auto& full_slice = s->full_slice();
         return make_reader(std::move(s), std::move(permit), range, full_slice, nullptr,
-                streamed_mutation::forwarding::no, mutation_reader::forwarding::no, gc_state);
+                streamed_mutation::forwarding::no, mutation_reader::forwarding::no, gc_state, std::move(get_max_purgeable));
     }
 
     // Only reads what is in the cache, doesn't populate.

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -360,7 +360,13 @@ void mutation_partition_json_writer::write_atomic_cell_value(const atomic_cell_v
 }
 
 void mutation_partition_json_writer::write_collection_value(const collection_mutation_view_description& mv, data_type type) {
-    write_each_collection_cell(mv, type, [&] (atomic_cell_view v, data_type t) { write_atomic_cell_value(v, t); });
+    write_each_collection_cell(mv, type, [&] (atomic_cell_view v, data_type t) {
+        if (v.is_live()) {
+            write_atomic_cell_value(v, t);
+        } else {
+            writer().Null();
+        }
+    });
 }
 
 void mutation_partition_json_writer::write(gc_clock::duration ttl, gc_clock::time_point expiry) {

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1995,6 +1995,12 @@ future<> database::do_apply(schema_ptr s, const frozen_mutation& m, tracing::tra
     // assume failure until proven otherwise
     auto update_writes_failed = defer([&] { ++_stats->total_writes_failed; });
 
+    utils::get_local_injector().inject("database_apply", [&s] () {
+        if (!is_system_keyspace(s->ks_name())) {
+            throw std::runtime_error("injected error");
+        }
+    });
+
     // I'm doing a nullcheck here since the init code path for db etc
     // is a little in flux and commitlog is created only when db is
     // initied from datadir.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1771,6 +1771,38 @@ future<mutation> database::do_apply_counter_update(column_family& cf, const froz
     co_return m;
 }
 
+api::timestamp_type memtable_list::min_live_timestamp(const dht::decorated_key& dk, is_shadowable is, api::timestamp_type max_seen_timestamp) const noexcept {
+    const auto get_min_ts = [is] (const memtable& mt) {
+        // see get_max_purgeable_timestamp() in compaction.cc for comments on choosing min timestamp
+        return is ? mt.get_min_live_row_marker_timestamp() : mt.get_min_live_timestamp();
+    };
+
+    auto min_live_ts = api::max_timestamp;
+
+    for (const auto& mt : _memtables) {
+        const auto mt_min_live_ts = get_min_ts(*mt);
+        if (mt_min_live_ts > max_seen_timestamp) {
+            continue;
+        }
+        // We cannot do lookups on flushing memtables, they might be in the
+        // process of merging into cache. Keys already merged will not be seen
+        // by the lookup.
+        if (!mt->is_merging_to_cache() && !mt->contains_partition(dk)) {
+            continue;
+        }
+        min_live_ts = std::min(min_live_ts, mt_min_live_ts);
+    }
+
+    for (const auto& mt : _flushed_memtables_with_active_reads) {
+        // We cannot check if the flushed memtable contains the key as it
+        // becomes empty after the merge to cache completes, so we only use the
+        // min ts metadata.
+        min_live_ts = std::min(min_live_ts, get_min_ts(mt));
+    }
+
+    return min_live_ts;
+}
+
 future<> memtable_list::flush() {
     if (!may_flush()) {
         return make_ready_future<>();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -78,6 +78,8 @@ class compaction_manager;
 class frozen_mutation;
 class reconcilable_result;
 
+namespace bi = boost::intrusive;
+
 namespace tracing { class trace_state_ptr; }
 namespace s3 { struct endpoint_config; }
 
@@ -181,8 +183,13 @@ class global_table_ptr;
 class memtable_list {
 public:
     using seal_immediate_fn_type = std::function<future<> (flush_permit&&)>;
+    using intrusive_memtable_list = bi::list<
+            memtable,
+            bi::base_hook<bi::list_base_hook<bi::link_mode<bi::auto_unlink>>>,
+            bi::constant_time_size<false>>;
 private:
     std::vector<shared_memtable> _memtables;
+    intrusive_memtable_list _flushed_memtables_with_active_reads;
     seal_immediate_fn_type _seal_immediate_fn;
     std::function<schema_ptr()> _current_schema;
     replica::dirty_memory_manager* _dirty_memory_manager;
@@ -238,6 +245,15 @@ public:
         return _memtables.back();
     }
 
+    // Returns the minimum live timestamp. Considers all memtables, even
+    // those that were flushed and removed with erase(), but an
+    // in-progress read is still using them.
+    // Memtables whose min live timestamp > max_seen_timestamp are ignored as we
+    // consider that their content is more recent than any potential tombstone in
+    // other mutation sources.
+    // Returns api::max_timestamp if the key is not in any of the memtables.
+    api::timestamp_type min_live_timestamp(const dht::decorated_key& dk, is_shadowable is, api::timestamp_type max_seen_timestamp) const noexcept;
+
     // # 8904 - this method is akin to std::set::erase(key_type), not
     // erase(iterator). Should be tolerant against non-existing.
     void erase(const shared_memtable& element) noexcept {
@@ -245,6 +261,7 @@ public:
         if (i != _memtables.end()) {
             _memtables.erase(i);
         }
+        _flushed_memtables_with_active_reads.push_back(*element);
     }
 
     // Synchronously swaps the active memtable with a new, empty one,

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -834,6 +834,10 @@ void memtable::mark_flushed(mutation_source underlying) noexcept {
     _underlying = std::move(underlying);
 }
 
+bool memtable::is_merging_to_cache() const noexcept {
+    return _merging_into_cache;
+}
+
 bool memtable::is_flushed() const noexcept {
     return bool(_underlying);
 }

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -127,6 +127,7 @@ private:
     // monotonic. That combined source in this case is cache + memtable.
     mutation_source_opt _underlying;
     uint64_t _flushed_memory = 0;
+    bool _merging_into_cache = false;
     bool _merged_into_cache = false;
     replica::table_stats& _table_stats;
 
@@ -304,6 +305,7 @@ public:
 
     bool empty() const noexcept { return partitions.empty(); }
     void mark_flushed(mutation_source) noexcept;
+    bool is_merging_to_cache() const noexcept;
     bool is_flushed() const noexcept;
     void on_detach_from_region_group() noexcept;
     void revert_flushed_memory() noexcept;

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -104,7 +104,10 @@ class dirty_memory_manager;
 struct table_stats;
 
 // Managed by lw_shared_ptr<>.
-class memtable final : public enable_lw_shared_from_this<memtable>, private dirty_memory_manager_logalloc::size_tracked_region {
+class memtable final
+    : public enable_lw_shared_from_this<memtable>
+    , public boost::intrusive::list_base_hook<boost::intrusive::link_mode<boost::intrusive::auto_unlink>>
+    , private dirty_memory_manager_logalloc::size_tracked_region {
 public:
     using partitions_type = double_decker<int64_t, memtable_entry,
                             dht::raw_token_less_comparator, dht::ring_position_comparator,

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -291,7 +291,12 @@ private:
             auto& cdef = _underlying_schema->column_at(kind, id);
             writer.writer().Key(cdef.name_as_text());
             if (cdef.is_atomic()) {
-                writer.write_atomic_cell_value(cell.as_atomic_cell(cdef), cdef.type);
+                auto acv = cell.as_atomic_cell(cdef);
+                if (acv.is_live()) {
+                    writer.write_atomic_cell_value(acv, cdef.type);
+                } else {
+                    writer.writer().Null();
+                }
             } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
                 cell.as_collection_mutation().with_deserialized(*cdef.type, [&] (collection_mutation_view_description mv) {
                     writer.write_collection_value(mv, cdef.type);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1663,6 +1663,17 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
                 co_await with_scheduling_group(_config.memtable_to_cache_scheduling_group, [this, old, &newtabs, &cg] {
                     return update_cache(cg, old, newtabs);
                 });
+
+                co_await utils::get_local_injector().inject("replica_post_flush_after_update_cache", [this] (auto& handler) -> future<> {
+                    const auto this_table_name = format("{}.{}", _schema->ks_name(), _schema->cf_name());
+                    if (this_table_name == handler.get("table_name")) {
+                        tlogger.info("error injection handler replica_post_flush_after_update_cache: suspending flush for table {}", this_table_name);
+                        handler.set("suspended", true);
+                        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes{5});
+                        tlogger.info("error injection handler replica_post_flush_after_update_cache: resuming flush for table {}", this_table_name);
+                    }
+                });
+
                 cg.memtables()->erase(old);
                 tlogger.debug("Memtable for {}.{} replaced, into {} sstables", old->schema()->ks_name(), old->schema()->cf_name(), newtabs.size());
                 co_return;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -246,7 +246,8 @@ table::make_reader_v2(schema_ptr s,
 
     const auto bypass_cache = slice.options.contains(query::partition_slice::option::bypass_cache);
     if (cache_enabled() && !bypass_cache) {
-        if (auto reader_opt = _cache.make_reader_opt(s, permit, range, slice, &_compaction_manager.get_tombstone_gc_state(), std::move(trace_state), fwd, fwd_mr)) {
+        if (auto reader_opt = _cache.make_reader_opt(s, permit, range, slice, &_compaction_manager.get_tombstone_gc_state(),
+                    get_max_purgeable_fn_for_cache_underlying_reader(), std::move(trace_state), fwd, fwd_mr)) {
             readers.emplace_back(std::move(*reader_opt));
         }
     } else {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2769,20 +2769,7 @@ max_purgeable_fn table::get_max_purgeable_fn_for_cache_underlying_reader() const
         auto max_purgeable_timestamp = api::max_timestamp;
 
         sg.for_each_compaction_group([&dk, is_shadowable, &max_purgeable_timestamp] (const compaction_group_ptr& cg) {
-            const auto& mt = cg->memtables()->active_memtable();
-            // see get_max_purgeable_timestamp() in compaction.cc for comments on choosing min timestamp
-            api::timestamp_type memtable_min_timestamp = is_shadowable ? mt.get_min_live_row_marker_timestamp() : mt.get_min_live_timestamp();
-            if (memtable_min_timestamp > cg->max_seen_timestamp()) {
-                // All the entries in the memtable are newer than the entries in the
-                // SSTable within this compaction group. So, no need to check further.
-                return;
-            }
-
-            // If a memtable with a minimum timestamp lower than the current maximum
-            // purgeable timestamp has the given key, the tombstone should not be purged.
-            if (memtable_min_timestamp < max_purgeable_timestamp && mt.contains_partition(dk)) {
-                max_purgeable_timestamp = memtable_min_timestamp;
-            }
+            max_purgeable_timestamp = std::min(cg->memtables()->min_live_timestamp(dk, is_shadowable, cg->max_seen_timestamp()), max_purgeable_timestamp);
         });
 
         return max_purgeable_timestamp;

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -15,6 +15,7 @@
 
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
+#include "test/lib/cql_assertions.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/mutation_reader_assertions.hh"
 #include "test/lib/mutation_source_test.hh"
@@ -4897,6 +4898,349 @@ SEASTAR_THREAD_TEST_CASE(test_reproduce_18045) {
         &gc_state);
     auto close_rd = deferred_close(rd);
     read_mutation_from_mutation_reader(rd).get();
+}
+
+struct decorated_key_with_value {
+    dht::decorated_key dk;
+    int32_t value;
+};
+
+std::vector<decorated_key_with_value> get_local_int32_dks(const replica::table& tbl, size_t num) {
+    const auto& schema = *tbl.schema();
+    std::vector<decorated_key_with_value> dks;
+
+    int32_t pk = 0;
+
+    while (dks.size() < num) {
+
+        auto dk = dht::decorate_key(schema, partition_key::from_exploded(schema, { int32_type->decompose(pk) }));
+        auto write_replicas = tbl.shard_for_writes(dk.token());
+        BOOST_REQUIRE_EQUAL(write_replicas.size(), 1);
+
+        if (write_replicas.size() == 1 && write_replicas.front() == this_shard_id()) {
+            dks.emplace_back(decorated_key_with_value{std::move(dk), pk});
+        }
+
+        pk++;
+    }
+
+    std::ranges::sort(dks, [&schema] (const decorated_key_with_value& a, const decorated_key_with_value& b) {
+        return dht::ring_position_tri_compare(schema, a.dk, b.dk) < 0;
+    });
+
+    return dks;
+}
+
+mutation create_mutation_with_rows(const schema& schema, const dht::decorated_key& dk, int32_t ck1, int32_t num_rows, sstring v, api::timestamp_type ts) {
+    const auto& v_def = *schema.get_column_definition(to_bytes("v"));
+
+    const auto raw = utf8_type->decompose(v);
+
+    mutation mut(schema.shared_from_this(), dk);
+    for (int32_t ck2 = 0; ck2 != num_rows; ++ck2) {
+        const auto ck = clustering_key::from_exploded(schema, { int32_type->decompose(ck1), int32_type->decompose(ck2) });
+        mut.set_clustered_cell(ck, v_def, atomic_cell::make_live(*v_def.type, ts, raw));
+    }
+    return mut;
+}
+
+using apply_delete_fn = std::function<void(mutation&, const clustering_key&, const column_definition&, tombstone)>;
+
+void run_cache_tombstone_gc_overlap_checks_scenario(
+        cql_test_env& env,
+        std::function<void(cql_test_env&, replica::table&, api::timestamp_type, tombstone, apply_delete_fn)> scenario,
+        std::string_view scenario_name,
+        apply_delete_fn apply_delete) {
+    testlog.info("Running scenario {}", scenario_name);
+
+    const auto table_name = scenario_name;
+
+    env.execute_cql(std::format("CREATE TABLE ks.{} (pk int, ck1 int, ck2 int, v text, PRIMARY KEY (pk, ck1, ck2))"
+            " WITH compaction = {{'class': 'NullCompactionStrategy'}}"
+            " AND tombstone_gc = {{'mode': 'immediate', 'propagation_delay_in_seconds': 0}}", table_name)).get();
+
+    replica::database& db = env.local_db();
+
+    auto& tbl = db.find_column_family("ks", table_name);
+    const auto schema = tbl.schema();
+
+    BOOST_REQUIRE(tbl.uses_tablets());
+
+    const auto& tablet_map = db.get_token_metadata().tablets().get_tablet_map(schema->id());
+    BOOST_REQUIRE_EQUAL(tablet_map.tablet_count(), 1);
+
+    const auto replica_shard = tablet_map.tablets().front().replicas.front().shard;
+
+    smp::submit_to(replica_shard, [&env, scenario, table_name, apply_delete] {
+        return async([&] {
+            replica::database& db = env.local_db();
+            auto& tbl = db.find_column_family("ks", table_name);
+
+            const api::timestamp_type live_timestamp = 100;
+            const api::timestamp_type dead_timestamp = live_timestamp + 100;
+
+            const auto deletion_time = gc_clock::now() - std::chrono::seconds(10);
+            const auto tomb = tombstone(dead_timestamp, deletion_time);
+
+            scenario(env, tbl, live_timestamp, tomb, apply_delete);
+        });
+    }).get();
+}
+
+void test_cache_tombstone_gc_overlap_checks_single_row_scenario(cql_test_env& env, replica::table& tbl,
+        api::timestamp_type live_timestamp, tombstone tomb, apply_delete_fn apply_delete) {
+    replica::database& db = env.local_db();
+
+    const auto schema = tbl.schema();
+    const auto& v_def = *schema->get_column_definition(to_bytes("v"));
+    const auto table_name = schema->cf_name();
+
+    auto dks = get_local_int32_dks(tbl, 1);
+    const auto& [dk, pk] = dks.front();
+
+    auto ck = clustering_key::from_exploded(*schema, { int32_type->decompose(100), int32_type->decompose(0) });
+
+    mutation dead_row_mut(schema, dk);
+    apply_delete(dead_row_mut, ck, v_def, tomb);
+
+    db.apply(schema, freeze(dead_row_mut), {}, db::commitlog_force_sync::no, db::no_timeout).get();
+
+    db.flush("ks", table_name).get();
+
+    auto live_row_mut = create_mutation_with_rows(*schema, dk, 100, 1, "value", live_timestamp);
+
+    db.apply(schema, freeze(live_row_mut), {}, db::commitlog_force_sync::no, db::no_timeout).get();
+
+    assert_that(env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {}", table_name, pk)).get()).is_rows().is_empty();
+    assert_that(env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {}", table_name, pk)).get()).is_rows().is_empty();
+}
+
+template <typename MemtableFlushPolicy>
+void test_cache_tombstone_gc_overlap_checks_concurrent_singular_reads_scenario(cql_test_env& env, replica::table& tbl,
+        api::timestamp_type live_timestamp, tombstone tomb, apply_delete_fn apply_delete) {
+    replica::database& db = env.local_db();
+
+    const auto schema = tbl.schema();
+    const auto& v_def = *schema->get_column_definition(to_bytes("v"));
+
+    const auto table_name = schema->cf_name();
+
+    auto dks = get_local_int32_dks(tbl, 1);
+    const auto& [dk, pk] = dks.front();
+
+    auto pr = dht::partition_range::make_singular(dk);
+
+    const auto ck1 = 100;
+
+    auto dead_ck = clustering_key::from_exploded(*schema, { int32_type->decompose(ck1), int32_type->decompose(20) });
+
+    mutation dead_row_mut(schema, dk);
+    apply_delete(dead_row_mut, dead_ck, v_def, tomb);
+
+    auto mut_v1 = create_mutation_with_rows(*schema, dk, ck1, 30, sstring(1024, '1'), live_timestamp);
+    auto mut_v2 = create_mutation_with_rows(*schema, dk, ck1, 30, sstring(1024, '2'), live_timestamp);
+
+    db.apply({ freeze(dead_row_mut), freeze(mut_v1) }, db::no_timeout).get();
+    db.flush("ks", table_name).get();
+
+    db.apply({ freeze(mut_v2) }, db::no_timeout).get();
+
+    auto reader1 = tbl.make_reader_v2(schema, db.obtain_reader_permit(tbl, "read1", db::no_timeout, {}).get(), pr, schema->full_slice());
+    const auto close_reader1 = deferred_close(reader1);
+
+    reader1.fill_buffer().get();
+
+    auto reader2 = tbl.make_reader_v2(schema, db.obtain_reader_permit(tbl, "read2", db::no_timeout, {}).get(), pr, schema->full_slice());
+    const auto close_reader2 = deferred_close(reader2);
+
+    reader2.fill_buffer().get();
+
+    MemtableFlushPolicy flush_policy(db, table_name);
+
+    // read 3
+    auto res = env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {}", table_name, pk)).get();
+
+    mutation expected_result(schema, dk);
+    expected_result.apply(mut_v2);
+    expected_result.apply(dead_row_mut);
+
+    for (auto* rd : {&reader1, &reader2}) {
+        auto m_opt = read_mutation_from_mutation_reader(*rd).get();
+
+        BOOST_REQUIRE(m_opt);
+        BOOST_REQUIRE(rd->is_end_of_stream());
+
+        assert_that(*m_opt).is_equal_to(expected_result);
+    }
+
+    const auto compacted_expected_result = expected_result.compacted();
+
+    assert_that(res).is_rows().with_size(compacted_expected_result.partition().live_row_count(*schema));
+}
+
+template <typename MemtableFlushPolicy>
+void test_cache_tombstone_gc_overlap_checks_concurrent_scanning_reads_scenario(cql_test_env& env, replica::table& tbl,
+        api::timestamp_type live_timestamp, tombstone tomb, apply_delete_fn apply_delete) {
+    replica::database& db = env.local_db();
+
+    const auto schema = tbl.schema();
+    const auto& v_def = *schema->get_column_definition(to_bytes("v"));
+
+    const auto table_name = schema->cf_name();
+
+    auto dks = get_local_int32_dks(tbl, 2);
+    const auto& [dk1, pk1] = dks[0];
+    const auto& [dk2, pk2] = dks[1];
+
+    const auto ck1 = 100;
+
+    auto mut1_v1 = create_mutation_with_rows(*schema, dk1, ck1, 20, sstring(1024, '1'), live_timestamp);
+    auto mut1_v2 = create_mutation_with_rows(*schema, dk1, ck1, 20, sstring(1024, '2'), live_timestamp);
+
+    auto dead_ck = clustering_key::from_exploded(*schema, { int32_type->decompose(ck1), int32_type->decompose(15) });
+
+    mutation mut2_dead_row(schema, dk2);
+    apply_delete(mut2_dead_row, dead_ck, v_def, tomb);
+
+    auto mut2_v1 = create_mutation_with_rows(*schema, dk2, ck1, 20, sstring(1024, '3'), live_timestamp);
+    auto mut2_v2 = create_mutation_with_rows(*schema, dk2, ck1, 20, sstring(1024, '4'), live_timestamp);
+
+    // Get the first version of partitions + deleted row to the disk.
+    db.apply({ freeze(mut1_v1), freeze(mut2_dead_row), freeze(mut2_v1) }, db::no_timeout).get();
+    db.flush("ks", table_name).get();
+
+    db.apply({ freeze(mut1_v2), freeze(mut2_v2) }, db::no_timeout).get();
+
+    // Make sure both partitions are in the cache
+    testlog.info("pre-populate partition {}", pk1);
+    assert_that(env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {} AND ck1 = {} and ck2 = {}", table_name, pk1, ck1, 0)).get()).is_rows();
+    testlog.info("pre-populate partition {}", pk2);
+    assert_that(env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {} AND ck1 = {} and ck2 = {}", table_name, pk2, ck1, 0)).get()).is_rows();
+
+    testlog.info("read 1");
+    auto reader1 = tbl.make_reader_v2(
+            schema,
+            db.obtain_reader_permit(tbl, "read1", db::no_timeout, {}).get(),
+            query::full_partition_range,
+            schema->full_slice());
+    const auto close_reader1 = deferred_close(reader1);
+
+    reader1.fill_buffer().get();
+
+    testlog.info("read 2");
+    auto reader2 = tbl.make_reader_v2(
+            schema,
+            db.obtain_reader_permit(tbl, "read2", db::no_timeout, {}).get(),
+            query::full_partition_range,
+            schema->full_slice());
+    const auto close_reader2 = deferred_close(reader2);
+
+    reader2.fill_buffer().get();
+
+    MemtableFlushPolicy flush_policy(db, table_name);
+
+    // read 3
+    testlog.info("read 3");
+    auto res = env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {}", table_name, pk2)).get();
+
+    mutation expected_mut2(schema, dk2);
+    expected_mut2.apply(mut2_v2);
+    expected_mut2.apply(mut2_dead_row);
+
+    for (auto* rd : {&reader1, &reader2}) {
+        auto m_opt = read_mutation_from_mutation_reader(*rd).get();
+        BOOST_REQUIRE(m_opt);
+        BOOST_REQUIRE(!rd->is_end_of_stream());
+        assert_that(*m_opt).is_equal_to(mut1_v2);
+
+        m_opt = read_mutation_from_mutation_reader(*rd).get();
+        BOOST_REQUIRE(m_opt);
+        BOOST_REQUIRE(rd->is_end_of_stream());
+        assert_that(*m_opt).is_equal_to(expected_mut2);
+    }
+
+    const auto compacted_expected_mut2 = expected_mut2.compacted();
+
+    assert_that(res).is_rows().with_size(compacted_expected_mut2.partition().live_row_count(*schema));
+}
+
+future<> test_cache_tombstone_gc_overlap_checks(apply_delete_fn apply_delete) {
+    cql_test_config cfg;
+    cfg.initial_tablets = 1;
+
+    struct flush_completely_policy {
+        flush_completely_policy(replica::database& db, std::string_view table_name) {
+            testlog.info("Creating flush_completely_policy");
+            db.flush("ks", sstring(table_name)).get();
+        }
+    };
+
+    static constexpr char injection_point_name[] = "replica_post_flush_after_update_cache";
+
+    class flush_halfway_policy {
+        future<> _fut;
+    public:
+        flush_halfway_policy(replica::database& db, std::string_view table_name) : _fut(make_ready_future<>()) {
+            testlog.info("Creating flush_halfway_policy");
+
+            auto& err_inj = utils::get_local_injector();
+
+            err_inj.enable(injection_point_name, false, {{"table_name", seastar::format("ks.{}", table_name)}});
+
+            _fut = db.flush("ks", sstring(table_name));
+
+            while (!err_inj.get_injection_parameters(injection_point_name).contains("suspended")) {
+                sleep(1s).get();
+            }
+        }
+        ~flush_halfway_policy() {
+            utils::get_local_injector().receive_message(injection_point_name);
+            _fut.get();
+        }
+    };
+
+    return do_with_cql_env_thread([apply_delete] (cql_test_env& env) {
+        run_cache_tombstone_gc_overlap_checks_scenario(env, test_cache_tombstone_gc_overlap_checks_single_row_scenario,
+                "single_row_scenario", apply_delete);
+        run_cache_tombstone_gc_overlap_checks_scenario(env, test_cache_tombstone_gc_overlap_checks_concurrent_singular_reads_scenario<flush_completely_policy>,
+                "concurrent_singular_reads_scenario_1", apply_delete);
+        run_cache_tombstone_gc_overlap_checks_scenario(env, test_cache_tombstone_gc_overlap_checks_concurrent_scanning_reads_scenario<flush_completely_policy>,
+                "concurrent_scanning_reads_scenario_1", apply_delete);
+
+#ifdef SCYLLA_ENABLE_ERROR_INJECTION
+        run_cache_tombstone_gc_overlap_checks_scenario(env, test_cache_tombstone_gc_overlap_checks_concurrent_singular_reads_scenario<flush_halfway_policy>,
+                "concurrent_singular_reads_scenario_2", apply_delete);
+        run_cache_tombstone_gc_overlap_checks_scenario(env, test_cache_tombstone_gc_overlap_checks_concurrent_scanning_reads_scenario<flush_halfway_policy>,
+                "concurrent_scanning_reads_scenario_2", apply_delete);
+#endif
+    }, cfg);
+}
+
+SEASTAR_TEST_CASE(test_cache_partition_tombstone_gc_overlap_checks) {
+    return test_cache_tombstone_gc_overlap_checks([] (mutation& m, const clustering_key& ck, const column_definition&, tombstone tomb) {
+        m.partition().apply(tomb);
+    });
+}
+
+SEASTAR_TEST_CASE(test_cache_row_tombstone_gc_overlap_checks) {
+    return test_cache_tombstone_gc_overlap_checks([] (mutation& m, const clustering_key& ck, const column_definition&, tombstone tomb) {
+        m.partition().apply_delete(*m.schema(), ck, tomb);
+    });
+}
+
+SEASTAR_TEST_CASE(test_cache_range_tombstone_gc_overlap_checks) {
+    return test_cache_tombstone_gc_overlap_checks([] (mutation& m, const clustering_key& ck, const column_definition&, tombstone tomb) {
+        const auto& schema = *m.schema();
+        const auto ck_components = ck.explode(schema);
+        const auto ck_prefix = clustering_key::from_exploded(schema, { ck_components.front() });
+        m.partition().apply_row_tombstone(schema, ck_prefix, tomb);
+    });
+}
+
+SEASTAR_TEST_CASE(test_cache_cell_tombstone_gc_overlap_checks) {
+    return test_cache_tombstone_gc_overlap_checks([] (mutation& m, const clustering_key& ck, const column_definition& v_def, tombstone tomb) {
+        m.set_clustered_cell(ck, v_def, atomic_cell::make_dead(tomb.timestamp, tomb.deletion_time));
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4581,7 +4581,7 @@ SEASTAR_TEST_CASE(test_cache_compacts_expired_tombstones_on_read) {
                 return gc_clock::now() - (std::chrono::seconds(s->gc_grace_seconds().count() + 600));
         });
 
-        auto rd1 = cache.make_reader(s, semaphore.make_permit(), query::full_partition_range, &gc_state);
+        auto rd1 = cache.make_reader(s, semaphore.make_permit(), query::full_partition_range, &gc_state, can_always_purge);
         auto close_rd = deferred_close(rd1);
         rd1.fill_buffer().get(); // cache_mutation_reader compacts cache on fill buffer
 
@@ -4659,7 +4659,7 @@ SEASTAR_TEST_CASE(test_compact_range_tombstones_on_read) {
         set_cells_timestamp_to_min(cp.clustered_row(*s.schema(), ck3));
 
         {
-            auto rd1 = cache.make_reader(s.schema(), semaphore.make_permit(), pr, &gc_state);
+            auto rd1 = cache.make_reader(s.schema(), semaphore.make_permit(), pr, &gc_state, can_always_purge);
             auto close_rd1 = deferred_close(rd1);
             rd1.fill_buffer().get();
 
@@ -4671,7 +4671,7 @@ SEASTAR_TEST_CASE(test_compact_range_tombstones_on_read) {
         }
 
         {
-            auto rd2 = cache.make_reader(s.schema(), semaphore.make_permit(), pr, &gc_state);
+            auto rd2 = cache.make_reader(s.schema(), semaphore.make_permit(), pr, &gc_state, can_always_purge);
             auto close_rd2 = deferred_close(rd2);
             rd2.fill_buffer().get();
 

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -1,0 +1,153 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import json
+import logging
+import pytest
+import time
+
+from cassandra.cluster import ConsistencyLevel  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+
+from test.cluster.conftest import skip_mode
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+
+logger = logging.getLogger(__name__)
+
+
+async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: list[tuple[str]]):
+    """Test for cache garbage collecting tombstones which cover data in the memtable.
+
+    1. Write a live row.
+    2. Write a tombstone to 2/3 replica (fail the write on node3 via error injection).
+    3. Run a repair so node3 also receives the tombstone.
+
+    At this stage, node1 and node2 have both the live row and the tombstone in
+    memtable, node3 has the live row in the memtable and the tombstone on disk.
+
+    4. Read the row from each node with CL=LOCAL_ONE. This will create an entry in cache
+       on node3, with the tombstone.
+       Check that population didn't drop the tombstone! #23291
+    5. Do another read round. This will use the existing entry in the cache.
+       Check that the cache read didn't drop the tombstone! #23252
+    """
+    cmdline = ["--hinted-handoff-enabled", "0", "--cache-hit-rate-read-balancing", "0", "--logger-log-level", "debug_error_injection=trace"]
+
+    nodes = await manager.servers_add(3, cmdline=cmdline)
+
+    node1, node2, node3 = nodes
+
+    cql = manager.get_cql()
+
+    host1, host2, host3 = await wait_for_cql_and_get_hosts(cql, nodes, time.time() + 30)
+
+    def execute_with_tracing(cql, statement, *args, **kwargs):
+        kwargs['trace'] = True
+        query_result = cql.execute(statement, *args, **kwargs)
+
+        tracing = query_result.get_all_query_traces(max_wait_sec_per=900)
+        page_traces = []
+        for trace in tracing:
+            trace_events = []
+            for event in trace.events:
+                trace_events.append(f"  {event.source} {event.source_elapsed} {event.description}")
+            page_traces.append("\n".join(trace_events))
+        logger.debug("Tracing {}:\n{}\n".format(statement, "\n".join(page_traces)))
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = { 'enabled': true }") as ks:
+        cql.execute(f"CREATE TABLE {ks}.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
+                    "     WITH speculative_retry = 'NONE'"
+                    "     AND tombstone_gc = {'mode': 'immediate', 'propagation_delay_in_seconds': 0}"
+                    "     AND compaction = {'class': 'NullCompactionStrategy'}")
+
+        for write_statement, delete_statement in statement_pairs:
+            execute_with_tracing(cql, write_statement.format(ks=ks))
+            await manager.api.enable_injection(node3.ip_addr, "database_apply", one_shot=False)
+            execute_with_tracing(cql, delete_statement.format(ks=ks))
+            await manager.api.disable_injection(node3.ip_addr, "database_apply")
+
+        def check_data(host, data):
+            res = cql.execute(SimpleStatement(f"SELECT JSON * FROM {ks}.tbl WHERE pk = 0", consistency_level=ConsistencyLevel.LOCAL_ONE), host=host, trace=True)
+            row_list = list(map(lambda row: json.loads(row[0]), res))
+            tracing = res.get_all_query_traces(max_wait_sec_per=900)
+            for trace in tracing:
+                for event in trace.events:
+                    # Make sure the read was executed on `host`.
+                    assert event.source == host.address
+            assert row_list == data
+
+        def dump_mutation_fragments(description):
+            for host in [host1, host2, host3]:
+                res = cql.execute(SimpleStatement(f"SELECT * FROM MUTATION_FRAGMENTS({ks}.tbl) WHERE pk = 0", consistency_level=ConsistencyLevel.LOCAL_ONE), host=host)
+                logger.info(f"MUTATION_FRAGMENTS {description} for {host.address}:\n{'\n'.join(map(str, res))}")
+
+        # Before repair: we expect node3 to have the deleted row as live.
+        check_data(host1, [])
+        check_data(host2, [])
+        check_data(host3, [{'pk': 0, 'ck': 100, 'v': 999}])
+
+        dump_mutation_fragments("before repair")
+
+        await manager.api.tablet_repair(node1.ip_addr, ks, "tbl", "all", await_completion=True)
+
+        # Give time for immediate-mode tombstone gc to take effect.
+        # It needs tombstone.expiry < now(), with second resolution.
+        time.sleep(2)
+
+        dump_mutation_fragments("after repair")
+
+        # Fist read - cache is populated with the tombstone
+        check_data(host1, [])
+        check_data(host2, [])
+        check_data(host3, [])
+
+        dump_mutation_fragments("after repair and after populating read")
+
+        # Second read - cache should *not* garbage-collects the tombstone
+        check_data(host1, [])
+        check_data(host2, [])
+        check_data(host3, [])
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cache_tombstone_gc_partition_tombstone(manager: ManagerClient):
+    await run_test_cache_tombstone_gc(manager,
+                                      [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0")])
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cache_tombstone_gc_row_tombstone(manager: ManagerClient):
+    await run_test_cache_tombstone_gc(manager,
+                                      [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cache_tombstone_gc_range_tombstone(manager: ManagerClient):
+    await run_test_cache_tombstone_gc(manager,
+                                      [("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck > 0 AND ck < 1000")])
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cache_tombstone_gc_cell_tombstone(manager: ManagerClient):
+    await run_test_cache_tombstone_gc(manager,
+                                      [("UPDATE {ks}.tbl SET v = 999 WHERE pk = 0 AND ck = 100", "DELETE v FROM {ks}.tbl WHERE pk = 0 AND ck = 100")])
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cache_tombstone_gc_cell_tombstone_and_row_tombstone(manager: ManagerClient):
+    await run_test_cache_tombstone_gc(manager,
+                                      [
+                                          ("INSERT INTO {ks}.tbl (pk, ck, v) VALUES (0, 100, 999)", "DELETE FROM {ks}.tbl WHERE pk = 0 AND ck = 100"),
+                                          ("UPDATE {ks}.tbl SET v = 999 WHERE pk = 0 AND ck = 100", "DELETE v FROM {ks}.tbl WHERE pk = 0 AND ck = 100"),
+                                      ])

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -107,6 +107,12 @@ async def wait_for_cql_and_get_hosts(cql: Session, servers: list[ServerInfo], de
 
     # Take only hosts from `ip_set` (there may be more)
     hosts = [h for h in hosts if h.address in ip_set]
+
+    # Make sure `hosts` has same order as `servers`, that is: a given index will
+    # refer to the same underlying Scylla instance in both `servers` and `hosts`.
+    servers_by_ip = {srv.rpc_address: i for i, srv in enumerate(servers)}
+    hosts.sort(key=lambda x: servers_by_ip[x.address])
+
     await asyncio.gather(*(wait_for_cql(cql, h, deadline) for h in hosts))
 
     return hosts

--- a/utils/error_injection.hh
+++ b/utils/error_injection.hh
@@ -166,6 +166,11 @@ class error_injection {
                 });
             }
         }
+
+        template <typename T>
+        void set(sstring name, const T& value) {
+            parameters[name] = std::to_string(value);
+        }
     };
 
     class injection_data;
@@ -247,6 +252,14 @@ public:
                 on_internal_error(errinj_logger, "injection_shared_data is not initialized");
             }
             return _shared_data->template get<T>(std::string(key));
+        }
+
+        template <typename T>
+        void set(std::string_view key, const T& value) const {
+            if (!_shared_data) {
+                on_internal_error(errinj_logger, "injection_shared_data is not initialized");
+            }
+            return _shared_data->template set<T>(sstring(key), value);
         }
 
         friend class error_injection;


### PR DESCRIPTION
The row cache can garbage-collect tombstones in two places:
1) When populating the cache - the underlying reader pipeline has a `compacting_reader` in it;
2) During reads - reads now compact data including garbage collection;

In both cases, garbage collection has to do overlap checks against memtables, to avoid collecting tombstones which cover data in the memtables.
This PR includes fixes for (2), which were not handled at all currently.
(1) was already supposed to be fixed, see https://github.com/scylladb/scylladb/issues/20916. But the test added in this PR showed that the test is incomplete: https://github.com/scylladb/scylladb/issues/23291. A fix for this issue is also included.

Fixes: https://github.com/scylladb/scylladb/issues/23291
Fixes: https://github.com/scylladb/scylladb/issues/23252

The fix will need backport to all live release.