### PR TITLE
[Backport 2025.1] Rack aware tablet merge colocation migration 

### DIFF
--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -124,6 +124,9 @@ Additionally to specific node states, there entire topology can also be in a tra
     it from group 0. We also use this state to rollback a failed bootstrap or decommission.
 - `rollback_to_normal` - the decommission or removenode operation failed. Rollback the operation by
     moving the node we tried to decommission/remove back to the normal state.
+- `lock` - the topology stays in this state until externally changed (to null state), preventing topology
+    requests from starting. Intended to be used in tests which want to prevent internally-triggered topology
+    operations during the test.
 
 When a node bootstraps, we create new tokens for it and a new CDC generation
 and enter the `commit_cdc_generation` state. Once the generation is committed,

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -315,7 +315,7 @@ static unsigned calculate_initial_tablets_from_topology(const schema& s, token_m
 
         for (const auto& ep : dc.second) {
             const auto* node = tm->get_topology().find_node(ep);
-            if (node != nullptr) {
+            if (node != nullptr && node->is_normal()) {
                 shards_in_dc += node->get_shard_count();
             }
         }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -430,8 +430,8 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             continue;
         }
         const auto& existing = replicas_per_rack[rack];
-        auto& candidate = existing.empty() ?
-                new_racks.emplace_back(rack) : existing_racks.emplace_back(rack);
+        candidates_list& rack_list = existing.empty() ? new_racks : existing_racks;
+        auto& candidate = rack_list.emplace_back(rack);
         for (const auto& node : nodes) {
             if (!node.get().is_normal()) {
                 continue;
@@ -442,7 +442,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             }
         }
         if (candidate.nodes.empty()) {
-            existing_racks.pop_back();
+            rack_list.pop_back();
             tablet_logger.trace("allocate_replica {}.{}: no candidate nodes left on rack={}", s->ks_name(), s->cf_name(), rack);
             // Note that this rack can't be in new_racks since
             // those had no existing replicas and if current rack has no nodes

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -752,6 +752,8 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
                 return read_new_t::no;
             }
             switch (*state) {
+                case topology::transition_state::lock:
+                    [[fallthrough]];
                 case topology::transition_state::join_group0:
                     [[fallthrough]];
                 case topology::transition_state::tablet_migration:

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -43,6 +43,8 @@ void load_balancer_stats_manager::setup_metrics(const dc_name& dc, load_balancer
                          stats.migrations_produced)(dc_lb),
         sm::make_counter("migrations_skipped", sm::description("number of migrations skipped by the load balancer due to load limits"),
                          stats.migrations_skipped)(dc_lb),
+        sm::make_counter("cross_rack_collocations", sm::description("number of co-locating migrations which move replica across racks"),
+                         stats.cross_rack_collocations)(dc_lb),
     });
 }
 
@@ -909,7 +911,7 @@ public:
         co_return all_colocated;
     }
 
-    future<migration_plan> make_merge_colocation_plan(node_load_map& nodes) {
+    future<migration_plan> make_merge_colocation_plan(const dc_name& dc, node_load_map& nodes) {
         migration_plan plan;
         table_resize_plan resize_plan;
 
@@ -935,8 +937,14 @@ public:
             auto migrating = [] (const tablet_desc& t) {
                 return bool(t.transition);
             };
+            auto rack_of = [&topo = _tm->get_topology()] (tablet_replica tr) -> const sstring& {
+                return topo.get_rack(tr.host);
+            };
+            auto cross_rack_migration = [&] (tablet_replica src, tablet_replica dst) {
+                return rack_of(src) != rack_of(dst);
+            };
 
-            auto first_non_matching_replicas = [] (tablet_replica_set r1, tablet_replica_set r2) -> std::optional<std::pair<tablet_replica, tablet_replica>> {
+            auto first_non_matching_replicas = [&] (tablet_replica_set r1, tablet_replica_set r2) -> std::optional<std::pair<tablet_replica, tablet_replica>> {
                 assert(r1.size() == r2.size());
                 // Subtract intersecting (co-located) elements from the replicas set of sibling tablets.
                 // Think for example that tablet 0 and 1 have replicas [n2, n4] and [n1, n2] respectively.
@@ -948,6 +956,7 @@ public:
                 r1.erase(r1_first, r1_last);
                 const auto [r2_first, r2_last] = std::ranges::remove_if(r2, [&] (tablet_replica r) { return intersection.contains(r); });
                 r2.erase(r2_first, r2_last);
+
                 // Favor replicas of different tablets that belong to same node. For example:
                 // tablet 0 replicas: [n2:s1, n3:s0]
                 // tablet 1 replicas: [n1:s0, n2:s0]
@@ -963,10 +972,41 @@ public:
                         return std::make_pair(r1_it->second, r2[i]);
                     }
                 }
-                // Since sets had intersection subtracted, the remaining replicas are certainly not co-located.
+
+                // Favor replicas which belong to the same rack. For example:
+                //
+                //   tablet 0: [n1:rack3, n2:rack1]
+                //   tablet 1: [n3:rack2, n4:rack3]
+                //
+                // We want to move tablet1's n4:rack3 to n1:rack3 first (within rack3), for the following reasons:
+                //   1) Minimize cross-rack migrations (they have higher cost)
+                //      In particular, this ensures that when RF=#racks, there will be no across-rack migrations.
+                //   2) Minimize breaking of pairing: view replica is determined by rack, cross-rack migration breaks it
+                //      In particular, this ensures that when RF=#racks, no pairing will be broken.
+                //   3) Avoid overloading racks temporarily, which is an availability risk in case the rack goes down.
+                //      Otherwise, n3:rack2 would be migrated to n1:rack3, and tablet 1 would have two replicas in rack3.
+                //
+                std::unordered_map<sstring, tablet_replica> r1_rack_map;
+                for (auto&& r : r1) {
+                    auto&& rack = rack_of(r);
+                    auto i = r1_rack_map.find(rack);
+                    if (i == r1_rack_map.end()) {
+                        r1_rack_map[rack] = r;
+                    }
+                }
+                for (auto&& r : r2) {
+                    auto&& rack = rack_of(r);
+                    auto i = r1_rack_map.find(rack);
+                    if (i != r1_rack_map.end()) {
+                        return std::make_pair(i->second, r);
+                    }
+                }
+
+                // r1 and r2 don't share replicas, hosts, or racks.
                 if (r1.size() > 0) {
                     return std::make_pair(r1[0], r2[0]);
                 }
+
                 return std::nullopt;
             };
 
@@ -1029,6 +1069,17 @@ public:
                 // Emits migration for replica of t2 to co-habit same shard as replica of t1.
                 auto src = ret->second;
                 auto dst = ret->first;
+
+                if (cross_rack_migration(src, dst)) {
+                    // FIXME: This is illegal if table has views, as it breaks base-view pairing.
+                    // Can happen when RF!=#racks.
+                    _stats.for_dc(_dc).cross_rack_collocations++;
+                    lblogger.debug("Cross-rack co-location migration for {}@{} (rack: {}) to co-habit {}@{} (rack: {})",
+                        t2_id, src, rack_of(src), t1_id, dst, rack_of(dst));
+                    utils::get_local_injector().inject("forbid_cross_rack_migration_attempt", [&] {
+                        on_fatal_internal_error(lblogger, "Cross rack colocation is not allowed, killing the node");
+                    });
+                }
 
                 // If migration will violate replication constraint, skip to next pair of replicas of sibling tablets.
                 auto skip = check_constraints(src, dst);
@@ -2667,7 +2718,7 @@ public:
         }
 
         if (_tm->tablets().balancing_enabled() && plan.empty()) {
-            auto dc_merge_plan = co_await make_merge_colocation_plan(nodes);
+            auto dc_merge_plan = co_await make_merge_colocation_plan(dc, nodes);
             lblogger.info("Prepared {} migrations for co-locating sibling tablets in DC {}", dc_merge_plan.tablet_migration_count(), dc);
             plan.merge(std::move(dc_merge_plan));
         }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -32,6 +32,7 @@ struct load_balancer_dc_stats {
     uint64_t stop_no_candidates = 0;
     uint64_t stop_skip_limit = 0;
     uint64_t stop_batch_size = 0;
+    uint64_t cross_rack_collocations = 0;
 
     load_balancer_dc_stats operator-(const load_balancer_dc_stats& other) const {
         return {
@@ -50,6 +51,7 @@ struct load_balancer_dc_stats {
             stop_no_candidates - other.stop_no_candidates,
             stop_skip_limit - other.stop_skip_limit,
             stop_batch_size - other.stop_batch_size,
+            cross_rack_collocations - other.cross_rack_collocations,
         };
     }
 };

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2357,6 +2357,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             case topology::transition_state::tablet_resize_finalization:
                 co_await handle_tablet_resize_finalization(std::move(guard));
                 break;
+            case topology::transition_state::lock:
+                release_guard(std::move(guard));
+                co_await await_event();
+                break;
             case topology::transition_state::left_token_ring: {
                 auto node = get_node_to_work_on(std::move(guard));
 

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -153,6 +153,7 @@ static std::unordered_map<topology::transition_state, sstring> transition_state_
     {topology::transition_state::left_token_ring, "left token ring"},
     {topology::transition_state::rollback_to_normal, "rollback to normal"},
     {topology::transition_state::truncate_table, "truncate table"},
+    {topology::transition_state::lock, "lock"},
 };
 
 // Allows old deprecated names to be recognized and point to the correct transition.

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -120,6 +120,7 @@ struct topology {
         left_token_ring,
         rollback_to_normal,
         truncate_table,
+        lock,
     };
 
     std::optional<transition_state> tstate;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1773,6 +1773,10 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
 SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
     // Verifies that new table doesn't get tablets allocated on a node being decommissioned
     // which may leave them on replicas absent in topology post decommission.
+    // Also verifies that the allocated tablet count doesn't take into account nodes being decommissioned
+    // to achieve the desired tablet count per shard in a DC.
+    auto cfg = tablet_cql_test_config();
+    cfg.db_config->tablets_initial_scale_factor(1);
     do_with_cql_env_thread([](auto& e) {
         inet_address ip1("192.168.0.1");
         inet_address ip2("192.168.0.2");
@@ -1794,13 +1798,11 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
             }
         });
 
