### PR TITLE
test/cqlpy: insert test names into Scylla logs

### DIFF
--- a/test/cqlpy/conftest.py
+++ b/test/cqlpy/conftest.py
@@ -24,6 +24,7 @@ import time
 import random
 
 from .util import unique_name, new_test_keyspace, keyspace_has_tablets, cql_session, local_process_id, is_scylla, config_value_context
+from .nodetool import scylla_log
 from test.pylib.minio_server import MinioServer
 
 print(f"Driver name {DRIVER_NAME}, version {DRIVER_VERSION}")
@@ -79,6 +80,7 @@ def cql(request):
 # crashed Scylla and stop running any more tests.
 @pytest.fixture(scope="function", autouse=True)
 def cql_test_connection(cql, request):
+    scylla_log(cql, f'test/cqlpy: Starting {request.node.parent.name}::{request.node.name}', 'info')
     yield
     try:
         # We want to run a do-nothing CQL command. 
@@ -86,6 +88,7 @@ def cql_test_connection(cql, request):
         cql.execute("BEGIN BATCH APPLY BATCH")
     except:
         pytest.exit(f"Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}")
+    scylla_log(cql, f'test/cqlpy: Ended {request.node.parent.name}::{request.node.name}', 'info')
 
 # Until Cassandra 4, NetworkTopologyStrategy did not support the option
 # replication_factor (https://issues.apache.org/jira/browse/CASSANDRA-14303).


### PR DESCRIPTION
Both test.py and test/cqlpy/run run many test functions against the same Scylla process. In the resulting log file, it is hard to understand which log messages are related to which test. In this patch, we log a message (using the "/system/log" REST API) every time a test is started or ends.

The messages look like this:

    INFO  2025-04-22 15:10:44,625 [shard 1:strm] api - /system/log:
    test/cqlpy: Starting test_lwt.py::test_lwt_missing_row_with_static
    ...
    INFO  2025-04-22 15:10:44,631 [shard 0:strm] api - /system/log:
    test/cqlpy: Ended test_lwt.py::test_lwt_missing_row_with_static

We already had a similar feature in test/alternator, added three years ago in commit b0371b6bf8f1e80c43967d599dee4dd83db0f71d. The implementation is similar but not identical due to different available utility functions, and in any case it's very simple.

While at it, this patch also fixes the has_rest_api() to timeout after one second. Without this, if the REST API is blocked in a way that a connection attempt just hangs, the tests can hang. With the new timeout, the test will hang for a second, realize the REST API is not available, and remember this decision (the next tests will not wait one second again). We had the same bug in Alternator, and fixed it in 758f8f01d77a6a2d16600d47cd6fc645a2d38e27. This one second "pause" will only happen if the REST API port is blocked - in the more typical case the REST API port is just not listening but not blocked, and the failure will be noticed immediately and won't wait a whole second.

This is a test-only feature for making test failure logs easier to debug, no real need to backport.