### PR TITLE
db: allow adding racks with RF-rack-valid keyspaces

### DIFF
--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -276,7 +276,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
                     locator::replication_strategy_params(ks_md_update->strategy_options(), ks_md_update->initial_tablets()));
 
             try {
-                // There are two things to note here:
+                // There are three things to note here:
                 // 1. We hold a group0_guard, so it's correct to check this here.
                 //    The topology or schema cannot change while we're performing this query.
                 // 2. The replication strategy we use here does NOT represent the actual state
@@ -285,10 +285,15 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
                 //    strategy we pass to this function, while in reality that means that the RF
                 //    will NOT change. That is not a problem:
                 //    - RF=0 is valid for all DCs, so it won't trigger an exception on its own,
-                //    - the keyspace must've been RF-rack-valid before this change. We check that
-                //      condition for all keyspaces at startup.
+                //    - the keyspace must've been RF-rack-valid (or at least replicated on RF racks)
+                //      before this change. We check that condition for all keyspaces at startup.
                 //    The second hyphen is not really true because currently topological changes can
                 //    disturb it (see scylladb/scylladb#23345), but we ignore that.
+                // 3. If the keyspace was not RF-rack-valid byt only replicated on RF racks, we
+                //    still check that after the change the keyspace is RF-rack-valid, instead of
+                //    checking the replication again. We do that because currently we do not support
+                //    moving from one non RF-rack-valid replication strategy to another. If a keyspace
+                //    is not RF-rack-valid, we only support changing its replication to an RF-rack-valid one.
                 locator::assert_rf_rack_valid_keyspace(_name, tmptr, *rs);
             } catch (const std::exception& e) {
                 // There's no guarantee what the type of the exception will be, so we need to

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -72,6 +72,30 @@ std::vector<column_definition> create_table_statement::get_columns() const
 
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector<mutation>, cql3::cql_warnings_vec>>
 create_table_statement::prepare_schema_mutations(query_processor& qp, const query_options&, api::timestamp_type ts) const {
+    const auto tmptr = qp.proxy().get_token_metadata_ptr();
+    const auto& cfg = qp.db().get_config();
+    // FIXME: After adding a new rack, the keyspace is not RF-rack-valid anymore,
+    // but because tablet migrations across racks are blocked, the existing tables
+    // are still limited to RF racks. However, we cannot create new tables
+    // because the tablets will be distributed across all racks. This limitation
+    // should be removed when we add support for specifying the racks that the tables
+    // in a keyspace should be replicated on.
+    if (cfg.rf_rack_valid_keyspaces()) {
+        try {
+            const auto& rs = qp.db().find_keyspace(keyspace()).get_replication_strategy();
+            // As a schema altering statement, we hold a group0_guard here,
+            // so the topology or schema cannot change while we're performing this query.
+            locator::assert_rf_rack_valid_keyspace(keyspace(), tmptr, rs);
+        } catch (const data_dictionary::no_such_keyspace& e) {
+            // We also check this in prepare(), but if we somehow reach here without passing
+            // through prepare(), add the corresponding error message.
+            throw exceptions::invalid_request_exception("Cannot create a table in a non-existent keyspace: " + keyspace());
+        } catch (const std::exception& e) {
+            // There's no guarantee what the type of the exception will be, so we need to
+            // wrap it manually here in a type that can be passed to the user.
+            throw exceptions::invalid_request_exception(e.what());
+        }
+    }
     std::vector<mutation> m;
 
     try {

--- a/db/config.cc
+++ b/db/config.cc
@@ -1457,7 +1457,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_create_table_with_compact_storage(this, "enable_create_table_with_compact_storage", liveness::LiveUpdate, value_status::Used, false, "Enable the deprecated feature of CREATE TABLE WITH COMPACT STORAGE.  This feature will eventually be removed in a future version.")
     , rf_rack_valid_keyspaces(this, "rf_rack_valid_keyspaces", liveness::MustRestart, value_status::Used, false,
         "Enforce RF-rack-valid keyspaces. Additionally, if there are existing RF-rack-invalid "
-        "keyspaces, attempting to start a node with this option ON will fail.")
+        "keyspaces, attempting to start a node with this option ON will fail unless they became RF-rack-invalid"
+        "due to adding new racks without increasing their RF.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -729,6 +729,13 @@ class abstract_replication_strategy;
 /// * The keyspace need not exist. We use its name purely for informational reasons (in error messages).
 void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr, const abstract_replication_strategy&);
 
+/// A more expensive but less restrictive version of the above function. Here we check
+/// for all tablets in all tables in the keyspace if they are replicated on the same racks,
+/// with one replica per rack (unless the RF for the given DC is 0 or 1).
+///
+/// Because we need to investigate specific tables, the keyspace must exist.
+void validate_rf_rack_valid_replication(const token_metadata_ptr, const replica::keyspace&);
+
 }
 
 template <>

--- a/main.cc
+++ b/main.cc
@@ -2169,9 +2169,9 @@ sharded<locator::shared_token_metadata> token_metadata;
             // At this point, `locator::topology` should be stable, i.e. we should have complete information
             // about the layout of the cluster (= list of nodes along with the racks/DCs).
             if (cfg->rf_rack_valid_keyspaces()) {
-                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                startlog.info("Verifying that all of the keyspaces are replicated on RF racks");
                 db.local().check_rf_rack_validity(token_metadata.local().get());
-                startlog.info("All keyspaces are RF-rack-valid");
+                startlog.info("All keyspaces are replicated on exactly RF racks");
             }
 
             dictionary_service dict_service(

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3236,7 +3236,7 @@ void database::check_rf_rack_validity(const locator::token_metadata_ptr tmptr) c
     SCYLLA_ASSERT(get_config().rf_rack_valid_keyspaces());
 
     for (const auto& [name, info] : get_keyspaces()) {
-        locator::assert_rf_rack_valid_keyspace(name, tmptr, info.get_replication_strategy());
+        locator::validate_rf_rack_valid_replication(tmptr, info);
     }
 }
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1974,6 +1974,9 @@ public:
     virtual future<> on_effective_service_levels_cache_reloaded() override;
 
     // Verify that the existing keyspaces are all RF-rack-valid.
+    // If that's not the case, but each of the non RF-rack-valid keyspaces is replicated on RF racks
+    // with one replica in each rack, the check still passes but to create new tables in those keyspaces
+    // the RF must be increased to the number of racks in the DC, making the keyspace RF-rack-valid.
     //
     // Preconditions:
     // * the option `rf_rack_valid_keyspaces` in enabled,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1053,9 +1053,9 @@ private:
             }
 
             if (cfg->rf_rack_valid_keyspaces()) {
-                startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
+                startlog.info("Verifying that all of the keyspaces are replicated on RF racks");
                 _db.local().check_rf_rack_validity(_token_metadata.local().get());
-                startlog.info("All keyspaces are RF-rack-valid");
+                startlog.info("All keyspaces are replicated on exactly RF racks");
             }
 
             utils::loading_cache_config perm_cache_config;


