### PR TITLE
test/cluster: Adjust tests to RF-rack-valid keyspaces

### DIFF
--- a/test/cluster/random_failures/cluster_events.py
+++ b/test/cluster/random_failures/cluster_events.py
@@ -474,7 +474,7 @@ async def add_new_node(manager: ManagerClient,
     yield
 
     LOGGER.info("Add a new node to the cluster")
-    await manager.server_add(timeout=TOPOLOGY_TIMEOUT)
+    await manager.server_add(config={"rf_rack_valid_keyspaces": False}, timeout=TOPOLOGY_TIMEOUT)
 
     yield
 

--- a/test/cluster/suite.yaml
+++ b/test/cluster/suite.yaml
@@ -6,6 +6,7 @@ extra_scylla_config_options:
     authenticator: AllowAllAuthenticator
     authorizer: AllowAllAuthorizer
     enable_user_defined_functions: False
+    rf_rack_valid_keyspaces: True
     tablets_mode_for_new_keyspaces: enabled
 run_first:
   - test_raft_recovery_stuck

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -20,7 +20,7 @@ from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
 from test.cluster.util import reconnect_driver
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 

--- a/test/cluster/test_change_rpc_address.py
+++ b/test/cluster/test_change_rpc_address.py
@@ -32,7 +32,7 @@ N_SERVERS = 2
 @pytest.fixture
 async def two_nodes_cluster(manager: ManagerClient) -> list[ServerNum]:
     logger.info(f"Booting initial 2-nodes cluster")
-    servers = [srv.server_id for srv in await manager.servers_add(N_SERVERS)]
+    servers = [srv.server_id for srv in await manager.servers_add(N_SERVERS, auto_rack_dc="dc1")]
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
     return servers
 

--- a/test/cluster/test_conflicting_keys_read_repair.py
+++ b/test/cluster/test_conflicting_keys_read_repair.py
@@ -42,7 +42,7 @@ async def test_read_repair_with_conflicting_hash_keys(request: pytest.FixtureReq
 
     """
     logger.info("Creating a new cluster")
-    srvs = await manager.servers_add(3)
+    srvs = await manager.servers_add(3, auto_rack_dc="dc1")
     cql, _ = await manager.get_ready_cql(srvs)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -39,7 +39,7 @@ async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: l
     """
     cmdline = ["--hinted-handoff-enabled", "0", "--cache-hit-rate-read-balancing", "0", "--logger-log-level", "debug_error_injection=trace"]
 
-    nodes = await manager.servers_add(3, cmdline=cmdline)
+    nodes = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
 
     node1, node2, node3 = nodes
 

--- a/test/cluster/test_global_ignore_nodes.py
+++ b/test/cluster/test_global_ignore_nodes.py
@@ -10,7 +10,7 @@ import uuid
 import logging
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -21,8 +21,8 @@ async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) 
        since ignore node is permanent now and B is removed from the quorum early so it is enough to
        have two live nodes for the quorum.
     """
-    await manager.servers_add(2)
     servers = await manager.running_servers()
+    servers += await manager.servers_add(2, property_file=[servers[1].property_file(), servers[2].property_file()])
     await manager.server_stop_gracefully(servers[3].server_id)
     await manager.server_stop_gracefully(servers[4].server_id)
     # test that non existing uuid is rejected
@@ -37,6 +37,6 @@ async def test_global_ignored_nodes_list(manager: ManagerClient, random_tables) 
     # is 2
     await manager.server_stop_gracefully(servers[2].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[2].server_id, reuse_ip_addr = False, use_host_id = True)
-    await manager.server_add(start=False, replace_cfg=replace_cfg)
+    await manager.server_add(start=False, replace_cfg=replace_cfg, property_file=servers[2].property_file())
 
 

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -46,7 +46,8 @@ async def test_long_query_timeout_erm(request, manager: ManagerClient, query, sh
     quickly shutdown nodes, even if query timeout is extremely long.
     """
     logger.info("Start four nodes cluster")
-    servers = await manager.servers_add(4)
+    # FIXME: Adjust this test to run with `rf_rack_valid_keyspaces` set to `True`.
+    servers = await manager.servers_add(4, config={"rf_rack_valid_keyspaces": False})
 
     selected_server = servers[0]
     logger.info(f"Creating a client with selected_server: {selected_server}")

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -58,10 +58,10 @@ async def test_putget_2dc_with_rf(
     table_name = "test_table_name"
     columns = [Column("name", TextType), Column("value", TextType)]
     logger.info("Create two servers in different DC's")
-    for i in nodes_list:
+    for rack_idx, dc_idx in enumerate(nodes_list):
         s_info = await manager.server_add(
             config=CONFIG,
-            property_file={"dc": f"dc{i}", "rack": "myrack"},
+            property_file={"dc": f"dc{dc_idx}", "rack": f"rack{rack_idx}"},
         )
         logger.info(s_info)
     conn = manager.get_cql()

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -23,14 +23,15 @@ async def test_not_enough_token_owners(manager: ManagerClient):
     """
     logging.info('Trying to add a zero-token server as the first server in the cluster')
     await manager.server_add(config={'join_ring': False},
+                             property_file={"dc": "dc1", "rack": "rz"},
                              expected_error='Cannot start the first node in the cluster as zero-token')
 
     logging.info('Adding the first server')
-    server_a = await manager.server_add()
+    server_a = await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})
 
     logging.info('Adding two zero-token servers')
     # The second server is needed only to preserve the Raft majority.
-    server_b = (await manager.servers_add(2, config={'join_ring': False}))[0]
+    server_b = (await manager.servers_add(2, config={'join_ring': False}, property_file={"dc": "dc1", "rack": "rz"}))[0]
 
     logging.info(f'Trying to decommission the only token owner {server_a}')
     await manager.decommission_node(server_a.server_id,
@@ -47,7 +48,7 @@ async def test_not_enough_token_owners(manager: ManagerClient):
     await manager.server_start(server_a.server_id)
 
     logging.info('Adding a normal server')
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "r2"})
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -316,7 +316,7 @@ async def test_read_repair_with_trace_logging(request, manager):
     cmdline = ["--hinted-handoff-enabled", "0", "--logger-log-level", "mutation_data=trace:debug_error_injection=trace"]
     config = {"read_request_timeout_in_ms": 60000}
 
-    [node1, node2] = await manager.servers_add(2, cmdline=cmdline, config=config)
+    [node1, node2] = await manager.servers_add(2, cmdline=cmdline, config=config, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
     srvs = await manager.running_servers()

--- a/test/cluster/test_remove_rpc_client_with_pending_requests.py
+++ b/test/cluster/test_remove_rpc_client_with_pending_requests.py
@@ -22,7 +22,7 @@ async def test_remove_rpc_client_with_pending_requests(request, manager: Manager
     # Regression test for #17445
 
     logger.info("starting first two nodes")
-    servers = await manager.servers_add(2)
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
     logger.info(f"wait_for_cql_and_get_hosts for the first node {servers[0]}")
     host0 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[0]], time.time() + 60))[0]
@@ -48,7 +48,7 @@ async def test_remove_rpc_client_with_pending_requests(request, manager: Manager
     expected_data.sort()
 
     logger.info(f"adding the third node")
-    servers += [await manager.server_add(start=False)]
+    servers += [await manager.server_add(start=False, property_file=servers[0].property_file())]
 
     logger.info(f"starting the third node [{servers[2]}]")
     third_node_future = asyncio.create_task(manager.server_start(servers[2].server_id))

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -40,8 +40,7 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     silently broken in the past.
     """
     cmdline = ["--enable-compacting-data-for-streaming-and-repair", "0", "--smp", "1", "--logger-log-level", "api=trace"]
-    node1 = await manager.server_add(cmdline=cmdline)
-    node2 = await manager.server_add(cmdline=cmdline)
+    node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 
@@ -89,8 +88,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
             "--hinted-handoff-enabled", "0",
             "--smp", "1",
             "--logger-log-level", "api=trace:database=trace"]
-    node1 = await manager.server_add(cmdline=cmdline)
-    node2 = await manager.server_add(cmdline=cmdline)
+    node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 
@@ -149,10 +147,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_repair_succeeds_with_unitialized_bm(manager):
-    await manager.server_add()
-    await manager.server_add()
-    servers = await manager.running_servers()
-
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
     cql = manager.get_cql()
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
@@ -171,8 +166,7 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
     total_repair_duration = 0
 
     cmdline = ["--repair-hints-batchlog-flush-cache-time-in-ms", str(cache_time_in_ms), "--smp", "1", "--logger-log-level", "api=trace"]
-    node1 = await manager.server_add(cmdline=cmdline)
-    node2 = await manager.server_add(cmdline=cmdline)
+    node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
@@ -226,10 +220,7 @@ async def test_batchlog_flush_in_repair_without_cache(manager):
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_repair_abort(manager):
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled'}
-    await manager.server_add(config=cfg)
-    await manager.server_add(config=cfg)
-    servers = await manager.running_servers()
-
+    servers = await manager.servers_add(2, config=cfg, auto_rack_dc="dc1")
     cql = manager.get_cql()
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -78,7 +78,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> Non
 @pytest.mark.asyncio
 async def test_replace_reuse_ip(request, manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address"""
-    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': 2000})
+    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': 2000}, auto_rack_dc="dc1")
     host2 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[2]], time.time() + 60))[0]
 
     logger.info(f"creating test table")
@@ -90,7 +90,7 @@ async def test_replace_reuse_ip(request, manager: ManagerClient) -> None:
 
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
-    replace_future = asyncio.create_task(manager.server_add(replace_cfg))
+    replace_future = asyncio.create_task(manager.server_add(replace_cfg, property_file=servers[0].property_file()))
     start_time = time.time()
     next_id = 0
     logger.info(f"running write requests in a loop while the replacing node is starting")

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -27,7 +27,7 @@ async def test_reversed_queries_during_upgrade(manager: ManagerClient) -> None:
     in order to test both native and legacy reversed formats.
     """
     cmdline = ["--hinted-handoff-enabled", "0"]
-    node1, _ = await manager.servers_add(2, cmdline)
+    node1, _ = await manager.servers_add(2, cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -61,7 +61,7 @@ async def test_basic(manager: ManagerClient) -> None:
         'internode_compression': "all",
         'internode_compression_zstd_max_cpu_fraction': 0.0}
     logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(servers_num=2, config=cfg)
+    servers = await manager.servers_add(servers_num=2, config=cfg, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 
@@ -108,7 +108,7 @@ async def test_dict_training(manager: ManagerClient) -> None:
         '--logger-log-level=dict_training=trace'
     ]
     logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline)
+    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 
@@ -170,7 +170,7 @@ async def test_external_dicts(manager: ManagerClient) -> None:
         '--logger-log-level=advanced_rpc_compressor=debug'
     ]
     logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline)
