### PR TITLE
test/cqlpy/test_service_level_api: update tests and fix flakiness

### DIFF
--- a/test/cqlpy/test_service_level_api.py
+++ b/test/cqlpy/test_service_level_api.py
@@ -18,6 +18,12 @@ import time
 def all_tests_are_scylla_only(scylla_only):
     pass
 
+def get_shard_count(cql):
+    return cql.execute("SELECT shard_count FROM system.topology").one().shard_count
+
+def read_barrier(cql):
+    cql.execute("DROP TABLE IF EXISTS nosuchkeyspace.nosuchtable")
+
 def count_opened_connections(cql, retry_unauthenticated=True):
     response = get_request(cql, "service_levels/count_connections")
     return response
@@ -53,22 +59,18 @@ def wait_until_all_connections_authenticated(cql, wait_s = 1, timeout_s = 30):
     
     raise RuntimeError(f"Awaiting for connections authentication timed out.")
 
-def wait_for_scheduling_group_assignment(cql, user, scheduling_group, wait_s = 2, timeout_s = 60):
-    start_time = time.time()
-    while time.time() - start_time < timeout_s:
-        connections = cql.execute(f"SELECT username, scheduling_group FROM system.clients WHERE client_type='cql' AND username='{user}' ALLOW FILTERING")
-        
-        require_wait = False
-        for row in connections:
-            if row[1] != f"sl:{scheduling_group}":
-                require_wait = True
-                break
-        if require_wait:
-            time.sleep(wait_s)
-            continue
-        return
+# The driver creates 1 connection per shard plus 1 control connection.
+# This function validates that all connections execept the control one use correct scheduling group.
+def verify_scheduling_group_assignment(cql, user, target_scheduling_group, shard_count):
+    shards_with_correct_sg = set()
+    connections = cql.execute(f"SELECT username, scheduling_group, shard_id FROM system.clients WHERE client_type='cql' AND username='{user}' ALLOW FILTERING")
 
-    raise RuntimeError(f"Awaiting for user '{user}' to switch tenant to scheduling group '{scheduling_group}' timed out.")
+    for conn in connections:
+        if target_scheduling_group in conn.scheduling_group:
+            shards_with_correct_sg.add(conn.shard_id)
+    
+    assert len(shards_with_correct_sg) == shard_count, (f"Not all user '{user}' connections are working under target scheduling group '{target_scheduling_group}'."
+                                                        f"Shards with correct scehduling group: {shards_with_correct_sg}, shard")
 
 # Test if `/service_levels/count_connections` prints counted CQL connections
 # per scheduling group per user.
@@ -79,14 +81,12 @@ def test_count_opened_cql_connections(cql):
     cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}'")
     cql.execute(f"CREATE SERVICE LEVEL {sl} WITH shares = 100")
     cql.execute(f"ATTACH SERVICE LEVEL {sl} TO {user}")
+    read_barrier(cql)
 
-    # Service level controller updates in 10 seconds interval, so wait
-    # for sl1 to be assgined to test_user
-    time.sleep(10)
     try:
-        with new_session(cql, user): # new sessions is created only to create user's connection to Scylla
+        with new_session(cql, user):
             wait_until_all_connections_authenticated(cql)
-            wait_for_scheduling_group_assignment(cql, user, sl)
+            verify_scheduling_group_assignment(cql, user, sl, get_shard_count(cql))
 
             api_response = count_opened_connections(cql)
             assert f"sl:{sl}" in api_response
@@ -110,45 +110,31 @@ def test_switch_tenants(cql):
     user = f"test_user_{unique_name()}"
     sl1 = f"sl1_{unique_name()}"
     sl2 = f"sl2_{unique_name()}"
+    shard_count = get_shard_count(cql)
 
-
-    cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}'")
+    cql.execute(f"CREATE ROLE {user} WITH login = true AND password='{user}' AND superuser = true")
     cql.execute(f"CREATE SERVICE LEVEL {sl1} WITH shares = 100")
     cql.execute(f"CREATE SERVICE LEVEL {sl2} WITH shares = 200")
     cql.execute(f"ATTACH SERVICE LEVEL {sl1} TO {user}")
+    read_barrier(cql)
 
-    # Service level controller updates in 10 seconds interval, so wait
-    # for sl1 to be assgined to test_user
-    time.sleep(10)
     try:
-        with new_session(cql, user): # new sessions is created only to create user's connection to Scylla
+        with new_session(cql, user) as user_session:
             wait_until_all_connections_authenticated(cql)
-            wait_for_scheduling_group_assignment(cql, user, sl1)
-
-            user_connections_sl1 = cql.execute(f"SELECT scheduling_group FROM system.clients WHERE username='{user}' ALLOW FILTERING")
-            for conn in user_connections_sl1:
-                assert conn[0] == f"sl:{sl1}"
+            verify_scheduling_group_assignment(cql, user, sl1, shard_count)
 
             cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
             cql.execute(f"ATTACH SERVICE LEVEL {sl2} TO {user}")
-            # Again wait for service level controller to notice the change
-            time.sleep(10)
+            read_barrier(cql)
 
             switch_tenants(cql)
-            wait_for_scheduling_group_assignment(cql, user, sl2)
-
-            user_connections_sl2 = cql.execute(f"SELECT scheduling_group FROM system.clients WHERE username='{user}' ALLOW FILTERING")
-            print(count_opened_connections(cql))
-            for conn in user_connections_sl2:
-                assert conn[0] == f"sl:{sl2}"
+            # Switching tenants may be blocked if a connection is waiting for a request (see 'generic_server::connection::process_until_tenant_switch()').
+            # Execute enough cheap statements, so that connection on each shard will process at one statement and update its tenant.
+            for _ in range(100):
+                read_barrier(user_session)
+            verify_scheduling_group_assignment(cql, user, sl2, shard_count)
     finally:
         cql.execute(f"DETACH SERVICE LEVEL FROM {user}")
         cql.execute(f"DROP ROLE {user}")
         cql.execute(f"DROP SERVICE LEVEL {sl1}")
         cql.execute(f"DROP SERVICE LEVEL {sl2}")
-
-
-            
-
-
-            


### PR DESCRIPTION
Tests in `test_service_level_api` were written before scylladb/scylladb#16585 and they were doing 10s sleeps to wait for service level controller to update its configuration. Now performing a read barrier is sufficient to ensure SL configuration is up-to-date, which significantly reduces tests time (from ~60s to ~2-3s).

Moreover, there was flakiness in the `test_switch_tenants` test. Until now, the test waited up to 60s for the connections to update their scheduling groups. However, it is difficult to determine how long the process might take because a connection may be blocked while waiting for the next request to be processed, and the scheduling group will be updated only after a request is processed (see `generic_server::connection::process_until_tenant_switch()`). To address this issue, 100 simple queries are executed so that connections on all shards process at least one request and update their scheduling groups.

Fixes scylladb/scylladb#22768

Backporting to 2025.1 to reduce flakiness.