### PR TITLE
[Backport 6.2] table: fix a race in table::take_storage_snapshot()

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -620,13 +620,6 @@ private:
     // Unsafe reference to all storage groups. Don't use it across preemption points.
     const storage_group_map& storage_groups() const;
 
-    // Safely iterate through SSTables, with deletion guard taken to make sure they're not
-    // removed during iteration.
-    // WARNING: Be careful that the action doesn't perform an operation that will itself
-    // take the deletion guard, as that will cause a deadlock. For example, memtable flush
-    // can wait on compaction (backpressure) which in turn takes deletion guard on completion.
-    future<> safe_foreach_sstable(const sstables::sstable_set&, noncopyable_function<future<>(const sstables::shared_sstable&)> action);
-
     // Returns a sstable set that can be safely used for purging any expired tombstone in a compaction group.
     // Only the sstables in the compaction group is not sufficient, since there might be other compaction
     // groups during tablet split with overlapping token range, and we need to include them all in a single


### PR DESCRIPTION
`safe_foreach_sstable` doesn't do its job correctly.

It iterates over an sstable set under the sstable deletion lock in an attempt to ensure that SSTables aren't deleted during the iteration.

The thing is, it takes the deletion lock after the SSTable set is already obtained, so SSTables might get unlinked _before_ we take the lock.

Remove this function and fix its usages to obtain the set and iterate over it under the lock.

I'm not sure what the effects are, but it seems like something that should be backported to all branches which contain this code.

Fixes #23396

* (cherry picked from commit [e23fdc0](https://github.com/scylladb/scylladb/commit/e23fdc0799e241c2263c0f0d1aac08c40c9a0950))

Parent PR: #23397