### PR TITLE
compress: make sstable compression dictionaries NUMA-aware 

### DIFF
--- a/compress.cc
+++ b/compress.cc
@@ -16,6 +16,7 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/core/thread.hh>
+#include <seastar/core/reactor.hh>
 #include "utils/reusable_buffer.hh"
 #include "sstables/compress.hh"
 #include "sstables/exceptions.hh"
@@ -752,20 +753,11 @@ size_t snappy_processor::compress_max_size(size_t input_len) const {
     return snappy_max_compressed_length(input_len);
 }
 
-// Constructs compressors and decompressors for SSTables,
-// making sure that the expensive identical parts (dictionaries) are shared
-// across nodes.
-//
 // Holds weak pointers to all live dictionaries
 // (so that they can be cheaply shared with new SSTables if an identical dict is requested),
 // and shared (lifetime-extending) pointers to the current writer ("recommended")
 // dict for each table (so that they can be shared with new SSTables without consulting
 // `system.dicts`).
-//
-// To make coordination work without resorting to std::mutex and such, dicts have owner shards,
-// (and are borrowed by foreign shared pointers) and all requests for a given dict ID go through its owner.
-// (Note: this shouldn't pose a performance problem because a dict is only requested once per an opening of an SSTable).
-// (Note: at the moment of this writing, one shard owns all. Later we can spread the ownership. (E.g. shard it by dict hash)).
 //
 // Whenever a dictionary dies (because its refcount reaches 0), its weak pointer
 // is removed from the factory.
@@ -775,10 +767,11 @@ size_t snappy_processor::compress_max_size(size_t input_len) const {
 // Has a configurable memory budget for live dicts. If the budget is exceeded,
 // will return null dicts to new writers (to avoid making the memory usage even worse)
 // and print warnings.
-class sstable_compressor_factory_impl : public sstable_compressor_factory, public weakly_referencable<sstable_compressor_factory_impl> {
+class sstable_compressor_factory_impl : public weakly_referencable<sstable_compressor_factory_impl> {
     mutable logger::rate_limit budget_warning_rate_limit{std::chrono::minutes(10)};
     shard_id _owner_shard;
-    config _cfg;
+    using config = default_sstable_compressor_factory::config;
+    const config& _cfg;
     uint64_t _total_live_dict_memory = 0;
     metrics::metric_groups _metrics;
     struct zstd_cdict_id {
@@ -790,7 +783,7 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
     std::map<zstd_cdict_id, const zstd_cdict*> _zstd_cdicts;
     std::map<dict_id, const zstd_ddict*> _zstd_ddicts;
     std::map<dict_id, const lz4_cdict*> _lz4_cdicts;
-    std::map<table_id, lw_shared_ptr<const raw_dict>> _recommended;
+    std::map<table_id, foreign_ptr<lw_shared_ptr<const raw_dict>>> _recommended;
 
     size_t memory_budget() const {
         return _cfg.memory_fraction_starting_at_which_we_stop_writing_dicts() * seastar::memory::stats().total_memory();
@@ -807,8 +800,12 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
             memory_budget()
         );
     }
+public:
     lw_shared_ptr<const raw_dict> get_canonical_ptr(std::span<const std::byte> dict) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
+        if (dict.empty()) {
+            return nullptr;
+        }
         auto id = get_sha256(dict);
         if (auto it = _raw_dicts.find(id); it != _raw_dicts.end()) {
             return it->second->shared_from_this();
@@ -821,6 +818,9 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
     using foreign_zstd_ddict = foreign_ptr<lw_shared_ptr<const zstd_ddict>>;
     foreign_zstd_ddict get_zstd_dict_for_reading(lw_shared_ptr<const raw_dict> raw, int level) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
+        if (!raw) {
+            return nullptr;
+        }
         lw_shared_ptr<const zstd_ddict> ddict;
         // Fo reading, we must allocate a new dict, even if memory budget is exceeded. We have no other choice.
         // In any case, if the budget is exceeded after we print a rate-limited warning about it.
@@ -836,15 +836,12 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
         }
         return make_foreign(std::move(ddict));
     }
-    future<foreign_zstd_ddict> get_zstd_dict_for_reading(std::span<const std::byte> dict, int level) {
-        return smp::submit_to(_owner_shard, [this, dict, level] -> foreign_zstd_ddict {
-            auto raw = get_canonical_ptr(dict);
-            return get_zstd_dict_for_reading(raw, level);
-        });
-    }
     using foreign_zstd_cdict = foreign_ptr<lw_shared_ptr<const zstd_cdict>>;
     foreign_zstd_cdict get_zstd_dict_for_writing(lw_shared_ptr<const raw_dict> raw, int level) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
+        if (!_cfg.enable_writing_dictionaries() || !raw) {
+            return nullptr;
+        }
         lw_shared_ptr<const zstd_cdict> cdict;
         // If we can share an already-allocated dict, we do that regardless of memory budget.
         // If we would have to allocate a new dict for writing, we only do that if we haven't exceeded
@@ -860,19 +857,6 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
         }
         return make_foreign(std::move(cdict));
     }
-    future<foreign_zstd_cdict> get_zstd_dict_for_writing(table_id t, int level) {
-        return smp::submit_to(_owner_shard, [this, t, level] -> foreign_zstd_cdict {
-            if (!_cfg.enable_writing_dictionaries()) {
-                return {};
-            }
-            auto rec_it = _recommended.find(t);
-            if (rec_it != _recommended.end()) {
-                return get_zstd_dict_for_writing(rec_it->second, level);
-            } else {
-                return {};
-            }
-        });
-    }
     using lz4_dicts = std::pair<
         foreign_ptr<lw_shared_ptr<const raw_dict>>,
         foreign_ptr<lw_shared_ptr<const lz4_cdict>>
@@ -881,17 +865,13 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
     using foreign_lz4_cdict = foreign_ptr<lw_shared_ptr<const lz4_cdict>>;
     foreign_lz4_ddict get_lz4_dict_for_reading(lw_shared_ptr<const raw_dict> raw) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
-        lw_shared_ptr<const raw_dict> ddict;
         return make_foreign(std::move(raw));
-    }
-    future<foreign_lz4_ddict> get_lz4_dicts_for_reading(std::span<const std::byte> dict) {
-        return smp::submit_to(_owner_shard, [this, dict] -> foreign_lz4_ddict {
-            auto raw = get_canonical_ptr(dict);
-            return get_lz4_dict_for_reading(raw);
-        });
     }
     foreign_lz4_cdict get_lz4_dict_for_writing(lw_shared_ptr<const raw_dict> raw) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
