### PR TITLE
alternator: support for TTL when using tablets

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -427,6 +427,14 @@ tablet_replica tablet_map::get_primary_replica(tablet_id id) const {
     return replicas.at(size_t(id) % replicas.size());
 }
 
+tablet_replica tablet_map::get_secondary_replica(tablet_id id) const {
+    if (get_tablet_info(id).replicas.size() < 2) {
+        throw std::runtime_error(format("No secondary replica for tablet id {}", id));
+    }
+    const auto& replicas = get_tablet_info(id).replicas;
+    return replicas.at((size_t(id)+1) % replicas.size());
+}
+
 tablet_replica tablet_map::get_primary_replica_within_dc(tablet_id id, const topology& topo, sstring dc) const {
     return maybe_get_primary_replica(id, get_tablet_info(id).replicas, [&] (const auto& tr) {
         const auto& node = topo.get_node(tr.host);

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -499,6 +499,10 @@ public:
     tablet_replica get_primary_replica(tablet_id id) const;
     tablet_replica get_primary_replica_within_dc(tablet_id id, const topology& topo, sstring dc) const;
 
+    /// Returns the secondary replica for the tablet, which is assumed to be directly following the primary replica in the replicas vector
+    /// \throws std::runtime_error if the tablet has less than 2 replicas.
+    tablet_replica get_secondary_replica(tablet_id id) const;
+
     // Returns the replica that matches hosts and dcs filters for tablet_task_info.
     std::optional<tablet_replica> maybe_get_selected_replica(tablet_id id, const topology& topo, const tablet_task_info& tablet_task_info) const;
 

--- a/test/alternator/test_tablets.py
+++ b/test/alternator/test_tablets.py
@@ -84,18 +84,6 @@ def test_initial_tablets_number(dynamodb):
     with new_test_table(dynamodb, **schema) as table:
         assert not uses_tablets(dynamodb, table)
 
-# Before Alternator TTL is supported with tablets (#16567), let's verify
-# that enabling TTL results in an orderly error. This test should be deleted
-# when #16567 is fixed.
-def test_ttl_enable_error_with_tablets(dynamodb):
-    with new_test_table(dynamodb,
-        Tags=[{'Key': initial_tablets_tag, 'Value': '4'}],
-        KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, ],
-        AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' } ]) as table:
-        with pytest.raises(ClientError, match='ValidationException.*tablets'):
-            table.meta.client.update_time_to_live(TableName=table.name,
-                TimeToLiveSpecification={'AttributeName': 'expiration', 'Enabled': True})
-
 # Before Alternator Streams is supported with tablets (#16317), let's verify
 # that enabling Streams results in an orderly error. This test should be
 # deleted when #16317 is fixed.

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -16,12 +16,24 @@ from botocore.exceptions import ClientError
 from test.alternator.util import new_test_table, random_string, full_query, unique_table_name, is_aws, \
     client_no_transform
 
-# All tests in this file are expected to fail with tablets due to #16567.
-# To ensure that Alternator TTL is still being tested, instead of
-# xfailing these tests, we temporarily coerce the tests below to avoid
-# using default tablets setting, even if it's available. We do this by
-# using the following tags when creating each table below:
-TAGS = [{'Key': 'experimental:initial_tablets', 'Value': 'none'}]
+# The following fixture is to ensure that Alternator TTL is being tested with both vnodes and tablets.
+# This fixture will run automatically for every test in the module.
+# It sets the TAGS variable in the module’s global namespace to the current parameter value before each test.
+# All tests that use the global TAGS variable will see the correct value, and each test will be run for
+# both values. Thanks to this, the tests will run for both vnodes and tables without the need to change
+# their argument list.
+@pytest.fixture(params=[
+    [{'Key': 'experimental:initial_tablets', 'Value': 'none'}],
+    # This enables tablets and disables LWT. It is meant as a temporary means of enabling regression tests
+    # with tablets until LWT is supported with tablets (#18068).
+    # FIXME After #18068 is resolved,
+    # 'system:write_isolation' should no longer be set and 'without LWT' part inside 'ids' should be removed.
+    [{'Key': 'experimental:initial_tablets', 'Value': '0'}, {'Key': 'system:write_isolation', 'Value': 'unsafe_rmw'}],
+], ids=["using vnodes", "using tablets without LWT"], autouse=True)
+def tags_param(request):
+    # Set TAGS in the global namespace of this module
+    global TAGS
+    TAGS = request.param
 
 # passes_or_raises() is similar to pytest.raises(), except that while raises()
 # expects a certain exception must happen, the new passes_or_raises()


### PR DESCRIPTION
alternator: Add support for TTL when using tablets

Support for TTL-based data removal when using tablets.
The essence of this commit is a separate code path for finding token
ranges owned by the current shard for the cases when tablets are used
and not vnodes. At the same time, the vnodes-case is not touched not to
cause any regressions.

The TTL-caused data removal is normally performed by the primary
replica (both when using vnodes and tablets). For the tablets case,
the already-existing method tablet_map::get_primary_replica(tablet_id)
is used to know if a shard execuring the TTL-related data removal is
the primary replica for each tablet.

A new method tablet_map::get_secondary_replica(tablet_id) has been
added. It is needed by the data invalidation procedure to remove data
when the primary replica node is down - the data is then removed by the
secondary replica node. The mechanism is the same as in the vnodes case.

Since alternator now supports TTL, the test
`test_ttl_enable_error_with_tablets` has been removed.

Fixes scylladb/scylladb#16567