### PR TITLE
alternator: fix schema "concurrent modification" errors

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -762,43 +762,54 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
     rjson::value table_description = co_await fill_table_description(schema, table_status::deleting, _proxy, client_state, trace_state, permit);
     co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::DROP);
     co_await _mm.container().invoke_on(0, [&, cs = client_state.move_to_other_shard()] (service::migration_manager& mm) -> future<> {
-        // FIXME: the following needs to be in a loop. If mm.announce() below
-        // fails, we need to retry the whole thing.
-        auto group0_guard = co_await mm.start_group0_operation();
+        size_t retries = mm.get_concurrent_ddl_retries();
+        for (;;) {
+            auto group0_guard = co_await mm.start_group0_operation();
 
-        std::optional<data_dictionary::table> tbl = p.local().data_dictionary().try_find_table(keyspace_name, table_name);
-        if (!tbl) {
-            throw api_error::resource_not_found(fmt::format("Requested resource not found: Table: {} not found", table_name));
-        }
+            std::optional<data_dictionary::table> tbl = p.local().data_dictionary().try_find_table(keyspace_name, table_name);
+            if (!tbl) {
+                throw api_error::resource_not_found(fmt::format("Requested resource not found: Table: {} not found", table_name));
+            }
 
-        auto m = co_await service::prepare_column_family_drop_announcement(_proxy, keyspace_name, table_name, group0_guard.write_timestamp(), service::drop_views::yes);
-        auto m2 = co_await service::prepare_keyspace_drop_announcement(_proxy.local_db(), keyspace_name, group0_guard.write_timestamp());
+            auto m = co_await service::prepare_column_family_drop_announcement(_proxy, keyspace_name, table_name, group0_guard.write_timestamp(), service::drop_views::yes);
+            auto m2 = co_await service::prepare_keyspace_drop_announcement(_proxy.local_db(), keyspace_name, group0_guard.write_timestamp());
 
-        std::move(m2.begin(), m2.end(), std::back_inserter(m));
+            std::move(m2.begin(), m2.end(), std::back_inserter(m));
 
-        // When deleting a table and its views, we need to remove this role's
-        // special permissions in those tables (undoing the "auto-grant" done
-        // by CreateTable). If we didn't do this, if a second role later
-        // recreates a table with the same name, the first role would still
-        // have permissions over the new table.
-        // To make things more robust we just remove *all* permissions for
-        // the deleted table (CQL's drop_table_statement also does this).
-        // Unfortunately, there is an API mismatch between this code (which
-        // uses separate group0_guard and vector<mutation>) and the function
-        // revoke_all() which uses a combined "group0_batch" structure - so
-        // we need to do some ugly back-and-forth conversions between the pair
-        // to the group0_batch and back to the pair :-(
-        service::group0_batch mc(std::move(group0_guard));
-        mc.add_mutations(std::move(m));
-        auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
-        co_await auth::revoke_all(*cs.get().get_auth_service(), resource, mc);
-        for (const view_ptr& v : tbl->views()) {
-            resource = auth::make_data_resource(v->ks_name(), v->cf_name());
+            // When deleting a table and its views, we need to remove this role's
+            // special permissions in those tables (undoing the "auto-grant" done
+            // by CreateTable). If we didn't do this, if a second role later
+            // recreates a table with the same name, the first role would still
+            // have permissions over the new table.
+            // To make things more robust we just remove *all* permissions for
+            // the deleted table (CQL's drop_table_statement also does this).
+            // Unfortunately, there is an API mismatch between this code (which
+            // uses separate group0_guard and vector<mutation>) and the function
+            // revoke_all() which uses a combined "group0_batch" structure - so
+            // we need to do some ugly back-and-forth conversions between the pair
+            // to the group0_batch and back to the pair :-(
+            service::group0_batch mc(std::move(group0_guard));
+            mc.add_mutations(std::move(m));
+            auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
             co_await auth::revoke_all(*cs.get().get_auth_service(), resource, mc);
-        }
-        std::tie(m, group0_guard) = co_await std::move(mc).extract();
+            for (const view_ptr& v : tbl->views()) {
+                resource = auth::make_data_resource(v->ks_name(), v->cf_name());
+                co_await auth::revoke_all(*cs.get().get_auth_service(), resource, mc);
+            }
+            std::tie(m, group0_guard) = co_await std::move(mc).extract();
 
-        co_await mm.announce(std::move(m), std::move(group0_guard), fmt::format("alternator-executor: delete {} table", table_name));
+            try {
+                co_await mm.announce(std::move(m), std::move(group0_guard), fmt::format("alternator-executor: delete {} table", table_name));
+                break;
+            } catch (const service::group0_concurrent_modification& ex) {
+                elogger.info("Failed to execute DeleteTable {} due to concurrent schema modifications. {}.",
+                        table_name, retries ? "Retrying" : "Number of retries exceeded, giving up");
+                if (retries--) {
+                    continue;
+                }
+                throw;
+            }
+        }
     });
 
     rjson::value response = rjson::empty_object();
@@ -1492,73 +1503,82 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
         view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
     }
 
-    // FIXME: the following needs to be in a loop. If mm.announce() below
-    // fails, we need to retry the whole thing.
-    auto group0_guard = co_await mm.start_group0_operation();
-    auto ts = group0_guard.write_timestamp();
-    std::vector<mutation> schema_mutations;
-    auto ksm = create_keyspace_metadata(keyspace_name, sp, gossiper, ts, tags_map, sp.features());
-    // Alternator Streams doesn't yet work when the table uses tablets (#16317)
-    if (stream_specification && stream_specification->IsObject()) {
-        auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
-        if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
-            locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
-            auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
-            if (rs->uses_tablets()) {
-                co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
-                "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");
+    size_t retries = mm.get_concurrent_ddl_retries();
+    for (;;) {
+        auto group0_guard = co_await mm.start_group0_operation();
+        auto ts = group0_guard.write_timestamp();
+        std::vector<mutation> schema_mutations;
+        auto ksm = create_keyspace_metadata(keyspace_name, sp, gossiper, ts, tags_map, sp.features());
+        // Alternator Streams doesn't yet work when the table uses tablets (#16317)
+        if (stream_specification && stream_specification->IsObject()) {
+            auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
+            if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
+                locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
+                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
+                if (rs->uses_tablets()) {
+                    co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
+                    "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");
+                }
             }
         }