### PR DESCRIPTION
In this patch we lift the restriction of refusing to add new racks to datacenters while RF-rack-valid keyspaces exist. Before this patch, if we enabled the RF-rack-valid-keyspaces option and created a keyspace, no new racks could be added, as these keyspaces would be no longer RF-rack-valid. The option affects all keyspaces with
 tablets, so in practice, if we had any data in the DC, we could no longer add or remove any racks.
This patch doesn't enable all configurations of keyspace RFs and racks, but it enables some extra configurations, not possible before:
* adding a new rack
* removing a rack, as long as no RF-rack-valid keyspace (with RF>1) is replicated on it
* increasing the RF of a keyspace, if it makes it RF-rack-valid

After a new rack is added, the usage of the existing RF-rack-valid keyspaces is limited - we can no longer create new tables in it until the RF is increased to match the number of racks.

Allowing adding new racks was accomplished by the following steps:
* on node startup, instead of checking whether all keyspaces are replicated on all racks, for each keyspace we now check if all tablets in all tables in this keyspace are replicated on the same racks
* the load balancer is adjusted to reject any cross-rack migrations of RF-rack-valid keyspaces, instead of only discouraging them
* when creating a table in a keyspace, to avoid allocating its tablets on too many racks, we now check whether the keyspace is RF-rack-valid

With these steps we make sure that at any point in time, every table in a (originally) RF-rack-valid keyspace with a given RF will be replicated on specific RF racks.

After this patch, we still can't decrease the RF of a keyspace, increase it to a number lower than the number of racks and we can't remove a rack that already contains some data from RF-rack-valid keyspaces, unless we drop these keyspaces before. These issues will need to be fixed in an additional, more comprehensive patch.

Fixes: https://github.com/scylladb/scylladb/issues/23426