### PR TITLE
backup: Optimize S3 throughput with shard-based upload

### DIFF
--- a/db/snapshot-ctl.cc
+++ b/db/snapshot-ctl.cc
@@ -142,7 +142,6 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
     }
 
     co_await coroutine::switch_to(_config.backup_sched_group);
-    auto cln = _storage_manager.get_endpoint_client(endpoint);
     snap_log.info("Backup sstables from {}({}) to {}", keyspace, snapshot_name, endpoint);
     auto global_table = co_await get_table_on_all_shards(_db, keyspace, table);
     auto& storage_options = global_table->get_storage_options();
@@ -172,7 +171,7 @@ future<tasks::task_id> snapshot_ctl::start_backup(sstring endpoint, sstring buck
                 sstables::snapshots_dir /
                 std::string_view(snapshot_name));
     auto task = co_await _task_manager_module->make_and_start_task<::db::snapshot::backup_task_impl>(
-        {}, *this, std::move(cln), std::move(bucket), std::move(prefix), keyspace, dir, global_table->schema()->id(), move_files);
+        {}, *this, _storage_manager.container(), std::move(endpoint), std::move(bucket), std::move(prefix), keyspace, dir, global_table->schema()->id(), move_files);
     co_return task->id();
 }
 

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -31,7 +31,8 @@ namespace db::snapshot {
 
 backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
                                    snapshot_ctl& ctl,
-                                   shared_ptr<s3::client> client,
+                                   sharded<sstables::storage_manager>& sstm,
+                                   sstring endpoint,
                                    sstring bucket,
                                    sstring prefix,
                                    sstring ks,
@@ -40,7 +41,9 @@ backup_task_impl::backup_task_impl(tasks::task_manager::module_ptr module,
                                    bool move_files) noexcept
     : tasks::task_manager::task::impl(module, tasks::task_id::create_random_id(), 0, "node", ks, "", "", tasks::task_id::create_null_id())
     , _snap_ctl(ctl)
-    , _client(std::move(client))
+    , _sstm(sstm)
+    , _endpoint(std::move(endpoint))
+    , _client(_sstm.local().get_endpoint_client(_endpoint))
     , _bucket(std::move(bucket))
     , _prefix(std::move(prefix))
     , _snapshot_dir(std::move(snapshot_dir))

--- a/db/snapshot/backup_task.hh
+++ b/db/snapshot/backup_task.hh
@@ -40,6 +40,8 @@ namespace snapshot {
 
 class backup_task_impl : public tasks::task_manager::task::impl {
     snapshot_ctl& _snap_ctl;
+    sharded<sstables::storage_manager>& _sstm;
+    sstring _endpoint;
     shared_ptr<s3::client> _client;
     sstring _bucket;
     sstring _prefix;
@@ -94,7 +96,8 @@ protected:
 public:
     backup_task_impl(tasks::task_manager::module_ptr module,
                      snapshot_ctl& ctl,
-                     shared_ptr<s3::client> cln,
+                     sharded<sstables::storage_manager>& sstm,
+                     sstring endpoint,
                      sstring bucket,
                      sstring prefix,
                      sstring ks,

--- a/utils/s3/client_fwd.hh
+++ b/utils/s3/client_fwd.hh
@@ -15,5 +15,6 @@ class client;
 struct upload_progress {
     size_t total = 0;
     size_t uploaded = 0;
+    upload_progress operator+(const upload_progress& other) const { return {total + other.total, uploaded + other.uploaded}; }
 };
 }


### PR DESCRIPTION
This PR enhances S3 throughput by leveraging every available shard to upload backup files concurrently. By distributing the load across multiple shards, we significantly improve the upload performance. Each shard retrieves an SSTable and processes its files sequentially, ensuring efficient, file-by-file uploads.

To prevent uncontrolled fiber creation and potential resource exhaustion, the backup task employs a directory semaphore from the sstables_manager. This mechanism helps regulate concurrency at the directory level, ensuring stable and predictable performance during large-scale backup operations.

Refs #22460
fixes: #22520

## Quick perf comparison

```
===========================================
 Release build, master, smp-16, mem-32GiB
 Bytes: 2342880184, backup time: 9.51 s
===========================================
 Release build, this PR, smp-16, mem-32GiB
 Bytes: 2342891015, backup time: 1.23 s
===========================================
```
Looks like it is faster at least x7.7

No backport needed since it (native backup) is still unused functionality
