### PR TITLE
test: Inherit sstable_assertions from sstables::test

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -665,6 +665,7 @@ private:
     // This should be called only before an sstable is sealed.
     void maybe_rebuild_filter_from_index(uint64_t num_partitions);
 
+    future<> read_toc() noexcept;
     future<> read_summary() noexcept;
 
     void write_summary() {
@@ -784,7 +785,6 @@ private:
     // runs in async context (called from storage::open)
     void write_toc(file_writer w);
 public:
-    future<> read_toc() noexcept;
 
     shareable_components& get_shared_components() const {
         return *_components;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -47,18 +47,17 @@
 
 using namespace sstables;
 
-class sstable_assertions final {
+class sstable_assertions final : public sstables::test {
     test_env& _env;
-    shared_sstable _sst;
 
     sstable_assertions(test_env& env, schema_ptr schema, const sstring& path, sstable_version_types version, sstables::generation_type generation)
-        : _env(env)
-        , _sst(_env.make_sstable(std::move(schema),
+        : test(env.make_sstable(std::move(schema),
                             path,
                             generation,
                             version,
                             sstable_format_types::big,
                             1))
+        , _env(env)
     { }
 public:
     sstable_assertions(test_env& env, schema_ptr schema, const sstring& path)
@@ -71,18 +70,6 @@ public:
 
     test_env& get_env() {
         return _env;
-    }
-    void read_toc() {
-        _sst->read_toc().get();
-    }
-    void read_summary() {
-        _sst->read_summary().get();
-    }
-    void read_filter() {
-        _sst->read_filter().get();
-    }
-    void read_statistics() {
-        _sst->read_statistics().get();
     }
     void load() {
         _sst->load(_sst->get_schema()->get_sharder()).get();
@@ -2649,7 +2636,7 @@ static thread_local const schema_ptr UNCOMPRESSED_SIMPLE_SCHEMA =
 SEASTAR_TEST_CASE(test_uncompressed_simple_read_toc) {
   return test_env::do_with_async([] (test_env& env) {
     sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
-    sst.read_toc();
+    sst.read_toc().get();
     using ct = component_type;
     sst.assert_toc({ct::Index,
                     ct::Data,
@@ -2665,24 +2652,24 @@ SEASTAR_TEST_CASE(test_uncompressed_simple_read_toc) {
 SEASTAR_TEST_CASE(test_uncompressed_simple_read_summary) {
   return test_env::do_with_async([] (test_env& env) {
     sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
-    sst.read_toc();
-    sst.read_summary();
+    sst.read_toc().get();
+    sst.read_summary().get();
   });
 }
 
 SEASTAR_TEST_CASE(test_uncompressed_simple_read_filter) {
   return test_env::do_with_async([] (test_env& env) {
     sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
-    sst.read_toc();
-    sst.read_filter();
+    sst.read_toc().get();
+    sst.read_filter().get();
   });
 }
 
 SEASTAR_TEST_CASE(test_uncompressed_simple_read_statistics) {
   return test_env::do_with_async([] (test_env& env) {
     sstable_assertions sst(env, UNCOMPRESSED_SIMPLE_SCHEMA, UNCOMPRESSED_SIMPLE_PATH);
-    sst.read_toc();
-    sst.read_statistics();
+    sst.read_toc().get();
+    sst.read_statistics().get();
   });
 }
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -107,7 +107,7 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         BOOST_REQUIRE(sst1_s.first_key.value == sst2_s.first_key.value);
         BOOST_REQUIRE(sst1_s.last_key.value == sst2_s.last_key.value);
 
-        sst2->read_toc().get();
+        sstables::test(sst2).read_toc().get();
         auto& sst1_c = sstables::test(sst).get_components();
         auto& sst2_c = sstables::test(sst2).get_components();
 

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -238,7 +238,7 @@ SEASTAR_TEST_CASE(check_statistics_func) {
 SEASTAR_TEST_CASE(check_toc_func) {
     auto s = make_schema_for_compressed_sstable();
     return write_and_validate_sst(std::move(s), "test/resource/sstables/compressed", [] (shared_sstable sst1, shared_sstable sst2) {
-        sst2->read_toc().get();
+        sstables::test(sst2).read_toc().get();
         auto& sst1_c = sstables::test(sst1).get_components();
         auto& sst2_c = sstables::test(sst2).get_components();
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -37,6 +37,7 @@ namespace sstables {
 using sstable_ptr = shared_sstable;
 
 class test {
+protected:
     sstable_ptr _sst;
 public:
 
@@ -89,6 +90,14 @@ public:
 
     future<> read_summary() noexcept {
         return _sst->read_summary();
+    }
+
+    future<> read_toc() {
+        return _sst->read_toc();
+    }
+
+    future<> read_filter() {
+        return _sst->read_filter();
     }
 
     future<summary_entry&> read_summary_entry(size_t i) {


### PR DESCRIPTION
The latter class is invented to let tests access private fields of an sstable (mostly methods). The former is in fact an extended version of that also does some checks. Howerver, they don't inherit from each other, and the sstable_assertions partially duplicates some funtionality of the test one.

Add the inheritance, remove the duplicated methods from the child class, update the callers (the test class returns future<>s, the assertions one "knows" it runs in seastar thread) and marm sstable::read_toc() private.
