### PR TITLE
build: when compiling without -g, don't leave debugging information

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -147,13 +147,20 @@ macro(update_build_flags config)
   endif()
   string(TOUPPER ${config} CONFIG)
   set(cxx_flags "CMAKE_CXX_FLAGS_${CONFIG}")
+  set(linker_flags "CMAKE_EXE_LINKER_FLAGS_${CONFIG}")
   string(APPEND ${cxx_flags}
     " -O${parsed_args_OPTIMIZATION_LEVEL}")
   if(parsed_args_WITH_DEBUG_INFO)
     string(APPEND ${cxx_flags} " -g -gz")
+  else()
+    # If Scylla is compiled without debug info, strip the debug symbols from
+    # the result in case one of the linked static libraries happens to have
+    # some debug symbols. See issue #23834.
+    string(APPEND ${linker_flags} " -Wl,--strip-debug")
   endif()
   unset(CONFIG)
   unset(cxx_flags)
+  unset(linker_flags)
 endmacro()
 
 set(pgo_opts "")

--- a/configure.py
+++ b/configure.py
@@ -2806,6 +2806,12 @@ def create_build_system(args):
         mode_config.update(query_seastar_flags(f'{outdir}/{mode}/seastar/seastar.pc',
                                                mode_config['build_seastar_shared_libs'],
                                                args.staticcxx))
+    # If Scylla is compiled without -g, strip the debug symbols from
+    # the result in case one of the linked static libraries happens to
+    ## have some debug symbols. See issue #23834.
+    for mode, mode_config in build_modes.items():
+        if '-g' not in user_cflags.split() + mode_config['cxxflags'].split():
+            mode_config['cxx_ld_flags'] += ' -Wl,--strip-debug'
 
     ninja = find_ninja()
     with open(args.buildfile, 'w') as f:


### PR DESCRIPTION
If Scylla is compiled without "-g" (this, for example, the default in dev build mode), any static library that we build with that contains any debugging information will cause the resulting executable to incorrectly look (e.g., to file(1) or to gdb) like it has debugging information.

For more than three years now (see #10863 for historical context), the wasmtime.a library, which has debugging symbols, has caused this to happen.

In this patch, if a certain build is compiled WITHOUT "-g", we add the "--strip-debug" option to the linker to remove the partial debugging information from the executable. Note that --strip-debug is not added in build modes which do use "-g", or if the user explicitly asked to add -g (e.g., "configure.py --cflags=-g").

Before this patch:
$ file build/dev/scylla
build/dev/scylla: ELF 64-bit LSB executable ... , with debug_info, not stripped

Ater this patch:
$ file build/dev/scylla
build/dev/scylla: ELF 64-bit LSB executable ... , not stripped

Fixes #23832.