### PR TITLE
service: fix misspellings

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -200,7 +200,7 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
         return async([this, ctx] () {
             service_levels_info service_levels;
             // The next statement can throw, but that's fine since we would like the caller
-            // to be able to agreggate those failures and only report when it is critical or noteworthy.
+            // to be able to aggregate those failures and only report when it is critical or noteworthy.
             // one common reason for failure is because one of the nodes comes down and before this node
             // detects it the scan query done inside this call is failing.
             service_levels = _sl_data_accessor->get_service_levels(ctx).get();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6565,9 +6565,9 @@ future<bool> storage_proxy::cas(schema_ptr schema, shared_ptr<cas_request> reque
                 tracing::trace(handler->tr_state, "CAS successful");
                 break;
             } else {
-                paxos::paxos_state::logger.debug("CAS[{}] PAXOS proposal not accepted (pre-empted by a higher ballot)",
+                paxos::paxos_state::logger.debug("CAS[{}] PAXOS proposal not accepted (preempted by a higher ballot)",
                         handler->id());
-                tracing::trace(handler->tr_state, "PAXOS proposal not accepted (pre-empted by a higher ballot)");
+                tracing::trace(handler->tr_state, "PAXOS proposal not accepted (preempted by a higher ballot)");
                 ++contentions;
                 co_await sleep_approx_50ms();
             }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -2315,7 +2315,7 @@ future<> storage_service::handle_state_normal(inet_address endpoint, locator::ho
     std::optional<inet_address> existing;
 
     if (tmptr->get_topology().find_node(host_id)) {
-        // If node is not in the topology there is no existsing address
+        // If node is not in the topology there is no existing address
         // If there are two addresses for the same id the "other" one is existing
         // If there is only one it is existing
         if (ips.size() == 2) {


### PR DESCRIPTION
these misspellings were flagged by codespell.

---

it's a cleanup, hence no need to backport.