### PR TITLE
test: get rid of the `universalasync` dependency

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -163,7 +163,6 @@ declare -A pip_packages=(
     [allure-pytest]=""
     [pytest-xdist]=""
     [pykmip]=""
-    [universalasync]=""
     [boto3-stubs[dynamodb]]=""
 )
 

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -23,7 +23,6 @@ import string
 
 from typing import Callable, Awaitable, Optional, TypeVar, Any
 
-import universalasync
 from cassandra.cluster import NoHostAvailable, Session, Cluster # type: ignore # pylint: disable=no-name-in-module
 from cassandra.protocol import InvalidRequest # type: ignore # pylint: disable=no-name-in-module
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
@@ -338,7 +337,6 @@ def prepare_dirs(tempdir_base: str, modes: list[str]) -> None:
             prepare_dir(os.path.join(tempdir_base, mode, "pytest"), "*")
 
 
-@universalasync.async_to_sync_wraps
 async def start_s3_mock_services(minio_tempdir_base: str) -> None:
     ms = MinioServer(
         tempdir_base=minio_tempdir_base,


### PR DESCRIPTION
This is a dependency that doesn't carry its weight. (And breaks my setup because it's not even packaged in Nix).

Remove it and replace its use with something else. We can use a session-scope autouse fixture instead of the hooks, and pytest-asyncio lets fixtures be async.

Test-only enhancement, no backporting.