### PR TITLE
Snapshot several tables at once in scrub API handler

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -108,10 +108,6 @@ future<> snapshot_ctl::do_take_column_family_snapshot(sstring ks_name, std::vect
     co_await replica::database::snapshot_tables_on_all_shards(_db, ks_name, std::move(tables), std::move(tag), bool(sf));
 }
 
-future<> snapshot_ctl::take_column_family_snapshot(sstring ks_name, sstring cf_name, sstring tag, skip_flush sf) {
-    return take_column_family_snapshot(ks_name, std::vector<sstring>{cf_name}, tag, sf);
-}
-
 future<> snapshot_ctl::clear_snapshot(sstring tag, std::vector<sstring> keyspace_names, sstring cf_name) {
     return run_snapshot_modify_operation([this, tag = std::move(tag), keyspace_names = std::move(keyspace_names), cf_name = std::move(cf_name)] {
         return _db.local().clear_snapshot(tag, keyspace_names, cf_name);

--- a/db/snapshot-ctl.hh
+++ b/db/snapshot-ctl.hh
@@ -90,15 +90,6 @@ public:
     future<> take_column_family_snapshot(sstring ks_name, std::vector<sstring> tables, sstring tag, skip_flush sf = skip_flush::no);
 
     /**
-     * Takes the snapshot of a specific column family. A snapshot name must be specified.
-     *
-     * @param ks_name the keyspace which holds the specified column family
-     * @param cf_name the column family to snapshot
-     * @param tag the tag given to the snapshot; may not be null or empty
-     */
-    future<> take_column_family_snapshot(sstring ks_name, sstring cf_name, sstring tag, skip_flush sf = skip_flush::no);
-
-    /**
      * Remove the snapshot with the given name from the given keyspaces.
      * If no tag is specified we will remove all snapshots.
      * If a cf_name is specified, only that table will be deleted


### PR DESCRIPTION
The scrub API handler may want to snapshot several tables. For that, it calls snapshot-ctl method to snapshot a single table for each table in the list. That's excessive, snapshot-ctl has a method to snapshot a bunch of tables at once, just what the scrub handler needs.

It's an improvement, so no need to backport