-        const unsigned shard_count = 1;
-
         stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-            tm.update_topology(host1, dcrack, node::state::normal, shard_count);
-            tm.update_topology(host2, dcrack, node::state::normal, shard_count);
-            tm.update_topology(host3, dcrack, node::state::being_decommissioned, shard_count);
-            tm.update_topology(host4, dcrack, node::state::left, shard_count);
+            tm.update_topology(host1, dcrack, node::state::normal, 1);
+            tm.update_topology(host2, dcrack, node::state::normal, 1);
+            tm.update_topology(host3, dcrack, node::state::being_decommissioned, 16);
+            tm.update_topology(host4, dcrack, node::state::left, 16);
             co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
             co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
             co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
@@ -1812,13 +1814,16 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
         sstring table_name = "table1";
         e.execute_cql(format("create keyspace {} with replication = "
                              "{{'class': 'NetworkTopologyStrategy', '{}': 1}} "
-                             "and tablets = {{'enabled': true, 'initial': 8}}", ks_name, dcrack.dc)).get();
+                             "and tablets = {{'enabled': true}}", ks_name, dcrack.dc)).get();
         e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
         auto s = e.local_db().find_schema(ks_name, table_name);
 
         auto* rs = e.local_db().find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
         BOOST_REQUIRE(rs);
-        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 8).get();
+        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 1).get();
+
+        // Verify we do not treat leaving nodes as having capacity.
+        BOOST_REQUIRE_EQUAL(tmap.tablet_count(), 2);
 
         tmap.for_each_tablet([&](auto tid, auto& tinfo) {
             for (auto& replica : tinfo.replicas) {
@@ -1827,7 +1832,7 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
             }
             return make_ready_future<>();
         }).get();
-    }, tablet_cql_test_config()).get();
+    }, cfg).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_table_creation_during_rack_decommission) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -12,6 +12,8 @@
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
 #include "test/lib/random_utils.hh"
+#include "service/topology_mutation.hh"
+#include "service/storage_service.hh"
 #include <fmt/ranges.h>
 #include <seastar/testing/thread_test_case.hh>
 #include "test/lib/cql_test_env.hh"
@@ -19,6 +21,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/key_utils.hh"
 #include "test/lib/test_utils.hh"
+#include "test/lib/topology_builder.hh"
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "schema/schema_builder.hh"
@@ -38,6 +41,7 @@
 #include "service/topology_state_machine.hh"
 
 #include <boost/regex.hpp>
+#include <atomic>
 
 BOOST_AUTO_TEST_SUITE(tablets_test)
 
@@ -49,13 +53,6 @@ static api::timestamp_type current_timestamp(cql_test_env& e) {
     // Mutations in system.tablets got there via group0, so in order for new
     // mutations to take effect, their timestamp should be "later" than that
     return utils::UUID_gen::micros_timestamp(e.get_system_keyspace().local().get_last_group0_state_id().get()) + 1;
-}
-
-static utils::UUID next_uuid() {
-    static uint64_t counter = 1;
-    return utils::UUID_gen::get_time_UUID(std::chrono::system_clock::time_point(
-            std::chrono::duration_cast<std::chrono::system_clock::duration>(
-                    std::chrono::seconds(counter++))));
 }
 
 static
@@ -107,6 +104,37 @@ future<table_id> add_table(cql_test_env& e, sstring test_ks_name = "") {
                 .build();
     });
     co_return id;
+}
+
+// Run in a seastar thread
+static
+sstring add_keyspace(cql_test_env& e, std::unordered_map<sstring, int> dc_rf, int initial_tablets = 0) {
+    static std::atomic<int> ks_id = 0;
+    auto ks_name = fmt::format("keyspace{}", ks_id.fetch_add(1));
+    sstring rf_options;
+    for (auto& [dc, rf] : dc_rf) {
+        rf_options += format(", '{}': {}", dc, rf);
+    }
+    e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy'{}}}"
+                              " and tablets = {{'enabled': true, 'initial': {}}}",
+                              ks_name, rf_options, initial_tablets)).get();
+    return ks_name;
+}
+
+// Run in a seastar thread
+void mutate_tablets(cql_test_env& e, const group0_guard& guard, seastar::noncopyable_function<future<>(tablet_metadata&)> mutator) {
+    auto& stm = e.shared_token_metadata().local();
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+        return mutator(tm.tablets());
+    }).get();
+    save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+}
+
+// Run in a seastar thread
+void mutate_tablets(cql_test_env& e, seastar::noncopyable_function<future<>(tablet_metadata&)> mutator) {
+    abort_source as;
+    auto guard = e.get_raft_group0_client().start_operation(as).get();
+    mutate_tablets(e, guard, std::move(mutator));
 }
 
 SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
@@ -1370,7 +1398,11 @@ void apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
 }
 
 static
-future<> handle_resize_finalize(tablet_allocator& talloc, shared_token_metadata& stm, const migration_plan& plan) {
+future<> handle_resize_finalize(cql_test_env& e, group0_guard& guard, const migration_plan& plan) {
+    auto& talloc = e.get_tablet_allocator().local();
+    auto& stm = e.shared_token_metadata().local();
+    bool changed = false;
+
     for (auto table_id : plan.resize_plan().finalize_resize) {
         auto tm = stm.get();
         const auto& old_tmap = tm->tablets().get_tablet_map(table_id);
@@ -1380,10 +1412,22 @@ future<> handle_resize_finalize(tablet_allocator& talloc, shared_token_metadata&
         new_resize_decision.sequence_number = old_tmap.resize_decision().next_sequence_number();
         new_tmap.set_resize_decision(std::move(new_resize_decision));
 
-        co_await stm.mutate_token_metadata([table_id, &new_tmap] (token_metadata& tm) {
+        co_await stm.mutate_token_metadata([table_id, &new_tmap, &changed] (token_metadata& tm) {
+            changed = true;
             tm.tablets().set_tablet_map(table_id, std::move(new_tmap));
             return make_ready_future<>();
         });
+    }
+
+    if (changed) {
+        // Need to reload on each resize because table object expects tablet count to change by a factor of 2.
+        co_await save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp());
+        co_await e.get_storage_service().local().load_tablet_metadata({});
+
+        // Need a new guard to make sure later changes use later timestamp.
+        release_guard(std::move(guard));
+        abort_source as;
+        guard = co_await e.get_raft_group0_client().start_operation(as);
     }
 }
 
@@ -1429,11 +1473,15 @@ static
 void check_tablet_invariants(const tablet_metadata& tmeta);
 
 static
-void rebalance_tablets(tablet_allocator& talloc,
-                       shared_token_metadata& stm,
-                       locator::load_stats_ptr load_stats = {},
-                       std::unordered_set<host_id> skiplist = {},
-                       std::function<bool(const migration_plan&)> stop = nullptr) {
+void do_rebalance_tablets(cql_test_env& e,
+                          group0_guard& guard,
+                          locator::load_stats_ptr load_stats = {},
+                          std::unordered_set<host_id> skiplist = {},
+                          std::function<bool(const migration_plan&)> stop = nullptr)
+{
+    auto& talloc = e.get_tablet_allocator().local();
+    auto& stm = e.shared_token_metadata().local();
+
     // Sanity limit to avoid infinite loops.
     // The x10 factor is arbitrary, it's there to account for more complex schedules than direct migration.
     auto max_iterations = 1 + get_tablet_count(stm.get()->tablets()) * 10;
@@ -1450,9 +1498,36 @@ void rebalance_tablets(tablet_allocator& talloc,
             apply_plan(tm, plan);
             return make_ready_future<>();
         }).get();
-        handle_resize_finalize(talloc, stm, plan).get();
+        handle_resize_finalize(e, guard, plan).get();
     }
     throw std::runtime_error("rebalance_tablets(): convergence not reached within limit");
+}
+
+// Invokes the tablet scheduler and executes its plan, continuously until it emits an empty plan.
+// Simulates topology coordinator but doesn't perform actual migration,
+// only reflects it in the metadata.
+// Run in a seastar thread.
+void rebalance_tablets(cql_test_env& e,
+                       load_stats_ptr load_stats = nullptr,
+                       std::unordered_set<host_id> skiplist = {},
+                       std::function<bool(const migration_plan&)> stop = nullptr) {
+    abort_source as;
+    testlog.debug("rebalance_tablets(): start");
+
+    auto guard = e.get_raft_group0_client().start_operation(as).get();
+    testlog.debug("rebalance_tablets(): took group0 guard");
+
+    do_rebalance_tablets(e, guard, std::move(load_stats), std::move(skiplist), std::move(stop));
+    testlog.debug("rebalance_tablets(): rebalanced");
+
+    // We should not introduce inconsistency between on-disk state and in-memory state
+    // as that may violate invariants and cause failures in later operations
+    // causing test flakiness.
+    auto& stm = e.shared_token_metadata().local();
+    save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+    e.get_storage_service().local().load_tablet_metadata({}).get();
+
+    testlog.debug("rebalance_tablets(): done");
 }
 
 static
@@ -1491,36 +1566,17 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
   do_with_cql_env_thread([] (auto& e) {
     // Tests the scenario of bootstrapping a single node
     // Verifies that load balancer sees it and moves tablets to that node.
-
-    inet_address ip1("192.168.0.1");
-    inet_address ip2("192.168.0.2");
-    inet_address ip3("192.168.0.3");
-
-    auto host1 = host_id(next_uuid());
-    auto host2 = host_id(next_uuid());
-    auto host3 = host_id(next_uuid());
-
-    auto table1 = table_id(next_uuid());
+    topology_builder topo(e);
 
     unsigned shard_count = 2;
+    auto host1 = topo.add_node(node_state::normal, shard_count);
+    auto host2 = topo.add_node(node_state::normal, shard_count);
+    auto host3 = topo.add_node(node_state::normal, shard_count);
 
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = ip1,
-            .this_host_id = host1,
-            .local_dc_rack = locator::endpoint_dc_rack::default_location
-        }
-    });
+    auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+    auto table1 = add_table(e, ks_name).get();
 
-    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+    mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
         tablet_map tmap(4);
         auto tid = tmap.first_tablet();
         tmap.set_tablet(tid, tablet_info {
@@ -1550,11 +1606,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
                         tablet_replica {host2, 0},
                 }
         });
