### PR TITLE
[Backport 2025.1] tablets: Make load balancing capacity-aware

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -536,6 +536,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The directory where the schema commit log is stored. This is a special commitlog instance used for schema and system tables. For optimal write performance, it is recommended the commit log be on a separate disk partition (ideally, a separate physical device) from the data file directories.")
     , data_file_directories(this, "data_file_directories", "datadir", value_status::Used, { },
         "The directory location where table data (SSTables) is stored.")
+    , data_file_capacity(this, "data_file_capacity", liveness::LiveUpdate, value_status::Used, 0,
+        "Total capacity in bytes for storing data files. Used by tablet load balancer to compute storage utilization."
+        " If not set, will use file system's capacity.")
     , hints_directory(this, "hints_directory", value_status::Used, "",
         "The directory where hints files are stored if hinted handoff is enabled.")
     , view_hints_directory(this, "view_hints_directory", value_status::Used, "",

--- a/db/config.hh
+++ b/db/config.hh
@@ -183,6 +183,7 @@ public:
     named_value<sstring> commitlog_directory;
     named_value<sstring> schema_commitlog_directory;
     named_value<string_list> data_file_directories;
+    named_value<uint64_t> data_file_capacity;
     named_value<sstring> hints_directory;
     named_value<sstring> view_hints_directory;
     named_value<sstring> saved_caches_directory;

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -162,6 +162,7 @@ public:
     gms::feature workload_prioritization { *this, "WORKLOAD_PRIORITIZATION"sv };
     gms::feature file_stream { *this, "FILE_STREAM"sv };
     gms::feature compression_dicts { *this, "COMPRESSION_DICTS"sv };
+    gms::feature tablet_load_stats_v2 { *this, "TABLET_LOAD_STATS_V2"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -24,8 +24,13 @@ struct table_load_stats final {
     int64_t split_ready_seq_number;
 };
 
-struct load_stats final {
+struct load_stats_v1 final {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
+};
+
+struct load_stats {
+    std::unordered_map<::table_id, locator::table_load_stats> tables;
+    std::unordered_map<locator::host_id, uint64_t> capacity;
 };
 
 }
@@ -69,6 +74,7 @@ verb raft_topology_cmd (raft::server_id dst_id, raft::term_t term, uint64_t cmd_
 verb [[cancellable]] raft_pull_snapshot (raft::server_id dst_id, service::raft_snapshot_pull_params) -> service::raft_snapshot;
 verb [[cancellable]] tablet_stream_data (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tablet_id);
+verb [[cancellable]] table_load_stats_v1 (raft::server_id dst_id) -> locator::load_stats_v1;
 verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
 verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id) -> service::tablet_operation_repair_result;
 }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -236,6 +236,19 @@ public:
         }
         return minmax;
     }
+
+    // Returns nullopt if capacity is not known.
+    std::optional<double> get_allocated_utilization(host_id node, const locator::load_stats& stats, uint64_t target_tablet_size) const {
+        if (!_nodes.contains(node)) {
+            return std::nullopt;
+        }
+        auto& n = _nodes.at(node);
+        if (!stats.capacity.contains(node)) {
+            return std::nullopt;
+        }
+        auto capacity = stats.capacity.at(node);
+        return capacity > 0 ? double(n.load() * target_tablet_size) / capacity : 0;
+    }
 };
 
 } // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -668,9 +668,16 @@ table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexce
     return *this;
 }
 
+load_stats load_stats::from_v1(load_stats_v1&& stats) {
+    return { .tables = std::move(stats.tables) };
+}
+
 load_stats& load_stats::operator+=(const load_stats& s) {
     for (auto& [id, stats] : s.tables) {
         tables[id] += stats;
+    }
+    for (auto& [host, cap] : s.capacity) {
+        capacity[host] = cap;
     }
     return *this;
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -356,14 +356,26 @@ struct table_load_stats {
     }
 };
 
+// Deprecated, use load_stats instead.
+struct load_stats_v1 {
+    std::unordered_map<table_id, table_load_stats> tables;
+};
+
 struct load_stats {
     std::unordered_map<table_id, table_load_stats> tables;
+
+    // Capacity in bytes for data file storage.
+    std::unordered_map<host_id, uint64_t> capacity;
+
+    static load_stats from_v1(load_stats_v1&&);
 
     load_stats& operator+=(const load_stats& s);
     friend load_stats operator+(load_stats a, const load_stats& b) {
         return a += b;
     }
 };
+
+using load_stats_v2 = load_stats;
 
 struct repair_scheduler_config {
     bool auto_repair_enabled = false;

--- a/main.cc
+++ b/main.cc
@@ -25,6 +25,7 @@
 #include "tasks/task_manager.hh"
 #include "utils/assert.hh"
 #include "utils/build_id.hh"
+#include "utils/only_on_shard0.hh"
 #include "supervisor.hh"
 #include "replica/database.hh"
 #include <seastar/core/reactor.hh>
@@ -1208,6 +1209,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 .normal_polling_interval = cfg->disk_space_monitor_normal_polling_interval_in_seconds,
                 .high_polling_interval = cfg->disk_space_monitor_high_polling_interval_in_seconds,
                 .polling_interval_threshold = cfg->disk_space_monitor_polling_interval_threshold,
+                .capacity_override = cfg->data_file_capacity
             };
             if (data_dir_set.get_paths().empty()) {
                 throw std::runtime_error("data_dir_set must be non-empty");
@@ -1731,7 +1733,8 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
                 std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller),
                 std::ref(tsm), std::ref(task_manager), std::ref(gossip_address_map),
