### PR TITLE
treewide: use angle brackets for including seastar headers

### DIFF
--- a/api/service_levels.cc
+++ b/api/service_levels.cc
@@ -11,7 +11,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "db/consistency_level_type.hh"
-#include "seastar/json/json_elements.hh"
+#include <seastar/json/json_elements.hh>
 #include "transport/controller.hh"
 #include <unordered_map>
 

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -8,7 +8,7 @@
 
 #include "gms/generation-number.hh"
 #include "gms/inet_address.hh"
-#include "seastar/core/shard_id.hh"
+#include <seastar/core/shard_id.hh>
 #include "utils/assert.hh"
 #include <fmt/ranges.h>
 #include <seastar/core/coroutine.hh>

--- a/test/boost/advanced_rpc_compressor_test.cc
+++ b/test/boost/advanced_rpc_compressor_test.cc
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include "seastar/core/manual_clock.hh"
-#include "seastar/util/closeable.hh"
+#include <seastar/core/manual_clock.hh>
+#include <seastar/util/closeable.hh>
 #include "test/lib/random_utils.hh"
 #include "test/lib/scylla_test_case.hh"
 #include "utils/advanced_rpc_compressor.hh"

--- a/test/boost/pluggable_test.cc
+++ b/test/boost/pluggable_test.cc
@@ -10,8 +10,8 @@
 #include <seastar/testing/test_case.hh>
 #include <stdexcept>
 
-#include "seastar/core/on_internal_error.hh"
-#include "seastar/core/shared_ptr.hh"
+#include <seastar/core/on_internal_error.hh>
+#include <seastar/core/shared_ptr.hh>
 #include "utils/pluggable.hh"
 
 BOOST_AUTO_TEST_SUITE(pluggable_test)

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -10,7 +10,7 @@
 
 #include "cql3/statements/batch_statement.hh"
 #include "cql3/statements/modification_statement.hh"
-#include "seastar/core/scheduling.hh"
+#include <seastar/core/scheduling.hh>
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -10,7 +10,7 @@
 
 #include "auth/service.hh"
 #include <seastar/core/seastar.hh>
-#include "seastar/core/scheduling.hh"
+#include <seastar/core/scheduling.hh>
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/migration_listener.hh"
 #include "auth/authenticator.hh"

--- a/utils/advanced_rpc_compressor.cc
+++ b/utils/advanced_rpc_compressor.cc
@@ -14,7 +14,7 @@
 #include "utils/advanced_rpc_compressor_protocol.hh"
 #include "stream_compressor.hh"
 #include "utils/dict_trainer.hh"
-#include "seastar/core/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
 
 namespace utils {
 


### PR DESCRIPTION
Seastar is an external library, so we use angle brackets to include its interfaces.

Cosmetic, no backport needed.