### PR TITLE
sstables_loader: Do not stop sharded<progress_monitor> unconditionally

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -639,8 +639,9 @@ public:
         // preserve the final progress, so we can access it after the task is
         // finished
         _final_progress = co_await get_progress();
-        _progress_state = progress_state::finalized;
-        co_await _progress_per_shard.stop();
+        if (std::exchange(_progress_state, progress_state::finalized) == progress_state::initialized) {
+            co_await _progress_per_shard.stop();
+        }
     }
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {


### PR DESCRIPTION
The member in question is unconditionally .stop()-ed in task's release_resources() method, however, it may happen that the thing wasn't .start()-ed in the first place. Start happens in the middle of the task's .run() method and there can be several reasons why it can be skipped -- e.g. the task is aborted early, or collecting sstables from S3 throws.

fixes: #23231
