### PR TITLE
CODEOWNERS: remove expired owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # AUTH
-auth/* @nuivall @ptrsmrn @KrzaQ
+auth/* @nuivall @ptrsmrn
 
 # CACHE
 row_cache* @tgrabiec
@@ -25,15 +25,15 @@ compaction/* @raphaelsc
 transport/*
 
 # CQL QUERY LANGUAGE
-cql3/* @tgrabiec @nuivall @ptrsmrn @KrzaQ
+cql3/* @tgrabiec @nuivall @ptrsmrn
 
 # COUNTERS
-counters* @nuivall @ptrsmrn @KrzaQ
-tests/counter_test* @nuivall @ptrsmrn @KrzaQ
+counters* @nuivall @ptrsmrn
+tests/counter_test* @nuivall @ptrsmrn
 
 # DOCS
 docs/* @annastuchlik @tzach
-docs/alternator @annastuchlik @tzach @nyh @nuivall @ptrsmrn @KrzaQ
+docs/alternator @annastuchlik @tzach @nyh
 
 # GOSSIP
 gms/* @tgrabiec @asias @kbr-scylla
@@ -74,8 +74,8 @@ streaming/* @tgrabiec @asias
 service/storage_service.* @tgrabiec @asias
 
 # ALTERNATOR
-alternator/* @nyh @nuivall @ptrsmrn @KrzaQ
-test/alternator/* @nyh @nuivall @ptrsmrn @KrzaQ
+alternator/* @nyh
+test/alternator/* @nyh
 
 # HINTED HANDOFF
 db/hints/* @piodul @vladzcloudius @eliransin


### PR DESCRIPTION
Removing krzaq, who's no longer with the company.
Removing core-frontend team members from Alternator areas, as it's no longer the domain of this team.

No need to backport.