### PR TITLE
test/alternator: enable debugging output during Python crashes

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -29,6 +29,12 @@ from packaging.version import Version
 if (Version(botocore.__version__) < Version('1.12.54')):
     pytest.exit("Your Boto library is too old. Please upgrade it,\ne.g. using:\n    sudo pip{} install --upgrade boto3".format(sys.version_info[0]))
 
+# We've been seeing Python crashing when shutting down after successfully
+# finishing Alternator tests, and couldn't figure out why (issue #17564).
+# Hopefully this will produce useful debugging information:
+import faulthandler
+faulthandler.enable(all_threads=True)
+
 # By default, tests run against a local Scylla installation on localhost:8080/.
 # The "--aws" option can be used to run against Amazon DynamoDB in the us-east-1
 # region.


### PR DESCRIPTION
For a long time now, we've been seeing (see #17564) once in a while Alternator tests crashing with the Python process getting killed on SIGSEGV after the tests have already finished successfully and all pytest had to is exit. We have no been able to figure out where the bug is. Unfortunately we've never been able to reproduce this bug locally - and only rarely we see it in CI runs, and when it happens we don't any information why it happend.

So the goal of this patch is to print more information that might hopefully help us next time we see this problem in CI (this patch does NOT fix the bug). This patch adds to test/alternator's conftest.py a call to faulthandler.enable(). This traps SIGSEGV and prints a stack trace (for each thread, if there are several) showing what Python was trying to do while it is crashing. Hopefully we'll see in this output some specific cleanup function belonging to boto3 or urllib or whatever, and be able to figure out where the bug is and how to avoid it.

We could have added this faulthandler.enable() call to the top-level conftest.py or to test.py, but since we only ever had this Python crash in Alternator tests, I think it is more suitable that we limit this desperate debugging attempt only to Alternator tests.

Refs #17564
