### PR TITLE
mv, index: Replace experimental flag with rf_rack_valid_keyspaces

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -10,6 +10,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include "create_index_statement.hh"
+#include "db/config.hh"
 #include "exceptions/exceptions.hh"
 #include "prepared_statement.hh"
 #include "validation.hh"
@@ -385,6 +386,26 @@ create_index_statement::prepare_schema_mutations(query_processor& qp, const quer
 
     ::shared_ptr<event::schema_change> ret;
     std::vector<mutation> m;
+
+    const auto& cfg = qp.db().get_config();
+    // Even when RF-rack-valid keyspaces are enforced, we have no guarantee the invariant will be preserved.
+    // It may happen that, for instance, a new rack is added after creating a keyspace, which will make it
+    // RF-rack-invalid. That's why we need to ensure here that the keyspace we're creating the view in
+    // really is RF-rack-valid. If not, we must reject this schema change.
+    if (cfg.rf_rack_valid_keyspaces()) {
+        const auto tmptr = qp.proxy().get_token_metadata_ptr();
+        const auto& rs = qp.db().find_keyspace(keyspace()).get_replication_strategy();
+
+        try {
+            // It's safe to perform the check here. This function is called by
+            // `schema_altering_statement::prepare_schema_mutations()`, which holds a Raft guard.
+            locator::assert_rf_rack_valid_keyspace(keyspace(), tmptr, rs);
+        } catch (const std::exception& e) {
+            // There's no guarantee what the type of the exception will be, so we need to
+            // wrap it manually here in a type that can be passed to the user.
+            throw exceptions::invalid_request_exception(e.what());
+        }
+    }
 
     if (res) {
         m = co_await service::prepare_column_family_update_announcement(qp.proxy(), std::move(res->schema), {}, ts);

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -92,9 +92,6 @@ std::vector<::shared_ptr<index_target>> create_index_statement::validate_while_e
         throw exceptions::invalid_request_exception(format("index names shouldn't be more than {:d} characters long (got \"{}\")", schema::NAME_LENGTH, _index_name.c_str()));
     }
 
-    if (!db.features().views_with_tablets && db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets()) {
-        throw exceptions::invalid_request_exception(format("Secondary indexes are not supported on base tables with tablets (keyspace '{}')", keyspace()));
-    }
     validate_for_local_index(*schema);
 
     std::vector<::shared_ptr<index_target>> targets;

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -151,9 +151,6 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
 
     schema_ptr schema = validation::validate_column_family(db, _base_name.get_keyspace(), _base_name.get_column_family());
 
-    if (!db.features().views_with_tablets && db.find_keyspace(keyspace()).get_replication_strategy().uses_tablets()) {
-        throw exceptions::invalid_request_exception(format("Materialized views are not supported on base tables with tablets"));
-    }
     if (schema->is_counter()) {
         throw exceptions::invalid_request_exception(format("Materialized views are not supported on counter tables"));
     }

--- a/db/config.cc
+++ b/db/config.cc
@@ -1669,7 +1669,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"broadcast-tables", feature::BROADCAST_TABLES},
         {"keyspace-storage-options", feature::KEYSPACE_STORAGE_OPTIONS},
         {"tablets", feature::UNUSED},
-        {"views-with-tablets", feature::VIEWS_WITH_TABLETS}
+        {"views-with-tablets", feature::UNUSED}
     };
 }
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -135,8 +135,7 @@ struct experimental_features_t {
         UDF,
         ALTERNATOR_STREAMS,
         BROADCAST_TABLES,
-        KEYSPACE_STORAGE_OPTIONS,
-        VIEWS_WITH_TABLETS
+        KEYSPACE_STORAGE_OPTIONS
     };
     static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();

--- a/docs/architecture/tablets.rst
+++ b/docs/architecture/tablets.rst
@@ -157,13 +157,7 @@ enabled:
 If you plan to use any of the above features, CREATE your keyspace
 :ref:`with tablets disabled <tablets-enable-tablets>`.
 