+        if (!_cfg.enable_writing_dictionaries() || !raw) {
+            return nullptr;
+        }
         lw_shared_ptr<const lz4_cdict> cdict;
         // If we can share an already-allocated dict, we do that regardless of memory budget.
         // If we would have to allocate a new dict for writing, we only do that if we haven't exceeded
@@ -906,24 +886,11 @@ class sstable_compressor_factory_impl : public sstable_compressor_factory, publi
         }
         return make_foreign(std::move(cdict));
     }
-    future<foreign_lz4_cdict> get_lz4_dicts_for_writing(table_id t) {
-        return smp::submit_to(_owner_shard, [this, t] -> foreign_lz4_cdict {
-            if (!_cfg.enable_writing_dictionaries()) {
-                return {};
-            }
-            auto rec_it = _recommended.find(t);
-            if (rec_it != _recommended.end()) {
-                return get_lz4_dict_for_writing(rec_it->second);
-            } else {
-                return {};
-            }
-        });
-    }
 
 public:
-    sstable_compressor_factory_impl(config cfg)
+    sstable_compressor_factory_impl(const config& cfg)
         : _owner_shard(this_shard_id())
-        , _cfg(std::move(cfg))
+        , _cfg(cfg)
     {
         if (_cfg.register_metrics) {
             namespace sm = seastar::metrics;
@@ -964,21 +931,25 @@ public:
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
         _lz4_cdicts.erase(id);
     }
-    future<> set_recommended_dict(table_id t, std::span<const std::byte> dict) override {
-        return smp::submit_to(_owner_shard, [this, t, dict] {
+    future<> set_recommended_dict(table_id t, foreign_ptr<lw_shared_ptr<const raw_dict>> dict) {
+        return smp::submit_to(_owner_shard, [this, t, dict = std::move(dict)] mutable {
             _recommended.erase(t);
-            if (dict.size()) {
-                auto canonical_ptr = get_canonical_ptr(dict);
-                _recommended.emplace(t, canonical_ptr);
+            if (dict) {
                 compressor_factory_logger.debug("set_recommended_dict: table={} size={} id={}",
-                    t, dict.size(), fmt_hex(canonical_ptr->id()));
+                    t, dict->raw().size(), fmt_hex(dict->id()));
+                _recommended.emplace(t, std::move(dict));
             } else {
                 compressor_factory_logger.debug("set_recommended_dict: table={} size=0", t);
             }
         });
     }
-    future<compressor_ptr> make_compressor_for_writing(schema_ptr) override;
-    future<compressor_ptr> make_compressor_for_reading(sstables::compression&) override;
+    future<foreign_ptr<lw_shared_ptr<const raw_dict>>> get_recommended_dict(table_id t) {
+        auto rec_it = _recommended.find(t);
+        if (rec_it == _recommended.end()) {
+            co_return nullptr;
+        }
+        co_return co_await rec_it->second.copy();
+    }
 
     void account_memory_delta(ssize_t n) {
         SCYLLA_ASSERT(this_shard_id() == _owner_shard);
@@ -991,8 +962,72 @@ public:
     }
 };
 
+default_sstable_compressor_factory::default_sstable_compressor_factory(config cfg)
+    : _cfg(std::move(cfg))
+    , _impl(std::make_unique<sstable_compressor_factory_impl>(_cfg))
+{
+    for (shard_id i = 0; i < smp::count; ++i) {
+        auto numa_id = _cfg.numa_config[i];
+        _numa_groups.resize(std::max<size_t>(_numa_groups.size(), numa_id + 1));
+        _numa_groups[numa_id].push_back(i);
+    }
+}
 
-future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_writing(schema_ptr s) {
+default_sstable_compressor_factory::~default_sstable_compressor_factory() {
+}
+
+std::vector<unsigned> default_sstable_compressor_factory_config::get_default_shard_to_numa_node_mapping() {
+    auto sp = local_engine->smp().shard_to_numa_node_mapping();
+    return std::vector<unsigned>(sp.begin(), sp.end());
+}
+
+unsigned default_sstable_compressor_factory::local_numa_id() {
+    return _cfg.numa_config[this_shard_id()];
+}
+
+shard_id default_sstable_compressor_factory::get_dict_owner(unsigned numa_id, const sha256_type& sha) {
+    auto hash = read_unaligned<uint64_t>(sha.data());
+    const auto& group = _numa_groups[numa_id];
+    if (group.empty()) {
+        on_internal_error(compressor_factory_logger, "get_dict_owner called on an empty NUMA group");
+    }
+    return group[hash % group.size()];
+}
+
+future<> default_sstable_compressor_factory::set_recommended_dict_local(table_id t, std::span<const std::byte> dict) {
+    if (_leader_shard != this_shard_id()) {
+        on_internal_error(compressor_factory_logger, fmt::format("set_recommended_dict_local called on wrong shard. Expected: {}, got {}", _leader_shard, this_shard_id()));
+    }
+    auto units = co_await get_units(_recommendation_setting_sem, 1);
+    auto sha = get_sha256(dict);
+    for (unsigned numa_id = 0; numa_id < _numa_groups.size(); ++numa_id) {
+        const auto& group = _numa_groups[numa_id];
+        if (group.empty()) {
+            continue;
+        }
+        auto r = get_dict_owner(numa_id, sha);
+        auto d = co_await container().invoke_on(r, [dict](self& local) {
+            return make_foreign(local._impl->get_canonical_ptr(dict));
+        });
+        auto local_coordinator = group[0];
+        co_await container().invoke_on(local_coordinator, coroutine::lambda([t, d = std::move(d)](self& local) mutable -> future<> {
+            co_await local._impl->set_recommended_dict(t, std::move(d));
+        }));
+    }
+}
+
+future<> default_sstable_compressor_factory::set_recommended_dict(table_id t, std::span<const std::byte> dict) {
+    return container().invoke_on(_leader_shard, &self::set_recommended_dict_local, t, dict);
+}
+
+future<foreign_ptr<lw_shared_ptr<const raw_dict>>> default_sstable_compressor_factory::get_recommended_dict(table_id t) {
+    const auto local_coordinator = _numa_groups[local_numa_id()][0];
+    return container().invoke_on(local_coordinator, [t](self& local) {
+        return local._impl->get_recommended_dict(t);
+    });
+}
+
+future<compressor_ptr> default_sstable_compressor_factory::make_compressor_for_writing(schema_ptr s) {
     const auto params = s->get_compressor_params();
     using algorithm = compression_parameters::algorithm;
     const auto algo = params.get_algorithm();
@@ -1001,9 +1036,12 @@ future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_writ
     case algorithm::lz4:
         co_return std::make_unique<lz4_processor>(nullptr, nullptr);
     case algorithm::lz4_with_dicts: {
-        auto cdict = _cfg.enable_writing_dictionaries()
-            ? co_await get_lz4_dicts_for_writing(s->id())
-            : nullptr;
+        impl::foreign_lz4_cdict cdict;
+        if (auto recommended = co_await get_recommended_dict(s->id())) {
+            cdict = co_await container().invoke_on(recommended.get_owner_shard(), [recommended = std::move(recommended)] (self& local) mutable {
+                return local._impl->get_lz4_dict_for_writing(recommended.release());
+            });
+        }
         if (cdict) {
             compressor_factory_logger.debug("make_compressor_for_writing: using dict id={}", fmt_hex(cdict->id()));
         }
@@ -1016,9 +1054,13 @@ future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_writ
     case algorithm::zstd:
         co_return std::make_unique<zstd_processor>(params, nullptr, nullptr);
     case algorithm::zstd_with_dicts: {
-        auto cdict = _cfg.enable_writing_dictionaries()
-            ? co_await get_zstd_dict_for_writing(s->id(), params.zstd_compression_level().value_or(ZSTD_defaultCLevel()))
-            : nullptr;
+        impl::foreign_zstd_cdict cdict;
+        if (auto recommended = co_await get_recommended_dict(s->id())) {
+            auto level = params.zstd_compression_level().value_or(ZSTD_defaultCLevel());
+            cdict = co_await container().invoke_on(recommended.get_owner_shard(), [level, recommended = std::move(recommended)] (self& local) mutable {
+                return local._impl->get_zstd_dict_for_writing(recommended.release(), level);
+            });
+        }
         if (cdict) {
             compressor_factory_logger.debug("make_compressor_for_writing: using dict id={}", fmt_hex(cdict->id()));
         }
@@ -1030,7 +1072,7 @@ future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_writ
     abort();
 }
 
-future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_reading(sstables::compression& c) {
+future<compressor_ptr> default_sstable_compressor_factory::make_compressor_for_reading(sstables::compression& c) {
     const auto params = compression_parameters(sstables::options_from_compression(c));
     using algorithm = compression_parameters::algorithm;
     const auto algo = params.get_algorithm();
@@ -1040,7 +1082,13 @@ future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_read
         co_return std::make_unique<lz4_processor>(nullptr, nullptr);
     case algorithm::lz4_with_dicts: {
         auto dict = dict_from_options(c);
-        auto ddict = co_await get_lz4_dicts_for_reading(std::as_bytes(std::span(*dict)));
+        auto dict_span = std::as_bytes(std::span(*dict));
+        auto sha = get_sha256(dict_span);
+        auto dict_owner = get_dict_owner(local_numa_id(), sha);
+        auto ddict = co_await container().invoke_on(dict_owner, [dict_span] (self& local) mutable {
+            auto d = local._impl->get_canonical_ptr(dict_span);
+            return local._impl->get_lz4_dict_for_reading(std::move(d));
+        });
         if (ddict) {
             compressor_factory_logger.debug("make_compressor_for_reading: using dict id={}", fmt_hex(ddict->id()));
         }
@@ -1056,7 +1104,13 @@ future<compressor_ptr> sstable_compressor_factory_impl::make_compressor_for_read
     case algorithm::zstd_with_dicts: {
         auto level = params.zstd_compression_level().value_or(ZSTD_defaultCLevel());
         auto dict = dict_from_options(c);
-        auto ddict = co_await get_zstd_dict_for_reading(std::as_bytes(std::span(*dict)), level);
+        auto dict_span = std::as_bytes(std::span(*dict));
+        auto sha = get_sha256(dict_span);
+        auto dict_owner = get_dict_owner(local_numa_id(), sha);
+        auto ddict = co_await container().invoke_on(dict_owner, [level, dict_span] (self& local) mutable {
+            auto d = local._impl->get_canonical_ptr(dict_span);
+            return local._impl->get_zstd_dict_for_reading(std::move(d), level);
+        });
         if (ddict) {
             compressor_factory_logger.debug("make_compressor_for_reading: using dict id={}", fmt_hex(ddict->id()));
         }
@@ -1163,11 +1217,28 @@ lz4_cdict::~lz4_cdict() {
     }
 }
 
-std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory(sstable_compressor_factory::config cfg) {
-    return std::make_unique<sstable_compressor_factory_impl>(std::move(cfg));
-}
-
 std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory_for_tests_in_thread() {
     SCYLLA_ASSERT(thread::running_in_thread());
-    return make_sstable_compressor_factory();
+    struct wrapper : sstable_compressor_factory {
+        using impl = default_sstable_compressor_factory;
+        sharded<impl> _impl;
+        future<compressor_ptr> make_compressor_for_writing(schema_ptr s) override {
+            return _impl.local().make_compressor_for_writing(s);
+        }
+        future<compressor_ptr> make_compressor_for_reading(sstables::compression& c) override {
+            return _impl.local().make_compressor_for_reading(c);
+        }
+        future<> set_recommended_dict(table_id t, std::span<const std::byte> d) override {
+            return _impl.local().set_recommended_dict(t, d);
+        };
+        wrapper(wrapper&&) = delete;
+        wrapper() {
+            _impl.start().get();
+        }
+        ~wrapper() {
+            _impl.stop().get();
+        }
+    };
+    return std::make_unique<wrapper>();
 }
+

--- a/compress.cc
+++ b/compress.cc
@@ -921,14 +921,14 @@ public:
         _lz4_cdicts.erase(id);
     }
     void set_recommended_dict(table_id t, foreign_ptr<lw_shared_ptr<const raw_dict>> dict) {
-            _recommended.erase(t);
-            if (dict) {
-                compressor_factory_logger.debug("set_recommended_dict: table={} size={} id={}",
-                    t, dict->raw().size(), fmt_hex(dict->id()));
-                _recommended.emplace(t, std::move(dict));
-            } else {
-                compressor_factory_logger.debug("set_recommended_dict: table={} size=0", t);
-            }
+        _recommended.erase(t);
+        if (dict) {
+            compressor_factory_logger.debug("set_recommended_dict: table={} size={} id={}",
+                t, dict->raw().size(), fmt_hex(dict->id()));
+            _recommended.emplace(t, std::move(dict));
+        } else {
+            compressor_factory_logger.debug("set_recommended_dict: table={} size=0", t);
+        }
     }
     future<foreign_ptr<lw_shared_ptr<const raw_dict>>> get_recommended_dict(table_id t) {
         auto rec_it = _recommended.find(t);

--- a/compress.cc
+++ b/compress.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/metrics.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/weak_ptr.hh>
+#include <seastar/core/thread.hh>
 #include "utils/reusable_buffer.hh"
 #include "sstables/compress.hh"
 #include "sstables/exceptions.hh"
@@ -1164,4 +1165,9 @@ lz4_cdict::~lz4_cdict() {
 
 std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory(sstable_compressor_factory::config cfg) {
     return std::make_unique<sstable_compressor_factory_impl>(std::move(cfg));
+}
+
+std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory_for_tests_in_thread() {
+    SCYLLA_ASSERT(thread::running_in_thread());
+    return make_sstable_compressor_factory();
 }

--- a/compress.hh
+++ b/compress.hh
@@ -64,6 +64,8 @@ public:
 
     virtual algorithm get_algorithm() const = 0;
 
+    virtual std::optional<unsigned> get_dict_owner_for_test() const;
+
     using ptr_type = std::unique_ptr<compressor>;
 };
 

--- a/configure.py
+++ b/configure.py
@@ -1538,6 +1538,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/secondary_index_test.cc',
     'test/boost/sessions_test.cc',
     'test/boost/sstable_compaction_test.cc',
+    'test/boost/sstable_compressor_factory_test.cc',
     'test/boost/sstable_directory_test.cc',
     'test/boost/sstable_set_test.cc',
     'test/boost/statement_restrictions_test.cc',

--- a/main.cc
+++ b/main.cc
@@ -1236,17 +1236,19 @@ sharded<locator::shared_token_metadata> token_metadata;
             auto stop_lang_man = defer_verbose_shutdown("lang manager", [] { langman.invoke_on_all(&lang::manager::stop).get(); });
             langman.invoke_on_all(&lang::manager::start).get();
 
-            auto sstable_compressor_factory = make_sstable_compressor_factory(sstable_compressor_factory::config{
-                .register_metrics = true,
-                .enable_writing_dictionaries = cfg->sstable_compression_dictionaries_enable_writing,
-                .memory_fraction_starting_at_which_we_stop_writing_dicts = cfg->sstable_compression_dictionaries_memory_budget_fraction,
+            sharded<default_sstable_compressor_factory> sstable_compressor_factory;
+            auto numa_groups = local_engine->smp().shard_to_numa_node_mapping();
+            sstable_compressor_factory.start(sharded_parameter(default_sstable_compressor_factory::config::from_db_config,
+                                                               std::cref(*cfg), std::cref(numa_groups))).get();
+            auto stop_compressor_factory = defer_verbose_shutdown("sstable_compressor_factory", [&sstable_compressor_factory] {
+                sstable_compressor_factory.stop().get();
             });
 
             checkpoint(stop_signal, "starting database");
 
             debug::the_database = &db;
             db.start(std::ref(*cfg), dbcfg, std::ref(mm_notifier), std::ref(feature_service), std::ref(token_metadata),
-                    std::ref(cm), std::ref(sstm), std::ref(langman), std::ref(sst_dir_semaphore), std::ref(*sstable_compressor_factory),
+                    std::ref(cm), std::ref(sstm), std::ref(langman), std::ref(sst_dir_semaphore), std::ref(sstable_compressor_factory),
                     std::ref(stop_signal.as_sharded_abort_source()), utils::cross_shard_barrier()).get();
             auto stop_database_and_sstables = defer_verbose_shutdown("database", [&db] {
                 // #293 - do not stop anything - not even db (for real)
@@ -1717,7 +1719,7 @@ sharded<locator::shared_token_metadata> token_metadata;
                 auto sstables_prefix = std::string_view("sstables/");
                 if (name.starts_with(sstables_prefix)) {
                     auto table = table_id(utils::UUID(name.substr(sstables_prefix.size())));
-                    co_await sstable_compressor_factory->set_recommended_dict(table, std::move(dict.data));
+                    co_await sstable_compressor_factory.local().set_recommended_dict(table, std::move(dict.data));
                 } else if (name == dictionary_service::rpc_compression_dict_name) {
                     co_await utils::announce_dict_to_shards(compressor_tracker, std::move(dict));
                 }

--- a/sstables/sstable_compressor_factory.hh
+++ b/sstables/sstable_compressor_factory.hh
@@ -27,3 +27,4 @@ struct sstable_compressor_factory {
 };
 
 std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory(sstable_compressor_factory::config cfg = {});
+std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory_for_tests_in_thread();

--- a/sstables/sstable_compressor_factory.hh
+++ b/sstables/sstable_compressor_factory.hh
@@ -82,12 +82,16 @@ private:
     shard_id get_dict_owner(unsigned numa_id, const sha256_type& sha);
     future<foreign_ptr<lw_shared_ptr<const raw_dict>>> get_recommended_dict(table_id t);
     future<> set_recommended_dict_local(table_id, std::span<const std::byte> dict);
+    future<compressor_ptr> make_compressor_for_writing_impl(const compression_parameters&, table_id);
+    future<compressor_ptr> make_compressor_for_reading_impl(const compression_parameters&, std::span<const std::byte> dict);
 public:
     default_sstable_compressor_factory(config = config{});
     ~default_sstable_compressor_factory();
 
     future<compressor_ptr> make_compressor_for_writing(schema_ptr) override;
+    future<compressor_ptr> make_compressor_for_writing_for_tests(const compression_parameters&, table_id);
     future<compressor_ptr> make_compressor_for_reading(sstables::compression&) override;
+    future<compressor_ptr> make_compressor_for_reading_for_tests(const compression_parameters&, std::span<const std::byte> dict);
     future<> set_recommended_dict(table_id, std::span<const std::byte> dict) override;
 };
 

--- a/sstables/sstable_compressor_factory.hh
+++ b/sstables/sstable_compressor_factory.hh
@@ -10,21 +10,85 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 #include "compress.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/updateable_value.hh"
+#include <span>
+
+namespace db {
+class config;
+} // namespace db
+
+struct sstable_compressor_factory_impl;
+class raw_dict;
 
 struct sstable_compressor_factory {
     virtual ~sstable_compressor_factory() {}
     virtual future<compressor_ptr> make_compressor_for_writing(schema_ptr) = 0;
     virtual future<compressor_ptr> make_compressor_for_reading(sstables::compression&) = 0;
     virtual future<> set_recommended_dict(table_id, std::span<const std::byte> dict) = 0;
-    struct config {
-        bool register_metrics = false;
-        utils::updateable_value<bool> enable_writing_dictionaries{true};
-        utils::updateable_value<float> memory_fraction_starting_at_which_we_stop_writing_dicts{1};
-    };
 };
 
-std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory(sstable_compressor_factory::config cfg = {});
+// Note: I couldn't make this an inner class of default_sstable_compressor_factory,
+// because then the compiler gives weird complains about default member initializers in line
+// ```
+// default_sstable_compressor_factory(config = config{});
+// ```
+// apparently due to some compiler bug related default initializers.
+struct default_sstable_compressor_factory_config {
+    using self = default_sstable_compressor_factory_config;
+    static std::vector<unsigned> get_default_shard_to_numa_node_mapping();
+    bool register_metrics = false;
+    utils::updateable_value<bool> enable_writing_dictionaries{true};
+    utils::updateable_value<float> memory_fraction_starting_at_which_we_stop_writing_dicts{1};
+    std::vector<unsigned> numa_config{get_default_shard_to_numa_node_mapping()};
+
+    static default_sstable_compressor_factory_config from_db_config(
+        const db::config&,
+        std::span<const unsigned> numa_config = get_default_shard_to_numa_node_mapping());
+};
+
+// Constructs compressors and decompressors for SSTables,
+// making sure that the expensive identical parts (dictionaries) are shared
+// between all shards within the same NUMA group.
+//
+// To make coordination work without resorting to std::mutex and such, dicts have owner shards,
+// decided by a content hash of the dictionary.
+// All requests for a given dict ID go through the owner of this ID and return a foreign shared pointer
+// to that dict.
+//
+// (Note: this centralization shouldn't pose a performance problem because a dict is only requested once
+// per an opening of an SSTable).
+struct default_sstable_compressor_factory : peering_sharded_service<default_sstable_compressor_factory>, sstable_compressor_factory {
+    using impl = sstable_compressor_factory_impl;
+public:
+    using self = default_sstable_compressor_factory;
+    using config = default_sstable_compressor_factory_config;
+private:
+    config _cfg;
+    // Maps NUMA node ID to the array of shards on that node.
+    std::vector<std::vector<shard_id>> _numa_groups;
+    // Holds dictionaries owned by this shard.
+    std::unique_ptr<sstable_compressor_factory_impl> _impl;
+    // All recommended dictionary updates are serialized by a single "leader shard".
+    // We do this to avoid dealing with concurrent updates altogether.
+    semaphore _recommendation_setting_sem{1};
+    constexpr static shard_id _leader_shard = 0;
+
+private:
+    using sha256_type = std::array<std::byte, 32>;
+    unsigned local_numa_id();
+    shard_id get_dict_owner(unsigned numa_id, const sha256_type& sha);
+    future<foreign_ptr<lw_shared_ptr<const raw_dict>>> get_recommended_dict(table_id t);
+    future<> set_recommended_dict_local(table_id, std::span<const std::byte> dict);
+public:
+    default_sstable_compressor_factory(config = config{});
+    ~default_sstable_compressor_factory();
+
+    future<compressor_ptr> make_compressor_for_writing(schema_ptr) override;
+    future<compressor_ptr> make_compressor_for_reading(sstables::compression&) override;
+    future<> set_recommended_dict(table_id, std::span<const std::byte> dict) override;
+};
+
 std::unique_ptr<sstable_compressor_factory> make_sstable_compressor_factory_for_tests_in_thread();

--- a/sstables/sstable_compressor_factory.hh
+++ b/sstables/sstable_compressor_factory.hh
@@ -20,7 +20,7 @@ namespace db {
 class config;
 } // namespace db
 
-struct sstable_compressor_factory_impl;
+struct dictionary_holder;
 class raw_dict;
 
 struct sstable_compressor_factory {
@@ -61,7 +61,7 @@ struct default_sstable_compressor_factory_config {
 // (Note: this centralization shouldn't pose a performance problem because a dict is only requested once
 // per an opening of an SSTable).
 struct default_sstable_compressor_factory : peering_sharded_service<default_sstable_compressor_factory>, sstable_compressor_factory {
-    using impl = sstable_compressor_factory_impl;
+    using holder = dictionary_holder;
 public:
     using self = default_sstable_compressor_factory;
     using config = default_sstable_compressor_factory_config;
@@ -70,7 +70,7 @@ private:
     // Maps NUMA node ID to the array of shards on that node.
     std::vector<std::vector<shard_id>> _numa_groups;
     // Holds dictionaries owned by this shard.
-    std::unique_ptr<sstable_compressor_factory_impl> _impl;
+    std::unique_ptr<dictionary_holder> _holder;
     // All recommended dictionary updates are serialized by a single "leader shard".
     // We do this to avoid dealing with concurrent updates altogether.
     semaphore _recommendation_setting_sem{1};

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -335,6 +335,7 @@ add_scylla_test(combined_tests
     secondary_index_test.cc
     sessions_test.cc
     sstable_compaction_test.cc
+    sstable_compressor_factory_test.cc
     sstable_directory_test.cc
     sstable_set_test.cc
     statement_restrictions_test.cc

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -566,7 +566,7 @@ SEASTAR_TEST_CASE(test_multiple_memtables_one_partition) {
 }
 
 SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
-  return sstables::test_env::do_with([] (sstables::test_env& env) {
+  return sstables::test_env::do_with_async([] (sstables::test_env& env) {
     auto s = schema_builder("ks", "cf")
         .with_column("pk", bytes_type, column_kind::partition_key)
         .with_column("v", bytes_type)
@@ -581,7 +581,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
     cfg.enable_incremental_backups = false;
     cfg.cf_stats = &*cf_stats;
 
-    return with_column_family(s, cfg, env.manager(), [&env, s](replica::column_family& cf) {
+    with_column_family(s, cfg, env.manager(), [&env, s](replica::column_family& cf) {
         return seastar::async([&env, s, &cf] {
             // populate
             auto new_key = [&] {
@@ -645,7 +645,7 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
 
             flushed.get();
         });
-    }).then([cf_stats] {});
+    }).get();
   });
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -2318,6 +2318,7 @@ public:
     using test_func = std::function<void(table_for_tests&, compaction::table_state&, std::vector<sstables::shared_sstable>)>;
 
 private:
+    std::unique_ptr<sstable_compressor_factory> scf = make_sstable_compressor_factory_for_tests_in_thread();
     sharded<test_env> _env;
     uint32_t _seed;
     std::unique_ptr<tests::random_schema_specification> _random_schema_spec;
@@ -2335,7 +2336,7 @@ public:
                 compress))
         , _random_schema(_seed, *_random_schema_spec)
     {
-        _env.start().get();
+        _env.start(test_env_config(), std::ref(*scf)).get();
         testlog.info("random_schema: {}", _random_schema.cql());
     }
 
@@ -2401,12 +2402,14 @@ public:
     using test_func = std::function<void(table_for_tests&, compaction::table_state&, std::vector<sstables::shared_sstable>)>;
 
 private:
+
+    std::unique_ptr<sstable_compressor_factory> scf = make_sstable_compressor_factory_for_tests_in_thread();
     sharded<test_env> _env;
 
 public:
     scrub_test_framework()
     {
-        _env.start().get();
+        _env.start(test_env_config(), std::ref(*scf)).get();
     }
 
     ~scrub_test_framework() {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -1666,7 +1666,7 @@ SEASTAR_TEST_CASE(time_window_strategy_time_window_tests) {
 }
 
 SEASTAR_TEST_CASE(time_window_strategy_ts_resolution_check) {
-  return test_env::do_with([] (test_env& env) {
+  return test_env::do_with_async([] (test_env& env) {
     auto ts = 1451001601000L; // 2015-12-25 @ 00:00:01, in milliseconds
     auto ts_in_ms = std::chrono::milliseconds(ts);
     auto ts_in_us = std::chrono::duration_cast<std::chrono::microseconds>(ts_in_ms);
@@ -1702,7 +1702,6 @@ SEASTAR_TEST_CASE(time_window_strategy_ts_resolution_check) {
 
         BOOST_REQUIRE(ret.second == expected);
     }
-    return make_ready_future<>();
   });
 }
 

--- a/test/boost/sstable_compressor_factory_test.cc
+++ b/test/boost/sstable_compressor_factory_test.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#undef SEASTAR_TESTING_MAIN
+#include <fmt/ranges.h>
+#include <seastar/util/defer.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include "sstables/sstable_compressor_factory.hh"
+#include "test/lib/log.hh"
+#include "test/lib/random_utils.hh"
+
+// 1. Create a random message.
+// 2. Set this random message as the recommended dict.
+// 3. On all shards, create compressors.
+// 4. Check that they are using the recommended dict (i.e. that the original message compresses perfectly).
+// 5. Check that the used dictionaries are owned by shards on the same NUMA node.
+// 6. Check that the number of dictionary copies is equal to number of NUMA nodes.
+// 7. Repeat this a few times for both lz4 and zstd.
+void test_one_numa_topology(std::span<unsigned> shard_to_numa_mapping) {
+    testlog.info("Testing NUMA topology {}", shard_to_numa_mapping);
+
+    // Create a compressor factory.
+    SCYLLA_ASSERT(shard_to_numa_mapping.size() == smp::count);
+    auto config = default_sstable_compressor_factory::config{
+        .numa_config = std::vector(shard_to_numa_mapping.begin(), shard_to_numa_mapping.end()),
+    };
+    sharded<default_sstable_compressor_factory> sstable_compressor_factory;
+    sstable_compressor_factory.start(std::cref(config)).get();
+    auto stop_compressor_factory = defer([&sstable_compressor_factory] { sstable_compressor_factory.stop().get(); });
+
+    // The factory keeps recommended dicts (i.e. dicts for writing) per table ID.
+    auto table = table_id::create_random_id();
+
+    // Retry a few times just to check that it works more than once.
+    for (int retry = 0; retry < 3; ++retry) {
+        // Generate a random (and hence uhcompressible without a dict) message.
+        auto message = tests::random::get_sstring(4096);
+        auto dict_view = std::as_bytes(std::span(message));
+        // Set the message as the dict to make the message perfectly compressible.
+        sstable_compressor_factory.local().set_recommended_dict(table, dict_view).get();
+
+        // We'll put the owners here to check that the number of owners matches the number of NUMA nodes.
+        std::vector<unsigned> compressor_numa_nodes(smp::count);
+        std::vector<unsigned> decompressor_numa_nodes(smp::count);
+
+        // Try for both algorithms, just in case there are some differences in how dictionary
+        // distribution over shards is implemented between them.
+        for (const auto algo : {compressor::algorithm::lz4_with_dicts, compressor::algorithm::zstd_with_dicts}) {
+            sstable_compressor_factory.invoke_on_all(coroutine::lambda([&] (default_sstable_compressor_factory& local) -> seastar::future<> {
+                // Validate that the dictionaries work as intended,
+                // and check that their owner is as expected.
+
+                auto params = compression_parameters(algo);
+
+                auto compressor = co_await local.make_compressor_for_writing_for_tests(params, table);
+                auto decompressor = co_await local.make_compressor_for_reading_for_tests(params, dict_view);
+
+                auto our_numa_node = shard_to_numa_mapping[this_shard_id()];
+                auto compressor_numa_node = shard_to_numa_mapping[compressor->get_dict_owner_for_test().value()];
+                auto decompressor_numa_node = shard_to_numa_mapping[decompressor->get_dict_owner_for_test().value()];
+
+                // Check that the dictionary used by this shard lies on the same NUMA node.
+                // This is important to avoid cross-node memory accesses on the hot path.
+                BOOST_CHECK_EQUAL(our_numa_node, compressor_numa_node);
+                BOOST_CHECK_EQUAL(our_numa_node, decompressor_numa_node);
+
+                compressor_numa_nodes[this_shard_id()] = compressor_numa_node;
+                decompressor_numa_nodes[this_shard_id()] = compressor_numa_node;
+
+                auto output_max_size = compressor->compress_max_size(message.size());
+                auto compressed = std::vector<char>(output_max_size);
+                auto compressed_size = compressor->compress(
+                    reinterpret_cast<const char*>(message.data()), message.size(),
+                    reinterpret_cast<char*>(compressed.data()), compressed.size());
+                BOOST_REQUIRE_GE(compressed_size, 0);
+                compressed.resize(compressed_size);
+
+                // Validate that the recommeded dict was actually used.
+                BOOST_CHECK(compressed.size() < message.size() / 10);
+
+                auto decompressed = std::vector<char>(message.size());
+                auto decompressed_size = decompressor->uncompress(
+                    reinterpret_cast<const char*>(compressed.data()), compressed.size(),
+                    reinterpret_cast<char*>(decompressed.data()), decompressed.size());
+                BOOST_REQUIRE_GE(decompressed_size, 0);
+                decompressed.resize(decompressed_size);
+
+                // Validate that the roundtrip through compressor and decompressor
+                // resulted in the original message.
+                BOOST_CHECK_EQUAL_COLLECTIONS(message.begin(), message.end(), decompressed.begin(), decompressed.end());
+            })).get();
+        }
+
+        // Check that the number of owners (and hence, copies) is equal to the number
+        // of NUMA nodes.
+        // This isn't that important, but we don't want to duplicate dictionaries
+        // within a NUMA node unnecessarily.
+        BOOST_CHECK_EQUAL(
+            std::set(compressor_numa_nodes.begin(), compressor_numa_nodes.end()).size(),
+            std::set(shard_to_numa_mapping.begin(), shard_to_numa_mapping.end()).size()
+        );
+        BOOST_CHECK_EQUAL(
+            std::set(decompressor_numa_nodes.begin(), decompressor_numa_nodes.end()).size(),
+            std::set(shard_to_numa_mapping.begin(), shard_to_numa_mapping.end()).size()
+        );
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_numa_awareness) {
+    {
+        std::vector<unsigned> one_numa_node(smp::count);
+        test_one_numa_topology(one_numa_node);
+    }
+    {
+        std::vector<unsigned> two_numa_nodes(smp::count);
+        for (size_t i = 0; i < two_numa_nodes.size(); ++i) {
+            two_numa_nodes[i] = i % 2;
+        }
+        test_one_numa_topology(two_numa_nodes);
+    }
+    {
+        std::vector<unsigned> n_numa_nodes(smp::count);
+        for (size_t i = 0; i < n_numa_nodes.size(); ++i) {
+            n_numa_nodes[i] = i;
+        }
+        test_one_numa_topology(n_numa_nodes);
+    }
+}

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -466,8 +466,8 @@ static shared_sstable sstable_for_overlapping_test(test_env& env, const schema_p
 }
 
 SEASTAR_TEST_CASE(check_read_indexes) {
-    return test_env::do_with([] (test_env& env) {
-        return for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
+    return test_env::do_with_async([] (test_env& env) {
+        for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
             return seastar::async([&env, version] {
                 auto builder = schema_builder("test", "summary_test")
                     .with_column("a", int32_type, column_kind::partition_key);
@@ -478,7 +478,7 @@ SEASTAR_TEST_CASE(check_read_indexes) {
                     auto list = sstables::test(sst).read_indexes(env.make_reader_permit()).get();
                         BOOST_REQUIRE(list.size() == 130);
             });
-        });
+        }).get();
     });
 }
 
@@ -499,8 +499,8 @@ SEASTAR_TEST_CASE(check_multi_schema) {
     //        d int,
     //        e blob
     //);
-    return test_env::do_with([] (test_env& env) {
-        return for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
+    return test_env::do_with_async([] (test_env& env) {
+        for_each_sstable_version([&env] (const sstables::sstable::version_types version) {
             return seastar::async([&env, version] {
                 auto set_of_ints_type = set_type_impl::get_instance(int32_type, true);
                 auto builder = schema_builder("test", "test_multi_schema")
@@ -532,7 +532,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
                     BOOST_REQUIRE(!m);
                 });
             });
-        });
+        }).get();
     });
 }
 
@@ -2413,7 +2413,7 @@ SEASTAR_TEST_CASE(sstable_run_identifier_correctness) {
 }
 
 SEASTAR_TEST_CASE(sstable_run_disjoint_invariant_test) {
-    return test_env::do_with([] (test_env& env) {
+    return test_env::do_with_async([] (test_env& env) {
         simple_schema ss;
         auto s = ss.schema();
 
@@ -2441,8 +2441,6 @@ SEASTAR_TEST_CASE(sstable_run_disjoint_invariant_test) {
         BOOST_REQUIRE(insert(2, 2) == true);
         BOOST_REQUIRE(insert(5, 5) == true);
         BOOST_REQUIRE(run.all().size() == 5);
-
-        return make_ready_future<>();
     });
 }
 

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -32,7 +32,9 @@ static auto copy_sst_to_tmpdir(fs::path tmp_path, test_env& env, sstables::schem
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
     tmpdir tmp;
-    auto env = test_env();
+
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+    auto env = test_env({}, *scf);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     sstables::sstable_generation_generator gen_generator{0};
@@ -56,7 +58,9 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move) {
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_idempotent) {
     tmpdir tmp;
-    auto env = test_env();
+
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+    auto env = test_env({}, *scf);
     auto stop_env = defer([&env] { env.stop().get(); });
     sstables::sstable_generation_generator gen_generator{0};
 
@@ -100,7 +104,8 @@ static bool partial_create_links(sstable_ptr sst, fs::path dst_path, sstables::g
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
     tmpdir tmp;
-    auto env = test_env();
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+    auto env = test_env({}, *scf);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     sstables::sstable_generation_generator gen_generator{0};
@@ -121,7 +126,9 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_replay) {
 
 SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     tmpdir tmp;
-    auto env = test_env();
+
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+    auto env = test_env({}, *scf);
     auto stop_env = defer([&env] { env.stop().get(); });
 
     // please note, the SSTables used by this test are stored under

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -128,7 +128,7 @@ public:
     static constexpr std::string_view ks_name = "ks";
     static std::atomic<bool> active;
 private:
-    std::unique_ptr<sstable_compressor_factory> _scf;
+    sharded<default_sstable_compressor_factory> _scf;
     sharded<replica::database> _db;
     sharded<gms::feature_service> _feature_service;
     sharded<sstables::storage_manager> _sstm;
@@ -657,10 +657,14 @@ private:
             auto stop_lang_manager = defer_verbose_shutdown("lang manager", [this] { _lang_manager.stop().get(); });
             _lang_manager.invoke_on_all(&lang::manager::start).get();
 
-            _scf = make_sstable_compressor_factory();
+            auto numa_groups = local_engine->smp().shard_to_numa_node_mapping();
+            _scf.start(sharded_parameter(default_sstable_compressor_factory::config::from_db_config, std::cref(*cfg), std::cref(numa_groups))).get();
+            auto stop_scf = defer_verbose_shutdown("sstable_compressor_factory", [this] {
+                _scf.stop().get();
+            });
 
             _db_config = &*cfg;
-            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), std::ref(*_scf), std::ref(abort_sources), utils::cross_shard_barrier()).get();
+            _db.start(std::ref(*cfg), dbcfg, std::ref(_mnotifier), std::ref(_feature_service), std::ref(_token_metadata), std::ref(_cm), std::ref(_sstm), std::ref(_lang_manager), std::ref(_sst_dir_semaphore), std::ref(_scf), std::ref(abort_sources), utils::cross_shard_barrier()).get();
             auto stop_db = defer_verbose_shutdown("database", [this] {
                 _db.stop().get();
             });

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -176,15 +176,6 @@ public:
 
     replica::table::config make_table_config();
 
-    template <typename Func>
-    static inline auto do_with(Func&& func, test_env_config cfg = {}) {
-        return seastar::do_with(test_env(std::move(cfg)), [func = std::move(func)] (test_env& env) mutable {
-            return futurize_invoke(func, env).finally([&env] {
-                return env.stop();
-            });
-        });
-    }
-
     static future<> do_with_async(noncopyable_function<void (test_env&)> func, test_env_config cfg = {});
 
     static future<> do_with_sharded_async(noncopyable_function<void (sharded<test_env>&)> func);

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -109,7 +109,7 @@ public:
 
     void maybe_start_compaction_manager(bool enable = true);
 
-    explicit test_env(test_env_config cfg = {}, sstables::storage_manager* sstm = nullptr, tmpdir* tmp = nullptr);
+    explicit test_env(test_env_config cfg, sstable_compressor_factory&, sstables::storage_manager* sstm = nullptr, tmpdir* tmp = nullptr);
     ~test_env();
     test_env(test_env&&) noexcept;
 
@@ -183,7 +183,8 @@ public:
     template <typename T>
     static future<T> do_with_async_returning(noncopyable_function<T (test_env&)> func) {
         return seastar::async([func = std::move(func)] {
-            test_env env;
+            auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+            test_env env({}, *scf);
             auto stop = defer([&] { env.stop().get(); });
             return func(env);
         });

--- a/test/perf/perf_sstable.cc
+++ b/test/perf/perf_sstable.cc
@@ -144,7 +144,8 @@ int scylla_sstable_main(int argc, char** argv) {
             }
             cfg.compaction_strategy = sstables::compaction_strategy::type(app.configuration()["compaction-strategy"].as<sstring>());
             cfg.timestamp_range = app.configuration()["timestamp-range"].as<api::timestamp_type>();
-            test.start(std::move(cfg)).get();
+            auto scf = make_sstable_compressor_factory_for_tests_in_thread();
+            test.start(std::move(cfg), std::ref(*scf)).get();
             auto stop_test = deferred_stop(test);
 
             switch (mode) {

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -195,7 +195,9 @@ private:
     }
 
 public:
-    perf_sstable_test_env(conf cfg) : _cfg(std::move(cfg))
+    perf_sstable_test_env(conf cfg, sstable_compressor_factory& scf)
+           : _env({}, scf)
+           , _cfg(std::move(cfg))
            , s(create_schema(cfg.compaction_strategy))
            , _distribution('@', '~')
            , _mt(make_lw_shared<replica::memtable>(s))

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -49,7 +49,7 @@ tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
                                         std::string_view table_name,
                                         reader_permit permit) {
     sharded<sstable_manager_service> sst_man;
-    auto scf = make_sstable_compressor_factory();
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     sst_man.start(std::ref(dbcfg), std::ref(*scf)).get();
     auto stop_sst_man_service = deferred_stop(sst_man);
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -396,7 +396,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     reader_concurrency_semaphore rcs_sem(reader_concurrency_semaphore::no_limits{}, __FUNCTION__, reader_concurrency_semaphore::register_metrics::no);
     auto stop_semaphore = deferred_stop(rcs_sem);
 
-    auto scf = make_sstable_compressor_factory();
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     sharded<sstable_manager_service> sst_man;
     sst_man.start(std::ref(dbcfg), std::ref(*scf)).get();
     auto stop_sst_man_service = deferred_stop(sst_man);
@@ -500,7 +500,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
     cache_tracker tracker;
     sstables::directory_semaphore dir_sem(1);
     abort_source abort;
-    auto scf = make_sstable_compressor_factory();
+    auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     sstables::sstables_manager sst_man("tools::load_schema_from_sstable", large_data_handler, dbcfg, feature_service, tracker,
         memory::stats().total_memory(), dir_sem,
         [host_id = locator::host_id::create_random_id()] { return host_id; }, *scf, abort);

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3559,7 +3559,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         }
 
         gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
-        auto scf = make_sstable_compressor_factory();
+        auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         cache_tracker tracker;
         sstables::directory_semaphore dir_sem(1);
         abort_source abort;


### PR DESCRIPTION
compress: distribute compression dictionaries over shards
We don't want each shard to have its own copy of each dictionary.
It would unnecessary pressure on cache and memory.
Instead, we want to share dictionaries between shards.

Before this commit, all dictionaries live on shard 0.
All other shards borrow foreign shared pointers from shard 0.

There's a problem with this setup: dictionary blobs receive many random
accesses. If shard 0 is on a remote NUMA node, this could pose
a performance problem.

Therefore, for each dictionary, we would like to have one copy per NUMA node,
not one copy per the entire machine. And each shard should use the copy
belonging to its own NUMA node. This is the main goal of this patch.

There is another issue with putting all dicts on shard 0: it eats
an assymetric amount of memory from shard 0.
This commit spreads the ownership of dicts over all shards within
the NUMA group, to make the situation more symmetric.
(Dict owner is decided based on the hash of dict contents).

It should be noted that the last part isn't necessarily a good thing,
though.
While it makes the situation more symmetric within each node,
it makes it less symmetric across the cluster, if different node
sizes are present.

If dicts occupy 1% of memory on each shard of a 100-shard node,
then the same dicts would occupy 100% of memory on a 1-shard node.

So for the sake of cluster-wide symmetry, we might later want to consider
e.g. making the memory limit for dictionaries inversely proportional
to the number of shards.

New functionality, added to a feature which isn't in any stable branch yet. No backporting.