+    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 
@@ -233,7 +233,7 @@ async def test_external_dicts_sanity(manager: ManagerClient) -> None:
         '--logger-log-level=advanced_rpc_compressor=debug',
     ]
     logger.info(f"Booting initial cluster")
-    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline)
+    servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_select_from_mutation_fragments.py
+++ b/test/cluster/test_select_from_mutation_fragments.py
@@ -16,7 +16,7 @@ from test.pylib.manager_client import ManagerClient
 
 @pytest.mark.asyncio
 async def test_sticky_coordinator_enforced(manager: ManagerClient) -> None:
-    await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'])
+    await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'], auto_rack_dc="dc1")
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_snapshot.py
+++ b/test/cluster/test_snapshot.py
@@ -14,7 +14,7 @@ from cassandra.query import SimpleStatement              # type: ignore # pylint
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -39,7 +39,7 @@ async def test_snapshot(manager, random_tables):
         await t.add_column()
 
     manager.driver_close()
-    server_d = await manager.server_add()
+    server_d = await manager.server_add(property_file=server_a.property_file())
     logger.info("Started D %s", server_d)
 
     logger.info("Stopping A %s, B %s, and C %s", server_a, server_b, server_c)

--- a/test/cluster/test_sstable_compression_dictionaries_autotrain.py
+++ b/test/cluster/test_sstable_compression_dictionaries_autotrain.py
@@ -54,14 +54,14 @@ async def test_autoretrain_dict(manager: ManagerClient):
     uncompressed_size = blob_size * n_blobs * rf
 
     logger.info("Bootstrapping cluster")
