### PR TITLE
test: test_zero_token_nodes_multidc: delay requests with CL=ONE

### DIFF
--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -62,9 +62,12 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
     logging.info('Sending requests with different consistency levels')
     for rf in range(normal_nodes_in_dc2 + 1):
         # FIXME: we may add LOCAL_QUORUM to the list below once scylladb/scylladb#20028 is fixed.
+        #
+        # Note that ONE cannot be the first element of the list below. With CL=ONE we don't have a guarantee that the
+        # replicas written to and read from have a non-empty intersection. Hence, a read could miss the written row.
         cls = [
-            ConsistencyLevel.ONE,
             ConsistencyLevel.TWO,
+            ConsistencyLevel.ONE,
             ConsistencyLevel.QUORUM,
             ConsistencyLevel.EACH_QUORUM,
             ConsistencyLevel.ALL


### PR DESCRIPTION
The test could fail with RF={DC1: 2, DC2: 0} and CL=ONE when:
- both writes succeeded with the same replica responding first,
- the second read (with the coordinator being the zero-token node
  in DC2) succeeded with the other replica responding before it
  applied mutations from any of the writes.

We fix the test by sending requests with CL=TWO first and relying
on the equality of all written rows. So, a read with CL=ONE can
still miss rows written with CL=ONE, but it cannot miss rows
written with CL=TWO.

Fixes scylladb/scylladb#22967


The fix addresses CI flakiness and only changes the test, so it
should be backported.