### PR TITLE
test.py: fix gathering logs in case of fail

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -232,7 +232,7 @@ async def manager(request: pytest.FixtureRequest,
     """
     test_case_name = request.node.name
     suite_testpy_log = testpy_test.log_filename
-    test_log = suite_testpy_log.parent / f"{suite_testpy_log.stem}.{test_case_name}.log"
+    test_log = suite_testpy_log.parent / f"{Path(suite_testpy_log.stem).stem}.{test_case_name}.log"
     # this should be consistent with scylla_cluster.py handler name in _before_test method
     test_py_log_test = suite_testpy_log.parent / f"{test_log.stem}_cluster.log"
 
@@ -253,7 +253,7 @@ async def manager(request: pytest.FixtureRequest,
             failed_test_dir_path,
             {'pytest.log': test_log, 'test_py.log': test_py_log_test}
         )
-        with open(failed_test_dir_path / "stacktrace", "w") as f:
+        with open(failed_test_dir_path / "stacktrace.txt", "w") as f:
             f.write(report.longreprtext)
         if request.config.getoption('artifacts_dir_url') is not None:
             # get the relative path to the tmpdir for the failed directory

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1348,10 +1348,8 @@ class ScyllaClusterManager:
         self.current_test_case_full_name = f'{self.test_uname}::{test_case_name}'
         root_logger = logging.getLogger()
         # file handler file name should be consistent with topology/conftest.py:manager test_py_log_test variable
-        parent_test_name = self.test_uname.replace('/', '_')
+        parent_test_name = pathlib.Path(self.test_uname.replace('/', '_')).stem
         self.test_case_log_fh = logging.FileHandler(f"{self.base_dir}/{parent_test_name}.{test_case_name}_cluster.log")
-        # to avoid fail when no cluster logs are not present creating an empty file here
-        open(self.test_case_log_fh.baseFilename, 'a').close()
         self.test_case_log_fh.setLevel(root_logger.getEffectiveLevel())
         # to have the custom formatter with a timestamp that used in a test.py but for each testcase's log, we need to
         # extract it from the root logger and apply to the handler


### PR DESCRIPTION
Currently, log files have information about run_id twice: cluster.object_store_test_backup.10.test_abort_restore_with_rpc_error.dev.10_cluster.log
However, sometimes the first run_id can be incorrect: cluster.object_store_test_backup.1.test_abort_restore_with_rpc_error.dev.10_cluster.log

Removing first run_id in the name to not face this issue and because it's actually redundant.

Removing creation empty file for scylla manager log, since it redundant and was done as incorrect assumption on the root cause of the fail. Add extension to the stacktrace file, so it will be opened in the browser in Jenkins in the new tab instead of downloading it.

Fixes: https://github.com/scylladb/scylladb/issues/23731
