### PR TITLE
test: stop using seastar::at_exit()

### DIFF
--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -19,6 +19,7 @@
 #include "utils/int_range.hh"
 #include "utils/div_ceil.hh"
 #include <seastar/core/reactor.hh>
+#include <seastar/util/defer.hh>
 
 static thread_local bool cancelled = false;
 
@@ -63,9 +64,8 @@ int main(int argc, char** argv) {
             auto reads_enabled = !app.configuration().contains("no-reads");
             auto seconds = app.configuration()["seconds"].as<unsigned>();
 
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 cancelled = true;
-                return make_ready_future();
             });
 
             timer<> completion_timer;

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -2099,9 +2099,8 @@ int scylla_fast_forward_main(int argc, char** argv) {
 
                     sleep(1s).get(); // wait for system table flushes to quiesce
 
-                    engine().at_exit([&] {
+                    auto stop_test = defer([] {
                         cancel = true;
-                        return make_ready_future();
                     });
 
                     auto requested_test_groups = app.configuration()["run-tests"].as<std::vector<std::string>>() | std::ranges::to<std::unordered_set>();

--- a/test/perf/perf_row_cache_reads.cc
+++ b/test/perf/perf_row_cache_reads.cc
@@ -223,9 +223,8 @@ int main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [] {
         return seastar::async([&] {
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 cancelled = true;
-                return make_ready_future();
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
             test_scans_with_dummy_entries();

--- a/test/perf/perf_row_cache_update.cc
+++ b/test/perf/perf_row_cache_update.cc
@@ -271,9 +271,8 @@ int scylla_row_cache_update_main(int argc, char** argv) {
     app_template app;
     return app.run(argc, argv, [] {
         return seastar::async([&] {
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 cancelled = true;
-                return make_ready_future();
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
             test_small_partitions();

--- a/test/perf/perf_tablets.cc
+++ b/test/perf/perf_tablets.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/util/defer.hh>
 
 #include "locator/tablets.hh"
 #include "replica/tablet_mutation_builder.hh"
@@ -210,9 +211,8 @@ int scylla_tablets_main(int argc, char** argv) {
                 logging::logger_registry().set_all_loggers_level(seastar::log_level::warn);
                 logging::logger_registry().set_logger_level("testlog", testlog_level);
             }
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 aborted.request_abort();
-                return make_ready_future();
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
             try {

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -470,9 +470,8 @@ int scylla_tablet_load_balancing_main(int argc, char** argv) {
                 logging::logger_registry().set_all_loggers_level(seastar::log_level::warn);
                 logging::logger_registry().set_logger_level("testlog", testlog_level);
             }
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 aborted.request_abort();
-                return make_ready_future();
             });
             logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
             try {

--- a/test/unit/row_cache_stress_test.cc
+++ b/test/unit/row_cache_stress_test.cc
@@ -294,9 +294,8 @@ int main(int argc, char** argv) {
             row_cache_stress_test::table t(partitions, rows);
             auto stop_t = deferred_stop(t);
 
-            engine().at_exit([] {
+            auto stop_test = defer([] {
                 cancelled = true;
-                return make_ready_future();
             });
 
             timer<> completion_timer;


### PR DESCRIPTION
seastar::at_exit() was marked deprecated recently. so let's use the recommended approach to perform cleanups.

following tests were updated in this changes

- scylla perf-tablets: tested with scylla perf-tablets
- scylla perf-row-cache-update: tested with scylla perf-row-cache-update
- scylla perf-fast-forward: tested with scylla perf-fast-forward --populate --run-tests small-partition-skips \ --smp 1 scylla perf-fast-forward --run-tests small-partition-skips \ --smp 1
- scylla perf-load-balancing: tested with scylla perf-load-balancing --nodes 3 --tablets1 16 --tablets2 16 --rf1 3 --rf2 3 --shards 16
- unit/row_cache_stress_test: tested with row_cache_stress_test --seconds 10
- perf/perf_cache_eviction: tested with ./perf_cache_eviction --seconds 1 --smp 1
- perf/perf_row_cache_reads: tested with ./perf_row_cache_reads

---

it's a cleanup, hence no need to backport.