### PR TITLE
test: mv: skip test_mv_tablets_empty_ip in debug mode

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 # remote view updates.
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
+@skip_mode('debug', 'node replace needs to wait for tablet rebuild, which takes a lot of time in debug mode')
 async def test_mv_tablets_empty_ip(manager: ManagerClient):
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(4, config = cfg, property_file=[


### PR DESCRIPTION
This test shuts down a node and then replaces it with another one while continuously writing to the cluster. The test has been observed to take a lot of time in debug mode and time out on the replace operation. Replace takes very long because rebuilding tablets on the new node is very slow, and the slowest part is memtable flush which happens at the beginning of streaming. The slowness seems to be specific to the debug mode.

Turn off the test in debug mode to deflake the CI. As a follow-up, the test is planned to be reworked into an quicker error injection test so that the code path tested by this test will be again exercised in debug unit tests (scylladb/scylladb#23898)

Fixes: scylladb/scylladb#20316

The test was not observed to fail on existing release branches, so no need to backport.