### PR TITLE
test.py: split boost pytest integration

### DIFF
--- a/test.py
+++ b/test.py
@@ -252,7 +252,7 @@ def parse_cmd_line() -> argparse.Namespace:
         args.coverage = True
 
     args.tmpdir = os.path.abspath(args.tmpdir)
-    prepare_dirs(tempdir_base=pathlib.Path(args.tmpdir), modes=args.modes)
+    prepare_dirs(tempdir_base=pathlib.Path(args.tmpdir), modes=args.modes, gather_metrics=args.gather_metrics)
 
     # Get the list of tests configured by configure.py
     try:
@@ -541,7 +541,6 @@ async def main() -> int:
     options = parse_cmd_line()
 
     open_log(options.tmpdir, f"test.py.{'-'.join(options.modes)}.log", options.log_level)
-    setup_cgroup(options.gather_metrics)
 
     init_testsuite_globals()
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -7,7 +7,7 @@
 import os
 from pathlib import Path
 
-__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "path_to"]
+__all__ = ["ALL_MODES", "BUILD_DIR", "DEBUG_MODES", "TEST_DIR", "TEST_RUNNER", "TOP_SRC_DIR", "COMBINED_TESTS", "path_to"]
 
 
 TEST_RUNNER = os.environ.get("SCYLLA_TEST_RUNNER", "pytest")
@@ -15,6 +15,7 @@ TEST_RUNNER = os.environ.get("SCYLLA_TEST_RUNNER", "pytest")
 TOP_SRC_DIR = Path(__file__).parent.parent  # ScyllaDB's source code root directory
 TEST_DIR = TOP_SRC_DIR / "test"
 BUILD_DIR = TOP_SRC_DIR / "build"
