### PR TITLE
Improve scoped restore test

### DIFF
--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -422,7 +422,8 @@ async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, 
     async def do_backup(s):
         await manager.api.take_snapshot(s.ip_addr, ks, snap_name)
         tid = await manager.api.backup(s.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name, prefix)
-        await manager.api.wait_task(s.ip_addr, tid)
+        status = await manager.api.wait_task(s.ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
 
     await asyncio.gather(*(do_backup(s) for s in servers))
 
@@ -435,7 +436,8 @@ async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, 
     async def do_restore(s, toc_names, scope):
         logger.info(f'Restore {s.ip_addr} with {toc_names}, scope={scope}')
         tid = await manager.api.restore(s.ip_addr, ks, cf, s3_server.address, s3_server.bucket_name, prefix, toc_names, scope)
-        await manager.api.wait_task(s.ip_addr, tid)
+        status = await manager.api.wait_task(s.ip_addr, tid)
+        assert (status is not None) and (status['state'] == 'done')
 
     if topology.dcs > 1:
         scope = 'dc'

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -406,21 +406,22 @@ async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, 
     for k in keys:
         cql.execute(f"INSERT INTO {ks}.{cf} ( pk, value ) VALUES ({k}, '{k}');")
 
-    logger.info(f'Collect sstables lists')
+    snap_name = unique_name('backup_')
+
+    logger.info(f'Take snapshot and collect sstables lists')
     sstables = []
     for s in servers:
         await manager.api.flush_keyspace(s.ip_addr, ks)
+        await manager.api.take_snapshot(s.ip_addr, ks, snap_name)
         workdir = await manager.server_get_workdir(s.server_id)
         cf_dir = os.listdir(f'{workdir}/data/{ks}')[0]
-        tocs = [ f.name for f in os.scandir(f'{workdir}/data/{ks}/{cf_dir}') if f.is_file() and f.name.endswith('TOC.txt') ]
-        logger.info(f'Collected sstables from {s.ip_addr}:{cf_dir}: {tocs}')
+        tocs = [ f.name for f in os.scandir(f'{workdir}/data/{ks}/{cf_dir}/snapshots/{snap_name}') if f.is_file() and f.name.endswith('TOC.txt') ]
+        logger.info(f'Collected sstables from {s.ip_addr}:{cf_dir}/snapshots/{snap_name}: {tocs}')
         sstables += tocs
 
-    snap_name = unique_name('backup_')
     logger.info(f'Backup to {snap_name}')
     prefix = f'{cf}/{snap_name}'
     async def do_backup(s):
-        await manager.api.take_snapshot(s.ip_addr, ks, snap_name)
         tid = await manager.api.backup(s.ip_addr, ks, cf, snap_name, s3_server.address, s3_server.bucket_name, prefix)
         status = await manager.api.wait_task(s.ip_addr, tid)
         assert (status is not None) and (status['state'] == 'done')


### PR DESCRIPTION
This PR includes several fixes to the nowadays flaky test_restore_with_streaming_scopes test.

1. Check that backup and restore APIs don't fail. Currently, if either of them does the test cases fails anyway checking that the data is not restored back, but it's better to know what exactly failed

2. For restore API the test collects the list of sstables to restore from. Currently collecting this list races with background compaction and sometimes leads to restore API to fail which, in turn, makes the whole test to fail

3. Add a test case that validates that restore-from-missing-sstable fails nicely

refs: #23189
No backport, as it's a relatively new test