### PR TITLE
sstables: store features early in write path

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1505,7 +1505,7 @@ void writer::consume_end_of_stream() {
     std::optional<scylla_metadata::ext_timestamp_stats> ts_stats(scylla_metadata::ext_timestamp_stats{
         .map = _collector.get_ext_timestamp_stats()
     });
-    _sst.write_scylla_metadata(_shard, _features, std::move(identifier), std::move(ld_stats), std::move(ts_stats));
+    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(ld_stats), std::move(ts_stats));
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1803,12 +1803,14 @@ sstable::read_scylla_metadata() noexcept {
         if (!has_component(component_type::Scylla)) {
             return make_ready_future<>();
         }
-        return read_simple<component_type::Scylla>(*_components->scylla_metadata);
+        return read_simple<component_type::Scylla>(*_components->scylla_metadata).then([this] {
+            _features = _components->scylla_metadata->get_features();
+        });
     });
 }
 
 void
-sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features, struct run_identifier identifier,
+sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
@@ -1826,7 +1828,8 @@ sstable::write_scylla_metadata(shard_id shard, sstable_enabled_features features
     }
 
     _components->scylla_metadata->data.set<scylla_metadata_type::Sharding>(std::move(sm));
-    _components->scylla_metadata->data.set<scylla_metadata_type::Features>(std::move(features));
+    // Note: data.set() wants an rvalue, so we have to make a copy. It's a uint64 anyway.
+    _components->scylla_metadata->data.set<scylla_metadata_type::Features>(sstable_enabled_features(_features));
     _components->scylla_metadata->data.set<scylla_metadata_type::RunIdentifier>(std::move(identifier));
     if (ld_stats) {
         _components->scylla_metadata->data.set<scylla_metadata_type::LargeDataStats>(std::move(*ld_stats));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -561,6 +561,7 @@ private:
     schema_ptr _schema;
     generation_type _generation{0};
     sstable_state _state;
+    sstable_enabled_features _features = {};
 
     std::unique_ptr<storage> _storage;
 
@@ -651,7 +652,6 @@ private:
     future<> read_scylla_metadata() noexcept;
 
     void write_scylla_metadata(shard_id shard,
-                               sstable_enabled_features features,
                                run_identifier identifier,
                                std::optional<scylla_metadata::large_data_stats> ld_stats,
                                std::optional<scylla_metadata::ext_timestamp_stats> ts_stats);
@@ -809,22 +809,27 @@ public:
     void validate_originating_host_id() const;
 
     bool has_correct_promoted_index_entries() const {
-        return _schema->is_compound() || !has_scylla_component() || _components->scylla_metadata->has_feature(sstable_feature::NonCompoundPIEntries);
+        return _schema->is_compound() || !has_scylla_component() || has_feature(sstable_feature::NonCompoundPIEntries);
     }
 
     bool has_correct_non_compound_range_tombstones() const {
-        return _schema->is_compound() || !has_scylla_component() || _components->scylla_metadata->has_feature(sstable_feature::NonCompoundRangeTombstones);
+        return _schema->is_compound() || !has_scylla_component() || has_feature(sstable_feature::NonCompoundRangeTombstones);
     }
 
     bool has_shadowable_tombstones() const {
-        return has_scylla_component() && _components->scylla_metadata->has_feature(sstable_feature::ShadowableTombstones);
+        return has_feature(sstable_feature::ShadowableTombstones);
     }
 
     sstable_enabled_features features() const {
-        if (!has_scylla_component()) {
-            return {};
-        }
-        return _components->scylla_metadata->get_features();
+        return _features;
+    }
+
+    void set_features(sstable_enabled_features sef) {
+        _features = sef;
+    }
+
+    bool has_feature(sstable_feature f) const {
+        return features().is_enabled(f);
     }
 
     const scylla_metadata* get_scylla_metadata() const {

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -620,9 +620,6 @@ struct scylla_metadata {
         }
         return *features;
     }
-    bool has_feature(sstable_feature f) const {
-        return get_features().is_enabled(f);
-    }
     const extension_attributes* get_extension_attributes() const {
         return data.get<scylla_metadata_type::ExtensionAttributes, extension_attributes>();
     }

--- a/sstables/writer_impl.hh
+++ b/sstables/writer_impl.hh
@@ -38,6 +38,7 @@ struct sstable_writer::writer_impl {
         if (!cfg.correct_pi_block_width) {
             _features.disable(CorrectLastPiBlockWidth);
         }
+        sst.set_features(_features);
     }
 
     virtual void consume_new_partition(const dht::decorated_key& dk) = 0;


### PR DESCRIPTION
sstable features indicate that an sstable has some extension, or that some bug was fixed. They allow us to know if we can rely on certain properties in a read sstables.

Currently, sstable features are set early in the read path (when we read the scylla metadata file) and very late in the write path (when we write the scylla metadata file just before sealing the sstable).

However, we happen to read features before we set them in the write path - when we resize the bloom filter for a newly written sstable we instantiate an index reader, and that depends on some features. As a result, we read a disengaged optional (for the scylla metadata component) as if it was engaged. This somehow worked so far, but fails with libstdc++ hash table implementation.

Fix it by moving storage of the features to the sstable itself, and setting it early in the write path.

Fixes https://github.com/scylladb/scylladb/issues/23484

Should be backported to all releases that contain b0a5bf8b4a6245a12c50b89377343bbaac27de7f, while it doesn't crash on the current toolchain, it does cause undefined behavior.