### PR TITLE
docs: update issues label

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -172,7 +172,7 @@ html_theme_options = {
     "hide_feedback_buttons": 'false',
     "github_issues_repository": "scylladb/scylladb",
     "github_repository": "scylladb/scylladb",
-    "github_label": "type/documentation",
+    "github_label": "documentation",
     "versions_unstable": UNSTABLE_VERSIONS,
     "versions_deprecated": DEPRECATED_VERSIONS,
     'banner_button_text': 'Register for Free',


### PR DESCRIPTION
Reported in https://github.com/scylladb/scylladb/issues/23132

Updates the default label when opening an issue from the docs from "type/documentation" to "documentation".