### PR TITLE
test.py: print out path to Scylla log for Python test suites

### DIFF
--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -213,7 +213,9 @@ class PythonTest(Test):
                     cc.execute(stmt)
                 cluster.prepare_cql_executed = True
             logger.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-            self.args.insert(0, "--host={}".format(cluster.endpoint()))
+            self.args.insert(0, f"--host={cluster.endpoint()}")
+            log_filename = next(server.log_filename for server in cluster.running.values())
+            self.args.insert(0, f"--scylla-log-filename={log_filename}")
             self.is_before_test_ok = True
             cluster.take_log_savepoint()
             status = await run_test(self, options, env=self.suite.scylla_env)


### PR DESCRIPTION
Test suites with `type: Python` are using single Scylla node created by test.py, but it's handy to print a path to a log file in pytest log too to make it easier to find the file on failures.

For example:

I added `assert False` at the beginning  of `broadcast_tables/test_broadcast_tables.py::test_broadcast_kv_store` to imitate a failure. In result, I got following line at the end of `testlog/dev/broadcast_tables.test_broadcast_tables.1.log`:

```
...
---------------------------- Captured log teardown -----------------------------
07:54:11.508 INFO>  ScyllaDB log file: /home/vagrant/PycharmProjects/scylladb/testlog/dev/scylla-1.log
...
```

And in the `testlog/test.py.dev.log`:

```
...
07:54:10.544 INFO> Starting test broadcast_tables.test_broadcast_tables.1: python --scylla-log-filename=/home/vagrant/PycharmProjects/scylladb/testlog/dev/scylla-1.log --host=127.64.217.1 -s --log-level=DEBUG -vv -o junit_family=xunit2 -o junit_suite_name=broadcast_tables --junit-xml=/home/vagrant/PycharmProjects/scylladb/testlog/dev/xml/broadcast_tables.test_broadcast_tables.1.xunit.xml -rs --run_id=1 --mode=dev --alluredir=/home/vagrant/PycharmProjects/scylladb/testlog/dev/allure test/broadcast_tables/test_broadcast_tables.py
...
```