### PR TITLE
raft: fix the data center remaining nodes initialization

### DIFF
--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -160,7 +160,10 @@ class datacenter_info {
     using racks_store_t = std::priority_queue<rack_info>;
     racks_store_t _racks;
 
-    static racks_store_t create_racks_list(std::ranges::input_range auto&& nodes, size_t nodes_remaining) {
+    static racks_store_t create_racks_list(std::ranges::input_range auto&& nodes, size_t* nodes_remaining) {
+        SCYLLA_ASSERT(nodes_remaining != nullptr);
+        *nodes_remaining = 0;
+
         const auto nodes_by_rack = nodes | std::views::transform([](const auto& node_entry) {
             const auto& [id, node] = node_entry;
             return std::make_pair(std::string_view{node.rack}, std::make_pair(id, std::cref(node)));
@@ -175,7 +178,7 @@ class datacenter_info {
                 return node_entry.second;
             }));
 
-            nodes_remaining += std::distance(first, last);
+            *nodes_remaining += std::distance(first, last);
         }
 
         return racks | std::ranges::to<racks_store_t>();
@@ -183,7 +186,7 @@ class datacenter_info {
 
 public:
     explicit datacenter_info(std::ranges::input_range auto&& nodes)
-        : _racks(create_racks_list(nodes, _nodes_remaining)) {
+        : _racks(create_racks_list(nodes, &_nodes_remaining)) {
     }
 
     // Select the "best" next voter from the datacenter
@@ -208,6 +211,8 @@ public:
             if (rack.has_more_candidates()) {
                 _racks.push(rack);
             }
+
+            SCYLLA_ASSERT(_nodes_remaining > 0);
 
             --_nodes_remaining;
             ++_voters_count;


### PR DESCRIPTION
The initialization of the data center `_remaining_nodes` attribute was not performed correctly, as the parameter has been passed by value to the initialization function (instead of by reference or pointer).

This lead to it being left initialized to zero, which caused the underflow when decrementing the value.

This bug didn't have a significant impact on the behavior, as there are also other guards (like for example capping the max voters per data center by the total amount of nodes) that have hidden this issue.

However it could lead to some inefficiencies in the code, as the remaining nodes check would not trigger.

Fixes: scylladb/scylladb#23702

No backport: The bug is only present in the master, so there is no need bor backport.