-The following ScyllaDB features are disabled by default when used with a keyspace
-that has tablets enabled:
-
-* Materialized Views (MV)
-* Secondary indexes (SI, as it depends on MV)
-
-To enable MV and SI for tablet keyspaces, use the `--experimental-features=views-with-tablets`
+To enable MV and SI for tablet keyspaces, use the `--rf-rack-valid-keyspaces`
 configuration option.  See :ref:`Views with tablets <admin-views-with-tablets>` for details.
 
 Resharding in keyspaces with tablets enabled has the following limitations:

--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -338,17 +338,13 @@ credentials and endpoint.
 Views with tablets
 ------------------
 
-By default, Materialized Views (MV) and Secondary Indexes (SI)
-are disabled in keyspaces that use tablets.
-
-Support for MV and SI with tablets is experimental and must be explicitly
-enabled in the ``scylla.yaml`` configuration file by specifying
-the ``views-with-tablets`` option:
+Materialized Views (MV) and Secondary Indexes (SI) are enabled in keyspaces that use tablets
+only when :term:`RF-rack-valid keyspaces <RF-rack-valid keyspace>` are enforced. That can be
+done in the ``scylla.yaml`` configuration file by specifying
 
 .. code-block:: yaml
 
-   experimental_features:
-     - views-with-tablets
+   rf_rack_valid_keyspaces: true
 
 
 Monitoring

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -82,9 +82,6 @@ feature_config feature_config_from_db_config(const db::config& cfg, std::set<sst
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         fcfg._disabled_features.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }
-    if (!cfg.check_experimental(db::experimental_features_t::feature::VIEWS_WITH_TABLETS)) {
-        fcfg._disabled_features.insert("VIEWS_WITH_TABLETS"s);
-    }
     if (cfg.force_gossip_topology_changes()) {
         if (cfg.enable_tablets_by_default()) {
             throw std::runtime_error("Tablets cannot be enabled with gossip topology changes.  Use either --tablets-mode-for-new-keyspaces=enabled|enforced or --force-gossip-topology-changes, but not both.");

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -135,7 +135,6 @@ public:
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
     gms::feature view_build_status_on_group0 { *this, "VIEW_BUILD_STATUS_ON_GROUP0"sv };
-    gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };
     gms::feature group0_limited_voters { *this, "GROUP0_LIMITED_VOTERS"sv };
 
     // Whether to allow fragmented commitlog entries. While this is a node-local feature as such, hide

--- a/main.cc
+++ b/main.cc
@@ -2174,6 +2174,10 @@ sharded<locator::shared_token_metadata> token_metadata;
                 startlog.info("All keyspaces are RF-rack-valid");
             }
 
+            // Make sure that if there are existing materialized views and indexes that use tablets,
+            // then the `rf_rack_valid_keyspaces` configuration option is enabled.
+            db.local().check_tablet_mvs_indexes();
+
             dictionary_service dict_service(
                 dict_sampler,
                 sys_ks.local(),

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3240,6 +3240,21 @@ void database::check_rf_rack_validity(const locator::token_metadata_ptr tmptr) c
     }
 }
 
