### PR TITLE
test: add OpenSearch to the toolchain

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -14,6 +14,7 @@ import tempfile
 import platform
 import urllib.parse
 from multiprocessing import Event, Process
+from opensearchpy import OpenSearch
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test.pylib.random_tables import RandomTables
@@ -329,3 +330,20 @@ async def prepare_3_nodes_cluster(request, manager):
 async def prepare_3_racks_cluster(request, manager):
     if request.node.get_closest_marker("prepare_3_racks_cluster"):
         await manager.servers_add(3, auto_rack_dc="dc1")
+
+
+@pytest.fixture(scope="function")
+async def opensearch():
+    client = OpenSearch(
+        hosts = [{'host': '127.0.0.1', 'port': '9200'}],
+        http_compress = True,
+        use_ssl = False,
+        verify_certs = False,
+        ssl_assert_hostname = False,
+        ssl_show_warn = False
+    )
+
+    try:
+        yield client
+    finally:
+        client.close()

--- a/test/cluster/test_opensearch.py
+++ b/test/cluster/test_opensearch.py
@@ -1,0 +1,28 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import pytest
+
+@pytest.mark.asyncio
+async def test_opensearch_basic(opensearch):
+
+    index_name = 'test-index'
+    index_body = {
+        'settings': {
+            'index': {
+            'number_of_shards': 4
+            }
+        }
+    }
+
+    response = opensearch.indices.create(index_name, body=index_body)
+    print(f"Index creation response: {response}")
+
+    response = opensearch.cat.indices(format='json')
+    for index in response:
+        print(index['index'])
+
+    response = opensearch.indices.delete(index=index_name)
+    print(f"Index deletion response: {response}")

