### PR TITLE
loading_cache_test: test_loading_cache_reload_during_eviction: use manual_clock

### DIFF
--- a/test/boost/loading_cache_test.cc
+++ b/test/boost/loading_cache_test.cc
@@ -645,12 +645,12 @@ SEASTAR_TEST_CASE(test_loading_cache_reload_during_eviction) {
         loading_cache_for_test<int, sstring, 0, utils::loading_cache_reload_enabled::yes> loading_cache({1, 100ms, 10ms}, testlog, loader.get());
         auto stop_cache_reload = seastar::defer([&loading_cache] { loading_cache.stop().get(); });
 
-        auto curr_time = lowres_clock::now();
+        auto curr_time = manual_clock::now();
         int i = 0;
 
         // this will cause reloading when values are being actively evicted due to the limited cache size
         do_until(
-            [&] { return lowres_clock::now() - curr_time > 1s; },
+            [&] { return manual_clock::now() - curr_time > 1s; },
             [&] { return loading_cache.get_ptr(i++ % 2).discard_result(); }
         ).get();
 


### PR DESCRIPTION
Rather than lowres_clock, as since
32b7cab917dabca67d8a54d3ba3055261bdf6b40,
loading_cache_for_test uses manual_clock for timing and relying on lowres_clock to time the test might run out of memory on fast test machines.

Fixes #23497

* Issue confined to master (2025.2-dev), so no backport required at the moment