### PR TITLE
test/scylla_gdb: better error message when running on dev build mode

### DIFF
--- a/test/scylla_gdb/conftest.py
+++ b/test/scylla_gdb/conftest.py
@@ -56,9 +56,9 @@ def gdb(request, scylla_gdb):
     try:
         gdb_library.lookup_type('size_t')
     except:
-        print('ERROR: Scylla executable was compiled without debugging information (-g)')
-        print('so cannot be used to test gdb. Please set SCYLLA environment variable.')
-        sys.exit(1)
+        pytest.exit('ERROR: Scylla executable was compiled without debugging '
+                    'information (-g) so cannot be used to test gdb. Please '
+                    'set SCYLLA environment variable.')
 
     # The gdb tests are known to be broken on aarch64 (see
     # https://sourceware.org/bugzilla/show_bug.cgi?id=27886) and untested


### PR DESCRIPTION
The test/scylla_gdb suite needs Scylla to have been built with debug symbols - which is NOT the case for the dev build. So the script test/scylla_gdb/run attempts to recognize when a developer runs it on an executable with the debug symbols missing - and prints a clear error.

Unfortunately, as we noticed in #10863, and again in #23832, because wasmtime is compiled with debug symbols and linked with Scylla, build/dev/scylla "pretends" to have debug symbols, foiling the check in test/scylla_gdb/run. Reviewers rejected two solutions to this problem (pull requests #10865 and #10923), so in pull request #10937 I added a cosmetic solution just for test/scylla_gdb: in test/scylla_gdb/conftest.py we check that there are **really** debug symbols that interest us, and if not, exit immediately instead of failing each test separately.

For some reason, the sys.exit() we used is no longer effective - it no longer exits pytest, so in this patch

Fixes #23832 (sort of, we leave build/dev/scylla with the fake claim that it has debug symbols, but test/scylla_gdb will handle this situation more gracefully).
