### PR TITLE
db, service: do not include unused header

### DIFF
--- a/db/config.hh
+++ b/db/config.hh
@@ -21,7 +21,6 @@
 #include "utils/enum_option.hh"
 #include "gms/inet_address.hh"
 #include "db/hints/host_filter.hh"
-#include "utils/updateable_value.hh"
 #include "utils/s3/creds.hh"
 #include "utils/error_injection.hh"
 #include "utils/dict_trainer.hh"

--- a/service/raft/group0_voter_handler.hh
+++ b/service/raft/group0_voter_handler.hh
@@ -13,9 +13,6 @@
 #include "raft/raft.hh"
 #include "service/topology_state_machine.hh"
 
-#include <seastar/core/coroutine.hh>
-
-
 namespace gms {
 class gossiper;
 class feature_service;


### PR DESCRIPTION
these unused headers were flagged by clang-include-cleaner.

---

it's a cleanup, hence no need to backport.