### PR TITLE
replica/memtable: s/make_flat_reader/make_mutation_reader/

### DIFF
--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -706,7 +706,7 @@ partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
 }
 
 mutation_reader_opt
-memtable::make_flat_reader_opt(schema_ptr query_schema,
+memtable::make_mutation_reader_opt(schema_ptr query_schema,
                       reader_permit permit,
                       const dht::partition_range& range,
                       const query::partition_slice& slice,
@@ -766,7 +766,7 @@ memtable::update(db::rp_handle&& h) {
 
 future<>
 memtable::apply(memtable& mt, reader_permit permit) {
-    if (auto reader_opt = mt.make_flat_reader_opt(_schema, std::move(permit), query::full_partition_range, _schema->full_slice())) {
+    if (auto reader_opt = mt.make_mutation_reader_opt(_schema, std::move(permit), query::full_partition_range, _schema->full_slice())) {
         return with_closeable(std::move(*reader_opt), [this] (auto&& rd) mutable {
             return consume_partitions(rd, [self = this->shared_from_this()] (mutation&& m) {
                 self->apply(m);
@@ -816,7 +816,7 @@ mutation_source memtable::as_data_source() {
             tracing::trace_state_ptr trace_state,
             streamed_mutation::forwarding fwd,
             mutation_reader::forwarding fwd_mr) {
-        return mt->make_flat_reader(std::move(s), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr);
+        return mt->make_mutation_reader(std::move(s), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr);
     });
 }
 

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -269,21 +269,21 @@ public:
     // The 'range' parameter must be live as long as the reader is being used
     //
     // Mutations returned by the reader will all have given schema.
-    mutation_reader make_flat_reader(schema_ptr s,
+    mutation_reader make_mutation_reader(schema_ptr s,
                                              reader_permit permit,
                                              const dht::partition_range& range,
                                              const query::partition_slice& slice,
                                              tracing::trace_state_ptr trace_state_ptr = nullptr,
                                              streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
                                              mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) {
-        if (auto reader_opt = make_flat_reader_opt(s, permit, range, slice, std::move(trace_state_ptr), fwd, fwd_mr)) {
+        if (auto reader_opt = make_mutation_reader_opt(s, permit, range, slice, std::move(trace_state_ptr), fwd, fwd_mr)) {
             return std::move(*reader_opt);
         }
         [[unlikely]] return make_empty_flat_reader_v2(std::move(s), std::move(permit));
     }
-    // Same as make_flat_reader, but returns an empty optional instead of a no-op reader when there is nothing to
+    // Same as make_mutation_reader, but returns an empty optional instead of a no-op reader when there is nothing to
     // read. This is an optimization.
-    mutation_reader_opt make_flat_reader_opt(schema_ptr query_schema,
+    mutation_reader_opt make_mutation_reader_opt(schema_ptr query_schema,
                                           reader_permit permit,
                                           const dht::partition_range& range,
                                           const query::partition_slice& slice,
@@ -291,11 +291,11 @@ public:
                                           streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
                                           mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes);
 
-    mutation_reader make_flat_reader(schema_ptr s,
+    mutation_reader make_mutation_reader(schema_ptr s,
                                              reader_permit permit,
                                              const dht::partition_range& range = query::full_partition_range) {
         auto& full_slice = s->full_slice();
-        return make_flat_reader(s, std::move(permit), range, full_slice);
+        return make_mutation_reader(s, std::move(permit), range, full_slice);
     }
 
     mutation_reader make_flush_reader(schema_ptr, reader_permit permit);

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -182,7 +182,7 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
         std::function<void(size_t)> reserve_fn) const {
     auto add_memtables_from_cg = [&] (compaction_group& cg) mutable {
         for (auto&& mt: *cg.memtables()) {
-            if (auto reader_opt = mt->make_flat_reader_opt(s, permit, range, slice, trace_state, fwd, fwd_mr)) {
+            if (auto reader_opt = mt->make_mutation_reader_opt(s, permit, range, slice, trace_state, fwd, fwd_mr)) {
                 readers.emplace_back(std::move(*reader_opt));
             }
         }

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -962,7 +962,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
             readers.reserve(memtables.size());
             auto permit = db.get_reader_concurrency_semaphore().make_tracking_only_permit(s, "test", db::no_timeout, {});
             for (auto mt : memtables) {
-                readers.push_back(mt->make_flat_reader(s, permit));
+                readers.push_back(mt->make_mutation_reader(s, permit));
             }
             auto rd = make_combined_reader(s, permit, std::move(readers));
             auto close_rd = deferred_close(rd);

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -84,7 +84,7 @@ static auto make_populate(bool evict_paused_readers, bool single_fragment_buffer
                     const query::partition_slice& slice,
                     tracing::trace_state_ptr trace_state,
                     mutation_reader::forwarding fwd_mr) {
-                    auto reader = remote_memtables->at(this_shard_id())->make_flat_reader(s, std::move(permit), range, slice, std::move(trace_state),
+                    auto reader = remote_memtables->at(this_shard_id())->make_mutation_reader(s, std::move(permit), range, slice, std::move(trace_state),
                             streamed_mutation::forwarding::no, fwd_mr);
                     if (single_fragment_buffer) {
                         reader.set_max_buffer_size(1);

--- a/test/boost/mutation_fragment_test.cc
+++ b/test/boost/mutation_fragment_test.cc
@@ -67,7 +67,7 @@ SEASTAR_TEST_CASE(test_mutation_merger_conforms_to_mutation_source) {
             {
                 std::vector<mutation_reader> readers;
                 for (int i = 0; i < n; ++i) {
-                    readers.push_back(memtables[i]->make_flat_reader(s, permit, range, slice, trace_state, fwd, fwd_mr));
+                    readers.push_back(memtables[i]->make_mutation_reader(s, permit, range, slice, trace_state, fwd, fwd_mr));
                 }
                 return make_combined_reader(s, std::move(permit), std::move(readers), fwd, fwd_mr);
             });

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -1100,10 +1100,10 @@ SEASTAR_THREAD_TEST_CASE(test_reverse_reader_reads_in_native_reverse_order) {
     };
 
     auto reversed_forward_reader = assert_that(compacted(
-            make_reversing_reader(forward_mt->make_flat_reader(forward_schema, permit),
+            make_reversing_reader(forward_mt->make_mutation_reader(forward_schema, permit),
                                   query::max_result_size(1 << 20))));
 
-    auto reverse_reader = compacted(reverse_mt->make_flat_reader(reverse_schema, permit));
+    auto reverse_reader = compacted(reverse_mt->make_mutation_reader(reverse_schema, permit));
     auto deferred_reverse_close = deferred_close(reverse_reader);
 
     while (auto mf_opt = reverse_reader().get()) {

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1270,7 +1270,7 @@ SEASTAR_THREAD_TEST_CASE(test_foreign_reader_as_mutation_source) {
                     mutation_reader::forwarding fwd_mr) {
                 auto remote_reader = env.db().invoke_on(remote_shard,
                         [&, s = global_schema_ptr(s), fwd_sm, fwd_mr, trace_state = tracing::global_trace_state_ptr(trace_state)] (replica::database& db) {
-                    return make_foreign(std::make_unique<mutation_reader>(remote_mt->make_flat_reader(s.get(),
+                    return make_foreign(std::make_unique<mutation_reader>(remote_mt->make_mutation_reader(s.get(),
                             make_reader_permit(env),
                             range,
                             slice,
@@ -2585,7 +2585,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_as_mutation_source) {
                     tracing::trace_state_ptr trace_state,
                     streamed_mutation::forwarding fwd_sm,
                     mutation_reader::forwarding fwd_mr) mutable {
-                auto source = mt->make_flat_reader(s, std::move(permit), range, slice, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
+                auto source = mt->make_mutation_reader(s, std::move(permit), range, slice, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
                 if (fwd_sm == streamed_mutation::forwarding::yes) {
                     source = make_forwardable(std::move(source));
                 }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -88,7 +88,7 @@ static atomic_cell make_collection_member(data_type dt, T value) {
 static mutation_partition get_partition(reader_permit permit, replica::memtable& mt, const partition_key& key) {
     auto dk = dht::decorate_key(*mt.schema(), key);
     auto range = dht::partition_range::make_singular(dk);
-    auto reader = mt.make_flat_reader(mt.schema(), std::move(permit), range);
+    auto reader = mt.make_mutation_reader(mt.schema(), std::move(permit), range);
     auto close_reader = deferred_close(reader);
     auto mo = read_mutation_from_mutation_reader(reader).get();
     BOOST_REQUIRE(bool(mo));
@@ -474,7 +474,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
         mt->apply(make_mutation_with_collection(pk, std::move(cmd1)));
         mt->apply(make_mutation_with_collection(pk, std::move(cmd2))); // this should trigger a merge of the two collections
 
-        auto rd = mt->make_flat_reader(schema, semaphore.make_permit());
+        auto rd = mt->make_mutation_reader(schema, semaphore.make_permit());
         auto close_rd = deferred_close(rd);
         auto res_mut_opt = read_mutation_from_mutation_reader(rd).get();
         BOOST_REQUIRE(res_mut_opt);

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -91,7 +91,7 @@ repair_rows_on_wire make_random_repair_rows_on_wire(random_mutation_generator& g
         partition_key pk = mut.key();
         auto m2 = make_memtable(s, {mut});
         m->apply(mut);
-        auto reader = mutation_fragment_v1_stream(m2->make_flat_reader(s, permit));
+        auto reader = mutation_fragment_v1_stream(m2->make_mutation_reader(s, permit));
         auto close_reader = deferred_close(reader);
         std::list<frozen_mutation_fragment> mfs;
         reader.consume_pausable([s, &mfs](mutation_fragment mf) {
@@ -136,7 +136,7 @@ SEASTAR_TEST_CASE(flush_repair_rows_on_wire_to_sstable) {
         std::list<repair_row> repair_rows = to_repair_rows_list(std::move(input), s, seed, repair_master::yes, permit, repair_hasher(seed, s)).get();
         flush_rows(s, repair_rows, writer);
         writer->wait_for_writer_done().get();
-        compare_readers(*s, m->make_flat_reader(s, permit), make_mutation_reader_from_fragments(s, permit, std::move(fragments)));
+        compare_readers(*s, m->make_mutation_reader(s, permit), make_mutation_reader_from_fragments(s, permit, std::move(fragments)));
     });
 }
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3207,8 +3207,8 @@ static sstables::shared_sstable write_sstables(test_env& env, schema_ptr s, lw_s
 
     sst->write_components(make_combined_reader(s,
         env.make_reader_permit(),
-        mt1->make_flat_reader(s, env.make_reader_permit()),
-        mt2->make_flat_reader(s, env.make_reader_permit())), 1, s, env.manager().configure_writer(), mt1->get_encoding_stats()).get();
+        mt1->make_mutation_reader(s, env.make_reader_permit()),
+        mt2->make_mutation_reader(s, env.make_reader_permit())), 1, s, env.manager().configure_writer(), mt1->get_encoding_stats()).get();
     return sst;
 }
 
@@ -5162,7 +5162,7 @@ static void test_sstable_write_large_row_f(schema_ptr s, reader_permit permit, r
         // trigger depends on the size of rows after they are written in the MC format and that size
         // depends on the encoding statistics (because of variable-length encoding). The original values
         // were chosen with the default-constructed encoding_stats, so let's keep it that way.
-        sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
+        sst->write_components(mt.make_mutation_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
         BOOST_REQUIRE_EQUAL(i, expected.size());
     }, { &handler }).get();
 }
@@ -5216,7 +5216,7 @@ static void test_sstable_write_large_cell_f(schema_ptr s, reader_permit permit, 
         // trigger depends on the size of rows after they are written in the MC format and that size
         // depends on the encoding statistics (because of variable-length encoding). The original values
         // were chosen with the default-constructed encoding_stats, so let's keep it that way.
-        sst->write_components(mt.make_flat_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
+        sst->write_components(mt.make_mutation_reader(s, std::move(permit)), 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
         BOOST_REQUIRE_EQUAL(i, expected.size());
     }, { &handler }).get();
 }
@@ -5275,7 +5275,7 @@ static void test_sstable_log_too_many_rows_f(int rows, int range_tombstones, uin
 
     sstables::test_env::do_with_async([&] (auto& env) {
         auto sst = env.make_sstable(sc, version);
-        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
         BOOST_REQUIRE_EQUAL(logged, expected);
     }, { &handler }).get();
@@ -5388,7 +5388,7 @@ static void test_sstable_log_too_many_dead_rows_f(int rows, uint64_t threshold, 
 
     sstables::test_env::do_with_async([&] (auto& env) {
         auto sst = env.make_sstable(sc, version);
-        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
         BOOST_REQUIRE_EQUAL(logged, expected);
     }, { &handler }).get();
@@ -5440,7 +5440,7 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
 
     sstables::test_env::do_with_async([&] (auto& env) {
         auto sst = env.make_sstable(sc, version);
-        sst->write_components(mt->make_flat_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()), 1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
 
         BOOST_REQUIRE_EQUAL(logged, expected);
     }, { &handler }).get();
@@ -5639,7 +5639,7 @@ SEASTAR_TEST_CASE(test_alter_bloom_fp_chance_during_write) {
         mt->apply(m);
 
         auto sst = env.make_sstable(s2, sstable_version_types::me);
-        sst->write_components(mt->make_flat_reader(s1, env.make_reader_permit()), 1, s1, env.manager().configure_writer(), mt->get_encoding_stats()).get();
+        sst->write_components(mt->make_mutation_reader(s1, env.make_reader_permit()), 1, s1, env.manager().configure_writer(), mt->get_encoding_stats()).get();
 
         sstable_assertions sa(env, sst);
         sa.load();
@@ -5679,7 +5679,7 @@ SEASTAR_TEST_CASE(test_alter_compression_during_write) {
         mt->apply(m);
 
         auto sst = env.make_sstable(s2, sstable_version_types::me);
-        sst->write_components(mt->make_flat_reader(s1, env.make_reader_permit()), 1, s1, env.manager().configure_writer(), mt->get_encoding_stats()).get();
+        sst->write_components(mt->make_mutation_reader(s1, env.make_reader_permit()), 1, s1, env.manager().configure_writer(), mt->get_encoding_stats()).get();
 
         sstable_assertions sa(env, sst);
         sa.load();

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -30,7 +30,7 @@ mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
     auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     auto mt = make_memtable(s, mutations);
-    auto mr = mt->make_flat_reader(s, env.make_reader_permit());
+    auto mr = mt->make_mutation_reader(s, env.make_reader_permit());
     sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();
     sst->load(s->get_sharder()).get();
     return sst->as_mutation_source();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1101,7 +1101,7 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
         auto mt2 = make_memtable(s, {m2});
         auto combined_permit = env.make_reader_permit();
         auto mr = make_combined_reader(s, combined_permit,
-            mt1->make_flat_reader(s, combined_permit), mt2->make_flat_reader(s, combined_permit));
+            mt1->make_mutation_reader(s, combined_permit), mt2->make_mutation_reader(s, combined_permit));
         auto sst = make_sstable_easy(env, std::move(mr), env.manager().configure_writer(), version);
 
         assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
@@ -1275,7 +1275,7 @@ SEASTAR_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) {
 
     auto pr = dht::partition_range::make_singular(small_keys[0]);
 
-    mutation expected = *with_closeable(mt->make_flat_reader(s, env.make_reader_permit(), pr), [] (auto& mt_reader) {
+    mutation expected = *with_closeable(mt->make_mutation_reader(s, env.make_reader_permit(), pr), [] (auto& mt_reader) {
         return read_mutation_from_mutation_reader(mt_reader);
     }).get();
 
@@ -1336,7 +1336,7 @@ SEASTAR_TEST_CASE(test_reading_serialization_header) {
         // carries over that wouldn't normally be read from disk.
         auto sst = env.make_sstable(s);
         gen.emplace(sst->generation());
-        sst->write_components(mt->make_flat_reader(s, env.make_reader_permit()), 2, s, env.manager().configure_writer(), mt->get_encoding_stats()).get();
+        sst->write_components(mt->make_mutation_reader(s, env.make_reader_permit()), 2, s, env.manager().configure_writer(), mt->get_encoding_stats()).get();
     }
 
     auto sst = env.reusable_sst(s, *gen).get();

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -39,7 +39,7 @@ public:
     virtual future<> execute(reader_permit permit, db::result_collector& rc) override {
         return async([this, permit, &rc] {
             auto mt = make_memtable(_s, _mutations);
-            auto rdr = mt->make_flat_reader(_s, permit);
+            auto rdr = mt->make_mutation_reader(_s, permit);
             auto close_rdr = deferred_close(rdr);
             rdr.consume_pausable([&rc] (mutation_fragment_v2 mf) {
                 return rc.take(std::move(mf)).then([] { return stop_iteration::no; });

--- a/test/lib/memtable_snapshot_source.hh
+++ b/test/lib/memtable_snapshot_source.hh
@@ -57,7 +57,7 @@ private:
         auto permit = semaphore.make_permit();
         std::vector<mutation_reader> readers;
         for (auto&& mt : _memtables) {
-            readers.push_back(mt->make_flat_reader(new_mt->schema(),
+            readers.push_back(mt->make_mutation_reader(new_mt->schema(),
                  permit,
                  query::full_partition_range,
                  new_mt->schema()->full_slice(),

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -102,7 +102,7 @@ shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writ
 
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
         sstables::generation_type gen, const sstable::version_types v, int estimated_partitions, gc_clock::time_point query_time) {
-    return make_sstable_easy(env, mt->make_flat_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
+    return make_sstable_easy(env, mt->make_mutation_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
 }
 
 future<compaction_result> compact_sstables(test_env& env, sstables::compaction_descriptor descriptor, table_for_tests t,

--- a/test/perf/perf_mutation_readers.cc
+++ b/test/perf/perf_mutation_readers.cc
@@ -370,12 +370,12 @@ protected:
 
 PERF_TEST_F(memtable_single_row, one_partition)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), single_partition_range()));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), single_partition_range()));
 }
 
 PERF_TEST_F(memtable_single_row, many_partitions)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), multi_partition_range(25)));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), multi_partition_range(25)));
 }
 
 class memtable_multi_row : public memtable {
@@ -405,12 +405,12 @@ protected:
 
 PERF_TEST_F(memtable_multi_row, one_partition)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), single_partition_range()));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), single_partition_range()));
 }
 
 PERF_TEST_F(memtable_multi_row, many_partitions)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), multi_partition_range(25)));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), multi_partition_range(25)));
 }
 
 class memtable_large_partition : public memtable {
@@ -440,12 +440,12 @@ protected:
 
 PERF_TEST_F(memtable_large_partition, one_partition)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), single_partition_range()));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), single_partition_range()));
 }
 
 PERF_TEST_F(memtable_large_partition, many_partitions)
 {
-    return consume_all(mt().make_flat_reader(schema(), permit(), multi_partition_range(25)));
+    return consume_all(mt().make_mutation_reader(schema(), permit(), multi_partition_range(25)));
 }
 
 }

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -88,7 +88,7 @@ void run_test(const sstring& name, schema_ptr s, MutationGenerator&& gen) {
         // Create a reader which tests the case of memtable snapshots
         // going away after memtable was merged to cache.
         auto rd = std::make_unique<mutation_fragment_v1_stream>(
-            mutation_fragment_v1_stream(make_combined_reader(s, permit, cache.make_reader(s, permit), mt->make_flat_reader(s, permit))));
+            mutation_fragment_v1_stream(make_combined_reader(s, permit, cache.make_reader(s, permit), mt->make_mutation_reader(s, permit))));
         auto close_rd = defer([&rd] { rd->close().get(); });
         rd->set_max_buffer_size(1);
         rd->fill_buffer().get();

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -156,10 +156,10 @@ struct table {
         std::vector<mutation_reader> rd;
         auto permit = make_permit();
         if (prev_mt) {
-            rd.push_back(prev_mt->make_flat_reader(s.schema(), permit, r->pr, r->slice, nullptr,
+            rd.push_back(prev_mt->make_mutation_reader(s.schema(), permit, r->pr, r->slice, nullptr,
                 streamed_mutation::forwarding::no, mutation_reader::forwarding::no));
         }
-        rd.push_back(mt->make_flat_reader(s.schema(), permit, r->pr, r->slice, nullptr,
+        rd.push_back(mt->make_mutation_reader(s.schema(), permit, r->pr, r->slice, nullptr,
             streamed_mutation::forwarding::no, mutation_reader::forwarding::no));
         rd.push_back(cache.make_reader(s.schema(), permit, r->pr, r->slice, nullptr,
             streamed_mutation::forwarding::no, mutation_reader::forwarding::no));


### PR DESCRIPTION
Following the recent refactoring of removing "flat" and "v2" from reader names, replacing all the fully qualified names with simply "mutation_reader".

Code cleanup, no backport needed.