-    }
-    try {
-        schema_mutations = service::prepare_new_keyspace_announcement(sp.local_db(), ksm, ts);
-    } catch (exceptions::already_exists_exception&) {
-        if (sp.data_dictionary().has_schema(keyspace_name, table_name)) {
-            co_return api_error::resource_in_use(fmt::format("Table {} already exists", table_name));
+        try {
+            schema_mutations = service::prepare_new_keyspace_announcement(sp.local_db(), ksm, ts);
+        } catch (exceptions::already_exists_exception&) {
+            if (sp.data_dictionary().has_schema(keyspace_name, table_name)) {
+                co_return api_error::resource_in_use(fmt::format("Table {} already exists", table_name));
+            }
         }
-    }
-    if (sp.data_dictionary().try_find_table(schema->id())) {
-        // This should never happen, the ID is supposed to be unique
-        co_return api_error::internal(format("Table with ID {} already exists", schema->id()));
-    }
-    co_await service::prepare_new_column_family_announcement(schema_mutations, sp, *ksm, schema, ts);
-    for (schema_builder& view_builder : view_builders) {
-        view_ptr view(view_builder.build());
-        db::schema_tables::add_table_or_view_to_schema_mutation(
-            view, ts, true, schema_mutations);
-        // add_table_or_view_to_schema_mutation() is a low-level function that
-        // doesn't call the callbacks that prepare_new_view_announcement()
-        // calls. So we need to call this callback here :-( If we don't, among
-        // other things *tablets* will not be created for the new view.
-        // These callbacks need to be called in a Seastar thread.
-        co_await seastar::async([&sp, &ksm, &view, &schema_mutations, ts] {
-            return sp.local_db().get_notifier().before_create_column_family(*ksm, *view, schema_mutations, ts);
-        });
-
-    }
-    // If a role is allowed to create a table, we must give it permissions to
-    // use (and eventually delete) the specific table it just created (and
-    // also the view tables). This is known as "auto-grant".
-    // Unfortunately, there is an API mismatch between this code (which uses
-    // separate group0_guard and vector<mutation>) and the function
-    // grant_applicable_permissions() which uses a combined "group0_batch"
-    // structure - so we need to do some ugly back-and-forth conversions
-    // between the pair to the group0_batch and back to the pair :-(
-    service::group0_batch mc(std::move(group0_guard));
-    mc.add_mutations(std::move(schema_mutations));
-    if (client_state.user()) {
-        auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
-        co_await auth::grant_applicable_permissions(
-            *client_state.get_auth_service(), *client_state.user(), resource, mc);
-        for (const schema_builder& view_builder : view_builders) {
-            resource = auth::make_data_resource(view_builder.ks_name(), view_builder.cf_name());
+        if (sp.data_dictionary().try_find_table(schema->id())) {
+            // This should never happen, the ID is supposed to be unique
+            co_return api_error::internal(format("Table with ID {} already exists", schema->id()));
+        }
+        co_await service::prepare_new_column_family_announcement(schema_mutations, sp, *ksm, schema, ts);
+        for (schema_builder& view_builder : view_builders) {
+            view_ptr view(view_builder.build());
+            db::schema_tables::add_table_or_view_to_schema_mutation(
+                view, ts, true, schema_mutations);
+            // add_table_or_view_to_schema_mutation() is a low-level function that
+            // doesn't call the callbacks that prepare_new_view_announcement()
+            // calls. So we need to call this callback here :-( If we don't, among
+            // other things *tablets* will not be created for the new view.
+            // These callbacks need to be called in a Seastar thread.
+            co_await seastar::async([&sp, &ksm, &view, &schema_mutations, ts] {
+                return sp.local_db().get_notifier().before_create_column_family(*ksm, *view, schema_mutations, ts);
+            });
+        }
+        // If a role is allowed to create a table, we must give it permissions to
+        // use (and eventually delete) the specific table it just created (and
+        // also the view tables). This is known as "auto-grant".
+        // Unfortunately, there is an API mismatch between this code (which uses
+        // separate group0_guard and vector<mutation>) and the function
+        // grant_applicable_permissions() which uses a combined "group0_batch"
+        // structure - so we need to do some ugly back-and-forth conversions
+        // between the pair to the group0_batch and back to the pair :-(
+        service::group0_batch mc(std::move(group0_guard));
+        mc.add_mutations(std::move(schema_mutations));
+        if (client_state.user()) {
+            auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
             co_await auth::grant_applicable_permissions(
                 *client_state.get_auth_service(), *client_state.user(), resource, mc);
+            for (const schema_builder& view_builder : view_builders) {
+                resource = auth::make_data_resource(view_builder.ks_name(), view_builder.cf_name());
+                co_await auth::grant_applicable_permissions(
+                    *client_state.get_auth_service(), *client_state.user(), resource, mc);
+            }
+        }
+        std::tie(schema_mutations, group0_guard) = co_await std::move(mc).extract();
+        try {
+            co_await mm.announce(std::move(schema_mutations), std::move(group0_guard), fmt::format("alternator-executor: create {} table", table_name));
+            break;
+        }  catch (const service::group0_concurrent_modification& ex) {
+            elogger.info("Failed to execute CreateTable {} due to concurrent schema modifications. {}.",
+                    table_name, retries ? "Retrying" : "Number of retries exceeded, giving up");
+            if (retries--) {
+                continue;
+            }
+            throw;
         }
     }
-    std::tie(schema_mutations, group0_guard) = co_await std::move(mc).extract();
-
-    co_await mm.announce(std::move(schema_mutations), std::move(group0_guard), fmt::format("alternator-executor: create {} table", table_name));
 
     co_await mm.wait_for_schema_agreement(sp.local_db(), db::timeout_clock::now() + 10s, nullptr);
     rjson::value status = rjson::empty_object();
@@ -1628,204 +1648,214 @@ future<executor::request_return_type> executor::update_table(client_state& clien
 
     co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request]
                                                 (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
-        // FIXME: the following needs to be in a loop. If mm.announce() below
-        // fails, we need to retry the whole thing.
-        auto group0_guard = co_await mm.start_group0_operation();
+        schema_ptr schema;
+        size_t retries = mm.get_concurrent_ddl_retries();
+        for (;;) {
+            auto group0_guard = co_await mm.start_group0_operation();
 
-        schema_ptr tab = get_table(p.local(), request);
+            schema_ptr tab = get_table(p.local(), request);
 
-        tracing::add_table_name(gt, tab->ks_name(), tab->cf_name());
+            tracing::add_table_name(gt, tab->ks_name(), tab->cf_name());
 
-        // the ugly but harmless conversion to string_view here is because
-        // Seastar's sstring is missing a find(std::string_view) :-()
-        if (std::string_view(tab->cf_name()).find(INTERNAL_TABLE_PREFIX) == 0) {
-            co_await coroutine::return_exception(api_error::validation(fmt::format("Prefix {} is reserved for accessing internal tables", INTERNAL_TABLE_PREFIX)));
-        }
-
-        schema_builder builder(tab);
-
-        rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
-        if (stream_specification && stream_specification->IsObject()) {
-            empty_request = false;
-            add_stream_options(*stream_specification, builder, p.local());
-            // Alternator Streams doesn't yet work when the table uses tablets (#16317)
-            auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
-            if (stream_enabled && stream_enabled->IsBool()) {
-                if (stream_enabled->GetBool()) {
-                    if (p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets()) {
-                    co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
-                        "If you want to enable streams, re-create this table with vnodes (with the tag 'experimental:initial_tablets' set to 'none').");
-                    }
-                    if (tab->cdc_options().enabled()) {
-                        co_return api_error::validation("Table already has an enabled stream: TableName: " + tab->cf_name());
-                    }
-                }
-                else if (!tab->cdc_options().enabled()) {
-                    co_return api_error::validation("Table has no stream to disable: TableName: " + tab->cf_name());
-                }
+            // the ugly but harmless conversion to string_view here is because
+            // Seastar's sstring is missing a find(std::string_view) :-()
+            if (std::string_view(tab->cf_name()).find(INTERNAL_TABLE_PREFIX) == 0) {
+                co_await coroutine::return_exception(api_error::validation(fmt::format("Prefix {} is reserved for accessing internal tables", INTERNAL_TABLE_PREFIX)));
             }
-        }
 
-        auto schema = builder.build();
-        std::vector<view_ptr> new_views;
-        std::vector<std::string> dropped_views;
+            schema_builder builder(tab);
 
-        rjson::value* gsi_updates = rjson::find(request, "GlobalSecondaryIndexUpdates");
-        if (gsi_updates) {
-            if (!gsi_updates->IsArray()) {
-                co_return api_error::validation("GlobalSecondaryIndexUpdates must be an array");
-            }
-            if (gsi_updates->Size() > 1) {
-                // Although UpdateTable takes an array of operations and could
-                // support multiple Create and/or Delete operations in one
-                // command, DynamoDB doesn't actually allows this, and throws
-                // a LimitExceededException if this is attempted.
-                co_return api_error::limit_exceeded("GlobalSecondaryIndexUpdates only allows one index creation or deletion");
-            }
-            if (gsi_updates->Size() == 1) {
+            rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
+            if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
-                if (!(*gsi_updates)[0].IsObject() || (*gsi_updates)[0].MemberCount() != 1) {
-                    co_return api_error::validation("GlobalSecondaryIndexUpdates array must contain one object with a Create, Delete or Update operation");
-                }
-                auto it = (*gsi_updates)[0].MemberBegin();
-                const std::string_view op = rjson::to_string_view(it->name);
-                if (!it->value.IsObject()) {
-                    co_return api_error::validation("GlobalSecondaryIndexUpdates entries must be objects");
-                }
-                const rjson::value* index_name_v = rjson::find(it->value, "IndexName");
-                if (!index_name_v || !index_name_v->IsString()) {
-                    co_return api_error::validation("GlobalSecondaryIndexUpdates operation must have IndexName");
-                }
-                std::string_view index_name = rjson::to_string_view(*index_name_v);
-                std::string_view table_name = schema->cf_name();
-                std::string_view keyspace_name = schema->ks_name();
-                std::string vname(view_name(table_name, index_name));
-                if (op == "Create") {
-                    const rjson::value* attribute_definitions = rjson::find(request, "AttributeDefinitions");
-                    if (!attribute_definitions) {
-                        co_return api_error::validation("GlobalSecondaryIndexUpdates Create needs AttributeDefinitions");
-                    }
-                    std::unordered_set<std::string> unused_attribute_definitions =
-                        validate_attribute_definitions("GlobalSecondaryIndexUpdates", *attribute_definitions);
-                    check_attribute_definitions_conflicts(*attribute_definitions, *schema);
-                    for (auto& view : p.local().data_dictionary().find_column_family(tab).views()) {
-                        check_attribute_definitions_conflicts(*attribute_definitions, *view);
-                    }
-
-                    if (p.local().data_dictionary().has_schema(keyspace_name, vname)) {
-                        // Surprisingly, DynamoDB uses validation error here, not resource_in_use
-                        co_return api_error::validation(fmt::format(
-                            "GSI {} already exists in table {}", index_name, table_name));
-                    }
-                    if (p.local().data_dictionary().has_schema(keyspace_name, lsi_name(table_name, index_name))) {
-                        co_return api_error::validation(fmt::format(
-                            "LSI {} already exists in table {}, can't use same name for GSI", index_name, table_name));
-                    }
-
-                    elogger.trace("Adding GSI {}", index_name);
-                    // FIXME: read and handle "Projection" parameter. This will
-                    // require the MV code to copy just parts of the attrs map.
-                    schema_builder view_builder(keyspace_name, vname);
-                    auto [view_hash_key, view_range_key] = parse_key_schema(it->value, "GlobalSecondaryIndexUpdates");
-                    // If an attribute is already a real column in the base
-                    // table (i.e., a key attribute in the base table or LSI),
-                    // we can use it directly as a view key. Otherwise, we
-                    // need to add it as a "computed column", which extracts
-                    // and deserializes the attribute from the ":attrs" map.
-                    bool view_hash_key_real_column =
-                        schema->get_column_definition(to_bytes(view_hash_key));
-                    add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
-                    unused_attribute_definitions.erase(view_hash_key);
-                    if (!view_range_key.empty()) {
-                        bool view_range_key_real_column =
-                            schema->get_column_definition(to_bytes(view_range_key));
-                        add_column(view_builder, view_range_key, *attribute_definitions, column_kind::clustering_key, !view_range_key_real_column);
-                        if (!schema->get_column_definition(to_bytes(view_range_key)) &&
-                            !schema->get_column_definition(to_bytes(view_hash_key))) {
-                            // FIXME: This warning should go away. See issue #6714
-                            elogger.warn("Only 1 regular column from the base table should be used in the GSI key in order to ensure correct liveness management without assumptions");
+                add_stream_options(*stream_specification, builder, p.local());
+                // Alternator Streams doesn't yet work when the table uses tablets (#16317)
+                auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
+                if (stream_enabled && stream_enabled->IsBool()) {
+                    if (stream_enabled->GetBool()) {
+                        if (p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets()) {
+                        co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
+                            "If you want to enable streams, re-create this table with vnodes (with the tag 'experimental:initial_tablets' set to 'none').");
                         }
-                        unused_attribute_definitions.erase(view_range_key);
-                    }
-                    // Surprisingly, although DynamoDB checks for unused
-                    // AttributeDefinitions in CreateTable, it does not
-                    // check it in UpdateTable. We decided to check anyway.
-                    if (!unused_attribute_definitions.empty()) {
-                        co_return api_error::validation(fmt::format(
-                            "AttributeDefinitions defines spurious attributes not used by any KeySchema: {}",
-                            unused_attribute_definitions));
-                    }
-                    // Base key columns which aren't part of the index's key need to
-                    // be added to the view nonetheless, as (additional) clustering
-                    // key(s).
-                    for (auto& def : schema->primary_key_columns()) {
-                        if  (def.name_as_text() != view_hash_key && def.name_as_text() != view_range_key) {
-                            view_builder.with_column(def.name(), def.type, column_kind::clustering_key);
+                        if (tab->cdc_options().enabled()) {
+                            co_return api_error::validation("Table already has an enabled stream: TableName: " + tab->cf_name());
                         }
                     }
-                    // GSIs have no tags:
-                    view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>());
-                    // Note below we don't need to add virtual columns, as all
-                    // base columns were copied to view. TODO: reconsider the need
-                    // for virtual columns when we support Projection.
-                    for (const column_definition& regular_cdef : schema->regular_columns()) {
-                        if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
-                            view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
-                        }
+                    else if (!tab->cdc_options().enabled()) {
+                        co_return api_error::validation("Table has no stream to disable: TableName: " + tab->cf_name());
                     }
-                    const bool include_all_columns = true;
-                    view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
-                    new_views.emplace_back(view_builder.build());
-                } else if (op == "Delete") {
-                    elogger.trace("Deleting GSI {}", index_name);
-                    if (!p.local().data_dictionary().has_schema(keyspace_name, vname)) {
-                        co_return api_error::resource_not_found(fmt::format("No GSI {} in table {}", index_name, table_name));
-                    }
-                    dropped_views.emplace_back(vname);
-                } else if (op == "Update") {
-                    co_return api_error::validation("GlobalSecondaryIndexUpdates Update not yet supported");
-                } else {
-                    co_return api_error::validation(fmt::format("GlobalSecondaryIndexUpdates supports a Create, Delete or Update operation, saw '{}'", op));
                 }
             }
-        }
 
-        if (empty_request) {
-            co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, StreamSpecification or BillingMode to be specified");
-        }
+            schema = builder.build();
+            std::vector<view_ptr> new_views;
+            std::vector<std::string> dropped_views;
 
-        co_await verify_permission(enforce_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER);
-        auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema, std::vector<view_ptr>(), group0_guard.write_timestamp());
-        for (view_ptr view : new_views) {
-            auto m2 = co_await service::prepare_new_view_announcement(p.local(), view, group0_guard.write_timestamp());
-            std::move(m2.begin(), m2.end(), std::back_inserter(m));
-        }
-        for (const std::string& view_name : dropped_views) {
-            auto m2 = co_await service::prepare_view_drop_announcement(p.local(), schema->ks_name(), view_name, group0_guard.write_timestamp());
-            std::move(m2.begin(), m2.end(), std::back_inserter(m));
-        }
-        // If a role is allowed to create a GSI, we should give it permissions
-        // to read the GSI it just created. This is known as "auto-grant".
-        // Also, when we delete a GSI we should revoke any permissions set on
-        // it - so if it's ever created again the old permissions wouldn't be
-        // remembered for the new GSI. This is known as "auto-revoke"
-        if (client_state_other_shard.get().user() && (!new_views.empty() || !dropped_views.empty())) {
-            service::group0_batch mc(std::move(group0_guard));
-            mc.add_mutations(std::move(m));
+            rjson::value* gsi_updates = rjson::find(request, "GlobalSecondaryIndexUpdates");
+            if (gsi_updates) {
+                if (!gsi_updates->IsArray()) {
+                    co_return api_error::validation("GlobalSecondaryIndexUpdates must be an array");
+                }
+                if (gsi_updates->Size() > 1) {
+                    // Although UpdateTable takes an array of operations and could
+                    // support multiple Create and/or Delete operations in one
+                    // command, DynamoDB doesn't actually allows this, and throws
+                    // a LimitExceededException if this is attempted.
+                    co_return api_error::limit_exceeded("GlobalSecondaryIndexUpdates only allows one index creation or deletion");
+                }
+                if (gsi_updates->Size() == 1) {
+                    empty_request = false;
+                    if (!(*gsi_updates)[0].IsObject() || (*gsi_updates)[0].MemberCount() != 1) {
+                        co_return api_error::validation("GlobalSecondaryIndexUpdates array must contain one object with a Create, Delete or Update operation");
+                    }
+                    auto it = (*gsi_updates)[0].MemberBegin();
+                    const std::string_view op = rjson::to_string_view(it->name);
+                    if (!it->value.IsObject()) {
+                        co_return api_error::validation("GlobalSecondaryIndexUpdates entries must be objects");
+                    }
+                    const rjson::value* index_name_v = rjson::find(it->value, "IndexName");
+                    if (!index_name_v || !index_name_v->IsString()) {
+                        co_return api_error::validation("GlobalSecondaryIndexUpdates operation must have IndexName");
+                    }
+                    std::string_view index_name = rjson::to_string_view(*index_name_v);
+                    std::string_view table_name = schema->cf_name();
+                    std::string_view keyspace_name = schema->ks_name();
+                    std::string vname(view_name(table_name, index_name));
+                    if (op == "Create") {
+                        const rjson::value* attribute_definitions = rjson::find(request, "AttributeDefinitions");
+                        if (!attribute_definitions) {
+                            co_return api_error::validation("GlobalSecondaryIndexUpdates Create needs AttributeDefinitions");
+                        }
+                        std::unordered_set<std::string> unused_attribute_definitions =
+                            validate_attribute_definitions("GlobalSecondaryIndexUpdates", *attribute_definitions);
+                        check_attribute_definitions_conflicts(*attribute_definitions, *schema);
+                        for (auto& view : p.local().data_dictionary().find_column_family(tab).views()) {
+                            check_attribute_definitions_conflicts(*attribute_definitions, *view);
+                        }
+
+                        if (p.local().data_dictionary().has_schema(keyspace_name, vname)) {
+                            // Surprisingly, DynamoDB uses validation error here, not resource_in_use
+                            co_return api_error::validation(fmt::format(
+                                "GSI {} already exists in table {}", index_name, table_name));
+                        }
+                        if (p.local().data_dictionary().has_schema(keyspace_name, lsi_name(table_name, index_name))) {
+                            co_return api_error::validation(fmt::format(
+                                "LSI {} already exists in table {}, can't use same name for GSI", index_name, table_name));
+                        }
+
+                        elogger.trace("Adding GSI {}", index_name);
+                        // FIXME: read and handle "Projection" parameter. This will
+                        // require the MV code to copy just parts of the attrs map.
+                        schema_builder view_builder(keyspace_name, vname);
+                        auto [view_hash_key, view_range_key] = parse_key_schema(it->value, "GlobalSecondaryIndexUpdates");
+                        // If an attribute is already a real column in the base
+                        // table (i.e., a key attribute in the base table or LSI),
+                        // we can use it directly as a view key. Otherwise, we
+                        // need to add it as a "computed column", which extracts
+                        // and deserializes the attribute from the ":attrs" map.
+                        bool view_hash_key_real_column =
+                            schema->get_column_definition(to_bytes(view_hash_key));
+                        add_column(view_builder, view_hash_key, *attribute_definitions, column_kind::partition_key, !view_hash_key_real_column);
+                        unused_attribute_definitions.erase(view_hash_key);
+                        if (!view_range_key.empty()) {
+                            bool view_range_key_real_column =
+                                schema->get_column_definition(to_bytes(view_range_key));
+                            add_column(view_builder, view_range_key, *attribute_definitions, column_kind::clustering_key, !view_range_key_real_column);
+                            if (!schema->get_column_definition(to_bytes(view_range_key)) &&
+                                !schema->get_column_definition(to_bytes(view_hash_key))) {
+                                // FIXME: This warning should go away. See issue #6714
+                                elogger.warn("Only 1 regular column from the base table should be used in the GSI key in order to ensure correct liveness management without assumptions");
+                            }
+                            unused_attribute_definitions.erase(view_range_key);
+                        }
+                        // Surprisingly, although DynamoDB checks for unused
+                        // AttributeDefinitions in CreateTable, it does not
+                        // check it in UpdateTable. We decided to check anyway.
+                        if (!unused_attribute_definitions.empty()) {
+                            co_return api_error::validation(fmt::format(
+                                "AttributeDefinitions defines spurious attributes not used by any KeySchema: {}",
+                                unused_attribute_definitions));
+                        }
+                        // Base key columns which aren't part of the index's key need to
+                        // be added to the view nonetheless, as (additional) clustering
+                        // key(s).
+                        for (auto& def : schema->primary_key_columns()) {
+                            if  (def.name_as_text() != view_hash_key && def.name_as_text() != view_range_key) {
+                                view_builder.with_column(def.name(), def.type, column_kind::clustering_key);
+                            }
+                        }
+                        // GSIs have no tags:
+                        view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>());
+                        // Note below we don't need to add virtual columns, as all
+                        // base columns were copied to view. TODO: reconsider the need
+                        // for virtual columns when we support Projection.
+                        for (const column_definition& regular_cdef : schema->regular_columns()) {
+                            if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
+                                view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+                            }
+                        }
+                        const bool include_all_columns = true;
+                        view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
+                        new_views.emplace_back(view_builder.build());
+                    } else if (op == "Delete") {
+                        elogger.trace("Deleting GSI {}", index_name);
+                        if (!p.local().data_dictionary().has_schema(keyspace_name, vname)) {
+                            co_return api_error::resource_not_found(fmt::format("No GSI {} in table {}", index_name, table_name));
+                        }
+                        dropped_views.emplace_back(vname);
+                    } else if (op == "Update") {
+                        co_return api_error::validation("GlobalSecondaryIndexUpdates Update not yet supported");
+                    } else {
+                        co_return api_error::validation(fmt::format("GlobalSecondaryIndexUpdates supports a Create, Delete or Update operation, saw '{}'", op));
+                    }
+                }
+            }
+
+            if (empty_request) {
+                co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, StreamSpecification or BillingMode to be specified");
+            }
+
+            co_await verify_permission(enforce_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER);
+            auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema, std::vector<view_ptr>(), group0_guard.write_timestamp());
             for (view_ptr view : new_views) {
-                auto resource = auth::make_data_resource(view->ks_name(), view->cf_name());
-                co_await auth::grant_applicable_permissions(
-                    *client_state_other_shard.get().get_auth_service(), *client_state_other_shard.get().user(), resource, mc);
+                auto m2 = co_await service::prepare_new_view_announcement(p.local(), view, group0_guard.write_timestamp());
+                std::move(m2.begin(), m2.end(), std::back_inserter(m));
             }
-            for (const auto& view_name : dropped_views) {
-                auto resource = auth::make_data_resource(schema->ks_name(), view_name);
-                co_await auth::revoke_all(*client_state_other_shard.get().get_auth_service(), resource, mc);
+            for (const std::string& view_name : dropped_views) {
+                auto m2 = co_await service::prepare_view_drop_announcement(p.local(), schema->ks_name(), view_name, group0_guard.write_timestamp());
+                std::move(m2.begin(), m2.end(), std::back_inserter(m));
+            }
+            // If a role is allowed to create a GSI, we should give it permissions
+            // to read the GSI it just created. This is known as "auto-grant".
+            // Also, when we delete a GSI we should revoke any permissions set on
+            // it - so if it's ever created again the old permissions wouldn't be
+            // remembered for the new GSI. This is known as "auto-revoke"
+            if (client_state_other_shard.get().user() && (!new_views.empty() || !dropped_views.empty())) {
+                service::group0_batch mc(std::move(group0_guard));
+                mc.add_mutations(std::move(m));
+                for (view_ptr view : new_views) {
+                    auto resource = auth::make_data_resource(view->ks_name(), view->cf_name());
+                    co_await auth::grant_applicable_permissions(
+                        *client_state_other_shard.get().get_auth_service(), *client_state_other_shard.get().user(), resource, mc);
+                }
+                for (const auto& view_name : dropped_views) {
+                    auto resource = auth::make_data_resource(schema->ks_name(), view_name);
+                    co_await auth::revoke_all(*client_state_other_shard.get().get_auth_service(), resource, mc);
+                }
+                std::tie(m, group0_guard) = co_await std::move(mc).extract();
+            }
+            try {
+                co_await mm.announce(std::move(m), std::move(group0_guard), format("alternator-executor: update {} table", tab->cf_name()));
+                break;
+            } catch (const service::group0_concurrent_modification& ex) {
+                elogger.info("Failed to execute UpdateTable {} due to concurrent schema modifications. {}.",
+                        tab->cf_name(), retries ? "Retrying" : "Number of retries exceeded, giving up");
+                if (retries--) {
+                    continue;
+                }
+                throw;
+            }
         }
-            std::tie(m, group0_guard) = co_await std::move(mc).extract();
-        }
-
-        co_await mm.announce(std::move(m), std::move(group0_guard), format("alternator-executor: update {} table", tab->cf_name()));
-
         co_await mm.wait_for_schema_agreement(p.local().local_db(), db::timeout_clock::now() + 10s, nullptr);
 
         rjson::value status = rjson::empty_object();

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -23,6 +23,8 @@ from botocore.exceptions import ClientError
 import requests
 import json
 from cassandra.auth import PlainTextAuthProvider
+import threading
+import random
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.util import wait_for
@@ -558,3 +560,259 @@ async def test_alternator_enforce_authorization_true(manager: ManagerClient):
             AttributeDefinitions=[ {'AttributeName': 'p', 'AttributeType': 'N' } ])
     # We could further test how GRANT works, but this would be unnecessary
     # repeating of the tests in test/alternator/test_cql_rbac.py.
+
+# Unfortunately by default a Python thread print the exception that kills
+# it (e.g., pytest assert failures) but it doesn't propagate the exception
+# to the join() - so the overall test doesn't fail. The following ThreadWrapper
+# causes join() to rethrow the exception, so the test will fail.
+class ThreadWrapper(threading.Thread):
+    def run(self):
+        try:
+            self.ret = self._target(*self._args, **self._kwargs)
+        except BaseException as e:
+            self.exception = e
+    def join(self, timeout=None):
+        super().join(timeout)
+        if hasattr(self, 'exception'):
+            raise self.exception
+        return self.ret
+
+# The following tests reproduce issue #13152, where if two schema changes
+# are attempted concurrently, one of them may fail with:
+#   "Internal server error: service::group0_concurrent_modification
+#    (Failed to apply group 0 change due to concurrent modification)."
+# We had this problem in six different operations - CreateTable, DeleteTable,
+# UpdateTable, TagResource, UntagResource and UpdateTimeToLive - so we have
+# several tests (the last three can be tested with almost identical code,
+# so they share one parameterized test).
+# Each of these tests checks concurrent invocation of just one operation
+# (e.g., CreateTable), to allow us to reproduce the missing code in that
+# specific operation. We assume that the correct code will use the same
+# lock for all operations, so we don't need to test collision of diffent
+# operations (e.g., CreateTable and DeleteTable) after we already test that
+# CreateTable and DeleteTable each does the locking and retry correctly.
+#
+# This issue can only be reproduced on a cluster of multiple nodes when
+# the operations are sent to different nodes - because a single node
+# serializes its own schema modifications. This is why these tests must
+# be here, in test/cluster, and not in the single-node test/alternator.
+
+async def test_concurrent_createtable(manager: ManagerClient):
+    """A reproducer for issue #13152 for the CreateTable operation:
+       concurrent CreateTable operations shouldn't fail "due to concurrent
+       "modification".
+    """
+    servers = await manager.servers_add(3, config=alternator_config)
+    # In boto3, "resources", the object returned by get_alternator(), are
+    # not thread-safe. However, we will create 3 threads each will write to
+    # a different alternators[i], so we're fine.
+    alternators = [get_alternator(server.ip_addr) for server in servers]
+
+    # Run the CreateTable operation, once, in each thread. There is no point
+    # in running multiple CreateTable operations, since only the very first
+    # CreateTable operation (before the table exists) will be slow and have
+    # an appreciatable chance of colliding with another concurrent operation.
+    # We'll use a barrier to increase the chance that the 3 threads start
+    # together and collide - on my test machine, before #15132 was fixed one
+    # attempt here fails around 80% of the time, which is good enough to
+    # reproduce the bug and test its fix. Nevertheless, we'll run (below)
+    # the whole check a "ntries" times in a loop, to bring number of test
+    # false-negatives even closer to zero.
+    table_name = unique_table_name()
+    barrier = threading.Barrier(len(servers), timeout=120)
+    def run_op(dynamodb):
+        barrier.wait()
+        try:
+            dynamodb.create_table(TableName=table_name,
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH' }],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N' }])
+        # Expect either a success or a ResourceInUseException.
+        # Anything else (e.g., InternalServerError) is a bug
+        except ClientError as e:
+            assert 'ResourceInUseException' in str(e)
+    ntries = 5
+    for i in range(ntries):
+        threads = [ThreadWrapper(target=run_op, args=[dynamodb]) for dynamodb in alternators]
+        for t in threads:
+            t.start()
+        try:
+            for t in threads:
+                t.join()
+            # If we're here, all the threads were successful, and the
+            # test passed. Actually it needs to pass ntries times before
+            # we really declare it successful.
+        finally:
+            barrier.reset()
+            # In theory (and in DynamoDB), delete_table() isn't possible
+            # until create_table() completed its asynchronous work, so
+            # we may need to try delete_table() multiple times.
+            timeout = time.time() + 120
+            while time.time() < timeout:
+                try:
+                    alternators[0].meta.client.delete_table(TableName=table_name)
+                    break
+                except ClientError as ce:
+                    if ce.response['Error']['Code'] == 'ResourceInUseException':
+                        time.sleep(1)
+                        continue
+                    elif ce.response['Error']['Code'] == 'ResourceNotFoundException':
+                        # The table was never created, probably we had an
+                        # exception from the table-creation threads, let's
+                        # not add more error messages here.
+                        break
+                    raise
+
+async def test_concurrent_deletetable(manager: ManagerClient):
+    """A reproducer for issue #13152 for the DeleteTable operation:
+       concurrent DeleteTable operations shouldn't fail "due to concurrent
+       "modification".
+    """
+    servers = await manager.servers_add(3, config=alternator_config)
+    alternators = [get_alternator(server.ip_addr) for server in servers]
+    table_name = unique_table_name()
+    barrier = threading.Barrier(len(servers), timeout=120)
+    def run_op(dynamodb):
+        barrier.wait()
+        try:
+            dynamodb.meta.client.delete_table(TableName=table_name)
+        # Expect either a success or a ResourceNotFoundException
+        # (indicating another thread deleted the table).
+        # Anything else (e.g., InternalServerError) is a bug
+        except ClientError as e:
+            assert 'ResourceNotFoundException' in str(e)
+    ntries = 5
+    try:
+        for i in range(ntries):
+            alternators[0].create_table(TableName=table_name,
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH' }],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N' }])
+            alternators[0].meta.client.get_waiter('table_exists').wait(TableName=table_name)
+            threads = [ThreadWrapper(target=run_op, args=[dynamodb]) for dynamodb in alternators]
+            for t in threads:
+                t.start()
+            try:
+                for t in threads:
+                    t.join()
+            finally:
+                barrier.reset()
+                try:
+                    alternators[0].meta.client.delete_table(TableName=table_name)
+                except ClientError as e:
+                    # If we got ResourceNotFoundException, the table was
+                    # already deleted by the threads, that's expected.
+                    if not 'ResourceNotFoundException' in str(e):
+                        raise
+    finally:
+        # Delete the table, if an exception above caused us not to do it.
+        try:
+            alternators[0].meta.client.delete_table(TableName=table_name)
+        except ClientError as e:
+            if not 'ResourceNotFoundException' in str(e):
+                raise
+
+async def test_concurrent_updatetable(manager: ManagerClient):
+    """A reproducer for issue #13152 for the UpdateTable operation:
+       concurrent UpdateTable operations shouldn't fail "due to concurrent
+       "modification".
+    """
+    servers = await manager.servers_add(3, config=alternator_config)
+    alternators = [get_alternator(server.ip_addr) for server in servers]
+    table_name = unique_table_name()
+    barrier = threading.Barrier(len(servers), timeout=120)
+    def run_op(dynamodb):
+        barrier.wait()
+        try:
+            # Pick a slow use case of UpdateTable (adding a GSI) to increase
+            # the likelihood of a collision.
+            dynamodb.meta.client.update_table(TableName=table_name,
+                AttributeDefinitions=[{ 'AttributeName': 'x', 'AttributeType': 'S' }],
+                GlobalSecondaryIndexUpdates=[ {  'Create':
+                    {  'IndexName': 'hello',
+                        'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                        'Projection': { 'ProjectionType': 'ALL' }
+                    }}])
+        # Expect either a success or an error indicating another thread
+        # already added this GSI.
+        # Anything else (e.g., InternalServerError) is a bug
+        except ClientError as e:
+            assert 'GSI hello already exists' in str(e)
+    ntries = 5
+    try:
+        for i in range(ntries):
+            alternators[0].create_table(TableName=table_name,
+                BillingMode='PAY_PER_REQUEST',
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH' }],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N' }])
+            alternators[0].meta.client.get_waiter('table_exists').wait(TableName=table_name)
+            threads = [ThreadWrapper(target=run_op, args=[dynamodb]) for dynamodb in alternators]
+            for t in threads:
+                t.start()
+            try:
+                for t in threads:
+                    t.join()
+            finally:
+                barrier.reset()
+                alternators[0].meta.client.delete_table(TableName=table_name)
+    finally:
+        # Delete the table, if an exception above caused us not to do it.
+        try:
+            alternators[0].meta.client.delete_table(TableName=table_name)
+        except ClientError as e:
+            if not 'ResourceNotFoundException' in str(e):
+                raise
+
+@pytest.mark.parametrize('op', ['TagResource', 'UntagResource', 'UpdateTimeToLive'])
+async def test_concurrent_modify_tags(manager: ManagerClient, op):
+    """A reproducer for issue #13152 for the TagResource, UntagResource
+       and UpdateTimeToLive operation (each one in a separate parametrization
+       of the test). Concurrent operations shouldn't fail "due to concurrent
+       "modification".
+       The name of this test is named after db::modify_tags(), which all
+       three of these operations use to implement the change to the table.
+    """
+    servers = await manager.servers_add(3, config=alternator_config)
+    alternators = [get_alternator(server.ip_addr) for server in servers]
+    table_name = unique_table_name()
+    barrier = threading.Barrier(len(servers), timeout=120)
+    def run_op(dynamodb):
+        barrier.wait()
+        if op == 'TagResource':
+            arn = dynamodb.meta.client.describe_table(TableName=table_name)['Table']['TableArn']
+            dynamodb.meta.client.tag_resource(ResourceArn=arn, Tags=[{'Key': 'animal', 'Value': 'dog'}])
+        elif op == 'UntagResource':
+            arn = dynamodb.meta.client.describe_table(TableName=table_name)['Table']['TableArn']
+            dynamodb.meta.client.untag_resource(ResourceArn=arn, TagKeys=['animal'])
+        elif op == 'UpdateTimeToLive':
+            # For the UpdateTimeToLive operation to actually attempt a write
+            # (and possibly notice a collision), we need to set Enabled to
+            # the opposite of what it is right now. Let's just pick a random
+            # boolean - 50% of the time it will do the right thing and
+            # we may see the collision.
+            try:
+                dynamodb.meta.client.update_time_to_live(TableName=table_name,
+                    TimeToLiveSpecification={'AttributeName': 'xxx', 'Enabled': bool(random.getrandbits(1))})
+            except ClientError as e:
+                if not 'TTL is already' in str(e):
+                    raise
+        else:
+            pytest.fail(f'oops, bad op {op}')
+    alternators[0].create_table(TableName=table_name,
+        BillingMode='PAY_PER_REQUEST',
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH' }],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'N' }])
+    alternators[0].meta.client.get_waiter('table_exists').wait(TableName=table_name)
+    ntries = 5
+    try:
+        for i in range(ntries):
+            threads = [ThreadWrapper(target=run_op, args=[dynamodb]) for dynamodb in alternators]
+            for t in threads:
+                t.start()
+            try:
+                for t in threads:
+                    t.join()
+            finally:
+                barrier.reset()
+    finally:
+        alternators[0].meta.client.delete_table(TableName=table_name)


### PR DESCRIPTION
In ScyllaDB, schema modification operations use "optimistic locking": A schema operation reads the current schema, decides what it wants to do and prepares changes to the schema, and then attempts to commit those changes - but only if the schema hasn't changed since the first read. If the schema has already been changed by some other node - we need to try again. In a loop.

In Alternator, there are six operations that perform schema modification: CreateTable, DeleteTable, UpdateTable, TagResource, UntagResource and UpdateTimeToLive. All of them were missing this loop. We knew about this - and even had FIXME in all places. So all these operations, when facing contention of concurrent schema modifications on different nodes may fail one of these operations with an error like:

   Internal server error: service::group0_concurrent_modification
   (Failed to apply group 0 change due to concurrent modification).

This problem had very minor effect, if any, on real users because the DynamoDB SDK automatically retries operations that fail with retryable errors - like this "Internal server error" - and most likely the schema operation will succeed upon retry. However, as shown in issue #13152 these failures were annoying in our CI, where tests - which disable request retries - failed on these errors.

This patch fixes all six operations (the last three operations all use one common function, db::modify_tags(), so are fixed by one change) to add the missing loop.

The patch also includes reproducing tests for all these operations - the new tests all fail before this patch, and pass with it.

These new tests are much more reliable reproducers than the dtests we had that only sometimes - very rarely - reproduced the problem. Moreover, the new tests reproduces the bug seperately for each of the six operations, so if we forget to fix one of the six operations, one of the tests would have continued to fail. Of course I checked this during development.

The new tests are in the test/cluster framework, not test/alternator, because this problem can only be reproduced in a multi-node cluster: On a single node, it serializes its schema modifications on its own; The collisions only happen when more than one node attempts schema modifications at the same time.

Fixes #13152

As explained above, this issue has minor, if any, impact on actual users so in theory should not have been backported. However, I propose to backport it to 2025.1 to help reduce the number of spurious test failures on that branch - but this too isn't critical (the failures on this problem were pretty rare). I propose not to backport this PR further back because the changes touch a lot of lines (almost all of them changing indentation, but still...) and I worry the backport won't be smooth.