### PR TITLE
mutation/frozen_mutation: frozen_mutation_consumer_adaptor: fix end-of-partition handling

### DIFF
--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -132,9 +132,7 @@ public:
 
     auto on_end_of_partition() {
         flush_rows_and_tombstones(position_in_partition::after_all_clustered_rows());
-        if (_consumer.consume_end_of_partition()) {
-            _stop_consuming = stop_iteration::yes;
-        }
+        _stop_consuming = _consumer.consume_end_of_partition();
         using consume_res_type = decltype(_consumer.consume_end_of_stream());
         if constexpr (std::is_same_v<consume_res_type, void>) {
             _consumer.consume_end_of_stream();


### PR DESCRIPTION
This adaptor adapts a mutation reader pausable consumer to the frozen mutation visitor interface. The pausable consumer protocol allows the consumer to skip the remaining parts of the partition and resume the consumption with the next one. To do this, the consumer just has to return stop_iteration::yes from one of the consume() overloads for clustering elements, then return stop_iteration::no from consume_end_of_partition(). Due to a bug in the adaptor, this sequence leads to terminating the consumption completely -- so any remaining partitions are also skipped.

This protocol implementation bug has user-visible effects, when the only user of the adaptor -- read repair -- happens during a query which has limitations on the amount of content in each partition. There are two such queries: select distinct ... and select ... with partition limit. When converting the repaired mutation to to query result, these queries will trigger the skip sequence in the consumer and due to the above described bug, will skip the remaining partitions in the results, omitting these from the final query result.

This patch fixes the protocol bug, the return value of the underlying consumer's consume_end_of_partition() is now respected.

A unit test is also added which reproduces the problem both with select distinct ... and select ... per partition limit.

Follow-up work:
* frozen_mutation_consumer_adaptor::on_end_of_partition() calls the underlying consumer's on_end_of_stream(), so when consuming multiple frozen mutations, the underlying's on_end_of_stream() is called for each partition. This is incorrect but benign.
* Improve documentation of mutation_reader::consume_pausable().

Fixes: #20084

Bug was introduced by https://github.com/scylladb/scylladb/commit/abbf5de68cfd45d1452047efe02b2db16f05edcc, needs backport to all live releases.