--- a/test/pylib/opensearch_cluster.py
+++ b/test/pylib/opensearch_cluster.py
@@ -1,0 +1,138 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+"""OpenSearch cluster for testing.
+   Provides helpers to setup and manage OpenSearch cluster for testing.
+"""
+import argparse
+import asyncio
+from asyncio.subprocess import Process
+from typing import Optional
+import logging
+import pathlib
+import shutil
+import time
+import tempfile
+import urllib.request
+from io import BufferedWriter
+
+class OpenSearchCluster:
+
+    log_file: BufferedWriter
+
+    def __init__(self, tempdir_base, address, logger):
+        self.compose_file = next(
+            (f for f in pathlib.Path('./test/').rglob('opensearch.yml') if f.is_file())
+        )
+        self.docker_exe = shutil.which('podman')
+        self.address = address
+        self.port = 9200
+        tempdir = tempfile.mkdtemp(dir=tempdir_base, prefix="opensearch-")
+        self.tempdir = pathlib.Path(tempdir)
+        self.logger = logger
+        self.cmd: Optional[Process] = None
+        self.log_filename = (self.tempdir / 'opensearch').with_suffix(".log")
+
+    def __repr__(self):
+        return f"[opensearch] {self.address}:{self.port}"
+
+    def check_server(self, port):
+        try:
+            with urllib.request.urlopen(f'http://{self.address}:{port}', timeout=2) as response:
+                return response.status == 200
+        except Exception:
+            return False
+
+    async def _run_cluster(self, port):
+        self.logger.info(f'Starting OpenSearch cluster at {self.address}:{port}')
+        cmd = await asyncio.create_subprocess_exec(
+            self.docker_exe,
+            *['compose',
+            '-f',
+            self.compose_file,
+            'up'],
+            stdout=self.log_file,
+            stderr=self.log_file,
+            start_new_session=True
+        )
+
+        timeout = time.time() + 30
+        while time.time() < timeout:
+            if cmd.returncode is not None:
+                self.logger.info('OpenSearch exited with %s', cmd.returncode)
+                raise RuntimeError("Failed to start OpenSearch cluster")
+            if self.check_server(port):
+                self.logger.info('Opensearch is up and running')
+                break
+
+            await asyncio.sleep(0.2)
+
+        return cmd
+
+    async def start(self):
+        if self.docker_exe is None:
+            self.logger.error("Container engine is not installed or not in PATH")
+            shutil.rmtree(self.tempdir)
+            return
+
+        if self.compose_file:
+            self.logger.info(f"Found opensearch.yml at: {self.compose_file}")
+        else:
+            self.logger.error("opensearch.yml not found in ./test/** directory")
+            shutil.rmtree(self.tempdir)
+            return
+
+        self.log_file = self.log_filename.open("wb")
+        self.cmd = await self._run_cluster(self.port)
+
+    async def stop(self):
+        self.logger.info('Stopping and removing OpenSearch container')
+        if not self.cmd:
+            return
+
+        try:
+            self.cmd.kill()
+        except ProcessLookupError:
+            pass
+        else:
+            await self.cmd.wait()
+        finally:
+            self.logger.info('Stopped OpenSearch cluster')
+            cmd_stop = await asyncio.create_subprocess_exec(
+                self.docker_exe,
+                *['compose',
+                '-f',
+                self.compose_file,
+                'down'],
+                stdout=self.log_file,
+                stderr=self.log_file,
+            )
+            await cmd_stop.communicate()
+            self.logger.info('Removed OpenSearch container')
+            self.cmd = None
+            shutil.rmtree(self.tempdir)
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Start a OpenSearch cluster")
+    parser.add_argument('--tempdir')
+    parser.add_argument('--host', default='127.0.0.1')
+    args = parser.parse_args()
+    with tempfile.TemporaryDirectory(suffix='-opensearch', dir=args.tempdir) as tempdir:
+        if args.tempdir is None:
+            print(f'{tempdir=}')
+        logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()], format='%(message)s')
+        server = OpenSearchCluster(tempdir, args.host, logging.getLogger('opensearch'))
+        await server.start()
+        try:
+            _ = input('server started. press any key to stop: ')
+        except KeyboardInterrupt:
+            pass
+        finally:
+            await server.stop()
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/test/pylib/resources/opensearch.yml
+++ b/test/pylib/resources/opensearch.yml
@@ -1,0 +1,21 @@
+services:
+  opensearch:
+    image: opensearchproject/opensearch:3.0.0
+    container_name: opensearch
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=ZPP-2025-VectorSearch
+    ports:
+      - 9200:9200
+      - 9600:9600
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    mem_limit: 1g
+    networks:
+      - opensearch-net
+
+networks:
+  opensearch-net:

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -31,6 +31,7 @@ from test.pylib.artifact_registry import ArtifactRegistry
 from test.pylib.host_registry import HostRegistry
 from test.pylib.ldap_server import start_ldap
 from test.pylib.minio_server import MinioServer
+from test.pylib.opensearch_cluster import OpenSearchCluster
 from test.pylib.resource_gather import get_resource_gather, setup_cgroup
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
@@ -560,6 +561,15 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
     )
     await ms.start()
     TestSuite.artifacts.add_exit_artifact(None, ms.stop)
+
+    if any("opensearch" in test.name for test in TestSuite.all_tests()):
+        opensearch_cluster = OpenSearchCluster(
+            tempdir_base=str(tempdir_base),
+            address="127.0.0.1",
+            logger=LogPrefixAdapter(logger=logging.getLogger("opensearch"), extra={"prefix": "opensearch"}),
+        )
+        await opensearch_cluster.start()
+        TestSuite.artifacts.add_exit_artifact(None, opensearch_cluster.stop)
 
     TestSuite.artifacts.add_exit_artifact(None, hosts.cleanup)
 


### PR DESCRIPTION
This pull request is an addition of OpenSearch to the toolchain.

As we want to use OpenSearch database as prototype implementation of Approximate Nearest Neighbour Search, we need to be able to run OpenSearch node/cluster in Scylla testing environment.

The patch contains:

- OpenSearch cluster manager
- basic OpenSearch test

Limitations:
- having in mind all the tests use the same OpenSearch instance, we must use unique names for indices to make them work properly