### PR TITLE
test/cqlpy/test_tools.py: use AIO backend in scylla-sstable query tests

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -1401,6 +1401,7 @@ class sstable_query_tester:
             sstable_query_result = json.loads(subprocess.check_output([
                 self._scylla_path, "sstable", "query",
                 "--logger-log-level", "scylla-sstable=debug",
+                "--reactor-backend=linux-aio",
                 "--output-format", "json",
                 "--schema-tables",
                 "--query-file", query_file.name] + self._sstables))
@@ -1680,7 +1681,7 @@ def test_scylla_sstable_query_validation(cql, scylla_path, scylla_data_dir):
     with nodetool.no_autocompaction_context(cql, "system.local"):
         sstables = get_sstables_for_table(scylla_data_dir, "system", "local")
 
-        common_params = [scylla_path, "sstable", "query", "--system-schema", "--keyspace", "system", "--table", "local", "--query"]
+        common_params = [scylla_path, "sstable", "query", "--system-schema", "--keyspace", "system", "--table", "local", "--reactor-backend=linux-aio", "--query"]
 
         def check(bad_query, expected_error):
             res = subprocess.run(common_params + [bad_query] + sstables, text=True, capture_output=True)


### PR DESCRIPTION
These tests seem to be hitting the io-uring bug in the kernel from time-to-time, making CI flaky. Force the use of the AIO backend in these tests, as a workaround until fixed kernels (>=6.8.13) are available.

Fixes: #23517
Fixes: #23546

Minor CI instability issue, no backport are needed. 2025.1 is probably affected, if this becomes annoying we can decide to backport later.