### PR TITLE
[RFC] compaction_manager: run_with_compaction_disabled: add stop_threshold

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -731,15 +731,15 @@ compaction_manager::compaction_reenabler::~compaction_reenabler() {
 }
 
 future<compaction_manager::compaction_reenabler>
-compaction_manager::stop_and_disable_compaction(table_state& t) {
+compaction_manager::stop_and_disable_compaction(table_state& t, double stop_threshold) {
     compaction_reenabler cre(*this, t);
-    co_await stop_ongoing_compactions("user-triggered operation", &t);
+    co_await stop_ongoing_compactions("user-triggered operation", &t, std::nullopt, stop_threshold);
     co_return cre;
 }
 
 future<>
-compaction_manager::run_with_compaction_disabled(table_state& t, std::function<future<> ()> func) {
-    compaction_reenabler cre = co_await stop_and_disable_compaction(t);
+compaction_manager::run_with_compaction_disabled(table_state& t, std::function<future<> ()> func, double stop_threshold) {
+    compaction_reenabler cre = co_await stop_and_disable_compaction(t, stop_threshold);
 
     co_await func();
 }
@@ -1067,13 +1067,16 @@ void compaction_manager::postpone_compaction_for_table(table_state* t) {
     _postponed.insert(t);
 }
 
-future<> compaction_manager::stop_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks, sstring reason) noexcept {
+void compaction_manager::stop_tasks(const std::vector<shared_ptr<compaction_task_executor>>& tasks, sstring reason) noexcept {
     // To prevent compaction from being postponed while tasks are being stopped,
     // let's stop all tasks before the deferring point below.
     for (auto& t : tasks) {
         cmlog.debug("Stopping {}", *t);
         t->stop_compaction(reason);
     }
+}
+
+future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks) const noexcept {
     co_await coroutine::parallel_for_each(tasks, [] (auto& task) -> future<> {
         auto unlink_task = deferred_action([task] { task->unlink(); });
         try {
@@ -1083,14 +1086,14 @@ future<> compaction_manager::stop_tasks(std::vector<shared_ptr<compaction_task_e
             // as it happens with reshard and reshape.
         } catch (...) {
             // just log any other errors as the callers have nothing to do with them.
-            cmlog.debug("Stopping {}: task returned error: {}", *task, std::current_exception());
+            cmlog.debug("Awaiting {}: task returned error: {}", *task, std::current_exception());
             co_return;
         }
-        cmlog.debug("Stopping {}: done", *task);
+        cmlog.debug("Awaiting {}: done", *task);
     });
 }
 
-future<> compaction_manager::stop_ongoing_compactions(sstring reason, table_state* t, std::optional<sstables::compaction_type> type_opt) noexcept {
+future<> compaction_manager::stop_ongoing_compactions(sstring reason, table_state* t, std::optional<sstables::compaction_type> type_opt, double stop_threshold) noexcept {
     try {
         auto ongoing_compactions = get_compactions(t).size();
         auto tasks = _tasks
@@ -1098,6 +1101,12 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, table_stat
                     return (!t || task.compacting_table() == t) && (!type_opt || task.compaction_type() == *type_opt);
                 })
                 | std::views::transform([] (auto& task) { return task.shared_from_this(); })
+                | std::ranges::to<std::vector<shared_ptr<compaction_task_executor>>>();
+        auto tasks_to_stop = tasks
+                | std::views::filter([stop_threshold] (const auto& task) {
+                    auto& cdata = task->compaction_data();
+                    return !cdata.compaction_size || (task->progress_monitor().get_progress() / cdata.compaction_size) <= stop_threshold;
+                })
                 | std::ranges::to<std::vector<shared_ptr<compaction_task_executor>>>();
         logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
         if (cmlog.is_enabled(level)) {
@@ -1110,11 +1119,11 @@ future<> compaction_manager::stop_ongoing_compactions(sstring reason, table_stat
             }
             cmlog.log(level, "Stopping {} tasks for {} ongoing compactions{} due to {}", tasks.size(), ongoing_compactions, scope, reason);
         }
-        return stop_tasks(std::move(tasks), std::move(reason));
+        stop_tasks(tasks_to_stop, std::move(reason));
+        co_await await_tasks(std::move(tasks));
     } catch (...) {
         cmlog.error("Stopping ongoing compactions failed: {}.  Ignored", std::current_exception());
     }
-    return make_ready_future();
 }
 
 future<> compaction_manager::drain() {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1713,7 +1713,7 @@ protected:
 template<typename TaskType, typename... Args>
 requires std::derived_from<TaskType, compaction_task_executor> &&
          std::derived_from<TaskType, compaction_task_impl>
-future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task_on_all_files(tasks::task_info info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args) {
+future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task_on_all_files(tasks::task_info info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, double stop_threshold, Args... args) {
     auto gh = start_compaction(t);
     if (!gh) {
         co_return std::nullopt;
@@ -1737,7 +1737,7 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_tas
         std::sort(sstables.begin(), sstables.end(), [](sstables::shared_sstable& a, sstables::shared_sstable& b) {
             return a->data_size() > b->data_size();
         });
-    });
+    }, stop_threshold);
     if (sstables.empty()) {
         co_return std::nullopt;
     }
@@ -1748,7 +1748,7 @@ future<compaction_manager::compaction_stats_opt>
 compaction_manager::rewrite_sstables(table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr,
                                      get_candidates_func get_func, tasks::task_info info, can_purge_tombstones can_purge,
                                      sstring options_desc) {
-    return perform_task_on_all_files<rewrite_sstables_compaction_task_executor>(info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_func), can_purge, std::move(options_desc));
+    return perform_task_on_all_files<rewrite_sstables_compaction_task_executor>(info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_func), 1, can_purge, std::move(options_desc));
 }
 
 namespace compaction {
@@ -2088,7 +2088,7 @@ future<> compaction_manager::try_perform_cleanup(owned_ranges_ptr sorted_owned_r
     };
 
     co_await perform_task_on_all_files<cleanup_sstables_compaction_task_executor>(info, t, sstables::compaction_type_options::make_cleanup(), std::move(sorted_owned_ranges),
-                                                                         std::move(get_sstables));
+                                                                         std::move(get_sstables), 1);
 }
 
 // Submit a table to be upgraded and wait for its termination.
