### PR TITLE
Move mutation_fragment_v2::kind into mutation_fragment_v2::data, mutation_fragment::kind into mutation_fragment::data

### DIFF
--- a/mutation/mutation_fragment.cc
+++ b/mutation/mutation_fragment.cc
@@ -30,35 +30,35 @@ partition_region parse_partition_region(std::string_view s) {
 }
 
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, static_row&& r)
-    : _kind(kind::static_row), _data(std::make_unique<data>(std::move(permit)))
+    : _data(std::make_unique<data>(std::move(permit), kind::static_row))
 {
     new (&_data->_static_row) static_row(std::move(r));
     reset_memory(s);
 }
 
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, clustering_row&& r)
-    : _kind(kind::clustering_row), _data(std::make_unique<data>(std::move(permit)))
+    : _data(std::make_unique<data>(std::move(permit), kind::clustering_row))
 {
     new (&_data->_clustering_row) clustering_row(std::move(r));
     reset_memory(s);
 }
 
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, range_tombstone&& r)
-    : _kind(kind::range_tombstone), _data(std::make_unique<data>(std::move(permit)))
+    : _data(std::make_unique<data>(std::move(permit), kind::range_tombstone))
 {
     new (&_data->_range_tombstone) range_tombstone(std::move(r));
     reset_memory(s);
 }
 
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, partition_start&& r)
-        : _kind(kind::partition_start), _data(std::make_unique<data>(std::move(permit)))
+        : _data(std::make_unique<data>(std::move(permit), kind::partition_start))
 {
     new (&_data->_partition_start) partition_start(std::move(r));
     reset_memory(s);
 }
 
 mutation_fragment::mutation_fragment(const schema& s, reader_permit permit, partition_end&& r)
-        : _kind(kind::partition_end), _data(std::make_unique<data>(std::move(permit)))
+        : _data(std::make_unique<data>(std::move(permit), kind::partition_end))
 {
     new (&_data->_partition_end) partition_end(std::move(r));
     reset_memory(s);
@@ -75,7 +75,7 @@ void mutation_fragment::reset_memory(const schema& s, std::optional<reader_resou
 
 void mutation_fragment::destroy_data() noexcept
 {
-    switch (_kind) {
+    switch (_data->_kind) {
     case kind::static_row:
         _data->_static_row.~static_row();
         break;
@@ -180,7 +180,7 @@ const clustering_key_prefix& mutation_fragment::key() const
 void mutation_fragment::apply(const schema& s, mutation_fragment&& mf)
 {
     SCYLLA_ASSERT(mergeable_with(mf));
-    switch (_kind) {
+    switch (_data->_kind) {
     case mutation_fragment::kind::partition_start:
         _data->_partition_start.partition_tombstone().apply(mf._data->_partition_start.partition_tombstone());
         mf._data->_partition_start.~partition_start();
@@ -209,7 +209,7 @@ position_in_partition_view mutation_fragment::position() const
 }
 
 position_range mutation_fragment::range(const schema& s) const {
-    switch (_kind) {
+    switch (_data->_kind) {
     case kind::static_row:
         return position_range::for_static_row();
     case kind::clustering_row:
@@ -247,7 +247,7 @@ auto fmt::formatter<mutation_fragment::printer>::format(const mutation_fragment:
         -> decltype(ctx.out()) {
     auto& mf = p._mutation_fragment;
     auto out = ctx.out();
-    out = fmt::format_to(out, "{{mutation_fragment: {} {} ", mf._kind, mf.position());
+    out = fmt::format_to(out, "{{mutation_fragment: {} {} ", mf._data->_kind, mf.position());
     out = mf.visit(make_visitor(
         [&] (const clustering_row& cr) { return fmt::format_to(out, "{}", clustering_row::printer(p._schema, cr)); },
         [&] (const static_row& sr) { return fmt::format_to(out, "{}", static_row::printer(p._schema, sr)); },

--- a/mutation/mutation_fragment.hh
+++ b/mutation/mutation_fragment.hh
@@ -253,7 +253,7 @@ concept MutationFragmentVisitor =
 
 class mutation_fragment {
 public:
-    enum class kind {
+    enum class kind : std::uint8_t {
         static_row,
         clustering_row,
         range_tombstone,

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -113,7 +113,7 @@ concept MutationFragmentVisitorV2 =
 
 class mutation_fragment_v2 {
 public:
-    enum class kind {
+    enum class kind : std::uint8_t {
         static_row,
         clustering_row,
         range_tombstone_change,


### PR DESCRIPTION
Move mutation_fragment_v2::kind field into mutation_fragment_v2::data.
Move mutation_fragment::kind field into mutation_fragment::data.

In both cases the move reduces size of the object by half (to 8 bytes).

On top of testsuite this patch was tested manually. First patched scylla was run. A keyspace and a table was created, with columns TEXT, INT, DOUBLE, BOOLEAN and TIMESTAMP. One row was inserted, `select *` was executed to make sure it's there. Then scylla was terminated and non-patched scylla was run, another row was inserted and `select *` was run to verify both rows exist. After this patched scylla was against started, third row was inserted and final `select *` was done to verify all three rows are there.

This is partial fix to https://github.com/scylladb/scylla-enterprise/issues/5288 issue.
