### PR TITLE
mv: make base_info in view schemas immutable

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1486,7 +1486,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
             }
         }
         const bool include_all_columns = true;
-        view_builder.with_view_info(*schema, include_all_columns, ""/*where clause*/);
+        view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
     }
 
     // FIXME: the following needs to be in a loop. If mm.announce() below
@@ -1771,7 +1771,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         }
                     }
                     const bool include_all_columns = true;
-                    view_builder.with_view_info(*schema, include_all_columns, ""/*where clause*/);
+                    view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
                     new_views.emplace_back(view_builder.build());
                 } else if (op == "Delete") {
                     elogger.trace("Deleting GSI {}", index_name);

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -284,7 +284,7 @@ void alter_table_statement::drop_column(const query_options& options, const sche
     }
 }
 
-std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_schema_update(data_dictionary::database db, const query_options& options) const {
+std::pair<schema_ptr, std::vector<view_ptr>> alter_table_statement::prepare_schema_update(data_dictionary::database db, const query_options& options) const {
     auto s = validation::validate_column_family(db, keyspace(), column_family());
     if (s->is_view()) {
         throw exceptions::invalid_request_exception("Cannot use ALTER TABLE on Materialized View");
@@ -378,6 +378,9 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
             validate_column_rename(db, *s, *from, *to);
             cfm.rename_column(from->name(), to->name());
         }
+        // New view schemas contain the new column names, so we need to base them on the
+        // new base schema.
+        schema_ptr new_base_schema = cfm.build();
         // If the view includes a renamed column, it must be renamed in
         // the view table and the definition.
         for (auto&& view : cf.views()) {
@@ -398,22 +401,21 @@ std::pair<schema_builder, std::vector<view_ptr>> alter_table_statement::prepare_
                         view->view_info()->where_clause(),
                         view_renames,
                         cql3::dialect{});
-                builder.with_view_info(view->view_info()->base_id(), view->view_info()->base_name(),
-                        view->view_info()->include_all_columns(), std::move(new_where));
+                builder.with_view_info(new_base_schema, view->view_info()->include_all_columns(), std::move(new_where));
                 view_updates.push_back(view_ptr(builder.build()));
             }
         }
-        break;
+        return make_pair(std::move(new_base_schema), std::move(view_updates));
     }
 
-    return make_pair(std::move(cfm), std::move(view_updates));
+    return make_pair(cfm.build(), std::move(view_updates));
 }
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
 alter_table_statement::prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type ts) const {
   data_dictionary::database db = qp.db();
-  auto [cfm, view_updates] = prepare_schema_update(db, options);
-  auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), cfm.build(), std::move(view_updates), ts);
+  auto [s, view_updates] = prepare_schema_update(db, options);
+  auto m = co_await service::prepare_column_family_update_announcement(qp.proxy(), std::move(s), std::move(view_updates), ts);
 
   using namespace cql_transport;
   auto ret = ::make_shared<event::schema_change>(

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -69,7 +69,7 @@ private:
     void add_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void alter_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
     void drop_column(const query_options& options, const schema& schema, data_dictionary::table cf, schema_builder& cfm, std::vector<view_ptr>& view_updates, const column_identifier& column_name, const cql3_type validator, const column_definition* def, bool is_static) const;
-    std::pair<schema_builder, std::vector<view_ptr>> prepare_schema_update(data_dictionary::database db, const query_options& options) const;
+    std::pair<schema_ptr, std::vector<view_ptr>> prepare_schema_update(data_dictionary::database db, const query_options& options) const;
 };
 
 class alter_table_statement::raw_statement : public raw::cf_statement {

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -378,7 +378,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     auto where_clause_text = util::relations_to_where_clause(_where_clause);
-    builder.with_view_info(schema->id(), schema->cf_name(), included.empty(), std::move(where_clause_text));
+    builder.with_view_info(schema, included.empty(), std::move(where_clause_text));
 
     return std::make_pair(view_ptr(builder.build()), std::move(warnings));
 }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -574,19 +574,23 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         // 2. The table was just created - the table is guaranteed to be published with the view in that case.
         // 3. The view itself was altered - in that case we already know the base table so we can take it from
         //    the database object.
-        view_ptr vp = create_view_from_mutations(proxy, std::move(sm));
+        query::result_set rs(sm.columnfamilies_mutation());
+        const query::result_set_row& view_row = rs.row(0);
+        auto ks_name = view_row.get_nonnull<sstring>("keyspace_name");
+        auto base_name = view_row.get_nonnull<sstring>("base_table_name");
+
         schema_ptr base_schema;
         for (auto&& altered : tables_diff.altered) {
             // Chose the appropriate version of the base table schema: old -> old, new -> new.
             schema_ptr s = side == schema_diff_side::left ? altered.old_schema : altered.new_schema;
-            if (s->ks_name() == vp->ks_name() && s->cf_name() == vp->view_info()->base_name() ) {
+            if (s->ks_name() == ks_name && s->cf_name() == base_name) {
                 base_schema = s;
                 break;
             }
         }
         if (!base_schema) {
             for (auto&& s : tables_diff.created) {
-                if (s.get()->ks_name() == vp->ks_name() && s.get()->cf_name() == vp->view_info()->base_name() ) {
+                if (s.get()->ks_name() == ks_name && s.get()->cf_name() == base_name) {
                     base_schema = s;
                     break;
                 }
@@ -594,8 +598,9 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         }
 
         if (!base_schema) {
-            base_schema = proxy.local().local_db().find_schema(vp->ks_name(), vp->view_info()->base_name());
+            base_schema = proxy.local().local_db().find_schema(ks_name, base_name);
         }
+        view_ptr vp = create_view_from_mutations(proxy, std::move(sm), base_schema);
 
         // Now when we have a referenced base - sanity check that we're not registering an old view
         // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -606,7 +606,6 @@ static future<> merge_tables_and_views(distributed<service::storage_proxy>& prox
         // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)
         check_no_legacy_secondary_index_mv_schema(proxy.local().get_db().local(), vp, base_schema);
 
-        vp->view_info()->set_base_info(vp->view_info()->make_base_dependent_view_info(*base_schema));
         return vp;
     });
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2458,14 +2458,8 @@ static index_metadata create_index_from_index_row(const query::result_set_row& r
     return index_metadata{index_name, options, kind, is_local};
 }
 
-/*
- * View metadata serialization/deserialization.
- * If the base schema is not provided, the schema context must have a reference to the database,
- * and the most up-to-date base schema will be pulled from there.
- */
-
-view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm, std::optional<schema_ptr> base_schema, std::optional<table_schema_version> version)  {
-    auto table_rs = query::result_set(sm.columnfamilies_mutation());
+static schema_builder prepare_view_schema_builder_from_mutations(const schema_ctxt& ctxt, const schema_mutations& sm, std::optional<table_schema_version> version,
+                                                                const query::result_set& table_rs) {
     const query::result_set_row& row = table_rs.row(0);
 
     auto ks_name = row.get_nonnull<sstring>("keyspace_name");
@@ -2499,20 +2493,47 @@ view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm
     } else {
         builder.with_version(sm.digest(ctxt.features().cluster_schema_features()));
     }
+    return builder;
+}
 
