### PR TITLE
[DRAFT] test: Adjust tests so all used keyspaces are RF-rack-valid

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/coroutine.hh>
 #include "cql3/statements/create_keyspace_statement.hh"
 #include "cql3/statements/ks_prop_defs.hh"
+#include "locator/network_topology_strategy.hh"
 #include "prepared_statement.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "data_dictionary/keyspace_metadata.hh"
@@ -76,6 +77,40 @@ void create_keyspace_statement::validate(query_processor& qp, const service::cli
     } catch (const std::runtime_error& e) {
         throw exceptions::invalid_request_exception(e.what());
     }
+
+    const auto& tm = *qp.proxy().get_token_metadata_ptr();
+    const auto& feat = qp.proxy().features();
+    const auto& cfg = qp.db().get_config();
+    auto ksm = _attrs->as_ks_metadata(_name, tm, feat, cfg);
+    auto rs = locator::abstract_replication_strategy::create_replication_strategy(
+            ksm->strategy_name(),
+            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()));
+
+    const bool restricted_keyspaces = cfg.rf_rack_valid_keyspaces();
+    // At this point, we don't know yet if the replication strategy is NetworkTopologyStrategy!
+    // It may happen that the user chooses SimpleStrategy, but they try to enable tablets as well.
+    // That's why we need to check the conjunction here.
+    const bool uses_tablets = rs->get_type() == locator::replication_strategy_type::network_topology && rs->uses_tablets();
+
+    if (restricted_keyspaces && uses_tablets) {
+        const auto* nts = static_cast<const locator::network_topology_strategy*>(rs.get());
+
+        for (const auto& [dc, rack_map] : tm.get_topology().get_datacenter_racks()) {
+            const auto rack_count = rack_map.size();
+            const auto rf = nts->get_replication_factor(dc);
+
+            // We must not allow for a keyspace to become RF-rack-invalid. Any attempt at that must be rejected.
+            // For more context, see: scylladb/scylladb#23071.
+            const bool invalid_rf = rf != rack_count && rf != 1 && rf != 0;
+            if (invalid_rf) {
+                throw exceptions::invalid_request_exception(seastar::format(
+                        "The option `rf_rack_valid_keyspaces` is enabled. It requires that keyspaces are RF-rack-valid. "
+                        "Your query would violate that: keyspace '{}' doesn't satisfy the condition for DC '{}': RF={} vs. rack count={}.",
+                        _name, dc, rf, rack_count));
+            }
+        }
+    }
+
 #if 0
     // The strategy is validated through KSMetaData.validate() in announceNewKeyspace below.
     // However, for backward compatibility with thrift, this doesn't validate unexpected options yet,

--- a/db/config.cc
+++ b/db/config.cc
@@ -1378,6 +1378,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , disk_space_monitor_high_polling_interval_in_seconds(this, "disk_space_monitor_high_polling_interval_in_seconds", value_status::Used, 1, "Disk-space polling interval at or above polling threshold")
     , disk_space_monitor_polling_interval_threshold(this, "disk_space_monitor_polling_interval_threshold", value_status::Used, 0.9, "Disk-space polling threshold. Polling interval is increased when disk utilization is greater than or equal to this threshold")
     , enable_create_table_with_compact_storage(this, "enable_create_table_with_compact_storage", liveness::LiveUpdate, value_status::Used, false, "Enable the deprecated feature of CREATE TABLE WITH COMPACT STORAGE.  This feature will eventually be removed in a future version.")
