### PR TITLE
Simplify test/sstable_assertions class API

### DIFF
--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -82,10 +82,6 @@ public:
         return _sst->make_reader(_sst->_schema, _env.make_reader_permit(), query::full_partition_range, _sst->_schema->full_slice());
     }
 
-    const stats_metadata& get_stats_metadata() const {
-        return _sst->get_stats_metadata();
-    }
-
     const sstable* operator->() const noexcept {
         return &*_sst;
     }
@@ -3273,7 +3269,7 @@ static void do_validate_stats_metadata(schema_ptr s, sstable_assertions& written
     auto orig_sst = written_sst.get_env().reusable_sst(s, get_write_test_path(table_name), 1, sstable_version_types::mc).get();
 
     const auto& orig_stats = orig_sst->get_stats_metadata();
-    const auto& written_stats = written_sst.get_stats_metadata();
+    const auto& written_stats = written_sst->get_stats_metadata();
 
     auto check_estimated_histogram = [] (const utils::estimated_histogram& lhs, const utils::estimated_histogram& rhs) {
         BOOST_REQUIRE(lhs.bucket_offsets == rhs.bucket_offsets);
@@ -3299,7 +3295,7 @@ static void do_validate_stats_metadata(schema_ptr s, sstable_assertions& written
 }
 
 static void check_min_max_column_names(sstable_assertions& written_sst, std::vector<bytes> min_components, std::vector<bytes> max_components) {
-    const auto& st = written_sst.get_stats_metadata();
+    const auto& st = written_sst->get_stats_metadata();
     BOOST_TEST_MESSAGE(fmt::format("min {}/{} max {}/{}", st.min_column_names.elements.size(), min_components.size(), st.max_column_names.elements.size(), max_components.size()));
     BOOST_REQUIRE(st.min_column_names.elements.size() == min_components.size());
     for (auto i = 0U; i < st.min_column_names.elements.size(); i++) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -86,8 +86,8 @@ public:
         return _sst->get_stats_metadata();
     }
 
-    const shared_sstable get_sstable() const noexcept {
-        return _sst;
+    const sstable* operator->() const noexcept {
+        return &*_sst;
     }
 
     mutation_reader make_reader(
@@ -3288,7 +3288,7 @@ static void do_validate_stats_metadata(schema_ptr s, sstable_assertions& written
     BOOST_REQUIRE_EQUAL(orig_stats.max_local_deletion_time, written_stats.max_local_deletion_time);
     BOOST_REQUIRE_EQUAL(orig_stats.min_ttl, written_stats.min_ttl);
     BOOST_REQUIRE_EQUAL(orig_stats.max_ttl, written_stats.max_ttl);
-    if (orig_sst->has_correct_min_max_column_names() && written_sst.get_sstable()->has_correct_min_max_column_names()) {
+    if (orig_sst->has_correct_min_max_column_names() && written_sst->has_correct_min_max_column_names()) {
         BOOST_REQUIRE(orig_stats.min_column_names.elements == written_stats.min_column_names.elements);
         BOOST_REQUIRE(orig_stats.max_column_names.elements == written_stats.max_column_names.elements);
     }


### PR DESCRIPTION
It had recently been patched to re-use the sstables::test class functionality (#23697), now it can be put on some more strict diet.