### PR TITLE
s3: remove an extraneous space

### DIFF
--- a/utils/s3/retryable_http_client.cc
+++ b/utils/s3/retryable_http_client.cc
@@ -62,7 +62,7 @@ future<> retryable_http_client::do_retryable_request(http::request req, http::ex
             request_ex = aws_exception(aws_error{aws_error_type::UNKNOWN, format("{}", e), retryable::no});
         }
 
-        if (!co_await  _retry_strategy.should_retry(request_ex.error(), retries)) {
+        if (!co_await _retry_strategy.should_retry(request_ex.error(), retries)) {
             break;
         }
         co_await seastar::sleep(_retry_strategy.delay_before_retry(request_ex.error(), retries));


### PR DESCRIPTION
it's a cleanup, hence no need to backport.