### PR TITLE
[Backport 2025.1] auth: forbid modifying system ks by non-superusers

### DIFF
--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -109,10 +109,10 @@ future<> service::client_state::has_schema_access(const sstring& ks_name, const 
 
 future<> service::client_state::has_access(const sstring& ks, auth::command_desc cmd) const {
     if (ks.empty()) {
-        return make_exception_future<>(exceptions::invalid_request_exception("You have not set a keyspace for this session"));
+        throw exceptions::invalid_request_exception("You have not set a keyspace for this session");
     }
     if (_is_internal) {
-        return make_ready_future();
+        co_return;
     }
 
     validate_login();
@@ -126,7 +126,7 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
         auto name = ks;
         std::transform(name.begin(), name.end(), name.begin(), ::tolower);
         if (is_system_keyspace(name)) {
-            return make_exception_future<>(exceptions::unauthorized_exception(ks + " keyspace is not user-modifiable."));
+            throw exceptions::unauthorized_exception(ks + " keyspace is not user-modifiable.");
         }
 
         //
@@ -141,8 +141,8 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
                 && (cmd.permission == auth::permission::DROP);
 
         if (dropping_anything_in_tracing || dropping_auth_keyspace) {
-            return make_exception_future<>(exceptions::unauthorized_exception(
-                    format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource)));
+            throw exceptions::unauthorized_exception(
+                    format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource));
         }
     }
 
@@ -158,11 +158,11 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
     }();
 
     if (cmd.permission == auth::permission::SELECT && readable_system_resources.contains(cmd.resource)) {
-        return make_ready_future();
+        co_return;
     }
     if (alteration_permissions.contains(cmd.permission)) {
         if (auth::is_protected(*_auth_service, cmd)) {
-            return make_exception_future<>(exceptions::unauthorized_exception(format("{} is protected", cmd.resource)));
+            throw exceptions::unauthorized_exception(format("{} is protected", cmd.resource));
         }
     }
 
@@ -178,14 +178,24 @@ future<> service::client_state::has_access(const sstring& ks, auth::command_desc
                         || resource_view.table() == db::system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION
                         || resource_view.table() == db::system_distributed_keyspace::CDC_TIMESTAMPS
                         || resource_view.table() == db::system_distributed_keyspace::CDC_GENERATIONS_V2)) {
-                    return make_exception_future<>(exceptions::unauthorized_exception(
-                            format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource)));
+                    throw exceptions::unauthorized_exception(
+                            format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource));
                 }
             }
         }
     }
 
-    return ensure_has_permission(cmd);
+    if (cmd.resource.kind() == auth::resource_kind::data
+            && !(cmd.permission == auth::permission::SELECT || cmd.permission == auth::permission::DESCRIBE)
+            && is_system_keyspace(ks)
+            && _user
+            && !auth::is_anonymous(*_user)
+            && !co_await _auth_service->underlying_role_manager().is_superuser(*_user->name)) [[unlikely]] {
+        throw exceptions::unauthorized_exception(
+                ks + " can be granted only SELECT or DESCRIBE permissions to a non-superuser.");
+    }
+
+    co_return co_await ensure_has_permission(cmd);
 }
 
 future<bool> service::client_state::check_has_permission(auth::command_desc cmd) const {


### PR DESCRIPTION
Before this patch, granting a user MODIFY permissions on ALL KEYSPACES allowed the user to write to system tables, where the user could also set himself to "superuser" granting him all other permissions. After this patch, MODIFY permissions on ALL KEYSPACES is limited only to non-system keyspaces.

Fixes: scylladb/scylladb#23218
(cherry picked from commit fee50f287cfd5332e889129520d1a126816a1cbe)

Parent PR: #23219