-                compression_dict_updated_callback
+                compression_dict_updated_callback,
+                only_on_shard0(&*disk_space_monitor_shard0)
             ).get();
 
             auto stop_storage_service = defer_verbose_shutdown("storage_service", [&] {

--- a/message/messaging_service.cc
+++ b/message/messaging_service.cc
@@ -682,6 +682,7 @@ static constexpr unsigned do_get_rpc_client_idx(messaging_verb verb) {
     case messaging_verb::TABLET_STREAM_DATA:
     case messaging_verb::TABLET_CLEANUP:
     case messaging_verb::TABLET_REPAIR:
+    case messaging_verb::TABLE_LOAD_STATS_V1:
     case messaging_verb::TABLE_LOAD_STATS:
         return 1;
     case messaging_verb::CLIENT_ID:

--- a/message/messaging_service.hh
+++ b/message/messaging_service.hh
@@ -207,12 +207,13 @@ enum class messaging_verb : int32_t {
     JOIN_NODE_RESPONSE = 69,
     TABLET_STREAM_FILES = 70,
     STREAM_BLOB = 71,
-    TABLE_LOAD_STATS = 72,
+    TABLE_LOAD_STATS_V1 = 72,
     JOIN_NODE_QUERY = 73,
     TASKS_GET_CHILDREN = 74,
     TABLET_REPAIR = 75,
     TRUNCATE_WITH_TABLETS = 76,
-    LAST = 77,
+    TABLE_LOAD_STATS = 77,
+    LAST = 78,
 };
 
 } // namespace netw

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -104,6 +104,10 @@ namespace tasks {
 class task_manager;
 }
 
+namespace utils {
+class disk_space_monitor;
+}
+
 namespace service {
 
 class storage_service;
@@ -237,7 +241,8 @@ public:
         topology_state_machine& topology_state_machine,
         tasks::task_manager& tm,
         gms::gossip_address_map& address_map,
-        std::function<future<void>()> compression_dictionary_updated_callback);
+        std::function<future<void>()> compression_dictionary_updated_callback,
+        utils::disk_space_monitor* disk_space_minitor);
     ~storage_service();
 
     node_ops::task_manager_module& get_node_ops_module() noexcept;
@@ -997,6 +1002,8 @@ private:
     abort_source _group0_as;
 
     std::function<future<void>()> _compression_dictionary_updated_callback;
+
+    utils::disk_space_monitor* _disk_space_monitor; // != nullptr only on shard0.
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -129,6 +129,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     // The reason load_stats_ptr is a shared ptr is that load balancer can yield, and we don't want it
     // to suffer lifetime issues when stats refresh fiber overrides the current stats.
     locator::load_stats_ptr _tablet_load_stats;
+    std::unordered_map<locator::host_id, locator::load_stats> _load_stats_per_node;
+    serialized_action _tablet_load_stats_refresh;
     // FIXME: make frequency per table in order to reduce work in each iteration.
     //  Bigger tables will take longer to be resized. similar-sized tables can be batched into same iteration.
     static constexpr std::chrono::seconds tablet_load_stats_refresh_interval = std::chrono::seconds(60);
@@ -2281,6 +2283,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     muts.emplace_back(rtbuilder.build());
                     co_await update_topology_state(take_guard(std::move(node)), std::move(muts),
                                                    "bootstrap: read fence completed");
+                    // Make sure the load balancer knows the capacity for the new node immediately.
+                    (void)_tablet_load_stats_refresh.trigger().handle_exception([] (auto ep) {
+                        rtlogger.warn("Error during tablet load stats refresh: {}", ep);
+                    });
                     }
                     break;
                 case node_state::removing: {
@@ -2812,7 +2818,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     // Returns true if the state machine was transitioned into tablet resize finalization path.
     future<bool> maybe_start_tablet_resize_finalization(group0_guard, const table_resize_plan& plan);
 
-    future<locator::load_stats> refresh_tablet_load_stats();
+    future<> refresh_tablet_load_stats();
     future<> start_tablet_load_stats_refresher();
 
     // Precondition: the state machine upgrade state is not at upgrade_state::done.
@@ -2847,6 +2853,7 @@ public:
         , _raft(raft_server), _term(raft_server.get_current_term())
         , _raft_topology_cmd_handler(std::move(raft_topology_cmd_handler))
         , _tablet_allocator(tablet_allocator)
+        , _tablet_load_stats_refresh([this] { return refresh_tablet_load_stats(); })
         , _ring_delay(ring_delay)
         , _group0_holder(_group0.hold_group0_gate())
     {}
@@ -2896,13 +2903,13 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     rtlogger.debug("Evaluating tablet balance");
 
     if (utils::get_local_injector().enter("tablet_load_stats_refresh_before_rebalancing")) {
-        _tablet_load_stats = make_lw_shared<const locator::load_stats>(co_await refresh_tablet_load_stats());
+        co_await _tablet_load_stats_refresh.trigger();
     }
 
     auto tm = get_token_metadata_ptr();
     auto plan = co_await _tablet_allocator.balance_tablets(tm, _tablet_load_stats, get_dead_nodes());
     if (plan.empty()) {
-        rtlogger.debug("Tablets are balanced");
+        rtlogger.debug("Tablet load balancer did not make any plan");
         co_return false;
     }
 
@@ -2946,19 +2953,21 @@ future<bool> topology_coordinator::maybe_start_tablet_resize_finalization(group0
     co_return true;
 }
 
-future<locator::load_stats> topology_coordinator::refresh_tablet_load_stats() {
+future<> topology_coordinator::refresh_tablet_load_stats() {
     auto tm = get_token_metadata_ptr();
 
     locator::load_stats stats;
     static constexpr std::chrono::seconds wait_for_live_nodes_timeout{30};
 
     std::unordered_map<table_id, size_t> total_replicas;
+    bool table_load_stats_invalid = false;
 
     for (auto& [dc, nodes] : tm->get_datacenter_token_owners_nodes()) {
         locator::load_stats dc_stats;
         rtlogger.info("raft topology: Refreshing table load stats for DC {} that has {} token owners", dc, nodes.size());
         co_await coroutine::parallel_for_each(nodes, [&] (const auto& node) -> future<> {
             auto dst = node.get().host_id();
+            auto dst_server = raft::server_id(dst.uuid());
 
             _as.check();
 
@@ -2975,11 +2984,29 @@ future<locator::load_stats> topology_coordinator::refresh_tablet_load_stats() {
             t.arm(timeout);
             auto sub = _as.subscribe(request_abort);
 
-            auto node_stats = co_await ser::storage_service_rpc_verbs::send_table_load_stats(&_messaging,
-                                                                                             dst,
-                                                                                             as,
-                                                                                             raft::server_id(dst.uuid()));
+            locator::load_stats node_stats;
+            if (!_gossiper.is_alive(dst)) {
+                if (_load_stats_per_node.contains(dst)) {
+                    node_stats = _load_stats_per_node[dst];
+                } else {
+                    rtlogger.debug("raft topology: Unable to refresh table load on {} because it's down.", dst);
+                    table_load_stats_invalid = true;
+                    co_return;
+                }
+            } else if (_feature_service.tablet_load_stats_v2) {
+                node_stats = co_await ser::storage_service_rpc_verbs::send_table_load_stats(&_messaging,
+                                                                                            dst,
+                                                                                            as,
+                                                                                            dst_server);
+            } else {
+                node_stats = locator::load_stats::from_v1(
+                    co_await ser::storage_service_rpc_verbs::send_table_load_stats_v1(&_messaging,
+                                                                                      dst,
+                                                                                      as,
+                                                                                      dst_server));
+            }
 
+            _load_stats_per_node[dst] = node_stats;
             dc_stats += node_stats;
         });
 
@@ -3018,9 +3045,14 @@ future<locator::load_stats> topology_coordinator::refresh_tablet_load_stats() {
         // the average tablet size by dividing total size by tablet count.
         table_load_stats.size_in_bytes /= table_total_replicas;
     }
+
+    if (table_load_stats_invalid) {
+        stats.tables.clear();
+    }
+
     rtlogger.debug("raft topology: Refreshed table load stats for all DC(s).");
 
-    co_return std::move(stats);
+    _tablet_load_stats = make_lw_shared<const locator::load_stats>(std::move(stats));
 }
 
 future<> topology_coordinator::start_tablet_load_stats_refresher() {
@@ -3028,7 +3060,7 @@ future<> topology_coordinator::start_tablet_load_stats_refresher() {
     while (can_proceed()) {
         bool sleep = true;
         try {
-            _tablet_load_stats = make_lw_shared<const locator::load_stats>(co_await refresh_tablet_load_stats());
+            co_await _tablet_load_stats_refresh.trigger();
             _topo_sm.event.broadcast(); // wake up load balancer.
         } catch (raft::request_aborted&) {
             rtlogger.debug("raft topology: Tablet load stats refresher aborted");
@@ -3381,6 +3413,7 @@ future<> topology_coordinator::run() {
 
     co_await _async_gate.close();
     co_await std::move(tablet_load_stats_refresher);
+    co_await _tablet_load_stats_refresh.join();
     co_await std::move(cdc_generation_publisher);
     co_await std::move(gossiper_orphan_remover);
 }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -51,6 +51,7 @@
 #include "db/system_keyspace.hh"
 #include "db/view/view_builder.hh"
 #include "replica/mutation_dump.hh"
+#include "utils/disk_space_monitor.hh"
 
 using namespace std::chrono_literals;
 using namespace sstables;
@@ -1610,6 +1611,56 @@ SEASTAR_TEST_CASE(mutation_dump_generated_schema_deterministic_id_version) {
     BOOST_REQUIRE_EQUAL(os1->version(), os2->version());
 
     return make_ready_future<>();
+}
+
+SEASTAR_TEST_CASE(test_disk_space_monitor_capacity_override) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        utils::disk_space_monitor& monitor = e.disk_space_monitor();
+        std::filesystem::space_info orig_space = {
+            .capacity = 100,
+            .free = 12,
+            .available = 11,
+        };
+        monitor.set_space_source([&] { return make_ready_future<std::filesystem::space_info>(orig_space); });
+
+        utils::phased_barrier poll_barrier; // new operation started whenever monitor calls listeners.
+        auto op = poll_barrier.start();
+        auto listener_registration = monitor.listen([&] (auto& mon) mutable {
+            op = poll_barrier.start();
+            return make_ready_future<>();
+        });
+
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE(monitor.space() == orig_space);
+
+        e.db_config().data_file_capacity(90);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 90);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 1);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 2);
+
+        e.db_config().data_file_capacity(10);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 10);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 0);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 0);
+
+        e.db_config().data_file_capacity(1000);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE_EQUAL(monitor.space().capacity, 1000);
+        BOOST_REQUIRE_EQUAL(monitor.space().available, 911);
+        BOOST_REQUIRE_EQUAL(monitor.space().free, 912);
+
+        e.db_config().data_file_capacity(0);
+        monitor.trigger_poll();
+        poll_barrier.advance_and_await().get();
+        BOOST_REQUIRE(monitor.space() == orig_space);
+    });
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -49,6 +49,22 @@ using namespace locator;
 using namespace replica;
 using namespace service;
 
