### PR TITLE
tasks: check whether a node is alive before rpc

### DIFF
--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -91,7 +91,7 @@ future<std::optional<tasks::task_status>> node_ops_virtual_task::get_status_help
         .entity = "",
         .progress_units = "",
         .progress = tasks::task_manager::task::progress{},
-        .children = started ? co_await get_children(get_module(), id) : std::vector<tasks::task_identity>{}
+        .children = started ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{}
     };
 }
 

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -157,9 +157,9 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
     } else if (is_resize_task(task_type)) {
         auto new_tablet_count = _ss.get_token_metadata().tablets().get_tablet_map(table).tablet_count();
         res->status.state = new_tablet_count == tablet_count ? tasks::task_manager::task_state::suspended : tasks::task_manager::task_state::done;
-        res->status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id) : std::vector<tasks::task_identity>{};
+        res->status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{};
     } else {
-        res->status.children = co_await get_children(get_module(), id);
+        res->status.children = co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper()));
     }
     res->status.end_time = db_clock::now(); // FIXME: Get precise end time.
     co_return res->status;
@@ -252,7 +252,7 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
             }
             return make_ready_future();
         });
-        res.status.children = co_await get_children(get_module(), id);
+        res.status.children = co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper()));
     } else if (is_migration_task(task_type)) {    // Migration task.
         auto tablet_id = hint.get_tablet_id();
         res.pending_replica = tmap.get_tablet_transition_info(tablet_id)->pending_replica;
@@ -266,7 +266,7 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
         if (task_info.tablet_task_id.uuid() == id.uuid()) {
             update_status(task_info, res.status, sched_nr);
             res.status.state = tasks::task_manager::task_state::running;
-            res.status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id) : std::vector<tasks::task_identity>{};
+            res.status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{};
             co_return res;
         }
     }

--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -417,6 +417,10 @@ future<std::vector<task_identity>> task_manager::virtual_task::impl::get_childre
     }
 
     auto nodes = module->get_nodes();
+    co_await utils::get_local_injector().inject("tasks_vt_get_children", [] (auto& handler) -> future<> {
+        tmlogger.info("tasks_vt_get_children: waiting");
+        co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{10});
+    });
     co_return co_await map_reduce(nodes, [ms, parent_id, is_host_alive = std::move(is_host_alive)] (auto host_id) -> future<std::vector<task_identity>> {
         if (is_host_alive(host_id)) {
             return ser::tasks_rpc_verbs::send_tasks_get_children(ms, host_id, parent_id).then([host_id] (auto resp) {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -280,7 +280,7 @@ public:
             impl& operator=(impl&&) = delete;
             virtual ~impl() = default;
         protected:
-            static future<std::vector<task_identity>> get_children(module_ptr module, task_id parent_id);
+            static future<std::vector<task_identity>> get_children(module_ptr module, task_id parent_id, std::function<bool(locator::host_id)> is_host_alive);
         public:
             virtual task_group get_group() const noexcept = 0;
             // Returns std::nullopt if an operation with task_id isn't tracked by this virtual_task.

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -255,3 +255,27 @@ async def test_node_ops_task_wait(manager: ManagerClient):
 
     await decommission_task
     await waiting_task
+
+@pytest.mark.asyncio
+async def test_get_children(manager: ManagerClient):
+    module_name = "node_ops"
+    tm = TaskManagerClient(manager.api)
+    servers = [await manager.server_add(cmdline=cmdline) for _ in range(2)]
+
+    injection = "tasks_vt_get_children"
+    handler = await inject_error_one_shot(manager.api, servers[0].ip_addr, injection)
+
+    log = await manager.server_open_log(servers[0].server_id)
+    mark = await log.mark()
+
+    bootstrap_task = [task for task in await tm.list_tasks(servers[0].ip_addr, module_name) if task.kind == "cluster"][0]
+
+    async def _decommission():
+        await log.wait_for('tasks_vt_get_children: waiting', from_mark=mark)
+        await manager.decommission_node(servers[1].server_id)
+        await handler.message()
+
+    async def _get_status():
+        await tm.get_task_status(servers[0].ip_addr, bootstrap_task.task_id)
+
+    await asyncio.gather(*(_decommission(), _get_status()))


### PR DESCRIPTION
Check whether a node is alive before making an rpc that gathers children
infos from the whole cluster in virtual_task::impl::get_children.

Fixes: https://github.com/scylladb/scylladb/issues/22514.

Needs backport to 2025.1 and 6.2 as they contain the bug.