### PR TITLE
topology coordinator: do not proceed further on invalid boostrap tokens

### DIFF
--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -365,6 +365,9 @@ cdc::topology_description make_new_generation_description(
         const noncopyable_function<std::pair<size_t, uint8_t>(dht::token)>& get_sharding_info,
         const locator::token_metadata_ptr tmptr) {
     const auto tokens = get_tokens(bootstrap_tokens, tmptr);
+    if (tokens.empty()) {
+        on_internal_error(cdc_log, "Attempted to create a CDC generation from an empty list of tokens");
+    }
 
     utils::chunked_vector<token_range_description> vnode_descriptions;
     vnode_descriptions.reserve(tokens.size());

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2080,6 +2080,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             bootstrap_tokens = dht::boot_strapper::get_bootstrap_tokens(tmptr, tokens_string, num_tokens, dht::check_token_endpoint::yes);
                         } catch (...) {
                             _rollback = fmt::format("Failed to assign tokens: {}", std::current_exception());
+                            break;
                         }
 
                         auto [gen_uuid, guard_, mutation] = co_await prepare_and_broadcast_cdc_generation_data(

--- a/test/cluster/test_bad_initial_token.py
+++ b/test/cluster/test_bad_initial_token.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from test.pylib.manager_client import ManagerClient
+
+import pytest
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_bad_initial_token(manager: ManagerClient):
+    # The validity of "initial_token" option is checked in the topology
+    # coordinator, even if this is the first node being bootstrap, and triggers
+    # rollback. Rollback currently gets stuck in case of rolling back the first
+    # node, so use two nodes in the test.
+    await manager.server_add()
+    await manager.server_add(config={"initial_token": "etaoin shrdlu"}, expected_error="Failed to assign tokens")


### PR DESCRIPTION
In case when dht::boot_strapper::get_boostrap_tokens fail to parse the
tokens, the topology coordinator handles the exception and schedules a
rollback. However, the current code tries to continue with the topology
coordinator logic even if an exception occurs, leaving boostrap_tokens
empty. This does not make sense and can actually cause issues,
specifically in prepare_and_broadcast_cdc_generation_data which
implicitly expect that the bootstrap_tokens of the first node in the
cluster will not be empty.
    
Fix this by adding the missing break.

Fixes: scylladb/scylladb#23897

From the code inspection alone it looks like 2025.1 and 6.2 have this problem, so marking for backport to both of them.