-        tablet_metadata tmeta;
         tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
         co_return;
-    }).get();
+    });
+
+    auto& stm = e.shared_token_metadata().local();
 
     // Sanity check
     {
@@ -1568,7 +1624,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
         BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
     }
 
-    rebalance_tablets(e.get_tablet_allocator().local(), stm);
+    rebalance_tablets(e);
 
     {
         load_sketch load(stm.get());
@@ -1590,32 +1646,17 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
     // Tests the scenario of balacning cluster with DOWN node
     // Verifies that load balancer doesn't moves tablets to that node.
 
-    inet_address ip1("192.168.0.1");
-    inet_address ip2("192.168.0.2");
-    inet_address ip3("192.168.0.3");
-
-    auto host1 = host_id(next_uuid());
-    auto host2 = host_id(next_uuid());
-    auto host3 = host_id(next_uuid());
-
-    auto table1 = table_id(next_uuid());
-
     unsigned shard_count = 2;
 
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = ip1,
-            .this_host_id = host1,
-            .local_dc_rack = locator::endpoint_dc_rack::default_location
-        }
-    });
+    topology_builder topo(e);
+    auto host1 = topo.add_node(node_state::normal, shard_count);
+    auto host2 = topo.add_node(node_state::normal, shard_count);
+    auto host3 = topo.add_node(node_state::normal, shard_count);
 
-    stm.mutate_token_metadata([&] (token_metadata& tm) {
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
+    auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+    auto table1 = add_table(e, ks_name).get();
 
+    mutate_tablets(e, [&] (tablet_metadata& tmeta) {
         tablet_map tmap(4);
         auto tid = tmap.first_tablet();
         tmap.set_tablet(tid, tablet_info {
@@ -1645,11 +1686,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
                         tablet_replica {host2, 0},
                 }
         });
-        tablet_metadata tmeta;
         tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
         return make_ready_future<>();
-    }).get();
+    });
+
+    auto& stm = e.shared_token_metadata().local();
 
     // Sanity check
     {
@@ -1663,7 +1704,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
     }
 
-    rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, {host3});
+    rebalance_tablets(e, {}, {host3});
 
     {
         load_sketch load(stm.get());
@@ -1678,36 +1719,17 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that replication factor of tablets can be satisfied after decommission.
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
+        unsigned shard_count = 2;
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, shard_count);
+        auto host2 = topo.add_node(node_state::normal, shard_count);
+        auto host3 = topo.add_node(node_state::decommissioning, shard_count);
 
-        auto table1 = table_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+        auto table1 = add_table(e, ks_name).get();
 
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = ip1,
-                        .this_host_id = host1,
-                        .local_dc_rack = locator::endpoint_dc_rack::default_location
-                }
-        });
-
-        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
-            const unsigned shard_count = 2;
-
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned,
-                               shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(4);
             auto tid = tmap.first_tablet();
             tmap.set_tablet(tid, tablet_info {
@@ -1737,13 +1759,13 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
                             tablet_replica {host3, 1},
                     }
             });
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm);
+        rebalance_tablets(e);
+
+        auto& stm = e.shared_token_metadata().local();
 
         {
             load_sketch load(stm.get());
@@ -1753,12 +1775,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
             BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
         }
 
-        stm.mutate_token_metadata([&](token_metadata& tm) {
-            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::left);
-            return make_ready_future<>();
-        }).get();
+        topo.set_node_state(host3, node_state::left);
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm);
+        rebalance_tablets(e);
 
         {
             load_sketch load(stm.get());
@@ -1778,49 +1797,18 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
     auto cfg = tablet_cql_test_config();
     cfg.db_config->tablets_initial_scale_factor(1);
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
-        inet_address ip4("192.168.0.4");
+        topology_builder topo(e);
+        topo.add_node(node_state::normal);
+        topo.add_node(node_state::normal);
+        auto host3 = topo.add_node(node_state::decommissioning);
+        auto host4 = topo.add_node(node_state::left);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
-        auto host4 = host_id(next_uuid());
-        locator::endpoint_dc_rack dcrack = { "datacenter1", "rack1" };
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}});
+        auto table1 = add_table(e, ks_name).get();
+        auto s = e.local_db().find_schema(table1);
 
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-            locator::topology::config {
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = dcrack
-            }
-        });
-
-        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-            tm.update_topology(host1, dcrack, node::state::normal, 1);
-            tm.update_topology(host2, dcrack, node::state::normal, 1);
-            tm.update_topology(host3, dcrack, node::state::being_decommissioned, 16);
-            tm.update_topology(host4, dcrack, node::state::left, 16);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
-            co_return;
-        }).get();
-
-        sstring ks_name = "test_ks";
-        sstring table_name = "table1";
-        e.execute_cql(format("create keyspace {} with replication = "
-                             "{{'class': 'NetworkTopologyStrategy', '{}': 1}} "
-                             "and tablets = {{'enabled': true}}", ks_name, dcrack.dc)).get();
-        e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
-        auto s = e.local_db().find_schema(ks_name, table_name);
-
-        auto* rs = e.local_db().find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
-        BOOST_REQUIRE(rs);
-        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 1).get();
+        auto& stm = e.shared_token_metadata().local();
+        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
 
         // Verify we do not treat leaving nodes as having capacity.
         BOOST_REQUIRE_EQUAL(tmap.tablet_count(), 2);
