### PR TITLE
generic_server: server: listen: ignore exceptions from listeners and accepts

### DIFF
--- a/generic_server.cc
+++ b/generic_server.cc
@@ -338,7 +338,7 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
 }
 
 future<> server::do_accepts(int which, bool keepalive, socket_address server_addr) {
-    for (;;) {
+    while (!_gate.is_closed()) {
         seastar::gate::holder holder(_gate);
         bool shed = false;
         try {


### PR DESCRIPTION
Currently, server::listen discards the results of
`when_all(std::move(_listeners_stopped), do_accepts(_listeners.size() - 1, keepalive, addr))`
However, this does not ignore exceptions.

This apparently causes warnings about ignored failed futures on shutdown like https://jenkins.scylladb.com/job/scylla-master/job/dtest-release/882/artifact/logs-full.release.000/1745100778759_materialized_views_test.py%3A%3ATestMaterializedViews%3A%3Atest_mv_populating_from_existing_data_during_node_stop/node1.log
```
INFO  2025-04-19 22:12:53,800 [shard 0:main] storage_service - Shutting down native transport server
WARN  2025-04-19 22:12:53,800 [shard 0:main] gossip - Fail to apply application_state: seastar::abort_requested_exception (abort requested)
WARN  2025-04-19 22:12:53,800 [shard 0:sl:d] seastar - Exceptional future ignored: seastar::named_gate_closed_exception (generic_server::server gate closed), backtrace: 0x223a2ae 0x1822d81 0x196f379 0x149abb6 0x2a62dc5 0x1afdfdb 0x2f16928 0x2f16fd4 0x2f16a32 0x2f14b35 0x28d6442 /jenkins/workspace/scylla-master/dtest-release/scylla/.ccm/scylla-repository/2314feeae2db98ffb385041bbab37ff2900dee0f/libreloc/libc.so.6+0x3247 /jenkins/workspace/scylla-master/dtest-release/scylla/.ccm/scylla-repository/2314feeae2db98ffb385041bbab37ff2900dee0f/libreloc/libc.so.6+0x330a 0x306ecf4
```

Fixes #23775

* Benign issue, no backport needed