### PR TITLE
main: Remove unused member variable `_sys_ks`

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1657,10 +1657,9 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             class sstable_dict_deleter : public service::migration_listener::empty_listener {
                 service::migration_notifier& _mn;
-                db::system_keyspace& _sys_ks;
                 gms::feature_service& _feat;
             public:
-                sstable_dict_deleter(service::migration_notifier& mn, db::system_keyspace& sys_ks, gms::feature_service& feat) : _mn(mn) , _sys_ks(sys_ks), _feat(feat) {
+                sstable_dict_deleter(service::migration_notifier& mn, gms::feature_service& feat) : _mn(mn) , _feat(feat) {
                     _mn.register_listener(this);
                 }
                 ~sstable_dict_deleter() {
@@ -1672,7 +1671,7 @@ sharded<locator::shared_token_metadata> token_metadata;
                     }
                 }
             };
-            auto the_sstable_dict_deleter = sstable_dict_deleter(mm_notifier.local(), sys_ks.local(), feature_service.local());
+            auto the_sstable_dict_deleter = sstable_dict_deleter(mm_notifier.local(), feature_service.local());
 
             checkpoint(stop_signal, "starting migration manager");
             debug::the_migration_manager = &mm;


### PR DESCRIPTION
Fixes a Clang error by removing the unused private field `sstable_dict_deleter::_sys_ks` that was flagged with: [-Werror,-Wunused-private-field]
```
/home/kefu/.local/bin/clang++ -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DSCYLLA_BUILD_MODE=release -DXXH_PRIVATE_API -DCMAKE_INTDIR=\"RelWithDebInfo\" -I/home/kefu/dev/scylladb -I/home/kefu/dev/scylladb/build/gen -I/home/kefu/dev/scylladb/build -isystem /home/kefu/dev/scylladb/seastar/include -isystem /home/kefu/dev/scylladb/build/RelWithDebInfo/seastar/gen/include -isystem /home/kefu/dev/scylladb/abseil -isystem /home/kefu/dev/scylladb/build/rust -I/usr/include/p11-kit-1 -ffunction-sections -fdata-sections -O3 -g -gz -std=gnu++23 -flto=thin -fvisibility=hidden -Wall -Werror -Wextra -Wno-error=deprecated-declarations -Wimplicit-fallthrough -Wno-c++11-narrowing -Wno-deprecated-copy -Wno-mismatched-tags -Wno-missing-field-initializers -Wno-overloaded-virtual -Wno-unsupported-friend -Wno-unused-parameter -ffile-prefix-map=/home/kefu/dev/scylladb/= -ffile-prefix-map=/home/kefu/dev/scylladb/build=. -ffile-prefix-map=/home/kefu/dev/scylladb/build/=build -march=westmere -Xclang -fexperimental-assignment-tracking=disabled -mllvm -inline-threshold=2500 -fno-slp-vectorize -ffat-lto-objects -std=gnu++23 -Werror=unused-result -DSEASTAR_API_LEVEL=7 -DSEASTAR_SSTRING -DSEASTAR_LOGGER_COMPILE_TIME_FMT -DSEASTAR_SCHEDULING_GROUPS_COUNT=19 -DSEASTAR_LOGGER_TYPE_STDOUT -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_DYN_LINK -DFMT_SHARED -MD -MT CMakeFiles/scylla.dir/RelWithDebInfo/main.cc.o -MF CMakeFiles/scylla.dir/RelWithDebInfo/main.cc.o.d -o CMakeFiles/scylla.dir/RelWithDebInfo/main.cc.o -c /home/kefu/dev/scylladb/main.cc
/home/kefu/dev/scylladb/main.cc:1660:38: error: private field '_sys_ks' is not used [-Werror,-Wunused-private-field]
 1660 |                 db::system_keyspace& _sys_ks;
      |                                      ^
```

The member variable is not referenced anywhere in the code, so removing it improves maintainability without affecting functionality.

---

it's a cleanup, hence no need to backport.