+struct shared_load_stats {
+    locator::load_stats stats;
+
+    locator::load_stats_ptr get() {
+        return make_lw_shared(stats);
+    }
+
+    void set_size(table_id table, size_t size_in_bytes) {
+        stats.tables[table].size_in_bytes = size_in_bytes;
+    }
+
+    void set_split_ready_seq_number(table_id table, size_t seq_number) {
+        stats.tables[table].split_ready_seq_number = seq_number;
+    }
+};
+
 static api::timestamp_type current_timestamp(cql_test_env& e) {
     // Mutations in system.tablets got there via group0, so in order for new
     // mutations to take effect, their timestamp should be "later" than that
@@ -1475,9 +1491,10 @@ void check_tablet_invariants(const tablet_metadata& tmeta);
 static
 void do_rebalance_tablets(cql_test_env& e,
                           group0_guard& guard,
-                          locator::load_stats_ptr load_stats = {},
+                          shared_load_stats* load_stats = nullptr,
                           std::unordered_set<host_id> skiplist = {},
-                          std::function<bool(const migration_plan&)> stop = nullptr)
+                          std::function<bool(const migration_plan&)> stop = nullptr,
+                          bool auto_split = false)
 {
     auto& talloc = e.get_tablet_allocator().local();
     auto& stm = e.shared_token_metadata().local();
@@ -1487,7 +1504,7 @@ void do_rebalance_tablets(cql_test_env& e,
     auto max_iterations = 1 + get_tablet_count(stm.get()->tablets()) * 10;
 
     for (size_t i = 0; i < max_iterations; ++i) {
-        auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist).get();
+        auto plan = talloc.balance_tablets(stm.get(), load_stats ? load_stats->get() : nullptr, skiplist).get();
         if (plan.empty()) {
             return;
         }
@@ -1498,6 +1515,17 @@ void do_rebalance_tablets(cql_test_env& e,
             apply_plan(tm, plan);
             return make_ready_future<>();
         }).get();
+
+        if (auto_split && load_stats) {
+            auto& tm = *stm.get();
+            for (auto& [table, tmap]: tm.tablets().all_tables()) {
+                if (std::holds_alternative<resize_decision::split>(tmap->resize_decision().way)) {
+                    testlog.debug("set_split_ready_seq_number({}, {})", table, tmap->resize_decision().sequence_number);
+                    load_stats->set_split_ready_seq_number(table, tmap->resize_decision().sequence_number);
+                }
+            }
+        }
+
         handle_resize_finalize(e, guard, plan).get();
     }
     throw std::runtime_error("rebalance_tablets(): convergence not reached within limit");
