### PR TITLE
test: perf_sstable: close frag_stream before destoying it

### DIFF
--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -186,6 +186,7 @@ private:
             }
             auto frozen_frag = freeze(*s, *frag);
         }
+        co_await frag_stream.close();
 
         const auto end = perf_sstable_test_env::now();
         const auto duration = std::chrono::duration<double>(end - start).count();


### PR DESCRIPTION
the underlying reader should be closed before being destroyed. otherwise we'd have following failure when testing the "full_scan_streaming":

```
$ scylla perf-sstable --parallelism 1 --iterations 20 --partitions 20 --testdir /tmp/sstable --mode full_scan_streaming

ERROR 2025-03-13 15:04:26,321 [shard  0:main] mutation_reader - N8sstables2mx27mx_sstable_full_scan_readerE [0x60015a36b650]: permit *.*:test: was not closed before destruction, at: 0x235931e 0x2359470 0x239deb3 0x62a1ed3 0x89fd156 0x89c3fba 0x22a6ed3 0x22a8fea 0x22aae17 0x22a9928 0x26bb7d0 0x26bbe3e 0x89bca67 0x246bd8d /lib64/libc.so.6+0x3247 /lib64/libc.so.6+0x330a 0x1657774
------
   seastar::internal::coroutine_traits_base<double>::promise_type
```

---

this perf test is neither used in production, nor is it performed in our CI/CD workflow. so no need to backport.