-    if (!base_schema) {
-        if (!ctxt.get_db()) {
-            on_internal_error(slogger, format("No database reference with missing base schema when creating view {}.{} from mutations",
-                    ks_name, cf_name));
-        }
-        auto base_id = table_id(row.get_nonnull<utils::UUID>("base_table_id"));
-        base_schema = ctxt.get_db()->find_schema(base_id);
-    }
-
+/*
+ * View metadata serialization/deserialization.
+ * If the base info is not provided, the schema context must have a reference to the database,
+ * and the most up-to-date base schema will be pulled from there.
+ */
+view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm, schema_ptr base_schema, std::optional<table_schema_version> version)  {
+    auto table_rs = query::result_set(sm.columnfamilies_mutation());
+    auto builder = prepare_view_schema_builder_from_mutations(ctxt, sm, version, table_rs);
+    const query::result_set_row& row = table_rs.row(0);
     auto include_all_columns = row.get_nonnull<bool>("include_all_columns");
     auto where_clause = row.get_nonnull<sstring>("where_clause");
 
-    builder.with_view_info(*base_schema, include_all_columns, std::move(where_clause));
+    builder.with_view_info(std::move(base_schema), include_all_columns, std::move(where_clause));
+    return view_ptr(builder.build());
+}
+
+view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm, std::optional<db::view::base_dependent_view_info> base_info, std::optional<table_schema_version> version)  {
+    auto table_rs = query::result_set(sm.columnfamilies_mutation());
+    auto builder = prepare_view_schema_builder_from_mutations(ctxt, sm, version, table_rs);
+    const query::result_set_row& row = table_rs.row(0);
+    auto id = table_id(row.get_nonnull<utils::UUID>("base_table_id"));
+    auto base_name = row.get_nonnull<sstring>("base_table_name");
+    auto include_all_columns = row.get_nonnull<bool>("include_all_columns");
+    auto where_clause = row.get_nonnull<sstring>("where_clause");
+
+    if (!base_info) {
+        if (!ctxt.get_db()) {
+            auto ks_name = row.get_nonnull<sstring>("keyspace_name");
+            auto cf_name = row.get_nonnull<sstring>("view_name");
+            on_internal_error(slogger, format("No database reference with missing base schema when creating view {}.{} from mutations",
+                ks_name, cf_name));
+        }
+        auto base_id = table_id(row.get_nonnull<utils::UUID>("base_table_id"));
+        auto base_schema = ctxt.get_db()->find_schema(base_id);
+        builder.with_view_info(base_schema, include_all_columns, std::move(where_clause));
+    } else {
+        builder.with_view_info(id, base_name, include_all_columns, std::move(where_clause), *base_info);
+    }
     return view_ptr(builder.build());
 }
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2460,9 +2460,11 @@ static index_metadata create_index_from_index_row(const query::result_set_row& r
 
 /*
  * View metadata serialization/deserialization.
+ * If the base schema is not provided, the schema context must have a reference to the database,
+ * and the most up-to-date base schema will be pulled from there.
  */
 
-view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm, std::optional<table_schema_version> version)  {
+view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm, std::optional<schema_ptr> base_schema, std::optional<table_schema_version> version)  {
     auto table_rs = query::result_set(sm.columnfamilies_mutation());
     const query::result_set_row& row = table_rs.row(0);
 
@@ -2498,12 +2500,19 @@ view_ptr create_view_from_mutations(const schema_ctxt& ctxt, schema_mutations sm
         builder.with_version(sm.digest(ctxt.features().cluster_schema_features()));
     }
 
-    auto base_id = table_id(row.get_nonnull<utils::UUID>("base_table_id"));
-    auto base_name = row.get_nonnull<sstring>("base_table_name");
+    if (!base_schema) {
+        if (!ctxt.get_db()) {
+            on_internal_error(slogger, format("No database reference with missing base schema when creating view {}.{} from mutations",
+                    ks_name, cf_name));
+        }
+        auto base_id = table_id(row.get_nonnull<utils::UUID>("base_table_id"));
+        base_schema = ctxt.get_db()->find_schema(base_id);
+    }
+
     auto include_all_columns = row.get_nonnull<bool>("include_all_columns");
     auto where_clause = row.get_nonnull<sstring>("where_clause");
 
-    builder.with_view_info(std::move(base_id), std::move(base_name), include_all_columns, std::move(where_clause));
+    builder.with_view_info(*base_schema, include_all_columns, std::move(where_clause));
     return view_ptr(builder.build());
 }
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -287,7 +287,7 @@ std::vector<mutation> make_drop_table_mutations(lw_shared_ptr<keyspace_metadata>
 
 schema_ptr create_table_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
 
-view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
+view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, std::optional<schema_ptr> = {}, std::optional<table_schema_version> version = {});
 
 future<std::vector<view_ptr>> create_views_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result::mapped_type& result);
 

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -17,6 +17,7 @@
 #include "schema_mutations.hh"
 #include "types/map.hh"
 #include "query-result-set.hh"
+#include "db/view/base_info.hh"
 
 #include <seastar/core/distributed.hh>
 
@@ -287,7 +288,8 @@ std::vector<mutation> make_drop_table_mutations(lw_shared_ptr<keyspace_metadata>
 
 schema_ptr create_table_from_mutations(const schema_ctxt&, schema_mutations, std::optional<table_schema_version> version = {});
 
-view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, std::optional<schema_ptr> = {}, std::optional<table_schema_version> version = {});
+view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, schema_ptr, std::optional<table_schema_version> version = {});
+view_ptr create_view_from_mutations(const schema_ctxt&, schema_mutations, std::optional<view::base_dependent_view_info> = {}, std::optional<table_schema_version> version = {});
 
 future<std::vector<view_ptr>> create_views_from_schema_partition(distributed<service::storage_proxy>& proxy, const schema_result::mapped_type& result);
 

--- a/db/view/base_info.hh
+++ b/db/view/base_info.hh
@@ -16,20 +16,8 @@ namespace db {
 
 namespace view {
 
-// Part of the view description which depends on the base schema version.
-//
-// This structure may change even though the view schema doesn't change, so
-// it needs to live outside view_ptr.
+// Part of the view description which depends on the base schema.
 struct base_dependent_view_info {
-private:
-    schema_ptr _base_schema;
-    // For tracing purposes, if the view is out of sync with its base table
-    // and there exists a column which is not in base, its name is stored
-    // and added to debug messages.
-    std::optional<bytes> _column_missing_in_base = {};
-public:
-    const schema_ptr& base_schema() const;
-
     bool has_computed_column_depending_on_base_non_primary_key;
 
     // True if the partition key columns of the view are the same as the
@@ -42,21 +30,11 @@ public:
     // succeeding to reliably build the former.
     bool has_base_non_pk_columns_in_view_pk;
 
-    // If base_non_pk_columns_in_view_pk couldn't reliably be built, this base
-    // info can't be used for computing view updates, only for reading the materialized
-    // view.
-    bool use_only_for_reads;
 
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
-    base_dependent_view_info(schema_ptr base_schema,
-            bool has_computed_column_depending_on_base_non_primary_key,
-            bool is_partition_key_permutation_of_base_partition_key,
-            bool has_base_non_pk_columns_in_view_pk);
-    // A constructor for a base info that can facilitate only reads from the materialized view.
     base_dependent_view_info(bool has_computed_column_depending_on_base_non_primary_key,
             bool is_partition_key_permutation_of_base_partition_key,
-            bool has_base_non_pk_columns_in_view_pk,
-            std::optional<bytes>&& column_missing_in_base);
+            bool has_base_non_pk_columns_in_view_pk);
 };
 
 // Immutable snapshot of view's base-schema-dependent part.

--- a/db/view/base_info.hh
+++ b/db/view/base_info.hh
@@ -30,22 +30,22 @@ private:
 public:
     const schema_ptr& base_schema() const;
 
-    const bool has_computed_column_depending_on_base_non_primary_key;
+    bool has_computed_column_depending_on_base_non_primary_key;
 
     // True if the partition key columns of the view are the same as the
     // partition key columns of the base, maybe in a different order.
-    const bool is_partition_key_permutation_of_base_partition_key;
+    bool is_partition_key_permutation_of_base_partition_key;
 
     // Indicates if the view hase pk columns which are not part of the base
     // pk, it seems that !base_non_pk_columns_in_view_pk.empty() is the same,
     // but actually there are cases where we can compute this boolean without
     // succeeding to reliably build the former.
-    const bool has_base_non_pk_columns_in_view_pk;
+    bool has_base_non_pk_columns_in_view_pk;
 
     // If base_non_pk_columns_in_view_pk couldn't reliably be built, this base
     // info can't be used for computing view updates, only for reading the materialized
     // view.
-    const bool use_only_for_reads;
+    bool use_only_for_reads;
 
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
     base_dependent_view_info(schema_ptr base_schema,

--- a/db/view/base_info.hh
+++ b/db/view/base_info.hh
@@ -37,9 +37,6 @@ struct base_dependent_view_info {
             bool has_base_non_pk_columns_in_view_pk);
 };
 
-// Immutable snapshot of view's base-schema-dependent part.
-using base_info_ptr = lw_shared_ptr<const base_dependent_view_info>;
-
 }
 
 }

--- a/db/view/base_info.hh
+++ b/db/view/base_info.hh
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <optional>
+#include "bytes_fwd.hh"
+#include "schema/schema_fwd.hh"
+
+namespace db {
+
+namespace view {
+
+// Part of the view description which depends on the base schema version.
+//
+// This structure may change even though the view schema doesn't change, so
+// it needs to live outside view_ptr.
+struct base_dependent_view_info {
+private:
+    schema_ptr _base_schema;
+    // For tracing purposes, if the view is out of sync with its base table
+    // and there exists a column which is not in base, its name is stored
+    // and added to debug messages.
+    std::optional<bytes> _column_missing_in_base = {};
+public:
+    const schema_ptr& base_schema() const;
+
+    const bool has_computed_column_depending_on_base_non_primary_key;
+
+    // True if the partition key columns of the view are the same as the
+    // partition key columns of the base, maybe in a different order.
+    const bool is_partition_key_permutation_of_base_partition_key;
+
+    // Indicates if the view hase pk columns which are not part of the base
+    // pk, it seems that !base_non_pk_columns_in_view_pk.empty() is the same,
+    // but actually there are cases where we can compute this boolean without
+    // succeeding to reliably build the former.
+    const bool has_base_non_pk_columns_in_view_pk;
+
+    // If base_non_pk_columns_in_view_pk couldn't reliably be built, this base
+    // info can't be used for computing view updates, only for reading the materialized
+    // view.
+    const bool use_only_for_reads;
+
+    // A constructor for a base info that can facilitate reads and writes from the materialized view.
+    base_dependent_view_info(schema_ptr base_schema,
+            bool has_computed_column_depending_on_base_non_primary_key,
+            bool is_partition_key_permutation_of_base_partition_key,
+            bool has_base_non_pk_columns_in_view_pk);
+    // A constructor for a base info that can facilitate only reads from the materialized view.
+    base_dependent_view_info(bool has_computed_column_depending_on_base_non_primary_key,
+            bool is_partition_key_permutation_of_base_partition_key,
+            bool has_base_non_pk_columns_in_view_pk,
+            std::optional<bytes>&& column_missing_in_base);
+};
+
+// Immutable snapshot of view's base-schema-dependent part.
+using base_info_ptr = lw_shared_ptr<const base_dependent_view_info>;
+
+}
+
+}

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -79,9 +79,10 @@ static inline void inject_failure(std::string_view operation) {
             [operation] { throw std::runtime_error(std::string(operation)); });
 }
 
