### PR TITLE
test: test_mv_topology_change: increase timeout for remove_node

### DIFF
--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -176,6 +176,7 @@ async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
 # issue #19529, it remains active until it timeouts, preventing topology changes
 # during this time.
 @pytest.mark.asyncio
+@skip_mode('debug', 'the test requires a short timeout for remove_node, but it is unpredictably slow in debug')
 async def test_mv_write_to_dead_node(manager: ManagerClient):
     servers = await manager.servers_add(4, property_file=[
         {"dc": "dc1", "rack": "r1"},
@@ -199,4 +200,4 @@ async def test_mv_write_to_dead_node(manager: ManagerClient):
         # If the MV write is not completed, as in issue #19529, the topology change
         # will be held for long time until the write timeouts.
         # Otherwise, it is expected to complete in short time.
-        await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=60)
+        await manager.remove_node(servers[0].server_id, servers[-1].server_id, timeout=180)


### PR DESCRIPTION
The test `test_mv_write_to_dead_node` currently uses a timeout of 60 seconds for remove_node, after it was increased from 30 seconds to fix scylladb/scylladb#22953. Apparently it is still too low, and it was observed to fail in debug mode.

Normally remove_node uses a default timeout of TOPOLOGY_TIMEOUT = 1000 seconds, but the test requires a timeout which is shorter than 5 minutes, because it is a regression test for an issue where MV updates hold topology changes for more than 5 minutes, and we want to verify in the test that the topology change completes in less than 5 minutes.

To resolve the issue, we set the test to skip in debug mode, because the remove node operation is unpredictably slow, and we increase the timeout to 180 seconds which is hopefully enough time for remove_node in non-debug modes, and still sufficient to satisfy the test requirements.

Fixes https://github.com/scylladb/scylladb/issues/22530

backport to 2025.1 to improve CI stability