### PR TITLE
test/cqlpy,alternator: fix reporting of Scylla crash during test

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -185,6 +185,8 @@ def dynamodbstreams(request):
 @pytest.fixture(scope="function", autouse=True)
 def dynamodb_test_connection(dynamodb, request, optional_rest_api):
     scylla_log(optional_rest_api, f'test/alternator: Starting {request.node.parent.name}::{request.node.name}', 'info')
+    if dynamodb_test_connection.scylla_crashed:
+        pytest.skip('Server down')
     yield
     try:
         # We want to run a do-nothing DynamoDB command. The health-check
@@ -193,9 +195,11 @@ def dynamodb_test_connection(dynamodb, request, optional_rest_api):
         response = requests.get(url, verify=False)
         assert response.ok
     except:
-        pytest.exit(f"Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}")
+        dynamodb_test_connection.scylla_crashed = True
+        pytest.fail(f'Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}')
     scylla_log(optional_rest_api, f'test/alternator: Ended {request.node.parent.name}::{request.node.name}', 'info')
 
+dynamodb_test_connection.scylla_crashed = False
 
 # "test_table" fixture: Create and return a temporary table to be used in tests
 # that need a table to work on. The table is automatically deleted at the end.

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -79,13 +79,18 @@ def cql(request):
 # crashed Scylla and stop running any more tests.
 @pytest.fixture(scope="function", autouse=True)
 def cql_test_connection(cql, request):
+    if cql_test_connection.scylla_crashed:
+        pytest.skip('Server down')
     yield
     try:
         # We want to run a do-nothing CQL command. 
         # "BEGIN BATCH APPLY BATCH" is the closest to do-nothing I could find...
         cql.execute("BEGIN BATCH APPLY BATCH")
     except:
-        pytest.exit(f"Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}")
+        cql_test_connection.scylla_crashed = True
+        pytest.fail(f'Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}')
+
+cql_test_connection.scylla_crashed = False
 
 # Until Cassandra 4, NetworkTopologyStrategy did not support the option
 # replication_factor (https://issues.apache.org/jira/browse/CASSANDRA-14303).


### PR DESCRIPTION
The cqlpy and alternator test frameworks use a single Scylla node started once for all tests to run on. In the distant past, we had a problem where if one test caused Scylla to crash, the result was a confusing report of hundreds of failed tests - all tests after the crash "failed" and it wasn't easy to find which test really caused the crash.

Our old solution to this problem was to have an autouse fixture (called cql_test_connection or dynamodb_test_connection) which tested the connection at the end of each test, and if it detected Scylla has crashed - it used pytest.exit() to report the error and have pytest exit and therefore stop running any further tests (which would have led to all of them testing).

This approach had two problems:

1. The pytest.exit() caused the entire cqlpy suite to report a failure, but but not the individual test - the individual test might have failed as well, but that isn't guaranteed and in any case this test's output is missing the informative message that Scylla crashed during the test. This was fine when for each cqlpy failure we had two separate error logs in Jenkins - the specific failed function, and the failed file - but when we recently got rid of the suplication by removing the second one, we no longer see the "Scylla crashed" messages any more.

2. Exiting pytest will be the wrong thing to do if the same pytest run could run tests from different test suites. We don't do this today, but we plan to support this approach soon.

This patch fixes both problems by replacing the pytest.exit() call by setting a "scylla_crashed" flag and using pytest.fail(). The pytest.fail() causes the current test - the one which caused Scylla to crash - to be reported as an "ERROR" and the "Scylla crashed" message will correctly appear in this test's log. The flag will cause all other tests in the same test suite to be skip()ed. But other tests in other directories, depending on different fixtures, might continue to run normally.

Fixes #23287