### PR TITLE
github: error if we see #include "seastar/..."

### DIFF
--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -12,6 +12,7 @@ env:
   # the "idl" subdirectory does not contain C++ source code. the .hh files in it are
   # supposed to be processed by idl-compiler.py, so we don't check them using the cleaner
   CLEANER_DIRS: test/unit exceptions alternator api auth cdc compaction db dht gms index lang message mutation mutation_writer node_ops redis replica
+  SEASTAR_BAD_INCLUDE_OUTPUT_PATH: build/seastar-bad-include.log
 
 permissions: {}
 
@@ -80,7 +81,16 @@ jobs:
           done
       - run: |
           echo "::remove-matcher owner=clang-include-cleaner::"
+      - run: |
+          if git -c safe.directory="$PWD" grep -E '#include +"seastar/' > "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH"; then
+            echo "ERROR: Found #include \"seastar/ in the source code. Use angle brackets instead."
+            exit 1
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: Logs (clang-include-cleaner)
           path: "./${{ env.CLEANER_OUTPUT_PATH }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Logs (seastar-bad-include)
+          path: "./${{ env.SEASTAR_BAD_INCLUDE_OUTPUT_PATH }}"


### PR DESCRIPTION
Seastar is a system library from ScyllaDB's persepective and so should use angle brackets for #include statements.

Enhancement (?) to CI, so no backport needed.