### PR TITLE
docs: renders os-support table from json file

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -1,0 +1,47 @@
+{
+    "Linux Distributions": {
+      "Ubuntu": ["20.04", "22.04", "24.04"],
+      "Debian": ["11"],
+      "Rocky / CentOS / RHEL": ["8", "9"],
+      "Amazon Linux": ["2023"]
+    },
+    "ScyllaDB Versions": [
+      {
+        "version": "Enterprise 2025.1",
+        "supported_OS": {
+          "Ubuntu": ["20.04", "22.04", "24.04"],
+          "Debian": ["11"],
+          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Amazon Linux": ["2023"]
+        }
+      },
+      {
+        "version": "Enterprise 2024.2",
+        "supported_OS": {
+          "Ubuntu": ["20.04", "22.04", "24.04"],
+          "Debian": ["11"],
+          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Amazon Linux": ["2023"]
+        }
+      },
+      {
+        "version": "Enterprise 2024.1",
+        "supported_OS": {
+          "Ubuntu": ["20.04", "22.04", "24.04*"],
+          "Debian": ["11"],
+          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Amazon Linux": []
+        }
+      },
+      {
+        "version": "Open Source 6.2",
+        "supported_OS": {
+          "Ubuntu": ["20.04", "22.04", "24.04"],
+          "Debian": ["11"],
+          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Amazon Linux": ["2023"]
+        }
+      }
+    ]
+  }
+  

--- a/docs/_templates/platforms.tmpl
+++ b/docs/_templates/platforms.tmpl
@@ -1,0 +1,63 @@
+{% set total_versions = { 'count': 0 } %}
+{% for dist, versions in data['Linux Distributions'].items() %}
+    {% set _ = total_versions.update({'count': total_versions['count'] + versions|length}) %}
+{% endfor %}
+
+.. list-table::
+   :header-rows: 2
+   :widths: 30 {% for dist, versions in data['Linux Distributions'].items() %}{% for version in versions %}10 {% endfor %}{% endfor %}
+   :class: os-support-table
+
+   * - Linux Distributions
+     {% for dist, versions in data['Linux Distributions'].items() -%}
+     - {{ dist }}
+     {% for i in range(versions|length - 1) -%}
+     - 
+     {% endfor %}
+     {% endfor %}
+   * - ScyllaDB Version / OS Version
+     {% for dist, versions in data['Linux Distributions'].items() -%}
+     {% for version in versions -%}
+     - {{ version }}
+     {% endfor %}
+     {% endfor %}
+{% for version in data['ScyllaDB Versions'] %}
+   * - {{ version['version'] }}
+     {% for dist, versions in data['Linux Distributions'].items() -%}
+     {% for ver in versions -%}
+     - {% set stripped_ver = ver.replace('*', '') %}{% if stripped_ver + '*' in version['supported_OS'][dist] %}|v| ``*``{% elif stripped_ver in version['supported_OS'][dist] %}|v|{% else %}|x|{% endif %}
+     {% endfor %}
+     {% endfor %}
+{% endfor %}
+
+.. raw:: html
+
+   <script>
+   // Adds colspan support for list-table
+   document.addEventListener('DOMContentLoaded', () => {
+       const firstRow = document.querySelector('.os-support-table thead tr:first-child');
+       if (!firstRow) return;
+
+       const cells = Array.from(firstRow.children);
+       let currentIndex = 0;
+
+       while (currentIndex < cells.length) {
+           const currentCell = cells[currentIndex];
+           if (currentCell.textContent.trim()) {
+               let colspan = 1;
+               while (currentIndex + colspan < cells.length && 
+                      !cells[currentIndex + colspan].textContent.trim()) {
+                   colspan++;
+               }
+               currentCell.colSpan = colspan;
+               for (let i = 1; i < colspan; i++) {
+                   cells[currentIndex + i].remove();
+               }
+               currentIndex += colspan;
+           } else {
+               currentCell.remove();
+               cells.splice(currentIndex, 1);
+           }
+       }
+   });
+   </script>

--- a/docs/getting-started/os-support.rst
+++ b/docs/getting-started/os-support.rst
@@ -4,22 +4,10 @@ OS Support by Linux Distributions and Version
 The following matrix shows which Linux distributions, containers, and images
 are :ref:`supported <os-support-definition>` with which versions of ScyllaDB.
 
-+-------------------------------+--------------------------+-------+------------------+---------------+
-| Linux Distributions           |Ubuntu                    | Debian| Rocky / Centos / | Amazon Linux  |
-|                               |                          |       | RHEL             |               |
-+-------------------------------+------+------+------------+-------+-------+----------+---------------+
-| ScyllaDB Version / OS Version |20.04 |22.04 |24.04       |  11   |   8   |   9      | 2023          |
-+===============================+======+======+============+=======+=======+==========+===============+
-|   Enterprise 2025.1           | |v|  | |v|  | |v|        | |v|   | |v|   | |v|      | |v|           |
-+-------------------------------+------+------+------------+-------+-------+----------+---------------+
-|   Enterprise 2024.2           | |v|  | |v|  | |v|        | |v|   | |v|   | |v|      | |v|           |
-+-------------------------------+------+------+------------+-------+-------+----------+---------------+
-|   Enterprise 2024.1           | |v|  | |v|  | |v| ``*``  | |v|   | |v|   | |v|      | |x|           |
-+-------------------------------+------+------+------------+-------+-------+----------+---------------+
-|   Open Source 6.2             | |v|  | |v|  | |v|        | |v|   | |v|   | |v|      | |v|           |
-+-------------------------------+------+------+------------+-------+-------+----------+---------------+
+.. datatemplate:json:: /_static/data/os-support.json
+  :template: platforms.tmpl
 
-  ``*`` 2024.1.9 and later
+``*`` 2024.1.9 and later
 
 All releases are available as a Docker container, EC2 AMI, GCP, and Azure images.
 


### PR DESCRIPTION
Closes https://github.com/scylladb/scylladb/issues/23467

## Motivation

Renders the  table published at [OS Support by Linux Distribution and Version](https://docs.scylladb.com/manual/stable/getting-started/os-support) from an [structured JSON file](https://github.com/scylladb/scylladb/compare/master...dgarcia360:scylla:docs-platform-tables?expand=1#diff-a2fe54e021da3108dcd94212499fec3939f629b96dd080623bbe274dbd1ab512).

The JSON file will be exposed at https://docs.scylladb.com/manual/stable/static/data/os-support.json to make it readable from other apps & services.

## How to test

1. Build the docs locally.

2. Check the table rendered at http://127.0.0.1:5500/getting-started/os-support/:


    ![image](https://github.com/user-attachments/assets/f8d1c3e4-005d-4bc1-b82c-41bf3f54e24b)
