### PR TITLE
test/cluster/test_read_repair.py: increase read request timeout

### DIFF
--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -380,9 +380,10 @@ async def test_incremental_read_repair(data_class: DataClass, workdir: str, mana
 async def test_read_repair_with_trace_logging(request, manager):
     logger.info("Creating a new cluster")
     cmdline = ["--hinted-handoff-enabled", "0", "--logger-log-level", "mutation_data=trace"]
+    config = {"read_request_timeout_in_ms": 60000}
 
     for i in range(2):
-        await manager.server_add(cmdline=cmdline)
+        await manager.server_add(cmdline=cmdline, config=config)
 
     cql = manager.get_cql()
     srvs = await manager.running_servers()


### PR DESCRIPTION
This test enables trace-level logging for the mutation_data logger, which seems to be too much in debug mode and the test read times out. Increase timeout to 1minute to avoid this.

Fixes: #23513

Flaky test fix, no backport required (for now)