### PR TITLE
tablets: Equalize per-table balance when allocating tablets for a new table

### DIFF
--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -120,8 +120,10 @@ public:
         co_await utils::clear_gently(_nodes);
 
         if (only_table) {
-            auto& tmap = _tm->tablets().get_tablet_map(*only_table);
-            co_await populate_table(tmap, host, only_dc);
+            if (_tm->tablets().has_tablet_map(*only_table)) {
+                auto& tmap = _tm->tablets().get_tablet_map(*only_table);
+                co_await populate_table(tmap, host, only_dc);
+            }
         } else {
             for (auto&& [table, tmap]: _tm->tablets().all_tables()) {
                 co_await populate_table(*tmap, host, only_dc);

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -308,7 +308,7 @@ future<tablet_map> network_topology_strategy::allocate_tablets_for_new_table(sch
 future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, token_metadata_ptr tm, tablet_map tablets) const {
     natural_endpoints_tracker::check_enough_endpoints(*tm, _dc_rep_factor);
     load_sketch load(tm);
-    co_await load.populate();
+    co_await load.populate(std::nullopt, s->id());
 
     tablet_logger.debug("Allocating tablets for {}.{} ({}): dc_rep_factor={} tablet_count={}", s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets.tablet_count());
 

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -269,6 +269,10 @@ const tablet_map& tablet_metadata::get_tablet_map(table_id id) const {
     }
 }
 
+bool tablet_metadata::has_tablet_map(table_id id) const {
+    return _tablets.contains(id);
+}
+
 void tablet_metadata::mutate_tablet_map(table_id id, noncopyable_function<void(tablet_map&)> func) {
     auto it = _tablets.find(id);
     if (it == _tablets.end()) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -624,6 +624,7 @@ private:
 public:
     bool balancing_enabled() const { return _balancing_enabled; }
     const tablet_map& get_tablet_map(table_id id) const;
+    bool has_tablet_map(table_id id) const;
     const table_to_tablet_map& all_tables() const { return _tablets; }
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2634,41 +2634,25 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         topology_builder topo(e);
         shared_load_stats& load_stats = topo.get_shared_load_stats();
 
-        std::vector<host_id> hosts;
-
-        uint64_t i4i_2xlarge_cap = 1'875'000'000'000;
-        uint64_t i4i_large_cap = 468'000'000'000;
-
-        auto add_i4i_2xlarge = [&] (endpoint_dc_rack rack) {
-            auto h = topo.add_node(node_state::normal, 7, rack);
-            load_stats.set_capacity(h, i4i_2xlarge_cap);
-            hosts.push_back(h);
-        };
-
-        auto add_i4i_large = [&] (endpoint_dc_rack rack) {
-            auto h = topo.add_node(node_state::normal, 2, rack);
-            load_stats.set_capacity(h, i4i_large_cap);
-            hosts.push_back(h);
-        };
-
         auto rack1 = topo.rack();
         auto rack2 = topo.start_new_rack();
         auto rack3 = topo.start_new_rack();
 
-        add_i4i_2xlarge(rack1);
-        add_i4i_2xlarge(rack2);
-        add_i4i_2xlarge(rack3);
+        topo.add_i4i_2xlarge(rack1);
+        topo.add_i4i_2xlarge(rack2);
+        topo.add_i4i_2xlarge(rack3);
 
         auto& stm = e.shared_token_metadata().local();
 
         auto ks_name = add_keyspace(e, {{topo.dc(), 3}});
         auto table1 = add_table(e, ks_name).get();
 
-        load_stats.set_size(table1, 0.9 * i4i_2xlarge_cap);
+        load_stats.set_size(table1, 0.9 * topo.get_capacity() / 3);
         rebalance_tablets(e, &load_stats);
         testlog.info("Initial cluster ready");
 
         std::unordered_map<host_id, double> initial_utilization;
+        auto& hosts = topo.hosts();
         {
             load_sketch load(stm.get());
             load.populate().get();
@@ -2679,7 +2663,7 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
             }
         }
 
-        add_i4i_large(rack1);
+        topo.add_i4i_large(rack1);
         rebalance_tablets(e, &load_stats);
         testlog.info("Expanded capacity in rack1");
 
@@ -2696,7 +2680,7 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
                              initial_utilization[hosts[2]]);
         }
 
-        add_i4i_large(rack2);
+        topo.add_i4i_large(rack2);
         rebalance_tablets(e, &load_stats);
         testlog.info("Expanded capacity in rack2");
 
@@ -2712,7 +2696,7 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
                              initial_utilization[hosts[2]]);
         }
 
-        add_i4i_large(rack3);
+        topo.add_i4i_large(rack3);
         rebalance_tablets(e, &load_stats);
         testlog.info("Expanded capacity in rack3");
 