@@ -1508,16 +1536,17 @@ void do_rebalance_tablets(cql_test_env& e,
 // only reflects it in the metadata.
 // Run in a seastar thread.
 void rebalance_tablets(cql_test_env& e,
-                       load_stats_ptr load_stats = nullptr,
+                       shared_load_stats* load_stats = nullptr,
                        std::unordered_set<host_id> skiplist = {},
-                       std::function<bool(const migration_plan&)> stop = nullptr) {
+                       std::function<bool(const migration_plan&)> stop = nullptr,
+                       bool auto_split = true) {
     abort_source as;
     testlog.debug("rebalance_tablets(): start");
 
     auto guard = e.get_raft_group0_client().start_operation(as).get();
     testlog.debug("rebalance_tablets(): took group0 guard");
 
-    do_rebalance_tablets(e, guard, std::move(load_stats), std::move(skiplist), std::move(stop));
+    do_rebalance_tablets(e, guard, load_stats, std::move(skiplist), std::move(stop), auto_split);
     testlog.debug("rebalance_tablets(): rebalanced");
 
     // We should not introduce inconsistency between on-disk state and in-memory state
@@ -2727,8 +2756,9 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
     auto tablet_count = [&] {
         return stm.get()->tablets().get_tablet_map(table1).tablet_count();
     };
-    auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
-        rebalance_tablets(e, make_lw_shared(std::move(load_stats)));
+    shared_load_stats load_stats;
+    auto do_rebalance_tablets = [&] () {
+        rebalance_tablets(e, &load_stats);
     };
 
     const uint64_t target_tablet_size = service::default_target_tablet_size;
@@ -2737,15 +2767,11 @@ static void do_test_load_balancing_merge_colocation(cql_test_env& e, const int n
     };
 
     while (tablet_count() > 1) {
-        locator::load_stats load_stats = {
-            .tables = {
-                { table1, table_load_stats{ .size_in_bytes = merge_threshold() - 1 }},
-            }
-        };
+        load_stats.set_size(table1, merge_threshold() - 1);
 
         auto old_tablet_count = tablet_count();
         check_tablet_invariants(stm.get()->tablets());
-        do_rebalance_tablets(std::move(load_stats));
+        do_rebalance_tablets();
         check_tablet_invariants(stm.get()->tablets());
         BOOST_REQUIRE_LT(tablet_count(), old_tablet_count);
     }
@@ -2930,8 +2956,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
             return stm.get()->tablets().get_tablet_map(table1).resize_decision();
         };
 
-        auto do_rebalance_tablets = [&] (locator::load_stats load_stats) {
-            rebalance_tablets(e, make_lw_shared(std::move(load_stats)));
+        shared_load_stats load_stats;
+        auto do_rebalance_tablets = [&] () {
+            rebalance_tablets(e, &load_stats, {}, nullptr, false); // no auto-split
         };
 
         const uint64_t max_tablet_size = service::default_target_tablet_size * 2;
@@ -2942,15 +2969,13 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
 
         const auto initial_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min();
 
+        load_stats.set_split_ready_seq_number(table1, initial_ready_seq_number);
+
         // avg size moved above target size, so merge is cancelled
         {
-            locator::load_stats load_stats = {
-                .tables = {
-                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(0.75), .split_ready_seq_number = initial_ready_seq_number }},
-                }
-            };
+            load_stats.set_size(table1, to_size_in_bytes(0.75));
 
-            do_rebalance_tablets(std::move(load_stats));
+            do_rebalance_tablets();
             BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
         }
