### PR TITLE
[Backport 2025.1] Merge 'test/pylib: servers_add: support list of property_files' from Benny Halevy

### DIFF
--- a/test/auth_cluster/test_auth_no_quorum.py
+++ b/test/auth_cluster/test_auth_no_quorum.py
@@ -25,7 +25,7 @@ async def test_auth_no_quorum(manager: ManagerClient) -> None:
         'permissions_validity_in_ms': 0,
         'permissions_update_interval_in_ms': 0,
     }
-    servers = await manager.servers_add(3, config=config)
+    servers = await manager.servers_add(3, config=config, auto_rack_dc="dc1")
 
     cql, _ = await manager.get_ready_cql(servers)
 

--- a/test/auth_cluster/test_auth_raft_command_split.py
+++ b/test/auth_cluster/test_auth_raft_command_split.py
@@ -16,7 +16,7 @@ Tests case when bigger auth operation is split into multiple raft commands.
 """
 @pytest.mark.asyncio
 async def test_auth_raft_command_split(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
     cql, hosts = await manager.get_ready_cql(servers)
 
     initial_perms = await cql.run_async("SELECT * FROM system.role_permissions")

--- a/test/auth_cluster/test_auth_v2_migration.py
+++ b/test/auth_cluster/test_auth_v2_migration.py
@@ -184,7 +184,7 @@ async def test_auth_v2_migration(request, manager: ManagerClient):
 
 @pytest.mark.asyncio
 async def test_auth_v2_during_recovery(manager: ManagerClient):
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
     cql, hosts = await manager.get_ready_cql(servers)
 
     logging.info("Checking auth version before recovery")

--- a/test/auth_cluster/test_raft_service_levels.py
+++ b/test/auth_cluster/test_raft_service_levels.py
@@ -105,7 +105,7 @@ async def test_service_levels_upgrade(request, manager: ManagerClient):
 
 @pytest.mark.asyncio
 async def test_service_levels_work_during_recovery(manager: ManagerClient):
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
 
     logging.info("Waiting until driver connects to every server")
     cql = manager.get_cql()
@@ -235,7 +235,7 @@ async def assert_connections_params(manager: ManagerClient, hosts, expect):
 @pytest.mark.asyncio
 @skip_mode('release', 'cql server testing REST API is not supported in release mode')
 async def test_connections_parameters_auto_update(manager: ManagerClient, build_mode):
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -318,7 +318,7 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
 
 @pytest.mark.asyncio
 async def test_service_level_cache_after_restart(manager: ManagerClient):
-    servers = await manager.servers_add(1)
+    servers = await manager.servers_add(1, auto_rack_dc="dc1")
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -446,7 +446,7 @@ async def test_service_levels_over_limit(manager: ManagerClient):
 # Reproduces issue scylla-enterprise#4912
 @pytest.mark.asyncio
 async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
-    servers = await manager.servers_add(2)
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
     s = servers[0]
     cql = manager.get_cql()
     [h] = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60)
@@ -477,5 +477,5 @@ async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     await cql.run_async(f"DROP SERVICE LEVEL {sl2}", host=h)
 
     # Check if group0 is healthy
-    s2 = await manager.server_add()
+    s2 = await manager.server_add(property_file={"dc": "dc1", "rack": "rack3"})
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)

--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -29,6 +29,9 @@ class ServerInfo(NamedTuple):
     def as_dict(self) -> dict[str, object]:
         return {"server_id": self.server_id, "ip_addr": self.ip_addr, "rpc_address": self.rpc_address, "datacenter": self.datacenter, "rack": self.rack}
 
+    def property_file(self) -> dict[str, str]:
+        return {"dc": self.datacenter, "rack": self.rack}
+
 
 class ServerUpState(Enum):
     PROCESS_STARTED = auto()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -207,6 +207,11 @@ class ManagerClient():
            To be used when a server was modified outside of this API."""
         await self.client.put_json("/cluster/mark-dirty")
 
+    async def mark_clean(self) -> None:
+        """Manually mark current cluster not dirty.
+           To be used when a current cluster wants to be reused."""
+        await self.client.put_json("/cluster/mark-clean")
+
     async def server_stop(self, server_id: ServerNum) -> None:
         """Stop specified server"""
         logger.debug("ManagerClient stopping %s", server_id)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1409,6 +1409,7 @@ class ScyllaClusterManager:
         add_put('/cluster/before-test/{test_case_name}', self._before_test_req)
         add_put('/cluster/after-test/{success}', self._after_test)
         add_put('/cluster/mark-dirty', self._mark_dirty)
