### PR TITLE
github: improve seastar bad include check

### DIFF
--- a/.github/seastar-bad-include.json
+++ b/.github/seastar-bad-include.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "seastar-bad-include",
+            "severity": "error",
+            "pattern": [
+                {
+                    "regexp": "^(.+):(\\d+):(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/iwyu.yaml
+++ b/.github/workflows/iwyu.yaml
@@ -82,15 +82,23 @@ jobs:
       - run: |
           echo "::remove-matcher owner=clang-include-cleaner::"
       - run: |
-          if git -c safe.directory="$PWD" grep -E '#include +"seastar/' > "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH"; then
-            echo "ERROR: Found #include \"seastar/ in the source code. Use angle brackets instead."
+          echo "::add-matcher::.github/seastar-bad-include.json"
+      - name: check for seastar includes
+        run: |
+          git -c safe.directory="$PWD"    \
+            grep -nE '#include +"seastar/' \
+            | tee "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH"
+      - run: |
+          echo "::remove-matcher owner=seastar-bad-include::"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Logs
+          path: |
+            ${{ env.CLEANER_OUTPUT_PATH }}
+            ${{ env.SEASTAR_BAD_INCLUDE_OUTPUT_PATH }}
+      - name: fail if seastar headers are included as an internal library
+        run: |
+          if [ -s "$SEASTAR_BAD_INCLUDE_OUTPUT_PATH" ]; then
+            echo "::error::Found #include \"seastar/ in the source code. Use angle brackets instead."
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
-        with:
-          name: Logs (clang-include-cleaner)
-          path: "./${{ env.CLEANER_OUTPUT_PATH }}"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: Logs (seastar-bad-include)
-          path: "./${{ env.SEASTAR_BAD_INCLUDE_OUTPUT_PATH }}"


### PR DESCRIPTION
for better developer experience:

- add inline annotations using problem matchers, see https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md
- use a single step for uploading both output files, because the `path`  setting is actually passed to [@actions/glob](https://github.com/actions/toolkit/tree/main/packages/glob), i removed the double quotes and the leading "./"  from the paths.
- use "::error" workflow command to signify the failure, see
  https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#example-creating-an-annotation-for-an-error

---

it's an improvement in the CI, so no need to backport.