### PR TITLE
Generalize the diversity of parse_table_infos() callers in API

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -902,17 +902,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     });
 
     ss::enable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
-
+        auto [keyspace, tables] = parse_table_infos(ctx, *req);
         apilog.info("enable_auto_compaction: keyspace={} tables={}", keyspace, tables);
         return set_tables_autocompaction(ctx, std::move(tables), true);
     });
 
     ss::disable_auto_compaction.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
-
+        auto [keyspace, tables] = parse_table_infos(ctx, *req);
         apilog.info("disable_auto_compaction: keyspace={} tables={}", keyspace, tables);
         return set_tables_autocompaction(ctx, std::move(tables), false);
     });
@@ -936,17 +932,13 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
     });
 
     ss::enable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
-
+        auto [keyspace, tables] = parse_table_infos(ctx, *req);
         apilog.info("enable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
         return set_tables_tombstone_gc(ctx, std::move(tables), true);
     });
 
     ss::disable_tombstone_gc.set(r, [&ctx](std::unique_ptr<http::request> req) {
-        auto keyspace = validate_keyspace(ctx, req);
-        auto tables = parse_table_infos(keyspace, ctx, req->query_parameters, "cf");
-
+        auto [keyspace, tables] = parse_table_infos(ctx, *req);
         apilog.info("disable_tombstone_gc: keyspace={} tables={}", keyspace, tables);
         return set_tables_tombstone_gc(ctx, std::move(tables), false);
     });

--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -111,8 +111,7 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
     });
 
     cm::stop_keyspace_compaction.set(r, [&ctx] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        auto ks_name = validate_keyspace(ctx, req);
-        auto tables = parse_table_infos(ks_name, ctx, req->query_parameters, "tables");
+        auto [ks_name, tables] = parse_table_infos(ctx, *req, "tables");
         auto type = req->get_query_param("type");
         co_await ctx.db.invoke_on_all([&] (replica::database& db) {
             auto& cm = db.get_compaction_manager();

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -157,9 +157,9 @@ std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_con
     return parse_table_infos(ks_name, ctx, it != query_params.end() ? it->second : "");
 }
 
-std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req) {
+std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req, sstring cf_param_name) {
     auto keyspace = validate_keyspace(ctx, req);
-    auto tis = parse_table_infos(keyspace, ctx, req.query_parameters, "cf");
+    auto tis = parse_table_infos(keyspace, ctx, req.query_parameters, cf_param_name);
     return std::make_pair(std::move(keyspace), std::move(tis));
 }
 

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -152,14 +152,11 @@ std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_con
     return res;
 }
 
-std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name) {
-    auto it = query_params.find(param_name);
-    return parse_table_infos(ks_name, ctx, it != query_params.end() ? it->second : "");
-}
-
 std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req, sstring cf_param_name) {
     auto keyspace = validate_keyspace(ctx, req);
-    auto tis = parse_table_infos(keyspace, ctx, req.query_parameters, cf_param_name);
+    const auto& query_params = req.query_parameters;
+    auto it = query_params.find(cf_param_name);
+    auto tis = parse_table_infos(keyspace, ctx, it != query_params.end() ? it->second : "");
     return std::make_pair(std::move(keyspace), std::move(tis));
 }
 

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -52,7 +52,6 @@ table_id validate_table(const replica::database& db, sstring ks_name, sstring ta
 // containing the description of the respective no_such_column_family error.
 // Returns a vector of all table infos given by the parameter, or
 // if the parameter is not found or is empty, returns a list of all table infos in the keyspace.
-std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, const std::unordered_map<sstring, sstring>& query_params, sstring param_name);
 
 std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, sstring value);
 

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -56,6 +56,8 @@ std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_con
 
 std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, sstring value);
 
+std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req);
+
 struct scrub_info {
     sstables::compaction_type_options::scrub opts;
     sstring keyspace;

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -56,7 +56,7 @@ std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_con
 
 std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, sstring value);
 
-std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req);
+std::pair<sstring, std::vector<table_info>> parse_table_infos(const http_context& ctx, const http::request& req, sstring cf_param_name = "cf");
 
 struct scrub_info {
     sstables::compaction_type_options::scrub opts;


### PR DESCRIPTION
The helper in question is used in several different ways -- by handlers directly (most of the callers), as a part of wrap_ks_cf() helper and by one of its overloads that unpack the "cf" query parameter from request. This PR generalizes most of the described callers thus reducing the number differently-looking of ways API handlers parse "keyspace" and "cf" request parameters.

Continuation of #22742