### PR TITLE
replica: fix 10-second pause during shutdown

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2395,12 +2395,12 @@ future<> database::stop() {
     co_await _dirty_memory_manager.shutdown();
     dblog.info("Shutting down memtable controller");
     co_await _memtable_controller.shutdown();
+    dblog.info("Stopping querier cache");
+    co_await _querier_cache.stop();
     dblog.info("Closing user sstables manager");
     co_await _user_sstables_manager->close();
     dblog.info("Closing system sstables manager");
     co_await _system_sstables_manager->close();
-    dblog.info("Stopping querier cache");
-    co_await _querier_cache.stop();
     dblog.info("Stopping concurrency semaphores");
     co_await _reader_concurrency_semaphores_group.stop();
     co_await _view_update_read_concurrency_semaphores_group.stop();


### PR DESCRIPTION
As noticed in issue #23687, if we shut down Scylla while a paged read is in progress - or even a paged read that the client had no intention of ever resume it - the shutdown pauses for 10 seconds.

The problem was the stop() order - we must stop the "querier cache" before we can close sstables - the "querier cache" is what holds paged readers alive waiting for clients to resume those reads, and while a reader is alive it holds on to sstables so they can't be closed. The querier cache's querier_cache::default_entry_ttl is set to 10 seconds, which is why the shutdown was un-paused after 10 seconds.

This fix in this patch is obvious: We need to stop the querier cache (and have it release all the readers it was holding) before we close the sstables.

Fixes #23687

Backport is not required - this patch just solves a 10-second slowdown of an orderly shutdown process, which isn't really a serious bug.