### PR TITLE
sstables_loader: fix the racing between get_progress() and release_resources()

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -650,26 +650,25 @@ public:
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
         co_return co_await with_shared(_progress_mutex, [this] -> future<tasks::task_manager::task::progress> {
-        // TODO: fix the indent
-        switch (_progress_state) {
-        case progress_state::uninitialized:
-            co_return tasks::task_manager::task::progress{};
-        case progress_state::finalized:
-            co_return _final_progress;
-        case progress_state::initialized:
-            break;
-        }
-        auto p = co_await _progress_per_shard.map_reduce(
-            adder<stream_progress>{},
-            [] (const progress_holder& holder) -> stream_progress {
-              auto p = holder.progress;
-              SCYLLA_ASSERT(p);
-              return *p;
-            });
-        co_return tasks::task_manager::task::progress {
-            .completed = p.completed,
-            .total = p.total,
-        };
+            switch (_progress_state) {
+            case progress_state::uninitialized:
+                co_return tasks::task_manager::task::progress{};
+            case progress_state::finalized:
+                co_return _final_progress;
+            case progress_state::initialized:
+                break;
+            }
+            auto p = co_await _progress_per_shard.map_reduce(
+                adder<stream_progress>{},
+                [] (const progress_holder& holder) -> stream_progress {
+                  auto p = holder.progress;
+                  SCYLLA_ASSERT(p);
+                  return *p;
+                });
+            co_return tasks::task_manager::task::progress {
+                .completed = p.completed,
+                .total = p.total,
+            };
         });
     }
 };

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -10,6 +10,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/map_reduce.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/shared_mutex.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/switch_to.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -588,6 +589,7 @@ class sstables_loader::download_task_impl : public tasks::task_manager::task::im
         // progress tracking while maintaining the base interface.
         shared_ptr<stream_progress> progress = make_shared<stream_progress>();
     };
+    mutable shared_mutex _progress_mutex;
     // user could query for the progress even before _progress_per_shard
     // is completed started, and this._status.state does not reflect the
     // state of progress, so we have to track it separately.
@@ -639,12 +641,16 @@ public:
         // preserve the final progress, so we can access it after the task is
         // finished
         _final_progress = co_await get_progress();
-        if (std::exchange(_progress_state, progress_state::finalized) == progress_state::initialized) {
-            co_await _progress_per_shard.stop();
-        }
+        co_await with_lock(_progress_mutex, [this] -> future<> {
+            if (std::exchange(_progress_state, progress_state::finalized) == progress_state::initialized) {
+                co_await _progress_per_shard.stop();
+            }
+        });
     }
 
     virtual future<tasks::task_manager::task::progress> get_progress() const override {
+        co_return co_await with_shared(_progress_mutex, [this] -> future<tasks::task_manager::task::progress> {
+        // TODO: fix the indent
         switch (_progress_state) {
         case progress_state::uninitialized:
             co_return tasks::task_manager::task::progress{};
@@ -664,6 +670,7 @@ public:
             .completed = p.completed,
             .total = p.total,
         };
+        });
     }
 };
 


### PR DESCRIPTION
This change addresses a critical race condition in the sstables_loader where `get_progress()` could access invalid `progress_holder` instances after `release_resources()` destroyed them.

Problem:
- Progress tracking uses two components: `_progress_state` (tracks state) and `_progress_per_shard` (sharded service with actual progress data)
- `get_progress()` first checks if `_progress_state` is initialized, then accumulates progress from `_progress_per_shard`
- As both functions are coroutines, `get_progress()` could be preempted after state check but before accessing `_progress_per_shard`
- If `release_resources()` runs during this preemption, it destroys the `progress_holder` instances in `_progress_per_shard`, causing `get_progress()` to access invalid memory.

Solution:
- Implemented shared/exclusive locking to protect access to both state and sharded progress data
- Multiple `get_progress()` calls can execute in parallel (shared access)
- `release_resources()` acquires exclusive access before modifying resources
- This prevents potential memory corruption and ensures consistent progress reporting

Fixes #23801

---

this change addresses a racing related to tracking the restore progress from S3 using scylla's native API, which is not used in production yet, hence no need to backport.