### PR TITLE
mutation/mutation_consumer_concepts: simplify consumer hierarchy

### DIFF
--- a/mutation/mutation_consumer_concepts.hh
+++ b/mutation/mutation_consumer_concepts.hh
@@ -20,9 +20,11 @@ concept FlatMutationReaderConsumer =
 
 template<typename T>
 concept FlattenedConsumer =
-    StreamedMutationConsumer<T> && requires(T obj, const dht::decorated_key& dk) {
+    FragmentConsumer<T> && requires(T obj, const dht::decorated_key& dk, tombstone tomb) {
         { obj.consume_new_partition(dk) };
+        { obj.consume(tomb) };
         { obj.consume_end_of_partition() };
+        { obj.consume_end_of_stream() };
     };
 
 template<typename T>
@@ -51,9 +53,11 @@ concept MutationConsumer =
 
 template<typename T>
 concept FlattenedConsumerV2 =
-    StreamedMutationConsumerV2<T> && requires(T obj, const dht::decorated_key& dk) {
+    FragmentConsumerV2<T> && requires(T obj, const dht::decorated_key& dk, tombstone tomb) {
         { obj.consume_new_partition(dk) };
+        { obj.consume(tomb) };
         { obj.consume_end_of_partition() };
+        { obj.consume_end_of_stream() };
     };
 
 template<typename T>

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -253,13 +253,6 @@ template<typename T>
 concept FragmentConsumer =
     FragmentConsumerReturning<T, stop_iteration> || FragmentConsumerReturning<T, future<stop_iteration>>;
 
-template<typename T>
-concept StreamedMutationConsumer =
-    FragmentConsumer<T> && requires(T t, static_row sr, clustering_row cr, range_tombstone rt, tombstone tomb) {
-        t.consume(tomb);
-        t.consume_end_of_stream();
-    };
-
 template<typename T, typename ReturnType>
 concept MutationFragmentVisitor =
     requires(T t, const static_row& sr, const clustering_row& cr, const range_tombstone& rt, const partition_start& ph, const partition_end& eop) {

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -242,18 +242,6 @@ concept MutationFragmentConsumer =
     };
 
 template<typename T, typename ReturnType>
-concept FragmentConsumerReturning =
-    requires(T t, static_row sr, clustering_row cr, range_tombstone rt, tombstone tomb) {
-        { t.consume(std::move(sr)) } -> std::same_as<ReturnType>;
-        { t.consume(std::move(cr)) } -> std::same_as<ReturnType>;
-        { t.consume(std::move(rt)) } -> std::same_as<ReturnType>;
-    };
-
-template<typename T>
-concept FragmentConsumer =
-    FragmentConsumerReturning<T, stop_iteration> || FragmentConsumerReturning<T, future<stop_iteration>>;
-
-template<typename T, typename ReturnType>
 concept MutationFragmentVisitor =
     requires(T t, const static_row& sr, const clustering_row& cr, const range_tombstone& rt, const partition_start& ph, const partition_end& eop) {
         { t(sr) } -> std::same_as<ReturnType>;

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -111,18 +111,6 @@ concept MutationFragmentVisitorV2 =
         { t(eop) } -> std::same_as<ReturnType>;
     };
 
-template<typename T, typename ReturnType>
-concept FragmentConsumerReturningV2 =
-requires(T t, static_row sr, clustering_row cr, range_tombstone_change rt, tombstone tomb) {
-    { t.consume(std::move(sr)) } -> std::same_as<ReturnType>;
-    { t.consume(std::move(cr)) } -> std::same_as<ReturnType>;
-    { t.consume(std::move(rt)) } -> std::same_as<ReturnType>;
-};
-
-template<typename T>
-concept FragmentConsumerV2 =
-FragmentConsumerReturningV2<T, stop_iteration> || FragmentConsumerReturningV2<T, future<stop_iteration>>;
-
 class mutation_fragment_v2 {
 public:
     enum class kind {

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -123,13 +123,6 @@ template<typename T>
 concept FragmentConsumerV2 =
 FragmentConsumerReturningV2<T, stop_iteration> || FragmentConsumerReturningV2<T, future<stop_iteration>>;
 
-template<typename T>
-concept StreamedMutationConsumerV2 =
-FragmentConsumerV2<T> && requires(T t, tombstone tomb) {
-    t.consume(tomb);
-    t.consume_end_of_stream();
-};
-
 class mutation_fragment_v2 {
 public:
     enum class kind {

--- a/test/lib/fragment_scatterer.hh
+++ b/test/lib/fragment_scatterer.hh
@@ -11,7 +11,7 @@
 #include "mutation/mutation.hh"
 #include "mutation/mutation_rebuilder.hh"
 
-// A StreamedMutationConsumer which distributes fragments randomly into several mutations.
+// A FlattenedConsumer which distributes fragments randomly into several mutations.
 class fragment_scatterer {
     schema_ptr _schema;
     size_t _n;


### PR DESCRIPTION
The reader consumer concept hierarchy is a sprawling confusing jungle of deeply nested concepts. Looking at `FlattenedConsumer[V2]` -- the subject of this PR: this consumer is defined in terms of the `StreamedMutationConsumer[V2]` which in terms is defined in terms of the `FragmentConsumer[V2]`.
This amount of nesting makes it really hard to see what a concept actually comes down to: made even more difficult by the fact that the concepts are scattered across two header files.
In theory, this nesting allows for greater flexibility: some code can use a lower lever concept directly while it can also serve as the basis for the higher lever concepts. But the fact of the matter is that none of the lower level concepts are used directly, so we pay the price in hard-to-follow code for no benefit.

This PR cuts down the complexity by folding up the entire hierarchy into the top-level `FlattenedConsumer[V2]` and `FlatteneConsumerReturning[V2]` concepts.
Doing this immediately reveals just how similar the two major consumer concepts (`FlattenedConsumer[V2]` and `MutationFragmentConsumer[V2]`) supported by `mutation_reader` are. In a follow-up PR, we will attempt to unify the two.

Refactoring, no backport needed.