### PR TITLE
transport: Remove connection::make_client_key()

### DIFF
--- a/transport/server.cc
+++ b/transport/server.cc
@@ -630,14 +630,10 @@ void cql_server::connection::on_connection_close()
     _server._notifier->unregister_connection(this);
 }
 
-std::pair<net::inet_address, int> cql_server::connection::make_client_key(const service::client_state& cli_state) {
-    return {cli_state.get_client_address().addr(),
-            cli_state.get_client_port()};
-}
-
 client_data cql_server::connection::make_client_data() const {
     client_data cd;
-    std::tie(cd.ip, cd.port) = make_client_key(_client_state);
+    cd.ip = _client_state.get_client_address().addr();
+    cd.port = _client_state.get_client_port();
     cd.shard_id = this_shard_id();
     cd.protocol_version = _version;
     cd.driver_name = _client_state.get_driver_name();

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -250,7 +250,6 @@ private:
         future<> process_request() override;
         void handle_error(future<>&& f) override;
         void on_connection_close() override;
-        static std::pair<net::inet_address, int> make_client_key(const service::client_state& cli_state);
         client_data make_client_data() const;
         const service::client_state& get_client_state() const { return _client_state; }
         void update_scheduling_group();


### PR DESCRIPTION
It's effectively unused, there's one place where connection initializes the client_data object using this helper, but that initialization looks better without it.
