### PR TITLE
commitlog: Keep track of high RP for flush request on a per table basis

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2173,7 +2173,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
     }
 
     // Now get a set of used CF ids:
-    std::unordered_set<cf_id_type> ids;
+    std::unordered_map<cf_id_type, replay_position> ids;
 
     uint64_t n = size_to_remove;
     uint64_t flushing = 0;
@@ -2198,7 +2198,8 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
         flushing += size - waste;
 
         for (auto& id : s->_cf_dirty |  std::views::keys) {
-            ids.insert(id);
+            auto& target_high = ids[id];
+            target_high = std::max(target_high, rp);
         }
 
         if (size_to_remove != 0) {
@@ -2214,11 +2215,11 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
 
     // For each CF id: for each callback c: call c(id, high)
     for (auto& f : callbacks) {
-        for (auto& id : ids) {
+        for (auto& [id, hp] : ids) {
             try {
-                f(id, high);
+                f(id, hp);
             } catch (...) {
-                clogger.error("Exception during flush request {}/{}: {}", id, high, std::current_exception());
+                clogger.error("Exception during flush request {}/{}: {} ({})", id, hp, high, std::current_exception());
             }
         }
     }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -94,6 +94,8 @@ public:
     virtual void release_cf_count(const cf_id_type&, const replay_position&) = 0;
 };
 
+const db::replay_position db::replay_position::max = db::replay_position(std::numeric_limits<db::segment_id_type>::max(), std::numeric_limits<db::position_type>::max());
+
 db::commitlog::config db::commitlog::config::from_db_config(const db::config& cfg, seastar::scheduling_group sg, size_t shard_available_memory) {
     config c;
 

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2218,7 +2218,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
     }
 
     // Now get a set of used CF ids:
-    std::unordered_set<cf_id_type> ids;
+    std::unordered_map<cf_id_type, replay_position> ids;
 
     uint64_t n = size_to_remove;
     uint64_t flushing = 0;
@@ -2243,7 +2243,8 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
         flushing += size - waste;
 
         for (auto& id : s->_cf_dirty |  std::views::keys) {
-            ids.insert(id);
+            auto& target_high = ids[id];
+            target_high = std::max(target_high, rp);
         }
 
         if (size_to_remove != 0) {
@@ -2259,11 +2260,11 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
 
     // For each CF id: for each callback c: call c(id, high)
     for (auto& f : callbacks) {
-        for (auto& id : ids) {
+        for (auto& [id, hp] : ids) {
             try {
-                f(id, high);
+                f(id, hp);
             } catch (...) {
-                clogger.error("Exception during flush request {}/{}: {}", id, high, std::current_exception());
+                clogger.error("Exception during flush request {}/{}: {} ({})", id, hp, high, std::current_exception());
             }
         }
     }

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -55,6 +55,8 @@ struct replay_position {
 
     template <typename Describer>
     auto describe_type(sstables::sstable_version_types v, Describer f) { return f(id, pos); }
+
+    static const replay_position max;
 };
 
 class commitlog;

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -59,6 +59,8 @@ struct replay_position {
     bool valid() const {
         return id != 0 && pos != 0;
     }
+
+    static const replay_position max;
 };
 
 class commitlog;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -19,6 +19,7 @@
 #include "locator/tablets.hh"
 #include "sstables/sstable_set.hh"
 #include "utils/chunked_vector.hh"
+#include "db/commitlog/replay_position.hh"
 #include <absl/container/flat_hash_map.h>
 
 #pragma once
@@ -91,6 +92,8 @@ class compaction_group {
     bool _tombstone_gc_enabled = true;
     std::optional<compaction::compaction_backlog_tracker> _backlog_tracker;
     repair_classifier_func _repair_sstable_classifier;
+    db::replay_position _lowest_rp;
+    friend class table;
 private:
     std::unique_ptr<compaction_group_view> make_compacting_view();
     std::unique_ptr<compaction_group_view> make_non_compacting_view();
@@ -160,7 +163,7 @@ public:
     // Clear memtable(s) content
     future<> clear_memtables();
 
-    future<> flush() noexcept;
+    future<> flush(std::optional<db::replay_position> = {}) noexcept;
     bool can_flush() const;
     bool needs_flush() const;
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -21,6 +21,7 @@
 #include "replica/logstor/segment_manager.hh"
 #include "sstables/sstable_set.hh"
 #include "utils/chunked_vector.hh"
+#include "db/commitlog/replay_position.hh"
 #include <absl/container/flat_hash_map.h>
 
 #pragma once
@@ -105,6 +106,8 @@ class compaction_group {
     std::vector<future<>> _separator_flushes;
     seastar::semaphore _separator_flush_sem{1};
 
+    db::replay_position _lowest_rp;
+    friend class table;
 private:
     std::unique_ptr<compaction_group_view> make_compacting_view();
     std::unique_ptr<compaction_group_view> make_non_compacting_view();
@@ -174,7 +177,7 @@ public:
     // Clear memtable(s) content
     future<> clear_memtables();
 
-    future<> flush() noexcept;
+    future<> flush(std::optional<db::replay_position> = {}) noexcept;
     bool can_flush() const;
     bool needs_flush() const;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -526,8 +526,6 @@ private:
     db::replay_position _highest_rp;
     // Tracks the highest replay position flushed to a sstable
     db::replay_position _highest_flushed_rp;
-    // Tracks the highest position before flush actually starts
-    db::replay_position _flush_rp;
     db::replay_position _lowest_allowed_rp;
 
     // Provided by the database that owns this commitlog

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -530,8 +530,6 @@ private:
     db::replay_position _highest_rp;
     // Tracks the highest replay position flushed to a sstable
     db::replay_position _highest_flushed_rp;
-    // Tracks the highest position before flush actually starts
-    db::replay_position _flush_rp;
     db::replay_position _lowest_allowed_rp;
 
     // Provided by the database that owns this commitlog

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1853,7 +1853,14 @@ public:
 future<>
 table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) noexcept {
     auto old = cg.memtables()->back();
-    tlogger.debug("Sealing active memtable of {}.{}, partitions: {}, occupancy: {}", _schema->ks_name(), _schema->cf_name(), old->partition_count(), old->occupancy());
+    // Reset low marker for CL initiated flush here. As stated above, this function never
+    // fails, and even if it did, all we are saying is that the work of moving data from
+    // _lowest_rp -> wherever is now on us. In any case, actual segment release will not
+    // happen until success and the commitlog callback below
+    // If we are being flushed for any other reason, we still change the RP range
+    // remaining unflushed in the memtable_list (to none)
+    auto old_low = std::exchange(cg._lowest_rp, db::replay_position::max);
+    tlogger.debug("Sealing active memtable of {}.{}, partitions: {}, occupancy: {}, low_rp: {}", _schema->ks_name(), _schema->cf_name(), old->partition_count(), old->occupancy(), old_low);
 
     if (old->empty()) {
         tlogger.debug("Memtable is empty");
@@ -3184,6 +3191,7 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
     , _backlog_tracker(t.get_compaction_strategy().make_backlog_tracker())
     , _repair_sstable_classifier(std::move(repair_classifier))
     , _logstor_segments(make_lw_shared<logstor::segment_set>())
+    , _lowest_rp(db::replay_position::max)
 {
 }
 
@@ -4521,7 +4529,14 @@ future<table::snapshot_details> table::get_snapshot_details(fs::path snapshot_di
     co_return details;
 }
 
-future<> compaction_group::flush() noexcept {
+future<> compaction_group::flush(std::optional<db::replay_position> pos) noexcept {
+    if (pos && *pos < _lowest_rp) {
+        return make_ready_future<>();
+    }
+    // Note: _lowest_rp will be reset in seal_active_memtable.
+    // This is a little asymmetric, and not the prettiest. But since we
+    // set the flush function, I guess it is ok. Retaining low until then
+    // for logging purposes as well.
     try {
         return _memtables->flush();
     } catch (...) {
@@ -4570,17 +4585,13 @@ size_t storage_group::memtable_count() const {
 }
 
 future<> table::flush(std::optional<db::replay_position> pos) {
-    if (pos && *pos < _flush_rp) {
-        co_return;
-    }
     // There is nothing to flush if the table was stopped.
     if (_pending_flushes_phaser.is_closed()) {
         co_return;
     }
     auto op = _pending_flushes_phaser.start();
-    auto fp = _highest_rp;
-    co_await parallel_foreach_compaction_group(std::mem_fn(&compaction_group::flush));
-    _flush_rp = std::max(_flush_rp, fp);
+    // no std::bind_back in the clang version I'm on... :-(
+    co_await parallel_foreach_compaction_group([pos](auto& cg) { return cg.flush(pos); });
 }
 
 bool storage_group::can_flush() const {
@@ -5013,6 +5024,11 @@ void table::do_apply(compaction_group& cg, db::rp_handle&& h, Args&&... args) {
     check_valid_rp(rp);
     try {
         cg.memtables()->active_memtable().apply(std::forward<Args>(args)..., std::move(h));
+        // keep track of lowest written RP in compaction group. This is the new
+        // flush range guard.
+        cg._lowest_rp = std::min(cg._lowest_rp, rp);
+        // must also retain highest RP in table, since this is required for
+        // truncation etc.
         _highest_rp = std::max(_highest_rp, rp);
     } catch (...) {
         _failed_counter_applies_to_memtable++;


### PR DESCRIPTION
Refs #23656
Fixes #28421

Keep track of each table high RP individually, instead of using the max range of all segments being flush-requested. The idea is to allow some tables to ignore a subsequent flush, close after an earlier one, if no additional data has been added that falls under the range being fr:d.

Instead of keeping track of "high" flush position, keep track of lowest written
replay position per compaction group.
    
This helps ensures we don't hit aliasing issues when trying to filter out memtables from subsequent flush request, while previous flush is still pending.

Since a flush request from commit log will always be on segment boundary, unless we track exact low position in table/compaction group, we can get false overlap between memtable generations.

Moving the counter to compaction group also makes it possible to only "partially" flush a table, if different compaction group ranges have different CL segment usage (very rare, but...).

Note: since we only keep track of the "low" counter here, removing/adding/replacing a compaction group will not affect truncation or other bookkeep that relies on the table "high" counters.