+    , rf_rack_valid_keyspaces(this, "rf_rack_valid_keyspaces", liveness::LiveUpdate, value_status::Used, false,
+        "Enforce RF-rack-valid keyspaces. Additionally, if there are existing RF-rack-invalid "
+        "keyspaces, attempting to start a node with this option ON will fail. This option will be "
+        "removed in a future version.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -544,6 +544,8 @@ public:
 
     named_value<bool> enable_create_table_with_compact_storage;
 
+    named_value<bool> rf_rack_valid_keyspaces;
+
     static const sstring default_tls_priority;
 private:
     template<typename T>

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -160,6 +160,12 @@ that has tablets enabled:
 To enable MV and SI for tablet keyspaces, use the `--experimental-features=views-with-tablets`
 configuration option.  See :ref:`Views with tablets <admin-views-with-tablets>` for details.
 
+.. warning::
+
+    If a keyspace has tablets enabled, it must remain :doc:`RF-rack-valid </reference/glossary>`
+    throughout its lifetime. Failing to keep that invariant satisfied may result in data inconsistencies,
+    performance problems, or other issues.
+
 Resharding in keyspaces with tablets enabled has the following limitations:
 
 * ScyllaDB does not support reducing the number of shards after node restart.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -224,7 +224,8 @@ By default, a keyspace is created with tablets enabled. You can use the ``tablet
 to opt out a keyspace from tablets-based distribution.
 
 You may want to opt out if you plan to use features that are not supported for keyspaces
-with tablets enabled. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
+with tablets enabled. Keyspaces using tablets must also remain :doc:`RF-rack-valid </reference/glossary>`
+throughout their lifetime. See :ref:`Limitations and Unsupported Features <tablets-limitations>`
 for details.
 
 **The ``initial`` sub-option (deprecated)**
@@ -300,6 +301,7 @@ Modifying a keyspace with tablets enabled is possible and doesn't require any sp
 - If there's any other ongoing global topology operation, executing the ``ALTER`` statement will fail (with an explicit and specific error) and needs to be repeated.
 - The ``ALTER`` statement may take longer than the regular query timeout, and even if it times out, it will continue to execute in the background.
 - The replication strategy cannot be modified, as keyspaces with tablets only support ``NetworkTopologyStrategy``.
+- The ``ALTER`` statement will fail if it would make the keyspace :doc:`RF-rack-invalid </reference/glossary>`.
 
 .. _drop-keyspace-statement:
 

--- a/docs/reference/glossary.rst
+++ b/docs/reference/glossary.rst
@@ -127,6 +127,14 @@ Glossary
       RBNO is enabled by default for a subset node operations. 
       See :doc:`Repair Based Node Operations </operating-scylla/procedures/cluster-management/repair-based-node-operation>` for details.
 
+    RF-rack-invalid keyspace
+      A keyspace is RF-rack-invalid if and only if it uses :doc:`tablet-based distribution </architecture/tablets>` and
+      there exists a data center for which the specified replication factor is not equal to: 0, 1, or the number of racks
+      in that data center.
+
+    RF-rack-valid keyspace
+      A keyspace is RF-rack-valid if and only if it's not RF-rack-invalid.
+
     Shard
       Each ScyllaDB node is internally split into *shards*, an independent thread bound to a dedicated core.
       Each shard of data is allotted CPU, RAM, persistent storage, and networking resources which it uses as efficiently as possible.

--- a/main.cc
+++ b/main.cc
@@ -2171,6 +2171,16 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();
 
+            // At this point, `locator::topology` should be stable, i.e. we should have complete information
+            // about the layout of the cluster (= list of nodes along with the racks/DCs).
+            if (cfg->rf_rack_valid_keyspaces()) {
+                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                db.invoke_on(0, [&tm = token_metadata] (const replica::database& local_db) {
+                    return local_db.check_rf_rack_validity(tm.local().get()->get_topology());
+                }).get();
+                startlog.info("All keyspaces are RF-rack-valid");
+            }
+
             dictionary_service dict_service(
                 dict_sampler,
                 sys_ks.local(),

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -10,6 +10,7 @@
 
 #include <fmt/ranges.h>
 #include <fmt/std.h>
+#include "locator/network_topology_strategy.hh"
 #include "utils/log.hh"
 #include "replica/database_fwd.hh"
 #include "utils/assert.hh"
@@ -3182,6 +3183,38 @@ future<> database::on_before_service_level_change(qos::service_level_options slo
 future<>
 database::on_effective_service_levels_cache_reloaded() {
     co_return;
+}
+
+void database::check_rf_rack_validity(const locator::topology& topology) const {
+    SCYLLA_ASSERT(get_config().rf_rack_valid_keyspaces());
+
+    for (const auto& [name, info] : get_keyspaces()) {
+        if (!info.uses_tablets()) {
+            continue;
+        }
+
+        dblog.debug("Verifying that keyspace='{}' is RF-rack-valid", name);
+
+        // Note: Tablets are only supported by NetworkTopologyStrategy.
+        SCYLLA_ASSERT(info.get_replication_strategy().get_type() == locator::replication_strategy_type::network_topology);
+        const auto* rs = static_cast<const locator::network_topology_strategy*>(std::addressof(info.get_replication_strategy()));
+
+        for (const auto& [dc, rack_map] : topology.get_datacenter_racks()) {
+            dblog.debug("Verifying RF-rack validity restriction for keyspace='{}' and DC='{}'", name, dc);
+
+            const auto rf = rs->get_replication_factor(dc);
+            const auto rack_count = rack_map.size();
+
+            const bool invalid_ks = rf != rack_count && rf != 1 && rf != 0;
+            if (invalid_ks) {
+                throw std::runtime_error(std::format(
+                        "The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. "
+                        "That condition is not satisfied by keyspace '{}' in DC '{}': RF={} vs. rack count={}. "
+                        "Alter all RF-rack-invalid keyspaces so that they're valid and try again.",
+                        std::string_view(name), std::string_view(dc), rf, rack_count));
+            }
+        }
+    }
 }
 
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1951,6 +1951,14 @@ public:
     /** This callback is going to be called just before the service level is changed **/
     virtual future<> on_before_service_level_change(qos::service_level_options slo_before, qos::service_level_options slo_after, qos::service_level_info sl_info) override;
     virtual future<> on_effective_service_levels_cache_reloaded() override;
+
+    // Verify that the existing keyspaces are all RF-rack-valid.
+    //
+    // Preconditions:
+    // * the option `rf_rack_valid_keyspaces` in enabled,
+    // * the passed `locator::topology` reference must contain a complete list
+    //   of racks and data centers in the cluster.
+    void check_rf_rack_validity(const locator::topology&) const;
 };
 
 // A helper function to parse the directory name back

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -8,6 +8,7 @@
 
 
 
+#include "locator/types.hh"
 #include <seastar/core/shard_id.hh>
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
@@ -2057,9 +2058,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
     // which is a proof that it doesn't stop due to active migrations.
 
     topology_builder topo(e);
-    auto host1 = topo.add_node(node_state::normal, 1);
-    auto host2 = topo.add_node(node_state::normal, 1);
-    auto host3 = topo.add_node(node_state::normal, 2);
+    auto host1 = topo.add_node(node_state::normal, 1, locator::endpoint_dc_rack{"dc1", "r1"});
+    auto host2 = topo.add_node(node_state::normal, 1, locator::endpoint_dc_rack{"dc1", "r1"});
+    auto host3 = topo.add_node(node_state::normal, 2, locator::endpoint_dc_rack{"dc1", "r2"});
 
     auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 4);
     auto table1 = add_table(e, ks_name).get();
@@ -2116,9 +2117,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_shuffle_mode) {
   do_with_cql_env_thread([] (auto& e) {
     topology_builder topo(e);
 
-    auto host1 = topo.add_node(node_state::normal, 1);
-    auto host2 = topo.add_node(node_state::normal, 1);
-    topo.add_node(node_state::normal, 2);
+    auto host1 = topo.add_node(node_state::normal, 1, locator::endpoint_dc_rack{"dc1", "r1"});
+    auto host2 = topo.add_node(node_state::normal, 1, locator::endpoint_dc_rack{"dc1", "r2"});
+    topo.add_node(node_state::normal, 2, locator::endpoint_dc_rack{"dc1", "r2"});
 
     auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 4);
     auto table1 = add_table(e, ks_name).get();
@@ -2159,10 +2160,10 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
     topology_builder topo(e);
 
     const auto shard_count = 2;
-    auto host1 = topo.add_node(node_state::normal, shard_count);
-    auto host2 = topo.add_node(node_state::normal, shard_count);
-    auto host3 = topo.add_node(node_state::normal, shard_count);
-    auto host4 = topo.add_node(node_state::normal, shard_count);
+    auto host1 = topo.add_node(node_state::normal, shard_count, locator::endpoint_dc_rack{"dc1", "r1"});
+    auto host2 = topo.add_node(node_state::normal, shard_count, locator::endpoint_dc_rack{"dc1", "r1"});
+    auto host3 = topo.add_node(node_state::normal, shard_count, locator::endpoint_dc_rack{"dc1", "r2"});
+    auto host4 = topo.add_node(node_state::normal, shard_count, locator::endpoint_dc_rack{"dc1", "r2"});
 
     auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, 16);
     auto table1 = add_table(e, ks_name).get();
@@ -3001,8 +3002,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
     do_with_cql_env_thread([] (auto& e) {
         topology_builder topo(e);
 
-        topo.add_node(node_state::normal, 2);
-        topo.add_node(node_state::normal, 2);
+        topo.add_node(node_state::normal, 2, locator::endpoint_dc_rack{"dc1", "r1"});
+        topo.add_node(node_state::normal, 2, locator::endpoint_dc_rack{"dc1", "r2"});
 
         const size_t initial_tablets = 2;
         auto ks_name = add_keyspace(e, {{topo.dc(), 2}}, initial_tablets);

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -279,5 +279,7 @@ def is_test_needed_cluster(request):
 async def prepare_3_nodes_cluster(is_test_needed_cluster, manager):
     servers = await  manager.running_servers()
     if not servers and is_test_needed_cluster:
-        await manager.servers_add(3)
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"})
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r3"})
         await manager.mark_clean()

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -33,7 +33,12 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
     the pairing would be shifted during replace.
     """
 
-    servers = await manager.servers_add(4)
+    servers = [
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"})
+    ]
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -62,7 +67,10 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
 
         logger.info('Replacing the node')
         replace_cfg = ReplaceConfig(replaced_id = server_to_replace.server_id, reuse_ip_addr = False, use_host_id = True)
-        replace_task = asyncio.create_task(manager.server_add(replace_cfg))
+        replace_task = asyncio.create_task(manager.server_add(replace_cfg, property_file={
+            "dc": server_to_replace.datacenter,
+            "rack": server_to_replace.rack
+        }))
 
         await coord_log.wait_for('tablet_transition_updates: waiting', from_mark=coord_mark)
 

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -369,9 +369,8 @@ class topo:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("topology", [
         topo(rf = 1, nodes = 3, racks = 1, dcs = 1),
-        topo(rf = 3, nodes = 5, racks = 1, dcs = 1),
+        topo(rf = 3, nodes = 5, racks = 3, dcs = 1),
         topo(rf = 1, nodes = 4, racks = 2, dcs = 1),
-        topo(rf = 3, nodes = 6, racks = 2, dcs = 1),
         topo(rf = 3, nodes = 6, racks = 3, dcs = 1),
         topo(rf = 2, nodes = 8, racks = 4, dcs = 2)
     ])

--- a/test/cluster/test_change_rpc_address.py
+++ b/test/cluster/test_change_rpc_address.py
@@ -32,7 +32,11 @@ N_SERVERS = 2
 @pytest.fixture
 async def two_nodes_cluster(manager: ManagerClient) -> list[ServerNum]:
     logger.info(f"Booting initial 2-nodes cluster")
-    servers = [srv.server_id for srv in await manager.servers_add(N_SERVERS)]
+    servers = [
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"})
+    ]
+    servers = [s.server_id for s in servers]
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     return servers
 

--- a/test/cluster/test_conflicting_keys_read_repair.py
+++ b/test/cluster/test_conflicting_keys_read_repair.py
@@ -42,7 +42,11 @@ async def test_read_repair_with_conflicting_hash_keys(request: pytest.FixtureReq
 
     """
     logger.info("Creating a new cluster")
-    srvs = await manager.servers_add(3)
+    srvs = [
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r3"})
+    ]
     cql, _ = await manager.get_ready_cql(srvs)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -64,12 +64,15 @@ async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bo
     cfg = {'enable_tablets' : tablets_enabled}
 
     logger.info("Bootstrapping first two nodes")
-    servers = await manager.servers_add(2, config=cfg)
+    servers = [
+        await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r2"})
+    ]
 
     # The third node is started as the last one, so we can be sure that is has
     # the latest topology version
     logger.info("Bootstrapping the last node")
-    servers += [await manager.server_add(config=cfg)]
+    servers += [await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r3"})]
 
     # Disable load balancer as it might bump topology version, undoing the decrement below.
     # This should be done before adding the last two servers,
@@ -123,9 +126,11 @@ async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bo
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_fence_hints(request, manager: ManagerClient):
     logger.info("Bootstrapping cluster with three nodes")
-    s0 = await manager.server_add(config={
-        'error_injections_at_startup': ['decrease_hints_flush_period']
-    }, cmdline=['--logger-log-level', 'hints_manager=trace'])
+    s0 = await manager.server_add(
+        config={'error_injections_at_startup': ['decrease_hints_flush_period']},
+        cmdline=['--logger-log-level', 'hints_manager=trace'],
+        property_file={"dc": "dc1", "rack": "r1"}
+    )
 
     # Disable load balancer as it might bump topology version, potentially creating a race condition
     # with read modify write below.
@@ -134,7 +139,10 @@ async def test_fence_hints(request, manager: ManagerClient):
     # which the test relies on.
     await manager.api.disable_tablet_balancing(s0.ip_addr)
 
-    [s1, s2] = await manager.servers_add(2)
+    [s1, s2] = [
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}),
+        await manager.server_add(property_file={"dc": "dc1", "rack": "r3"})
+    ]
 
     logger.info(f'Creating test table')
     random_tables = RandomTables(request.node.name, manager, unique_name(), 3)

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -60,10 +60,10 @@ async def test_putget_2dc_with_rf(
     table_name = "test_table_name"
     columns = [Column("name", TextType), Column("value", TextType)]
     logger.info("Create two servers in different DC's")
-    for i in nodes_list:
+    for i, dc_idx in enumerate(nodes_list):
         s_info = await manager.server_add(
             config=CONFIG,
-            property_file={"dc": f"dc{i}", "rack": "myrack"},
+            property_file={"dc": f"dc{dc_idx}", "rack": f"myrack{i}"},
         )
         logger.info(s_info)
     conn = manager.get_cql()

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -309,14 +309,16 @@ def testKeyspace(cql):
     execute(cql, n, "DROP KEYSPACE %s")
 
 #  Test {@link ConfigurationException} is thrown on create keyspace with invalid DC option in replication configuration .
-def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
+def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc, has_tablets):
+    extra_opts = "AND TABLETS = {'enabled': false}" if has_tablets else ""
+
     n = unique_name()
-    assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
-    execute(cql, n, "CREATE KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }")
+    assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }" + extra_opts)
+    execute(cql, n, "CREATE KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }" + extra_opts)
     execute(cql, n, "DROP KEYSPACE IF EXISTS %s")
 
     # Mix valid and invalid, should throw an exception
-    assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
+    assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}" + extra_opts)
     execute(cql, n, "DROP KEYSPACE IF EXISTS %s")
 
 # Test {@link ConfigurationException} is not thrown on create NetworkTopologyStrategy keyspace without any options.

