### PR TITLE
test/database: Remove most of take_snapshot() helper overloads and re-use them more

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1581,7 +1581,7 @@ SEASTAR_TEST_CASE(drop_table_with_explicit_snapshot) {
 
     co_await do_with_some_data({table_name}, [&] (cql_test_env& e) -> future<> {
         auto snapshot_tag = format("test-{}", db_clock::now().time_since_epoch().count());
-        co_await replica::database::snapshot_table_on_all_shards(e.db(), ks_name, table_name, snapshot_tag, false);
+        co_await take_snapshot(e, ks_name, table_name, snapshot_tag);
         auto cf_dir = table_dir(e.local_db().find_column_family(ks_name, table_name)).native();
 
         // With explicit snapshot and with_snapshot=false


### PR DESCRIPTION
This helper facilitate snapshot creation by various test cases in database_test.cc. This PR generalizes all overloads into one that suits all callers and patches one more test case to use it as well.