### PR TITLE
test/cluster/test_tablets.py: Fix test

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -43,8 +43,8 @@ async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
         with pytest.raises(ConfigurationException, match=f"Datacenter {this_dc} doesn't have enough token-owning nodes"):
             await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
-            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
-            await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Some of the statements in the test are not indented properly and, as a result, are never run. It's most likely a small mistake, so let's fix it.

Backport: these changes are extremely small and fix a test, so let's backport it at least to 2025.1 to improve test coverage there too.