@@ -2960,13 +2985,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
 
         // avg size hits split threshold, and balancer emits split request
         {
-            locator::load_stats load_stats = {
-                .tables = {
-                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(1.1), .split_ready_seq_number = initial_ready_seq_number }},
-                }
-            };
+            load_stats.set_size(table1, to_size_in_bytes(1.1));
 
-            do_rebalance_tablets(std::move(load_stats));
+            do_rebalance_tablets();
             BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::split>(resize_decision().way));
             BOOST_REQUIRE_GT(resize_decision().sequence_number, 0);
@@ -2975,13 +2996,9 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
         // replicas set their split status as ready, and load balancer finalizes split generating a new
         // tablet map, twice as large as the previous one.
         {
-            locator::load_stats load_stats = {
-                .tables = {
-                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(1.1), .split_ready_seq_number = resize_decision().sequence_number }},
-                }
-            };
+            load_stats.set_split_ready_seq_number(table1, resize_decision().sequence_number);
 
-            do_rebalance_tablets(std::move(load_stats));
+            do_rebalance_tablets();
 
             BOOST_REQUIRE_EQUAL(tablet_count(), initial_tablets * 2);
             BOOST_REQUIRE(std::holds_alternative<locator::resize_decision::none>(resize_decision().way));
@@ -2989,13 +3006,10 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
 
         // Check that balancer detects table size dropped to 0 and reduces tablet count down to 1 through merges.
         {
-            locator::load_stats load_stats = {
-                .tables = {
-                    { table1, table_load_stats{ .size_in_bytes = to_size_in_bytes(0.0), .split_ready_seq_number = initial_ready_seq_number }},
-                }
-            };
+            load_stats.set_size(table1, to_size_in_bytes(0.0));
+            load_stats.set_split_ready_seq_number(table1, initial_ready_seq_number);
 
-            do_rebalance_tablets(std::move(load_stats));
+            do_rebalance_tablets();
             BOOST_REQUIRE_EQUAL(tablet_count(), 1);
         }
 

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -58,6 +58,7 @@
 #include "db/sstables-format-selector.hh"
 #include "repair/row_level.hh"
 #include "utils/assert.hh"
+#include "utils/only_on_shard0.hh"
 #include "utils/class_registrator.hh"
 #include "utils/cross-shard-barrier.hh"
 #include "streaming/stream_manager.hh"
@@ -592,6 +593,7 @@ private:
                 .normal_polling_interval = cfg->disk_space_monitor_normal_polling_interval_in_seconds,
                 .high_polling_interval = cfg->disk_space_monitor_high_polling_interval_in_seconds,
                 .polling_interval_threshold = cfg->disk_space_monitor_polling_interval_threshold,
+                .capacity_override = cfg->data_file_capacity,
             };
             _disk_space_monitor_shard0.emplace(abort_sources.local(), data_dir_path, dsm_cfg);
             _disk_space_monitor_shard0->start().get();