+        add_put('/cluster/mark-clean', self._mark_clean)
         add_put('/cluster/server/{server_id}/stop', self._cluster_server_stop)
         add_put('/cluster/server/{server_id}/stop_gracefully', self._cluster_server_stop_gracefully)
         add_put('/cluster/server/{server_id}/start', self._cluster_server_start)
@@ -1517,6 +1518,12 @@ class ScyllaClusterManager:
         """Mark current cluster dirty"""
         assert self.cluster
         self.cluster.is_dirty = True
+
+    async def _mark_clean(self, _request) -> None:
+        """Mark current cluster clean"""
+        assert self.cluster
+        self.cluster.is_dirty = False
+        self.cluster.keyspace_count = self.cluster._get_keyspace_count()
 
     async def _server_stop(self, request: aiohttp.web.Request, gracefully: bool) -> None:
         """Stop a server. No-op if already stopped."""

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -10,6 +10,7 @@ markers =
     without_scylla: run without attaching to a scylla process
     enable_tablets: create keyspace with tablets enabled or disabled
     repair: tests for repair
+    prepare_3_nodes_cluster: prepare 3 nodes cluster for test case based on suite.yaml (all tests from old topology folder)
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -11,6 +11,7 @@ markers =
     enable_tablets: create keyspace with tablets enabled or disabled
     repair: tests for repair
     prepare_3_nodes_cluster: prepare 3 nodes cluster for test case based on suite.yaml (all tests from old topology folder)
+    prepare_3_racks_cluster: prepare 3 nodes cluster in 1 dc and 3 racks for test case based on suite.yaml
 norecursedirs = manual perf lib
 # Ignore warnings about HTTPS requests without certificate verification
 # (see issue #15287). Pytest breaks urllib3.disable_warnings() in conftest.py,

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -172,7 +172,7 @@ async def manager_internal(event_loop, request):
 
 
 @pytest.fixture(scope="function")
-async def manager(request, manager_internal, record_property, build_mode):
+async def manager(request, manager_internal, record_property, build_mode, is_test_needed_cluster):
     """Per test fixture to notify Manager client object when tests begin so it can
     perform checks for cluster state.
     """
@@ -189,6 +189,8 @@ async def manager(request, manager_internal, record_property, build_mode):
     test_py_log_test = suite_testpy_log.parent / f"{suite_testpy_log.stem}_{test_case_name}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
+    if not is_test_needed_cluster:
+        await manager_client.mark_dirty()
     await manager_client.before_test(test_case_name, test_log)
     yield manager_client
     # `request.node.stash` contains a report stored in `pytest_runtest_makereport` from where we can retrieve
@@ -271,3 +273,17 @@ def pytest_collection_modifyitems(items, config):
     run_id = config.getoption('run_id')
     for item in items:
         item.name = f"{item.name}.{run_id}"
+
+
+@pytest.fixture(scope="function")
+def is_test_needed_cluster(request):
+    prepare_marker = request.node.get_closest_marker("prepare_3_nodes_cluster")
+    return bool(prepare_marker)
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def prepare_3_nodes_cluster(is_test_needed_cluster, manager):
+    servers = await  manager.running_servers()
+    if not servers and is_test_needed_cluster:
+        await manager.servers_add(3)
+        await manager.mark_clean()

--- a/test/topology/conftest.py
+++ b/test/topology/conftest.py
@@ -277,3 +277,9 @@ def pytest_collection_modifyitems(items, config):
 async def prepare_3_nodes_cluster(request, manager):
     if request.node.get_closest_marker("prepare_3_nodes_cluster"):
         await manager.servers_add(3)
+
+
+@pytest.fixture(scope="function", autouse=True)
+async def prepare_3_racks_cluster(request, manager):
+    if request.node.get_closest_marker("prepare_3_racks_cluster"):
+        await manager.servers_add(3, auto_rack_dc="dc1")

--- a/test/topology/suite.yaml
+++ b/test/topology/suite.yaml
@@ -1,7 +1,7 @@
 type: Topology
 pool_size: 4
 cluster:
-  initial_size: 3
+  initial_size: 0
 extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer

--- a/test/topology/test_automatic_cleanup.py
+++ b/test/topology/test_automatic_cleanup.py
@@ -10,6 +10,8 @@ import logging
 import asyncio
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_no_cleanup_when_unnecessary(request, manager: ManagerClient):

--- a/test/topology/test_automatic_cleanup.py
+++ b/test/topology/test_automatic_cleanup.py
@@ -10,7 +10,7 @@ import logging
 import asyncio
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -25,8 +25,8 @@ async def test_no_cleanup_when_unnecessary(request, manager: ManagerClient):
     servers = await manager.running_servers()
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]
     marks = [await log.mark() for log in logs]
