### PR TITLE
Adjust tablet-mon.py for capacity-aware load balancing

### DIFF
--- a/db/virtual_table.hh
+++ b/db/virtual_table.hh
@@ -55,7 +55,14 @@ public:
     // Override one of these execute() overloads.
     // The handler is always allowed to produce more data than implied by the query_restrictions.
     virtual future<> execute(std::function<void(mutation)> mutation_sink) { return make_ready_future<>(); }
-    virtual future<> execute(std::function<void(mutation)> mutation_sink, const query_restrictions&) { return execute(mutation_sink); }
+
+    virtual future<> execute(std::function<void(mutation)> mutation_sink, reader_permit) {
+        return execute(mutation_sink);
+    }
+
+    virtual future<> execute(std::function<void(mutation)> mutation_sink, const query_restrictions&, reader_permit permit) {
+        return execute(mutation_sink, permit);
+    }
 
     mutation_source as_mutation_source() override;
 };

--- a/db/virtual_tables.hh
+++ b/db/virtual_tables.hh
@@ -20,10 +20,15 @@ class database;
 namespace service {
 class storage_service;
 class raft_group_registry;
+class tablet_allocator;
 }
 
 namespace gms {
 class gossiper;
+}
+
+namespace netw {
+class messaging_service;
 }
 
 namespace db {
@@ -36,7 +41,9 @@ future<> initialize_virtual_tables(
     distributed<service::storage_service>&,
     sharded<gms::gossiper>&,
     sharded<service::raft_group_registry>&,
-    sharded<db::system_keyspace>& sys_ks,
+    sharded<db::system_keyspace>&,
+    sharded<service::tablet_allocator>&,
+    sharded<netw::messaging_service>&,
     db::config&);
 
 

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -307,6 +307,35 @@ CREATE TABLE system.cluster_status (
 
 Implemented by `cluster_status_table` in `db/system_keyspace.cc`.
 
+## system.load_per_node
+
+Contains information about the current tablet load with node granularity.
+Can be queried on any node, but the data comes from the group0 leader.
+Reads wait for group0 leader to be elected and load balancer stats to become available.
+
+Schema:
+```cql
+CREATE TABLE system.load_per_node (
+    node uuid PRIMARY KEY,
+    dc text,
+    rack text,
+    storage_allocated_load bigint,
+    storage_allocated_utilization double,
+    storage_capacity bigint,
+    tablets_allocated bigint,
+    tablets_allocated_per_shard double
+);
+```
+
+Columns:
+* `dc` - The name of the data center to which the node belongs.
+* `rack` - The name of the rack to which the node belongs.
+* `storage_allocated_load` - Disk space allocated for tablets, assuming each tablet has a fixed size (target_tablet_size).
+* `storage_allocated_utilization` - Fraction of node's disk capacity taken for `storage_allocated_load`, where 1.0 means full utilization.
+* `storage_capacity` - Total disk capacity in bytes. Used to compute `storage_allocated_utilization`. By default equal to file system's capacity.
+* `tablets_allocated` - Number of tablet replicas on the node. Migrating tablets are accounted as if migration already finished.
+* `tablets_allocated_per_shard` - `tablets_allocated` divided by shard count on the node.
+
 ## system.protocol_servers
 
 The list of all the client-facing data-plane protocol servers and listen addresses (if running).

--- a/docs/dev/virtual-tables.md
+++ b/docs/dev/virtual-tables.md
@@ -35,7 +35,7 @@ Even though not widely known, CQL also has built-in JSON support (`select json..
 The process of adding a new virtual table is as follows:
 * Choose the appropriate class to inherit from: `db::memtable_filling_virtual_table` or `db::streaming_virtual_table` (located in `db/virtual_table.hh`);
 * Implement the interface generating the data, mind shard awareness and query restrictions if they apply;
-* Instantiate and register your virtual table in `register_virtual_tables()` in `db/system_keyspace.cc`;
+* Instantiate and register your virtual table in `initialize_virtual_tables()` in `db/virtual_tables.cc`;
 
 ### Choosing the right class for you virtual table
 

--- a/main.cc
+++ b/main.cc
@@ -1782,7 +1782,7 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             checkpoint(stop_signal, "initializing virtual tables");
             smp::invoke_on_all([&] {
-                return db::initialize_virtual_tables(db, ss, gossiper, raft_gr, sys_ks, *cfg);
+                return db::initialize_virtual_tables(db, ss, gossiper, raft_gr, sys_ks, tablet_allocator, messaging, *cfg);
             }).get();
 
             // #293 - do not stop anything

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -20,7 +20,7 @@
 #
 # Key bindings:
 #
-#  t - toggle display of table tags. Each table has a unique color which is displayed in the bottom part of the tablet.
+#  t - toggle display of table tags. Each table has a unique color which fills tablets of that table.
 #  i - toggle display of tablet ids. Only visible when table tags are visible.
 #
 
@@ -573,7 +573,7 @@ def draw_tablet(tablet, x, y):
                                          w,
                                          h - 2 * tablet_frame_size), border_radius=tablet_radius)
 
-        if show_table_tag:
+        if show_table_tag and tablet.state[0] != Tablet.STATE_NORMAL:
             table_tag_h = tablet_radius
             pygame.draw.rect(window, color, (x + tablet_frame_size + (tablet_w - w) / 2,
                                              y + tablet_frame_size,
@@ -582,11 +582,11 @@ def draw_tablet(tablet, x, y):
                              border_top_left_radius=tablet_radius,
                              border_top_right_radius=tablet_radius)
 
-            if show_tablet_id:
-                number_text = str(tablet.seq)
-                number_image = number_font.render(number_text, True, BLACK)
-                window.blit(number_image, (x + tablet_frame_size + (w - number_image.get_width()) / 2,
-                                           y + tablet_frame_size + (h-1 - number_image.get_height()) / 2))
+        if show_table_tag and show_tablet_id:
+            number_text = str(tablet.seq)
+            number_image = number_font.render(number_text, True, BLACK)
+            window.blit(number_image, (x + tablet_frame_size + (w - number_image.get_width()) / 2,
+                                       y + tablet_frame_size + (h-1 - number_image.get_height()) / 2))
 
 def draw_node_frame(x, y, x2, y2, color):
     pygame.draw.rect(window, color, (x, y, x2 - x, y2 - y), node_frame_thickness,

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -586,7 +586,7 @@ def draw_tablet(tablet, x, y):
             number_text = str(tablet.seq)
             number_image = number_font.render(number_text, True, BLACK)
             window.blit(number_image, (x + tablet_frame_size + (w - number_image.get_width()) / 2,
-                                       y + tablet_frame_size + (h-1 - number_image.get_height()) / 2))
+                                       y + tablet_frame_size + (h - 2 * tablet_frame_size - number_image.get_height()) / 2))
 
 def draw_node_frame(x, y, x2, y2, color):
     pygame.draw.rect(window, color, (x, y, x2 - x, y2 - y), node_frame_thickness,

--- a/scripts/tablet-mon.py
+++ b/scripts/tablet-mon.py
@@ -22,6 +22,9 @@
 #
 #  t - toggle display of table tags. Each table has a unique color which fills tablets of that table.
 #  i - toggle display of tablet ids. Only visible when table tags are visible.
+#  s - toggle mode of scaling of tablet size. Modes:
+#        - fixed-size (each tablet has the same displayed size)
+#        - scaled-to-capacity (tablet size is proportional to its utilization of shard's storage capacity)
 #
 
 import math
@@ -31,6 +34,9 @@ import logging
 import pygame
 
 from cassandra.cluster import Cluster
+
+tablet_size_modes = ["fixed size", "scaled to capacity"]
+tablet_size_mode_idx = 1
 
 # Layout settings
 tablet_size = 60
@@ -71,6 +77,8 @@ class Node(object):
     def __init__(self, id):
         self.shards = []
         self.id = id
+        self.capacity = None
+        self.capacity_weight = 1
 
 
 class Shard(object):
@@ -86,7 +94,7 @@ class Tablet(object):
     STATE_JOINING = 1
     STATE_LEAVING = 2
 
-    def __init__(self, id, state, initial):
+    def __init__(self, id, node, state, initial):
         self.id = id
         self.state = state
         self.insert_time = pygame.time.get_ticks()
@@ -104,14 +112,23 @@ class Tablet(object):
         self.size_frac = 0
         self.speed = 0
         self.fall_start = None
+        self.h_scale = 1
+
+        self.update_h_scale(node)
 
         if initial:
-            self.h = tablet_h + tablet_frame_size * 2
+            self.h = self.h_scale * (tablet_h + tablet_frame_size * 2)
             self.size_frac = 1
 
         # Updated by redraw()
         self.x = 0
         self.y = 0
+
+    def update_h_scale(self, node):
+        if tablet_size_mode_idx == 0:
+            self.h_scale = 1
+        else:
+            self.h_scale = node.capacity_weight
 
     def get_mid_x(self):
         return self.x + tablet_frame_size + float(tablet_w) / 2
@@ -341,6 +358,13 @@ def move_tracers(now):
             tracers.remove(tracer)
 
 
+def on_capacity_weight_changed():
+    for node in nodes:
+        for shard in node.shards:
+            for tablet in shard.tablets.values():
+                tablet.update_h_scale(node)
+    changed = True
+
 BLACK = (0, 0, 0)
 WHITE = (255, 255, 255)
 GRAY = (192, 192, 192)
@@ -401,6 +425,7 @@ cluster = Cluster(['127.0.0.1'])
 session = cluster.connect()
 topo_query = session.prepare("SELECT host_id, shard_count FROM system.topology")
 tablets_query = session.prepare("SELECT * FROM system.tablets")
+load_per_node_query = session.prepare("SELECT * FROM system.load_per_node")
 
 data_source_alive = False
 
@@ -430,12 +455,33 @@ def update_from_cql(initial=False):
         while len(n.shards) < host.shard_count:
             n.shards.append(Shard())
 
-
     for id in nodes_by_id:
         if id not in all_host_ids:
             nodes.remove(nodes_by_id[id])
             del nodes_by_id[id]
             changed = True
+
+    for row in session.execute(load_per_node_query):
+        host_id = row.node
+        if host_id in nodes_by_id:
+            n = nodes_by_id[host_id]
+            if row.storage_capacity:
+                n.capacity = int(row.storage_capacity)
+
+
+    # Nodes are scaled to the node with smallest capacity.
+    # Nodes with more capacity will have smaller tablets (smaller capacity_weight).
+    min_capacity = min([n.capacity for n in nodes if n.capacity], default=0)
+    capacity_changed = False
+    for n in nodes:
+        if n.capacity:
+            new_weight = float(min_capacity) / n.capacity
+            if n.capacity_weight != new_weight:
+                n.capacity_weight = new_weight
+                capacity_changed = True
+
+    if capacity_changed:
+        on_capacity_weight_changed()
 
     tablets_by_shard = set()
     tablet_id_by_table = {}
@@ -474,9 +520,10 @@ def update_from_cql(initial=False):
             else:
                 state = (Tablet.STATE_NORMAL, None)
 
-            s = nodes_by_id[host].shards[shard]
+            node = nodes_by_id[host]
+            s = node.shards[shard]
             if id not in s.tablets:
-                s.tablets[id] = Tablet(id, state, initial=initial)
+                s.tablets[id] = Tablet(id, node, state, initial=initial)
                 stage_change = True
                 inserted = True
                 changed = True
@@ -560,7 +607,7 @@ def draw_tablet(tablet, x, y):
     tablet.x = x
     tablet.y = y
     w = tablet.size_frac * tablet_w
-    h = tablet.size_frac * (tablet_h + 2 * tablet_frame_size)
+    h = tablet.h
     if h > 2 * tablet_frame_size:
         color = tablet_colors[tablet.state]
         if show_table_tag:
@@ -605,12 +652,16 @@ def animate(now):
             tablet_max_pos = 0
             for tablet in shard.ordered_tablets():
                 # Appearing
-                if tablet.h < tablet_max_h:
+                if tablet.h < tablet.h_scale * tablet_max_h:
                     frac = cubic_ease_in(interpolate(tablet.insert_time, insert_time_ms))
-                    new_h = frac * tablet_max_h
+                    new_h = frac * tablet.h_scale * tablet_max_h
                     tablet.pos += new_h - tablet.h
                     tablet.h = new_h
                     tablet.size_frac = frac
+                    changed = True
+                elif tablet.h > tablet_max_h * tablet.h_scale:
+                    tablet.h = tablet_max_h * tablet.h_scale
+                    tablet.size_frac = 1
                     changed = True
 
                 # Falling
@@ -688,6 +739,10 @@ while running:
             elif event.key == pygame.K_i:
                 show_tablet_id = not show_tablet_id
                 changed = True
+            elif event.key == pygame.K_s:
+                tablet_size_mode_idx = (tablet_size_mode_idx + 1) % len(tablet_size_modes)
+                print("Tablet size mode:", tablet_size_modes[tablet_size_mode_idx])
+                on_capacity_weight_changed()
 
     now = float(pygame.time.get_ticks())
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3077,6 +3077,7 @@ class tablet_allocator_impl : public tablet_allocator::impl
     load_balancer_stats_manager _load_balancer_stats;
     bool _stopped = false;
     bool _use_tablet_aware_balancing = true;
+    locator::load_stats_ptr _load_stats;
 private:
     load_balancer make_load_balancer(token_metadata_ptr tm,
             locator::load_stats_ptr table_load_stats,
@@ -3109,8 +3110,16 @@ public:
     }
 
     future<migration_plan> balance_tablets(token_metadata_ptr tm, locator::load_stats_ptr table_load_stats, std::unordered_set<host_id> skiplist) {
-        auto lb = make_load_balancer(tm, std::move(table_load_stats), std::move(skiplist));
+        auto lb = make_load_balancer(tm, table_load_stats ? table_load_stats : _load_stats, std::move(skiplist));
         co_return co_await lb.make_plan();
+    }
+
+    void set_load_stats(locator::load_stats_ptr load_stats) {
+        _load_stats = std::move(load_stats);
+    }
+
+    locator::load_stats_ptr get_load_stats() {
+        return _load_stats;
     }
 
     void set_use_tablet_aware_balancing(bool use_tablet_aware_balancing) {
@@ -3160,6 +3169,7 @@ public:
 
     void on_leadership_lost() {
         _load_balancer_stats.unregister();
+        _load_stats = {};
     }
 
     load_balancer_stats_manager& stats() {
@@ -3269,6 +3279,14 @@ future<> tablet_allocator::stop() {
 
 future<migration_plan> tablet_allocator::balance_tablets(locator::token_metadata_ptr tm, locator::load_stats_ptr load_stats, std::unordered_set<host_id> skiplist) {
     return impl().balance_tablets(std::move(tm), std::move(load_stats), std::move(skiplist));
+}
+
+void tablet_allocator::set_load_stats(locator::load_stats_ptr load_stats) {
+    impl().set_load_stats(std::move(load_stats));
+}
+
+locator::load_stats_ptr tablet_allocator::get_load_stats() {
+    return impl().get_load_stats();
 }
 
 void tablet_allocator::set_use_table_aware_balancing(bool use_tablet_aware_balancing) {

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -232,6 +232,10 @@ public:
     ///
     future<migration_plan> balance_tablets(locator::token_metadata_ptr, locator::load_stats_ptr = {}, std::unordered_set<locator::host_id> = {});
 
+    void set_load_stats(locator::load_stats_ptr);
+
+    locator::load_stats_ptr get_load_stats();
+
     load_balancer_stats_manager& stats();
 
     void set_use_table_aware_balancing(bool);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -128,7 +128,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
     // The reason load_stats_ptr is a shared ptr is that load balancer can yield, and we don't want it
     // to suffer lifetime issues when stats refresh fiber overrides the current stats.
-    locator::load_stats_ptr _tablet_load_stats;
     std::unordered_map<locator::host_id, locator::load_stats> _load_stats_per_node;
     serialized_action _tablet_load_stats_refresh;
     // FIXME: make frequency per table in order to reduce work in each iteration.
@@ -1537,7 +1536,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
 
         bool has_nodes_to_drain = false;
         if (!preempt) {
-            auto plan = co_await _tablet_allocator.balance_tablets(get_token_metadata_ptr(), _tablet_load_stats, get_dead_nodes());
+            auto plan = co_await _tablet_allocator.balance_tablets(get_token_metadata_ptr(), {}, get_dead_nodes());
             has_nodes_to_drain = plan.has_nodes_to_drain();
             if (!drain || plan.has_nodes_to_drain()) {
                 co_await generate_migration_updates(updates, guard, plan);
@@ -1617,7 +1616,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         auto guard = co_await global_tablet_token_metadata_barrier(std::move(g));
 
         auto tm = get_token_metadata_ptr();
-        auto plan = co_await _tablet_allocator.balance_tablets(tm, _tablet_load_stats, get_dead_nodes());
+        auto plan = co_await _tablet_allocator.balance_tablets(tm, {}, get_dead_nodes());
 
         std::vector<canonical_mutation> updates;
         updates.reserve(plan.resize_plan().finalize_resize.size() * 2 + 1);
@@ -2911,7 +2910,7 @@ future<bool> topology_coordinator::maybe_start_tablet_migration(group0_guard gua
     }
 
     auto tm = get_token_metadata_ptr();
-    auto plan = co_await _tablet_allocator.balance_tablets(tm, _tablet_load_stats, get_dead_nodes());
+    auto plan = co_await _tablet_allocator.balance_tablets(tm, {}, get_dead_nodes());
     if (plan.empty()) {
         rtlogger.debug("Tablet load balancer did not make any plan");
         co_return false;
@@ -3060,7 +3059,7 @@ future<> topology_coordinator::refresh_tablet_load_stats() {
 
     rtlogger.debug("raft topology: Refreshed table load stats for all DC(s).");
 
-    _tablet_load_stats = make_lw_shared<const locator::load_stats>(std::move(stats));
+    _tablet_allocator.set_load_stats(make_lw_shared<const locator::load_stats>(std::move(stats)));
 }
 
 future<> topology_coordinator::start_tablet_load_stats_refresher() {

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -22,8 +22,8 @@ public:
             : memtable_filling_virtual_table(s)
             , _mutations(std::move(mutations)) {}
 
-    future<> execute(std::function<void(mutation)> mutation_sink) override {
-        return with_timeout(db::no_timeout, do_for_each(_mutations, [mutation_sink = std::move(mutation_sink)] (const mutation& m) { mutation_sink(m); }));
+    future<> execute(std::function<void(mutation)> mutation_sink, reader_permit permit) override {
+        return with_timeout(permit.timeout(), do_for_each(_mutations, [mutation_sink = std::move(mutation_sink)] (const mutation& m) { mutation_sink(m); }));
     }
 };
 

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -1,0 +1,83 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from test.cluster.conftest import skip_mode
+from test.pylib.manager_client import ManagerClient
+from test.cluster.util import get_topology_coordinator, trigger_stepdown
+
+import pytest
+import logging
+
+from test.pylib.rest_client import read_barrier
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_load_stats_on_coordinator_failover(manager: ManagerClient):
+    cfg = {
+        'data_file_capacity': 7000000,
+        'error_injections_at_startup': ['short_tablet_stats_refresh_interval'],
+    }
+    servers = await manager.servers_add(3, config=cfg)
+    host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+    cql = manager.get_cql()
+
+    coord = await get_topology_coordinator(manager)
+    coord_idx = host_ids.index(coord)
+    await trigger_stepdown(manager, servers[coord_idx])
+
+    async def get_capacity():
+        rows = cql.execute(f"SELECT * FROM system.load_per_node WHERE node = {host_ids[coord_idx]}")
+        return rows.one().storage_capacity
+
+    # Check that query works when there is no leader yet, it should wait for election
+    assert await get_capacity() == 7000000
+
+    while True:
+        coord2 = await get_topology_coordinator(manager)
+        if coord2:
+            break
+        assert await get_capacity() == 7000000
+
+    # Check that query works immediately after election, it should wait for stats to become available
+    assert await get_capacity() == 7000000
+
+    assert coord != coord2
+
+    # Now "coord" has stats with capacity=70000000.
+    # Change capacity and trigger failover back to "coord" and see that it doesn't
+    # present stale stats. That's a serious bug because load balancer could make incorrect
+    # decisions based on stale stats.
+
+    await manager.server_update_config(servers[coord_idx].server_id, 'data_file_capacity', 3000000)
+    logger.info("Waiting for load balancer to pick up new capacity")
+    while True:
+        if await get_capacity() == 3000000:
+            break
+
+    non_coord = None
+    for h in host_ids:
+        if h != coord and h != coord2:
+            non_coord =  h
+            break
+
+    logger.info("Trigger stepdown of coord2")
+    await trigger_stepdown(manager, servers[host_ids.index(coord2)])
+
+    # Wait for election
+    await read_barrier(manager.api, servers[host_ids.index(non_coord)].ip_addr)
+
+    # Make sure "coord" gets the leadership again
+    if await get_topology_coordinator(manager) == non_coord:
+        await trigger_stepdown(manager, servers[host_ids.index(non_coord)])
+
+    while True:
+        # Check that the new leader doesn't work with stale stats
+        assert await get_capacity() == 3000000
+        coord3 = await get_topology_coordinator(manager)
+        if coord3:
+            break

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -923,7 +923,7 @@ private:
             });
 
             smp::invoke_on_all([&] {
-                return db::initialize_virtual_tables(_db, _ss, _gossiper, _group0_registry, _sys_ks, *cfg);
+                return db::initialize_virtual_tables(_db, _ss, _gossiper, _group0_registry, _sys_ks, _tablet_allocator, _ms, *cfg);
             }).get();
 
             _qp.invoke_on_all([this, &group0_client] (cql3::query_processor& qp) {


### PR DESCRIPTION
After load-balancer was made capacity-aware it no longer equalizes tablet count per shard, but rather utilization of shard's storage. This makes the old presentation mode not useful in assessing whether balance was reached, since nodes with less capacity will get fewer tablets when in balanced state. This PR adds a new default presentation mode which scales tablet size by its storage utilization so that tablets which have equal shard utilization take equal space on the graph.

To facilitate that, a new virtual table was added: system.load_per_node, which allows the tool to learn about load balancer's view on per-node capacity. It can also serve as a debugging interface to get a view of current balance according to the load-balancer.
