### PR TITLE
cql3: prevent from empty option use in cf_statement::column_family()

### DIFF
--- a/cql3/statements/cf_statement.cc
+++ b/cql3/statements/cf_statement.cc
@@ -53,7 +53,8 @@ const sstring& cf_statement::keyspace() const
 
 const sstring& cf_statement::column_family() const
 {
-    return _cf_name->get_column_family();
+    thread_local static sstring empty = "";
+    return bool(_cf_name) ? _cf_name->get_column_family() : empty;
 }
 
 }


### PR DESCRIPTION
Implementation of cf_statement::column_family() dereferences _cf_name option without checking if the option is non-empty. On enterprise branch, there is a safeguard that prevents from such an empty option dereferencing. Although the current code seems to not call columny_family() when _cf_name is empty, it is safer to introduce the workaround on master, to avoid regression.

This change:
 - Prevent from empty option use in cf_statement::column_family()

Fixes: [scylla-enterprise#5273](https://github.com/scylladb/scylla-enterprise/issues/5273)

No backport is needed, as no misuse of columny_family()  were found in the existing codebase.