--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -2,6 +2,8 @@ type: Python
 pool_size: 4
 dirties_cluster:
   - test_native_transport
+extra_scylla_config_options:
+  rf_rack_valid_keyspaces: True
 extra_scylla_cmdline_options:
   - '--experimental-features=udf'
   - '--experimental-features=keyspace-storage-options'

--- a/test/cqlpy/test_guardrail_replication_strategy.py
+++ b/test/cqlpy/test_guardrail_replication_strategy.py
@@ -38,7 +38,7 @@ def test_given_default_config_when_creating_ks_should_only_produce_warning_for_s
 
     for key, value in {'NetworkTopologyStrategy': this_dc, 'EverywhereStrategy': 'replication_factor',
                        'LocalStrategy': 'replication_factor'}.items():
-        create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+        create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                  unexpected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -49,7 +49,7 @@ def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_er
 
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      unexpected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -59,7 +59,7 @@ def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed
                                                                 'SimpleStrategy,LocalStrategy,NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      expected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -74,7 +74,7 @@ def test_given_non_empty_warn_and_fail_lists_when_creating_ks_should_fail_query_
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             # note: even though warn list is not empty, no warnings should be generated, because failures come first -
             #  we don't want to issue a warning and also fail the query at the same time
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      warnings_count=0, fails_count=1)
 
 

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -30,7 +30,7 @@ def test_create_keyspace_if_not_exists(cql, this_dc):
     cql.execute("CREATE KEYSPACE IF NOT EXISTS test_create_keyspace_if_not_exists WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
     # It doesn't matter if the second invocation has different parameters,
     # they are ignored.
-    cql.execute("CREATE KEYSPACE IF NOT EXISTS test_create_keyspace_if_not_exists WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }")
+    cql.execute("CREATE KEYSPACE IF NOT EXISTS test_create_keyspace_if_not_exists WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor': 2}")
     cql.execute("DROP KEYSPACE test_create_keyspace_if_not_exists")
 
 # The "WITH REPLICATION" part of CREATE KEYSPACE may not be omitted - trying
@@ -101,11 +101,11 @@ def test_create_keyspace_double_with(cql):
 def test_create_keyspace_with_case_sensitive_replication_factor_tag(cql):
     ks = unique_name()
     # lowercase 'replication_factor' should be accepted
-    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 3 }"):
+    with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }"):
         pass
     # 'replication_factor' in any other case than the lowercase should be rejected
     with pytest.raises(ConfigurationException):