@@ -880,7 +882,8 @@ private:
                 std::ref(_topology_state_machine),
                 std::ref(_task_manager),
                 std::ref(_gossip_address_map),
-                compression_dict_updated_callback
+                compression_dict_updated_callback,
+                only_on_shard0(&*_disk_space_monitor_shard0)
             ).get();
             auto stop_storage_service = defer([this] { _ss.stop().get(); });
 
@@ -1141,6 +1144,10 @@ public:
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() override {
         return _sl_controller;
+    }
+
+    utils::disk_space_monitor& disk_space_monitor() override {
+        return *_disk_space_monitor_shard0;
     }
 
     db::config& db_config() override {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -168,6 +168,7 @@ private:
     sharded<gms::gossip_address_map> _gossip_address_map;
     sharded<service::direct_fd_pinger> _fd_pinger;
     sharded<cdc::cdc_service> _cdc;
+    db::config* _db_config;
 
     service::raft_group0_client* _group0_client;
 
@@ -638,6 +639,7 @@ private:
             _lang_manager.invoke_on_all(&lang::manager::start).get();
 
 
+            _db_config = &*cfg;
             _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), std::ref(abort_sources), utils::cross_shard_barrier()).get();
             auto stop_db = defer([this] {
                 _db.stop().get();
@@ -1139,6 +1141,10 @@ public:
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() override {
         return _sl_controller;
+    }
+
+    db::config& db_config() override {
+        return *_db_config;
     }
 };
 

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -194,6 +194,8 @@ public:
     data_dictionary::database data_dictionary();
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;
+
+    virtual db::config& db_config() = 0;
 };
 
 future<> do_with_cql_env(std::function<future<>(cql_test_env&)> func, cql_test_config = {}, std::optional<cql_test_init_configurables> = {});

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -49,6 +49,10 @@ namespace cql3 {
     class query_processor;
 }
 
