### PR TITLE
test/backup: Check that backup and restore succeed

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -422,7 +422,8 @@ async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, 
     async def do_backup(s):
         await manager.api.take_snapshot(s.ip_addr, ks, snap_name)
         tid = await manager.api.backup(s.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name, prefix)
-        await manager.api.wait_task(s.ip_addr, tid)
+        status = await manager.api.wait_task(s.ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
 
     await asyncio.gather(*(do_backup(s) for s in servers))
 
@@ -435,7 +436,8 @@ async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, 
     async def do_restore(s, toc_names, scope):
         logger.info(f'Restore {s.ip_addr} with {toc_names}, scope={scope}')
         tid = await manager.api.restore(s.ip_addr, ks, cf, s3_server.address, s3_server.bucket_name, prefix, toc_names, scope)
-        await manager.api.wait_task(s.ip_addr, tid)
+        status = await manager.api.wait_task(s.ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
 
     if topology.dcs > 1:
         scope = 'dc'


### PR DESCRIPTION
The scoped-restore test calls backup and restore APIs on several nodes, but doesn't check if any of the operations actually succeeds. Sometimes they indeed don't and test captures this, but in a weird manner -- the post-test checks for data presense fails, because the expected data is not in fact in its place.

It's more debugging-friendly if we know in advance if backup or restore fails, rather than see that some data is missing after (failed) restore.

refs: #23189

It's a new test, not present in maintained branches, thus no backport