### PR TITLE
sstables: Lazily access statistics for trace-level logging

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3298,7 +3298,7 @@ gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::tim
     // No need to query gc_before for the sstable if the max_deletion_time is max()
     if (deletion_time == gc_clock::time_point(gc_clock::duration(std::numeric_limits<int>::max()))) {
         sstlog.trace("sstable={}, ks={}, cf={}, get_max_local_deletion_time={}, min_timestamp={}, gc_grace_seconds={}, shortcut",
-                get_filename(), s->ks_name(), s->cf_name(), deletion_time, get_stats_metadata().min_timestamp, s->gc_grace_seconds().count());
+                get_filename(), s->ks_name(), s->cf_name(), deletion_time, seastar::value_of([this] { return get_stats_metadata().min_timestamp; }), s->gc_grace_seconds().count());
         return gc_clock::time_point::min();
     }
     auto start = get_first_decorated_key().token();


### PR DESCRIPTION
There's a message in sstable::get_gc_before_for_fully_expire() method that is trace-level and one of its argument finds a value in sstable statisitics. Finding the value is not quite cheap (makes a lookup in std::unordered_map) and for mostly-off trace messages is just a waste of cycles.

It's a tiny enhancement, no real benefit in back-porting