+COMBINED_TESTS = Path('test/boost/combined_tests')
 
 ALL_MODES = {
     "debug": "Debug",

--- a/test/boost/conftest.py
+++ b/test/boost/conftest.py
@@ -7,8 +7,9 @@ from pathlib import PosixPath
 
 from pytest import Collector
 
-from test.pylib.cpp.boost.boost_facade import BoostTestFacade, COMBINED_TESTS
-from test.pylib.cpp.common_cpp_conftest import collect_items, get_combined_tests
+from test.pylib.cpp.boost.boost_facade import BoostTestFacade, get_combined_tests
+from test import COMBINED_TESTS
+from test.pylib.cpp.common_cpp_conftest import collect_items
 
 
 def pytest_collect_file(file_path: PosixPath, parent: Collector):
@@ -19,4 +20,4 @@ def pytest_collect_file(file_path: PosixPath, parent: Collector):
     # One of the files in the directory has additional extensions .inc. It's not a test and will not have a binary for
     # execution, so it should be excluded from collecting
     if file_path.suffix == '.cc' and '.inc' not in file_path.suffixes and file_path.stem != COMBINED_TESTS.stem:
-        return collect_items(file_path, parent, facade=BoostTestFacade(parent.config, get_combined_tests()))
+        return collect_items(file_path, parent, facade=BoostTestFacade(parent.config, combined_tests=get_combined_tests(parent.config)))

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from argparse import BooleanOptionalAction
 from pathlib import Path
 from random import randint
 from typing import TYPE_CHECKING
@@ -44,6 +45,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption('--run_id', action='store', default=None, help='Run id for the test run')
     parser.addoption('--byte-limit', action="store", default=randint(0, 2000), type=int,
                      help="Specific byte limit for failure injection (random by default)")
+    parser.addoption("--gather-metrics", action=BooleanOptionalAction, default=False,
+                     help='Switch on gathering cgroup metrics')
 
     # Following option is to use with bare pytest command.
     #

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -39,8 +39,8 @@ from test import BUILD_DIR, COMBINED_TESTS
 from test.pylib.cpp.common_cpp_conftest import get_modes_to_run
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure, run_process
 
-TIMEOUT_DEBUG = 60 * 5 # seconds
-TIMEOUT = 60 * 2 # seconds
+TIMEOUT_DEBUG = 60 * 30 # seconds
+TIMEOUT = 60 * 15 # seconds
 
 class BoostTestFacade(CppTestFacade):
     """

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -85,6 +85,7 @@ class BoostTestFacade(CppTestFacade):
         mode: str,
         file_name: Path,
         test_args:Sequence[str] = (),
+        env: dict = None,
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         def read_file(name: Path) -> str:
             try:

--- a/test/pylib/cpp/common_cpp_conftest.py
+++ b/test/pylib/cpp/common_cpp_conftest.py
@@ -3,18 +3,14 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
-import collections
 import os
-import subprocess
 from copy import copy
-from functools import cache
 from pathlib import Path, PosixPath
 
 import yaml
 from pytest import Collector
 
-from test import ALL_MODES, DEBUG_MODES, TOP_SRC_DIR
-from test.pylib.cpp.boost.boost_facade import COMBINED_TESTS
+from test import ALL_MODES, DEBUG_MODES
 from test.pylib.cpp.facade import CppTestFacade
 from test.pylib.cpp.item import CppFile
 from test.pylib.util import get_modes_to_run
@@ -114,24 +110,3 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
         args.extend(custom_args)
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, no_parallel_run=no_parallel_run,
                                    modes=modes, disabled_tests=disabled_tests, run_id=run_id, facade=facade, project_root=project_root, env=test_env)
-
-@cache
-def get_combined_tests():
-    suites = collections.defaultdict()
-    executable = TOP_SRC_DIR / COMBINED_TESTS
-    args = [executable, '--list_content']
-
-    output = subprocess.check_output(
-        args,
-        stderr=subprocess.STDOUT,
-        universal_newlines=True,
-    )
-    current_suite = ''
-    for line in output.splitlines():
-        if not line.startswith('    '):
-            current_suite = line.strip().rstrip('*')
-            suites[current_suite] = []
-        else:
-            case_name = line.strip().rstrip('*')
-            suites[current_suite].append(case_name)
-    return suites

--- a/test/pylib/cpp/common_cpp_conftest.py
+++ b/test/pylib/cpp/common_cpp_conftest.py
@@ -97,10 +97,12 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
     disabled_tests = get_disabled_tests(suite_config, modes)
     args = copy(DEFAULT_ARGS)
     custom_args_config = suite_config.get('custom_args', {})
+    extra_scylla_cmdline_options = suite_config.get('extra_scylla_cmdline_options', [])
     test_name = file_path.stem
     no_parallel_run = True if test_name in no_parallel_cases else False
 
     custom_args = custom_args_config.get(file_path.stem, ['-c2 -m2G'])
+    args.extend(extra_scylla_cmdline_options)
     if len(custom_args) > 1:
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, parameters=custom_args,
                                    no_parallel_run=no_parallel_run, modes=modes, disabled_tests=disabled_tests,

--- a/test/pylib/cpp/common_cpp_conftest.py
+++ b/test/pylib/cpp/common_cpp_conftest.py
@@ -92,7 +92,6 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
     )
     run_id = parent.config.getoption('run_id')
     modes = get_modes_to_run(parent.session.config)
-    project_root = Path(parent.session.config.rootpath).parent
     suite_config = read_suite_config(file_path.parent)
     no_parallel_cases = suite_config.get('no_parallel_cases', [])
     disabled_tests = get_disabled_tests(suite_config, modes)
@@ -105,8 +104,8 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
     if len(custom_args) > 1:
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, parameters=custom_args,
                                    no_parallel_run=no_parallel_run, modes=modes, disabled_tests=disabled_tests,
-                                   run_id=run_id, facade=facade, project_root=project_root, env=test_env)
+                                   run_id=run_id, facade=facade,  env=test_env)
     else:
         args.extend(custom_args)
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, no_parallel_run=no_parallel_run,
-                                   modes=modes, disabled_tests=disabled_tests, run_id=run_id, facade=facade, project_root=project_root, env=test_env)
+                                   modes=modes, disabled_tests=disabled_tests, run_id=run_id, facade=facade, env=test_env)

--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -57,7 +57,7 @@ class CppTestFacade(ABC):
         self.temp_dir: Path = Path(config.getoption('tmpdir'))
         self.combined_suites: dict[str, list[str]] = combined_tests
 
-    def list_tests(self, executable: Path , no_parallel: bool) -> tuple[bool,list[str]]:
+    def list_tests(self, executable: Path , no_parallel: bool, mode: str) -> tuple[bool,list[str]]:
         raise NotImplementedError
 
     def run_test(self, executable: Path, original_name: str, test_id: str, mode: str, file_name: Path,

--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -60,7 +60,8 @@ class CppTestFacade(ABC):
     def list_tests(self, executable: Path , no_parallel: bool) -> tuple[bool,list[str]]:
         raise NotImplementedError
 
-    def run_test(self, executable: Path, original_name: str, test_id: str, mode:str, file_name: Path, test_args: Sequence[str] = ()) -> tuple[Sequence[CppTestFailure] | None, str]:
+    def run_test(self, executable: Path, original_name: str, test_id: str, mode: str, file_name: Path,
+                 test_args: Sequence[str] = (), env: dict = None) -> tuple[Sequence[CppTestFailure] | None, str]:
          raise NotImplementedError
 
 

--- a/test/pylib/cpp/item.py
+++ b/test/pylib/cpp/item.py
@@ -142,7 +142,7 @@ class CppFile(pytest.File):
             if test_name in self.disabled_tests[mode]:
                 continue
             executable = Path(f'{self.project_root}/build/{mode}/test/{self.path.parent.name}/{test_name}')
-            combined, tests = self.facade.list_tests(executable, self.no_parallel_run)
+            combined, tests = self.facade.list_tests(executable, self.no_parallel_run, mode)
             if combined:
                 executable = executable.parent / COMBINED_TESTS.stem
             for test_name in tests:

--- a/test/pylib/cpp/item.py
+++ b/test/pylib/cpp/item.py
@@ -32,7 +32,7 @@ import pytest
 from _pytest._code.code import TerminalRepr, ReprFileLocation
 from _pytest._io import TerminalWriter
 
-from test.pylib.cpp.boost.boost_facade import COMBINED_TESTS
+from test import COMBINED_TESTS, BUILD_DIR
 from test.pylib.cpp.facade import CppTestFailure, CppTestFailureList, CppTestFacade
 
 
@@ -122,7 +122,7 @@ class CppFile(pytest.File):
     Represents the C++ test file with all necessary information for test execution
     """
     def __init__(self, *, no_parallel_run: bool = False, modes: list[str], disabled_tests: dict[str, set[str]],
-                 run_id=None, facade: CppTestFacade, arguments: Sequence[str], parameters: list[str] = None, project_root: Path,
+                 run_id=None, facade: CppTestFacade, arguments: Sequence[str], parameters: list[str] = None,
                  env: dict = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.facade = facade
@@ -131,7 +131,6 @@ class CppFile(pytest.File):
         self.disabled_tests = disabled_tests
         self.no_parallel_run = no_parallel_run
         self.parameters = parameters
-        self.project_root = project_root
         self.env = env
         self._arguments = arguments
 
@@ -141,7 +140,7 @@ class CppFile(pytest.File):
             self.env['TMPDIR'] = Path(self.parent.config.getoption('tmpdir'), mode).absolute()
             if test_name in self.disabled_tests[mode]:
                 continue
-            executable = Path(f'{self.project_root}/build/{mode}/test/{self.path.parent.name}/{test_name}')
+            executable = Path(f'{BUILD_DIR}/{mode}/test/{self.path.parent.name}/{test_name}')
             combined, tests = self.facade.list_tests(executable, self.no_parallel_run, mode)
             if combined:
                 executable = executable.parent / COMBINED_TESTS.stem

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -18,7 +18,8 @@ class UnitTestFacade(CppTestFacade):
     def list_tests(
             self,
             executable: Path,
-            no_parallel_run: bool
+            no_parallel_run: bool,
+            mode: str
     ) -> tuple[bool, list[str]]:
         return False, [os.path.basename(os.path.splitext(executable)[0])]
 

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -11,7 +11,7 @@ from typing import Sequence
 
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure, run_process
 
-TIMEOUT = 30 # seconds
+TIMEOUT = 60 * 10 # seconds
 
 class UnitTestFacade(CppTestFacade):
 

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -30,6 +30,7 @@ class UnitTestFacade(CppTestFacade):
         mode: str,
         file_name: Path,
         test_args: Sequence[str] = (),
+        env: dict = None,
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         args = [str(executable), *test_args]
         os.chdir(self.temp_dir.parent)

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -31,7 +31,7 @@ from test.pylib.artifact_registry import ArtifactRegistry
 from test.pylib.host_registry import HostRegistry
 from test.pylib.ldap_server import start_ldap
 from test.pylib.minio_server import MinioServer
-from test.pylib.resource_gather import get_resource_gather
+from test.pylib.resource_gather import get_resource_gather, setup_cgroup
 from test.pylib.s3_proxy import S3ProxyServer
 from test.pylib.s3_server_mock import MockS3Server
 from test.pylib.util import LogPrefixAdapter, get_xdist_worker_id
@@ -521,8 +521,9 @@ def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
         p.unlink()
 
 
-def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str]) -> None:
+def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool) -> None:
     prepare_dir(tempdir_base, "*.log")