-    servers = (await manager.servers_add(2, cmdline=[
+    servers = await manager.servers_add(2, cmdline=[
         '--logger-log-level=storage_service=debug',
         '--logger-log-level=database=debug',
         '--logger-log-level=sstable_dict_autotrainer=debug',
         '--sstable-compression-dictionaries-retrain-period-in-seconds=1',
         '--sstable-compression-dictionaries-autotrainer-tick-period-in-seconds=1',
         f'--sstable-compression-dictionaries-min-training-dataset-bytes={int(uncompressed_size/2)}',
-    ]))
+    ], auto_rack_dc="dc1")
 
     logger.info("Creating table")
     cql = manager.get_cql()

--- a/test/cluster/test_sstable_compression_dictionaries_basic.py
+++ b/test/cluster/test_sstable_compression_dictionaries_basic.py
@@ -74,7 +74,7 @@ async def test_retrain_dict(manager: ManagerClient):
 
     servers = (await manager.servers_add(2, cmdline=[
         *common_debug_cli_options,
-    ]))
+    ], auto_rack_dc="dc1"))
 
     logger.info("Creating table")
     cql = manager.get_cql()
@@ -185,7 +185,7 @@ async def test_estimate_compression_ratios(manager: ManagerClient):
 
     servers = (await manager.servers_add(2, cmdline=[
         *common_debug_cli_options,
-    ]))
+    ], auto_rack_dc="dc1"))
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -265,8 +265,8 @@ async def test_tablet_repair_hosts_filter(manager: ManagerClient, included_host_
 
 async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraSession, list[Host], str, str]:
     servers = [await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}),
-               await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}),
-               await manager.server_add(property_file = {'dc': 'DC2', 'rack' : 'R2'})]
+               await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R2'}),
+               await manager.server_add(property_file = {'dc': 'DC2', 'rack' : 'R3'})]
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', "
                   "'DC1': 2, 'DC2': 1} AND tablets = {'initial': 8};")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -33,6 +33,12 @@ logger = logging.getLogger(__name__)
 @pytest.mark.asyncio
 async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
+    # This test verifies that Scylla rejects creating a table if there are too few token-owning nodes.
+    # That means that a keyspace must already be in place, but that's impossible with RF-rack-valid
+    # keyspaces being enforced. We could go over this constraint by creating 3 nodes and then
+    # decommissioning one of them before attempting to create a table, but if we decide to constraint
+    # decommission later on, this test will have to be modified again. Let's simply disable the option.
+    cfg = cfg | {'rf_rack_valid_keyspaces': False}
     servers = await manager.servers_add(2, config=cfg)
 
     cql = manager.get_cql()

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -66,7 +66,12 @@ async def test_tablet_scaling_option_is_respected(manager: ManagerClient):
 async def test_tablet_cannot_decommision_below_replication_factor(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
-    servers = await manager.servers_add(4, config=cfg)
+    servers = await manager.servers_add(4, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"}
+    ])
 
     logger.info("Creating table")
     cql = manager.get_cql()
@@ -199,7 +204,11 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
     not owned by the node is attempted to be read."""
     cfg = {'enable_user_defined_functions': False,
            'tablets_mode_for_new_keyspaces': 'enabled' }
-    servers = await manager.servers_add(3, config=cfg)
+    servers = await manager.servers_add(3, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"}
+    ])
 
     cql = manager.get_cql()
 
@@ -1115,15 +1124,15 @@ async def check_tablet_rebuild_with_repair(manager: ManagerClient, fail: bool):
     host_ids = []
     servers = []
 
-    async def make_server():
-        s = await manager.server_add(config=cfg)
+    async def make_server(rack: str):
+        s = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": rack})
         servers.append(s)
         host_ids.append(await manager.get_host_id(s.server_id))
         await manager.api.disable_tablet_balancing(s.ip_addr)
 
-    await make_server()
-    await make_server()
-    await make_server()
+    await make_server("r1")
+    await make_server("r1")
+    await make_server("r2")
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -797,12 +797,14 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
     and when there is another down node in the datacenter, leaving no normal token owners.
     """
     servers: dict[str, list[ServerInfo]] = dict()
