### PR TITLE
service: restore default timeout in `announce_with_raft`

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -918,7 +918,7 @@ future<> migration_manager::announce_with_raft(std::vector<mutation> schema, gro
         },
         guard, std::move(description));
 
-    return _group0_client.add_entry(std::move(group0_cmd), std::move(guard), _as);
+    return _group0_client.add_entry(std::move(group0_cmd), std::move(guard), _as, raft_timeout{});
 }
 
 future<> migration_manager::announce_without_raft(std::vector<mutation> schema, group0_guard guard) {


### PR DESCRIPTION
This restored timeout seems to have been accidentally removed in https://github.com/scylladb/scylladb/pull/16723/commits/7081215552ecd00babd94ad85cebfe4819891ad8#r2005352424. Without it, `raft_server_with_timeouts::run_with_timeout` will get `std::nullopt` as a value of the `timeout` parameter and perform an operation without any timeout, whereas previously it would have waited for the default timeout specified in
`raft_server_for_group::default_op_timeout`.

I don't think it should be backported, no issue has been opened against it so far, hence it seems minor.