### PR TITLE
repair: release erm in repair_writer_impl::create_writer when possible

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -532,6 +532,7 @@ void repair_writer_impl::create_writer(lw_shared_ptr<repair_writer> w) {
     t.stream_in_progress()).then([w] (uint64_t partitions) {
         rlogger.debug("repair_writer: keyspace={}, table={}, managed to write partitions={} to sstable",
             w->schema()->ks_name(), w->schema()->cf_name(), partitions);
+        return utils::get_local_injector().inject("repair_writer_impl_create_writer_wait", utils::wait_for_message(200s));
     }).handle_exception([w, keepalive = std::move(sharder.keepalive)] (std::exception_ptr ep) {
         rlogger.warn("repair_writer: keyspace={}, table={}, multishard_writer failed: {}",
                 w->schema()->ks_name(), w->schema()->cf_name(), ep);

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -5,6 +5,7 @@
 #
 from cassandra.protocol import ConfigurationException, InvalidRequest, SyntaxException
 from cassandra.query import SimpleStatement, ConsistencyLevel
+from test.cluster.test_tablets2 import safe_rolling_restart
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.pylib.repair import create_table_insert_data_for_repair
@@ -934,3 +935,41 @@ async def test_tablet_split_finalization_with_migrations(manager: ManagerClient)
     # ensure all migrations complete
     logger.info("Waiting for migrations to complete")
     await log.wait_for("Tablet load balancer did not make any plan", migration_mark)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(manager: ManagerClient):
+    injection = "repair_writer_impl_create_writer_wait"
+    cmdline = [
+        '--logger-log-level', 'repair=debug',
+    ]
+    servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager, cmdline=cmdline)
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    async def insert_with_down(down_server):
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k + 1});") for k in range(10)])
+
+    cql = await safe_rolling_restart(manager, [servers[0]], with_down=insert_with_down)
+
+    all_replicas = await get_all_tablet_replicas(manager, servers[1], ks, "test")
+    all_replicas.sort(key=lambda x: x.last_token)
+    assert len(all_replicas) >= 3
+    repair_replicas = all_replicas[1]
+    migration_replicas = all_replicas[0]
+
+    logs = [await manager.server_open_log(s.server_id) for s in servers]
+    marks = [await log.mark() for log in logs]
+
+    async def repair_task():
+        [await manager.api.enable_injection(s.ip_addr, injection, one_shot=True) for s in servers]
+        await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", repair_replicas.last_token)
+
+    async def migration_task():
+        done, pending = await asyncio.wait([asyncio.create_task(log.wait_for(f'repair_writer: keyspace={ks}', from_mark=mark)) for log, mark in zip(logs, marks)], return_when=asyncio.FIRST_COMPLETED)
+        for task in pending:
+            task.cancel()
+        await manager.api.move_tablet(servers[0].ip_addr, ks, "test", migration_replicas.replicas[0][0], migration_replicas.replicas[0][1], migration_replicas.replicas[0][0], 0 if migration_replicas.replicas[0][1] != 0 else 1, migration_replicas.last_token)
+        [await manager.api.message_injection(s.ip_addr, injection) for s in servers]
+        [await manager.api.disable_injection(s.ip_addr, injection) for s in servers]
+
+    await asyncio.gather(repair_task(), migration_task())

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -44,14 +44,14 @@ async def load_tablet_repair_task_infos(cql, host, table_id):
 
     return repair_task_infos
 
-async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256, disable_flush_cache_time = False) -> (list[ServerInfo], CassandraSession, list[Host], str, str):
+async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256, disable_flush_cache_time = False, cmdline = None) -> (list[ServerInfo], CassandraSession, list[Host], str, str):
     if fast_stats_refresh:
         config = {'error_injections_at_startup': ['short_tablet_stats_refresh_interval']}
     else:
         config = {}
     if disable_flush_cache_time:
         config.update({'repair_hints_batchlog_flush_cache_time_in_ms': 0})
-    servers = [await manager.server_add(config=config), await manager.server_add(config=config), await manager.server_add(config=config)]
+    servers = [await manager.server_add(config=config, cmdline=cmdline), await manager.server_add(config=config, cmdline=cmdline), await manager.server_add(config=config, cmdline=cmdline)]
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))


### PR DESCRIPTION
Currently, repair_writer_impl::create_writer keeps erm to ensure that a sharder is valid. If we repair a tablet, erm blocks the state machine and no operation on any tablet of this table might be performed.

Use auto_refreshing_sharder and topology_guard to ensure that the operation is safe and that tablet operations on the whole table aren't blocked.

Fixes: #23453.

Needs backport to 2025.1 that introduces the tablet repair scheduler.