### PR TITLE
Fix regexp in `check_node_log_for_failed_mutations`

### DIFF
--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -301,7 +301,7 @@ async def check_system_topology_and_cdc_generations_v3_consistency(manager: Mana
 async def check_node_log_for_failed_mutations(manager: ManagerClient, server: ServerInfo):
     logging.info(f"Checking that node {server} had no failed mutations")
     log = await manager.server_open_log(server.server_id)
-    occurrences = await log.grep(expr="^(?!.*\b(INFO|DEBUG|TRACE)\b).*Failed to apply mutation from")
+    occurrences = await log.grep(expr="Failed to apply mutation from", filter_expr="(TRACE|DEBUG|INFO)")
     assert len(occurrences) == 0
 
 


### PR DESCRIPTION
The regexp that was added in https://github.com/scylladb/scylladb/pull/23658 does not work as expected: `TRACE`, `INFO` and `DEBUG` level messages are not ignored. This patch corrects the pattern to ensure those log levels are excluded.

Fixes scylladb/scylladb#23688

This is a test framework issue. No backport needed. 