### PR TITLE
cqlpy/test_tools: various tests: use with scylla_sstable

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -1618,7 +1618,7 @@ def test_scylla_sstable_query_advanced_queries(cql, test_keyspace, scylla_path, 
     No attempt is made to cover all CQL featues.
     """
     table = util.unique_name()
-    schema = f"CREATE TABLE {test_keyspace}.{table} (pk int, ck int, v int, PRIMARY KEY (pk, ck))"
+    schema = f"CREATE TABLE {test_keyspace}.{table} (pk int, ck int, v int, PRIMARY KEY (pk, ck)) WITH compaction = {{'class': 'NullCompactionStrategy'}}"
 
     cql.execute(schema)
 


### PR DESCRIPTION
Do not rely on disabling autocompaction in
the system keyspace since test cases may run in parallel
on the same node, interfering with each other.

Instead, use `with scylla_sstable` to create a unique
table per test that uses NullCompactionStrategy.

Fixes #23203

* tests introduced in ddab1b939b3595566b0ca3da37d8ee1ec5777299 (2025.2.dev), no backport needed at this time
