### PR TITLE
raft: make sure to retain the existing voters including the current leader (topology coordinator)

### DIFF
--- a/service/raft/group0_voter_calculator.hh
+++ b/service/raft/group0_voter_calculator.hh
@@ -41,6 +41,7 @@ public:
         sstring rack;
         bool is_voter;
         bool is_alive;
+        bool is_leader = false;
     };
 
     using nodes_list_t = std::unordered_map<raft::server_id, node_descriptor>;

--- a/service/raft/group0_voter_handler.cc
+++ b/service/raft/group0_voter_handler.cc
@@ -295,9 +295,8 @@ class calculator_impl {
         return std::min(nodes_count_exclude_largest - 1, (voters_max - 1) / 2);
     }
 
-    static datacenters_store_t create_datacenters_list(const group0_voter_calculator::nodes_list_t& nodes, size_t* largest_dc_size) {
-        SCYLLA_ASSERT(largest_dc_size != nullptr);
-        *largest_dc_size = 0;
+    static datacenters_store_t create_datacenters_list(const group0_voter_calculator::nodes_list_t& nodes, size_t& largest_dc_size) {
+        largest_dc_size = 0;
 
         std::unordered_map<std::string_view, nodes_ref_list_t> nodes_by_dc;
         for (const auto& [id, node] : nodes) {
@@ -305,7 +304,7 @@ class calculator_impl {
         }
 
         if (!nodes_by_dc.empty()) {
-            *largest_dc_size = std::ranges::max_element(nodes_by_dc, [](const auto& dc1, const auto& dc2) {
+            largest_dc_size = std::ranges::max_element(nodes_by_dc, [](const auto& dc1, const auto& dc2) {
                 return dc1.second.size() < dc2.second.size();
             })->second.size();
         }
@@ -349,7 +348,7 @@ public:
     constexpr static size_t VOTERS_MAX_DEFAULT = 5;
 
     calculator_impl(uint64_t voters_max, const group0_voter_calculator::nodes_list_t& nodes)
-        : _datacenters(create_datacenters_list(nodes, &_largest_dc_size))
+        : _datacenters(create_datacenters_list(nodes, _largest_dc_size))
         , _voters_max(calc_voters_max(voters_max, nodes, _datacenters, _largest_dc_size))
         , _voters_max_per_dc(calc_voters_max_per_dc(_voters_max, nodes, _datacenters, _largest_dc_size)) {
 


### PR DESCRIPTION
Fix an issue in the voter calculator where existing voters were not retained across data centers and racks in certain scenarios. This occurred when voters were distributed across more data centers and racks than the maximum allowed number of voters.
Previously, the prioritization logic for data centers and racks did not consider the number of existing assigned voters. It only prioritized nodes within a single data center or rack, which could result in unnecessary reassignment of voters.
Improved the prioritization logic to account for the number of existing assigned voters in each data center and rack.

Additionally, the limited voters feature did not account for the existing topology coordinator (Raft leader) when selecting voters to be removed. As a result, the limited voters calculator could inadvertently remove the votership of the topology coordinator, triggering unnecessary Raft leader re-election.
To address this, the topology coordinator's votership status is now preserved unless absolutely necessary. When choosing between otherwise equivalent voters, the node other than the existing topology coordinator is prioritized for removal.

This change ensures a more stable voter distribution and reduces unnecessary voter reassignments.

The limited voters calculator is refactored to use a priority queue for sorting nodes by their priorities. This change simplifies the voter selection logic and makes it more extensible for future enhancements, such as supporting more complex priority calculations.

Fixes: scylladb/scylladb#23950
Fixes: scylladb/scylladb#23588
Fixes: scylladb/scylladb#23786

No backport: The limited voters feature is currently only present in master.