### PR TITLE
raft: make group0 Raft operation timeout configurable

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -942,6 +942,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The default timeout for other, miscellaneous operations.\n"
         "\n"
         "Related information: About hinted handoff writes")
+    , group0_raft_op_timeout_in_ms(this, "group0_raft_op_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 60000,
+            "The time in milliseconds that group0 allows a Raft operation to complete.")
     /**
     * @Group Inter-node settings
     */

--- a/db/config.hh
+++ b/db/config.hh
@@ -323,6 +323,7 @@ public:
     named_value<uint32_t> truncate_request_timeout_in_ms;
     named_value<uint32_t> write_request_timeout_in_ms;
     named_value<uint32_t> request_timeout_in_ms;
+    named_value<uint32_t> group0_raft_op_timeout_in_ms;
     named_value<bool> cross_node_timeout;
     named_value<uint32_t> internode_send_buff_size_in_bytes;
     named_value<uint32_t> internode_recv_buff_size_in_bytes;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -268,17 +268,13 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
 
     // initialize the corresponding timer to tick the raft server instance
     auto ticker = std::make_unique<raft_ticker_type>([srv = server.get()] { srv->tick(); });
-    lowres_clock::duration default_op_timeout = std::chrono::minutes(1);
-    if (const auto ms = utils::get_local_injector().inject_parameter<int64_t>("group0-raft-op-timeout-in-ms"); ms) {
-        default_op_timeout = std::chrono::milliseconds(*ms);
-    }
     return raft_server_for_group{
         .gid = std::move(gid),
         .server = std::move(server),
         .ticker = std::move(ticker),
         .rpc = rpc_ref,
         .persistence = persistence_ref,
-        .default_op_timeout = default_op_timeout
+        .default_op_timeout_in_ms = qp.proxy().get_db().local().get_config().group0_raft_op_timeout_in_ms
     };
 }
 

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -445,12 +445,12 @@ raft_server_with_timeouts::run_with_timeout(Op&& op, const char* op_name,
         co_return co_await op(as);
     }
     if (!timeout->value) {
-        if (!_group_server.default_op_timeout) {
+        if (!_group_server.default_op_timeout_in_ms) {
             on_internal_error(rslog, ::format("raft operation [{}], timeout requested at [{}],"
                                               "but no value for it has been defined",
                 op_name, fmt_loc(timeout->loc)));
         }
-        timeout->value = lowres_clock::now() + _group_server.default_op_timeout.value();
+        timeout->value = lowres_clock::now() + std::chrono::milliseconds(_group_server.default_op_timeout_in_ms->get());
     }
     utils::composite_abort_source composite_as;
 

--- a/service/raft/raft_group_registry.hh
+++ b/service/raft/raft_group_registry.hh
@@ -17,6 +17,7 @@
 #include "utils/recent_entries_map.hh"
 #include "service/direct_failure_detector/failure_detector.hh"
 #include "service/raft/group0_fwd.hh"
+#include "utils/updateable_value.hh"
 
 namespace db {
 class system_keyspace;
@@ -51,7 +52,7 @@ struct raft_server_for_group {
     raft_rpc& rpc;
     raft_sys_table_storage& persistence;
     std::optional<seastar::future<>> aborted;
-    std::optional<lowres_clock::duration> default_op_timeout;
+    std::optional<utils::updateable_value<uint32_t>> default_op_timeout_in_ms;
 };
 
 class raft_operation_timeout_error : public std::runtime_error {
@@ -67,7 +68,7 @@ class raft_operation_timeout_error : public std::runtime_error {
 // to calling the original raft methods without timeout.
 // Passing raft_timeout{} means 'use default timeout for this group', which is taken
 // from raft_server_for_group::default_op_timeout. For group0 default_op_timeout
-// is set to 1 minute and can be overridden in tests through the group0-raft-op-timeout-in-ms injection.
+// is set to 1 minute and can be overridden through the group0_raft_op_timeout_in_ms option.
 // A custom timeout can be passed via raft_timeout::value, it will take precedence over
 // the default timeout default_op_timeout.
 // If no default_op_timeout is configured for a group and raft_timeout{} is passed without

--- a/test/boost/user_types_test.cc
+++ b/test/boost/user_types_test.cc
@@ -111,10 +111,9 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
     // this may take a while in debug builds,
     // to avoid raft operation timeout set the threshold
     // to some big value.
-    co_await utils::get_local_injector().enable_on_all("group0-raft-op-timeout-in-ms", false, {
-        {"value", "600000" } // ten minutes
-    });
-
+    auto db_cfg_ptr = make_shared<db::config>();
+    auto& db_cfg = *db_cfg_ptr;
+    db_cfg.group0_raft_op_timeout_in_ms(600000); // ten minutes
     co_await do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create type ut1 (a int)").discard_result().get();
 
@@ -219,7 +218,7 @@ SEASTAR_TEST_CASE(test_invalid_user_type_statements) {
         e.execute_cql("create table cf4 (pk int, ck frozen<ut8>, primary key(pk, ck))").discard_result().get();
         REQUIRE_INVALID(e, "alter type ut8 add d duration",
                 "Cannot add new field to type ks.ut8 because it is used in the clustering key column ck of table ks.cf4 where durations are not allowed");
-    });
+    }, db_cfg_ptr);
 }
 
 SEASTAR_TEST_CASE(test_drop_user_type_used_in_udf) {

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -42,11 +42,8 @@ async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int)
 
     config = {
         'direct_failure_detector_ping_timeout_in_ms': 300,
+        'group0_raft_op_timeout_in_ms': raft_op_timeout,
         'error_injections_at_startup': [
-            {
-                'name': 'group0-raft-op-timeout-in-ms',
-                'value': raft_op_timeout
-            },
             {
                 'name': 'raft-group-registry-fd-threshold-in-ms',
                 'value': '500'
@@ -78,11 +75,8 @@ async def test_cannot_add_new_node(manager: ManagerClient, raft_op_timeout: int)
 @skip_mode('debug', 'aarch64/debug is unpredictably slow', platform_key='aarch64')
 async def test_quorum_lost_during_node_join(manager: ManagerClient, raft_op_timeout: int) -> None:
     config = {
+        'group0_raft_op_timeout_in_ms': raft_op_timeout,
         'error_injections_at_startup': [
-            {
-                'name': 'group0-raft-op-timeout-in-ms',
-                'value': raft_op_timeout
-            },
             {
                 'name': 'raft-group-registry-fd-threshold-in-ms',
                 'value': '500'
@@ -130,11 +124,8 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ManagerCli
 
     logger.info("adding a third node")
     servers += [await manager.server_add(config={
+        'group0_raft_op_timeout_in_ms': raft_op_timeout,
         'error_injections_at_startup': [
-            {
-                'name': 'group0-raft-op-timeout-in-ms',
-                'value': raft_op_timeout
-            },
             {
                 'name': 'raft-group-registry-fd-threshold-in-ms',
                 'value': '500'
@@ -174,11 +165,8 @@ async def test_quorum_lost_during_node_join_response_handler(manager: ManagerCli
 async def test_cannot_run_operations(manager: ManagerClient, raft_op_timeout: int) -> None:
     logger.info("starting a first node (the leader)")
     servers = [await manager.server_add(config={
+        'group0_raft_op_timeout_in_ms': raft_op_timeout,
         'error_injections_at_startup': [
-            {
-                'name': 'group0-raft-op-timeout-in-ms',
-                'value': raft_op_timeout
-            },
             {
                 'name': 'raft-group-registry-fd-threshold-in-ms',
                 'value': '500'

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -306,6 +306,7 @@ def run_scylla_cmd(pid, dir):
         '--write-request-timeout-in-ms', '300000',
         '--request-timeout-in-ms', '300000',
         '--user-defined-function-time-limit-ms', '1000',
+        '--group0-raft-op-timeout-in-ms=300000',
         # Allow testing experimental features. Following issue #9467, we need
         # to add here specific experimental features as they are introduced.
         # Note that Alternator-specific experimental features are listed in
@@ -393,6 +394,8 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.append('--force-schema-commit-log=true')
     if major < [2025,1]:
         cmd.remove('--tablets-initial-scale-factor=1')
+    if major < [2025,2]:
+        cmd.remove('--group0-raft-op-timeout-in-ms=300000')
     return (cmd, env)
 
 # Get a Cluster object to connect to CQL at the given IP address (and with

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -118,6 +118,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'truncate_request_timeout_in_ms': request_timeout_in_ms,
         'write_request_timeout_in_ms': request_timeout_in_ms,
         'request_timeout_in_ms': request_timeout_in_ms,
+        'group0_raft_op_timeout_in_ms': 300000,
         'user_defined_function_time_limit_ms': 1000,
 
         'strict_allow_filtering': True,


### PR DESCRIPTION
A recent commit 370707b111a614a79a0cd23f78fff406d6b9a0cf (re)introduced a timeout for every group0 Raft operation. This timeout was set to 60 seconds, which, paraphrasing Bill Gates, "ought to be enough for anybody".

However, one of the things we do as a group0 operation is schema changes, and we already noticed a few years ago, see commit 0b2cf21932c49ee29bd5afadd37e0a07fa0b900e, that in some extremely overloaded test machines where tests run hundreds of times (!) slower than usual, a single big schema operation - such as Alternator's DeleteTable deleting a table and multiple of its CDC or view tables - sometimes takes more than 60 seconds. The above fix changed the client's timeout to wait for 300 seconds instead of 60 seconds, but now we also need to increase our Raft timeout, or the server can time out. We've seen this happening recently making some tests flaky in CI (issue #23543).

So let's make this timeout configurable, as a new configuration option group0_raft_op_timeout_in_ms. This option defaults to 60000 (i.e, 60 seconds), the same as the existing default. The test framework overrides this default with a a higher 300 second timeout, matching the client-side timeout.

Before this patch, this timeout was already configurable in a strange way, using injections. But this was a misstep: We already have more than a dozen timeouts configurable through the normal configration, and this one should have been configured in the same way. There is nothing "holy" about the default of 60 seconds we chose, and who knows maybe in the future we might need to tweek it in the field, just like we made the other timeouts tweakable. Injections cannot be used in release mode, but configuration options can.

Fixes #23543

No need to backport because 370707b111a614a79a0cd23f78fff406d6b9a0cf is a recent change which was not backported 2025.1. If that commit ever does get backported, this one would need to be backported as well (our backporting process has no way to remember that fact, unfortunately).