### PR TITLE
test.py: Make the testpy log files in pytest follow the same format

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -14,6 +14,7 @@ import tempfile
 import platform
 import urllib.parse
 from multiprocessing import Event, Process
+from pathlib import Path
 from typing import TYPE_CHECKING
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
@@ -233,7 +234,7 @@ async def manager(request: pytest.FixtureRequest,
     suite_testpy_log = testpy_test.log_filename
     test_log = suite_testpy_log.parent / f"{suite_testpy_log.stem}.{test_case_name}.log"
     # this should be consistent with scylla_cluster.py handler name in _before_test method
-    test_py_log_test = suite_testpy_log.parent / f"{suite_testpy_log.stem}_{test_case_name}_cluster.log"
+    test_py_log_test = suite_testpy_log.parent / f"{test_log.stem}_cluster.log"
 
     manager_client = manager_internal()  # set up client object in fixture with scope function
     await manager_client.before_test(test_case_name, test_log)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -88,7 +88,11 @@ async def testpy_testsuite(request: pytest.FixtureRequest, build_mode: str) -> T
 
 @pytest.fixture(scope="module")
 async def testpy_test(request: pytest.FixtureRequest, testpy_testsuite: TestSuite) -> Test:
-    await testpy_testsuite.add_test(shortname=request.node.name, casename=None)
+    # this name modification is done to have the same output as everywhere is used:
+    # suite_name.directory_subdirectory_file
+    # The first directory represents suite, and it deleted since later it added in Test class
+    shortname = "_".join(request.node.nodeid.split('.')[0].split('/')[1:])
+    await testpy_testsuite.add_test(shortname=shortname, casename=None)
     return testpy_testsuite.tests[-1]  # most recent test added to the test suite; i.e., by the previous line.
 
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1347,7 +1347,9 @@ class ScyllaClusterManager:
         root_logger = logging.getLogger()
         # file handler file name should be consistent with topology/conftest.py:manager test_py_log_test variable
         parent_test_name = self.test_uname.replace('/', '_')
-        self.test_case_log_fh = logging.FileHandler(f"{self.base_dir}/{parent_test_name}_{test_case_name}_cluster.log")
+        self.test_case_log_fh = logging.FileHandler(f"{self.base_dir}/{parent_test_name}.{test_case_name}_cluster.log")
+        # to avoid fail when no cluster logs are not present creating an empty file here
+        open(self.test_case_log_fh.baseFilename, 'a').close()
         self.test_case_log_fh.setLevel(root_logger.getEffectiveLevel())
         # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
         # extract it from the root logger and apply to the handler
@@ -1524,7 +1526,8 @@ class ScyllaClusterManager:
             self.cluster.after_test(self.current_test_case_full_name, success)
         finally:
             logging.getLogger().removeHandler(self.test_case_log_fh)
-            pathlib.Path(self.test_case_log_fh.baseFilename).unlink()
+            if success:
+                pathlib.Path(self.test_case_log_fh.baseFilename).unlink()
             self.current_test_case_full_name = ''
         self.is_after_test_ok = True
         cluster_str = str(self.cluster)


### PR DESCRIPTION
Fix the incorrect log file names between conftest and scylla_manager.
This regression issue, was introduced in https://github.com/scylladb/scylladb/pull/22960.

Currently, scylla manager will output it's logs to the file with the
next pattern:
suite_name.path_to_the_test_file_with_subfolders.run_id.function_name.mode.run_id_cluster.log
On the same time pytest will try to find this log with next name:
suite_name.file_name_without_subfolders_path.py.run_id.function_name.mode.run_id_cluster.log

This inconsistency leads to the situation when the test failed, scylla
manager log file will not be copied to the failed_test directory and
test will have exception on teardown.

Additionally, added not deleting scylla manager log file in case test failed.