### PR TITLE
test.py: python: run tests using bare pytest command

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -15,6 +15,7 @@ import requests
 import re
 
 from test.alternator.util import create_test_table, is_aws, scylla_log
+from test.pylib.suite.python import add_host_option
 from urllib.parse import urlparse
 from functools import cache
 
@@ -48,8 +49,8 @@ def pytest_addoption(parser):
         help="communicate with given URL instead of defaults")
     parser.addoption("--runveryslow", action="store_true",
         help="run tests marked veryslow instead of skipping them")
-    parser.addoption('--host', action='store', default='localhost',
-        help='Scylla server host to connect to')
+    add_host_option(parser)
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "veryslow: mark test as very slow to run")
 

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -48,11 +48,6 @@ def pytest_addoption(parser):
         help="communicate with given URL instead of defaults")
     parser.addoption("--runveryslow", action="store_true",
         help="run tests marked veryslow instead of skipping them")
-    # Used by the wrapper script only, not by pytest, added here so it appears
-    # in --help output and so that pytest's argparser won't protest against its
-    # presence.
-    parser.addoption('--omit-scylla-output', action='store_true',
-        help='Omit scylla\'s output from the test output')
     parser.addoption('--host', action='store', default='localhost',
         help='Scylla server host to connect to')
 def pytest_configure(config):

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -56,8 +56,6 @@ if "-h" in sys.argv or "--help" in sys.argv:
     run.run_pytest(sys.path[0], sys.argv)
     exit(0)
 
-run.omit_scylla_output = "--omit-scylla-output" in sys.argv
-
 # run_alternator_cmd runs the same as run_scylla_cmd with *additional*
 # parameters, so in particular both CQL and Alternator will be enabled.
 # This is useful for us because we need CQL to setup authentication.

--- a/test/alternator/test_batch.py
+++ b/test/alternator/test_batch.py
@@ -14,7 +14,6 @@ import pytest
 import urllib3
 from botocore.exceptions import ClientError, HTTPClientError
 
-from test.alternator.conftest import new_dynamodb_session
 from test.alternator.util import random_string, full_query, multiset, scylla_inject_error
 
 
@@ -405,9 +404,9 @@ def test_batch_write_item_large(test_table_sn):
 
 # Test if client breaking connection during HTTP response
 # streaming doesn't break the server.
-def test_batch_write_item_large_broken_connection(test_table_sn, request, dynamodb):
+def test_batch_write_item_large_broken_connection(test_table_sn, new_dynamodb_session):
     fn_name = sys._getframe().f_code.co_name
-    ses = new_dynamodb_session(request, dynamodb)
+    ses = new_dynamodb_session()
 
     p = random_string()
     long_content = random_string(100)*500

--- a/test/alternator/test_describe_endpoints.py
+++ b/test/alternator/test_describe_endpoints.py
@@ -5,12 +5,11 @@
 # Test for the DescribeEndpoints operation
 
 import boto3
-from test.alternator.conftest import get_valid_alternator_role
 
 # Test that the DescribeEndpoints operation works as expected: that it
 # returns one endpoint (it may return more, but it never does this in
 # Amazon), and this endpoint can be used to make more requests.
-def test_describe_endpoints(request, dynamodb):
+def test_describe_endpoints(request, dynamodb, get_valid_alternator_role):
     endpoints = dynamodb.meta.client.describe_endpoints()['Endpoints']
     # It is not strictly necessary that only a single endpoint be returned,
     # but this is what Amazon DynamoDB does today (and so does Alternator).

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -390,7 +390,7 @@ def test_total_operations(dynamodb, metrics):
 # this configuration does not exist, skip this test. If the configuration
 # isn't low enough (it is more than one second), skip this test unless
 # the "--runveryslow" option is used.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def alternator_ttl_period_in_seconds(dynamodb, request):
     # If not running on Scylla, skip the test
     if is_aws(dynamodb):

