### PR TITLE
[Backport 2025.1] db/hints: Cancel draining when stopping node

### DIFF
--- a/db/hints/internal/hint_endpoint_manager.cc
+++ b/db/hints/internal/hint_endpoint_manager.cc
@@ -146,6 +146,10 @@ future<> hint_endpoint_manager::stop(drain should_drain) noexcept {
     });
 }
 
+void hint_endpoint_manager::cancel_draining() noexcept {
+    _sender.cancel_draining();
+}
+
 hint_endpoint_manager::hint_endpoint_manager(const endpoint_id& key, fs::path hint_directory, manager& shard_manager)
     : _key(key)
     , _shard_manager(shard_manager)

--- a/db/hints/internal/hint_endpoint_manager.hh
+++ b/db/hints/internal/hint_endpoint_manager.hh
@@ -102,6 +102,8 @@ public:
     /// \return Ready future when all operations are complete
     future<> stop(drain should_drain = drain::no) noexcept;
 
+    void cancel_draining() noexcept;
+
     /// \brief Start the timer.
     void start();
 
@@ -142,6 +144,10 @@ public:
 
     bool stopped() const noexcept {
         return _state.contains(state::stopped);
+    }
+
+    bool canceled_draining() const noexcept {
+        return _sender.canceled_draining();
     }
 
     /// \brief Returns replay position of the most recently written hint.

--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -10,6 +10,7 @@
 #include "db/hints/internal/hint_sender.hh"
 
 // Seastar features.
+#include <chrono>
 #include <exception>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -190,6 +191,14 @@ future<> hint_sender::stop(drain should_drain) noexcept {
         //       relies on the old one.
         manager_logger.trace("ep_manager({})::sender: exiting", end_point_key());
     });