-view_info::view_info(const schema& schema, const raw_view_info& raw_view_info)
+view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema)
         : _schema(schema)
         , _raw(raw_view_info)
+        , _base_info(make_base_dependent_view_info(*base_schema))
         , _has_computed_column_depending_on_base_non_primary_key(false)
 { }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -85,6 +85,12 @@ view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, s
         , _base_info(make_base_dependent_view_info(*base_schema))
 { }
 
+view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, db::view::base_dependent_view_info base_info)
+        : _schema(schema)
+        , _raw(raw_view_info)
+        , _base_info(make_lw_shared<const db::view::base_dependent_view_info>(base_info))
+{ }
+
 cql3::statements::select_statement& view_info::select_statement(data_dictionary::database db) const {
     if (!_select_statement) {
         std::unique_ptr<cql3::statements::raw::select_statement> raw;

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -139,8 +139,7 @@ const column_definition* view_info::view_column(const column_definition& base_de
     return _schema.get_column_definition(base_def.name());
 }
 
-void view_info::set_base_info(db::view::base_info_ptr base_info) {
-    _base_info = std::move(base_info);
+void view_info::reset_view_info() {
     // Forget the cached objects which may refer to the base schema.
     _select_statement = nullptr;
     _partition_slice = std::nullopt;

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -23,6 +23,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
+#include "db/view/base_info.hh"
 #include "replica/database.hh"
 #include "clustering_bounds_comparator.hh"
 #include "cql3/statements/select_statement.hh"
@@ -88,7 +89,7 @@ view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, s
 view_info::view_info(const schema& schema, const raw_view_info& raw_view_info, db::view::base_dependent_view_info base_info)
         : _schema(schema)
         , _raw(raw_view_info)
-        , _base_info(make_lw_shared<const db::view::base_dependent_view_info>(base_info))
+        , _base_info(std::move(base_info))
 { }
 
 cql3::statements::select_statement& view_info::select_statement(data_dictionary::database db) const {
@@ -154,7 +155,7 @@ db::view::base_dependent_view_info::base_dependent_view_info(bool has_computed_c
         , has_base_non_pk_columns_in_view_pk{has_base_non_pk_columns_in_view_pk}
 { }
 
-db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& base) const {
+db::view::base_dependent_view_info view_info::make_base_dependent_view_info(const schema& base) const {
     bool is_partition_key_permutation_of_base_partition_key =
         std::ranges::all_of(_schema.partition_key_columns(), [&base] (const column_definition& view_col) {
             const column_definition* base_col = base.get_column_definition(view_col.name());
@@ -182,35 +183,20 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
             has_base_non_pk_columns_in_view_pk = true;
         }
     }
-    return make_lw_shared<db::view::base_dependent_view_info>(has_computed_column_depending_on_base_non_primary_key,
+    return db::view::base_dependent_view_info(has_computed_column_depending_on_base_non_primary_key,
         is_partition_key_permutation_of_base_partition_key, has_base_non_pk_columns_in_view_pk);
 }
 
 bool view_info::has_base_non_pk_columns_in_view_pk() const {
-    // The base info is not always available, this is because
-    // the base info initialization is separate from the view
-    // info construction. If we are trying to get this info without
-    // initializing the base information it means that we have a
-    // schema integrity problem as the creator of owning view schema
-    // didn't make sure to initialize it with base information.
-    if (!_base_info) {
-        on_internal_error(vlogger, "Tried to perform a view query which is base info dependent without initializing it");
-    }
-    return _base_info->has_base_non_pk_columns_in_view_pk;
+    return _base_info.has_base_non_pk_columns_in_view_pk;
 }
 
 bool view_info::has_computed_column_depending_on_base_non_primary_key() const {
-    if (!_base_info) {
-        on_internal_error(vlogger, "Tried to perform a view query which is base info dependent without initializing it");
-    }
-    return _base_info->has_computed_column_depending_on_base_non_primary_key;
+    return _base_info.has_computed_column_depending_on_base_non_primary_key;
 }
 
 bool view_info::is_partition_key_permutation_of_base_partition_key() const {
-    if (!_base_info) {
-        on_internal_error(vlogger, "Tried to perform a view query which is base info dependent without initializing it");
-    }
-    return _base_info->is_partition_key_permutation_of_base_partition_key;
+    return _base_info.is_partition_key_permutation_of_base_partition_key;
 }
 
 clustering_row db::view::clustering_or_static_row::as_clustering_row(const schema& s) const {
@@ -960,7 +946,7 @@ bool view_updates::can_skip_view_updates(const clustering_or_static_row& update,
         // as part of its PK, there are NO virtual columns corresponding to the unselected columns in the view.
         // Because of that, we don't generate view updates when the value in an unselected column is created
         // or changes.
-        if (!column_is_selected && _base_info->has_base_non_pk_columns_in_view_pk) {
+        if (!column_is_selected && _base_info.has_base_non_pk_columns_in_view_pk) {
             return true;
         }
 
@@ -1135,7 +1121,7 @@ void view_updates::generate_update(
     // may change the view key and may require deleting an old view row and
     // inserting a new row. The other case, which we'll handle here first,
     // is easier and require just modifying one view row.
-    if (!_base_info->has_base_non_pk_columns_in_view_pk &&
+    if (!_base_info.has_base_non_pk_columns_in_view_pk &&
         !_view_info.has_computed_column_depending_on_base_non_primary_key()) {
         if (update.is_static_row()) {
             // TODO: support static rows in views with pk only including columns from base pk

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -142,16 +142,13 @@ void view_info::set_base_info(db::view::base_info_ptr base_info) {
 
 // A constructor for a base info that can facilitate reads and writes from the materialized view.
 db::view::base_dependent_view_info::base_dependent_view_info(schema_ptr base_schema,
-        std::vector<column_id>&& base_regular_columns_in_view_pk,
-        std::vector<column_id>&& base_static_columns_in_view_pk,
         bool has_computed_column_depending_on_base_non_primary_key,
-        bool is_partition_key_permutation_of_base_partition_key)
+        bool is_partition_key_permutation_of_base_partition_key,
+        bool has_base_non_pk_columns_in_view_pk)
         : _base_schema{std::move(base_schema)}
-        , _base_regular_columns_in_view_pk{std::move(base_regular_columns_in_view_pk)}
-        , _base_static_columns_in_view_pk{std::move(base_static_columns_in_view_pk)}
         , has_computed_column_depending_on_base_non_primary_key{has_computed_column_depending_on_base_non_primary_key}
         , is_partition_key_permutation_of_base_partition_key{is_partition_key_permutation_of_base_partition_key}
-        , has_base_non_pk_columns_in_view_pk{!_base_regular_columns_in_view_pk.empty() || !_base_static_columns_in_view_pk.empty()}
+        , has_base_non_pk_columns_in_view_pk{has_base_non_pk_columns_in_view_pk}
         , use_only_for_reads{false} {
 
 }
@@ -169,24 +166,6 @@ db::view::base_dependent_view_info::base_dependent_view_info(bool has_computed_c
         , use_only_for_reads{true} {
 }
 
-const std::vector<column_id>& db::view::base_dependent_view_info::base_regular_columns_in_view_pk() const {
-    if (use_only_for_reads) {
-        on_internal_error(vlogger,
-                seastar::format("base_regular_columns_in_view_pk(): operation unsupported when initialized only for view reads. "
-                "Missing column in the base table: {}", to_string_view(_column_missing_in_base.value_or(bytes()))));
-    }
-    return _base_regular_columns_in_view_pk;
-}
-
-const std::vector<column_id>& db::view::base_dependent_view_info::base_static_columns_in_view_pk() const {
-    if (use_only_for_reads) {
-        on_internal_error(vlogger,
-                seastar::format("base_static_columns_in_view_pk(): operation unsupported when initialized only for view reads. "
-                "Missing column in the base table: {}", to_string_view(_column_missing_in_base.value_or(bytes()))));
-    }
-    return _base_static_columns_in_view_pk;
-}
-
 const schema_ptr& db::view::base_dependent_view_info::base_schema() const {
     if (use_only_for_reads) {
         on_internal_error(vlogger,
@@ -197,9 +176,6 @@ const schema_ptr& db::view::base_dependent_view_info::base_schema() const {
 }
 
 db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& base) const {
-    std::vector<column_id> base_regular_columns_in_view_pk;
-    std::vector<column_id> base_static_columns_in_view_pk;
-
     bool is_partition_key_permutation_of_base_partition_key =
         std::ranges::all_of(_schema.partition_key_columns(), [&base] (const column_definition& view_col) {
             const column_definition* base_col = base.get_column_definition(view_col.name());
@@ -208,6 +184,7 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
         && _schema.partition_key_size() == base.partition_key_size();
 
     bool has_computed_column_depending_on_base_non_primary_key = false;
+    bool has_base_non_pk_columns_in_view_pk = false;
     bytes column_missing_in_base = bytes();
     for (auto&& view_col : _schema.primary_key_columns()) {
         if (view_col.is_computed()) {
@@ -220,9 +197,9 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
         const bytes& view_col_name = view_col.name();
         auto* base_col = base.get_column_definition(view_col_name);
         if (base_col && base_col->is_regular()) {
-            base_regular_columns_in_view_pk.push_back(base_col->id);
+            has_base_non_pk_columns_in_view_pk = true;
         } else if (base_col && base_col->is_static()) {
-            base_static_columns_in_view_pk.push_back(base_col->id);
+            has_base_non_pk_columns_in_view_pk = true;
         } else if (!base_col) {
             vlogger.error("Column {} in view {}.{} was not found in the base table {}.{}",
                     to_string_view(view_col_name), _schema.ks_name(), _schema.cf_name(), base.ks_name(), base.cf_name());
@@ -244,8 +221,8 @@ db::view::base_info_ptr view_info::make_base_dependent_view_info(const schema& b
         return make_lw_shared<db::view::base_dependent_view_info>(has_computed_column_depending_on_base_non_primary_key,
             is_partition_key_permutation_of_base_partition_key, true, column_missing_in_base);
     }
-    return make_lw_shared<db::view::base_dependent_view_info>(base.shared_from_this(), std::move(base_regular_columns_in_view_pk), std::move(base_static_columns_in_view_pk),
-        has_computed_column_depending_on_base_non_primary_key, is_partition_key_permutation_of_base_partition_key);
+    return make_lw_shared<db::view::base_dependent_view_info>(base.shared_from_this(), has_computed_column_depending_on_base_non_primary_key,
+        is_partition_key_permutation_of_base_partition_key, has_base_non_pk_columns_in_view_pk);
 }
 
 bool view_info::has_base_non_pk_columns_in_view_pk() const {
@@ -512,6 +489,30 @@ bool matches_view_filter(data_dictionary::database db, const schema& base, const
 
     return clustering_prefix_matches(db, base, view, key, *update.key())
             && visitor.matches_view_filter();
+}
+
+view_updates::view_updates(view_and_base vab)
+    : _view(std::move(vab.view))
+    , _view_info(*_view->view_info())
+    , _base(vab.base->base_schema())
+    , _base_info(vab.base)
+    , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view))
+{
+    for (auto&& view_col : _view->primary_key_columns()) {
+        if (view_col.is_computed()) {
+            continue;
+        }
+        const bytes& view_col_name = view_col.name();
+        auto* base_col = _base->get_column_definition(view_col_name);
+        if (base_col && base_col->is_regular()) {
+            _base_regular_columns_in_view_pk.push_back(base_col->id);
+        } else if (base_col && base_col->is_static()) {
+            _base_static_columns_in_view_pk.push_back(base_col->id);
+        } else if (!base_col) {
+            on_internal_error(vlogger, format("Column {} in view {}.{} was not found in the base table {}.{}",
+                    view_col_name, _view->ks_name(), _view->cf_name(), _base->ks_name(), _base->cf_name()));
+        }
+    }
 }
 
 future<> view_updates::move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations) {
@@ -943,8 +944,8 @@ void view_updates::do_delete_old_entry(const partition_key& base_key, const clus
     const auto kind = existing.column_kind();
     for (const auto& [r, action] : view_rows) {
         const auto& col_ids = existing.is_clustering_row()
-                ? _base_info->base_regular_columns_in_view_pk()
-                : _base_info->base_static_columns_in_view_pk();
+                ? _base_regular_columns_in_view_pk
+                : _base_static_columns_in_view_pk;
         if (!col_ids.empty() || _view_info.has_computed_column_depending_on_base_non_primary_key()) {
             // The view key could have been modified because it contains or
             // depends on a non-primary-key. The fact that this function was

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3170,6 +3170,7 @@ public:
 
     stop_iteration consume_end_of_partition() {
         inject_failure("view_builder_consume_end_of_partition");
+        utils::get_local_injector().inject("view_builder_consume_end_of_partition_delay", utils::wait_for_message(std::chrono::seconds(60))).get();
         flush_fragments();
         return stop_iteration(_step.build_status.empty());
     }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -312,11 +312,11 @@ bool may_be_affected_by(data_dictionary::database db, const schema& base, const 
 }
 
 static bool update_requires_read_before_write(data_dictionary::database db, const schema& base,
-        const std::vector<view_and_base>& views,
+        const std::vector<view_ptr>& views,
         const dht::decorated_key& key,
         const rows_entry& update) {
     for (auto&& v : views) {
-        view_info& vf = *v.view->view_info();
+        view_info& vf = *v->view_info();
         if (may_be_affected_by(db, base, vf, key, update)) {
             return true;
         }
@@ -453,11 +453,11 @@ bool matches_view_filter(data_dictionary::database db, const schema& base, const
             && visitor.matches_view_filter();
 }
 
-view_updates::view_updates(view_and_base vab, schema_ptr base)
-    : _view(std::move(vab.view))
+view_updates::view_updates(view_ptr v, schema_ptr base)
+    : _view(std::move(v))
     , _view_info(*_view->view_info())
     , _base(std::move(base))
-    , _base_info(vab.base)
+    , _base_info(_view_info.base_info())
     , _updates(8, partition_key::hashing(*_view), partition_key::equality(*_view))
 {
     for (auto&& view_col : _view->primary_key_columns()) {
@@ -1665,11 +1665,11 @@ view_update_builder make_view_update_builder(
         data_dictionary::database db,
         const replica::table& base_table,
         const schema_ptr& base,
-        std::vector<view_and_base>&& views_to_update,
+        std::vector<view_ptr>&& views_to_update,
         mutation_reader&& updates,
         mutation_reader_opt&& existings,
         gc_clock::time_point now) {
-    auto vs = views_to_update | std::views::transform([&] (view_and_base v) {
+    auto vs = views_to_update | std::views::transform([&] (view_ptr v) {
         return view_updates(std::move(v), base);
     }) | std::ranges::to<std::vector<view_updates>>();
     return view_update_builder(std::move(db), base_table, base, std::move(vs), std::move(updates), std::move(existings), now);
@@ -1679,7 +1679,7 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(data_d
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
-        const std::vector<view_and_base>& views) {
+        const std::vector<view_ptr>& views) {
     // WARNING: interval<clustering_key_prefix_view> is unsafe - refer to scylladb#22817 and scylladb#21604
     utils::chunked_vector<interval<clustering_key_prefix_view>> row_ranges;
     utils::chunked_vector<interval<clustering_key_prefix_view>> view_row_ranges;
@@ -1687,11 +1687,11 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(data_d
     if (mp.partition_tombstone() || !mp.row_tombstones().empty()) {
         for (auto&& v : views) {
             // FIXME: #2371
-            if (v.view->view_info()->select_statement(db).get_restrictions()->has_unrestricted_clustering_columns()) {
+            if (v->view_info()->select_statement(db).get_restrictions()->has_unrestricted_clustering_columns()) {
                 view_row_ranges.push_back(interval<clustering_key_prefix_view>::make_open_ended_both_sides());
                 break;
             }
-            for (auto&& r : v.view->view_info()->partition_slice(db).default_row_ranges()) {
+            for (auto&& r : v->view_info()->partition_slice(db).default_row_ranges()) {
                 view_row_ranges.push_back(r.transform(std::mem_fn(&clustering_key_prefix::view)));
                 co_await coroutine::maybe_yield();
             }
@@ -1741,7 +1741,7 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(data_d
     co_return result_ranges;
 }
 
-bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views) {
+bool needs_static_row(const mutation_partition& mp, const std::vector<view_ptr>& views) {
     // TODO: We could also check whether any of the views need static rows
     // and return false if none of them do
     return mp.partition_tombstone() || !mp.static_row().empty();
@@ -3168,13 +3168,12 @@ public:
         if (!_fragments.empty()) {
             _fragments.emplace_front(*_step.reader.schema(), _builder._permit, partition_start(_step.current_key, tombstone()));
             auto base_schema = _step.base->schema();
-            auto views = with_base_info_snapshot(_views_to_build);
             auto reader = make_mutation_reader_from_fragments(_step.reader.schema(), _builder._permit, std::move(_fragments));
             auto close_reader = defer([&reader] { reader.close().get(); });
             reader.upgrade_schema(base_schema);
             _gen->populate_views(
                     *_step.base,
-                    std::move(views),
+                    _views_to_build,
                     _step.current_token(),
                     std::move(reader),
                     _now).get();
@@ -3442,12 +3441,6 @@ view_updating_consumer::view_updating_consumer(view_update_generator& gen, schem
         return table->stream_view_replica_updates(gen, std::move(s), std::move(m), db::no_timeout, excluded_sstables);
     })
 { }
-
-std::vector<db::view::view_and_base> with_base_info_snapshot(std::vector<view_ptr> vs) {
-    return vs | std::views::transform([] (const view_ptr& v) {
-        return db::view::view_and_base{v, v->view_info()->base_info()};
-    }) | std::ranges::to<std::vector>();
-}
 
 delete_ghost_rows_visitor::delete_ghost_rows_visitor(service::storage_proxy& proxy, service::query_state& state, view_ptr view, db::timeout_clock::duration timeout_duration)
         : _proxy(proxy)

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -15,6 +15,7 @@
 #include "mutation/frozen_mutation.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "db/view/base_info.hh"
 
 class frozen_mutation_and_schema;
 
@@ -27,52 +28,6 @@ namespace db {
 namespace view {
 
 class stats;
-
-// Part of the view description which depends on the base schema version.
-//
-// This structure may change even though the view schema doesn't change, so
-// it needs to live outside view_ptr.
-struct base_dependent_view_info {
-private:
-    schema_ptr _base_schema;
-    // For tracing purposes, if the view is out of sync with its base table
-    // and there exists a column which is not in base, its name is stored
-    // and added to debug messages.
-    std::optional<bytes> _column_missing_in_base = {};
-public:
-    const schema_ptr& base_schema() const;
-
-    const bool has_computed_column_depending_on_base_non_primary_key;
-
-    // True if the partition key columns of the view are the same as the
-    // partition key columns of the base, maybe in a different order.
-    const bool is_partition_key_permutation_of_base_partition_key;
-
-    // Indicates if the view hase pk columns which are not part of the base
-    // pk, it seems that !base_non_pk_columns_in_view_pk.empty() is the same,
-    // but actually there are cases where we can compute this boolean without
-    // succeeding to reliably build the former.
-    const bool has_base_non_pk_columns_in_view_pk;
-
-    // If base_non_pk_columns_in_view_pk couldn't reliably be built, this base
-    // info can't be used for computing view updates, only for reading the materialized
-    // view.
-    const bool use_only_for_reads;
-
-    // A constructor for a base info that can facilitate reads and writes from the materialized view.
-    base_dependent_view_info(schema_ptr base_schema,
-            bool has_computed_column_depending_on_base_non_primary_key,
-            bool is_partition_key_permutation_of_base_partition_key,
-            bool has_base_non_pk_columns_in_view_pk);
-    // A constructor for a base info that can facilitate only reads from the materialized view.
-    base_dependent_view_info(bool has_computed_column_depending_on_base_non_primary_key,
-            bool is_partition_key_permutation_of_base_partition_key,
-            bool has_base_non_pk_columns_in_view_pk,
-            std::optional<bytes>&& column_missing_in_base);
-};
-
-// Immutable snapshot of view's base-schema-dependent part.
-using base_info_ptr = lw_shared_ptr<const base_dependent_view_info>;
 
 // Snapshot of the view schema and its base-schema-dependent part.
 struct view_and_base {

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -29,12 +29,6 @@ namespace view {
 
 class stats;
 
-// Snapshot of the view schema and its base-schema-dependent part.
-struct view_and_base {
-    view_ptr view;
-    base_info_ptr base;
-};
-
 // An immutable representation of a clustering or static row of the base table.
 struct clustering_or_static_row {
 private:
@@ -174,7 +168,7 @@ class view_updates final {
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
     size_t _op_count = 0;
 public:
-    explicit view_updates(view_and_base v, schema_ptr b);
+    explicit view_updates(view_ptr v, schema_ptr b);
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 
@@ -264,7 +258,7 @@ view_update_builder make_view_update_builder(
         data_dictionary::database db,
         const replica::table& base_table,
         const schema_ptr& base_schema,
-        std::vector<view_and_base>&& views_to_update,
+        std::vector<view_ptr>&& views_to_update,
         mutation_reader&& updates,
         mutation_reader_opt&& existings,
         gc_clock::time_point now);
@@ -274,9 +268,9 @@ future<query::clustering_row_ranges> calculate_affected_clustering_ranges(
         const schema& base,
         const dht::decorated_key& key,
         const mutation_partition& mp,
-        const std::vector<view_and_base>& views);
+        const std::vector<view_ptr>& views);
 
-bool needs_static_row(const mutation_partition& mp, const std::vector<view_and_base>& views);
+bool needs_static_row(const mutation_partition& mp, const std::vector<view_ptr>& views);
 
 // Whether this node and shard should generate and send view updates for the given token.
 // Checks that the node is one of the replicas (not a pending replicas), and is ready for reads.
@@ -298,13 +292,6 @@ size_t memory_usage_of(const frozen_mutation_and_schema& mut);
  *        When type is a multi-cell collection, so will be the virtual column.
  */
  void create_virtual_column(schema_builder& builder, const bytes& name, const data_type& type);
-
-/**
- * Converts a collection of view schema snapshots into a collection of
- * view_and_base objects, which are snapshots of both the view schema
- * and the base-schema-dependent part of view description.
- */
-std::vector<view_and_base> with_base_info_snapshot(std::vector<view_ptr>);
 
 std::optional<locator::host_id> get_view_natural_endpoint(
     locator::host_id node,

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -48,6 +48,12 @@ public:
     const std::vector<column_id>& base_static_columns_in_view_pk() const;
     const schema_ptr& base_schema() const;
 
+    const bool has_computed_column_depending_on_base_non_primary_key;
+
+    // True if the partition key columns of the view are the same as the
+    // partition key columns of the base, maybe in a different order.
+    const bool is_partition_key_permutation_of_base_partition_key;
+
     // Indicates if the view hase pk columns which are not part of the base
     // pk, it seems that !base_non_pk_columns_in_view_pk.empty() is the same,
     // but actually there are cases where we can compute this boolean without
@@ -62,9 +68,14 @@ public:
     // A constructor for a base info that can facilitate reads and writes from the materialized view.
     base_dependent_view_info(schema_ptr base_schema,
             std::vector<column_id>&& base_regular_columns_in_view_pk,
-            std::vector<column_id>&& base_static_columns_in_view_pk);
+            std::vector<column_id>&& base_static_columns_in_view_pk,
+            bool has_computed_column_depending_on_base_non_primary_key,
+            bool is_partition_key_permutation_of_base_partition_key);
     // A constructor for a base info that can facilitate only reads from the materialized view.
-    base_dependent_view_info(bool has_base_non_pk_columns_in_view_pk, std::optional<bytes>&& column_missing_in_base);
+    base_dependent_view_info(bool has_computed_column_depending_on_base_non_primary_key,
+            bool is_partition_key_permutation_of_base_partition_key,
+            bool has_base_non_pk_columns_in_view_pk,
+            std::optional<bytes>&& column_missing_in_base);
 };
 
 // Immutable snapshot of view's base-schema-dependent part.

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -174,7 +174,7 @@ class view_updates final {
     std::unordered_map<partition_key, mutation_partition, partition_key::hashing, partition_key::equality> _updates;
     size_t _op_count = 0;
 public:
-    explicit view_updates(view_and_base vab);
+    explicit view_updates(view_and_base v, schema_ptr b);
 
     future<> move_to(utils::chunked_vector<frozen_mutation_and_schema>& mutations);
 

--- a/db/view/view.hh
+++ b/db/view/view.hh
@@ -160,7 +160,7 @@ class view_updates final {
     view_ptr _view;
     const view_info& _view_info;
     schema_ptr _base;
-    base_info_ptr _base_info;
+    const base_dependent_view_info& _base_info;
     // Id of a regular base table column included in the view's PK, if any.
     // Scylla views only allow one such column, alternator can have up to two.
     std::vector<column_id> _base_regular_columns_in_view_pk;

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -329,7 +329,7 @@ static size_t memory_usage_of(const utils::chunked_vector<frozen_mutation_and_sc
  * @return a future that resolves when the updates have been acknowledged by the view replicas
  */
 future<> view_update_generator::populate_views(const replica::table& table,
-        std::vector<view_and_base> views,
+        std::vector<view_ptr> views,
         dht::token base_token,
         mutation_reader&& reader,
         gc_clock::time_point now) {
@@ -402,7 +402,7 @@ struct view_update_generation_timeout_exception : public seastar::timed_out_erro
 future<> view_update_generator::generate_and_propagate_view_updates(const replica::table& table,
         const schema_ptr& base,
         reader_permit permit,
-        std::vector<view_and_base>&& views,
+        std::vector<view_ptr>&& views,
         mutation&& m,
         mutation_reader_opt existings,
         tracing::trace_state_ptr tr_state,

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -26,6 +26,7 @@ struct frozen_mutation_and_schema;
 class mutation;
 class reader_permit;
 class mutation_reader;
+class view_ptr;
 using mutation_reader_opt = optimized_optional<mutation_reader>;
 
 namespace dht {
@@ -51,7 +52,6 @@ using allow_hints = bool_class<allow_hints_tag>;
 namespace db::view {
 
 class stats;
-struct view_and_base;
 struct wait_for_all_updates_tag {};
 using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 
@@ -104,7 +104,7 @@ public:
 
     // Reader's schema must be the same as the base schema of each of the views.
     future<> populate_views(const replica::table& base,
-            std::vector<view_and_base>,
+            std::vector<view_ptr>,
             dht::token base_token,
             mutation_reader&&,
             gc_clock::time_point);
@@ -112,7 +112,7 @@ public:
     future<> generate_and_propagate_view_updates(const replica::table& table,
             const schema_ptr& base,
             reader_permit permit,
-            std::vector<view_and_base>&& views,
+            std::vector<view_ptr>&& views,
             mutation&& m,
             mutation_reader_opt existings,
             tracing::trace_state_ptr tr_state,

--- a/frozen_schema.cc
+++ b/frozen_schema.cc
@@ -8,6 +8,7 @@
 
 #include "frozen_schema.hh"
 #include "db/schema_tables.hh"
+#include "db/view/view.hh"
 #include "mutation/canonical_mutation.hh"
 #include "schema_mutations.hh"
 #include "idl/frozen_schema.dist.hh"
@@ -25,13 +26,16 @@ frozen_schema::frozen_schema(const schema_ptr& s)
     }())
 { }
 
-schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt, std::optional<schema_ptr> base_schema) const {
+schema_ptr frozen_schema::unfreeze(const db::schema_ctxt& ctxt, std::optional<db::view::base_dependent_view_info> base_info) const {
     auto in = ser::as_input_stream(_data);
     auto sv = ser::deserialize(in, std::type_identity<ser::schema_view>());
     auto sm = sv.mutations();
     if (sm.is_view()) {
-        return db::schema_tables::create_view_from_mutations(ctxt, std::move(sm), base_schema, sv.version());
+        return db::schema_tables::create_view_from_mutations(ctxt, std::move(sm), std::move(base_info), sv.version());
     } else {
+        if (base_info) {
+            throw std::runtime_error("Trying to unfreeze regular table schema with base info");
+        }
         return db::schema_tables::create_table_from_mutations(ctxt, std::move(sm), sv.version());
     }
 }

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -27,6 +27,6 @@ public:
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;
     frozen_schema& operator=(frozen_schema&&) = default;
-    schema_ptr unfreeze(const db::schema_ctxt&) const;
+    schema_ptr unfreeze(const db::schema_ctxt&, std::optional<schema_ptr> base = std::nullopt) const;
     const bytes_ostream& representation() const;
 };

--- a/frozen_schema.hh
+++ b/frozen_schema.hh
@@ -11,6 +11,7 @@
 #include "schema/schema_fwd.hh"
 #include "mutation/frozen_mutation.hh"
 #include "bytes_ostream.hh"
+#include "db/view/base_info.hh"
 
 namespace db {
 class schema_ctxt;
@@ -27,6 +28,6 @@ public:
     frozen_schema(const frozen_schema&) = default;
     frozen_schema& operator=(const frozen_schema&) = default;
     frozen_schema& operator=(frozen_schema&&) = default;
-    schema_ptr unfreeze(const db::schema_ctxt&, std::optional<schema_ptr> base = std::nullopt) const;
+    schema_ptr unfreeze(const db::schema_ctxt&, std::optional<db::view::base_dependent_view_info> base_info = {}) const;
     const bytes_ostream& representation() const;
 };

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -302,7 +302,7 @@ view_ptr secondary_index_manager::create_view_for_index(const index_metadata& im
         (target_type == cql3::statements::index_target::target_type::regular_values) ?
         format("{} IS NOT NULL", index_target->name_as_cql_string()) :
         "";
-    builder.with_view_info(*schema, false, where_clause);
+    builder.with_view_info(schema, false, where_clause);
     // A local secondary index should be backed by a *synchronous* view,
     // see #16371. A view is marked synchronous with a tag. Non-local indexes
     // do not need the tags schema extension at all.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -963,14 +963,6 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
 }
 
 future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new) {
-    if (schema->is_view()) {
-        try {
-            auto base_schema = find_schema(schema->view_info()->base_id());
-            schema->view_info()->set_base_info(schema->view_info()->make_base_dependent_view_info(*base_schema));
-        } catch (no_such_column_family&) {
-            throw std::invalid_argument("The base table " + schema->view_info()->base_name() + " was already dropped");
-        }
-    }
     schema = local_schema_registry().learn(schema);
     auto&& rs = ks.get_replication_strategy();
     locator::effective_replication_map_ptr erm;
@@ -1016,14 +1008,6 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema, is_ne
 }
 
 bool database::update_column_family(schema_ptr new_schema) {
-    if (new_schema->is_view()) {
-        try {
-            auto base_schema = find_schema(new_schema->view_info()->base_id());
-            new_schema->view_info()->set_base_info(new_schema->view_info()->make_base_dependent_view_info(*base_schema));
-        } catch (no_such_column_family&) {
-            throw std::invalid_argument("The base table " + new_schema->view_info()->base_name() + " was already dropped");
-        }
-    }
     column_family& cfm = find_column_family(new_schema->id());
     bool columns_changed = !cfm.schema()->equal_columns(*new_schema);
     auto s = local_schema_registry().learn(new_schema);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3257,14 +3257,9 @@ void table::set_schema(schema_ptr s) {
     _schema = std::move(s);
 
     for (auto&& v : _views) {
-        auto base_info = v->view_info()->make_base_dependent_view_info(*_schema);
-        v->view_info()->set_base_info(base_info);
-        if (v->registry_entry()) {
-            v->registry_entry()->update_base_info(*base_info);
-        }
+        v->view_info()->reset_view_info();
         if (auto reverse_schema = local_schema_registry().get_or_null(reversed(v->version()))) {
-            reverse_schema->view_info()->set_base_info(base_info);
-            reverse_schema->registry_entry()->update_base_info(*base_info);
+            reverse_schema->view_info()->reset_view_info();
         }
     }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3821,7 +3821,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
         co_return row_locker::lock_holder();
     }
 
-    auto views = db::view::with_base_info_snapshot(affected_views(gen, base, m));
+    auto views = affected_views(gen, base, m);
     if (views.empty()) {
         co_return row_locker::lock_holder();
     }

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3260,11 +3260,11 @@ void table::set_schema(schema_ptr s) {
         auto base_info = v->view_info()->make_base_dependent_view_info(*_schema);
         v->view_info()->set_base_info(base_info);
         if (v->registry_entry()) {
-            v->registry_entry()->update_base_schema(_schema);
+            v->registry_entry()->update_base_info(*base_info);
         }
         if (auto reverse_schema = local_schema_registry().get_or_null(reversed(v->version()))) {
             reverse_schema->view_info()->set_base_info(base_info);
-            reverse_schema->registry_entry()->update_base_schema(_schema);
+            reverse_schema->registry_entry()->update_base_info(*base_info);
         }
     }
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -529,9 +529,6 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
     rebuild();
     if (o.is_view()) {
         _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), *o.view_info()->base_info());
-        if (o.view_info()->base_info()) {
-            _view_info->set_base_info(o.view_info()->base_info());
-        }
     }
 }
 

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -528,7 +528,7 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
 
     rebuild();
     if (o.is_view()) {
-        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), *o.view_info()->base_info());
+        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), o.view_info()->base_info());
     }
 }
 
@@ -1284,7 +1284,7 @@ schema_builder::schema_builder(const schema_ptr s)
     : schema_builder(s->_raw)
 {
     if (s->is_view()) {
-        _base_info = *s->view_info()->base_info();
+        _base_info = s->view_info()->base_info();
         _view_info = s->view_info()->raw();
     }
 }
@@ -2072,10 +2072,7 @@ schema_ptr schema::get_reversed() const {
         auto s = make_reversed();
 
         if (s->is_view()) {
-            if (!s->view_info()->base_info()) {
-                on_internal_error(dblog, format("Tried to make a reverse schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-            }
-            return {frozen_schema(s), *s->view_info()->base_info()};
+            return {frozen_schema(s), s->view_info()->base_info()};
         }
         return {frozen_schema(s)};
     });

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -413,7 +413,7 @@ schema::raw_schema::raw_schema(table_id id)
     , _sharder(::get_sharder(smp::count, default_partitioner_ignore_msb))
 { }
 
-schema::schema(private_tag, const raw_schema& raw, const schema_static_props& props, std::optional<schema_ptr> base_schema)
+schema::schema(private_tag, const raw_schema& raw, const schema_static_props& props, std::optional<std::variant<schema_ptr, db::view::base_dependent_view_info>> base)
     : _raw(raw)
     , _static_props(props)
     , _offsets([this] {
@@ -497,14 +497,21 @@ schema::schema(private_tag, const raw_schema& raw, const schema_static_props& pr
 
     rebuild();
     if (_raw._view_info) {
-        if (!base_schema) {
-            on_internal_error(dblog, format("Tried to create schema for view {}.{} without schema of the base {}",
+        if (!base) {
+            on_internal_error(dblog, format("Tried to create schema for view {}.{} without schema or base info of {}",
                                             _raw._ks_name, _raw._cf_name, _raw._view_info->base_name()));
         }
-        _view_info = std::make_unique<::view_info>(*this, *_raw._view_info, *base_schema);
-    } else if (base_schema) {
-        on_internal_error(dblog, format("Tried to create schema for view {}.{} of base {} without view info",
-                                        _raw._ks_name, _raw._cf_name, base_schema.value()->cf_name()));
+        _view_info = std::visit(make_visitor(
+            [&] (const schema_ptr& base_schema) -> std::unique_ptr<::view_info> {
+                return std::make_unique<::view_info>(*this, *_raw._view_info, base_schema);
+            },
+            [&] (const db::view::base_dependent_view_info& base_info) -> std::unique_ptr<::view_info> {
+                return std::make_unique<::view_info>(*this, *_raw._view_info, base_info);
+            }
+        ), *base);
+    } else if (base) {
+        on_internal_error(dblog, format("Tried to create schema for table/view {}.{} with base info but without view info",
+                                        _raw._ks_name, _raw._cf_name));
     }
 }
 
@@ -1524,6 +1531,12 @@ schema_builder& schema_builder::with_view_info(schema_ptr base, bool include_all
     return *this;
 }
 
+schema_builder& schema_builder::with_view_info(table_id base_id, sstring base_name, bool include_all_columns, sstring where_clause, db::view::base_dependent_view_info base) {
+    _base_info = std::move(base);
+    _raw._view_info = raw_view_info(std::move(base_id), std::move(base_name), include_all_columns, std::move(where_clause));
+    return *this;
+}
+
 schema_builder& schema_builder::with_index(const index_metadata& im) {
     _raw._indices_by_name.emplace(im.name(), im);
     return *this;
@@ -1625,7 +1638,12 @@ schema_ptr schema_builder::build(schema::raw_schema& new_raw) {
         }
     ), _version);
 
-    return make_lw_shared<schema>(schema::private_tag{}, new_raw, static_props, _base_schema);
+    if (_base_info) {
+        return make_lw_shared<schema>(schema::private_tag{}, new_raw, static_props, _base_info);
+    } else if (_base_schema) {
+        return make_lw_shared<schema>(schema::private_tag{}, new_raw, static_props, _base_schema);
+    }
+    return make_lw_shared<schema>(schema::private_tag{}, new_raw, static_props);
 }
 
 auto schema_builder::static_configurators() -> std::vector<static_configurator>& {
@@ -2053,14 +2071,14 @@ schema_ptr schema::make_reversed() const {
 }
 
 schema_ptr schema::get_reversed() const {
-    return local_schema_registry().get_or_load(reversed(_raw._version), [this] (table_schema_version) -> base_and_view_schemas {
+    return local_schema_registry().get_or_load(reversed(_raw._version), [this] (table_schema_version) -> view_schema_and_base_info {
         auto s = make_reversed();
 
         if (s->is_view()) {
             if (!s->view_info()->base_info()) {
                 on_internal_error(dblog, format("Tried to make a reverse schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
             }
-            return {frozen_schema(s), s->view_info()->base_info()->base_schema()};
+            return {frozen_schema(s), *s->view_info()->base_info()};
         }
         return {frozen_schema(s)};
     });

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -528,7 +528,7 @@ schema::schema(const schema& o, const std::function<void(schema&)>& transform)
 
     rebuild();
     if (o.is_view()) {
-        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), o.view_info()->base_info()->base_schema());
+        _view_info = std::make_unique<::view_info>(*this, o.view_info()->raw(), *o.view_info()->base_info());
         if (o.view_info()->base_info()) {
             _view_info->set_base_info(o.view_info()->base_info());
         }
@@ -1287,7 +1287,7 @@ schema_builder::schema_builder(const schema_ptr s)
     : schema_builder(s->_raw)
 {
     if (s->is_view()) {
-        _base_schema = s->view_info()->base_info()->base_schema();
+        _base_info = *s->view_info()->base_info();
         _view_info = s->view_info()->raw();
     }
 }

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -628,7 +628,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, const schema_static_props& props);
+    schema(private_tag, const raw_schema&, const schema_static_props& props, std::optional<schema_ptr> base_schema);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -32,6 +32,7 @@
 #include "db/per_partition_rate_limit_options.hh"
 #include "db/tablet_options.hh"
 #include "schema_fwd.hh"
+#include "db/view/base_info.hh"
 
 namespace dht {
 
@@ -628,7 +629,7 @@ private:
     schema(const schema&, const std::function<void(schema&)>&);
     class private_tag{};
 public:
-    schema(private_tag, const raw_schema&, const schema_static_props& props, std::optional<schema_ptr> base_schema);
+    schema(private_tag, const raw_schema&, const schema_static_props& props, std::optional<std::variant<schema_ptr, db::view::base_dependent_view_info>> base = std::nullopt);
     schema(const schema&);
     // See \ref make_reversed().
     schema(reversed_tag, const schema&);

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -29,6 +29,7 @@ private:
     std::optional<compact_storage> _compact_storage;
     std::variant<from_time, from_hash, table_schema_version> _version = from_time{};
     std::optional<raw_view_info> _view_info;
+    std::optional<schema_ptr> _base_schema;
     schema_builder(const schema::raw_schema&);
     static std::vector<static_configurator>& static_configurators();
 public:
@@ -273,10 +274,7 @@ public:
     // of table_schema_version (even in ABA changes).
     schema_builder& with_hash_version();
 
-    schema_builder& with_view_info(table_id base_id, sstring base_name, bool include_all_columns, sstring where_clause);
-    schema_builder& with_view_info(const schema& base_schema, bool include_all_columns, sstring where_clause) {
-        return with_view_info(base_schema.id(), base_schema.cf_name(), include_all_columns, where_clause);
-    }
+    schema_builder& with_view_info(schema_ptr base_schema, bool include_all_columns, sstring where_clause);
 
     schema_builder& with_index(const index_metadata& im);
     schema_builder& without_index(const sstring& name);

--- a/schema/schema_builder.hh
+++ b/schema/schema_builder.hh
@@ -13,6 +13,7 @@
 #include "cdc/log.hh"
 #include "timestamp.hh"
 #include "tombstone_gc_options.hh"
+#include "db/view/base_info.hh"
 
 namespace db {
 class per_partition_rate_limit_options;
@@ -30,6 +31,7 @@ private:
     std::variant<from_time, from_hash, table_schema_version> _version = from_time{};
     std::optional<raw_view_info> _view_info;
     std::optional<schema_ptr> _base_schema;
+    std::optional<db::view::base_dependent_view_info> _base_info;
     schema_builder(const schema::raw_schema&);
     static std::vector<static_configurator>& static_configurators();
 public:
@@ -275,6 +277,7 @@ public:
     schema_builder& with_hash_version();
 
     schema_builder& with_view_info(schema_ptr base_schema, bool include_all_columns, sstring where_clause);
+    schema_builder& with_view_info(table_id base_id, sstring base_name, bool include_all_columns, sstring where_clause, db::view::base_dependent_view_info base);
 
     schema_builder& with_index(const index_metadata& im);
     schema_builder& without_index(const sstring& name);

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -189,7 +189,7 @@ schema_ptr schema_registry_entry::load(view_schema_and_base_info fs) {
 schema_ptr schema_registry_entry::load(schema_ptr s) {
     _frozen_schema = frozen_schema(s);
     if (s->is_view()) {
-        _base_info = *s->view_info()->base_info();
+        _base_info = s->view_info()->base_info();
     }
     _schema = &*s;
     _schema->_registry_entry = this;
@@ -371,10 +371,7 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
         } else {
             return local_schema_registry().get_or_load(s->version(), [&s] (table_schema_version) -> view_schema_and_base_info {
                 if (s->is_view()) {
-                    if (!s->view_info()->base_info()) {
-                        on_internal_error(slogger, format("Tried to build a global schema for view {}.{} with an uninitialized base info", s->ks_name(), s->cf_name()));
-                    }
-                    return {frozen_schema(s), *s->view_info()->base_info()};
+                    return {frozen_schema(s), s->view_info()->base_info()};
                 } else {
                     return {frozen_schema(s)};
                 }
@@ -384,6 +381,6 @@ global_schema_ptr::global_schema_ptr(const schema_ptr& ptr)
 
     _ptr = ensure_registry_entry(ptr);
     if (_ptr->is_view()) {
-        _base_info = *_ptr->view_info()->base_info();
+        _base_info = _ptr->view_info()->base_info();
     }
 }

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -234,7 +234,7 @@ future<schema_ptr> schema_registry_entry::start_loading(async_schema_loader load
 schema_ptr schema_registry_entry::get_schema() {
     if (!_schema) {
         slogger.trace("Activating {}", _version);
-        auto s = _frozen_schema->unfreeze(*_registry._ctxt);
+        schema_ptr s = _frozen_schema->unfreeze(*_registry._ctxt, _base_schema);
         if (s->version() != _version) {
             throw std::runtime_error(format("Unfrozen schema version doesn't match entry version ({}): {}", _version, *s));
         }

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -94,9 +94,6 @@ public:
     future<> maybe_sync(std::function<future<>()> sync);
     // Marks this schema version as synced. Syncing cannot be in progress.
     void mark_synced();
-    // Updates the frozen base info for a view, should be called when updating the base info
-    // Is not needed when we set the base info for the first time - that means this schema is not in the registry
-    void update_base_info(db::view::base_dependent_view_info);
     // Can be called from other shards
     frozen_schema frozen() const;
     // Can be called from other shards

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -180,7 +180,7 @@ schema_registry& local_schema_registry();
 // chain will last.
 class global_schema_ptr {
     schema_ptr _ptr;
-    schema_ptr _base_schema;
+    std::optional<db::view::base_dependent_view_info> _base_info;
     unsigned _cpu_of_origin;
 public:
     // Note: the schema_ptr must come from the current shard and can't be nullptr.

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1072,7 +1072,7 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, locator:
             }
             return db::schema_tables::store_column_mapping(proxy, us, true).then([us, base_schema] -> view_schema_and_base_info {
                 if (us->is_view()) {
-                    return {frozen_schema(us), *us->view_info()->base_info()};
+                    return {frozen_schema(us), us->view_info()->base_info()};
                 } else {
                     return {frozen_schema(us)};
                 }

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1070,9 +1070,9 @@ static future<schema_ptr> get_schema_definition(table_schema_version v, locator:
                 base_schema = db.find_schema(us->view_info()->base_id());
                 db::schema_tables::check_no_legacy_secondary_index_mv_schema(db, view_ptr(us), base_schema);
             }
-            return db::schema_tables::store_column_mapping(proxy, us, true).then([us, base_schema] -> base_and_view_schemas {
+            return db::schema_tables::store_column_mapping(proxy, us, true).then([us, base_schema] -> view_schema_and_base_info {
                 if (us->is_view()) {
-                    return {frozen_schema(us), base_schema};
+                    return {frozen_schema(us), *us->view_info()->base_info()};
                 } else {
                     return {frozen_schema(us)};
                 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4130,7 +4130,7 @@ SEASTAR_TEST_CASE(test_view_with_two_regular_base_columns_in_key) {
                 .with_column(to_bytes("v2"), int32_type, column_kind::clustering_key)
                 .with_column(to_bytes("p"), int32_type, column_kind::clustering_key)
                 .with_column(to_bytes("c"), int32_type, column_kind::clustering_key)
-                .with_view_info(*schema, false, "v1 IS NOT NULL AND v2 IS NOT NULL AND p IS NOT NULL AND c IS NOT NULL");
+                .with_view_info(schema, false, "v1 IS NOT NULL AND v2 IS NOT NULL AND p IS NOT NULL AND c IS NOT NULL");
 
         schema_ptr view_schema = view_builder.build();
         auto& mm = e.migration_manager().local();

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -291,7 +291,6 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
             .with_view_info(base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
             .build();
     auto base_info = view_schema->view_info()->make_base_dependent_view_info(*base_schema);
-    view_schema->view_info()->set_base_info(base_info);
     local_schema_registry().get_or_load(view_schema->version(),
         [view_schema, base_info] (table_schema_version) -> view_schema_and_base_info { return {frozen_schema(view_schema), *base_info}; });
     auto view_registry_schema = local_schema_registry().get_or_null(view_schema->version());

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -288,7 +288,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
     auto view_schema = schema_builder("ks", "cf_view")
             .with_column("v", int32_type, column_kind::partition_key)
             .with_column("pk", int32_type)
-            .with_view_info(*base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
+            .with_view_info(base_schema, false, "pk IS NOT NULL AND v IS NOT NULL")
             .build();
     view_schema->view_info()->set_base_info(view_schema->view_info()->make_base_dependent_view_info(*base_schema));
     local_schema_registry().get_or_load(view_schema->version(),

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -292,10 +292,9 @@ SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {
             .build();
     auto base_info = view_schema->view_info()->make_base_dependent_view_info(*base_schema);
     local_schema_registry().get_or_load(view_schema->version(),
-        [view_schema, base_info] (table_schema_version) -> view_schema_and_base_info { return {frozen_schema(view_schema), *base_info}; });
+        [view_schema, base_info] (table_schema_version) -> view_schema_and_base_info { return {frozen_schema(view_schema), base_info}; });
     auto view_registry_schema = local_schema_registry().get_or_null(view_schema->version());
     BOOST_REQUIRE(view_registry_schema);
-    BOOST_REQUIRE(view_registry_schema->view_info()->base_info());
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -272,10 +272,7 @@ SEASTAR_THREAD_TEST_CASE(test_schema_is_recovered_after_dying) {
         [base_schema] (table_schema_version) -> view_schema_and_base_info { return {frozen_schema(base_schema)}; });
     base_registry_schema = nullptr;
     auto recovered_registry_schema = local_schema_registry().get_or_null(base_schema->version());
-    BOOST_REQUIRE(recovered_registry_schema);
-    recovered_registry_schema = nullptr;
-    seastar::sleep(dummy.grace_period).get();
-    BOOST_REQUIRE(!local_schema_registry().get_or_null(base_schema->version()));
+    BOOST_REQUIRE(recovered_registry_schema->version() == base_schema->version());
 }
 
 SEASTAR_THREAD_TEST_CASE(test_view_info_is_recovered_after_dying) {

--- a/view_info.hh
+++ b/view_info.hh
@@ -23,11 +23,6 @@ class view_info final {
     mutable shared_ptr<cql3::statements::select_statement> _select_statement;
     mutable std::optional<query::partition_slice> _partition_slice;
     db::view::base_info_ptr _base_info;
-    mutable bool _has_computed_column_depending_on_base_non_primary_key;
-
-    // True if the partition key columns of the view are the same as the
-    // partition key columns of the base, maybe in a different order.
-    mutable bool _is_partition_key_permutation_of_base_partition_key;
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
 
@@ -56,13 +51,9 @@ public:
     const column_definition* view_column(const schema& base, column_kind kind, column_id base_id) const;
     const column_definition* view_column(const column_definition& base_def) const;
     bool has_base_non_pk_columns_in_view_pk() const;
-    bool has_computed_column_depending_on_base_non_primary_key() const {
-        return _has_computed_column_depending_on_base_non_primary_key;
-    }
+    bool has_computed_column_depending_on_base_non_primary_key() const;
 
-    bool is_partition_key_permutation_of_base_partition_key() const {
-        return _is_partition_key_permutation_of_base_partition_key;
-    }
+    bool is_partition_key_permutation_of_base_partition_key() const;
 
     /// Returns a pointer to the base_dependent_view_info which matches the current
     /// schema of the base table.

--- a/view_info.hh
+++ b/view_info.hh
@@ -59,7 +59,7 @@ public:
     /// base_dependent_view_info contains information about the view that depends on the base table,
     /// which isn't dependent on the base schema version
     const db::view::base_info_ptr& base_info() const { return _base_info; }
-    void set_base_info(db::view::base_info_ptr);
+    void reset_view_info();
     db::view::base_info_ptr make_base_dependent_view_info(const schema& base_schema) const;
 
     friend bool operator==(const view_info& x, const view_info& y) {

--- a/view_info.hh
+++ b/view_info.hh
@@ -56,17 +56,8 @@ public:
 
     bool is_partition_key_permutation_of_base_partition_key() const;
 
-    /// Returns a pointer to the base_dependent_view_info which matches the current
-    /// schema of the base table.
-    ///
-    /// base_dependent_view_info lives separately from the view schema.
-    /// It can change without the view schema changing its value.
-    /// This pointer is updated on base table schema changes as long as this view_info
-    /// corresponds to the current schema of the view. After that the pointer stops tracking
-    /// the base table schema.
-    ///
-    /// The snapshot of both the view schema and base_dependent_view_info is represented
-    /// by view_and_base. See with_base_info_snapshot().
+    /// base_dependent_view_info contains information about the view that depends on the base table,
+    /// which isn't dependent on the base schema version
     const db::view::base_info_ptr& base_info() const { return _base_info; }
     void set_base_info(db::view::base_info_ptr);
     db::view::base_info_ptr make_base_dependent_view_info(const schema& base_schema) const;

--- a/view_info.hh
+++ b/view_info.hh
@@ -29,7 +29,7 @@ class view_info final {
     // partition key columns of the base, maybe in a different order.
     mutable bool _is_partition_key_permutation_of_base_partition_key;
 public:
-    view_info(const schema& schema, const raw_view_info& raw_view_info);
+    view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
 
     const raw_view_info& raw() const {
         return _raw;

--- a/view_info.hh
+++ b/view_info.hh
@@ -25,6 +25,7 @@ class view_info final {
     db::view::base_info_ptr _base_info;
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
+    view_info(const schema& schema, const raw_view_info& raw_view_info, db::view::base_dependent_view_info base_info);
 
     const raw_view_info& raw() const {
         return _raw;

--- a/view_info.hh
+++ b/view_info.hh
@@ -22,7 +22,7 @@ class view_info final {
     // The following fields are used to select base table rows.
     mutable shared_ptr<cql3::statements::select_statement> _select_statement;
     mutable std::optional<query::partition_slice> _partition_slice;
-    db::view::base_info_ptr _base_info;
+    db::view::base_dependent_view_info _base_info;
 public:
     view_info(const schema& schema, const raw_view_info& raw_view_info, schema_ptr base_schema);
     view_info(const schema& schema, const raw_view_info& raw_view_info, db::view::base_dependent_view_info base_info);
@@ -58,9 +58,9 @@ public:
 
     /// base_dependent_view_info contains information about the view that depends on the base table,
     /// which isn't dependent on the base schema version
-    const db::view::base_info_ptr& base_info() const { return _base_info; }
+    const db::view::base_dependent_view_info& base_info() const { return _base_info; }
     void reset_view_info();
-    db::view::base_info_ptr make_base_dependent_view_info(const schema& base_schema) const;
+    db::view::base_dependent_view_info make_base_dependent_view_info(const schema& base_schema) const;
 
     friend bool operator==(const view_info& x, const view_info& y) {
         return x._raw == y._raw;


### PR DESCRIPTION
Currently, the base_info may or may not be set in view schemas.
Even when it's set, it may be modified. This necessitates extra
checks when handling view schemas, as we'll as potentially causing
errors when we forget to set it at some point.

Instead, we want to make the base info an immutable member of view
schemas (inside view_info). To achieve this, in this series we remove
all base_info members that can change due to a base schema update,
and we calculate the remaining values during view update generation,
using the most up-to-date base schema version.

To calculate the values that depend on the base schema version, we
need to iterate over the view primary key and find the corresponding
columns, which adds extra overhead for each batch of view updates.
However, this overhead should be relatively small, as when creating
a view update, we need to prepare each of its columns anyway. And
if we need to read the old value of the base row, the relative
overhead is even lower.

After this change, the base info in view schemas stays the same
for all base schema updates, so we'll no longer get issues with
base_info being incompatible with a base schema version. Additionally,
it's a step towards making the schema objects immutable, which
we sometimes incorrectly assumed in the past (they're still not
completely immutable yet, as some other fields in view_info other
than base_info are initialized lazily and may depend on the base
schema version).

Fixes https://github.com/scylladb/scylladb/issues/9059
Fixes https://github.com/scylladb/scylladb/issues/21292
Fixes https://github.com/scylladb/scylladb/issues/22194
Fixes https://github.com/scylladb/scylladb/issues/22410