@@ -1840,54 +1828,20 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_rack_decommission) {
     // The problematic scenario happens when allocating tablets for a new table
     // when there is a rack with only non-normal nodes.
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
-        inet_address ip4("192.168.0.4");
+        topology_builder topo(e);
+        topo.add_node();
+        topo.add_node();
+        topo.start_new_rack();
+        auto host3 = topo.add_node(node_state::decommissioning);
+        auto host4 = topo.add_node(node_state::left);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
-        auto host4 = host_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 8);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto dc = "datacenter1";
-        locator::endpoint_dc_rack dcrack  = { dc, "rack1" };
-        locator::endpoint_dc_rack dcrack2 = { dc, "rack2" };
+        rebalance_tablets(e);
 
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-            locator::topology::config {
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = dcrack
-            }
-        });
-
-        const unsigned shard_count = 1;
-
-        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-            tm.update_topology(host1, dcrack, node::state::normal, shard_count);
-            tm.update_topology(host2, dcrack, node::state::normal, shard_count);
-            tm.update_topology(host3, dcrack2, node::state::being_decommissioned, shard_count);
-            tm.update_topology(host4, dcrack2, node::state::left, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
-            co_return;
-        }).get();
-
-        sstring ks_name = "test_ks";
-        sstring table_name = "table1";
-        e.execute_cql(format("create keyspace {} with replication = "
-                             "{{'class': 'NetworkTopologyStrategy', '{}': 1}} "
-                             "and tablets = {{'enabled': true, 'initial': 8}}", ks_name, dcrack.dc)).get();
-        e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
-        auto s = e.local_db().find_schema(ks_name, table_name);
-
-        auto* rs = e.local_db().find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
-        BOOST_REQUIRE(rs);
-        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 8).get();
+        auto& stm = e.shared_token_metadata().local();
+        auto& tmap = stm.get()->tablets().get_tablet_map(table1);
 
         tmap.for_each_tablet([&](auto tid, auto& tinfo) {
             for (auto& replica : tinfo.replicas) {
@@ -1903,45 +1857,21 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that replication constraints of tablets can be satisfied after decommission.
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
-        inet_address ip4("192.168.0.4");
+        std::vector<endpoint_dc_rack> racks;
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
-        auto host4 = host_id(next_uuid());
+        topology_builder topo(e);
+        racks.push_back(topo.rack());
+        auto host1 = topo.add_node(node_state::normal);
+        auto host3 = topo.add_node(node_state::normal);
+        topo.start_new_rack();
+        racks.push_back(topo.rack());
+        auto host2 = topo.add_node(node_state::normal);
+        auto host4 = topo.add_node(node_state::decommissioning);
 
-        std::vector<endpoint_dc_rack> racks = {
-                endpoint_dc_rack{ "dc1", "rack-1" },
-                endpoint_dc_rack{ "dc1", "rack-2" }
-        };
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = ip1,
-                        .this_host_id = host1,
-                        .local_dc_rack = racks[0]
-                }
-        });
-
-        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
-            const unsigned shard_count = 1;
-
-            tm.update_topology(host1, racks[0], node::state::normal, shard_count);
-            tm.update_topology(host2, racks[1], node::state::normal, shard_count);
-            tm.update_topology(host3, racks[0], node::state::normal, shard_count);
-            tm.update_topology(host4, racks[1], node::state::being_decommissioned,
-                               shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(4);
             auto tid = tmap.first_tablet();
             tmap.set_tablet(tid, tablet_info {
@@ -1971,13 +1901,13 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
                             tablet_replica {host2, 0},
                     }
             });
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm);
+        rebalance_tablets(e);
+
+        auto& stm = e.shared_token_metadata().local();
 
         {
             load_sketch load(stm.get());
@@ -2006,45 +1936,21 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that it is impossible to distribute replicas without violating rack uniqueness.
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
-        inet_address ip4("192.168.0.4");
+        std::vector<endpoint_dc_rack> racks;
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
-        auto host4 = host_id(next_uuid());
+        topology_builder topo(e);
+        racks.push_back(topo.rack());
+        auto host1 = topo.add_node(node_state::normal);
+        auto host2 = topo.add_node(node_state::normal);
+        auto host3 = topo.add_node(node_state::normal);
+        topo.start_new_rack();
+        racks.push_back(topo.rack());
+        auto host4 = topo.add_node(node_state::decommissioning);
 
-        std::vector<endpoint_dc_rack> racks = {
-                endpoint_dc_rack{ "dc1", "rack-1" },
-                endpoint_dc_rack{ "dc1", "rack-2" }
-        };
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = ip1,
-                        .this_host_id = host1,
-                        .local_dc_rack = racks[0]
-                }
-        });
-
-        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
-            const unsigned shard_count = 1;
-
-            tm.update_topology(host1, racks[0], node::state::normal, shard_count);
-            tm.update_topology(host2, racks[0], node::state::normal, shard_count);
-            tm.update_topology(host3, racks[0], node::state::normal, shard_count);
-            tm.update_topology(host4, racks[1], node::state::being_decommissioned,
-                               shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(4);
             auto tid = tmap.first_tablet();
             tmap.set_tablet(tid, tablet_info {
@@ -2074,13 +1980,11 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
                             tablet_replica {host4, 0},
                     }
             });
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
-        BOOST_REQUIRE_THROW(rebalance_tablets(e.get_tablet_allocator().local(), stm), std::runtime_error);
+        BOOST_REQUIRE_THROW(rebalance_tablets(e), std::runtime_error);
     }).get();
 }
 
@@ -2088,36 +1992,15 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_not_met) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that replication factor of tablets can be satisfied after decommission.
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 2);
+        auto host2 = topo.add_node(node_state::normal, 2);
+        auto host3 = topo.add_node(node_state::decommissioning, 2);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 1);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = ip1,
-                        .this_host_id = host1,
-                        .local_dc_rack = locator::endpoint_dc_rack::default_location
-                }
-        });
-
-        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
-            const unsigned shard_count = 2;
-
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned,
-                               shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(1);
             auto tid = tmap.first_tablet();
             tmap.set_tablet(tid, tablet_info {
@@ -2127,13 +2010,11 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_not_met) {
                             tablet_replica {host3, 0},
                     }
             });
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
-        BOOST_REQUIRE_THROW(rebalance_tablets(e.get_tablet_allocator().local(), stm), std::runtime_error);
+        BOOST_REQUIRE_THROW(rebalance_tablets(e), std::runtime_error);
     }).get();
 }
 
@@ -2146,33 +2027,15 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
     // which when executed will achieve perfect balance,
     // which is a proof that it doesn't stop due to active migrations.
 
-    inet_address ip1("192.168.0.1");
-    inet_address ip2("192.168.0.2");
-    inet_address ip3("192.168.0.3");
+    topology_builder topo(e);
+    auto host1 = topo.add_node(node_state::normal, 1);
+    auto host2 = topo.add_node(node_state::normal, 1);
+    auto host3 = topo.add_node(node_state::normal, 2);
 
-    auto host1 = host_id(next_uuid());
-    auto host2 = host_id(next_uuid());
-    auto host3 = host_id(next_uuid());
+    auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 4);
+    auto table1 = add_table(e, ks_name).get();
 
-    auto table1 = table_id(next_uuid());
-
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = ip1,
-            .this_host_id = host1,
-            .local_dc_rack = locator::endpoint_dc_rack::default_location
-        }
-    });
-
-    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+    mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
         tablet_map tmap(4);
         std::optional<tablet_id> tid = tmap.first_tablet();
         for (int i = 0; i < 4; ++i) {
@@ -2193,11 +2056,13 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
                 },
                 tablet_replica {host3, 0}
         });
-        tablet_metadata tmeta;
         tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
         co_return;
-    }).get();
+    });
+
+    abort_source as;
+    auto guard = e.get_raft_group0_client().start_operation(as).get();
+    auto& stm = e.shared_token_metadata().local();
 
     rebalance_tablets_as_in_progress(e.get_tablet_allocator().local(), stm);
     execute_transitions(stm);
@@ -2211,39 +2076,25 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
             BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2);
         }
     }
+
+    // Restore consistency between stm and system tables before releasing group0 guard.
+    save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
   }).get();
 }
 
 #ifdef SCYLLA_ENABLE_ERROR_INJECTION
 SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
   do_with_cql_env_thread([] (auto& e) {
-    inet_address ip1("192.168.0.1");
-    inet_address ip2("192.168.0.2");
-    inet_address ip3("192.168.0.3");
+    topology_builder topo(e);
 
-    auto host1 = host_id(next_uuid());
-    auto host2 = host_id(next_uuid());
-    auto host3 = host_id(next_uuid());
+    auto host1 = topo.add_node(node_state::normal, 1);
+    auto host2 = topo.add_node(node_state::normal, 1);
+    topo.add_node(node_state::normal, 2);
 
-    auto table1 = table_id(next_uuid());
+    auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 4);
+    auto table1 = add_table(e, ks_name).get();
 
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = ip1,
-            .this_host_id = host1,
-            .local_dc_rack = locator::endpoint_dc_rack::default_location
-        }
-    });
-
-    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+    mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
         tablet_map tmap(4);
         std::optional<tablet_id> tid = tmap.first_tablet();
         for (int i = 0; i < 4; ++i) {
@@ -2255,14 +2106,13 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
             });
             tid = tmap.next_tablet(*tid);
         }
-        tablet_metadata tmeta;
         tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
         co_return;
-    }).get();
+    });
 
-    rebalance_tablets(e.get_tablet_allocator().local(), stm);
+    rebalance_tablets(e);
 
+    auto& stm = e.shared_token_metadata().local();
     BOOST_REQUIRE(e.get_tablet_allocator().local().balance_tablets(stm.get()).get().empty());
 
     utils::get_local_injector().enable("tablet_allocator_shuffle");
@@ -2277,39 +2127,18 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
   do_with_cql_env_thread([] (auto& e) {
-    inet_address ip1("192.168.0.1");
-    inet_address ip2("192.168.0.2");
-    inet_address ip3("192.168.0.3");
-    inet_address ip4("192.168.0.4");
+    topology_builder topo(e);
 
-    auto host1 = host_id(next_uuid());
-    auto host2 = host_id(next_uuid());
-    auto host3 = host_id(next_uuid());
-    auto host4 = host_id(next_uuid());
+    const auto shard_count = 2;
+    auto host1 = topo.add_node(node_state::normal, shard_count);
+    auto host2 = topo.add_node(node_state::normal, shard_count);
+    auto host3 = topo.add_node(node_state::normal, shard_count);
+    auto host4 = topo.add_node(node_state::normal, shard_count);
 
-    auto table1 = table_id(next_uuid());
+    auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 16);
+    auto table1 = add_table(e, ks_name).get();
 
-    unsigned shard_count = 2;
-
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = ip1,
-            .this_host_id = host1,
-            .local_dc_rack = locator::endpoint_dc_rack::default_location
-        }
-    });
-
-    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-        tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        tm.update_topology(host4, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
-        co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
-
+    mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
         tablet_map tmap(16);
         for (auto tid : tmap.tablet_ids()) {
             tmap.set_tablet(tid, tablet_info {
@@ -2319,13 +2148,13 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
                 }
             });
         }
