### PR TITLE
storage_service: fix tablet split of materialized views

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3243,6 +3243,9 @@ future<> storage_service::replicate_to_all_cores(mutable_token_metadata_ptr tmpt
                     }
                     auto& view = db.find_column_family(view_id);
                     view.update_effective_replication_map(std::move(view_it->second));
+                    if (view.uses_tablets()) {
+                        register_tablet_split_candidate(view_it->first);
+                    }
                     view_erms.erase(view_it);
                 }
                 if (cf.uses_tablets()) {


### PR DESCRIPTION
This fixes an issue where materialized view tablets are not split because they are not registered as split candidates by the storage service.

The code in storage_service::replicate_to_all_cores was changed in 4bfa3060d0a to handle normal tables and view tables separately, but with that change register_tablet_split_candidate is applied only to normal tables and not every table like before. We fix it by registering view tables as well.

We add a test to verify that split of MV tables works.

backport is not needed because MV with tablets is an experimental feature.