@@ -2744,30 +2728,13 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
         topology_builder topo(e);
         shared_load_stats& load_stats = topo.get_shared_load_stats();
 
-        std::vector<host_id> hosts;
-
-        uint64_t i4i_2xlarge_cap = 1'875'000'000'000;
-        uint64_t i4i_large_cap = 468'000'000'000;
-
-        auto add_i4i_2xlarge = [&] (endpoint_dc_rack rack) {
-            auto h = topo.add_node(node_state::normal, 7, rack);
-            load_stats.set_capacity(h, i4i_2xlarge_cap);
-            hosts.push_back(h);
-        };
-
-        auto add_i4i_large = [&] (endpoint_dc_rack rack) {
-            auto h = topo.add_node(node_state::normal, 2, rack);
-            load_stats.set_capacity(h, i4i_large_cap);
-            hosts.push_back(h);
-        };
-
         auto rack1 = topo.rack();
         auto rack2 = topo.start_new_rack();
         auto rack3 = topo.start_new_rack();
 
-        add_i4i_2xlarge(rack1);
-        add_i4i_2xlarge(rack2);
-        add_i4i_2xlarge(rack3);
+        topo.add_i4i_2xlarge(rack1);
+        topo.add_i4i_2xlarge(rack2);
+        topo.add_i4i_2xlarge(rack3);
 
         auto& stm = e.shared_token_metadata().local();
 
@@ -2776,14 +2743,16 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
         load_stats.set_size(table1, 0);
         testlog.info("Initial cluster ready");
 
-        add_i4i_large(rack1);
-        add_i4i_large(rack2);
-        add_i4i_large(rack3);
+        topo.add_i4i_large(rack1);
+        topo.add_i4i_large(rack2);
+        topo.add_i4i_large(rack3);
         rebalance_tablets(e, &load_stats);
         testlog.info("Expanded capacity");
 
         auto ks2_name = add_keyspace(e, {{topo.dc(), 3}}, 128);
         auto table2 = add_table(e, ks2_name).get();
+
+        auto& hosts = topo.hosts();
 
         {
             load_sketch load(stm.get());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2773,6 +2773,52 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
     }).get();
 }
 
+// Reproduces https://github.com/scylladb/scylladb/issues/23631
+SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbalanced) {
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+
+        auto rack1 = topo.rack();
+        auto rack2 = topo.start_new_rack();
+        auto rack3 = topo.start_new_rack();
+
+        topo.add_i4i_2xlarge(rack1);
+        topo.add_i4i_2xlarge(rack2);
+        topo.add_i4i_2xlarge(rack3);
+
+        auto& stm = e.shared_token_metadata().local();
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 3}}, 512);
+        auto table1 = add_table(e, ks_name).get();
+        load_stats.set_size(table1, topo.get_capacity() * 0.8 / 3);
+        testlog.info("Initial cluster ready");
+
+        topo.add_i4i_large(rack1);
+        topo.add_i4i_large(rack2);
+        topo.add_i4i_large(rack3);
+        testlog.info("Expanded capacity");
+
+        auto ks2_name = add_keyspace(e, {{topo.dc(), 3}});
+        auto table2 = add_table(e, ks2_name).get();
+
+        auto& hosts = topo.hosts();
+
+        {
+            load_sketch load(stm.get());
+            load.populate(std::nullopt, table2).get();
+
+            min_max_tracker<double> node_utilization;
+            for (auto h : hosts) {
+                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                testlog.info("table2: {}: {}", h, u);
+                node_utilization.update(u.value_or(0));
+            }
+            BOOST_REQUIRE_LT(node_utilization.max() - node_utilization.min(), 0.13);
+        }
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
     do_with_cql_env_thread([] (auto& e) {
         auto per_shard_goal = e.local_db().get_config().tablets_per_shard_goal();


### PR DESCRIPTION
Fixes the following scenario:

1. Scale out adds new nodes to each rack
2. Table is created - all tablets are allocated to new nodes because they have low load
3. Rebalancing moves tablets from old nodes to new nodes - table balance for the new table is not fixed

We're wrong to try to equalize global load when allocating tablets,
and we should equalize per-table load instead, and let background load
balancing fix it in a fair way. It will add to the allocated storage
imbalance, but:

1. The table is initially empty, so doesn't impact actual storage imbalance.
2. It's more important to avoid overloading CPU on the nodes - imbalance hurts this aspect immediately.
3. If the table was created before imbalance was formed, we would end up in the same situation as in the problematic scenario after the patch.
4. It's the job of the load balancing to keep up with storage growing, and if it's not, scale out should kick in.

Before we have CPU-aware tablet allocation, and thus can prove we have
CPU capacity on the small nodes, we should respect per-table balance
as this is the way in which we achieve full CPU utilization.

Fixes #23631

Backport to 2025.1 because load imbalance is a serious problem in production.