-        tablet_metadata tmeta;
         tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
         co_return;
-    }).get();
+    });
 
-    rebalance_tablets(e.get_tablet_allocator().local(), stm);
+    rebalance_tablets(e);
+
+    auto& stm = e.shared_token_metadata().local();
 
     {
         load_sketch load(stm.get());
@@ -2342,33 +2171,16 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
     do_with_cql_env_thread([](auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
+        topology_builder topo(e);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
+        auto host1 = topo.add_node(node_state::decommissioning, 8);
+        auto host2 = topo.add_node(node_state::normal, 1);
+        auto host3 = topo.add_node(node_state::normal, 7);
 
-        auto table1 = table_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 16);
+        auto table1 = add_table(e, ks_name).get();
 
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-            locator::topology::config {
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = locator::endpoint_dc_rack::default_location
-            }
-        });
-
-        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::being_decommissioned, 8);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, 1);
-            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, node::state::normal, 7);
-            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(1. / 4))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(2. / 4))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set {token(tests::d2t(3. / 4))}, host3);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(16);
             for (auto tid: tmap.tablet_ids()) {
                 tmap.set_tablet(tid, tablet_info {
@@ -2377,17 +2189,17 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
                     }
               });
             }
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
         auto until_nodes_drained = [] (const migration_plan& plan) {
             return !plan.has_nodes_to_drain();
         };
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, {}, until_nodes_drained);
+        rebalance_tablets(e, {}, {}, until_nodes_drained);
+
+        auto& stm = e.shared_token_metadata().local();
 
         {
           load_sketch load(stm.get());
@@ -2404,33 +2216,20 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
     do_with_cql_env_thread([] (auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::normal, 2);
+        topo.add_node(node_state::normal, 2);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 16);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
-
-        unsigned shard_count = 2;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-            locator::topology::config{
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = locator::endpoint_dc_rack::default_location
-            }
-        });
+        abort_source as;
+        auto guard = e.get_raft_group0_client().start_operation(as).get();
+        auto& stm = e.shared_token_metadata().local();
 
         // host1 is loaded and host2 is empty, resulting in an imbalance.
         // host1's shard 0 is loaded and shard 1 is empty, resulting in intra-node imbalance.
-        stm.mutate_token_metadata([&] (auto& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 2))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 2))}, host2);
-
+        mutate_tablets(e, guard, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(16);
             for (auto tid : tmap.tablet_ids()) {
                 tmap.set_tablet(tid, tablet_info {
@@ -2439,11 +2238,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
                     }
                 });
             }
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
         {
             auto plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
@@ -2496,31 +2293,18 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
 
 SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
     do_with_cql_env_thread([] (auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
+        topology_builder topo(e);
+        auto host1 = topo.add_node(node_state::removing, 2);
+        topo.add_node(node_state::normal, 2);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 16);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
+        abort_source as;
+        auto guard = e.get_raft_group0_client().start_operation(as).get();
+        auto& stm = e.shared_token_metadata().local();
 
-        unsigned shard_count = 2;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-            locator::topology::config{
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = locator::endpoint_dc_rack::default_location
-            }
-        });
-
-        stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, locator::node::state::being_removed, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 2))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 2))}, host2);
-
+        mutate_tablets(e, guard, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(16);
             for (auto tid : tmap.tablet_ids()) {
                 tmap.set_tablet(tid, tablet_info {
@@ -2529,11 +2313,9 @@ SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
                     }
                 });
             }
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
         migration_plan plan = e.get_tablet_allocator().local().balance_tablets(stm.get()).get();
         BOOST_REQUIRE(plan.has_nodes_to_drain());
@@ -2545,42 +2327,27 @@ SEASTAR_THREAD_TEST_CASE(test_drained_node_is_not_balanced_internally) {
 
 SEASTAR_THREAD_TEST_CASE(test_plan_fails_when_removing_last_replica) {
     do_with_cql_env_thread([] (auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
+        topology_builder topo(e);
+        auto host1 = topo.add_node();
 
-        auto host1 = host_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 1);
+        auto table1 = add_table(e, ks_name).get();
 
-        auto table1 = table_id(next_uuid());
+        topo.set_node_state(host1, node_state::removing);
 
-        unsigned shard_count = 1;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-            locator::topology::config{
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = locator::endpoint_dc_rack::default_location
-            }
-        });
-
-        stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, locator::node::state::being_removed, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 2))}, host1);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(1);
             for (auto tid : tmap.tablet_ids()) {
                 tmap.set_tablet(tid, tablet_info {
                     tablet_replica_set{tablet_replica{host1, 0}}
                 });
             }
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
         std::unordered_set<host_id> skiplist = {host1};
-        BOOST_REQUIRE_THROW(rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, skiplist), std::runtime_error);
+        BOOST_REQUIRE_THROW(rebalance_tablets(e, {}, skiplist), std::runtime_error);
     }).get();
 }
 
@@ -2593,35 +2360,16 @@ SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
     // all the tablets of the drained node, doubling its load.
     // It's safer to let the drain fail/stall.
     do_with_cql_env_thread([] (auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
-        inet_address ip3("192.168.0.3");
+        topology_builder topo(e);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
-        auto host3 = host_id(next_uuid());
+        auto host1 = topo.add_node(node_state::removing);
+        auto host2 = topo.add_node(node_state::normal);
+        auto host3 = topo.add_node(node_state::normal);
 
-        auto table1 = table_id(next_uuid());
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 2);
+        auto table1 = add_table(e, ks_name).get();
 
-        unsigned shard_count = 1;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-            locator::topology::config{
-                .this_endpoint = ip1,
-                .this_host_id = host1,
-                .local_dc_rack = locator::endpoint_dc_rack::default_location
-            }
-        });
-
-        stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, locator::node::state::being_removed, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, locator::node::state::normal, shard_count);
-            tm.update_topology(host3, locator::endpoint_dc_rack::default_location, locator::node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 3))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 3))}, host2);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 3))}, host3);
-
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(2);
             auto tid = tmap.first_tablet();
             tmap.set_tablet(tid, tablet_info {
@@ -2631,14 +2379,13 @@ SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
             tmap.set_tablet(tid, tablet_info {
                 tablet_replica_set{tablet_replica{host1, 0}}
             });
-            tablet_metadata tmeta;
             tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
             co_return;
-        }).get();
+        });
 
+        auto& stm = e.shared_token_metadata().local();
         std::unordered_set<host_id> skiplist = {host2};
