### PR TITLE
test: tablets: Fix flakiness due to ungraceful shutdown

### DIFF
--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -116,7 +116,7 @@ async def test_replace(manager: ManagerClient):
     finish_writes = await start_writes(cql, ks3, "test2")
 
     logger.info('Replacing a node')
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     servers.append(await manager.server_add(replace_cfg))
     servers = servers[1:]


### PR DESCRIPTION
The test fails sporadically with:

cassandra.ReadFailure: Error from server: code=1300 [Replica(s) failed to execute read] message="Operation failed for test3.test2 - received 1 responses and 1 failures from 2 CL=QUORUM." info={'consistency': 'QUORUM', 'required_responses': 2, 'received_responses': 1, 'failures': 1}

That's becase a server is stopped in the middle of the workload.

The server is stopped ungracefully which will cause some requests to time out. We should stop it gracefully to allow in-flight requests to finish.

Fixes #20492

Fixes CI flakiness and scope limited to tests so should be backported to maintained branches.