### PR TITLE
tablets: Make tablet allocation equalize per-shard load 

### DIFF
--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -401,7 +401,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             }
             const auto& host_id = node.get().host_id();
             if (!existing.contains(host_id)) {
-                candidate.nodes.emplace_back(host_id, load.get_load(host_id));
+                candidate.nodes.emplace_back(host_id, load.get_avg_shard_load(host_id));
             }
         }
         if (candidate.nodes.empty()) {

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -2400,6 +2400,7 @@ public:
                 max_shard_load = std::max(max_shard_load, load);
                 this_node_max_shard_load = std::max(this_node_max_shard_load, load);
             }
+            node_load /= node.shard_count;
             lblogger.debug("Load on host {} for table {}: total={}, max={}", host, table, node_load, this_node_max_shard_load);
         }
         auto avg_load = double(total_load) / shard_count;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2738,6 +2738,71 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
     }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+
+        std::vector<host_id> hosts;
+
+        uint64_t i4i_2xlarge_cap = 1'875'000'000'000;
+        uint64_t i4i_large_cap = 468'000'000'000;
+
+        auto add_i4i_2xlarge = [&] (endpoint_dc_rack rack) {
+            auto h = topo.add_node(node_state::normal, 7, rack);
+            load_stats.set_capacity(h, i4i_2xlarge_cap);
+            hosts.push_back(h);
+        };
+
+        auto add_i4i_large = [&] (endpoint_dc_rack rack) {
+            auto h = topo.add_node(node_state::normal, 2, rack);
+            load_stats.set_capacity(h, i4i_large_cap);
+            hosts.push_back(h);
+        };
+
+        auto rack1 = topo.rack();
+        auto rack2 = topo.start_new_rack();
+        auto rack3 = topo.start_new_rack();
+
+        add_i4i_2xlarge(rack1);
+        add_i4i_2xlarge(rack2);
+        add_i4i_2xlarge(rack3);
+
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 3}}, 128);
+        auto table1 = add_table(e, ks_name).get();
+        load_stats.set_size(table1, 0);
+        testlog.info("Initial cluster ready");
+
+        add_i4i_large(rack1);
+        add_i4i_large(rack2);
+        add_i4i_large(rack3);
+        rebalance_tablets(e, &load_stats);
+        testlog.info("Expanded capacity");
+
+        auto ks2_name = add_keyspace(e, {{topo.dc(), 3}}, 128);
+        auto table2 = add_table(e, ks2_name).get();
+
+        {
+            load_sketch load(stm.get());
+            load.populate(std::nullopt, table2).get();
+
+            // Check that utilization difference is < 4%
+            min_max_tracker<double> node_utilization;
+            for (auto h: hosts) {
+                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                BOOST_REQUIRE(u);
+                testlog.info("table2: {}: {}", h, u);
+                node_utilization.update(*u);
+            }
+            // Initial allocation is not capacity-aware so we're still not perfect here.
+            // See https://github.com/scylladb/scylladb/issues/23378
+            BOOST_REQUIRE_LT(node_utilization.max() - node_utilization.min(), 0.13);
+        }
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
     do_with_cql_env_thread([] (auto& e) {
         auto per_shard_goal = e.local_db().get_config().tablets_per_shard_goal();


### PR DESCRIPTION
Before, it was equalizing per-node load (tablet count), which is wrong
in heterogeneous clusters. Nodes with fewer shards will end up with
overloaded shards.

Refs #23378