-        rebalance_tablets(e.get_tablet_allocator().local(), stm, {}, skiplist);
+        rebalance_tablets(e, {}, skiplist);
 
         {
             load_sketch load(stm.get());
@@ -2692,59 +2439,48 @@ allocate_replicas_in_racks(const std::vector<endpoint_dc_rack>& racks, int rf,
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
   do_with_cql_env_thread([] (auto& e) {
+    topology_builder topo(e);
     const int n_hosts = 6;
+    auto shard_count = 2;
 
     std::vector<host_id> hosts;
-    for (int i = 0; i < n_hosts; ++i) {
-        hosts.push_back(host_id(next_uuid()));
-    }
+    std::unordered_map<sstring, std::vector<host_id>> hosts_by_rack;
 
-    std::vector<endpoint_dc_rack> racks = {
-        endpoint_dc_rack{ "dc1", "rack-1" },
-        endpoint_dc_rack{ "dc1", "rack-2" }
+    std::vector<endpoint_dc_rack> racks {
+        topo.rack(),
+        topo.start_new_rack(),
     };
 
+    for (int i = 0; i < n_hosts; ++i) {
+        auto rack = racks[(i + 1) % racks.size()];
+        auto h = topo.add_node(node_state::normal, shard_count, rack);
+        if (i) {
+            // Leave the first host empty by making it invisible to allocation algorithm.
+            hosts_by_rack[rack.rack].push_back(h);
+        }
+    }
+
+    auto& stm = e.shared_token_metadata().local();
+
     for (int i = 0; i < 13; ++i) {
-        std::unordered_map<sstring, std::vector<host_id>> hosts_by_rack;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = inet_address("192.168.0.1"),
-                        .this_host_id = hosts[0],
-                        .local_dc_rack = racks[1]
-                }
-        });
-
         size_t total_tablet_count = 0;
-        stm.mutate_token_metadata([&](token_metadata& tm) {
-            tablet_metadata tmeta;
-
-            int i = 0;
-            for (auto h : hosts) {
-                auto shard_count = 2;
-                auto rack = racks[++i % racks.size()];
-                tm.update_topology(h, rack, node::state::normal, shard_count);
-                if (h != hosts[0]) {
-                    // Leave the first host empty by making it invisible to allocation algorithm.
-                    hosts_by_rack[rack.rack].push_back(h);
-                }
+        std::vector<sstring> keyspaces;
+        size_t tablet_count_bits = 8;
+        int rf = tests::random::get_int<shard_id>(2, 4);
+        for (size_t log2_tablets = 0; log2_tablets < tablet_count_bits; ++log2_tablets) {
+            if (tests::random::get_bool()) {
+                continue;
             }
-
-            size_t tablet_count_bits = 8;
-            int rf = tests::random::get_int<shard_id>(2, 4);
-            for (size_t log2_tablets = 0; log2_tablets < tablet_count_bits; ++log2_tablets) {
-                if (tests::random::get_bool()) {
-                    continue;
-                }
-                auto table = table_id(next_uuid());
-                tablet_map tmap(1 << log2_tablets);
+            auto initial_tablets = 1 << log2_tablets;
+            keyspaces.push_back(add_keyspace(e, {{topo.dc(), rf}}, initial_tablets));
+            auto table = add_table(e, keyspaces.back()).get();
+            mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
+                tablet_map tmap(initial_tablets);
                 for (auto tid : tmap.tablet_ids()) {
                     // Choose replicas randomly while loading racks evenly.
                     std::vector<host_id> replica_hosts = allocate_replicas_in_racks(racks, rf, hosts_by_rack);
                     tablet_replica_set replicas;
                     for (auto h : replica_hosts) {
-                        auto shard_count = tm.get_topology().find_node(h)->get_shard_count();
                         auto shard = tests::random::get_int<shard_id>(0, shard_count - 1);
                         replicas.push_back(tablet_replica {h, shard});
                     }
@@ -2752,17 +2488,16 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                 }
                 total_tablet_count += tmap.tablet_count();
                 tmeta.set_tablet_map(table, std::move(tmap));
-            }
-            tm.set_tablets(std::move(tmeta));
-            return make_ready_future<>();
-        }).get();
+                return make_ready_future<>();
+            });
+        }
 
         testlog.debug("tablet metadata: {}", stm.get()->tablets());
         testlog.info("Total tablet count: {}, hosts: {}", total_tablet_count, hosts.size());
 
         check_tablet_invariants(stm.get()->tablets());
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm);
+        rebalance_tablets(e);
 
         check_tablet_invariants(stm.get()->tablets());
 
@@ -2788,6 +2523,10 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
 //          Uncomment the following line when the algorithm is improved.
 //          BOOST_REQUIRE(min_max_load.max() - min_max_load.min() <= 1);
         }
+
+        seastar::parallel_for_each(keyspaces, [&] (const sstring& ks) {
+            return e.execute_cql(fmt::format("DROP KEYSPACE {}", ks)).discard_result();
+        }).get();
     }
   }).get();
 }
@@ -2863,57 +2602,54 @@ using hosts_by_rack_map = std::unordered_map<sstring, std::vector<host_id>>;
 static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n_racks, const int rf, const int n_hosts,
                                                     const unsigned shard_count, const unsigned initial_tablets,
                                                     std::function<void(token_metadata&, tablet_map&, const rack_vector&, const hosts_by_rack_map&)> set_tablets) {
+    topology_builder topo(e);
+
     rack_vector racks;
     for (int i = 0; i < n_racks; i++) {
-        racks.push_back(endpoint_dc_rack{"dc1", format("rack-{}", i + 1)});
+        racks.push_back(topo.rack());
+        topo.start_new_rack();
     }
 
     testlog.info("merge colocation test - hosts={}, racks={}, rf={}, shard_count={}, initial_tablets={}", n_hosts, racks.size(), rf, shard_count, initial_tablets);
 
-    std::vector<host_id> hosts;
+    hosts_by_rack_map hosts_by_rack;
+
     for (int i = 0; i < n_hosts; ++i) {
-        hosts.push_back(host_id(next_uuid()));
+        auto rack = racks[i % racks.size()];
+        auto h = topo.add_node(node_state::normal, shard_count, rack);
+        hosts_by_rack[rack.rack].push_back(h);
     }
 
-    auto table1 = add_table(e).get();
+    auto ks_name = add_keyspace(e, {{topo.dc(), rf}}, initial_tablets);
+    auto table1 = add_table(e, ks_name).get();
+    auto& stm = e.shared_token_metadata().local();
 
-    hosts_by_rack_map hosts_by_rack;
-    semaphore sem(1);
-    shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-        locator::topology::config{
-            .this_endpoint = inet_address("192.168.0.1"),
-            .this_host_id = hosts[0],
-            .local_dc_rack = racks[std::min(1, n_racks - 1)]
-        }
-    });
+    {
+        abort_source as;
+        auto guard = e.get_raft_group0_client().start_operation(as).get();
+        stm.mutate_token_metadata([&](token_metadata& tm) -> future<> {
+            tablet_metadata& tmeta = tm.tablets();
+            tablet_map tmap(initial_tablets);
+            locator::resize_decision decision;
+            // leaves growing mode, allowing for merge decision.
+            decision.sequence_number = decision.next_sequence_number();
+            tmap.set_resize_decision(std::move(decision));
+            set_tablets(tm, tmap, racks, hosts_by_rack);
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            tm.set_tablets(std::move(tmeta));
+            return make_ready_future < > ();
+        }).get();
+        save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+    }
 
-    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-        tablet_metadata tmeta;
-
-        int i = 0;
-        for (auto h : hosts) {
-            auto rack = racks[++i % racks.size()];
-            hosts_by_rack[rack.rack].push_back(h);
-            tm.update_topology(h, rack, node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(float(i) / hosts.size()))}, h);
-            testlog.debug("adding host {}, rack {}, token {}", h, rack.rack, token(tests::d2t(1. / hosts.size())));
-        }
-
-        tablet_map tmap(initial_tablets);
-        locator::resize_decision decision;
-        // leaves growing mode, allowing for merge decision.
-        decision.sequence_number = decision.next_sequence_number();
-        tmap.set_resize_decision(std::move(decision));
-        set_tablets(tm, tmap, racks, hosts_by_rack);
-        tmeta.set_tablet_map(table1, std::move(tmap));
-        tm.set_tablets(std::move(tmeta));
-    }).get();
+    // Lower "initial" tablets option, allowing for merge decision.
+    e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_name)).get();
 
     auto tablet_count = [&] {
         return stm.get()->tablets().get_tablet_map(table1).tablet_count();
     };
     auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
-        rebalance_tablets(e.get_tablet_allocator().local(), stm, make_lw_shared(std::move(load_stats)));
+        rebalance_tablets(e, make_lw_shared(std::move(load_stats)));
     };
 
     const uint64_t target_tablet_size = service::default_target_tablet_size;
@@ -2934,6 +2670,8 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
         check_tablet_invariants(stm.get()->tablets());
         BOOST_REQUIRE_LT(tablet_count(), old_tablet_count);
     }
+
+    e.execute_cql(fmt::format("drop keyspace {}", ks_name)).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_random_load) {
@@ -3055,57 +2793,29 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_decomission) 
 
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
     do_with_cql_env_thread([] (auto& e) {
-        inet_address ip1("192.168.0.1");
-        inet_address ip2("192.168.0.2");
+        topology_builder topo(e);
 
-        auto host1 = host_id(next_uuid());
-        auto host2 = host_id(next_uuid());
+        topo.add_node(node_state::normal, 2);
+        topo.add_node(node_state::normal, 2);
 
-        auto table1 = add_table(e).get();
+        const size_t initial_tablets = 2;
+        auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, initial_tablets);
+        auto table1 = add_table(e, ks_name).get();
 
-        unsigned shard_count = 2;
-
-        semaphore sem(1);
-        shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
-                locator::topology::config{
-                        .this_endpoint = ip1,
-                        .this_host_id = host1,
-                        .local_dc_rack = locator::endpoint_dc_rack::default_location
-                }
-        });
-
-        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-            tm.update_topology(host1, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            tm.update_topology(host2, locator::endpoint_dc_rack::default_location, node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 2))}, host1);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 2))}, host2);
-
-            tablet_map tmap(2);
-            for (auto tid : tmap.tablet_ids()) {
-                tmap.set_tablet(tid, tablet_info {
-                        tablet_replica_set {
-                                tablet_replica {host1, tests::random::get_int<shard_id>(0, shard_count - 1)},
-                                tablet_replica {host2, tests::random::get_int<shard_id>(0, shard_count - 1)},
-                        }
-                });
-            }
-            tablet_metadata tmeta;
-            tmeta.set_tablet_map(table1, std::move(tmap));
-            tm.set_tablets(std::move(tmeta));
-        }).get();
+        auto& stm = e.shared_token_metadata().local();
 
         auto tablet_count = [&] {
             return stm.get()->tablets().get_tablet_map(table1).tablet_count();
         };
+
         auto resize_decision = [&] {
             return stm.get()->tablets().get_tablet_map(table1).resize_decision();
         };
 
         auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
-            rebalance_tablets(e.get_tablet_allocator().local(), stm, make_lw_shared(std::move(load_stats)));
+            rebalance_tablets(e, make_lw_shared(std::move(load_stats)));
         };
 
