### PR TITLE
install-dependencies.sh: disabiguate python magic package

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -80,7 +80,7 @@ fedora_packages=(
     python3
     python3-aiohttp
     python3-pip
-    python3-magic
+    python3-file-magic
     python3-colorama
     python3-tabulate
     python3-boto3


### PR DESCRIPTION
There are in fact two python magic packages, file-magic (that binds to libmagic and comes from the file package), magic, an independent one. The name we use in install-depedencies.sh, python3-magic, resolves to file-magic.

In Fedora 42, the resolution from the name python3-magic to file-magic was removed [1], and so install-dependencies.sh now tries to install the wrong magic package, which turns out not to coexist with the one we want anyway.

Fix by naming python3-file-magic directly instead. Since this is what's installed in the current frozen toolchain, there's no need to regenerate it; we're just making the package list work in Fedora 42.

[1] https://src.fedoraproject.org/rpms/file/c/81910b7d885873b6fdfd4e750875172f1e031179

No backport necessary as we're only preparing for a new toolchain. Older branches have a frozen toolchain.