### PR TITLE
cql3: Remove unnecessary 'virtual' specifiers from final class methods

### DIFF
--- a/cql3/column_identifier.hh
+++ b/cql3/column_identifier.hh
@@ -82,7 +82,7 @@ public:
 
     const sstring& text() const;
 
-    virtual sstring to_string() const;
+    sstring to_string() const;
     sstring to_cql_string() const;
 
     friend std::hash<column_identifier_raw>;


### PR DESCRIPTION
Remove 'virtual' specifiers from member functions in final classes where they can never be overridden. This addresses Clang errors like:

```
/home/kefu/dev/scylladb/cql3/column_identifier.hh:85:21: error: virtual method 'to_string' is inside a 'final' class and can never be overridden [-Werror,-Wunnecessary-virtual-specifier]
   85 |     virtual sstring to_string() const;
      |                     ^
1 error generated.
```

This change improves code clarity and maintainability by eliminating redundant modifiers that could cause confusion.

---

it's a cleanup, hence no need to backport.