+void database::check_tablet_mvs_indexes() const {
+    if (!get_config().rf_rack_valid_keyspaces()) {
+        for (const auto& view : get_views()) {
+            dblog.debug("[check_tablet_mvs_indexes]: Checking '{}.{}'", view->ks_name(), view->cf_name());
+
+            if (view->table().uses_tablets()) {
+                throw std::runtime_error(std::format(
+                        "Materialized views/secondary indexes with tablets can only be used with the option `rf_rack_valid_keyspaces` "
+                        "enabled. That condition is violated for `{}.{}` because the option is disabled.",
+                        std::string_view(view->ks_name()), std::string_view(view->cf_name())));
+            }
+        }
+    }
+}
+
 utils::chunked_vector<uint64_t> compute_random_sorted_ints(uint64_t max_value, uint64_t n_values) {
     static thread_local std::minstd_rand rng{std::random_device{}()};
     std::uniform_int_distribution<uint64_t> dist(0, max_value);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1980,6 +1980,13 @@ public:
     // * the `locator::topology` instance corresponding to the passed `locator::token_metadata_ptr`
     //   must contain a complete list of racks and data centers in the cluster.
     void check_rf_rack_validity(const locator::token_metadata_ptr) const;
+
+    // Verify that if there's a materialized view or a secondary index using tablets,
+    // then `rf_rack_valid_keyspaces` is enabled.
+    //
+    // If that condition is not satisfied, the function throws an exception. The exception will
+    // have a message that can be passed to the user, but there are no guarantees about its type.
+    void check_tablet_mvs_indexes() const;
 private:
     // SSTable sampling might require considerable amounts of memory,
     // so we want to limit the number of concurrent sampling operations.

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -8,7 +8,7 @@
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
-from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.internal_types import ServerInfo
 from test.cluster.conftest import skip_mode
 from test.cluster.util import new_test_keyspace
@@ -369,3 +369,62 @@ async def test_mv_tablet_split(manager: ManagerClient):
 
         tablet_count = await get_tablet_count(manager, servers[0], ks, 'tv', True)
         assert tablet_count > 1
+
+@pytest.mark.parametrize("mv_type", ["mv", "index"])
+@pytest.mark.asyncio
+async def test_try_start_with_tablet_mv_index(manager: ManagerClient, mv_type: str):
+    """
+    This test verifies that Scylla refuses to start if all of the following conditions are satisfied:
+
+    1. There exists a materialized view using tablets.
+    2. The `rf_rack_valid_keyspaces` configuration option is disabled.
+
+    For more context, see: scylladb/scylladb#23030.
+    """
+    s, _, _ = await manager.servers_add(3, cmdline=["--experimental-features=views-with-tablets"],
+                                        config={"rf_rack_valid_keyspaces": True}, auto_rack_dc="dc1")
+    cql = manager.get_cql()
+
+    async def create_schema(ks: str, table: str) -> str:
+        mv = unique_name()
+        cql = manager.get_cql()
+        if mv_type == "mv":
+            await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.{mv} AS SELECT * FROM {ks}.{table} "
+                                f"WHERE p IS NOT NULL AND v IS NOT NULL PRIMARY KEY(v, p)")
+        else:
+            await cql.run_async(f"CREATE INDEX {mv} ON {ks}.{table} (v)")
+        return f"{ks}.{mv}"
+
+    async def drop_schema(mv: str) -> None:
+        if mv_type == "mv":
+            await cql.run_async(f"DROP MATERIALIZED VIEW IF EXISTS {mv}")
+        else:
+            await cql.run_async(f"DROP INDEX IF EXISTS {mv}")
+
+    async def prepare_mv(tablets: bool) -> str:
+        tablets = str(tablets).lower()
+        ks, table = [unique_name() for _ in range(2)]
+
+        await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 3}} "
+                            f"AND tablets = {{'enabled': {tablets}}}")
+        await cql.run_async(f"CREATE TABLE {ks}.{table} (p int PRIMARY KEY, v int)")
+        return await create_schema(ks, table)
+
+    # Tablet & vnode schema.
+    tmv, _ = await asyncio.gather(*[prepare_mv(True), prepare_mv(False)])
+
+    async def try_start(value: bool, should_fail: bool):
+        mv_name = tmv if mv_type == "mv" else f"{tmv}_index"
+        err = r"Materialized views/secondary indices with tablets can only be used with the option `rf_rack_valid_keyspaces` " \
+              rf"enabled. That condition is violated for `{mv_name}` because the option is disabled."
+        err = err if should_fail else None
+        await manager.server_update_config(server_id=s.server_id, key="rf_rack_valid_keyspaces", value=value)
+        await manager.server_start(server_id=s.server_id, expected_error=err)
+
+    # Scenario 1. Try to start the node with the option disabled. It should fail because we have an MV using tablets.
+    await manager.server_stop_gracefully(s.server_id)
+    await try_start(False, True)
+
+    # Scenario 2. We get rid of the tablet MV and the node starts successfully.
+    await drop_schema(tmv)
+    await try_start(False, False)

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -6,12 +6,13 @@
 
 # Tests for interaction of materialized views with *tablets*
 