--- a/test/alternator/test_scan.py
+++ b/test/alternator/test_scan.py
@@ -291,7 +291,7 @@ def test_scan_paging_bytes(test_table_b):
 # A fixture to read query_tombstone_page_limit from Scylla's configuration.
 # A test using this fixture will be skipped if the test is not running
 # against Scylla.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def query_tombstone_page_limit(dynamodb, scylla_only):
     config_table = dynamodb.Table('.scylla.alternator.system.config')
     return int(config_table.query(

--- a/test/alternator/test_scylla.py
+++ b/test/alternator/test_scylla.py
@@ -31,7 +31,7 @@ def test_localnodes(scylla_only, dynamodb):
 
 # The "this_dc" fixture figures out the name of Scylla DC to which "dynamodb"
 # is connected. Any test using this fixture automatically becomes scylla_only.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def this_dc(dynamodb, scylla_only):
     tbl = dynamodb.Table('.scylla.alternator.system.local')
     dc = tbl.scan(AttributesToGet=['data_center'])['Items'][0]['data_center']
@@ -39,7 +39,7 @@ def this_dc(dynamodb, scylla_only):
 
 # The "this_rack" fixture figures out the name of Scylla rack to which "dynamodb"
 # is connected. Any test using this fixture automatically becomes scylla_only.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def this_rack(dynamodb, scylla_only):
     tbl = dynamodb.Table('.scylla.alternator.system.local')
     rack = tbl.scan(AttributesToGet=['rack'])['Items'][0]['rack']

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -457,7 +457,7 @@ def test_update_table_non_existent(dynamodb, test_table):
 # option enabled, and pass with it enabled (and also pass on Cassandra).
 # These tests should use the "fails_without_consistent_cluster_management"
 # fixture. When consistent mode becomes the default, this fixture can be removed.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def check_pre_consistent_cluster_management(dynamodb):
     # If not running on Scylla, return false.
     if is_aws(dynamodb):

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -57,7 +57,7 @@ def passes_or_raises(expected_exception, match=None):
 # very slow on Scylla or reasonably fast depends on the
 # alternator_ttl_period_in_seconds configuration - test/alternator/run sets
 # it very low, but Scylla may have been run manually.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def waits_for_expiration(dynamodb, request):
     if is_aws(dynamodb):
         if request.config.getoption('runveryslow'):
@@ -77,7 +77,7 @@ def waits_for_expiration(dynamodb, request):
 # always reasonably fast on Scylla. If fastness on Scylla requires a
 # specific setting of alternator_ttl_period_in_seconds, don't use this
 # fixture - use the above waits_for_expiration instead.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def veryslow_on_aws(dynamodb, request):
     if is_aws(dynamodb) and not request.config.getoption('runveryslow'):
         pytest.skip('need --runveryslow option to run')

--- a/test/broadcast_tables/conftest.py
+++ b/test/broadcast_tables/conftest.py
@@ -4,4 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 
-from test.pylib.cql_repl.conftest import *
+from test.pylib.suite.python import add_host_option, add_cql_connection_options
+
+# Add required fixtures:
+from test.cqlpy.conftest import host, cql
+from test.pylib.cql_repl.conftest import cql_test_connection
+
+
+def pytest_addoption(parser):
+    add_host_option(parser)
+    add_cql_connection_options(parser)

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -16,11 +16,13 @@ import urllib.parse
 from multiprocessing import Event, Process
 from pathlib import Path
 from typing import TYPE_CHECKING
+from test.conftest import testpy_test_fixture_scope
 from test.pylib.random_tables import RandomTables
 from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.pylib.async_cql import run_async
 from test.pylib.scylla_cluster import ScyllaClusterManager
+from test.pylib.suite.base import get_testpy_test
 from test.pylib.suite.python import add_cql_connection_options
 import logging
 import pytest
@@ -158,10 +160,10 @@ def cluster_con(hosts: list[IPAddress | EndPoint], port: int, use_ssl: bool, aut
                    )
 
 
-@pytest.fixture(scope="module")
-async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Test) -> AsyncGenerator[str]:
-    if manager_api := request.config.getoption("--manager-api"):
-        yield manager_api
+@pytest.fixture(scope=testpy_test_fixture_scope)
+async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Test | None) -> AsyncGenerator[str]:
+    if testpy_test is None:
+        yield request.config.getoption("--manager-api")
     else:
         test_uname = testpy_test.uname
         clusters = testpy_test.suite.clusters
