### PR TITLE
test: test_zero_token_nodes_topology_ops: use host IDs for ignored nodes

### DIFF
--- a/test/cluster/test_zero_token_nodes_topology_ops.py
+++ b/test/cluster/test_zero_token_nodes_topology_ops.py
@@ -84,8 +84,9 @@ async def test_zero_token_nodes_topology_ops(manager: ManagerClient, tablets_ena
     logging.info(f'Stopping {server_d}')
     await manager.server_stop_gracefully(server_d.server_id)
 
-    logging.info(f'Initiating removenode of {server_b} by {server_a}, ignore_dead={[server_d.ip_addr]}')
-    await manager.remove_node(server_a.server_id, server_b.server_id, [server_d.ip_addr])
+    server_d_id = await manager.get_host_id(server_d.server_id)
+    logging.info(f'Initiating removenode of {server_b} by {server_a}, ignore_dead={[server_d_id]}')
+    await manager.remove_node(server_a.server_id, server_b.server_id, [server_d_id])
 
     logging.info(f'Initiating removenode of {server_d} by {server_a}')
     await manager.remove_node(server_a.server_id, server_d.server_id)


### PR DESCRIPTION
Providing IP of an ignored node during removenode made the test flaky.
It could happen that the address map contained mappings of two
nodes with the same IP:
1. the node being ignored,
2. the node that expectedly failed replacing earlier in the test.

So, `address_map::find_by_addr()` called in `find_raft_nodes_from_hoeps`
could return the host ID of the second node instead of the first node
and cause removenode to fail.

We fix flakiness in this patch by providing the host ID of the ignored
node instead of its IP. We would have to do it anyway sooner or later
because providing IP is deprecated.

The bug in `find_raft_nodes_from_hoeps` is tracked by
scylladb/scylladb#23846.

The test became flaky because of f0af3f261e3cc605bd3e3033f62406ed6359c99c.
That patch is not present in 2025.1, so the test isn't flaky outside
master, and hence there is no reason to backport this patch.

Fixes scylladb/scylladb#23499