-    servers['dc1'] = await manager.servers_add(servers_num=2, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    servers['dc1'] = await manager.servers_add(servers_num=2, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1_1'},
+        {'dc': 'dc1', 'rack': 'rack1_2'}])
     # if testing with no zero-token-node, add an additional node to dc2 to maintain raft quorum
     extra_node = 0 if with_zero_token_node else 1
     servers['dc2'] = await manager.servers_add(servers_num=2 + extra_node, property_file={'dc': 'dc2', 'rack': 'rack2'})
     if with_zero_token_node:
-        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1'}))
+        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
     cql = manager.get_cql()
@@ -824,7 +826,7 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
 
         logger.info(f"Replacing {node_to_replace} with a new node")
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
-        await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': 'rack1'})
+        await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
@@ -836,10 +838,12 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
     And then verify that that node can be replaced successfully.
     """
     servers: dict[str, list[ServerInfo]] = dict()
-    servers['dc1'] = await manager.servers_add(servers_num=2, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    servers['dc1'] = await manager.servers_add(servers_num=2, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1_1'},
+        {'dc': 'dc1', 'rack': 'rack1_2'}])
     servers['dc2'] = await manager.servers_add(servers_num=2, property_file={'dc': 'dc2', 'rack': 'rack2'})
     if with_zero_token_node:
-        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1'}))
+        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
     cql = manager.get_cql()
@@ -857,7 +861,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
 
         logger.info(f"Replacing {node_to_remove} with a new node")
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
-        await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': 'rack1'})
+        await manager.server_add(replace_cfg=replace_cfg, property_file=node_to_remove.property_file())
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("with_zero_token_node", [False, True])
@@ -870,12 +874,14 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
     but other datacenters can be used to rebuild the data.
     """
     servers: dict[str, list[ServerInfo]] = dict()
-    servers['dc1'] = await manager.servers_add(servers_num=2, property_file={'dc': 'dc1', 'rack': 'rack1'})
+    servers['dc1'] = await manager.servers_add(servers_num=2, property_file=[
+        {'dc': 'dc1', 'rack': 'rack1_1'},
+        {'dc': 'dc1', 'rack': 'rack1_2'}])
     # if testing with no zero-token-node, add an additional node to dc2 to maintain raft quorum
     extra_node = 0 if with_zero_token_node else 1
     servers['dc2'] = await manager.servers_add(servers_num=2 + extra_node, property_file={'dc': 'dc2', 'rack': 'rack2'})
     if with_zero_token_node:
-        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1'}))
+        servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
     cql = manager.get_cql()
@@ -897,11 +903,11 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
         logger.info(f"Replacing {nodes_to_replace[0]} with a new node")
         replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[0].server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True,
                                     ignore_dead_nodes=[replaced_host_id])
-        await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': 'rack1'})
+        await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[0].property_file())
 
         logger.info(f"Replacing {nodes_to_replace[1]} with a new node")
         replace_cfg = ReplaceConfig(replaced_id=nodes_to_replace[1].server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)
-        await manager.server_add(replace_cfg=replace_cfg, property_file={'dc': 'dc1', 'rack': 'rack1'})
+        await manager.server_add(replace_cfg=replace_cfg, property_file=nodes_to_replace[1].property_file())
 
         logger.info("Verifying data")
         for node in servers['dc2']:

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -137,7 +137,7 @@ async def test_reshape_with_tablets(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_rf_change(manager: ManagerClient, direction):
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
-    servers = await manager.servers_add(3, config=cfg)
+    servers = await manager.servers_add(2, config=cfg, auto_rack_dc="dc1")
     for s in servers:
         await manager.api.disable_tablet_balancing(s.ip_addr)
 
@@ -146,14 +146,14 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     this_dc = res[0].data_center
 
     if direction == 'up':
-        rf_from = 2
-        rf_to = 3
+        rf_from = 1
+        rf_to = 2
     if direction == 'down':
-        rf_from = 3
-        rf_to = 2
-    if direction == 'none':
         rf_from = 2
-        rf_to = 2
+        rf_to = 1
+    if direction == 'none':
+        rf_from = 1
+        rf_to = 1
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_from}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -95,7 +95,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
         '--logger-log-level', 'messaging_service=trace',
         '--logger-log-level', 'rpc=trace',
         ]
-    servers = await manager.servers_add(3, cmdline=cmdline)
+    servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
 
     s0 = servers[0].server_id
     not_s0 = servers[1:]
@@ -496,7 +496,11 @@ async def test_tablet_repair(manager: ManagerClient):
         '--logger-log-level', 'repair=trace',
         '--task-ttl-in-seconds', '3600',    # Make sure the test passes with non-zero task_ttl.
     ]