@@ -190,7 +192,7 @@ async def manager_api_sock_path(request: pytest.FixtureRequest, testpy_test: Tes
         manager_process.join()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path: str) -> Callable[[], ManagerClient]:
     """Session fixture to prepare client object for communicating with the Cluster API.
        Pass the Unix socket path where the Manager server API is listening.
@@ -218,10 +220,11 @@ async def manager_internal(request: pytest.FixtureRequest, manager_api_sock_path
 async def manager(request: pytest.FixtureRequest,
                   manager_internal: Callable[[], ManagerClient],
                   record_property: Callable[[str, object], None],
-                  testpy_test: Test) -> AsyncGenerator[ManagerClient]:
+                  build_mode: str) -> AsyncGenerator[ManagerClient]:
     """
     Per test fixture to notify Manager client object when tests begin so it can perform checks for cluster state.
     """
+    testpy_test = await get_testpy_test(path=request.path, options=request.config.option, mode=build_mode)
     test_case_name = request.node.name
     suite_testpy_log = testpy_test.log_filename
     test_log = suite_testpy_log.parent / f"{Path(suite_testpy_log.stem).stem}.{test_case_name}.log"

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -57,10 +57,6 @@ def pytest_addoption(parser):
     parser.addoption('--manager-api', action='store',
                      help='Manager unix socket path')
     add_cql_connection_options(parser)
-    parser.addoption('--auth_username', action='store', default=None,
-                        help='username for authentication')
-    parser.addoption('--auth_password', action='store', default=None,
-                        help='password for authentication')
     parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
                      help='Provide the URL to artifacts directory to generate the link to failed tests directory '
                           'with logs')

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -21,6 +21,7 @@ from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.pylib.async_cql import run_async
 from test.pylib.scylla_cluster import ScyllaClusterManager
+from test.pylib.suite.python import add_cql_connection_options
 import logging
 import pytest
 from cassandra.auth import PlainTextAuthProvider                         # type: ignore # pylint: disable=no-name-in-module
@@ -55,12 +56,7 @@ print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 def pytest_addoption(parser):
     parser.addoption('--manager-api', action='store',
                      help='Manager unix socket path')
-    parser.addoption('--host', action='store', default='localhost',
-                     help='CQL server host to connect to')
-    parser.addoption('--port', action='store', default='9042',
-                     help='CQL server port to connect to')
-    parser.addoption('--ssl', action='store_true',
-                     help='Connect to CQL via an encrypted TLSv1.2 connection')
+    add_cql_connection_options(parser)
     parser.addoption('--auth_username', action='store', default=None,
                         help='username for authentication')
     parser.addoption('--auth_password', action='store', default=None,

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -1,4 +1,9 @@
-#!/usr/bin/python3
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
 import os
 import boto3
 import logging
@@ -6,17 +11,11 @@ import pytest
 import pathlib
 # use minio_server
 from test.pylib.minio_server import MinioServer
+from test.pylib.suite.python import add_s3_options
 
 
 def pytest_addoption(parser):
-    # reserved for tests with real S3
-    s3_options = parser.getgroup("s3-server", description="S3 Server settings")
-    s3_options.addoption('--s3-server-address')
-    s3_options.addoption('--s3-server-port', type=int)
-    s3_options.addoption('--aws-access-key')
-    s3_options.addoption('--aws-secret-key')
-    s3_options.addoption('--aws-region')
-    s3_options.addoption('--s3-server-bucket')
+    add_s3_options(parser)
 
 
 def format_tuples(tuples=None, **kwargs):

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -9,8 +9,6 @@ from test.pylib.minio_server import MinioServer
 
 
 def pytest_addoption(parser):
-    parser.addoption('--keep-tmp', action='store_true',
-                     help="keep the whole temp path")
     # reserved for tests with real S3
     s3_options = parser.getgroup("s3-server", description="S3 Server settings")
     s3_options.addoption('--s3-server-address')
@@ -19,10 +17,6 @@ def pytest_addoption(parser):
     s3_options.addoption('--aws-secret-key')
     s3_options.addoption('--aws-region')
     s3_options.addoption('--s3-server-bucket')
-    parser.addoption("--input", action="store", default="",
-                     help="Input file")
-    parser.addoption("--output", action="store", default="",
-                     help="Output file")
 
 
 def format_tuples(tuples=None, **kwargs):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,7 +91,7 @@ def build_mode(request: pytest.FixtureRequest) -> str:
     mode = request.config.getoption("modes")
     if mode:
         return mode[0]
-    return mode
+    return "unknown"
 
 
 @pytest.fixture(autouse=True)

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -23,6 +23,7 @@ import tempfile
 import time
 import random
 
+from test.pylib.suite.python import add_host_option, add_cql_connection_options, add_s3_options
 from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla, config_value_context
 from .nodetool import scylla_log
 from test.pylib.minio_server import MinioServer
@@ -34,20 +35,11 @@ print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 # on localhost:9042. Add the --host and --port options to allow overriding
 # these defaults.
 def pytest_addoption(parser):
-    parser.addoption('--host', action='store', default='localhost',
-        help='CQL server host to connect to')
-    parser.addoption('--port', action='store', default='9042',
-        help='CQL server port to connect to')
-    parser.addoption('--ssl', action='store_true',
-        help='Connect to CQL via an encrypted TLSv1.2 connection')
+    add_host_option(parser)
+    add_cql_connection_options(parser)
     parser.addoption('--no-minio', action="store_true", help="Signal to not run S3 related tests")
-    s3_options = parser.getgroup("s3-server", description="S3 Server settings")
-    s3_options.addoption('--s3-server-address')
-    s3_options.addoption('--s3-server-port', type=int)
-    s3_options.addoption('--aws-access-key')
-    s3_options.addoption('--aws-secret-key')
-    s3_options.addoption('--aws-region')
-    s3_options.addoption('--s3-server-bucket')
+    add_s3_options(parser)
+
 
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -40,11 +40,6 @@ def pytest_addoption(parser):
         help='CQL server port to connect to')
     parser.addoption('--ssl', action='store_true',
         help='Connect to CQL via an encrypted TLSv1.2 connection')
-    # Used by the wrapper script only, not by pytest, added here so it appears
-    # in --help output and so that pytest's argparser won't protest against its
-    # presence.
-    parser.addoption('--omit-scylla-output', action='store_true',
-        help='Omit scylla\'s output from the test output')
     parser.addoption('--no-minio', action="store_true", help="Signal to not run S3 related tests")
     s3_options = parser.getgroup("s3-server", description="S3 Server settings")
     s3_options.addoption('--s3-server-address')

--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -23,10 +23,10 @@ import tempfile
 import time
 import random
 
-from test.pylib.suite.python import add_host_option, add_cql_connection_options, add_s3_options
+from test.conftest import testpy_test_fixture_scope
+from test.pylib.suite.python import PythonTest, add_host_option, add_cql_connection_options, add_s3_options
 from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla, config_value_context
 from .nodetool import scylla_log
-from test.pylib.minio_server import MinioServer
 
 print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
 
@@ -41,13 +41,20 @@ def pytest_addoption(parser):
     add_s3_options(parser)
 
 
+@pytest.fixture(scope=testpy_test_fixture_scope)
+async def host(request, testpy_test: PythonTest | None):
+    if testpy_test is None:
+        yield request.config.getoption("--host")
+    else:
+        async with testpy_test.run_ctx(options=testpy_test.suite.options):
+            yield testpy_test.server_address
+
+
 # "cql" fixture: set up client object for communicating with the CQL API.
 # The host/port combination of the server are determined by the --host and
 # --port options, and defaults to localhost and 9042, respectively.
-# We use scope="session" so that all tests will reuse the same client object.
-@pytest.fixture(scope="session")
-def cql(request):
-    host = request.config.getoption("--host")
+@pytest.fixture(scope=testpy_test_fixture_scope)
+def cql(request, host):
     port = request.config.getoption("--port")
     try:
         # Use the default superuser credentials, which work for both Scylla and Cassandra
@@ -92,11 +99,11 @@ cql_test_connection.scylla_crashed = False
 # syntax that needs to specify a DC name explicitly. For this, will have
 # a "this_dc" fixture to figure out the name of the current DC, so it can be
 # used in NetworkTopologyStrategy.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def this_dc(cql):
     yield cql.execute("SELECT data_center FROM system.local").one()[0]
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def test_keyspace_tablets(cql, this_dc, has_tablets):
     if not is_scylla(cql) or not has_tablets:
         yield None
@@ -107,7 +114,7 @@ def test_keyspace_tablets(cql, this_dc, has_tablets):
     yield name
     cql.execute("DROP KEYSPACE " + name)
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def test_keyspace_vnodes(cql, this_dc, has_tablets):
     name = unique_name()
     if has_tablets:
@@ -120,9 +127,8 @@ def test_keyspace_vnodes(cql, this_dc, has_tablets):
 
 # "test_keyspace" fixture: Creates and returns a temporary keyspace to be
 # used in tests that need a keyspace. The keyspace is created with RF=1,
-# and automatically deleted at the end. We use scope="session" so that all
-# tests will reuse the same keyspace.
-@pytest.fixture(scope="session")
+# and automatically deleted at the end.
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, this_dc):
     if hasattr(request, "param"):
         if request.param == "vnodes":
@@ -142,7 +148,7 @@ def test_keyspace(request, test_keyspace_vnodes, test_keyspace_tablets, cql, thi
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on Apache Cassandra. A test using this fixture will be
 # skipped if running with "run-cassandra".
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def scylla_only(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
@@ -153,7 +159,7 @@ def scylla_only(cql):
 # the test, it is expected to fail (xfail) on Cassandra. It should be used
 # in rare cases where we consider Scylla's behavior to be the correct one,
 # and Cassandra's to be the bug.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def cassandra_bug(cql):
     # We recognize Scylla by checking if there is any system table whose name
     # contains the word "scylla":
@@ -223,7 +229,7 @@ def random_seed():
 # If such a process exists, we verify that it is Scylla, and return the
 # executable's path. If we can't find the Scylla executable we use
 # pytest.skip() to skip tests relying on this executable.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def scylla_path(cql):
     pid = local_process_id(cql)
     if not pid:
@@ -261,7 +267,7 @@ def temp_workdir():
     with tempfile.TemporaryDirectory() as workdir:
         yield workdir
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope=testpy_test_fixture_scope)
 def has_tablets(cql, this_dc):
     with new_test_keyspace(cql, " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "': 1}") as keyspace:
         return keyspace_has_tablets(cql, keyspace)

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -156,7 +156,8 @@ def abort_run_with_dir(pid, tmpdir):
 def abort_run_with_temporary_dir(pid):
     return abort_run_with_dir(pid, pid_to_dir(pid))
 
-omit_scylla_output = "--omit-scylla-output" in sys.argv
+if omit_scylla_output := "--omit-scylla-output" in sys.argv:
+    sys.argv.remove("--omit-scylla-output")  # don't pass this option to pytest
 summary=''
 run_pytest_pids = set()
 

--- a/test/cqlpy/test_udf.py
+++ b/test/cqlpy/test_udf.py
@@ -16,7 +16,7 @@ from cassandra.protocol import InvalidRequest
 # Cassandra supports Java and ScyllaDB doesn't - but ScyllaDB supports
 # Lua. The following fixture can be used to check if the server supports
 # Java UDFs - and if it doesn't, the test should use Lua.
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def has_java_udf(cql, test_keyspace):
     try:
         with new_function(cql, test_keyspace, "(i int) CALLED ON NULL INPUT RETURNS int LANGUAGE java AS 'return 42;'"):

--- a/test/cqlpy/test_using_timestamp.py
+++ b/test/cqlpy/test_using_timestamp.py
@@ -15,7 +15,7 @@ from cassandra.protocol import FunctionFailure, InvalidRequest
 import pytest
 import time
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
     table = test_keyspace + "." + unique_name()
     cql.execute(f"CREATE TABLE {table} (k int PRIMARY KEY, v int, w int)")

--- a/test/cqlpy/test_wasm.py
+++ b/test/cqlpy/test_wasm.py
@@ -494,10 +494,9 @@ def test_abi_v2(cql, test_keyspace, table1, scylla_with_wasm_only):
         assert len(res) == 1 and res[0].result == 'doggo'
 
 @pytest.fixture(scope="module")
-def metrics(request, scylla_with_wasm_only):
-    url = request.config.getoption('host')
+def metrics(request, scylla_with_wasm_only, cql):
     # The Prometheus API is on port 9180, and always http
-    url = 'http://' + url + ':9180/metrics'
+    url = f'http://{cql.cluster.contact_points[0]}:9180/metrics'
     resp = requests.get(url)
     if resp.status_code != 200:
         pytest.skip('Metrics port 9180 is not available')

--- a/test/pylib/cql_repl/conftest.py
+++ b/test/pylib/cql_repl/conftest.py
@@ -16,11 +16,11 @@ from cassandra.auth import PlainTextAuthProvider                         # type:
 from cassandra.cluster import Cluster              # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import ConsistencyLevel     # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import ExecutionProfile     # type: ignore # pylint: disable=no-name-in-module
-from cassandra.cluster import EXEC_PROFILE_DEFAULT  # pylint: disable=no-name-in-module
 from cassandra.policies import RoundRobinPolicy    # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
+from test.cqlpy.conftest import cql, this_dc  # add required fixtures
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
 
 
@@ -42,51 +42,6 @@ def pytest_addoption(parser) -> None:
     add_cql_connection_options(parser)
 
 
-# "cql" fixture: set up client object for communicating with the CQL API.
-# The host/port combination of the server are determined by the --host and
-# --port options, and defaults to localhost and 9042, respectively.
-# We use scope="session" so that all tests will reuse the same client object.
-@pytest.fixture(scope="session")
-def cql(request):
-    """A shared CQL connection object for all tests in this pytest session"""
-    profile = ExecutionProfile(
-        load_balancing_policy=RoundRobinPolicy(),
-        consistency_level=ConsistencyLevel.LOCAL_QUORUM,
-        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
-        # The default timeout (in seconds) for execute() commands is 10, which
-        # should have been more than enough, but in some extreme cases with a
-        # very slow debug build running on a very busy machine and a very slow
-        # request (e.g., a DROP KEYSPACE needing to drop multiple tables)
-        # 10 seconds may not be enough, so let's increase it. See issue #7838.
-        request_timeout=120)
-    if request.config.getoption('ssl'):
-        # Scylla does not support any earlier TLS protocol. If you try,
-        # you will get mysterious EOF errors (see issue #6971) :-(
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-    else:
-        ssl_context = None
-    cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-                      contact_points=[request.config.getoption('host')],
-                      port=int(request.config.getoption('port')),
-                      # TODO: make the protocol version an option, to allow testing with
-                      # different versions. If we drop this setting completely, it will
-                      # mean pick the latest version supported by the client and the server.
-                      protocol_version=4,
-                      # Use default superuser credentials, which work for both Scylla and Cassandra
-                      auth_provider=PlainTextAuthProvider(username='cassandra',
-                                                          password='cassandra'),
-                      ssl_context=ssl_context,
-                      # The default timeout for new connections is 5 seconds, and for
-                      # requests made by the control connection is 2 seconds. These should
-                      # have been more than enough, but in some extreme cases with a very
-                      # slow debug build running on a very busy machine, they may not be.
-                      # so let's increase them to 60 seconds. See issue #11289.
-                      connect_timeout = 60,
-                      control_connection_timeout = 60,
-                      )
-    return cluster.connect()
-
-
 # A function-scoped autouse=True fixture allows us to test after every test
 # that the CQL connection is still alive - and if not report the test which
 # crashed Scylla and stop running any more tests.
@@ -101,19 +56,6 @@ def cql_test_connection(cql, request):  # pylint: disable=redefined-outer-name
     except Exception:     # noqa: E722     pylint: disable=broad-except
         pytest.exit("Scylla appears to have crashed in test "
                     f"{request.node.parent.name}::{request.node.name}")
-
-
-# Until Cassandra 4, NetworkTopologyStrategy did not support the option
-# replication_factor (https://issues.apache.org/jira/browse/CASSANDRA-14303).
-# We want to allow these tests to run on Cassandra 3.* (for the convenience
-# of developers who happen to have it installed), so we'll use the older
-# syntax that needs to specify a DC name explicitly. For this, will have
-# a "this_dc" fixture to figure out the name of the current DC, so it can be
-# used in NetworkTopologyStrategy.
-@pytest.fixture(scope="session")
-def this_dc(cql):                       # pylint: disable=redefined-outer-name
-    """Fixture to get current DC, for backwards compatibility"""
-    yield cql.execute("SELECT data_center FROM system.local").one()[0]
 
 
 # "" fixture: Creates and returns a temporary keyspace to be

--- a/test/pylib/cql_repl/conftest.py
+++ b/test/pylib/cql_repl/conftest.py
@@ -21,6 +21,8 @@ from cassandra.policies import RoundRobinPolicy    # type: ignore # pylint: disa
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
+from test.pylib.suite.python import add_host_option, add_cql_connection_options
+
 
 logger = logging.getLogger(__name__)
 logger.warning("Driver name %s", DRIVER_NAME)
@@ -36,12 +38,8 @@ def pytest_addoption(parser) -> None:
                      help="Input file")
     parser.addoption("--output", action="store", default="",
                      help="Output file")
-    parser.addoption('--host', action='store', default='localhost',
-        help='CQL server host to connect to')
-    parser.addoption('--port', action='store', default='9042',
-        help='CQL server port to connect to')
-    parser.addoption('--ssl', action='store_true',
-        help='Connect to CQL via an encrypted TLSv1.2 connection')
+    add_host_option(parser)
+    add_cql_connection_options(parser)
 
 
 # "cql" fixture: set up client object for communicating with the CQL API.

--- a/test/pylib/cql_repl/conftest.py
+++ b/test/pylib/cql_repl/conftest.py
@@ -20,7 +20,7 @@ from cassandra.policies import RoundRobinPolicy    # type: ignore # pylint: disa
 from cassandra.connection import DRIVER_NAME       # type: ignore # pylint: disable=no-name-in-module
 from cassandra.connection import DRIVER_VERSION    # type: ignore # pylint: disable=no-name-in-module
 
-from test.cqlpy.conftest import cql, this_dc  # add required fixtures
+from test.cqlpy.conftest import host, cql, this_dc  # add required fixtures
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
 
 

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -312,7 +312,6 @@ class Test:
         if xdist_worker_id := get_xdist_worker_id():
             self.uname = f"{xdist_worker_id}.{self.uname}"
         self.log_filename = self.suite.log_dir / f"{self.uname}.log"
-        self.log_filename.parent.mkdir(parents=True, exist_ok=True)
         self.is_flaky = self.shortname in suite.flaky_tests
         # True if the test was retried after it failed
         self.is_flaky_failure = False
@@ -402,6 +401,7 @@ toxiproxy_id_gen = 0
 async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, env=dict()) -> bool:
     """Run test program, return True if success else False"""
 
+    test.log_filename.parent.mkdir(parents=True, exist_ok=True)
     with test.log_filename.open("wb") as log:
         def report_error(error, failure_injection_desc = None):
             msg = "=== TEST.PY SUMMARY START ===\n"

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -590,3 +590,12 @@ def find_suite_config(path: pathlib.Path) -> pathlib.Path:
         if suite_config.exists():
             return suite_config
     raise FileNotFoundError(f"Unable to find a suite config file ({SUITE_CONFIG_FILENAME}) related to {path}")
+
+
+async def get_testpy_test(path: pathlib.Path, options: argparse.Namespace, mode: str) -> Test:
+    """Create an instance of Test class for the path provided."""
+
+    suite_config = find_suite_config(path)
+    suite = TestSuite.opt_create(path=str(suite_config.parent), options=options, mode=mode)
+    await suite.add_test(shortname=str(path.relative_to(suite.suite_path).with_suffix("")), casename=None)
+    return suite.tests[-1]

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -268,6 +268,10 @@ def add_cql_connection_options(parser: Parser) -> None:
                           help="CQL port to connect to")
     cql_options.addoption("--ssl", action="store_true",
                           help="Connect to CQL via an encrypted TLSv1.2 connection")
+    cql_options.addoption("--auth_username",
+                          help="username for authentication")
+    cql_options.addoption("--auth_password",
+                          help="password for authentication")
 
 
 # Use cache to execute this function once per pytest session.

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -150,6 +150,7 @@ class PythonTest(Test):
         self.core_args = ["-m", "pytest"]
         self.casename = casename
         self.xmlout = self.suite.log_dir / "xml" / f"{self.uname}.xunit.xml"
+        self.server_address: str | None = None
         self.server_log: Optional[str] = None
         self.server_log_filename: Optional[pathlib.Path] = None
         self.is_before_test_ok = False
@@ -225,7 +226,8 @@ class PythonTest(Test):
                     cc.execute(stmt)
                 cluster.prepare_cql_executed = True
             logger.info("Leasing Scylla cluster %s for test %s", cluster, self.uname)
-            self.args.insert(0, f"--host={cluster.endpoint()}")
+            self.server_address = cluster.endpoint()
+            self.args.insert(0, f"--host={self.server_address}")
             self.server_log_filename = cluster.server_log_filename()
             self.args.insert(0, f"--scylla-log-filename={self.server_log_filename}")
             self.is_before_test_ok = True

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 asyncio_mode = auto
-asyncio_default_fixture_loop_scope = module
+asyncio_default_fixture_loop_scope = session
 
 log_format = %(asctime)s.%(msecs)03d %(levelname)s>  %(message)s
 log_date_format = %H:%M:%S

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -11,16 +11,10 @@
 
 import pytest
 import requests
-import ssl
-import sys
 
-from cassandra.auth import PlainTextAuthProvider
-from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_PROFILE_DEFAULT
-from cassandra.policies import RoundRobinPolicy
-
-
+from test.cqlpy.conftest import cql, this_dc  # add required fixtures
+from test.cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
 from test.pylib.suite.python import add_host_option, add_cql_connection_options
-from ..cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
 
 # By default, tests run against a Scylla server listening
 # on localhost:9042 for CQL and localhost:10000 for the REST API.
@@ -56,59 +50,6 @@ def rest_api(request):
     host = request.config.getoption('host')
     port = request.config.getoption('api_port')
     return RestApiSession(host, port)
-
-# "cql" fixture: set up client object for communicating with the CQL API.
-# The host/port combination of the server are determined by the --host and
-# --port options, and defaults to localhost and 9042, respectively.
-# We use scope="session" so that all tests will reuse the same client object.
-@pytest.fixture(scope="session")
-def cql(request):
-    profile = ExecutionProfile(
-        load_balancing_policy=RoundRobinPolicy(),
-        consistency_level=ConsistencyLevel.LOCAL_QUORUM,
-        serial_consistency_level=ConsistencyLevel.LOCAL_SERIAL,
-        # The default timeout (in seconds) for execute() commands is 10, which
-        # should have been more than enough, but in some extreme cases with a
-        # very slow debug build running on a very busy machine and a very slow
-        # request (e.g., a DROP KEYSPACE needing to drop multiple tables)
-        # 10 seconds may not be enough, so let's increase it. See issue #7838.
-        request_timeout = 120)
-    if request.config.getoption('ssl'):
-        # Scylla does not support any earlier TLS protocol. If you try,
-        # you will get mysterious EOF errors (see issue #6971) :-(
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-    else:
-        ssl_context = None
-    cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-        contact_points=[request.config.getoption('host')],
-        port=int(request.config.getoption('port')),
-        # TODO: make the protocol version an option, to allow testing with
-        # different versions. If we drop this setting completely, it will
-        # mean pick the latest version supported by the client and the server.
-        protocol_version=4,
-        # Use the default superuser credentials, which work for both Scylla and Cassandra
-        auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'),
-        ssl_context=ssl_context,
-        # The default timeout for new connections is 5 seconds, and for
-        # requests made by the control connection is 2 seconds. These should
-        # have been more than enough, but in some extreme cases with a very
-        # slow debug build running on a very busy machine, they may not be.
-        # so let's increase them to 60 seconds. See issue #11289.
-        connect_timeout = 60,
-        control_connection_timeout = 60,
-    )
-    return cluster.connect()
-
-# Until Cassandra 4, NetworkTopologyStrategy did not support the option
-# replication_factor (https://issues.apache.org/jira/browse/CASSANDRA-14303).
-# We want to allow these tests to run on Cassandra 3.* (for the convenience
-# of developers who happen to have it installed), so we'll use the older
-# syntax that needs to specify a DC name explicitly. For this, will have
-# a "this_dc" fixture to figure out the name of the current DC, so it can be
-# used in NetworkTopologyStrategy.
-@pytest.fixture(scope="session")
-def this_dc(cql):
-    yield cql.execute("SELECT data_center FROM system.local").one()[0]
 
 # The "scylla_only" fixture can be used by tests for Scylla-only features,
 # which do not exist on Apache Cassandra. A test using this fixture will be

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -19,18 +19,15 @@ from cassandra.cluster import Cluster, ConsistencyLevel, ExecutionProfile, EXEC_
 from cassandra.policies import RoundRobinPolicy
 
 
+from test.pylib.suite.python import add_host_option, add_cql_connection_options
 from ..cqlpy.util import unique_name, new_test_keyspace, keyspace_has_tablets, is_scylla
 
 # By default, tests run against a Scylla server listening
 # on localhost:9042 for CQL and localhost:10000 for the REST API.
 # Add the --host, --port, --ssl, or --api-port options to allow overriding these defaults.
 def pytest_addoption(parser):
-    parser.addoption('--host', action='store', default='localhost',
-        help='Scylla server host to connect to')
-    parser.addoption('--port', action='store', default='9042',
-        help='Scylla CQL port to connect to')
-    parser.addoption('--ssl', action='store_true',
-        help='Connect to CQL via an encrypted TLSv1.2 connection')
+    add_host_option(parser)
+    add_cql_connection_options(parser)
     parser.addoption('--api-port', action='store', default='10000',
         help='server REST API port to connect to')
 


### PR DESCRIPTION
Main change is splitting logic of `PythonTest.run()` method into `PythonTest.run_ctx()` context manager and `PythonTest.run()` method itself and add the `host` fixture which uses `PythonTest.run_ctx()` context manager to setup and teardown ScyllaDB node if `--test-py-init` argument is used. Otherwise, this fixture returns a value of `--host` CLI argument. Use dynamic scope provided by `testpy_test_fixture_scope()` function instead of `session` to maintain compatibility with `test.py` and `./run` scripts.

Other related changes:

* Add utility `get_testpy_test()` function to `pylib.suite.base` which combines all required steps to create an instance of `Test` class and rework `testpy_test` fixture to use it.

* Switch to use dynamic fixture scope controlled by `--test-py-init` CLI argument to improve compatibility with test.py.  And because in test.py mode the scope is `session`, also change default event loop scope to `session`.

* Convert `get_valid_alternator_role()` to fixture to have more control on the scope of the cache used. Additionally, function `new_dynamodb_session()` was also converted to a fixture, because it uses `get_valid_alternator_role()`.
  
* Replace dups of `cql` and `this_dc` fixtures in `rest_api` and `pylib/cql_repl` with imports from `cqlpy`.

* Change `build_mode` fixture to return "unknown" if no --mode arguments provided (this is mainly for alternator and cqlpy tests)
  
* Create a parent directory for a test log file just before opening this file in `run_test()` function instead of having this as a side effect in `Test.__init__()`.

And changes that remove pytest CLI argument duplicates to be able to run tests from different test suites in one pytest session:

* Add 3 supplementary functions to `test.pylib.suite.python`: `add_host_option()` (which adds `--host` options to pytest session), `add_cql_connection_options()` (which adds `--port`, and `--ssl`), and `--add-s3-options` (which adds options related to S3 connection.) Each function decorated with `@cache` decorator to be executed once per pytest session and avoid CLI options duplication for runs which executes `alternator`, `cqlpy`, `rest_api`, or `broadcast_tables` in one pytest session.

* Move `--auth_username` and `--auth_password` options from `cluster/conftest.py` to add_scylla_cql_connection_options() and slightly rework `cql` fixture to support these options.
  
* Remove `--input`, `--output`, and `--keep-tmp` pytest CLI opionts from `cluster/object_store/conftest.py` because they are not used in these suite.

* Remove `--omit-scylla-output` CLI option from pytest argparser. Instead, remove it from `sys.argv` in `cqlpy/run.py`.  Also, no need to check this option in `alternator/run`.