+from typing import Any
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.internal_types import ServerInfo
 from test.cluster.conftest import skip_mode
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_materialized_view, new_test_keyspace, new_test_table
 
 from test.cluster.test_alternator import get_alternator, alternator_config, full_query
 
@@ -381,8 +382,7 @@ async def test_try_start_with_tablet_mv_index(manager: ManagerClient, mv_type: s
 
     For more context, see: scylladb/scylladb#23030.
     """
-    s, _, _ = await manager.servers_add(3, cmdline=["--experimental-features=views-with-tablets"],
-                                        config={"rf_rack_valid_keyspaces": True}, auto_rack_dc="dc1")
+    s, _, _ = await manager.servers_add(3, config={"rf_rack_valid_keyspaces": True}, auto_rack_dc="dc1")
     cql = manager.get_cql()
 
     async def create_schema(ks: str, table: str) -> str:
@@ -428,3 +428,46 @@ async def test_try_start_with_tablet_mv_index(manager: ManagerClient, mv_type: s
     # Scenario 2. We get rid of the tablet MV and the node starts successfully.
     await drop_schema(tmv)
     await try_start(False, False)
+
+@pytest.mark.asyncio
+async def test_create_mv_index_with_tablets(manager: ManagerClient):
+    """
+    This test verifies that creating a materialized view in a keyspace that uses tablets is impossible
+    unless Scylla was started with the `rf_rack_valid_keyspaces` configuration option enabled.
+    For more context, see: scylladb/scylladb#23030.
+    """
+    srvs = await manager.servers_add(2, config={"rf_rack_valid_keyspaces": False}, auto_rack_dc="dc1")
+
+    async def try_create(func: Any):
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'enabled': true}") as ks:
+            async with new_test_table(manager, ks, "p int PRIMARY KEY, v int") as table:
+                await func(table)
+
+    async def try_create_mv():
+        async def aux(table: str):
+            async with new_materialized_view(manager, table, "*", "v, p", "p IS NOT NULL AND v IS NOT NULL"):
+                pass
+        await try_create(aux)
+
+    async def try_create_index():
+        async def aux(table: str):
+            cql = manager.get_cql()
+            idx = unique_name()
+            await cql.run_async(f"CREATE INDEX {idx} ON {table} (v)")
+        await try_create(aux)
+
+    err = lambda mv_type: f"Creating a {mv_type} in a keyspace using tablets requires that Scylla " \
+                          "use the `rf_rack_valid_keyspaces` configuration option."
+
+    with pytest.raises(Exception, match=err("materialized view")):
+        await try_create_mv()
+    with pytest.raises(Exception, match=err("secondary index")):
+        await try_create_index()
+
+    for s in srvs:
+        await manager.server_stop_gracefully(s.server_id)
+        await manager.server_update_config(s.server_id, "rf_rack_valid_keyspaces", True)
+        await manager.server_start(s.server_id)
+
+    await try_create_mv()
+    await try_create_index()

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -7,11 +7,12 @@ import asyncio
 import logging
 import sys
 
-from typing import List, Union
+from typing import Any, List, Union
 
 import pytest
 from cassandra.policies import WhiteListRoundRobinPolicy
 
+from test.cluster.util import new_materialized_view
 from test.cqlpy import nodetool
 from cassandra import ConsistencyLevel
 from cassandra.protocol import InvalidRequest
@@ -464,3 +465,131 @@ async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager
 
     await manager.server_stop_gracefully(s_info.server_id)
     await manager.server_start(s_info.server_id)
+
+async def verify_create_mv_si_with_racks(manager: ManagerClient, create_schema: Any):
+    cmdline = ["--experimental-features=views-with-tablets"]
+    cfg = {"rf_rack_valid_keyspaces": "true"}
+
+    _ = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1_1"},
+        {"dc": "dc1", "rack": "r1_2"},
+        {"dc": "dc2", "rack": "r2_1"},
+    ])
+
+    cql = manager.get_cql()
+
+    # Create a keyspace and table with replication: {dc1: rf1, dc2: rf2} and tablets on.
+    async def prepare(rf1: int, rf2: int) -> tuple[str, str]:
+        ks = unique_name()
+        t = unique_name()
+
+        await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': {rf1}, 'dc2': {rf2}}} AND tablets = {{'enabled': true}}")
+        await cql.run_async(f"CREATE TABLE {ks}.{t} (p int PRIMARY KEY, v int)")
+
+        return (ks, t)
+
+    async def test_scenario(good: list[Any], bad: list[Any], dc: int | None = None, rf: int | None = None, rack_count: int | None = None):
+        async def try_pass(ks: str, table: str) -> None:
+            await create_schema(ks, table)
+
+        async def try_fail(ks: str, table: str, dc: int, rf: int, rack_count: int) -> None:
+            err = "The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+                f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{dc}': RF={rf} vs. rack count={rack_count}."
+            with pytest.raises(InvalidRequest, match=err):
+                await try_pass(ks, table)
+
+        good = [try_pass(ks, t) for ks, t in good]
+        bad = [try_fail(ks, t, dc, rf, rack_count) for ks, t in bad]
+
+        await asyncio.gather(*[*good, *bad])
+
+    # Scenario 1: [dc1: 2 racks, dc2: 1 rack].
+    # ----------------------------------------
+    setups1 = await asyncio.gather(*[
+        prepare(0, 0),
+        prepare(0, 1),
+        prepare(1, 0),
+        prepare(1, 1),
+        prepare(2, 0),
+        prepare(2, 1)
+    ])
+
+    # All of the created keyspaces are RF-rack-valid, so creating views in them should proceed without an issue.
+    await test_scenario(setups1, [])
+
+    # Valid in the next scenario.
+    valid_setups1 = setups1[:-2]
+    # Invalid in the next scenario.
+    invalid_setups1 = setups1[-2:]
+
+    # Scenario 2: [dc1: 3 racks, dc2: 2 racks].
+    # -----------------------------------------
+    _ = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1_3"},
+        {"dc": "dc1", "rack": "r1_1"},
+        {"dc": "dc2", "rack": "r2_2"}])
+
+    setups2 = await asyncio.gather(*[
+        prepare(3, 0),
+        prepare(3, 1),
+        prepare(3, 2),
+        prepare(1, 2),
+        prepare(0, 2)
+    ])
+
+    await test_scenario(valid_setups1 + setups2, invalid_setups1, dc=1, rf=2, rack_count=3)
+
+    valid_setups2 = valid_setups1 + setups2[:-3]
+    invalid_setups2 = setups2[-3:]
+
+    # Scenario 3: [dc1: 3 racks, dc2: 3 racks].
+    # -----------------------------------------
+    _ = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc2", "rack": "r2_3"})
+
+    setups3 = await asyncio.gather(*[
+        prepare(0, 3),
+        prepare(1, 3),
+        prepare(3, 3)])
+
+    await test_scenario(valid_setups2 + setups3, invalid_setups2, dc=2, rf=2, rack_count=3)
+
+    valid_setups3 = valid_setups2 + setups3
+
+    # Scenario 4: [dc1: 3 racks + 1 zero-token rack, dc2: 3 racks].
+    # -------------------------------------------------------------
+    _ = await manager.servers_add(2, cmdline=cmdline, config=cfg | {"join_ring": False}, property_file=[
+        {"dc": "dc1", "rack": "r1_1"},
+        {"dc": "dc1", "rack": "r1_z"}
+    ])
+
+    await test_scenario(valid_setups3, [])
+
+@pytest.mark.asyncio
+async def test_create_mv_with_racks(manager: ManagerClient):
+    """
+    This test verifies that creating a materialized view is only possible in RF-rack-valid keyspaces.
+    For more context, see: scylladb/scylladb#23030.
+    """
+
+    async def create_mv(ks: str, table: str):
+        async with new_materialized_view(manager, f"{ks}.{table}", "*", "p, v", "p IS NOT NULL AND v IS NOT NULL"):
+            pass
+
+    await verify_create_mv_si_with_racks(manager, create_mv)
+
+@pytest.mark.asyncio
+async def test_create_si_with_racks(manager: ManagerClient):
+    """
+    This test verifies that creating a secondary index is only possible in RF-rack-valid keyspaces.
+    For more context, see: scylladb/scylladb#23030.
+    """
+
+    async def create_si(ks: str, table: str):
+        si = unique_name()
+        cql = manager.get_cql()
+        try:
+            await cql.run_async(f"CREATE INDEX {si} ON {ks}.{table}(v)")
+        finally:
+            await cql.run_async(f"DROP INDEX IF EXISTS {si}")
+
+    await verify_create_mv_si_with_racks(manager, create_si)

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -467,10 +467,9 @@ async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager
     await manager.server_start(s_info.server_id)
 
 async def verify_create_mv_si_with_racks(manager: ManagerClient, create_schema: Any):
-    cmdline = ["--experimental-features=views-with-tablets"]
     cfg = {"rf_rack_valid_keyspaces": "true"}
 
-    _ = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=[
+    _ = await manager.servers_add(3, config=cfg, property_file=[
         {"dc": "dc1", "rack": "r1_1"},
         {"dc": "dc1", "rack": "r1_2"},
         {"dc": "dc2", "rack": "r2_1"},
@@ -524,7 +523,7 @@ async def verify_create_mv_si_with_racks(manager: ManagerClient, create_schema: 
 
     # Scenario 2: [dc1: 3 racks, dc2: 2 racks].
     # -----------------------------------------
-    _ = await manager.servers_add(3, cmdline=cmdline, config=cfg, property_file=[
+    _ = await manager.servers_add(3, config=cfg, property_file=[
         {"dc": "dc1", "rack": "r1_3"},
         {"dc": "dc1", "rack": "r1_1"},
         {"dc": "dc2", "rack": "r2_2"}])
@@ -544,7 +543,7 @@ async def verify_create_mv_si_with_racks(manager: ManagerClient, create_schema: 
 
     # Scenario 3: [dc1: 3 racks, dc2: 3 racks].
     # -----------------------------------------
-    _ = await manager.server_add(cmdline=cmdline, config=cfg, property_file={"dc": "dc2", "rack": "r2_3"})
+    _ = await manager.server_add(config=cfg, property_file={"dc": "dc2", "rack": "r2_3"})
 
     setups3 = await asyncio.gather(*[
         prepare(0, 3),
@@ -557,7 +556,7 @@ async def verify_create_mv_si_with_racks(manager: ManagerClient, create_schema: 
 
     # Scenario 4: [dc1: 3 racks + 1 zero-token rack, dc2: 3 racks].
     # -------------------------------------------------------------
-    _ = await manager.servers_add(2, cmdline=cmdline, config=cfg | {"join_ring": False}, property_file=[
+    _ = await manager.servers_add(2, config=cfg | {"join_ring": False}, property_file=[
         {"dc": "dc1", "rack": "r1_1"},
         {"dc": "dc1", "rack": "r1_z"}
     ])

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1058,6 +1058,8 @@ private:
                 startlog.info("All keyspaces are RF-rack-valid");
             }
 
+            _db.local().check_tablet_mvs_indexes();
+
             utils::loading_cache_config perm_cache_config;
             perm_cache_config.max_size = cfg->permissions_cache_max_entries();
             perm_cache_config.expiry = std::chrono::milliseconds(cfg->permissions_validity_in_ms());

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -236,7 +236,6 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
 
     gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
     feature_service.enable(feature_service.supported_feature_set()).get();
-    feature_service.views_with_tablets.enable();
 
     sharded<locator::shared_token_metadata> token_metadata;
 


### PR DESCRIPTION
In this PR, we implement the following things:

* Restrict creating MVs and indexes with tablets to
  RF-rack-valid keyspaces.
* Starting a node when there are existing MVs or
  secondary indexes using tablets requires enabling
  the `rf_rack_valid_keyspaces` configuration option.
* Get rid of the experimental feature `views-with-tablets`
  and fully replace it with `rf_rack_valid_keyspaces`.
* Update user documentation.
* Provide tests.

Fixes scylladb/scylladb#23030

Backport: not needed, this is an enhacement.