+    setup_cgroup(gather_metrics)
     shutil.rmtree(tempdir_base / "ldap_instances", ignore_errors=True)
     prepare_dir(tempdir_base / "ldap_instances", "*")
     for mode in modes:

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -524,8 +524,10 @@ def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
 def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool) -> None:
     prepare_dir(tempdir_base, "*.log")
     setup_cgroup(gather_metrics)
-    shutil.rmtree(tempdir_base / "ldap_instances", ignore_errors=True)
-    prepare_dir(tempdir_base / "ldap_instances", "*")
+    for directory in ['report', 'ldap_instances']:
+        full_path_directory = tempdir_base / directory
+        shutil.rmtree(full_path_directory, ignore_errors=True)
+        prepare_dir(full_path_directory, '*')
     for mode in modes:
         prepare_dir(tempdir_base / mode, "*.log")
         prepare_dir(tempdir_base / mode, "*.reject")

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -163,8 +163,10 @@ class PythonTest(Test):
             "--junit-xml={}".format(self.xmlout),
             "-rs",
             "--run_id={}".format(self.id),
-            "--mode={}".format(self.mode)
+            "--mode={}".format(self.mode),
         ]
+        if options.gather_metrics:
+            self.args.append("--gather-metrics")
         self.args.append(f"--alluredir={self.allure_dir}")
         if not options.save_log_on_success:
             self.args.append("--allure-no-capture")

--- a/test/pylib/suite/tool.py
+++ b/test/pylib/suite/tool.py
@@ -60,6 +60,8 @@ class ToolTest(Test):
             "--mode={}".format(self.mode),
             "--run_id={}".format(self.id)
         ]
+        if options.gather_metrics:
+            self.args.append("--gather-metrics")
         self.args.append(f"--alluredir={self.allure_dir}")
         if not options.save_log_on_success:
             self.args.append("--allure-no-capture")


### PR DESCRIPTION
This PR contains changes that do not add new functionality, and have small refactoring of the existing code.
The most significant change is the refactoring of resource gathering, so it will not create another cgroup to put itself in. So there will be no nested redundant 'initial' groups, e.x. `/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/initial/initial/initial.../initial`
This is part two of splitting the original PR.

This PR is an extraction of several commits from https://github.com/scylladb/scylladb/pull/22894 as reviewer https://github.com/scylladb/scylladb/pull/22894?notification_referrer_id=NT_kwDOACiLR7MxNDg0ODk2MDU1MjoyNjU3MDk1&notifications_query=reason%3Aparticipating#pullrequestreview-2778582278.