### PR TITLE
Allow abort during join_cluster

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -171,8 +171,8 @@ public:
         _broadcasts_to_abort_sources_done.get();
         _abort_sources.stop().get();
     }
-    void ready() {
-        _ready = true;
+    void ready(bool state = true) {
+        _ready = state;
         check();
     }
     void check() {
@@ -2111,9 +2111,13 @@ sharded<locator::shared_token_metadata> token_metadata;
             }).get();
 
             checkpoint(stop_signal, "join cluster");
+            // Allow abort during join_cluster since bootstrap or replace
+            // can take a long time.
+            stop_signal.ready(true);
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();
+            stop_signal.ready(false);
 
             dictionary_service dict_service(
                 dict_sampler,

--- a/main.cc
+++ b/main.cc
@@ -2110,6 +2110,7 @@ sharded<locator::shared_token_metadata> token_metadata;
                     });
             }).get();
 
+            checkpoint(stop_signal, "join cluster");
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return ss.local().join_cluster(proxy, service::start_hint_manager::yes, generation_number);
             }).get();

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1480,6 +1480,11 @@ raft::server* storage_service::get_group_server_if_raft_topolgy_enabled() {
     return raft_topology_change_enabled() ? &_group0->group0_server() : nullptr;
 }
 
+future<> storage_service::start_sys_dist_ks() const {
+    slogger.info("starting system distributed keyspace shards");
+    return _sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
+}
+
 future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
         std::unordered_set<gms::inet_address> initial_contact_nodes,
         std::unordered_map<locator::host_id, gms::loaded_endpoint_state> loaded_endpoints,
@@ -1795,8 +1800,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
 
         // Need to start system_distributed_keyspace before bootstrap because bootstrapping
         // process may access those tables.
-        supervisor::notify("starting system distributed keyspace");
-        co_await _sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
+        co_await start_sys_dist_ks();
 
         if (_sys_ks.local().bootstrap_complete()) {
             if (_topology_state_machine._topology.left_nodes.contains(raft_server->id())) {
@@ -1918,13 +1922,12 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
             slogger.info("Replacing a node with token(s): {}", bootstrap_tokens);
             // bootstrap_tokens was previously set using tokens gossiped by the replaced node
         }
-        co_await _sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
+        co_await start_sys_dist_ks();
         co_await _view_builder.local().mark_existing_views_as_built();
         co_await _sys_ks.local().update_tokens(bootstrap_tokens);
         co_await bootstrap(bootstrap_tokens, cdc_gen_id, ri);
     } else {
-        supervisor::notify("starting system distributed keyspace");
-        co_await _sys_dist_ks.invoke_on_all(&db::system_distributed_keyspace::start);
+        co_await start_sys_dist_ks();
         bootstrap_tokens = co_await _sys_ks.local().get_saved_tokens();
         if (bootstrap_tokens.empty()) {
             bootstrap_tokens = boot_strapper::get_bootstrap_tokens(get_token_metadata_ptr(), _db.local().get_config(), dht::check_token_endpoint::no);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -414,6 +414,7 @@ private:
     bool is_replacing();
     bool is_first_node();
     raft::server* get_group_server_if_raft_topolgy_enabled();
+    future<> start_sys_dist_ks() const;
     future<> join_topology(sharded<service::storage_proxy>& proxy,
             std::unordered_set<gms::inet_address> initial_contact_nodes,
             std::unordered_map<locator::host_id, gms::loaded_endpoint_state> loaded_endpoints,


### PR DESCRIPTION
Bootstrap or replace can take a long time, but
since feef7d3fa13e69f6eb2b8f612a8d409a3d416bb4,
the stop_signal is checked only in checkpoints,
and in particular, abort isn't requested during
join_cluster.

Fixes #23222

* requires backport on top of https://github.com/scylladb/scylladb/pull/23184