### PR TITLE
doc: add info about Scylla Doctor Automation to the docs

### DIFF
--- a/docs/troubleshooting/report-scylla-problem.rst
+++ b/docs/troubleshooting/report-scylla-problem.rst
@@ -81,6 +81,19 @@ You need to run the tool **on every node in the cluster**.
    :ref:`Send files to ScyllaDB support <report-problem-send-files-to-support>` 
    section.
 
+ScyllaDB Doctor Automation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+ScyllaDB provides an extension for automating ScyllaDB Doctor to run on
+the entire cluster and collect ScyllaDB Doctor reports from all cluster nodes.
+It may be especially useful for troubleshooting large clusters, as it saves you
+the time and effort of running ScyllaDB Doctor manually on every node.
+
+To automate ScyllaDB Doctor:
+
+#. Download the extension at https://downloads.scylladb.com/downloads/scylla-doctor/automation/scylla-doctor-ansible.tgz.
+#. Follow the instructions at https://downloads.scylladb.com/downloads/scylla-doctor/automation/README.md.
+
 .. _report-scylla-problem-core-dump:
 
 Core Dump


### PR DESCRIPTION
This PR adds the information about Scylla Doctor automation tool to the ScyllaDB documentation. Both the tool and the instructions in the README are under downloads. 

Fixes https://github.com/scylladb/scylladb/issues/23642

It would be great to backport this PR to branch-2025.1 as the new paragraph would raise awareness of the tool among the 2025.1 customers and help them report problems on large clusters.
