### PR TITLE
generic_server: Don't mess with db::config

### DIFF
--- a/generic_server.cc
+++ b/generic_server.cc
@@ -17,8 +17,6 @@
 #include <seastar/core/smp.hh>
 #include <utility>
 
-#include "db/config.hh"
-
 namespace generic_server {
 
 class counted_data_source_impl : public data_source_impl {
@@ -235,17 +233,6 @@ future<> connection::shutdown()
     } catch (...) {
     }
     return make_ready_future<>();
-}
-
-config::config(const db::config& cfg)
-    : uninitialized_connections_semaphore_cpu_concurrency(
-            cfg.uninitialized_connections_semaphore_cpu_concurrency)
-{
-}
-
-config::config(uint32_t uninitialized_connections_semaphore_cpu_concurrency)
-    : uninitialized_connections_semaphore_cpu_concurrency(
-            uninitialized_connections_semaphore_cpu_concurrency) {
 }
 
 server::server(const sstring& server_name, logging::logger& logger, config cfg)

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include "db/config.hh"
 #include "utils/log.hh"
 
 #include "seastarx.hh"
@@ -83,9 +82,6 @@ public:
 
 struct config {
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
-
-    explicit config(const db::config& cfg);
-    explicit config(uint32_t uninitialized_connections_semaphore_cpu_concurrency);
 };
 
 // A generic TCP socket server.

--- a/redis/server.cc
+++ b/redis/server.cc
@@ -13,6 +13,7 @@
 #include "redis/reply.hh"
 
 #include "db/consistency_level_type.hh"
+#include "db/config.hh"
 
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -30,7 +31,7 @@ namespace redis_transport {
 static logging::logger logging("redis_server");
 
 redis_server::redis_server(seastar::sharded<redis::query_processor>& qp, auth::service& auth_service, const db::config& cfg, redis_server_config config)
-    : server("Redis", logging, generic_server::config(cfg))
+    : server("Redis", logging, generic_server::config{cfg.uninitialized_connections_semaphore_cpu_concurrency})
     , _query_processor(qp)
     , _config(std::move(config))
     , _max_request_size(_config._max_request_size)

--- a/test/boost/generic_server_test.cc
+++ b/test/boost/generic_server_test.cc
@@ -24,7 +24,7 @@ static logger test_logger("test_server");
 
 class test_server : public server {
 public:
-    test_server(const db::config& cfg) : server("test_server", test_logger, config(cfg)) {};
+    test_server(const utils::updateable_value_source<uint32_t>& c) : server("test_server", test_logger, config{utils::updateable_value<uint32_t>(c)}) {};
 protected:
     [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override {
         SCYLLA_ASSERT(false);
@@ -32,8 +32,8 @@ protected:
 };
 
 SEASTAR_TEST_CASE(stop_without_listening) {
-    db::config cfg;
-    test_server srv(cfg);
+    utils::updateable_value_source<uint32_t> concurrency(1);
+    test_server srv(concurrency);
     co_await with_timeout(lowres_clock::now() + 5min, srv.stop());
     co_return;
 }

--- a/test/perf/perf_generic_server.cc
+++ b/test/perf/perf_generic_server.cc
@@ -73,7 +73,7 @@ public:
 
     test_server(const test_config& conf)
     : generic_server::server("test_server", plog,
-            generic_server::config(std::numeric_limits<uint32_t>::max()))
+            generic_server::config{utils::updateable_value<uint32_t>(std::numeric_limits<uint32_t>::max())})
     , _conf(conf) {}
 };
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -247,7 +247,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
-    : server("CQLServer", clogger, generic_server::config(db_cfg))
+    : server("CQLServer", clogger, generic_server::config{db_cfg.uninitialized_connections_semaphore_cpu_concurrency})
     , _query_processor(qp)
     , _config(std::move(config))
     , _max_request_size(_config.max_request_size)


### PR DESCRIPTION
The db::config is top-level configuration of scylla, we generally try to avoid using it even in scylla components: each uses its own config initialized by the service creator out of the db::config itself. The generic_server is not an exception, all the more so, it already has its own config.
