### PR TITLE
doc: remove the outdated info on seeds-info

### DIFF
--- a/docs/kb/seed-nodes.rst
+++ b/docs/kb/seed-nodes.rst
@@ -2,19 +2,6 @@
 ScyllaDB Seed Nodes
 ===================
 
-**Topic: ScyllaDB Seed Nodes Overview**
-
-**Learn: What a seed node is, and how they should be used in a ScyllaDB Cluster**
-
-**Audience: ScyllaDB Administrators**
-
-
-What is the Function of a Seed Node in ScyllaDB?
-------------------------------------------------
-
-.. note:: 
-    Seed nodes function was changed in ScyllaDB Open Source 4.3 and ScyllaDB Enterprise 2021.1; if you are running an older version, see :ref:`Older Version Of ScyllaDB <seeds-older-versions>`.
-
 A ScyllaDB seed node is a node specified with the ``seeds`` configuration parameter in ``scylla.yaml``. It is used by new node joining as the first contact point.
 It allows nodes to discover the cluster ring topology on startup (when joining the cluster). This means that any time a node is joining the cluster, it needs to learn the cluster ring topology, meaning:
 
@@ -22,27 +9,8 @@ It allows nodes to discover the cluster ring topology on startup (when joining t
 -  Which token ranges are available
 -  Which nodes will own which tokens when a new node joins the cluster
 
-**Once the nodes have joined the cluster, seed node has no function.**
+**Once the nodes have joined the cluster, the seed node has no function.**
      
-The first node in a new cluster needs to be a seed node.
-
-.. _seeds-older-versions:
-
-Older Version Of ScyllaDB
--------------------------
-
-In ScyllaDB releases older than ScyllaDB Open Source 4.3 and ScyllaDB Enterprise 2021.1, seed node has one more function: it assists with :doc:`gossip </kb/gossip>` convergence.
-Gossiping with other nodes ensures that any update to the cluster is propagated across the cluster. This includes detecting and alerting whenever a node goes down, comes back, or is removed from the cluster.
-
-This functions was removed, as described in `Seedless NoSQL: Getting Rid of Seed Nodes in ScyllaDB <https://www.scylladb.com/2020/09/22/seedless-nosql-getting-rid-of-seed-nodes-in-scylla/>`_.
-
-If you run an older ScyllaDB release, we recommend upgrading to version 4.3 (ScyllaDB Open Source) or 2021.1 (ScyllaDB Enterprise) or later. If you choose to run an older version, it is good practice to follow these guidelines:
-
-* The first node in a new cluster needs to be a seed node.
-* Ensure that all nodes in the cluster have the same seed nodes listed in each node's scylla.yaml.
-* To maintain resiliency of the cluster, it is recommended to have more than one seed node in the cluster.
-* If you have more than one seed in a DC with multiple racks (or availability zones), make sure to put your seeds in different racks.
-* You must have at least one node that is not a seed node. You cannot create a cluster where all nodes are seed nodes.
-* You should have more than one seed node.
-
+The first node in a new cluster must be a seed node. In typical scenarios,
+there's no need to configure more than one seed node.
 

--- a/docs/operating-scylla/procedures/cluster-management/remove-seed.rst
+++ b/docs/operating-scylla/procedures/cluster-management/remove-seed.rst
@@ -5,9 +5,10 @@ Remove a Seed Node from Seed List
 This procedure describes how to remove a seed node from the seed list.
 
 .. note::
-   The seed concept in gossip has been removed. A seed node 
-   is only used by a new node during startup to learn about the cluster topology. As a result, you only need to configure one 
-   seed node in a node's ``scylla.yaml`` file.
+   A seed node is only used by a new node during startup to learn about the cluster topology.
+   This means it is sufficient to configure one seed node in a node's ``scylla.yaml`` file.
+
+   The first node in a new cluster must be a seed node.
 
 
 Prerequisites

--- a/docs/operating-scylla/procedures/cluster-management/replace-seed-node.rst
+++ b/docs/operating-scylla/procedures/cluster-management/replace-seed-node.rst
@@ -3,12 +3,27 @@
 Replacing a Dead Seed Node
 ===========================
 
-.. note::
-    The seed concept in gossip has been removed. 
-    A seed node is only used by a new node during startup to learn about the cluster topology. As a result, there's no need 
-    to replace the node configured with the ``seeds`` parameter in the ``scylla.yaml`` file.
-
 In ScyllaDB, it is not possible to bootstrap a seed node. The following steps describe how to replace a dead seed node.
+
+.. note::
+   A seed node is only used by a new node during startup to learn about
+   the cluster topology.
+   Once the nodes have joined the cluster, the seed node has no function.
+   In typical scenarios, there's no need to replace the node
+   configured with the ``seeds`` parameter in the ``scylla.yaml`` file.
+
+* The first node in a new cluster must be a seed node.
+* It is sufficient to configure one seed node in a node's ``scylla.yaml`` file.
+  You may choose to configure two or three seed nodes if your cluster is large.
+* It’s not recommended that all the nodes in the cluster be defined as seed nodes.
+* If you update the IP address of a seed node or remove it from the cluster,
+  you should update configuration files on all the remaining nodes to keep the
+  configuration consistent.
+  Once a node has joined the cluster and has all the peer information saved
+  locally in the ``system.peers`` system table, seed nodes are no longer used,
+  but they are still contacted on each restart. To avoid configuration errors
+  and to be able to reach out to the cluster if the seed IP address changes,
+  the seed configuration should be valid.
 
 Prerequisites
 -------------
@@ -35,4 +50,4 @@ Procedure
         Use ``nodetool status`` to verify that restarted nodes are online before restarting more nodes. If too many nodes are offline, the cluster may suffer temporary service degradation or outage. 
 #. Replace the dead node using the :doc:`dead node replacement procedure </operating-scylla/procedures/cluster-management/replace-dead-node/>`.
 
-Your cluster should have more than one seed node, but it's not allowed to define all the nodes in the cluster to be seed nodes.
+

--- a/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
+++ b/docs/operating-scylla/procedures/tips/best-practices-scylla-on-docker.rst
@@ -199,11 +199,13 @@ The ScyllaDB image supports many command line options that are passed to the Doc
 -------------
 The ``--seeds`` command line option configures ScyllaDB's seed nodes. If no ``--seeds`` option is specified, ScyllaDB uses its own IP address as the seed.
 
-For example, to configure ScyllaDB to run with two seed nodes ``192.168.0.100`` and ``192.168.0.200``.
+For example, to configure ScyllaDB to run with the seed node ``192.168.0.100``, run:
 
 .. code-block:: console
 
- docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100,192.168.0.200
+ docker run --name some-scylla -d scylladb/scylla --seeds 192.168.0.100
+
+See :doc:`ScyllaDB Seed Nodes </kb/seed-nodes>` for details.
 
 --listen-address ADDR
 ---------------------


### PR DESCRIPTION
This PR removes the outdated information about seed nodes. We no longer need it in the docs, as a) the documentation is versioned, and b) the ScyllaDB Open Source 4.3 and ScyllaDB Enterprise 2021.1 versions mentioned in the docs are no longer supported.

In addition, some clarification has been added to the existing sections.

Fixes https://github.com/scylladb/scylladb/issues/22400

This PR should be backported to branch-2025.1 as it removes the OSS and Enterprise references we don't want to have in the docs for version 2025.1.