### PR TITLE
s3/client: Optimize file streaming with zero-copy multipart uploads

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1120,8 +1120,9 @@ class client::do_upload_file : private multipart_upload {
                 if (buf.empty()) {
                     break;
                 }
-                co_await output.write(buf.get(), buf.size());
-                progress.uploaded += buf.size();
+                const size_t buf_size = buf.size();
+                co_await output.write(std::move(buf));
+                progress.uploaded += buf_size;
             }
             co_await output.flush();
         } catch (...) {


### PR DESCRIPTION
When streaming files using multipart upload, switch from using `output_stream::write(const char*, size_t)` to passing buffer objects directly to `output_stream::write()`. This eliminates unnecessary memory copying that occurred when the original implementation had to defensively copy data before sending.

The buffer objects can now be safely reused by the output stream instead of creating deep copies, which should improve performance by reducing memory operations during S3 file uploads.

---

this change improve the performance of a feature not used in production, hence no need to backport.