### PR TITLE
sstable_directory: Move highest_generation_seen() to distributed_load…

### DIFF
--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -111,6 +111,16 @@ highest_version_seen(sharded<sstables::sstable_directory>& dir, sstables::sstabl
     });
 }
 
+future<sstables::generation_type>
+highest_generation_seen(sharded<sstables::sstable_directory>& directory) {
+    co_return co_await directory.map_reduce0(
+        std::mem_fn(&sstables::sstable_directory::highest_generation_seen),
+        sstables::generation_type{},
+        [] (sstables::generation_type a, sstables::generation_type b) {
+            return std::max(a, b);
+        });
+}
+
 future<>
 distributed_loader::reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstables::reshape_mode mode,
         sstring ks_name, sstring table_name, sstables::compaction_sstable_creator_fn creator,

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -94,4 +94,6 @@ public:
     static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name);
 };
 
+future<sstables::generation_type> highest_generation_seen(sharded<sstables::sstable_directory>& directory);
+
 }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -760,14 +760,4 @@ future<> sstable_directory::filesystem_components_lister::handle_sstables_pendin
     co_await when_all_succeed(futures.begin(), futures.end()).discard_result();
 }
 
-future<sstables::generation_type>
-highest_generation_seen(sharded<sstables::sstable_directory>& directory) {
-    co_return co_await directory.map_reduce0(
-        std::mem_fn(&sstables::sstable_directory::highest_generation_seen),
-        sstables::generation_type{},
-        [] (sstables::generation_type a, sstables::generation_type b) {
-            return std::max(a, b);
-        });
-}
-
 }

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -313,6 +313,4 @@ public:
     sstable_state state() const noexcept { return _state; }
 };
 
-future<sstables::generation_type> highest_generation_seen(sharded<sstables::sstable_directory>& directory);
-
 }

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -177,7 +177,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
 
         with_sstable_directory(env, [] (sharded<sstables::sstable_directory>& sstdir) {
             distributed_loader_for_tests::process_sstable_dir(sstdir, {}).get();
-            auto max_generation_seen = highest_generation_seen(sstdir).get();
+            auto max_generation_seen = replica::highest_generation_seen(sstdir).get();
             // No generation found on empty directory.
             BOOST_REQUIRE(!max_generation_seen);
         });
@@ -528,7 +528,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly) {
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get();
+        auto max_generation_seen = replica::highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -579,7 +579,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get();
+        auto max_generation_seen = replica::highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -632,7 +632,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_distributes_well_eve
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get();
+        auto max_generation_seen = replica::highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 
@@ -682,7 +682,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_respect_max_threshol
         verify_that_all_sstables_are_local(sstdir, 0).get();
 
         sharded<sstables::sstable_generation_generator> sharded_gen;
-        auto max_generation_seen = highest_generation_seen(sstdir).get();
+        auto max_generation_seen = replica::highest_generation_seen(sstdir).get();
         sharded_gen.start(max_generation_seen.as_int()).get();
         auto stop_generator = deferred_stop(sharded_gen);
 


### PR DESCRIPTION
…er.cc

This method is only used by the loader code (and tests). Also, There's the highest_version_seen() peer that sits in the loader code either.
