### PR TITLE
test: gdb: avoid using `file(1)` to determine if debug information is present

### DIFF
--- a/test/scylla_gdb/run
+++ b/test/scylla_gdb/run
@@ -14,7 +14,7 @@ print('Scylla is: ' + run.find_scylla() + '.')
 # (e.g., Scylla's release or debug build modes mode, but not dev mode).
 # Check this quickly up-front, instead of waiting for gdb to fail in a
 # mysterious way when it can't look up types.
-if not 'debug_info' in subprocess.run(['file', run.scylla],
+if not '.debug_info' in subprocess.run(['objdump', '-h', run.scylla],
         capture_output=True, text=True).stdout:
     print(f'Scylla executable was compiled without debugging information (-g)')
     print(f'so cannot be used to test gdb. Please set SCYLLA environment variable.')


### PR DESCRIPTION

The scylla_gdb tests verify, as a sanity check, that the executable was built with debug information. They do so via file(1).

In Fedora 42, file(1) crashes on ELF files that have interpreter pathnames larger than 128 characters[1]. This was later fixed[2], but the fix is not in any release.

Work around the problem by using objdump instead of file.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2354970
[2] https://github.com/file/file/commit/b3384a1fbfa1fee99986e5750ab8e700de4f24ad

No release uses Fedora 42 for the toolchain, so this isn't important to backport.