### PR TITLE
test/pylib: servers_add: support list of property_files

### DIFF
--- a/test/cluster/auth_cluster/test_auth_no_quorum.py
+++ b/test/cluster/auth_cluster/test_auth_no_quorum.py
@@ -27,7 +27,7 @@ async def test_auth_no_quorum(manager: ManagerClient) -> None:
         'permissions_validity_in_ms': 0,
         'permissions_update_interval_in_ms': 0,
     }
-    servers = await manager.servers_add(3, config=config)
+    servers = await manager.servers_add(3, config=config, auto_rack_dc="dc1")
 
     cql, _ = await manager.get_ready_cql(servers)
 

--- a/test/cluster/auth_cluster/test_auth_raft_command_split.py
+++ b/test/cluster/auth_cluster/test_auth_raft_command_split.py
@@ -17,7 +17,7 @@ Tests case when bigger auth operation is split into multiple raft commands.
 """
 @pytest.mark.asyncio
 async def test_auth_raft_command_split(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(3, config=auth_config)
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql, hosts = await manager.get_ready_cql(servers)
 
     initial_perms = await cql.run_async("SELECT * FROM system.role_permissions")

--- a/test/cluster/auth_cluster/test_auth_v2_migration.py
+++ b/test/cluster/auth_cluster/test_auth_v2_migration.py
@@ -187,7 +187,7 @@ async def test_auth_v2_migration(request, manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_auth_v2_during_recovery(manager: ManagerClient):
     # FIXME: move this test to the Raft-based recovery procedure or remove it if unneeded.
-    servers = await manager.servers_add(3, config=auth_config)
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql, hosts = await manager.get_ready_cql(servers)
 
     logging.info("Checking auth version before recovery")

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -107,7 +107,7 @@ async def test_service_levels_upgrade(request, manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_service_levels_work_during_recovery(manager: ManagerClient):
     # FIXME: move this test to the Raft-based recovery procedure or remove it if unneeded.
-    servers = await manager.servers_add(3, config=auth_config)
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
 
     logging.info("Waiting until driver connects to every server")
     cql = manager.get_cql()
@@ -237,7 +237,7 @@ async def assert_connections_params(manager: ManagerClient, hosts, expect):
 @pytest.mark.asyncio
 @skip_mode('release', 'cql server testing REST API is not supported in release mode')
 async def test_connections_parameters_auto_update(manager: ManagerClient, build_mode):
-    servers = await manager.servers_add(3, config=auth_config)
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -320,7 +320,7 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
 
 @pytest.mark.asyncio
 async def test_service_level_cache_after_restart(manager: ManagerClient):
-    servers = await manager.servers_add(1, config=auth_config)
+    servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -449,7 +449,7 @@ async def test_service_levels_over_limit(manager: ManagerClient):
 # Reproduces issue scylla-enterprise#4912
 @pytest.mark.asyncio
 async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(2, config=auth_config)
+    servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
     s = servers[0]
     cql = manager.get_cql()
     [h] = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60)
@@ -480,5 +480,5 @@ async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     await cql.run_async(f"DROP SERVICE LEVEL {sl2}", host=h)
 
     # Check if group0 is healthy
-    s2 = await manager.server_add(config=auth_config)
+    s2 = await manager.server_add(config=auth_config, property_file={"dc": "dc1", "rack": "rack3"})
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -271,3 +271,9 @@ def skip_mode_fixture(request, build_mode):
 async def prepare_3_nodes_cluster(request, manager):
     if request.node.get_closest_marker("prepare_3_nodes_cluster"):
         await manager.servers_add(3)
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def prepare_3_racks_cluster(request, manager):
+    if request.node.get_closest_marker("prepare_3_racks_cluster"):
+        await manager.servers_add(3, auto_rack_dc="dc1")

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -18,7 +18,7 @@ from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace, new_test_table
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -10,7 +10,7 @@ import logging
 import asyncio
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -25,8 +25,8 @@ async def test_no_cleanup_when_unnecessary(request, manager: ManagerClient):
     servers = await manager.running_servers()
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]
     marks = [await log.mark() for log in logs]
-    await manager.server_add()
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack1"})
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack2"})
     matches = [await log.grep("raft_topology - start cleanup", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 0
 
@@ -44,7 +44,7 @@ async def test_no_cleanup_when_unnecessary(request, manager: ManagerClient):
     matches = [await log.grep("raft_topology - start cleanup", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 0
 
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack3"})
     servers = await manager.running_servers()
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]
     marks = [await log.mark() for log in logs]

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -22,7 +22,7 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 
@@ -145,13 +145,13 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
 
     # Try to add a node that doesn't support the feature - should fail
-    new_server_info = await manager.server_add(start=False)
+    new_server_info = await manager.server_add(start=False, property_file=servers[0].property_file())
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
 
     # Try to replace with a node that doesn't support the feature - should fail
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id=servers[0].server_id, reuse_ip_addr=False, use_host_id=False)
-    new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg)
+    new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg, property_file=servers[0].property_file())
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
 
 

--- a/test/cluster/test_concurrent_schema.py
+++ b/test/cluster/test_concurrent_schema.py
@@ -10,7 +10,7 @@ from test.pylib.random_tables import Column, UUIDType, IntType
 
 
 logger = logging.getLogger('schema-test')
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 

--- a/test/cluster/test_gossiper.py
+++ b/test/cluster/test_gossiper.py
@@ -7,7 +7,7 @@
 from test.pylib.manager_client import ManagerClient
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_mutation_schema_change.py
+++ b/test/cluster/test_mutation_schema_change.py
@@ -17,7 +17,7 @@ from cassandra.query import SimpleStatement              # type: ignore # pylint
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -18,7 +18,7 @@ from test.cluster.util import new_test_keyspace, new_test_table, new_materialize
 ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 } AND TABLETS = {'enabled': false }"
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -17,31 +17,31 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_rolling_upgrade_happy_path(manager)
 
 
 @pytest.mark.asyncio
 async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_partial_upgrade(manager)
 
 
 @pytest.mark.asyncio
 async def test_joining_old_node_fails(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_joining_old_node_fails(manager)
 
 
 @pytest.mark.asyncio
 async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_successful_upgrade_fails(manager)
 
 
 @pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
 
 
@@ -53,7 +53,7 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
        missing feature. Unblock the topology coordinator, restart the node
        and observe that the feature was enabled.
     """
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
 
     # Rolling restart so that all nodes support the feature - but do not
     # allow enabling yet

