### PR TITLE
test: introduce upgrade tests to test.py, add a SSTable dict compression upgrade test

### DIFF
--- a/test.py
+++ b/test.py
@@ -200,6 +200,8 @@ def parse_cmd_line() -> argparse.Namespace:
                         help='Let me manually run the test executable at the moment this script would run it')
     parser.add_argument('--byte-limit', action="store", default=randint(0, 2000), type=int,
                         help="Specific byte limit for failure injection (random by default)")
+    parser.add_argument('--skip-internet-dependent-tests', action="store_true",
+                        help="Skip tests which depend on artifacts from the internet.")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -59,6 +59,8 @@ def pytest_addoption(parser):
     parser.addoption('--manager-api', action='store',
                      help='Manager unix socket path')
     add_cql_connection_options(parser)
+    parser.addoption('--skip-internet-dependent-tests', action='store_true',
+                     help='Skip tests which depend on artifacts from the internet')
     parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
                      help='Provide the URL to artifacts directory to generate the link to failed tests directory '
                           'with logs')

--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -1,0 +1,209 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import asyncio
+import random
+import logging
+import pytest
+import itertools
+import os
+import pathlib
+import contextlib
+import time
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.rest_client import read_barrier, HTTPError
+from test.pylib.scylla_cluster import ScyllaVersionDescription, get_scylla_2025_1_description
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from cassandra.cluster import ConsistencyLevel
+from cassandra.policies import FallthroughRetryPolicy, ConstantReconnectionPolicy
+from cassandra.protocol import ServerError
+from cassandra.query import SimpleStatement
+from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope="function")
+def internet_dependency_enabled(request) -> None:
+    if request.config.getoption('skip_internet_dependent_tests'):
+        pytest.skip(reason="skip_internet_dependent_tests is set")
+
+@pytest.fixture(scope="function")
+async def scylla_2025_1(request, build_mode, internet_dependency_enabled) -> AsyncIterator[ScyllaVersionDescription]:
+    yield await get_scylla_2025_1_description(build_mode)
+
+async def change_version(manager: ManagerClient, s: ServerInfo, exe: str):
+    await manager.server_stop_gracefully(s.server_id)
+    await manager.server_switch_executable(s.server_id, exe)
+    await manager.server_start(s.server_id)
+
+async def test_upgrade_and_rollback(manager: ManagerClient, scylla_2025_1: ScyllaVersionDescription):
+    new_exe = os.getenv("SCYLLA")
+    assert new_exe
+
+    logger.info("Bootstrapping cluster")
+    servers = (await manager.servers_add(2, cmdline=[
+        '--logger-log-level=storage_service=debug',
+        '--logger-log-level=api=trace',
+        '--logger-log-level=database=debug',
+        '--abort-on-seastar-bad-alloc',
+        '--dump-memory-diagnostics-on-alloc-failure-kind=all',
+    ], version=scylla_2025_1))
+
+    logger.info("Creating tables")
+    cql = manager.get_cql()
+
+    algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4WithDicts', 'ZstdWithDicts']
+    initial_algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4', 'Zstd']
+
+    await cql.run_async("""
+        CREATE KEYSPACE test
+        WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}
+    """)
+    await asyncio.gather(*[
+        cql.run_async(f'''
+            CREATE TABLE test."{algo}" (pk int PRIMARY KEY, c blob)
+            WITH COMPRESSION = {{'sstable_compression': '{initial_algo}Compressor'}};
+        ''')
+        for algo, initial_algo in zip(algorithms, initial_algorithms)
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Disabling autocompaction for the tables")
+    for algo in algorithms:
+        await asyncio.gather(*[manager.api.disable_autocompaction(s.ip_addr, "test", algo) for s in servers])
+
+    logger.info("Populating tables")
+    blob = random.randbytes(16*1024);
+    n_blobs = 100
+    for algo in algorithms:
+        insert = cql.prepare(f'''INSERT INTO test."{algo}" (pk, c) VALUES (?, ?);''')
+        insert.consistency_level = ConsistencyLevel.ALL;
+        for pks in itertools.batched(range(n_blobs), n=100):
+            await asyncio.gather(*[
+                cql.run_async(insert, [k, blob])
+                for k in pks
+            ])
+    total_uncompressed_size = len(blob) * n_blobs * 2
+
+    logger.info("Flushing tables")
+    await asyncio.gather(*[manager.api.keyspace_flush(s.ip_addr, "test") for s in servers])
+
+    async def validate_select():
+        logger.info("Validating readability of tables")
+        for algo in algorithms:
+            select = cql.prepare(f'''SELECT c FROM test."{algo}" WHERE pk = ? BYPASS CACHE;''')
+            select.consistency_level = ConsistencyLevel.ALL
+            results = await cql.run_async(select, [42])
+            assert results[0][0] == blob
+
+    async def get_data_size_for_server(server: ServerInfo, cf: str) -> int:
+        sstable_info = await manager.api.get_sstable_info(server.ip_addr, "test", cf)
+        sizes = [x['data_size'] for s in sstable_info for x in s['sstables']]
+        return sum(sizes)
+
+    async def get_total_data_size(cf: str) -> int:
+        return sum(await asyncio.gather(*[get_data_size_for_server(s, cf) for s in servers]))
+
+    logger.info("Checking size of initial SSTables")
+    for algo in algorithms:
+        assert (await get_total_data_size(algo)) > 0.9 * total_uncompressed_size
+
+    logger.info("Sanity check: old version returns 404 on retrain_dict")
+    try:
+        await manager.api.retrain_dict(servers[0].ip_addr, "test", algorithms[0])
+    except HTTPError as e:
+        assert e.code == 404
+    else:
+        raise Exception(f'Expected HTTPError, got no exception')
+
+    logger.info("Upgrading server 0")
+    await change_version(manager, servers[0], new_exe)
+
+    logger.info("Checking that new version returns 500 on retrain_dict before full upgrade")
+    try:
+        await manager.api.retrain_dict(servers[0].ip_addr, "test", algorithms[0])
+    except HTTPError as e:
+        assert e.code == 500
+    else:
+        raise Exception(f'Expected HTTPError, got no exception')
+
+    await validate_select()
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    for new_algo in ['LZ4WithDicts', 'ZstdWithDicts']:
+        @contextlib.asynccontextmanager
+        async def with_expect_server_error(msg):
+            try:
+                yield
+            except ServerError as e:
+                if e.message != msg:
+                    raise
+            else:
+                raise Exception('Expected a ServerError, got no exceptions')
+
+        expected_error = f"sstable_compression {new_algo}Compressor can't be used before all nodes are upgraded to a versions which supports it"
+
+        logger.info("Checking that new version before full upgrade rejects CREATE TABLE with new compressors")
+        async with with_expect_server_error(expected_error):
+            await cql.run_async(SimpleStatement(f'''
+                CREATE TABLE test.bad (pk int PRIMARY KEY, c blob)
+                WITH COMPRESSION = {{'sstable_compression': '{new_algo}Compressor'}};
+            ''', retry_policy=FallthroughRetryPolicy()), host=hosts[0])
+
+        logger.info("Checking that new version before full upgrade rejects ALTER TABLE with new compressors")
+        async with with_expect_server_error(expected_error):
+            await cql.run_async(SimpleStatement(f'''
+                ALTER TABLE test."Zstd"
+                WITH COMPRESSION = {{'sstable_compression': '{new_algo}Compressor'}};
+            ''', retry_policy=FallthroughRetryPolicy()), host=hosts[0])
+
+
+    logger.info("Rewriting SSTables after server 0 upgrade")
+    await manager.api.keyspace_upgrade_sstables(servers[0].ip_addr, "test")
+
+    await validate_select()
+
+    logger.info("Downgrading server 0")
+    await change_version(manager, servers[0], scylla_2025_1.path)
+
+    await validate_select()
+
+    logger.info("Upgrading both servers")
+    await asyncio.gather(
+        change_version(manager, servers[0], new_exe),
+        change_version(manager, servers[1], new_exe)
+    )
+
+    logger.info("Waiting for SSTABLE_COMPRESSION_DICTS cluster feature")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await asyncio.gather(*(wait_for_feature("SSTABLE_COMPRESSION_DICTS", cql, h, time.time() + 60) for h in hosts))
+
+    logger.info("Enabling dict-aware algorithms")
+    await asyncio.gather(*[
+        cql.run_async(f'''
+            ALTER TABLE test."{algo}" WITH COMPRESSION = {{'sstable_compression': '{algo}Compressor'}};
+        ''')
+        for algo in algorithms
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Retraining dict")
+    await asyncio.gather(*[
+        manager.api.retrain_dict(servers[0].ip_addr, "test", algo)
+        for algo in algorithms
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Rewriting SSTables")
+    await asyncio.gather(*[manager.api.keyspace_upgrade_sstables(s.ip_addr, "test") for s in servers])
+
+    await validate_select()
+
+    logger.info("Checking SSTable sizes")
+    assert (await get_total_data_size("ZstdWithDicts")) < 0.1 * total_uncompressed_size
+    assert (await get_total_data_size("LZ4WithDicts")) < 0.1 * total_uncompressed_size
+    assert (await get_total_data_size("Zstd")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("LZ4")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("Snappy")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("Deflate")) > 0.9 * total_uncompressed_size

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -316,6 +316,12 @@ class ManagerClient:
         logger.debug("ManagerClient unpausing %s", server_id)
         await self.client.put_json(f"/cluster/server/{server_id}/unpause")
 
+    async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
+        """Switch the executable path of a stopped server"""
+        logger.debug("ManagerClient starting %s", server_id)
+        data = {"path": path}
+        await self.client.put_json(f"/cluster/server/{server_id}/switch_executable", data)
+
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str) -> None:
         """Delete all files for the given table from the data directory"""
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -89,7 +89,7 @@ class PythonTestSuite(TestSuite):
 
             server = ScyllaServer(
                 mode=self.mode,
-                version=get_current_version_description(self.scylla_exe),
+                version=(create_cfg.version or get_current_version_description(self.scylla_exe)),
                 vardir=self.log_dir,
                 logger=create_cfg.logger,
                 cluster_name=create_cfg.cluster_name,

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -18,7 +18,7 @@ from typing import TYPE_CHECKING
 from scripts import coverage
 from test import path_to
 from test.pylib.pool import Pool
-from test.pylib.scylla_cluster import ScyllaCluster, ScyllaServer, merge_cmdline_options
+from test.pylib.scylla_cluster import ScyllaCluster, ScyllaServer, merge_cmdline_options, get_current_version_description
 from test.pylib.suite.base import Test, TestSuite, read_log, run_test
 from test.pylib.util import LogPrefixAdapter
 
@@ -89,7 +89,7 @@ class PythonTestSuite(TestSuite):
 
             server = ScyllaServer(
                 mode=self.mode,
-                exe=self.scylla_exe,
+                version=get_current_version_description(self.scylla_exe),
                 vardir=self.log_dir,
                 logger=create_cfg.logger,
                 cluster_name=create_cfg.cluster_name,

--- a/test/pylib/suite/topology.py
+++ b/test/pylib/suite/topology.py
@@ -48,6 +48,8 @@ class TopologyTest(PythonTest):
         async with get_cluster_manager(self.uname, self.suite.clusters, str(self.suite.log_dir)) as manager:
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
+            if options.skip_internet_dependent_tests:
+                self.args.insert(0, "--skip-internet-dependent-tests")
             if options.artifacts_dir_url:
                 self.args.insert(0, "--artifacts_dir_url={}".format(options.artifacts_dir_url))
 

--- a/test/pylib/suite/topology.py
+++ b/test/pylib/suite/topology.py
@@ -54,7 +54,7 @@ class TopologyTest(PythonTest):
             try:
                 # Note: start manager here so cluster (and its logs) is available in case of failure
                 await manager.start()
-                self.success = await run_test(self, options)
+                self.success = await run_test(self, options, env=self.suite.scylla_env)
             except Exception as e:
                 self.server_log = manager.cluster.read_server_log()
                 self.server_log_filename = manager.cluster.server_log_filename()

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -143,6 +143,9 @@ if [[ -z "$CARGO_HOME" ]]; then
     mkdir -p "$CARGO_HOME"
 fi
 
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+mkdir -p "$XDG_CACHE_HOME/scylladb"
+
 is_podman="$($tool --help | grep -o podman)"
 
 docker_common_args=()
@@ -226,6 +229,8 @@ docker_common_args+=(
        -v /etc/localtime:/etc/localtime:ro \
        --env CARGO_HOME \
        -v "${CARGO_HOME}:${CARGO_HOME}" \
+       --env XDG_CACHE_HOME \
+       -v "${XDG_CACHE_HOME}/scylladb:${XDG_CACHE_HOME}/scylladb" \
        -w "$PWD" \
        -e HOME="$HOME" \
        "${docker_args[@]}" \


### PR DESCRIPTION
This PR adds an upgrade test for SSTable compression with shared dictionaries, and adds some bits to pylib and test.py to support that.

In the series, we:
1. Mount `$XDG_CACHE_DIR` into dbuild.
2. Add a pylib function which downloads and installs a released ScyllaDB package into a subdirectory of `$XDG_CACHE_DIR/scylladb/test.py`, and returns the path to `bin/scylla`.
3. Add new methods and params to the cluster manager, which let the test start nodes with historical Scylla executables, and switch executables during the test.
4. Add a test which uses the above to run an upgrade test between the released package and the current build.
5. Add `--run-internet-dependent-tests` to `test.py` which lets the user of `test.py` skip this test (and potentially other internet-dependent tests in the future).

(The patch modifying `wait_for_cql_and_get_hosts` is a part of the new test — the new test needs it to test how particular nodes in a mixed-version cluster react to some CQL queries.) 

This is a follow-up to #23025, split into a separate PR because the potential addition of upgrade tests to `test.py` deserved a separate thread.

Needs backport to 2025.2, because that's where the tested feature is introduced.

Fixes #24110