+namespace utils {
+class disk_space_monitor;
+}
+
 namespace service {
 
 class client_state;
@@ -192,6 +196,9 @@ public:
     virtual sharded<service::topology_state_machine>& get_topology_state_machine() = 0;
 
     data_dictionary::database data_dictionary();
+
+    // Call only on shard0.
+    virtual utils::disk_space_monitor& disk_space_monitor() = 0;
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() = 0;
 

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -20,6 +20,7 @@
 #include "locator/tablet_replication_strategy.hh"
 #include "locator/network_topology_strategy.hh"
 #include "locator/load_sketch.hh"
+#include "test/lib/topology_builder.hh"
 #include "replica/tablets.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "db/config.hh"
@@ -48,15 +49,33 @@ cql_test_config tablet_cql_test_config() {
 }
 
 static
-future<table_id> add_table(cql_test_env& e) {
+future<table_id> add_table(cql_test_env& e, sstring test_ks_name = "") {
     auto id = table_id(utils::UUID_gen::get_time_UUID());
-    co_await e.create_table([id] (std::string_view ks_name) {
+    co_await e.create_table([&] (std::string_view ks_name) {
+        if (!test_ks_name.empty()) {
+            ks_name = test_ks_name;
+        }
         return *schema_builder(ks_name, id.to_sstring(), id)
                 .with_column("p1", utf8_type, column_kind::partition_key)
                 .with_column("r1", int32_type)
                 .build();
     });
     co_return id;
+}
+
+// Run in a seastar thread
+static
+sstring add_keyspace(cql_test_env& e, std::unordered_map<sstring, int> dc_rf, int initial_tablets = 0) {
+    static std::atomic<int> ks_id = 0;
+    auto ks_name = fmt::format("keyspace{}", ks_id.fetch_add(1));
+    sstring rf_options;
+    for (auto& [dc, rf] : dc_rf) {
+        rf_options += format(", '{}': {}", dc, rf);
+    }
+    e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy'{}}}"
+                              " and tablets = {{'enabled': true, 'initial': {}}}",
+                              ks_name, rf_options, initial_tablets)).get();
+    return ks_name;
 }
 
 static
@@ -116,8 +135,13 @@ struct rebalance_stats {
 };
 
 static
-rebalance_stats rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, locator::load_stats_ptr load_stats = {}, std::unordered_set<host_id> skiplist = {}) {
+rebalance_stats rebalance_tablets(cql_test_env& e, locator::load_stats_ptr load_stats = {}, std::unordered_set<host_id> skiplist = {}) {
     rebalance_stats stats;
+    abort_source as;
+
+    auto guard = e.get_raft_group0_client().start_operation(as).get();
+    auto& talloc = e.get_tablet_allocator().local();
+    auto& stm = e.shared_token_metadata().local();
 
     // Sanity limit to avoid infinite loops.
     // The x10 factor is arbitrary, it's there to account for more complex schedules than direct migration.
@@ -126,7 +150,9 @@ rebalance_stats rebalance_tablets(tablet_allocator& talloc, shared_token_metadat
     for (size_t i = 0; i < max_iterations; ++i) {
         auto prev_lb_stats = talloc.stats().for_dc(dc);
         auto start_time = std::chrono::steady_clock::now();
+
         auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist).get();
+
         auto end_time = std::chrono::steady_clock::now();
         auto lb_stats = talloc.stats().for_dc(dc) - prev_lb_stats;
 
@@ -149,6 +175,11 @@ rebalance_stats rebalance_tablets(tablet_allocator& talloc, shared_token_metadat
                       lb_stats.tablets_skipped_node);
 
         if (plan.empty()) {
+            // We should not introduce inconsistency between on-disk state and in-memory state
+            // as that may violate invariants and cause failures in later operations
+            // causing test flakiness.
+            save_tablet_metadata(e.local_db(), stm.get()->tablets(), guard.write_timestamp()).get();
+            e.get_storage_service().local().load_tablet_metadata({}).get();
             testlog.info("Rebalance took {:.3f} [s] after {} iteration(s)", stats.elapsed_time.count(), i + 1);
             return stats;
         }
@@ -230,42 +261,30 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
         const shard_id shard_count = p.shards;
         const int cycles = p.iterations;
 
-        auto rack1 = endpoint_dc_rack{ dc, "rack-1" };
-
+        topology_builder topo(e);
         std::vector<host_id> hosts;
-        std::vector<inet_address> ips;
+        locator::load_stats stats;
 
-        int host_seq = 1;
         auto add_host = [&] {
-            hosts.push_back(host_id(utils::make_random_uuid()));
-            ips.push_back(inet_address(format("192.168.0.{}", host_seq++)));
-            testlog.info("Added new node: {} ({})", hosts.back(), ips.back());
+            auto host = topo.add_node(service::node_state::normal, shard_count);
+            hosts.push_back(host);
+            stats.capacity[host] = default_target_tablet_size * shard_count;
+            testlog.info("Added new node: {}", host);
         };
 
-        auto add_host_to_topology = [&] (token_metadata& tm, int i) -> future<> {
-            tm.update_topology(hosts[i], rack1, node::state::normal, shard_count);
-            co_await tm.update_normal_tokens(std::unordered_set{token(tests::d2t(float(i) / hosts.size()))}, hosts[i]);
+        auto make_stats = [&] {
+            return make_lw_shared<locator::load_stats>(stats);
         };
 
         for (int i = 0; i < n_hosts; ++i) {
             add_host();
         }
 
-        semaphore sem(1);
-        auto stm = shared_token_metadata([&sem]() noexcept { return get_units(sem, 1); }, locator::token_metadata::config {
-                locator::topology::config {
-                        .this_endpoint = ips[0],
-                        .this_host_id = hosts[0],
-                        .local_dc_rack = rack1
-                }
-        });
+        auto& stm = e.shared_token_metadata().local();
 
         auto bootstrap = [&] {
-            stm.mutate_token_metadata([&] (token_metadata& tm) {
-                add_host();
-                return add_host_to_topology(tm, hosts.size() - 1);
-            }).get();
-            global_res.stats += rebalance_tablets(e.get_tablet_allocator().local(), stm);
+            add_host();
+            global_res.stats += rebalance_tablets(e, make_stats());
         };
 
         auto decommission = [&] (host_id host) {
@@ -273,44 +292,22 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
             if ((size_t)i == hosts.size()) {
                 throw std::runtime_error(format("No such host: {}", host));
             }
-            stm.mutate_token_metadata([&] (token_metadata& tm) {
-                tm.update_topology(hosts[i], rack1, locator::node::state::being_decommissioned, shard_count);
-                return make_ready_future<>();
-            }).get();
-
-            global_res.stats += rebalance_tablets(e.get_tablet_allocator().local(), stm);
-
-            stm.mutate_token_metadata([&] (token_metadata& tm) {
-                tm.remove_endpoint(host);
-                return make_ready_future<>();
-            }).get();
-            testlog.info("Node decommissioned: {} ({})", hosts[i], ips[i]);
-            hosts.erase(hosts.begin() + i);
-            ips.erase(ips.begin() + i);
-        };
-
-        stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-            for (int i = 0; i < n_hosts; ++i) {
-                co_await add_host_to_topology(tm, i);
+            topo.set_node_state(host, service::node_state::decommissioning);
+            global_res.stats += rebalance_tablets(e, make_stats());
+            if (stm.get()->tablets().has_replica_on(host)) {
+                throw std::runtime_error(format("Host {} still has replicas!", host));
             }
-        }).get();
-
-        auto allocate = [&] (schema_ptr s, int rf, std::optional<int> initial_tablets) {
-            replication_strategy_config_options opts;
-            opts[rack1.dc] = format("{}", rf);
-            network_topology_strategy tablet_rs(replication_strategy_params(opts, initial_tablets.value_or(0)));
-            stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
-                auto map = co_await tablet_rs.allocate_tablets_for_new_table(s, stm.get(), 1);
-                tm.tablets().set_tablet_map(s->id(), std::move(map));
-            }).get();
+            topo.set_node_state(host, service::node_state::left);
+            testlog.info("Node decommissioned: {}", host);
+            hosts.erase(hosts.begin() + i);
         };
 
-        auto id1 = add_table(e).get();
-        auto id2 = add_table(e).get();
+        auto ks1 = add_keyspace(e, {{topo.dc(), p.rf1}}, p.tablets1.value_or(1));
+        auto ks2 = add_keyspace(e, {{topo.dc(), p.rf2}}, p.tablets2.value_or(1));
+        auto id1 = add_table(e, ks1).get();
+        auto id2 = add_table(e, ks2).get();
         schema_ptr s1 = e.local_db().find_schema(id1);
         schema_ptr s2 = e.local_db().find_schema(id2);
-        allocate(s1, p.rf1, p.tablets1);
-        allocate(s2, p.rf2, p.tablets2);
 
         auto check_balance = [&] () -> cluster_balance {
             cluster_balance res;
@@ -374,7 +371,7 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
 
         check_balance();
 
-        rebalance_tablets(e.get_tablet_allocator().local(), stm);
+        rebalance_tablets(e, make_stats());
 
         global_res.init = global_res.worst = check_balance();
 

--- a/test/topology_custom/test_tablets_removenode.py
+++ b/test/topology_custom/test_tablets_removenode.py
@@ -14,6 +14,7 @@ import logging
 
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.util import start_writes
+from test.topology.util import get_topology_coordinator
 
 logger = logging.getLogger(__name__)
 
@@ -26,6 +27,39 @@ async def create_keyspace(cql, name, initial_tablets, rf):
 async def run_async_cl_all(cql, query: str):
     stmt = SimpleStatement(query, consistency_level = ConsistencyLevel.ALL)
     return await cql.run_async(stmt)
+
+
+@pytest.mark.asyncio
+async def test_removenode_with_coordinator_restart(manager: ManagerClient):
+    """
+    Verifies that removenode can proceed when the coordinator is restarted
+    with some normal nodes down, so cannot obtain table stats for them.
+    Tablet draining should still be able to make progress
+    as long as all non-excluded nodes are up. This verifies that capacity
+    is obtained per node and not in all-or-nothing fashion.
+    """
+    logger.info("Bootstrapping cluster")
+    cmdline = ['--logger-log-level', 'load_balancer=debug']
+
+    servers = await manager.servers_add(3, cmdline=cmdline)
+    cql = manager.get_cql()
+
+    ks1 = "test"
+    await create_keyspace(cql, ks1, 3, rf=1)
+    await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
+
+    logger.info('Stopping a node to be removed')
+    await manager.server_stop(servers[2].server_id)
+
+    logger.info('Restarting leader')
+    raft_leader_host_id = await get_topology_coordinator(manager)
+    for s in servers:
+        if raft_leader_host_id == await manager.get_host_id(s.server_id):
+            await manager.server_restart(s.server_id)
+            break
+
+    logger.info('Removing a node')
+    await manager.remove_node(servers[1].server_id, servers[2].server_id)
 
 
 @pytest.mark.asyncio

--- a/utils/only_on_shard0.hh
+++ b/utils/only_on_shard0.hh
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shard_id.hh>
+
+// When passed to sharded<>::start(), translates to "val" passed to sharded instances on shard 0 and T{} on other shards.
+template <typename T>
+auto only_on_shard0(T val) {
+    return sharded_parameter([val] {
+        if (seastar::this_shard_id() == 0) {
+            return val;
+        }
+        return T{};
+    });
+}


### PR DESCRIPTION
Before this patch, the load balancer was equalizing tablet count per
shard, so it achieved balance assuming that:
 1) tablets have the same size
 2) shards have the same capacity

That can cause imbalance of utilization if shards have different
capacity, which can happen in heterogeneous clusters with different
instance types. One of the causes for capacity difference is that
larger instances run with fewer shards due to vCPUs being dedicated to
IRQ handling. This makes those shards have more disk capacity, and
more CPU power.

After this patch, the load balancer equalizes shard's storage
utilization, so it no longer assumes that shards have the same
capacity. It still assumes that each tablet has equal size. So it's a
middle step towards full size-aware balancing.

One consequence is that to be able to balance, the load balancer need
to know about every node's capacity, which is collected with the same
RPC which collects load_stats for average tablet size. This is not a
significant set back because migrations cannot proceed anyway if nodes
are down due to barriers. We could make intra-node migration
scheduling work without capacity information, but it's pointless due
to above, so not implemented.

Also, per-shard goal for tablet count is still the same for all nodes in the cluster,
so nodes with less capacity will be below limit and nodes with more capacity will
be slightly above limit. This shouldn't be a significant problem in practice, we could
compensate for this by increasing the limit.

Fixes #23042

* github.com:scylladb/scylladb:
  tablets: Make load balancing capacity-aware
  topology_coordinator: Fix confusing log message
  topology_coordinator: Refresh load stats after adding a new node
  topology_coordinator: Allow capacity stats to be refreshed with some nodes down
  topology_coordinator: Refactor load status refreshing so that it can be triggered from multiple places
  test: boost: tablets_test: Always provide capacity in load_stats
  test: perf_load_balancing: Set node capacity
  test: perf_load_balancing: Convert to topology_builder
  config, disk_space_monitor: Allow overriding capacity via config
  storage_service, tablets: Collect per-node capacity in load_stats
  test: tablets_test: Add support for auto-split mode
  test: cql_test_env: Expose db config

