### PR TITLE
sstable_set: incremental_reader_selector: be more careful when filtering out already engaged sstables

### DIFF
--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -824,9 +824,12 @@ public:
             irclogger.trace("{}: {} sstables to consider, advancing selector to {}", fmt::ptr(this), selection.sstables.size(),
                     _selector_position);
 
-            readers = std::ranges::to<std::vector<mutation_reader>>(selection.sstables
-                    | std::views::filter([this] (auto& sst) { return _read_sstable_gens.emplace(sst->generation()).second; })
-                    | std::views::transform([this] (auto& sst) { return this->create_reader(sst); }));
+            readers.clear();
+            for (auto& sst : selection.sstables) {
+                if (_read_sstable_gens.emplace(sst->generation()).second) {
+                    readers.push_back(create_reader(sst));
+                }
+            }
         } while (!_selector_position.is_max() && readers.empty() && (!pos || dht::ring_position_tri_compare(*_s, *pos, _selector_position) >= 0));
 
         irclogger.trace("{}: created {} new readers", fmt::ptr(this), readers.size());


### PR DESCRIPTION
The incremental reader selector maintains an unordered_set of sstables that are already engaged, and uses std::views::filter to filter those out. It adds the sstable under consideration to the set, and if addition failed (because it's already in) then it filters it out.

This breaks if the filter view is executed twice - the first pass will add every sstable to the set, and the second will consider every sstable already filtered. This is what happens with libstdc++ 15 (due to the addition of vector(from_range_t) constructor), which uses the first pass to calculate the vector size and the second pass to insert the elements into a correctly-sized vector.

Fix by open-coding the loop.

Not backporting: while the bug is logically there, it only hits with libstdc++15 which isn't in any release toolchain and will not make it there.