### PR TITLE
test: disable flaky test `test_two_tablets_concurrent_repair_and_migration_repair_writer_level`

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -938,6 +938,7 @@ async def test_tablet_split_finalization_with_migrations(manager: ManagerClient)
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.skip(reason="flaky, needs to be fixed: https://github.com/scylladb/scylladb/issues/23620")
 async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(manager: ManagerClient):
     injection = "repair_writer_impl_create_writer_wait"
     cmdline = [


### PR DESCRIPTION
The test `test_two_tablets_concurrent_repair_and_migration_repair_writer_level` has a high failure rate, making it unreliable. This commit disables the test temporarily until the root cause can be investigated and resolved.

Refs: scylladb/scylladb#23620

No backport: The issue appears to be specific to the master branch, so no backport is required.