### PR TITLE
tree: fix misspellings

### DIFF
--- a/docs/operating-scylla/admin-tools/cassandra-stress.rst
+++ b/docs/operating-scylla/admin-tools/cassandra-stress.rst
@@ -3,6 +3,6 @@ Cassandra Stress
 
 The cassandra-stress tool is used for benchmarking and load testing both ScyllaDB and Cassandra clusters. The cassandra-stress tool also supports testing arbitrary CQL tables and queries to allow users to benchmark their data model.
 
-Cassandra Stress is not part of ScyllaDB and it is not distributed along side it anymore. It has it's own seperate repository and release cycle. More information about it can be found on `GitHub <https://github.com/scylladb/cassandra-stress>`_ or on `DockerHub <https://hub.docker.com/r/scylladb/cassandra-stress>`_.
+Cassandra Stress is not part of ScyllaDB and it is not distributed along side it anymore. It has it's own separate repository and release cycle. More information about it can be found on `GitHub <https://github.com/scylladb/cassandra-stress>`_ or on `DockerHub <https://hub.docker.com/r/scylladb/cassandra-stress>`_.
 
 .. include:: /rst_include/apache-copyrights.rst

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -731,7 +731,7 @@ future<> raft_group0::setup_group0(
         std::optional<replace_info> replace_info, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool topology_change_enabled,
         const join_node_request_params& params) {
     if (!co_await use_raft()) {
-        // The node is in the RECOVERY mode. We are in Maintenence Mode or the gossip-based recovery procedure.
+        // The node is in the RECOVERY mode. We are in Maintenance Mode or the gossip-based recovery procedure.
         co_return;
     }
 


### PR DESCRIPTION
these two misspellings were flagged by codespell.

---

it's a cleanup, hence no need to backport.