-        cql.execute(f"CREATE KEYSPACE {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'Replication_factor' : 3 }}")
+        cql.execute(f"CREATE KEYSPACE {ks} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'Replication_factor' : 1 }}")
 
 # Test trying a non-existent keyspace - with or without the IF EXISTS flag.
 # This test demonstrates a change of the exception produced between Cassandra 4.0
@@ -122,7 +122,7 @@ def test_drop_keyspace_nonexistent(cql):
 # Test trying to ALTER a keyspace.
 def test_alter_keyspace(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
-        cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 2 }} AND DURABLE_WRITES = false")
+        cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 0 }} AND DURABLE_WRITES = false")
 
 # Test trying to ALTER RF of tablets-enabled KS by more than 1 at a time
 def test_alter_keyspace_rf_by_more_than_1(cql, this_dc):

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1047,6 +1047,14 @@ private:
                 throw;
             }
 
+            if (cfg->rf_rack_valid_keyspaces()) {
+                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                _db.invoke_on(0, [&tm = _token_metadata] (const replica::database& local_db) {
+                    return local_db.check_rf_rack_validity(tm.local().get()->get_topology());
+                }).get();
+                startlog.info("All keyspaces are RF-rack-valid");
+            }
+
             utils::loading_cache_config perm_cache_config;
             perm_cache_config.max_size = cfg->permissions_cache_max_entries();
             perm_cache_config.expiry = std::chrono::milliseconds(cfg->permissions_validity_in_ms());

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -107,6 +107,8 @@ cql_test_config::cql_test_config(shared_ptr<db::config> cfg)
 
     db_config->flush_schema_tables_after_modification.set(false);
     db_config->commitlog_use_o_dsync(false);
+
+    db_config->rf_rack_valid_keyspaces.set(true);
 }
 
 cql_test_config::cql_test_config(const cql_test_config&) = default;

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -51,7 +51,11 @@ async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fas
         config = {}
     if disable_flush_cache_time:
         config.update({'repair_hints_batchlog_flush_cache_time_in_ms': 0})
-    servers = [await manager.server_add(config=config), await manager.server_add(config=config), await manager.server_add(config=config)]
+    servers = [
+        await manager.server_add(config=config, property_file={"dc": "dc1", "rack": f"r{0 % rf}"}),
+        await manager.server_add(config=config, property_file={"dc": "dc1", "rack": f"r{1 % rf}"}),
+        await manager.server_add(config=config, property_file={"dc": "dc1", "rack": f"r{2 % rf}"})
+    ]
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))


### PR DESCRIPTION
Draft for illustration of the progress. Rebased on top of some version of scylladb/scylladb#23138.