### PR TITLE
test.py: cluster/suite.yaml: update test filters

### DIFF
--- a/test/cluster/suite.yaml
+++ b/test/cluster/suite.yaml
@@ -26,12 +26,11 @@ skip_in_release:
 skip_in_debug:
   - test_shutdown_hang
   - test_replace
-  - test_old_ip_notification_repro
   - test_node_shutdown_waits_for_pending_requests
   - test_cdc_generation_clearing
   - test_cdc_generation_publishing
 run_in_release:
-    - test_gossiper
+  - test_gossiper
 run_in_dev:
   - test_raft_ignore_nodes
   - test_group0_schema_versioning
@@ -41,4 +40,4 @@ run_in_dev:
   - test_not_enough_token_owners
   - test_replace_alive_node
 run_in_debug:
-  - test_random_failures
+  - random_failures/test_random_failures


### PR DESCRIPTION
After switching to subfolders the filter `run_in_debug` for random failures test was just copied as is, but need to include the subfolder, actually.

Also, `test_old_ip_notification_repro` was deleted, so, we don't need it in the `skip_in_debug` list.
