### PR TITLE
topology_coordinator: Use shorter fault-injection overloads

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1679,10 +1679,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 // Release the guard to avoid blocking group0 for long periods of time while invoking RPCs
                 release_guard(std::move(guard));
 
-                co_await utils::get_local_injector().inject("truncate_table_wait", [] (auto& handler) {
-                    rtlogger.info("truncate_table_wait: start");
-                    return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(2));
-                });
+                co_await utils::get_local_injector().inject("truncate_table_wait", utils::wait_for_message(std::chrono::minutes(2)));
 
                 // Check if all the nodes with replicas are alive
                 for (const locator::host_id& replica_host: replica_hosts) {
@@ -2269,10 +2266,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 rtbuilder.done();
                 switch(node.rs->state) {
                 case node_state::bootstrapping: {
-                    co_await utils::get_local_injector().inject("delay_node_bootstrap", [](auto& handler) {
-                        rtlogger.info("delay_node_bootstrap: waiting for message");
-                        return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
-                    });
+                    co_await utils::get_local_injector().inject("delay_node_bootstrap", utils::wait_for_message(std::chrono::minutes(5)));
                     std::vector<canonical_mutation> muts;
                     // Since after bootstrapping a new node some nodes lost some ranges they need to cleanup
                     muts = mark_nodes_as_cleanup_needed(node, false);
@@ -2291,10 +2285,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
                     break;
                 case node_state::removing: {
-                    co_await utils::get_local_injector().inject("delay_node_removal", [](auto& handler) {
-                        rtlogger.info("delay_node_removal: waiting for message");
-                        return handler.wait_for_message(db::timeout_clock::now() + std::chrono::minutes(5));
-                    });
+                    co_await utils::get_local_injector().inject("delay_node_removal", utils::wait_for_message(std::chrono::minutes(5)));
                     node = retake_node(co_await remove_from_group0(std::move(node.guard), node.id), node.id);
                 }
                     [[fallthrough]];

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -112,7 +112,7 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
         # Start a TRUNCATE in the background
         trunc_future = cql.run_async(f'TRUNCATE TABLE {ks}.test', host=trunc_host)
         # Wait for the topology coordinator to reach a point wher it is about to start sending the truncate RPCs
-        await raft_leader_log.wait_for('truncate_table_wait: start')
+        await raft_leader_log.wait_for('truncate_table_wait: waiting for message')
         # Execute DROP TABLE
         await cql.run_async(f'DROP TABLE {ks}.test', host=drop_host)
         # Release TRUNCATE table in topology coordinator


### PR DESCRIPTION
There are few places that want to pause until a message is received from the test. There's a convenience one-line suger to do it.

One test needs update its expectations about log message that appears when scylle steps on it and actually starts waiting.
