### PR TITLE
test/alternator: increase timeout in Alternator RBAC test

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -429,12 +429,15 @@ def cql(dynamodb):
     profile = ExecutionProfile(
         load_balancing_policy=RoundRobinPolicy(),
         consistency_level=ConsistencyLevel.LOCAL_QUORUM,
-        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL)
+        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
+        request_timeout=120)
     cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
         contact_points=[host],
         port=9042,
         protocol_version=4,
         auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
+        connect_timeout=60,
+        control_connection_timeout=60
     )
     try:
         ret = cluster.connect()


### PR DESCRIPTION
On our testing infrastructure, tests often run a hundred times (!) slower than usual, for various reasons that we can't always avoid. This is why all our test frameworks drastically increase the default timeouts.

We forgot to increase the timeout in one place - where Alternator tests use CQL. This is needed for the Alternator role-based access control (RBAC) tests, which is configured via CQL and therefore the Alternator test unusually uses CQL.

So in this patch we increase the timeout of CQL driver used by Alternator tests to the same high timeouts (60-120 seconds) used by the regular CQL tests. As the famous saying goes, these timeouts should be enough for anyone.

Fixes #23569.

CI flakiness improvement, no risk to code (it's just a test fix) we should probably backport it to whichever older versions have the same test code.