### PR TITLE
alternator: in GetRecords, enforce Limit to be <= 1000

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -808,6 +808,9 @@ future<executor::request_return_type> executor::get_records(client_state& client
     if (limit < 1) {
         throw api_error::validation("Limit must be 1 or more");
     }
+    if (limit > 1000) {
+        throw api_error::validation("Limit must be less than or equal to 1000");
+    }
 
     auto db = _proxy.data_dictionary();
     schema_ptr schema, base;

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -1594,6 +1594,34 @@ def test_stream_list_tables(dynamodb):
                 if table.name != listed_name:
                     assert table.name not in listed_name
 
+# The DynamoDB documentation for GetRecords says that "GetRecords can retrieve
+# a maximum of 1 MB of data or 1000 stream records, whichever comes first.",
+# and that for Limit, "the upper limit is 1000". Indeed, if we try Limit=1001,
+# we get a ValidationException. There is no reason why Alternator must
+# implement exactly the same maximum, but since it's documented, there is
+# no reason not to. In any case, some maximum is needed unless we make
+# sure the relevant code (executor::get_records()) has preemption points -
+# and currently it does not. Reproduces issue #23534
+def test_get_records_too_high_limit(test_table_ss_keys_only, dynamodbstreams):
+    table, arn = test_table_ss_keys_only
+    # Get just one shard - any shard - and its LATEST iterator. Because it's
+    # LATEST, there will be no data to read from this iterator, but we don't
+    # care, we just want to run the GetRecords request, we don't care what
+    # is returned.
+    shard = dynamodbstreams.describe_stream(StreamArn=arn, Limit=1)['StreamDescription']['Shards'][0]
+    shard_id = shard['ShardId']
+    iter = dynamodbstreams.get_shard_iterator(StreamArn=arn, ShardId=shard_id, ShardIteratorType='LATEST')['ShardIterator']
+    # Limit=1000 should be allowed:
+    response = dynamodbstreams.get_records(ShardIterator=iter, Limit=1000)
+    # Limit=1001 should NOT be allowed
+    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+        response = dynamodbstreams.get_records(ShardIterator=iter, Limit=1001)
+    # Limit must be >= 0:
+    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+        response = dynamodbstreams.get_records(ShardIterator=iter, Limit=0)
+    with pytest.raises(ClientError, match='ValidationException.*[Ll]imit'):
+        response = dynamodbstreams.get_records(ShardIterator=iter, Limit=-1)
+
 # TODO: tests on multiple partitions
 # TODO: write a test that disabling the stream and re-enabling it works, but
 #   requires the user to wait for the first stream to become DISABLED before


### PR DESCRIPTION
Alternator Streams' "GetRecords" operation has a "Limit" parameter on how many records to return. The DynamoDB documentations says that the upper limit on this Limit parameter is 1000 - but Alternator didn't enforce this. In this patch we begin enforcing this highest Limit, and also add a test for verifying this enforcement. As usual, the new test passes on DynamoDB, and after this patch - also on Alternator.

The reason why it's useful to have *some* upper limit on Limit is that the existing executor::get_records() implementation does not really have preemption points in all the necessary places. In particular, we have a loop on all returned records without preemption points. We also store the returned records in a RapidJson vector, which requires a contiguous allocation.

Even before this patch, GetRecords had a hard limit of 1 MB of results. But still, in some cases 1 MB of results may be a lot of results, and we can see stalls in the aforementioned places being O(number of results).

Fixes #23534

This is only a minor stability improvement (preventing users from shooting themselves in the foot), not a bug fix, so I suggest to either not backport it at all, or just backport it to the current 2025.1.