-    await manager.server_add()
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack1"})
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack2"})
     matches = [await log.grep("raft_topology - start cleanup", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 0
 
@@ -44,7 +44,7 @@ async def test_no_cleanup_when_unnecessary(request, manager: ManagerClient):
     matches = [await log.grep("raft_topology - start cleanup", from_mark=mark) for log, mark in zip(logs, marks)]
     assert sum(len(x) for x in matches) == 0
 
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "rack3"})
     servers = await manager.running_servers()
     logs = [await manager.server_open_log(srv.server_id) for srv in servers]
     marks = [await log.mark() for log in logs]

--- a/test/topology/test_change_ip.py
+++ b/test/topology/test_change_ip.py
@@ -20,6 +20,8 @@ from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
 from test.topology.util import reconnect_driver
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -22,6 +22,8 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 
 TEST_FEATURE_NAME = "TEST_ONLY_FEATURE"

--- a/test/topology/test_cluster_features.py
+++ b/test/topology/test_cluster_features.py
@@ -22,7 +22,7 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 
@@ -145,13 +145,13 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))
 
     # Try to add a node that doesn't support the feature - should fail
-    new_server_info = await manager.server_add(start=False)
+    new_server_info = await manager.server_add(start=False, property_file=servers[0].property_file())
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
 
     # Try to replace with a node that doesn't support the feature - should fail
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id=servers[0].server_id, reuse_ip_addr=False, use_host_id=False)
-    new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg)
+    new_server_info = await manager.server_add(start=False, replace_cfg=replace_cfg, property_file=servers[0].property_file())
     await manager.server_start(new_server_info.server_id, expected_error="Feature check failed")
 
 

--- a/test/topology/test_concurrent_schema.py
+++ b/test/topology/test_concurrent_schema.py
@@ -10,7 +10,7 @@ from test.pylib.random_tables import Column, UUIDType, IntType
 
 
 logger = logging.getLogger('schema-test')
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 

--- a/test/topology/test_concurrent_schema.py
+++ b/test/topology/test_concurrent_schema.py
@@ -10,6 +10,8 @@ from test.pylib.random_tables import Column, UUIDType, IntType
 
 
 logger = logging.getLogger('schema-test')
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 
 # #1207 Schema changes are not linearizable, so concurrent updates may lead to

--- a/test/topology/test_coordinator_queue_management.py
+++ b/test/topology/test_coordinator_queue_management.py
@@ -12,6 +12,8 @@ import logging
 import asyncio
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')

--- a/test/topology/test_global_ignore_nodes.py
+++ b/test/topology/test_global_ignore_nodes.py
@@ -10,6 +10,8 @@ import uuid
 import logging
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) -> None:

--- a/test/topology/test_gossiper.py
+++ b/test/topology/test_gossiper.py
@@ -7,6 +7,9 @@
 from test.pylib.manager_client import ManagerClient
 import pytest
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
+
 @pytest.mark.asyncio
 async def test_gossiper_endpoints(manager: ManagerClient) -> None:
     servers = await manager.running_servers()

--- a/test/topology/test_gossiper.py
+++ b/test/topology/test_gossiper.py
@@ -7,7 +7,7 @@
 from test.pylib.manager_client import ManagerClient
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -17,7 +17,7 @@ from cassandra.query import SimpleStatement              # type: ignore # pylint
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_mutation_schema_change.py
+++ b/test/topology/test_mutation_schema_change.py
@@ -17,6 +17,7 @@ from cassandra.query import SimpleStatement              # type: ignore # pylint
 
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_mv.py
+++ b/test/topology/test_mv.py
@@ -19,7 +19,7 @@ from test.topology.util import new_test_keyspace, new_test_table, new_materializ
 ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 } AND TABLETS = {'enabled': false }"
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_mv.py
+++ b/test/topology/test_mv.py
@@ -19,6 +19,8 @@ from test.topology.util import new_test_keyspace, new_test_table, new_materializ
 ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 } AND TABLETS = {'enabled': false }"
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_mv_tombstone_gc_setting(manager):

--- a/test/topology/test_nodetool.py
+++ b/test/topology/test_nodetool.py
@@ -5,6 +5,8 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for_first_completed
 from test.topology.conftest import skip_mode
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 async def validate_status_operation(result: str, live_eps: list, down_eps: list, leaving: list, joining: list,
                                     zero_token_eps: list, host_id_map: dict, num_tokens: object):

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -10,7 +10,7 @@ from cassandra.protocol import InvalidRequest, ReadFailure                      
 from cassandra.query import SimpleStatement                                        # type: ignore
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 # Simple test of schema helper

--- a/test/topology/test_random_tables.py
+++ b/test/topology/test_random_tables.py
@@ -10,6 +10,8 @@ from cassandra.protocol import InvalidRequest, ReadFailure                      
 from cassandra.query import SimpleStatement                                        # type: ignore
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 # Simple test of schema helper
 @pytest.mark.asyncio

