### PR TITLE
.github: add delay before checking for required PR labels

### DIFF
--- a/.github/workflows/pr-require-backport-label.yaml
+++ b/.github/workflows/pr-require-backport-label.yaml
@@ -13,6 +13,8 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - name: Wait for label to be added
+        run: sleep 1m
       - uses: mheap/github-action-required-labels@v5
         with:
           mode: minimum


### PR DESCRIPTION
Improve the GitHub workflow to prevent premature email notifications about missing labels. Previously, contributors without write permissions to the scylladb repo would receive immediate notification emails about missing required backport labels, even if they were in the process of adding them.

This change introduces a 1-minute grace period before checking for required labels, giving contributors sufficient time to add necessary labels (like backport labels) to their pull requests before any warning notifications are sent.

The delay makes the experience more user-friendly for non-maintainer contributors while maintaining the labeling requirements.

---

enhancement of developer's experience, hence no need to backport.