@@ -2126,7 +2126,7 @@ future<compaction_manager::compaction_stats_opt> compaction_manager::perform_spl
     owned_ranges_ptr owned_ranges_ptr = {};
     auto options = sstables::compaction_type_options::make_split(std::move(opt.classifier));
 
-    return perform_task_on_all_files<split_compaction_task_executor>(info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_sstables));
+    return perform_task_on_all_files<split_compaction_task_executor>(info, t, std::move(options), std::move(owned_ranges_ptr), std::move(get_sstables), 0.5);
 }
 
 future<std::vector<sstables::shared_sstable>>

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -177,7 +177,8 @@ private:
     }
     future<compaction_manager::compaction_stats_opt> perform_compaction(throw_if_stopping do_throw_if_stopping, tasks::task_info parent_info, Args&&... args);
 
-    future<> stop_tasks(std::vector<shared_ptr<compaction::compaction_task_executor>> tasks, sstring reason) noexcept;
+    void stop_tasks(const std::vector<shared_ptr<compaction::compaction_task_executor>>& tasks, sstring reason) noexcept;
+    future<> await_tasks(std::vector<shared_ptr<compaction::compaction_task_executor>>) const noexcept;
     future<> update_throughput(uint32_t value_mbs);
 
     // Return the largest fan-in of currently running compactions
@@ -386,10 +387,13 @@ public:
 
     // Disable compaction temporarily for a table t.
     // Caller should call the compaction_reenabler::reenable
-    future<compaction_reenabler> stop_and_disable_compaction(compaction::table_state& t);
+    future<compaction_reenabler> stop_and_disable_compaction(compaction::table_state& t, double stop_threshold = 1.0);
 
     // Run a function with compaction temporarily disabled for a table T.
-    future<> run_with_compaction_disabled(compaction::table_state& t, std::function<future<> ()> func);
+    // Stop compaction only if their progress is less than the stop_threshold.
+    // stop_threshold=1: to stop all compactions
+    // stop_threshold=0: to wait for all compactions
+    future<> run_with_compaction_disabled(compaction::table_state& t, std::function<future<> ()> func, double stop_threshold = 1.0);
 
     void plug_system_keyspace(db::system_keyspace& sys_ks) noexcept;
     future<> unplug_system_keyspace() noexcept;
@@ -418,7 +422,7 @@ public:
     future<> stop_compaction(sstring type, compaction::table_state* table = nullptr);
 
     // Stops ongoing compaction of a given table and/or compaction_type.
-    future<> stop_ongoing_compactions(sstring reason, compaction::table_state* t = nullptr, std::optional<sstables::compaction_type> type_opt = {}) noexcept;
+    future<> stop_ongoing_compactions(sstring reason, compaction::table_state* t = nullptr, std::optional<sstables::compaction_type> type_opt = {}, double stop_threshold = 1.0) noexcept;
 
     double backlog() {
         return _backlog_manager.backlog();
@@ -590,6 +594,10 @@ public:
     const sstring& description() const noexcept {
         return _description;
     }
+
+    const sstables::compaction_progress_monitor& progress_monitor() const noexcept {
+        return _progress_monitor;
+    }
 private:
     // Before _compaction_done is set in compaction_task_executor::run_compaction(), compaction_done() returns ready future.
     future<compaction_manager::compaction_stats_opt> compaction_done() noexcept {
@@ -617,7 +625,8 @@ public:
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_compaction(throw_if_stopping do_throw_if_stopping, tasks::task_info parent_info, Args&&... args);
     friend future<compaction_manager::compaction_stats_opt> compaction_manager::perform_task(shared_ptr<compaction_task_executor> task, throw_if_stopping do_throw_if_stopping);
     friend fmt::formatter<compaction_task_executor>;
-    friend future<> compaction_manager::stop_tasks(std::vector<shared_ptr<compaction_task_executor>> tasks, sstring reason) noexcept;
+    //friend void compaction_manager::stop_tasks(const std::vector<shared_ptr<compaction_task_executor>>& tasks, sstring reason) noexcept;
+    friend future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_executor>>) const noexcept;
     friend sstables::test_env_compaction_manager;
 };
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -238,7 +238,7 @@ private:
     template<typename TaskType, typename... Args>
     requires std::derived_from<TaskType, compaction_task_executor> &&
             std::derived_from<TaskType, compaction_task_impl>
-    future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(tasks::task_info info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, Args... args);
+    future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(tasks::task_info info, table_state& t, sstables::compaction_type_options options, owned_ranges_ptr owned_ranges_ptr, get_candidates_func get_func, double stop_threshold, Args... args);
 
     future<compaction_stats_opt> rewrite_sstables(compaction::table_state& t, sstables::compaction_type_options options, owned_ranges_ptr, get_candidates_func, tasks::task_info info,
                                                   can_purge_tombstones can_purge = can_purge_tombstones::yes, sstring options_desc = "");


### PR DESCRIPTION
Prepare for stopping only compaction tasks that did not
achieve much progress and wait for all others to compelte.

* Improvement, no backport needed
