### PR TITLE
./github/scripts/auto-backport.py: don't remove backport label when backport process has an error

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -7,7 +7,7 @@ on:
       - branch-*.*
       - enterprise
   pull_request_target:
-    types: [labeled]
+    types: [labeled, unlabeled]
     branches: [master, next, enterprise]
 
 jobs:
@@ -53,19 +53,28 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --commits ${{ github.event.before }}..${{ github.sha }}
-      - name: Check if label starts with 'backport/' and contains digits
+      - name: Check if a valid backport label exists and no backport_error
         id: check_label
         run: |
-          label_name="${{ github.event.label.name }}"
-          if [[ "$label_name" =~ ^backport/[0-9]+\.[0-9]+$ ]]; then
-            echo "Label matches backport/X.X pattern."
-            echo "backport_label=true" >> $GITHUB_OUTPUT
+          labels_json='${{ toJson(github.event.pull_request.labels) }}'
+          echo "Checking labels: $(echo "$labels_json" | jq -r '.[].name')"
+
+          # Check if a valid backport label exists
+          if echo "$labels_json" | jq -e 'any(.[] | .name; test("backport/[0-9]+\\.[0-9]+$"))' > /dev/null; then
+            # Ensure scylladbbot/backport_error is NOT present
+            if ! echo "$labels_json" | jq -e '.[] | select(.name == "scylladbbot/backport_error")' > /dev/null; then
+              echo "A matching backport label was found and no backport_error label exists."
+              echo "ready_for_backport=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            else
+              echo "The label 'scylladbbot/backport_error' is present, invalidating backport."
+            fi
           else
-            echo "Label does not match the required pattern."
-            echo "backport_label=false" >> $GITHUB_OUTPUT
+            echo "No matching backport label found."
           fi
-      - name: Run auto-backport.py when label was added
-        if: ${{ github.event_name == 'pull_request_target' && steps.check_label.outputs.backport_label == 'true' && github.event.pull_request.state == 'closed' }}
+          echo "ready_for_backport=false" >> "$GITHUB_OUTPUT"
+      - name: Run auto-backport.py when PR is closed
+        if: ${{ github.event_name == 'pull_request_target' && steps.check_label.outputs.ready_for_backport == 'true' && github.event.pull_request.state == 'closed' }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
-        run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --pull-request ${{ github.event.pull_request.number }} --head-commit ${{ github.event.pull_request.base.sha }}
+        run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --pull-request ${{ github.event.pull_request.number }} --head-commit ${{ github.event.pull_request.base.sha }} --github-event ${{ github.event.action }}


### PR DESCRIPTION
Today, when the `Fixes` prefix is missing or the developer is not a collaborator with `scylladbbot` we remove the backport labels to prevent the process from starting and notifying the developers.

Developers are worried that removing these backport labels will cause us to forget we need to do these backports. @nyh suggested to add a `scylladbbot/backport_error` label instead

Applied those changes, so when a `Fixes` prefix is missing we will add a `scylladbbot/backport_error` label and stop the process

When a user doesn't accept the invite we will still open the PR but he will not be assigned and will not be able to edit the branch when we have conflicts

Fixes: https://github.com/scylladb/scylla-pkg/issues/4898
Fixes: https://github.com/scylladb/scylla-pkg/issues/4897

**Backport automation improvements, no need for backport**