### PR TITLE
dist: install sbin tools into /usr/bin on Fedora 42

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -62,6 +62,15 @@ This package installs all required packages for ScyllaDB,  including
 install_arg="--housekeeping"
 %endif
 ./install.sh --packaging --root "$RPM_BUILD_ROOT" --p11-trust-paths /etc/pki/ca-trust/source:/usr/share/pki/ca-trust-source $install_arg
+%if "%{_sbindir}" == "%{_bindir}"
+# according to the latest FHS, fedora 42 unifies /usr/bin and /usr/sbin, and
+# its /usr/sbin/ becomes a symlink to bin. see
+# https://fedoraproject.org/wiki/Releases/42/ChangeSet#Unify_/usr/bin_and_/usr/sbin
+mv -v %{buildroot}/usr/sbin/scylla_*setup %{buildroot}%{_bindir}/
+mv -v %{buildroot}/usr/sbin/scylla_kernel_check %{buildroot}%{_bindir}/
+mv -v %{buildroot}/usr/sbin/node_health_check %{buildroot}%{_bindir}/
+mv -v %{buildroot}/usr/sbin/seastar-cpu-map.sh %{buildroot}%{_bindir}/
+%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -128,7 +137,8 @@ ln -sfT /etc/scylla /var/lib/scylla/conf
 %{_bindir}/iotune
 %{_bindir}/scyllatop
 %{_bindir}/nodetool
-%{_sbindir}/scylla*
+%{_sbindir}/scylla_*setup
+%{_sbindir}/scylla_kernel_check
 %{_sbindir}/node_health_check
 %{_sbindir}/seastar-cpu-map.sh
 /opt/scylladb/scripts/*


### PR DESCRIPTION
Fedora 42 unifies /usr/bin and /usr/sbin directories, causing our RPM build to fail when the `install.sh` script places tools in /usr/sbin while the package expects them in /usr/bin. This results in errors like:

```
RPM build errors:
    File not found: /home/kefu/dev/scylladb/build/dist/Debug/redhat/BUILD/scylla-2025.2.0_dev-build/BUILDROOT/usr/bin/node_health_check
    File not found: /home/kefu/dev/scylladb/build/dist/Debug/redhat/BUILD/scylla-2025.2.0_dev-build/BUILDROOT/usr/bin/seastar-cpu-map.sh
```

This change conditionally installs tools to /usr/bin when `_sbindir` and `_bindir` are identical (Fedora 42), while maintaining backward compatibility with Fedora 41 and earlier releases.
Also, in order to avoid the warning like:

```
    File listed twice: /usr/bin/scylla
    File listed twice: /usr/bin/scyllatop
```
this change also use the same glob used by install.sh, so we don't list
scylla and scyllatop twice as the previous glob pattern of
`%{_sbindir}/scylla*` was too permissive and was able to match scylla
and scyllatop as well on fedora 42 where sbin is a symlink to bin.

---

this change prepares for building packages on a new toolchain, hence no need to backport.