--- a/test/cluster/test_random_tables.py
+++ b/test/cluster/test_random_tables.py
@@ -10,7 +10,7 @@ from cassandra.protocol import InvalidRequest, ReadFailure                      
 from cassandra.query import SimpleStatement                                        # type: ignore
 from test.cluster.util import wait_for_token_ring_and_group0_consistency
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 # Simple test of schema helper

--- a/test/cluster/test_replace_alive_node.py
+++ b/test/cluster/test_replace_alive_node.py
@@ -8,7 +8,7 @@ from test.pylib.manager_client import ManagerClient
 import asyncio
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -24,4 +24,5 @@ async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
         replace_cfg = ReplaceConfig(replaced_id = srv.server_id, reuse_ip_addr = False,
                                     use_host_id = False, wait_replaced_dead = False)
         await manager.server_add(replace_cfg=replace_cfg,
+                                 property_file=srv.property_file(),
                                  expected_error="the topology coordinator rejected request to join the cluster")

--- a/test/cluster/test_topology_rejoin.py
+++ b/test/cluster/test_topology_rejoin.py
@@ -9,7 +9,7 @@ Test rejoin of a server after it was stopped suddenly (crash-like)
 from test.pylib.manager_client import ManagerClient
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_topology_schema.py
+++ b/test/cluster/test_topology_schema.py
@@ -10,7 +10,7 @@ import time
 from test.cluster.util import wait_for_token_ring_and_group0_consistency
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -26,7 +26,7 @@ async def test_topology_schema_changes(manager, random_tables):
     await random_tables.verify_schema()
 
     # Test add column after adding a server
-    await manager.server_add()
+    await manager.server_add(property_file=servers[1].property_file())
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     await table.add_column()
     await random_tables.verify_schema()

--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -29,6 +29,9 @@ class ServerInfo(NamedTuple):
     def as_dict(self) -> dict[str, object]:
         return {"server_id": self.server_id, "ip_addr": self.ip_addr, "rpc_address": self.rpc_address, "datacenter": self.datacenter, "rack": self.rack}
 
+    def property_file(self) -> dict[str, str]:
+        return {"dc": self.datacenter, "rack": self.rack}
+
 
 class ServerUpState(Enum):
     PROCESS_STARTED = auto()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -385,12 +385,17 @@ class ManagerClient():
                           seeds: Optional[List[IPAddress]] = None,
                           driver_connect_opts: dict[str, Any] = {},
                           expected_error: Optional[str] = None,
-                          server_encryption: str = "none") -> List[ServerInfo]:
+                          server_encryption: str = "none",
+                          auto_rack_dc: Optional[str] = None) -> List[ServerInfo]:
         """Add new servers concurrently.
         This function can be called only if the cluster uses consistent topology changes, which support
         concurrent bootstraps. If your test does not fulfill this condition and you want to add multiple
         servers, you should use multiple server_add calls."""
         assert servers_num > 0, f"servers_add: cannot add {servers_num} servers, servers_num must be positive"
+        assert not (property_file and auto_rack_dc), f"Either property_file or auto_rack_dc can be provided, but not both"
+
+        if auto_rack_dc:
+            property_file = [{"dc":auto_rack_dc, "rack":f"rack{i+1}"} for i in range(servers_num)]
 
         try:
             data = self._create_server_add_data(None, cmdline, config, property_file, start, seeds, expected_error, server_encryption, None)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -12,7 +12,7 @@ import pathlib
 import shutil
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import List, Optional, Callable, Any, Awaitable, Dict, Tuple
+from typing import List, Optional, Callable, Any, Awaitable, Dict, Tuple, Union
 from time import time
 import logging
 from test.pylib.log_browsing import ScyllaLogFile
@@ -297,7 +297,7 @@ class ManagerClient():
                                 replace_cfg: Optional[ReplaceConfig],
                                 cmdline: Optional[List[str]],
                                 config: Optional[dict[str, Any]],
-                                property_file: Optional[dict[str, Any]],
+                                property_file: Union[List[dict[str, Any]], dict[str, Any], None],
                                 start: bool,
                                 seeds: Optional[List[IPAddress]],
                                 expected_error: Optional[str],
@@ -380,7 +380,7 @@ class ManagerClient():
     async def servers_add(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,
                           config: Optional[dict[str, Any]] = None,
-                          property_file: Optional[dict[str, Any]] = None,
+                          property_file: Union[List[dict[str, Any]], dict[str, Any], None] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
                           driver_connect_opts: dict[str, Any] = {},

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -12,6 +12,7 @@ markers =
     repair: tests for repair
     cpp: marker for c++ tests
     prepare_3_nodes_cluster: prepare 3 nodes cluster for test case based on suite.yaml (all tests from old topology folder)
+    prepare_3_racks_cluster: prepare 3 nodes cluster in 1 dc and 3 racks for test case based on suite.yaml
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,


### PR DESCRIPTION
So that a multi-dc/multi-rack cluster can be populated
in a single call.

* Enhancement, no backport required