### PR TITLE
cql: Remove unused "initial_tablets" mention from guardrails

### DIFF
--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -237,9 +237,6 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     // We ignore errors (non-number, negative number, etc.) here,
     // these are checked and reported elsewhere.
     for (auto opt : attrs.get_replication_options()) {
-        if (opt.first == sstring("initial_tablets")) {
-            continue;
-        }
         try {
             auto rf = std::stol(opt.second);
             if (rf > 0) {


### PR DESCRIPTION
All tablets configuration was moved into its own "with tablets" section, this option name cannot be met among replication factors.

No problems having it in 2025, it's fairly simple patch