--- a/test/topology/test_replace_alive_node.py
+++ b/test/topology/test_replace_alive_node.py
@@ -8,7 +8,7 @@ from test.pylib.manager_client import ManagerClient
 import asyncio
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -24,4 +24,5 @@ async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:
         replace_cfg = ReplaceConfig(replaced_id = srv.server_id, reuse_ip_addr = False,
                                     use_host_id = False, wait_replaced_dead = False)
         await manager.server_add(replace_cfg=replace_cfg,
+                                 property_file=srv.property_file(),
                                  expected_error="the topology coordinator rejected request to join the cluster")

--- a/test/topology/test_replace_alive_node.py
+++ b/test/topology/test_replace_alive_node.py
@@ -8,6 +8,8 @@ from test.pylib.manager_client import ManagerClient
 import asyncio
 import pytest
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_replacing_alive_node_fails(manager: ManagerClient) -> None:

--- a/test/topology/test_snapshot.py
+++ b/test/topology/test_snapshot.py
@@ -14,6 +14,7 @@ from cassandra.query import SimpleStatement              # type: ignore # pylint
 
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/topology/test_start_bootstrapped_with_invalid_seed.py
@@ -12,6 +12,7 @@ from test.pylib.internal_types import IPAddress
 from test.pylib.manager_client import ManagerClient
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_tls.py
+++ b/test/topology/test_tls.py
@@ -12,6 +12,8 @@ import logging
 import pytest
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_upgrade_to_ssl(manager: ManagerClient) -> None:

--- a/test/topology/test_topology_failure_recovery.py
+++ b/test/topology/test_topology_failure_recovery.py
@@ -14,6 +14,7 @@ import random
 import sys
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 def init_random_seed():

--- a/test/topology/test_topology_rejoin.py
+++ b/test/topology/test_topology_rejoin.py
@@ -9,6 +9,8 @@ Test rejoin of a server after it was stopped suddenly (crash-like)
 from test.pylib.manager_client import ManagerClient
 import pytest
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_start_after_sudden_stop(manager: ManagerClient, random_tables) -> None:

--- a/test/topology/test_topology_rejoin.py
+++ b/test/topology/test_topology_rejoin.py
@@ -9,7 +9,7 @@ Test rejoin of a server after it was stopped suddenly (crash-like)
 from test.pylib.manager_client import ManagerClient
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_topology_remove_decom.py
+++ b/test/topology/test_topology_remove_decom.py
@@ -19,6 +19,7 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
+pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio

--- a/test/topology/test_topology_schema.py
+++ b/test/topology/test_topology_schema.py
@@ -10,6 +10,8 @@ import time
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 import pytest
 
+pytestmark = pytest.mark.prepare_3_nodes_cluster
+
 
 @pytest.mark.asyncio
 async def test_topology_schema_changes(manager, random_tables):

--- a/test/topology/test_topology_schema.py
+++ b/test/topology/test_topology_schema.py
@@ -10,7 +10,7 @@ import time
 from test.topology.util import wait_for_token_ring_and_group0_consistency
 import pytest
 
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -26,7 +26,7 @@ async def test_topology_schema_changes(manager, random_tables):
     await random_tables.verify_schema()
 
     # Test add column after adding a server
-    await manager.server_add()
+    await manager.server_add(property_file=servers[1].property_file())
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     await table.add_column()
     await random_tables.verify_schema()

--- a/test/topology_custom/test_raft_cluster_features.py
+++ b/test/topology_custom/test_raft_cluster_features.py
@@ -19,31 +19,31 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_rolling_upgrade_happy_path(manager)
 
 
 @pytest.mark.asyncio
 async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_partial_upgrade(manager)
 
 
 @pytest.mark.asyncio
 async def test_joining_old_node_fails(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_joining_old_node_fails(manager)
 
 
 @pytest.mark.asyncio
 async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_downgrade_after_successful_upgrade_fails(manager)
 
 
 @pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
-    await manager.servers_add(3)
+    await manager.servers_add(3, auto_rack_dc="dc1")
     await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
 
 
@@ -55,7 +55,7 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
        missing feature. Unblock the topology coordinator, restart the node
        and observe that the feature was enabled.
     """
-    servers = await manager.servers_add(3)
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
 
     # Rolling restart so that all nodes support the feature - but do not
     # allow enabling yet


### PR DESCRIPTION
So that a multi-dc/multi-rack cluster can be populated in a single call.

Original PR: scylladb/scylladb#23341

Fixes https://github.com/scylladb/scylladb/issues/23551

(cherry picked from commit 0fdf2a2090b0151c6edbe449d7a29d919e8f06e4)