-        const size_t initial_tablets = tablet_count();
         const uint64_t max_tablet_size = service::default_target_tablet_size * 2;
         auto to_size_in_bytes = [&] (double max_tablet_size_pctg) -> uint64_t {
             return (max_tablet_size * max_tablet_size_pctg) * tablet_count();
@@ -3126,6 +2836,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
         }
+
+        // Drop initial tablet count to 1 so merge can happen.
+        e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_name)).get();
 
         // avg size hits split threshold, and balancer emits split request
         {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1830,6 +1830,70 @@ SEASTAR_THREAD_TEST_CASE(test_table_creation_during_decommission) {
     }, tablet_cql_test_config()).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_table_creation_during_rack_decommission) {
+    // Reproduces #22625
+    // The problematic scenario happens when allocating tablets for a new table
+    // when there is a rack with only non-normal nodes.
+    do_with_cql_env_thread([](auto& e) {
+        inet_address ip1("192.168.0.1");
+        inet_address ip2("192.168.0.2");
+        inet_address ip3("192.168.0.3");
+        inet_address ip4("192.168.0.4");
+
+        auto host1 = host_id(next_uuid());
+        auto host2 = host_id(next_uuid());
+        auto host3 = host_id(next_uuid());
+        auto host4 = host_id(next_uuid());
+
+        auto dc = "datacenter1";
+        locator::endpoint_dc_rack dcrack  = { dc, "rack1" };
+        locator::endpoint_dc_rack dcrack2 = { dc, "rack2" };
+
+        semaphore sem(1);
+        shared_token_metadata stm([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
+            locator::topology::config {
+                .this_endpoint = ip1,
+                .this_host_id = host1,
+                .local_dc_rack = dcrack
+            }
+        });
+
+        const unsigned shard_count = 1;
+
+        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
+            tm.update_topology(host1, dcrack, node::state::normal, shard_count);
+            tm.update_topology(host2, dcrack, node::state::normal, shard_count);
+            tm.update_topology(host3, dcrack2, node::state::being_decommissioned, shard_count);
+            tm.update_topology(host4, dcrack2, node::state::left, shard_count);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(1. / 4))}, host1);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(2. / 4))}, host2);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(3. / 4))}, host3);
+            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(4. / 4))}, host4);
+            co_return;
+        }).get();
+
+        sstring ks_name = "test_ks";
+        sstring table_name = "table1";
+        e.execute_cql(format("create keyspace {} with replication = "
+                             "{{'class': 'NetworkTopologyStrategy', '{}': 1}} "
+                             "and tablets = {{'enabled': true, 'initial': 8}}", ks_name, dcrack.dc)).get();
+        e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
+        auto s = e.local_db().find_schema(ks_name, table_name);
+
+        auto* rs = e.local_db().find_keyspace(ks_name).get_replication_strategy().maybe_as_tablet_aware();
+        BOOST_REQUIRE(rs);
+        auto tmap = rs->allocate_tablets_for_new_table(s, stm.get(), 8).get();
+
+        tmap.for_each_tablet([&](auto tid, auto& tinfo) {
+            for (auto& replica : tinfo.replicas) {
+                BOOST_REQUIRE_NE(replica.host, host3);
+                BOOST_REQUIRE_NE(replica.host, host4);
+            }
+            return make_ready_future<>();
+        }).get();
+    }, tablet_cql_test_config()).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
     // Verifies that load balancer moves tablets out of the decommissioned node.
     // The scenario is such that replication constraints of tablets can be satisfied after decommission.

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1641,6 +1641,85 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
   }).get();
 }
 
+// Throws if tablets have more than 1 replica in a given rack.
+// Run in seastar thread.
+void check_no_rack_overload(const token_metadata& tm) {
+    auto& topo = tm.get_topology();
+    for (auto&& [table, tmap_p] : tm.tablets().all_tables()) {
+        const tablet_map& tmap = *tmap_p;
+        tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& tinfo) {
+            std::unordered_map<sstring, std::unordered_set<sstring>> racks_by_dc;
+            auto replicas = tinfo.replicas;
+            for (auto& r : tinfo.replicas) {
+                auto& rack = topo.get_rack(r.host);
+                auto& racks = racks_by_dc[topo.get_datacenter(r.host)];
+                if (racks.contains(rack)) {
+                    throw std::runtime_error("rack overloaded");
+                }
+                racks.insert(rack);
+            }
+            return make_ready_future<>();
+        }).get();
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_merge_does_not_overload_racks) {
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        auto rack1 = topo.rack();
+        auto rack2 = topo.start_new_rack();
+        auto rack3 = topo.start_new_rack();
+
+        auto host1 = topo.add_node(node_state::normal, 1, rack3);
+        auto host2 = topo.add_node(node_state::normal, 1, rack2);
+        auto host3 = topo.add_node(node_state::normal, 1, rack1);
+        auto host4 = topo.add_node(node_state::normal, 1, rack3);
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 2); // RF=2
+        auto table1 = add_table(e, ks_name).get();
+
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
+            tablet_map tmap(2);
+            auto tid = tmap.first_tablet();
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica{host1, 0},
+                    tablet_replica{host3, 0},
+                }
+            });
+            tid = *tmap.next_tablet(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica{host2, 0},
+                    tablet_replica{host4, 0},
+                }
+            });
+
+            // Leaves growing mode, allows for merge
+            locator::resize_decision decision;
+            decision.sequence_number = decision.next_sequence_number();
+            tmap.set_resize_decision(std::move(decision));
+
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            co_return;
+        });
+
+        // Trigger merge
+        e.execute_cql(fmt::format("alter keyspace {} with tablets = {{'enabled': true, 'initial': 1}}", ks_name)).get();
+
+        auto& stm = e.shared_token_metadata().local();
+        locator::load_stats load_stats;
+        load_stats.tables[table1] = {};
+        rebalance_tablets(e, make_lw_shared(std::move(load_stats)), {}, [&] (const migration_plan& plan) {
+            check_no_rack_overload(*stm.get());
+            return false;
+        });
+
+        BOOST_REQUIRE_EQUAL(1, stm.get()->tablets().get_tablet_map(table1).tablet_count());
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
   do_with_cql_env_thread([] (auto& e) {
     // Tests the scenario of balacning cluster with DOWN node
@@ -2730,6 +2809,45 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_single_rack) 
                 tablet_replica_set {
                     tablet_replica {host2, shard_id(0)},
                     tablet_replica {host1, shard_id(0)},
+                }
+            });
+        };
+
+        do_test_load_balancing_merge_colocation(e, n_racks, rf, n_hosts, shard_count, initial_tablets, set_tablets);
+    }).get();
+}
+
+// Verify merge can proceed with multiple racks and RF=#racks
+//
+// Given replica sets (not in rack order):
+// rack1 { n1, n2 }
+// rack2 { n3, n4 }
+//
+// t0: { n1, n3 }
+// t1: { n4, n2 }
+//
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_merge_colocation_with_multiple_racks_and_rf_equals_racks) {
+    do_with_cql_env_thread([] (auto& e) {
+        const int rf = 2;
+        const int n_racks = rf;
+        const int n_hosts = 4; // 2 nodes in each rack.
+        const unsigned shard_count = 1;
+        const unsigned initial_tablets = 2;
+
+        auto set_tablets = [] (token_metadata&, tablet_map& tmap, const rack_vector& racks, const hosts_by_rack_map& hosts_by_rack) {
+            auto& first_rack_hosts = hosts_by_rack.at(racks[0].rack);
+            auto& second_rack_hosts = hosts_by_rack.at(racks[1].rack);
+
+            tmap.set_tablet(tablet_id(0), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {first_rack_hosts[0], shard_id(0)},
+                    tablet_replica {second_rack_hosts[0], shard_id(0)},
+                }
+            });
+            tmap.set_tablet(tablet_id(1), tablet_info {
+                tablet_replica_set {
+                    tablet_replica {second_rack_hosts[1], shard_id(0)},
+                    tablet_replica {first_rack_hosts[1], shard_id(0)},
                 }
             });
         };

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -411,6 +411,10 @@ public:
         return _token_metadata;
     }
 