-    servers = await manager.servers_add(3, cmdline=cmdline)
+    servers = await manager.servers_add(3, cmdline=cmdline, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"}
+    ])
 
     await inject_error_on(manager, "tablet_allocator_shuffle", servers)
 
@@ -559,7 +563,11 @@ async def test_concurrent_tablet_repair_and_split(manager: ManagerClient):
     ]
     servers = await manager.servers_add(3, cmdline=cmdline, config={
         'error_injections_at_startup': ['short_tablet_stats_refresh_interval']
-    })
+    }, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"}
+    ])
 
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)
 
@@ -623,9 +631,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
     cmdline = [
         '--hinted-handoff-enabled', 'false',
         ]
-    servers = [await manager.server_add(cmdline=cmdline),
-               await manager.server_add(cmdline=cmdline),
-               await manager.server_add(cmdline=cmdline)]
+    servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', "
@@ -661,7 +667,7 @@ async def test_tablet_missing_data_repair(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_repair_history(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
-    servers = [await manager.server_add(), await manager.server_add(), await manager.server_add()]
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
 
     rf = 3
     tablets = 8
@@ -687,7 +693,7 @@ async def test_tablet_repair_history(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_tablet_repair_ranges_selection(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
-    servers = [await manager.server_add(), await manager.server_add()]
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
     rf = 2
     tablets = 4
@@ -1888,7 +1894,7 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
     """Test truncate operation during topology change."""
 
     # Start 3 node cluster
-    servers = await manager.servers_add(3, config = { 'enable_tablets': True })
+    servers = await manager.servers_add(3, config = { 'enable_tablets': True }, auto_rack_dc="dc1")
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (k int PRIMARY KEY, v int)")
@@ -1906,7 +1912,8 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
 
         truncate_task = asyncio.create_task(truncate_table())
         logger.info("Adding fourth node")
-        new_server = await manager.server_add(config={'error_injections_at_startup': ['delay_bootstrap_120s'], 'enable_tablets': True})
+        new_server = await manager.server_add(config={'error_injections_at_startup': ['delay_bootstrap_120s'], 'enable_tablets': True},
+                                              property_file=servers[0].property_file())
         await truncate_task
 
         # Wait for bootstrap completion

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -76,10 +76,10 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
     }
 
     logger.info("starting a node (the leader)")
-    servers = [await manager.server_add(config=config)]
+    servers = [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r1"})]
 
     logger.info("starting a second node (the follower)")
-    servers += [await manager.server_add(config=config)]
+    servers += [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r2"})]
 
     async with new_test_keyspace(manager, "with "
                                       "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -27,15 +27,15 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
     host_ids = []
     servers = []
 
-    async def make_server():
-        s = await manager.server_add(config=cfg)
+    async def make_server(rack: str):
+        s = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": rack})
         servers.append(s)
         host_ids.append(await manager.get_host_id(s.server_id))
         await manager.api.disable_tablet_balancing(s.ip_addr)
 
-    await make_server()
-    await make_server()
-    await make_server()
+    await make_server("r1")
+    await make_server("r1")
+    await make_server("r2")
 
     cql = manager.get_cql()
 
@@ -109,22 +109,22 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
     host_ids = []
     servers = []
 
-    async def make_server():
-        s = await manager.server_add(config=cfg)
+    async def make_server(rack: str):
+        s = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": rack})
         servers.append(s)
         host_ids.append(await manager.get_host_id(s.server_id))
         await manager.api.disable_tablet_balancing(s.ip_addr)
 
-    await make_server()
+    await make_server("r1")
+    await make_server("r2")
     cql = manager.get_cql()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
-        await make_server()
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
-        await make_server()
+        await make_server("r2")
 
         if fail_stage in ["cleanup_target", "revert_migration"]:
             # we'll stop 2 servers, group0 quorum should be there - we need five
@@ -136,8 +136,8 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
             # attempt to remove the 2nd node, to make cleanup_target stage
             # go ahead, will step on the legacy API lock on storage_service,
             # so we need to ask some other node to do it
-            for _ in range(2):
-                await make_server()
+            await make_server("r1")
+            await make_server("r2")
 
         logger.info(f"Cluster is [{host_ids}]")
 

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -69,7 +69,8 @@ async def test_replace(manager: ManagerClient):
         '--logger-log-level', 'raft_topology=trace',
     ]
 
-    servers = await manager.servers_add(3, cmdline=cmdline)
+    config = {"rf_rack_valid_keyspaces": False}
+    servers = await manager.servers_add(3, cmdline=cmdline, config=config)
 
     cql = manager.get_cql()
 
@@ -118,7 +119,7 @@ async def test_replace(manager: ManagerClient):
     logger.info('Replacing a node')
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
-    servers.append(await manager.server_add(replace_cfg))
+    servers.append(await manager.server_add(replace_cfg, config=config))
     servers = servers[1:]
 
     key_count = await finish_writes()
@@ -146,8 +147,10 @@ async def test_removenode(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cmdline = ['--logger-log-level', 'storage_service=trace']
 
+    config = {"rf_rack_valid_keyspaces": False}
+
     # 4 nodes so that we can find new tablet replica for the RF=3 table on removenode
-    servers = await manager.servers_add(4, cmdline=cmdline)
+    servers = await manager.servers_add(4, cmdline=cmdline, config=config)
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -211,7 +211,13 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
 
     # 5 nodes because we need a quorum with 2 nodes down.
     # 4 nodes would be enough to not lose data with RF=3.
-    servers = await manager.servers_add(5, cmdline=cmdline)
+    servers = await manager.servers_add(5, cmdline=cmdline, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"}
+    ])
 
     cql = manager.get_cql()
 

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -13,7 +13,7 @@ import logging
 import pytest
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_topology_ops.py
+++ b/test/cluster/test_topology_ops.py
@@ -22,7 +22,8 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("tablets_enabled", [True, False])
 async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bool):
     """Test basic topology operations using the topology coordinator."""
-    cfg = {'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled'}
+    rf_rack_cfg = {'rf_rack_valid_keyspaces': False}
+    cfg = {'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled'} | rf_rack_cfg
     rf = 3
     num_nodes = rf
     if tablets_enabled:
@@ -57,7 +58,7 @@ async def test_topology_ops(request, manager: ManagerClient, tablets_enabled: bo
 
     logger.info(f"Replacing node {servers[0]}")
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
-    servers = servers[1:] + [await manager.server_add(replace_cfg)]
+    servers = servers[1:] + [await manager.server_add(replace_cfg, config=rf_rack_cfg)]
     await check_token_ring_and_group0_consistency(manager)
 
     logger.info(f"Stopping node {servers[0]}")

--- a/test/cluster/test_topology_ops_encrypted.py
+++ b/test/cluster/test_topology_ops_encrypted.py
@@ -25,9 +25,11 @@ async def test_topology_ops_encrypted(request, manager: ManagerClient, tablets_e
     d.mkdir()
     k = d / "system_key"
     k.write_text('AES/CBC/PKCS5Padding:128:ApvJEoFpQmogvam18bb54g==')
+    rf_rack_cfg = {'rf_rack_valid_keyspaces': False}
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled',
            'user_info_encryption': {'enabled': True, 'key_provider': 'LocalFileSystemKeyProviderFactory'},
            'system_key_directory': d.as_posix()}
+    cfg = cfg | rf_rack_cfg
     rf = 3
     num_nodes = rf
     if tablets_enabled:
@@ -62,7 +64,7 @@ async def test_topology_ops_encrypted(request, manager: ManagerClient, tablets_e
 
     logger.info(f"Replacing node {servers[0]}")
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = False)
-    servers = servers[1:] + [await manager.server_add(replace_cfg)]
+    servers = servers[1:] + [await manager.server_add(replace_cfg, config=rf_rack_cfg)]
     await check_token_ring_and_group0_consistency(manager)
 
     logger.info(f"Stopping node {servers[0]}")

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -19,7 +19,7 @@ import pytest
 
 
 logger = logging.getLogger(__name__)
-pytestmark = pytest.mark.prepare_3_nodes_cluster
+pytestmark = pytest.mark.prepare_3_racks_cluster
 
 
 @pytest.mark.asyncio
@@ -27,7 +27,7 @@ async def test_remove_node_add_column(manager: ManagerClient, random_tables: Ran
     """Add a node, remove an original node, add a column"""
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
-    await manager.server_add()
+    await manager.server_add(property_file=servers[1].property_file())
     await manager.server_stop_gracefully(servers[1].server_id)              # stop     [1]
     await manager.remove_node(servers[0].server_id, servers[1].server_id)   # Remove   [1]
     await check_token_ring_and_group0_consistency(manager)
@@ -53,7 +53,7 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
     # 7. If #11780 is not fixed, this will fail the node_ops_verb RPC, causing decommission to fail
     await manager.api.enable_injection(
         decommission_target.ip_addr, 'storage_service_notify_joined_sleep', one_shot=True)
-    bootstrapped_server = await manager.server_add()
+    bootstrapped_server = await manager.server_add(property_file=decommission_target.property_file())
     async def no_joining_nodes():
         joining_nodes = await manager.api.get_joining_nodes(decommission_target.ip_addr)
         return not joining_nodes

--- a/test/cluster/test_topology_smp.py
+++ b/test/cluster/test_topology_smp.py
@@ -54,11 +54,11 @@ async def test_nodes_with_different_smp(request: FixtureRequest, manager: Manage
         ]
 
     logger.info(f'Adding --smp=3 server')
-    await manager.server_add(cmdline=['--smp', '3'] + log_args)
+    await manager.server_add(cmdline=['--smp', '3'] + log_args, property_file={"dc": "dc1", "rack": "r1"})
     logger.info(f'Adding --smp=4 server')
-    await manager.server_add(cmdline=['--smp', '4'] + log_args)
+    await manager.server_add(cmdline=['--smp', '4'] + log_args, property_file={"dc": "dc1", "rack": "r2"})
     logger.info(f'Adding --smp=5 server')
-    await manager.server_add(cmdline=['--smp', '5'] + log_args)
+    await manager.server_add(cmdline=['--smp', '5'] + log_args, property_file={"dc": "dc1", "rack": "r3"})
 
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 

--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -18,20 +18,20 @@ from test.cluster.util import create_new_test_keyspace
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('zero_token_nodes', [1, 2])
-async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token_nodes: int):
+@pytest.mark.parametrize('rf_rack_valid_keyspaces', [False, True])
+async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token_nodes: int, rf_rack_valid_keyspaces: bool):
     """
     Test the basic functionality of a DC with zero-token nodes:
     - adding zero-token nodes to a new DC succeeds
     - with tablets, ensuring enough replicas for tables depends on the number of token-owners in a DC, not all nodes
     - client requests in the presence of zero-token nodes succeed (also when zero-token nodes coordinate)
     """
-    normal_cfg = {'endpoint_snitch': 'GossipingPropertyFileSnitch'}
-    zero_token_cfg = {'endpoint_snitch': 'GossipingPropertyFileSnitch', 'join_ring': False}
-    property_file_dc1 = {'dc': 'dc1', 'rack': 'rack'}
+    normal_cfg = {'endpoint_snitch': 'GossipingPropertyFileSnitch', 'rf_rack_valid_keyspaces': rf_rack_valid_keyspaces}
+    zero_token_cfg = normal_cfg | {'join_ring': False}
     property_file_dc2 = {'dc': 'dc2', 'rack': 'rack'}
 
     logging.info('Creating dc1 with 2 token-owning nodes')
-    servers = await manager.servers_add(2, config=normal_cfg, property_file=property_file_dc1)
+    servers = await manager.servers_add(2, config=normal_cfg, auto_rack_dc='dc1')
 
     normal_nodes_in_dc2 = 2 - zero_token_nodes
     logging.info(f'Creating dc2 with {normal_nodes_in_dc2} token-owning and {zero_token_nodes} zero-token nodes')
@@ -47,7 +47,17 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
 
     ks_names = list[str]()
     logging.info('Trying to create tables for different replication factors')
-    for rf in range(3):
+
+    # With `rf_rack_valid_keyspaces` set to true, we cannot create a keyspace with RF > #racks.
+    # Because of that, the test will fail not at the stage when a TABLE is created, but when
+    # the KEYSPACE is. We want to avoid that and hence this statement.
+    #
+    # rf_rack_valid_keyspaces == False: We'll attempt to create tables in keyspaces with too few normal token owners.
+    # rf_rack_valid_keyspaces == True:  We'll only create RF-rack-valid keyspaces and so all of the created tables
+    #                                   will have enough normal token owners.
+    rf_range = (normal_nodes_in_dc2 + 1) if rf_rack_valid_keyspaces else 3
+
+    for rf in range(rf_range):
         failed = False
         ks_name = await create_new_test_keyspace(dc2_cql, f"""WITH replication =
                                      {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2, 'dc2': {rf}}}

--- a/test/cluster/test_zero_token_nodes_no_replication.py
+++ b/test/cluster/test_zero_token_nodes_no_replication.py
@@ -22,11 +22,11 @@ async def test_zero_token_nodes_no_replication(manager: ManagerClient):
     Test that zero-token nodes aren't replicas in all non-local replication strategies with and without tablets.
     """
     logging.info('Adding the first server')
-    server_a = await manager.server_add()
+    server_a = await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})
     logging.info('Adding the second server as zero-token')
-    server_b = await manager.server_add(config={'join_ring': False})
+    server_b = await manager.server_add(config={'join_ring': False}, property_file={"dc": "dc1", "rack": "r2"})
     logging.info('Adding the third server')
-    await manager.server_add()
+    await manager.server_add(property_file={"dc": "dc1", "rack": "r3"})
 
     logging.info(f'Initiating connections to {server_a} and {server_b}')
     cql_a = cluster_con([server_a.ip_addr], 9042, False,

--- a/test/cluster/test_zero_token_nodes_topology_ops.py
+++ b/test/cluster/test_zero_token_nodes_topology_ops.py
@@ -24,29 +24,34 @@ async def test_zero_token_nodes_topology_ops(manager: ManagerClient, tablets_ena
     - topology operations in the Raft-based topology involving zero-token nodes succeed
     - client requests to normal nodes in the presence of zero-token nodes (2 normal nodes, RF=2, CL=2) succeed
     """
+
+    def get_pf(rack: str) -> dict[str, str]:
+        return {"dc": "dc1", "rack": rack}
+
     logging.info('Trying to add a zero-token server in the gossip-based topology')
     await manager.server_add(config={'join_ring': False,
                                      'force_gossip_topology_changes': True,
                                      'tablets_mode_for_new_keyspaces': 'disabled'},
+                             property_file=get_pf("rz"),
                              expected_error='the raft-based topology is disabled')
 
     normal_cfg = {'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled'}
     zero_token_cfg = {'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled', 'join_ring': False}
 
     logging.info('Adding the first server')
-    server_a = await manager.server_add(config=normal_cfg)
+    server_a = await manager.server_add(config=normal_cfg, property_file=get_pf("r1"))
 
     logging.info('Adding the second server as zero-token')
-    server_b = await manager.server_add(config=zero_token_cfg)
+    server_b = await manager.server_add(config=zero_token_cfg, property_file=get_pf("rz"))
 
     logging.info('Adding the third server')
-    server_c = await manager.server_add(config=normal_cfg)
+    server_c = await manager.server_add(config=normal_cfg, property_file=get_pf("r2"))
 
     await wait_for_cql_and_get_hosts(manager.cql, [server_a, server_c], time.time() + 60)
     finish_writes = await start_writes(manager.cql, 2, ConsistencyLevel.TWO)
 
     logging.info('Adding the fourth server as zero-token')
-    await manager.server_add(config=zero_token_cfg)  # Necessary to preserve the Raft majority.
+    await manager.server_add(config=zero_token_cfg, property_file=get_pf("rz"))  # Necessary to preserve the Raft majority.
 
     logging.info(f'Restarting {server_b}')
     await manager.server_stop_gracefully(server_b.server_id)
@@ -57,23 +62,24 @@ async def test_zero_token_nodes_topology_ops(manager: ManagerClient, tablets_ena
 
     replace_cfg_b = ReplaceConfig(replaced_id=server_b.server_id, reuse_ip_addr=False, use_host_id=False)
     logging.info(f'Trying to replace {server_b} with a token-owing server')
-    await manager.server_add(replace_cfg_b, config=normal_cfg, expected_error='Cannot replace the zero-token node')
+    await manager.server_add(replace_cfg_b, config=normal_cfg, property_file=server_b.property_file(),
+                             expected_error='Cannot replace the zero-token node')
 
     logging.info(f'Replacing {server_b}')
-    server_b = await manager.server_add(replace_cfg_b, config=zero_token_cfg)
+    server_b = await manager.server_add(replace_cfg_b, config=zero_token_cfg, property_file=server_b.property_file())
 
     logging.info(f'Stopping {server_b}')
     await manager.server_stop_gracefully(server_b.server_id)
 
     replace_cfg_b = ReplaceConfig(replaced_id=server_b.server_id, reuse_ip_addr=True, use_host_id=False)
     logging.info(f'Replacing {server_b} with the same IP')
-    server_b = await manager.server_add(replace_cfg_b, config=zero_token_cfg)
+    server_b = await manager.server_add(replace_cfg_b, config=zero_token_cfg, property_file=server_b.property_file())
 
     logging.info(f'Decommissioning {server_b}')
     await manager.decommission_node(server_b.server_id)
 
     logging.info('Adding two zero-token servers')
-    [server_b, server_d] = await manager.servers_add(2, config=zero_token_cfg)
+    [server_b, server_d] = await manager.servers_add(2, config=zero_token_cfg, property_file=get_pf("rz"))
 
     logging.info(f'Rebuilding {server_b}')
     await manager.rebuild_node(server_b.server_id)
@@ -92,21 +98,21 @@ async def test_zero_token_nodes_topology_ops(manager: ManagerClient, tablets_ena
     await manager.remove_node(server_a.server_id, server_d.server_id)
 
     logging.info('Adding a zero-token server')
-    await manager.server_add(config=zero_token_cfg)
+    await manager.server_add(config=zero_token_cfg, property_file=get_pf("rz"))
 
     # FIXME: Finish writes after the last server_add call once scylladb/scylladb#19737 is fixed.
     logging.info('Checking results of the background writes')
     await finish_writes()
 
     logging.info('Adding a normal server')
-    server_e = await manager.server_add(config=normal_cfg)
+    server_e = await manager.server_add(config=normal_cfg, property_file=get_pf("r1"))
 
     logging.info(f'Stopping {server_e}')
     await manager.server_stop_gracefully(server_e.server_id)
 
     replace_cfg_e = ReplaceConfig(replaced_id=server_e.server_id, reuse_ip_addr=False, use_host_id=False)
     logging.info(f'Trying to replace {server_e} with a zero-token server')
-    await manager.server_add(replace_cfg_e, config=zero_token_cfg,
+    await manager.server_add(replace_cfg_e, config=zero_token_cfg, property_file=server_e.property_file(),
                              expected_error='Cannot replace the token-owning node')
 
     await check_node_log_for_failed_mutations(manager, server_a)

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -45,13 +45,16 @@ async def load_tablet_repair_task_infos(cql, host, table_id):
     return repair_task_infos
 
 async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fast_stats_refresh = True, nr_keys = 256, disable_flush_cache_time = False, cmdline = None) -> (list[ServerInfo], CassandraSession, list[Host], str, str):
+    assert rf <= 3, "A keyspace with RF > 3 will be RF-rack-invalid if there are fewer racks than the RF"
+
     if fast_stats_refresh:
         config = {'error_injections_at_startup': ['short_tablet_stats_refresh_interval']}
     else:
         config = {}
     if disable_flush_cache_time:
         config.update({'repair_hints_batchlog_flush_cache_time_in_ms': 0})
-    servers = [await manager.server_add(config=config, cmdline=cmdline), await manager.server_add(config=config, cmdline=cmdline), await manager.server_add(config=config, cmdline=cmdline)]
+    servers = await manager.servers_add(3, config=config, cmdline=cmdline,
+                                        property_file=[{"dc": "dc1", "rack": f"r{i % rf}"} for i in range(rf)])
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))


### PR DESCRIPTION
In this PR, we're adjusting most of the cluster tests so that they pass
with the `rf_rack_valid_keyspaces` configuration option enabled. In most
cases, the changes are straightforward and require little to no additional
insight into what the tests are doing or verifying. In some, however, doing
that does require a deeper understanding of the tests we're modifying.
The justification for those changes and their correctness is included in
the commit messages corresponding to them.

Note that this PR does not cover all of the cluster tests. There are few
remaining ones, but they require a bit more effort, so we delegate that
work to a separate PR.

I tested all of the modified tests locally with `rf_rack_valid_keyspaces`
set to true, and they all passed.

Fixes scylladb/scylladb#23959

Backport: we want to backport these changes to 2025.1 since that's the version where we introduced RF-rack-valid keyspaces in. Although the tests are not, by default, run with `rf_rack_valid_keyspaces` enabled yet, that will most likely change in the near future and we'll also want to backport those changes too. The reason for this is that we want to verify that Scylla works correctly even with that constraint.