### PR TITLE
.github: Make "make-pr-ready-for-review" workflow run in base repo

### DIFF
--- a/.github/workflows/make-pr-ready-for-review.yaml
+++ b/.github/workflows/make-pr-ready-for-review.yaml
@@ -16,6 +16,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ env.DEFAULT_BRANCH }}
+          token: ${{ secrets.AUTO_BACKPORT_TOKEN }}
+          fetch-depth: 1
       - name: Mark pull request as ready for review
         run:  gh pr ready "${{ github.event.pull_request.number }}"
         env:


### PR DESCRIPTION
In 57683c1a50b1ba05736fda2e815b018858e86579 we fixed the `token` error, but removed the checkout part, which is now causing the following error
```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```
Adding the repo checkout stage to avoid such an error

Fixes: https://github.com/scylladb/scylladb/issues/22765

**Regression in `6.2` and `2025.1` since 57683c1a50b1ba05736fda2e815b018858e86579 was backported, need to backport this as well**

Verified this change with - https://github.com/yaronkaikov/trigger/actions/runs/14315121385/job/40119386652