### PR TITLE
test.py: Enhance error handling for toxiproxy-cli failures

### DIFF
--- a/test/pylib/cpp/ldap/prepare_instance.py
+++ b/test/pylib/cpp/ldap/prepare_instance.py
@@ -269,7 +269,8 @@ def setup(project_root: Path, port: int, instance_root: Path, byte_limit: int):
     proxy_name = 'p{}'.format(port)
     subprocess.check_output(
         ['toxiproxy-cli', 'c', proxy_name, '--listen', 'localhost:{}'.format(port + 2), '--upstream',
-            'localhost:{}'.format(port)])
+            'localhost:{}'.format(port)],
+        stderr=subprocess.STDOUT)
     subprocess.check_output(['toxiproxy-cli', 't', 'a', proxy_name, '-t', 'limit_data', '-n', 'limiter', '-a',
                              'bytes={}'.format(byte_limit)])
     # Change the data folder in the default config.

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import re
 import shlex
+import subprocess
 import sys
 import time
 import traceback
@@ -419,6 +420,8 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
 
         try:
             cleanup_fn, finject_desc, test_env = await test.setup(ldap_port, options)
+        except subprocess.CalledProcessError as e:
+            report_error("Test setup failed ({}: {})\n{}".format(e, e.stdout))
         except Exception as e:
             report_error("Test setup failed ({})\n{}".format(str(e), traceback.format_exc()))
             return False


### PR DESCRIPTION
Include both stdout and stderr in error messages when `setup()` fails, providing better visibility into root causes. This improvement helps with debugging by capturing complete failure context instead of just the exception.

Refs #23331
Signed-off-by: Kefu Chai <kefu.chai@scylladb.com>

---

this change improves the debuggability of a testing issue, so no need to backport.