### PR TITLE
Update seastar submodule

### DIFF
--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -222,8 +222,8 @@ SEASTAR_TEST_CASE(check_statistics_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
         sstables::test(sst2).read_statistics().get();
-        const statistics& sst1_s = sst1->get_statistics();
-        const statistics& sst2_s = sst2->get_statistics();
+        const auto& sst1_s = sst1->get_statistics();
+        const auto& sst2_s = sst2->get_statistics();
 
         BOOST_REQUIRE(sst1_s.offsets.elements.size() == sst2_s.offsets.elements.size());
         BOOST_REQUIRE(sst1_s.contents.size() == sst2_s.contents.size());

--- a/utils/s3/retryable_http_client.cc
+++ b/utils/s3/retryable_http_client.cc
@@ -47,7 +47,7 @@ future<> retryable_http_client::do_retryable_request(http::request req, http::ex
                     "EACCESS fault injected to simulate authorization failure", aws::retryable::no});
             }
             e = {};
-            co_return co_await (as ? http.make_request(req, handler, *as, std::nullopt) : http.make_request(req, handler, std::nullopt));
+            co_return co_await (as ? http.make_request(req, handler, std::nullopt, as) : http.make_request(req, handler, std::nullopt));
         } catch (const aws::aws_exception& ex) {
             e = std::current_exception();
             request_ex = ex;


### PR DESCRIPTION
* seastar 5b95d1d7...bfe8525f (61):
  > build: Include DPDK dependency libraries in Seastar linkage
  > demos/tls_echo_server_demo: Modernize with seastar::async
  > http/client: Pass abort source by pointer
  > rpc: remove deprecated logging function support
  > github: Add Alpine Linux workflow to test builds with musl libc
  > exception_hacks: Make dl_iterate_phdr resolution manual
  > tests: relax test_file_system_space check for empty filesystems
  > demos/udp_server_demo:  Modernize with seastar::async and proper teardown
  > future: remove deprecated functions/concepts
  > util: logger: remove deprecated set_stdout_enabled and logger_ostream_type::{stdout,stderr}
  > memory: guard __GLIBC_PREREQ usage with __GLIBC__ check
  > scheduling_specific: Add noexcept wrapper for free()
  > file: Replace __gid_t with standard POSIX gid_t
  > aio_storage_context: Use reactor::do_at_exit()
  > json2code: support chunked_fifo
  > json: remove unused headers
  > httpd: test cases for streaming
  > build: use find_dependency() instead find_package() in config file
  > build: stop using a loop for finding dependencies
  > dns: Fix event processing to work safely with recent c-ares
  > tutorial: add a section about initialization and cleanup
  > reactor: deprecate at_exit()
  > httpclient: Add exception handling to connection::close
  > file: document max_length-limits for dma_read/write funcs taking vector<iovec>
  > build: fix P2582R1 detection in GCC compatibility check
  > json2code: optimize string handling using std::string_view
  > tests/unit: fix typo in test output
  > doc: Update documentation after removing build.sh
  > test: Add direct exception passing for awaits for perf test
  > github:  add Docker build verification workflow
  > docker: update LLVM debian repo for Ubuntu Orcular migration
  > tests/unit: Use http.HTTPStatus constants instead of raw status codes
  > tests/unit: Fix exception verification in json2code_test.py
  > httpd: handle streaming results in more handlers
  > json: stream_object now moves value
  > json: support for rvalue ranges
  > chunked_fifo: make copyable
  > reactor: deprecate at_destroy()
  > testing: prevent test scheduling after reactor exit
  > net: Add bytes sent/received metrics
  > net: switch rss_key_type to std::span instead of std::string_view
  > log: fixes for libc++ 19
  > sstring: fixes for lib++ 19
  > build: finalize numactl dependency removal
  > build: link DPDK against libnuma when detected during build
  > memory: remove libnuma dependency
  > treewide: replace assert with SEASTAR_ASSERT
  > future: fix typo in comment
  > http: Unwrap nested exceptions to handle retryable transport errors
  > net/ip, net: sed -i 's/to_ulong/to_uint/'
  > core: function_traits noexcept specializations
  > util/variant: seastar::visit forward value arg
  > net/tls: fix missing include
  > tls: Add a way to inspect peer certificate chain
  > websocket: Extract encode_base64() function
  > websocket: Rename wlogger to websocket_logger
  > websocket: Extract parts of server_connection usable for client
  > websocket: Rename connection to server_connection
  > websocket: Extract websocket parser to separate file
  > json2code_test: factor out query method
  > seastar-json2code: fix error handling

in addition to updating the seastar submodule, we also have to adapt
to be compatible with the changes in seastar's public interface:

- utils/s3/retryable_http_client.cc was adapted to Seastar's API change in
  commit f1821a07 where `seastar::experimental::client::make_request()` now
  takes an `abort_source` pointer parameter instead of a reference. This
  commit updates our code to match this interface change.
- test/boost/sstable_test.cc was updated to use `auto` instead of
  `statistics` to avoid the ambiguity. because we added `struct statistics`
  in 87c221cb `seastar/include/seastar/net/api.hh` recently, this name is
  identical to the one defined in `scylladb/sstables/types.hh`. but we open
  the namespace of `seastar` in scylladb to ease the migration to the separated
  `seastar` library. this ends up with the name colision. let's use `auto`
  to workaround this.

---

no critical fixes included, hence no need to backport.