+}
+
+void hint_sender::cancel_draining() {
+    manager_logger.info("Draining of {} has been marked as canceled", _ep_key);
+    if (_state.contains(state::draining)) {
+        _state.remove(state::draining);
+    }
+    _state.set(state::canceled_draining);
 }
 
 void hint_sender::add_segment(sstring seg_name) {
@@ -449,6 +458,8 @@ bool hint_sender::send_one_file(const sstring& fname) {
     gc_clock::duration secs_since_file_mod = std::chrono::seconds(last_mod.tv_sec);
     lw_shared_ptr<send_one_file_ctx> ctx_ptr = make_lw_shared<send_one_file_ctx>(_last_schema_ver_to_column_mapping);
 
+    struct canceled_draining_exception {};
+
     try {
         commitlog::read_log_file(fname, manager::FILENAME_PREFIX, [this, secs_since_file_mod, &fname, ctx_ptr] (commitlog::buffer_and_replay_position buf_rp) -> future<> {
             auto& buf = buf_rp.buffer;
@@ -459,6 +470,12 @@ bool hint_sender::send_one_file(const sstring& fname) {
                 // is DOWN or if we have already failed to send some of the previous hints.
                 if (!draining() && ctx_ptr->segment_replay_failed) {
                     co_return;
+                }
+
+                if (canceled_draining()) {
+                    manager_logger.debug("[{}] Exiting reading from commitlog because of canceled draining", _ep_key);
+                    // We need to throw an exception here to cancel reading the segment.
+                    throw canceled_draining_exception{};
                 }
 
                 // Break early if stop() was called or the destination node went down.
@@ -491,6 +508,8 @@ bool hint_sender::send_one_file(const sstring& fname) {
         manager_logger.error("{}: {}. Dropping...", fname, ex.what());
         ctx_ptr->segment_replay_failed = false;
         ++this->shard_stats().corrupted_files;
+    } catch  (const canceled_draining_exception&) {
+        manager_logger.debug("[{}] Loop in send_one_file finishes due to canceled draining", _ep_key);
     } catch (...) {
         manager_logger.trace("sending of {} failed: {}", fname, std::current_exception());
         ctx_ptr->segment_replay_failed = true;
@@ -498,6 +517,12 @@ bool hint_sender::send_one_file(const sstring& fname) {
 
     // wait till all background hints sending is complete
     ctx_ptr->file_send_gate.close().get();
+
+    // If draining was canceled, we can't say anything about the segment's state,
+    // so return immediately. We return false here because of that reason too.
+    if (canceled_draining()) {
+        return false;
+    }
 
     // If we are draining ignore failures and drop the segment even if we failed to send it.
     if (draining() && ctx_ptr->segment_replay_failed) {
@@ -556,6 +581,10 @@ void hint_sender::send_hints_maybe() noexcept {
 
     try {
         while (true) {
+            if (canceled_draining()) {
+                manager_logger.debug("[{}] Exiting loop in send_hints_maybe because of canceled draining", _ep_key);
+                break;
+            }
             const sstring* seg_name = name_of_current_segment();
             if (!seg_name || !replay_allowed() || !can_send()) {
                 break;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -382,6 +382,12 @@ private:
     /// ALL requested sync points will be canceled, i.e. an exception will be issued
     /// in the corresponding futures.
     future<> perform_migration();
+
+public:
+    /// Performs draining for all nodes that have already left the cluster.
+    /// This should only be called when the hint endpoint managers have been initialized
+    /// and the hint manager has started.
+    future<> drain_left_nodes();
 };
 
 } // namespace db::hints

--- a/db/hints/resource_manager.cc
+++ b/db/hints/resource_manager.cc
@@ -239,6 +239,15 @@ future<> resource_manager::stop() noexcept {
     });
 }
 
+future<> resource_manager::drain_hints_for_left_nodes() {
+    for (manager& m : _shard_managers) {
+        // It's safe to discard the future here. It's awaited in `manager::stop()`.
+        (void) m.drain_left_nodes();
+    }
+
+    co_return;
+}
+
 future<> resource_manager::register_manager(manager& m) {
     return with_semaphore(_operation_lock, 1, [this, &m] () {
         return with_semaphore(_space_watchdog.update_lock(), 1, [this, &m] {

--- a/db/hints/resource_manager.hh
+++ b/db/hints/resource_manager.hh
@@ -188,6 +188,8 @@ public:
     /// \brief Allows replaying hints for managers which are registered now or will be in the future.
     void allow_replaying() noexcept;
 
+    future<> drain_hints_for_left_nodes();
+
     /// \brief Registers the hints::manager in resource_manager, and starts it, if resource_manager is already running.
     ///
     /// The hints::managers can be added either before or after resource_manager starts.

--- a/main.cc
+++ b/main.cc
@@ -2288,6 +2288,24 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             supervisor::notify("allow replaying hints");
             proxy.invoke_on_all(&service::storage_proxy::allow_replaying_hints).get();
 
+            // Note: This is here because we can only start draining after we allow for replaying hints.
+            //
+            //       We want the draining to be started before exposing the API of hinted handoff to
+            //       the user (note it happens in the following step in this file). That's a preventive
+            //       measure to avoid situations when e.g. the user decides to change the host filter
+            //       and effectively disable sending hints towards some nodes. Since we only drain hints
+            //       for nodes that have left the cluster, we want to perform that before the user has
+            //       the means to interrupt it in any way.
+            //
+            //       Lastly, note that this call does NOT await the draining. It only starts the draining
+            //       process that will be taking place in the background. Thus, it does not slow down
+            //       the initialization of the node.
+            //
+            //       See the logic of draining in `db::hints::internal::hint_sender` for more details
+            //       of the semantics of the process of draining hints.
+            supervisor::notify("Drain hints for nodes that have already left the cluster");
+            proxy.invoke_on_all(&service::storage_proxy::drain_hints_for_left_nodes).get();
+
             api::set_hinted_handoff(ctx, proxy, gossiper).get();
             auto stop_hinted_handoff_api = defer_verbose_shutdown("hinted handoff API", [&ctx] {
                 api::unset_hinted_handoff(ctx).get();

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6772,6 +6772,10 @@ void storage_proxy::allow_replaying_hints() noexcept {
     return _hints_resource_manager.allow_replaying();
 }
 
+future<> storage_proxy::drain_hints_for_left_nodes() {
+    return _hints_resource_manager.drain_hints_for_left_nodes();
+}
+
 future<> storage_proxy::change_hints_host_filter(db::hints::host_filter new_filter) {
     if (new_filter == _hints_manager.get_host_filter()) {
         co_return;

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -704,6 +704,7 @@ public:
     future<> stop();
     future<> start_hints_manager();
     void allow_replaying_hints() noexcept;
+    future<> drain_hints_for_left_nodes();
     future<> abort_view_writes();
 
     future<> change_hints_host_filter(db::hints::host_filter new_filter);


### PR DESCRIPTION
Draining hints may occur in one of the two scenarios:

* a node leaves the cluster and the local node drains all of the hints saved for that node,
* the local node is being decommissioned.

Draining may take some time and the hint manager won't stop until it finishes. It's not a problem when decommissioning a node, especially because we want the cluster to retain the data stored in the hints. However, it may become a problem when the local node started draining hints saved for another node and now it's being shut down.

There are two reasons for that:

* Generally, in situations like that, we'd like to be able to shut down nodes as fast as possible. The data stored in the hints won't disappear from the cluster yet since we can restart the local node.
* Draining hints may introduce flakiness in tests. Replaying hints doesn't have the highest priority and it's reflected in the scheduling groups we use as well as the explicitly enforced throughput. If there are a large number of hints to be replayed, it might affect our tests. It's already happened, see: scylladb/scylladb#21949.

To solve those problems, we change the semantics of draining. It will behave as before when the local node is being decommissioned. However, when the local node is only being stopped, we will immediately cancel all ongoing draining processes and stop the hint manager. To amend for that, when we start a node and it initializes a hint endpoint manager corresponding to a node that's already left the cluster, we will begin the draining process of that endpoint manager right away.

That should ensure all data is retained, while possibly speeding up the shutdown process.

There's a small trade-off to it, though. If we stop a node, we can then remove it. It won't have a chance to replay hints it might've before these changes, but that's an edge case. We expect this commit to bring more benefit than harm.

We also provide tests verifying that the implementation works as intended.

Fixes scylladb/scylladb#21949

Closes scylladb/scylladb#22811

(cherry picked from commit 0a6137218aa12a703bb146297ab5bb1c34f8dc91)

Backport: backporting because of the flakiness of tests that stems from the problem these changes solve.