### PR TITLE
test/cqlpy: Adjust tests to RF-rack-valid keyspaces

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -224,19 +224,19 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 # invalid DC option in replication configuration.
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
-    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:
+    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
         # try modifying the keyspace
         assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
-        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3 }")
+        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace
-    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }") as ks:
+    with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
         # try modifying the keyspace
-        assert_invalid_throw(cql, ks, SyntaxException, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2, '" + this_dc + "' : 3 }")
-        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 3}")
+        assert_invalid_throw(cql, ks, SyntaxException, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2, '" + this_dc + "' : 1 }")
+        execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1}")
 
 # Test for bug of CASSANDRA-5232,
 # migrated from cql_tests.py:TestCQL.alter_bug_test()

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -312,7 +312,7 @@ def testKeyspace(cql):
 def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
     n = unique_name()
     assertInvalidThrow(cql, n, ConfigurationException, "CREATE KEYSPACE %s WITH replication = { 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
-    execute(cql, n, "CREATE KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 2 }")
+    execute(cql, n, "CREATE KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
     execute(cql, n, "DROP KEYSPACE IF EXISTS %s")
 
     # Mix valid and invalid, should throw an exception

--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -3,6 +3,7 @@ pool_size: 4
 dirties_cluster:
   - test_native_transport
 extra_scylla_cmdline_options:
+  - '--rf-rack-valid-keyspaces=1'
   - '--experimental-features=udf'
   - '--experimental-features=keyspace-storage-options'
   - '--experimental-features=views-with-tablets'

--- a/test/cqlpy/test_guardrail_replication_strategy.py
+++ b/test/cqlpy/test_guardrail_replication_strategy.py
@@ -38,7 +38,7 @@ def test_given_default_config_when_creating_ks_should_only_produce_warning_for_s
 
     for key, value in {'NetworkTopologyStrategy': this_dc, 'EverywhereStrategy': 'replication_factor',
                        'LocalStrategy': 'replication_factor'}.items():
-        create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+        create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                  unexpected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -49,7 +49,7 @@ def test_given_cleared_guardrails_when_creating_ks_should_not_get_warning_nor_er
 
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      unexpected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -59,7 +59,7 @@ def test_given_non_empty_warn_list_when_creating_ks_should_only_warn_when_listed
                                                                 'SimpleStrategy,LocalStrategy,NetworkTopologyStrategy,EverywhereStrategy'))
         for key, value in {'SimpleStrategy': 'replication_factor', 'NetworkTopologyStrategy': this_dc,
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      expected_warning='replication_strategy_warn_list', fails_count=0)
 
 
@@ -74,7 +74,7 @@ def test_given_non_empty_warn_and_fail_lists_when_creating_ks_should_fail_query_
                            'EverywhereStrategy': 'replication_factor', 'LocalStrategy': 'replication_factor'}.items():
             # note: even though warn list is not empty, no warnings should be generated, because failures come first -
             #  we don't want to issue a warning and also fail the query at the same time
-            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 3 }}",
+            create_ks_and_assert_warnings_and_errors(cql, f" WITH REPLICATION = {{ 'class' : '{key}', '{value}' : 1 }}",
                                                      warnings_count=0, fails_count=1)
 
 

--- a/test/cqlpy/test_tablets.py
+++ b/test/cqlpy/test_tablets.py
@@ -331,35 +331,6 @@ def test_lwt_support_with_tablets(cql, test_keyspace, skip_without_tablets):
         assert res.val == 0
 
 
-# We want to ensure that we can only change the RF of any DC by at most 1 at a time
-# if we use tablets. That provides us with the guarantee that the old and the new QUORUM
-# overlap by at least one node.
-def test_alter_tablet_keyspace_rf(cql, this_dc, skip_without_tablets):
-    with new_test_keyspace(cql, f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 1 }} "
-                                f"AND TABLETS = {{ 'enabled': true, 'initial': 128 }}") as keyspace:
-        def change_opt_rf(rf_opt, new_rf):
-            cql.execute(f"ALTER KEYSPACE {keyspace} "
-                        f"WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{rf_opt}' : {new_rf} }}")
-
-        def change_dc_rf(new_rf):
-            change_opt_rf(this_dc, new_rf)
-
-        change_dc_rf(2)  # increase RF by 1 should be OK
-        change_dc_rf(3)  # increase RF by 1 again should be OK
-        change_dc_rf(3)  # setting the same RF shouldn't cause problems
-        change_dc_rf(4)  # increase RF by 1 again should be OK
-        change_dc_rf(3)  # decrease RF by 1 should be OK
-
-        with pytest.raises(InvalidRequest):
-            change_dc_rf(5)  # increase RF by 2 should fail
-        with pytest.raises(InvalidRequest):
-            change_dc_rf(1)  # decrease RF by 2 should fail
-        with pytest.raises(InvalidRequest):
-            change_dc_rf(10)  # increase RF by 2+ should fail
-        with pytest.raises(InvalidRequest):
-            change_dc_rf(0)  # decrease RF by 2+ should fail
-
-
 def test_tablet_options(cql, skip_without_tablets):
     def describe_table(cql, table):
         return cql.execute(f"DESC TABLE {table}").one().create_statement


### PR DESCRIPTION
In this PR, we adjust tests in the cqlpy test suite so they
only use RF-rack-valid keyspaces. After that, we enable
the configuration option `rf_rack_valid_keyspaces` in the
suite by default.

Refs scylladb/scylladb#23428

Backport: backporting to 2025.1 so we can test the option there too.