### PR TITLE
test: ignore unused fmt::to_string() result

### DIFF
--- a/test/boost/sstable_generation_test.cc
+++ b/test/boost/sstable_generation_test.cc
@@ -48,7 +48,8 @@ BOOST_AUTO_TEST_CASE(from_string_int_good) {
 
 BOOST_AUTO_TEST_CASE(invalid_identifier) {
   const auto invalid_id = sstables::generation_type{};
-  BOOST_CHECK_NO_THROW(fmt::to_string(invalid_id));
+  // Ignore return value explicitly since in fmt 11.1 it is marked as [[nodiscard]]
+  BOOST_CHECK_NO_THROW((void)fmt::to_string(invalid_id));
   BOOST_CHECK(!invalid_id);
 }
 


### PR DESCRIPTION
fmt 11.1 apparently marks to_string() as [[nodiscard]]. Here we aren't interested in the result, so explicitly ignore it to avoid an error.

Backport not needed as the branches have a frozen toolchain without the problem.