### PR TITLE
test: avoid spaces when defining user-defined literal operator

### DIFF
--- a/test/boost/vint_serialization_test.cc
+++ b/test/boost/vint_serialization_test.cc
@@ -22,7 +22,7 @@ using namespace seastar;
 
 namespace {
 
-typename bytes::value_type operator "" _b(unsigned long long value) {
+typename bytes::value_type operator ""_b(unsigned long long value) {
     return static_cast<bytes::value_type>(value);
 }
 

--- a/test/raft/logical_timer.hh
+++ b/test/raft/logical_timer.hh
@@ -18,7 +18,7 @@
 
 using namespace seastar;
 
-constexpr raft::logical_clock::duration operator "" _t(unsigned long long ticks) {
+constexpr raft::logical_clock::duration operator ""_t(unsigned long long ticks) {
     return raft::logical_clock::duration{ticks};
 }
 


### PR DESCRIPTION
Clang 20 complains when it sees a user-defined literal operator defined with a space before the underscore. Assume it's adhering to the standard and comply.

No backport as we're only increasing compatibility with Fedora 42. Older releases use a frozen toolchain.