+    virtual sharded<service::topology_state_machine>& get_topology_state_machine() override {
+        return _topology_state_machine;
+    }
+
     virtual future<> refresh_client_state() override {
         return _core_local.invoke_on_all([] (core_local_state& state) {
             return state.client_state.maybe_update_per_service_level_params();

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -189,6 +189,8 @@ public:
 
     virtual sharded<locator::shared_token_metadata>& get_shared_token_metadata() = 0;
 
+    virtual sharded<service::topology_state_machine>& get_topology_state_machine() = 0;
+
     data_dictionary::database data_dictionary();
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
+ */
+
+#pragma once
+
+#include "cql_test_env.hh"
+#include "locator/topology.hh"
+#include "gms/inet_address.hh"
+#include "service/topology_mutation.hh"
+#include "service/topology_state_machine.hh"
+#include "service/raft/raft_group0_client.hh"
+#include "locator/host_id.hh"
+#include "test/lib/log.hh"
+#include "version.hh"
+
+#include <atomic>
+
+
+/// Modifies topology inside a given cql_test_env.
+/// Local node's membership is not affected, but it belongs to a different DC than those produced by this builder.
+///
+/// Creating the builder locks the topology state machine so there are no concurrent topology operations
+/// and load balancing.
+/// The built topology is not removed when the builder is destroyed and the state machine is left locked.
+///
+/// All methods expect to be run in a seastar thread.
+///
+/// Examples usage:
+///
+///     topology_builder topo(e);
+///     auto host1 = topo.add_node(); // dc1 rack1
+///     auto host2 = topo.add_node(); // dc1 rack1
+///     topo.start_new_dc();
+///     auto host3 = topo.add_node(); // dc2 rack1
+///     auto host4 = topo.add_node(); // dc2 rack1
+///     topo.start_new_rack();
+///     auto host5 = topo.add_node(); // dc2 rack2
+///     auto host6 = topo.add_node(); // dc2 rack2
+///
+class topology_builder {
+public:
+    using inet_address = locator::inet_address;
+    using endpoint_dc_rack = locator::endpoint_dc_rack;
+private:
+    cql_test_env& _env;
+    int _nr_nodes = 0;
+    int _rack_id;
+    sstring _dc;
+    sstring _rack;
+private:
+    inet_address make_node_address(int n) {
+        assert(n > 0);
+        int a = n % 256;
+        n /= 256;
+        int b = n % 256;
+        n /= 256;
+        assert(n < 256);
+        return inet_address(fmt::format("10.{}.{}.{}", n, b, a));
+    }
+
+    // Locks the topology to prevent concurrent topology operations and load balancing.
+    // Setting transition_state to "lock" blocks background load-balancing which could interfere with the test
+    // and prevents errors from load_topology_state() complaining about nodes in transition with no transition state.
+    void lock_topology() {
+        abort_source as;
+        auto& client = _env.get_raft_group0_client();
+        service::topology& topo = _env.get_topology_state_machine().local()._topology;
+
+        while (true) {
+            if (topo.tstate && *topo.tstate == service::topology::transition_state::lock) {
+                testlog.info("Topology is locked");
+                return;
+            }
+
+            auto guard = client.start_operation(as).get();
+
+            if (topo.tstate) {
+                testlog.info("Waiting for topology state machine to be idle");
+                release_guard(std::move(guard));
+                _env.get_topology_state_machine().local().await_not_busy().get();
+                testlog.info("Woken up");
+                continue;
+            }
+
+            service::topology_change change({service::topology_mutation_builder(guard.write_timestamp())
+                                                 .set_transition_state(service::topology::transition_state::lock)
+                                                 .build()});
+            service::group0_command g0_cmd = client.prepare_command(std::move(change), guard, "locking topology");
+            try {
+                client.add_entry(std::move(g0_cmd), std::move(guard), as).get();
+            } catch (service::group0_concurrent_modification&) {
+                testlog.info("Concurrent modification detected while locking topology, retrying");
+            }
+        }
+    }
+public:
+    topology_builder(cql_test_env& e)
+        : _env(e)
+    {
+        start_new_dc();
+        lock_topology();
+    }
+
+    // Returns a new token from some sequence of unique tokens.
+    // Uniqueness is in the scope of the process, not just this object.
+    dht::token new_token() {
+        static std::atomic<int64_t> next_token = 1;
+        return dht::token(next_token.fetch_add(1));
+    }
+
+    // Returns the name of the currently built DC.
+    const sstring& dc() const {
+        return _dc;
+    }
+
+    // Returns location of the currently built rack.
+    endpoint_dc_rack rack() const {
+        return {_dc, _rack};
+    }
+
+    // Starts building a new rack in the current DC.
+    // Returns location of the new rack.
+    endpoint_dc_rack start_new_rack() {
+        _rack_id++;
+        _rack = fmt::format("rack{}", _rack_id);
+        return rack();
+    }
+
+    // Starts building a new DC.
+    // DC is named uniquely in the scope of the process, not just this object.
+    endpoint_dc_rack start_new_dc() {
+        static std::atomic<int> next_id = 1;
+        _dc = fmt::format("dc{}", next_id.fetch_add(1));
+        _rack_id = 0;
+        return start_new_rack();
+    }
+
+    locator::host_id add_node(service::node_state state = service::node_state::normal,
+                              unsigned shard_count = 1,
+                              std::optional<endpoint_dc_rack> rack_override = {})
+    {
+        ++_nr_nodes;
+
+        auto ip = make_node_address(_nr_nodes);
+        auto id = locator::host_id(utils::UUID_gen::get_time_UUID());
+        auto dc_rack = rack_override.value_or(rack());
+        dht::token token = new_token();
+        std::unordered_set<dht::token> tokens({token});
+
+        abort_source as;
+        auto& client = _env.get_raft_group0_client();
+
+        while (true) {
+            auto guard = client.start_operation(as).get();
+
+            service::topology_mutation_builder builder(guard.write_timestamp());
+            builder.with_node(raft::server_id(id.uuid()))
+                    .set("datacenter", dc_rack.dc)
+                    .set("rack", dc_rack.rack)
+                    .set("node_state", state)
+                    .set("shard_count", (uint32_t) shard_count)
+                    .set("cleanup_status", service::cleanup_status::clean)
+                    .set("release_version", version::release())
+                    .set("num_tokens", (uint32_t) 1)
+                    .set("tokens_string", fmt::format("{}", token))
+                    .set("tokens", tokens)
+                    .set("supported_features", std::set<sstring>())
+                    .set("request_id", utils::UUID())
+                    .set("ignore_msb", (uint32_t) 0);
+            service::topology_change change({builder.build()});
+            service::group0_command g0_cmd = client.prepare_command(std::move(change), guard,
+                                                                    format("adding node {} to topology", id));
+            testlog.info("Adding node {}/{} dc={} rack={} to topology", id, ip, dc_rack.dc, dc_rack.rack);
+            try {
+                client.add_entry(std::move(g0_cmd), std::move(guard), as).get();
+                break;
+            } catch (service::group0_concurrent_modification&) {
+                testlog.warn("Concurrent modification detected, retrying");
+            }
+        }
+        return id;
+    }
+
+    void set_node_state(locator::host_id id, service::node_state state) {
+        abort_source as;
+        auto& client = _env.get_raft_group0_client();
+        while (true) {
+            auto guard = client.start_operation(as).get();
+            service::topology_mutation_builder builder(guard.write_timestamp());
+            builder.with_node(raft::server_id(id.uuid()))
+                    .set("node_state", state);
+            service::topology_change change({builder.build()});
+            service::group0_command g0_cmd = client.prepare_command(std::move(change), guard,
+                                                                    format("node {} state={}", id, state));
+            testlog.info("Changing node {} state={}", id, state);
+            try {
+                client.add_entry(std::move(g0_cmd), std::move(guard), as).get();
+                break;
+            } catch (service::group0_concurrent_modification&) {
+                testlog.warn("Concurrent modification detected, retrying");
+            }
+        }
+    }
+};


### PR DESCRIPTION
service: Introduce rack-aware co-location migrations for tablet merge

Merge co-location can emit migrations across racks even when RF=#racks,
reducing availability and affecting consistency of base-view pairing.

Given replica set of sibling tablets T0 and T1 below:
[T0: (rack1,rack3,rack2)]
[T1: (rack2,rack1,rack3)]

Merge will co-locate T1:rack2 into T0:rack1, T1 will be temporarily only at
only a subset of racks, reducing availability.

This is the main problem fixed by this patch.

It also lays the ground for consistent base-view replica pairing,
which is rack-based. For tables on which views can be created we plan
to enforce the constraint that replicas don't move across racks and
that all tablets use the same set of racks (RF=#racks). This patch
avoids moving replicas across racks unless it's necessary, so if the
constraint is satisfied before merge, there will be no co-locating
migrations across racks. This constraint of RF=#racks is not enforced
yet, it requires more extensive changes.

Fixes #22994.
Refs #17265.

This patch is based on Raphael's work done in PR #23081. The main differences are:

1) Instead of sorting replicas by rack, we try to find
    replicas in sibling tablets which belong to the same rack.
    This is similar to how we match replicas within the same host.
    It reduces number of across-rack migrations even if RF!=#racks,
    which the original patch didn't handle.
    Unlike the original patch, it also avoids rack-overloaded in case
    RF!=#racks

2) We emit across-rack co-locating migrations if we have no other choice
   in order to finalize the merge


   This is ok, since views are not supported with tablets yet. Later,
   we will disallow this for tables which have views, and we will
   allow creating views in the first place only when no such migrations
   can happen (RF=#racks).

3) Added boost unit test which checks that rack overload is avoided during merge
   in case RF<#racks

4) Moved logging of across-rack migration to debug level

5) Exposed metric for across-rack co-locating migrations

(cherry picked from commit af949f3b6a4af78bfb0ad3decef1b8a23ba1780d)

Also backports dependent patches:
  - locator: network_topology_strategy: Fix SIGSEGV when creating a table when there is a rack with no normal nodes
  - locator: network_topology_startegy: Ignore leaving nodes when computing capacity for new tables
  - Merge 'test: tablets_test: Create proper schema in load balancer tests' from Tomasz Grabiec
 
Closes scylladb/scylladb#22657
Closes scylladb/scylladb#22652
