### PR TITLE
test_tablets_cql: test_alter_dropped_tablets_keyspace: extend expected error

### DIFF
--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -65,7 +65,7 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
                                          f"data_dictionary::no_such_keyspace \(Can't find a keyspace {ks}\)")
     assert not matches
 
-    with pytest.raises(InvalidRequest, match=f"Can't ALTER keyspace {ks}, keyspace doesn't exist") as e:
+    with pytest.raises(InvalidRequest, match=f"Can't ALTER keyspace {ks}, keyspace doesn't exist|Can't find a keyspace {ks}") as e:
         await task
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The query may fail also on a no_such_keyspace
exception, which generates the following cql error:
```
Error from server: code=2200 [Invalid query] message="Can\'t find a keyspace test_1745198244144_qoohq"
```
Extend the pytest.raises match expression to include this error as well.

Fixes #23812

* Requires backport to 2025.1 as the test fails there too