### PR TITLE
pip installation: use --no-cache-dir

### DIFF
--- a/dist/docker/redhat/build_docker.sh
+++ b/dist/docker/redhat/build_docker.sh
@@ -90,7 +90,7 @@ run microdnf clean all
 run microdnf --setopt=tsflags=nodocs -y update
 run microdnf --setopt=tsflags=nodocs -y install hostname python3 python3-pip kmod
 run microdnf clean all
-run pip3 install --prefix /usr supervisor
+run pip3 install --no-cache-dir --prefix /usr supervisor
 run bash -ec "echo LANG=C.UTF-8 > /etc/locale.conf"
 run bash -ec "rpm -ivh packages/*.rpm"
 run bash -ec "cat /scylla_bashrc >> /etc/bash.bashrc"

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -360,7 +360,7 @@ elif [ "$ID" = "fedora" ]; then
     do
         pip_constrained_packages="${pip_constrained_packages} ${package}${pip_packages[$package]}"
     done
-    pip3 install --upgrade "$PIP_DEFAULT_ARGS" $pip_constrained_packages
+    pip3 install --upgrade --no-cache-dir "$PIP_DEFAULT_ARGS" $pip_constrained_packages
 
     if [ -f "$(node_exporter_fullpath)" ] && node_exporter_checksum; then
         echo "$(node_exporter_filename) already exists, skipping download"


### PR DESCRIPTION
There are two/three reasons we may want NOT to use caching of pip deps:
1. When building a container, unless we specifically clean it up, it'll remain, even when we squash the image layers later.
2. When building a container, that cache is not useful, as we squash our containers later (so that layer is not cached really). And our CI cleans up the layers repo anyway.
3. Caching sometimes isn't great, and doesn't ensure we pick up the exact version (or latest) that we wish to...

This PR changes two locations in Scylla, both of which (also) build containers, so certainly relevant for 1, 2 above and possibly 3.
This is very similar to what dtest Dockerfile has https://github.com/scylladb/scylla-dtest/blob/417073cea7f0ca6e61871a03a3b0eebef87c8100/Dockerfile#L35C5-L35C21 (it uses an environment variable, I have preferred a concrete command line usage) as well as cqlsh (https://github.com/scylladb/scylla-cqlsh/blob/49ab6ec8836aecad1c7722dcf0504115672f99b0/Dockerfile#L14 )

No real need to backport.