### PR TITLE
Add out of space prevention mechanisms

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1523,6 +1523,7 @@ deps['test/boost/combined_tests'] += [
     'test/boost/cql_query_test.cc',
     'test/boost/database_test.cc',
     'test/boost/data_listeners_test.cc',
+    'test/boost/disk_space_monitor_test.cc',
     'test/boost/error_injection_test.cc',
     'test/boost/extensions_test.cc',
     'test/boost/filtering_test.cc',

--- a/db/config.cc
+++ b/db/config.cc
@@ -1483,6 +1483,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , disk_space_monitor_normal_polling_interval_in_seconds(this, "disk_space_monitor_normal_polling_interval_in_seconds", value_status::Used, 10, "Disk-space polling interval while below polling threshold")
     , disk_space_monitor_high_polling_interval_in_seconds(this, "disk_space_monitor_high_polling_interval_in_seconds", value_status::Used, 1, "Disk-space polling interval at or above polling threshold")
     , disk_space_monitor_polling_interval_threshold(this, "disk_space_monitor_polling_interval_threshold", value_status::Used, 0.9, "Disk-space polling threshold. Polling interval is increased when disk utilization is greater than or equal to this threshold")
+    , critical_disk_utilization_level(this, "critical_disk_utilization_level", liveness::LiveUpdate, value_status::Used, 0.98, "Disk utilization level above which mechanisms preventing a node getting out of space are activated")
     , enable_create_table_with_compact_storage(this, "enable_create_table_with_compact_storage", liveness::LiveUpdate, value_status::Used, false, "Enable the deprecated feature of CREATE TABLE WITH COMPACT STORAGE.  This feature will eventually be removed in a future version.")
     , rf_rack_valid_keyspaces(this, "rf_rack_valid_keyspaces", liveness::MustRestart, value_status::Used, false,
         "Enforce RF-rack-valid keyspaces. Additionally, if there are existing RF-rack-invalid "

--- a/db/config.hh
+++ b/db/config.hh
@@ -595,6 +595,7 @@ public:
     named_value<int> disk_space_monitor_normal_polling_interval_in_seconds;
     named_value<int> disk_space_monitor_high_polling_interval_in_seconds;
     named_value<float> disk_space_monitor_polling_interval_threshold;
+    named_value<float> critical_disk_utilization_level;
 
     named_value<bool> enable_create_table_with_compact_storage;
 

--- a/docs/troubleshooting/error-messages/critical-disk-utilization.rst
+++ b/docs/troubleshooting/error-messages/critical-disk-utilization.rst
@@ -1,0 +1,31 @@
+Critical disk utilization
+=========================
+
+Issue
+^^^^^
+
+SELECT/INSERT/UPDATE/DELETE cqlsh operations fail with ``Critical disk utilization: rejected write mutation`` error message.
+
+
+For example
+
+.. code-block:: shell
+
+   WriteFailure: Error from server: code=1500 [Replica(s) failed to execute write] message="Critical disk utilization: rejected write mutation" info={'consistency': 'QUORUM', 'required_responses': 2, 'received_responses': 1, 'failures': 2}
+
+Problem
+^^^^^^^
+
+Scaling out a cluster failed or is delayed. As a consequence the disk space becomes critically low and mechanisms preventing nodes going out of space have been activated. User write activity was paused, but the node remains able to migrate data to other nodes.
+
+How to Verify
+^^^^^^^^^^^^^
+
+Run ``nodetool status`` to check nodes are up and running.
+
+Run ``df -h /var/lib/scylla/`` to verify that the current disk utilization (in %) is higher than the configured threshold :ref:`critical_disk_utilization_level <confprop_critical_disk_utilization_level>`.
+
+Solution
+^^^^^^^^
+
+Scale out the cluster. Adding new nodes to the same rack as the node that reached critical condition, will bring the disk utilization down below the critical threshold and the prevention mechanisms will be deactivated.

--- a/docs/troubleshooting/error-messages/index.rst
+++ b/docs/troubleshooting/error-messages/index.rst
@@ -8,6 +8,7 @@ Error Messages
    address-already-in-use
    schema-mismatch
    invalid-ssl-prot-error
+   critical-disk-utilization
 
 
 .. panel-box::
@@ -22,3 +23,5 @@ Error Messages
   * :doc:`Schema Mismatch </troubleshooting/error-messages/schema-mismatch>`
 
   * :doc:`Invalid SSL Protocol </troubleshooting/error-messages/invalid-ssl-prot-error>`
+
+  * :doc:`Critical disk utilization </troubleshooting/error-messages/critical-disk-utilization/>`

--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -23,12 +23,17 @@ class stale_topology_exception {
 class abort_requested_exception {
 };
 
+class critical_disk_utilization_exception {
+    sstring failed_action();
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
             replica::rate_limit_exception,
             replica::stale_topology_exception,
-            replica::abort_requested_exception
+            replica::abort_requested_exception,
+            replica::critical_disk_utilization_exception
     > reason;
 };
 

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -31,6 +31,7 @@ struct load_stats_v1 final {
 struct load_stats {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
     std::unordered_map<locator::host_id, uint64_t> capacity;
+    std::unordered_map<locator::host_id, bool> critical_disk_utilization [[version 2025.3]];
 };
 
 }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -813,6 +813,10 @@ load_stats& load_stats::operator+=(const load_stats& s) {
     for (auto& [host, cap] : s.capacity) {
         capacity[host] = cap;
     }
+    for (auto& [host, cdu] : s.critical_disk_utilization) {
+        critical_disk_utilization[host] = cdu;
+    }
+
     return *this;
 }
 

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -400,6 +400,9 @@ struct load_stats {
     // Capacity in bytes for data file storage.
     std::unordered_map<host_id, uint64_t> capacity;
 
+    // Critical disk utilization check for each host.
+    std::unordered_map<locator::host_id, bool> critical_disk_utilization;
+
     static load_stats from_v1(load_stats_v1&&);
 
     load_stats& operator+=(const load_stats& s);

--- a/main.cc
+++ b/main.cc
@@ -1200,6 +1200,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             auto stop_cm = defer_verbose_shutdown("compaction_manager", [&cm] {
                cm.stop().get();
             });
+            cm.invoke_on_all(&compaction_manager::start, std::ref(*cfg), only_on_shard0(&*disk_space_monitor_shard0)).get();
 
             checkpoint(stop_signal, "starting storage manager");
             sstables::storage_manager::config stm_cfg;

--- a/main.cc
+++ b/main.cc
@@ -1767,7 +1767,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {
                 repair.stop().get();
             });
-            repair.invoke_on_all(&repair_service::start).get();
+            repair.invoke_on_all(&repair_service::start, only_on_shard0(&*disk_space_monitor_shard0)).get();
             api::set_server_repair(ctx, repair, gossip_address_map).get();
             auto stop_repair_api = defer_verbose_shutdown("repair API", [&ctx] {
                 api::unset_server_repair(ctx).get();

--- a/main.cc
+++ b/main.cc
@@ -1272,7 +1272,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             // not include reserve segments created by active commitlogs.
             db.local().init_commitlog().get();
             checkpoint(stop_signal, "starting per-shard database core");
-            db.invoke_on_all(&replica::database::start, std::ref(sl_controller)).get();
+            db.invoke_on_all(&replica::database::start, std::ref(sl_controller), only_on_shard0(&*disk_space_monitor_shard0)).get();
 
             ::sigquit_handler sigquit_handler(db);
 

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -23,6 +23,8 @@ exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
         return e;
     } catch (abort_requested_exception&) {
         return abort_requested_exception();
+    } catch (const critical_disk_utilization_exception& e) {
+        return e;
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -63,6 +63,23 @@ public:
     virtual const char* what() const noexcept override { return _message.c_str(); }
 };
 
+class critical_disk_utilization_exception final: public replica_exception {
+    seastar::sstring _failed_action;
+    seastar::sstring _message;
+public:
+    critical_disk_utilization_exception(std::string_view failed_action) noexcept
+        : replica_exception()
+        , _failed_action(failed_action)
+        , _message(seastar::format("Critical disk utilization: {}", failed_action))
+    { }
+
+    const seastar::sstring& failed_action() const {
+        return _failed_action;
+    }
+
+    virtual const char* what() const noexcept override { return _message.c_str(); }
+};
+
 using abort_requested_exception = seastar::abort_requested_exception;
 
 struct exception_variant {
@@ -70,7 +87,8 @@ struct exception_variant {
             no_exception,
             rate_limit_exception,
             stale_topology_exception,
-            abort_requested_exception
+            abort_requested_exception,
+            critical_disk_utilization_exception
     > reason;
 
     exception_variant()

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -774,6 +774,9 @@ private:
                     } else if constexpr (std::is_same_v<Ex, replica::abort_requested_exception>) {
                         msg = e.what();
                         return error::FAILURE;
+                    } else if constexpr (std::is_same_v<Ex, replica::critical_disk_utilization_exception>) {
+                        msg = e.what();
+                        return error::FAILURE;
                     }
                 }, exception->reason);
             }
@@ -4491,6 +4494,8 @@ void storage_proxy::send_to_live_endpoints(storage_proxy::response_id_type respo
                 err = error::TIMEOUT;
             } else if (auto* e = try_catch<db::virtual_table_update_exception>(eptr)) {
                 msg = e->grab_cause();
+            } else if (auto* e = try_catch<replica::critical_disk_utilization_exception>(eptr)) {
+                msg = e->what();
             } else {
                 slogger.error("exception during mutation write to {}: {}", coordinator, eptr);
             }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6957,6 +6957,7 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
 
     auto this_host = _db.local().get_token_metadata().get_my_id();
     load_stats.capacity[this_host] = _disk_space_monitor->space().capacity;
+    load_stats.critical_disk_utilization[this_host] = _disk_space_monitor->disk_utilization() > _db.local().get_config().critical_disk_utilization_level();
 
     co_return std::move(load_stats);
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1056,13 +1056,14 @@ private:
     std::function<future<void>(std::string_view)> _compression_dictionary_updated_callback;
     using byte_vector = std::vector<std::byte>;
     std::function<future<byte_vector>(std::vector<byte_vector>)> _train_dict;
+
+    utils::disk_space_monitor* _disk_space_monitor; // != nullptr only on shard0.
+
 public:
     future<uint64_t> estimate_total_sstable_volume(table_id);
     future<std::vector<std::byte>> train_dict(utils::chunked_vector<temporary_buffer<char>> sample);
     future<> publish_new_sstable_dict(table_id, std::span<const std::byte>, service::raft_group0_client&);
     void set_train_dict_callback(decltype(_train_dict));
-
-    utils::disk_space_monitor* _disk_space_monitor; // != nullptr only on shard0.
 
     friend class join_node_rpc_handshaker;
     friend class node_ops::node_ops_virtual_task;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1458,8 +1458,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
 
                     if (action_failed(tablet_state.streaming)) {
-                        bool cleanup = utils::get_local_injector().enter("stream_tablet_move_to_cleanup");
-                        if (cleanup || check_excluded_replicas()) {
+                        const bool cleanup = utils::get_local_injector().enter("stream_tablet_move_to_cleanup");
+                        bool critical_disk_utilization = false;
+                        if (auto stats = _tablet_allocator.get_load_stats()) {
+                            const auto& util = stats->critical_disk_utilization;
+                            auto it = util.find(trinfo.pending_replica->host);
+                            critical_disk_utilization = (it != util.end() && it->second);
+                        }
+
+                        if (cleanup || check_excluded_replicas() || critical_disk_utilization) {
                             if (do_barrier()) {
                                 rtlogger.debug("Will set tablet {} stage to {}", gid, locator::tablet_transition_stage::cleanup_target);
                                 updates.emplace_back(get_mutation_builder()

--- a/streaming/stream_blob.cc
+++ b/streaming/stream_blob.cc
@@ -30,6 +30,7 @@
 #include <cfloat>
 #include <filesystem>
 #include <fmt/ranges.h>
+#include "replica/exceptions.hh"
 
 namespace streaming {
 
@@ -178,6 +179,10 @@ future<> stream_blob_handler(replica::database& db,
                 }
                 blogger.info("stream_mutation_fragments: released (tablets)");
             });
+
+            if (db.is_in_critical_disk_utilization_mode()) {
+                throw replica::critical_disk_utilization_exception("rejected streamed file");
+            }
 
             stream_blob_cmd_data& cmd_data = std::get<0>(*opt);
             auto cmd = cmd_data.cmd;

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -322,6 +322,7 @@ add_scylla_test(combined_tests
     cql_query_test.cc
     database_test.cc
     data_listeners_test.cc
+    disk_space_monitor_test.cc
     error_injection_test.cc
     extensions_test.cc
     filtering_test.cc

--- a/test/boost/disk_space_monitor_test.cc
+++ b/test/boost/disk_space_monitor_test.cc
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ *
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include "test/lib/log.hh"
+#include "test/lib/tmpdir.hh"
+
+#include "utils/disk_space_monitor.hh"
+#include "utils/updateable_value.hh"
+
+BOOST_AUTO_TEST_SUITE(disk_space_monitor_test)
+
+SEASTAR_THREAD_TEST_CASE(test_capacity_override) {
+    utils::updateable_value_source<uint64_t> data_file_capacity(0);
+
+    utils::disk_space_monitor::config dsm_cfg = {
+        .sched_group = create_scheduling_group("streaming", 200).get(),
+        // The test controls polling by triggering it manually so make it big
+        .normal_polling_interval = utils::updateable_value<int>(std::numeric_limits<int>::max()),
+        .high_polling_interval = utils::updateable_value<int>(std::numeric_limits<int>::max()),
+        .polling_interval_threshold = utils::updateable_value<float>(1.0),
+        .capacity_override = utils::updateable_value<uint64_t>(data_file_capacity),
+    };
+
+    seastar::abort_source as;
+    tmpdir data_dir;
+    auto data_dir_path = data_dir.path().string();
+
+    utils::disk_space_monitor dsm(as, data_dir_path, dsm_cfg);
+    auto stop_dsm = defer([&dsm] { dsm.stop().get(); });
+
+    std::filesystem::space_info orig_space = {
+        .capacity = 100,
+        .free = 12,
+        .available = 11,
+    };
+    auto reg = dsm.set_space_source([orig_space] { return make_ready_future<std::filesystem::space_info>(orig_space); });
+
+    dsm.start().get();
+
+    utils::phased_barrier poll_barrier("poll_barrier"); // new operation started whenever monitor calls listeners.
+    auto op = poll_barrier.start();
+    auto listener_registration = dsm.listen([&] (auto& mon) mutable {
+        op = poll_barrier.start();
+        return make_ready_future<>();
+    });
+
+    dsm.trigger_poll();
+    poll_barrier.advance_and_await().get();
+    BOOST_REQUIRE(dsm.space() == orig_space);
+
+    data_file_capacity.set(90);
+    dsm.trigger_poll();
+    poll_barrier.advance_and_await().get();
+
+    BOOST_REQUIRE_EQUAL(dsm.space().capacity, 90);
+    BOOST_REQUIRE_EQUAL(dsm.space().available, 1);
+    BOOST_REQUIRE_EQUAL(dsm.space().free, 2);
+
+    data_file_capacity.set(10);
+    dsm.trigger_poll();
+    poll_barrier.advance_and_await().get();
+    BOOST_REQUIRE_EQUAL(dsm.space().capacity, 10);
+    BOOST_REQUIRE_EQUAL(dsm.space().available, 0);
+    BOOST_REQUIRE_EQUAL(dsm.space().free, 0);
+
+    data_file_capacity.set(1000);
+    dsm.trigger_poll();
+    poll_barrier.advance_and_await().get();
+    BOOST_REQUIRE_EQUAL(dsm.space().capacity, 1000);
+    BOOST_REQUIRE_EQUAL(dsm.space().available, 911);
+    BOOST_REQUIRE_EQUAL(dsm.space().free, 912);
+
+    data_file_capacity.set(0);
+    dsm.trigger_poll();
+    poll_barrier.advance_and_await().get();
+    BOOST_REQUIRE(dsm.space() == orig_space);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_subscription_options) {
+    utils::disk_space_monitor::config dsm_cfg = {
+        .sched_group = create_scheduling_group("streaming", 200).get(),
+        // The test controls polling by triggering it manually so make it big
+        .normal_polling_interval = utils::updateable_value<int>(std::numeric_limits<int>::max()),
+        .high_polling_interval = utils::updateable_value<int>(std::numeric_limits<int>::max()),
+        .polling_interval_threshold = utils::updateable_value<float>(1.0),
+        .capacity_override = utils::updateable_value<uint64_t>(0),
+    };
+
+    seastar::abort_source as;
+    tmpdir data_dir;
+    auto data_dir_path = data_dir.path().string();
+
+    utils::disk_space_monitor dsm(as, data_dir_path, dsm_cfg);
+    auto stop_dsm = defer([&dsm] { dsm.stop().get(); });
+    dsm.start().get();
+
+    float disk_utilization = 0.1;
+    auto registration = dsm.set_space_source([&] {
+        std::filesystem::space_info space = {
+            .capacity = 100,
+            .free = 100*(1.0-disk_utilization),
+            .available = 100*(1-disk_utilization),
+        };
+        return make_ready_future<std::filesystem::space_info>(space);
+    });
+
+    struct stats {
+        size_t constant_updates = 0;
+        size_t constant_updates_only_above = 0;
+        size_t constant_updates_only_below = 0;
+
+        size_t crossing_threshold_updates = 0;
+        size_t crossing_threshold_updates_only_above = 0;
+        size_t crossing_threshold_updates_only_below = 0;
+    } stats;
+
+    utils::phased_barrier poll_barrier("poll_barrier");
+    auto op = poll_barrier.start();
+    auto listener_registration = dsm.listen([&] (auto&) mutable {
+        op = poll_barrier.start();
+        return make_ready_future<>();
+    });
+
+    auto s1 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.constant_updates;
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = false, .when_above_threshold = true, .when_below_threshold = true});
+
+    auto s2 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.constant_updates_only_above;
+        BOOST_CHECK(above_threshold == utils::disk_space_monitor::above_threshold::yes);
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = false, .when_above_threshold = true, .when_below_threshold = false});
+
+    auto s3 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.constant_updates_only_below;
+        BOOST_CHECK(above_threshold == utils::disk_space_monitor::above_threshold::no);
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = false, .when_above_threshold = false, .when_below_threshold = true});
+
+    auto s4 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.crossing_threshold_updates;
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = true, .when_above_threshold = true, .when_below_threshold = true});
+
+    auto s5 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.crossing_threshold_updates_only_above;
+        BOOST_CHECK(above_threshold == utils::disk_space_monitor::above_threshold::yes);
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = true, .when_above_threshold = true, .when_below_threshold = false});
+
+    auto s6 = dsm.subscribe(0.8, [&stats] (auto above_threshold) -> future<> {
+        ++stats.crossing_threshold_updates_only_below;
+        BOOST_CHECK(above_threshold == utils::disk_space_monitor::above_threshold::no);
+        return make_ready_future<>();
+    }, {.only_crossing_threshold = true, .when_above_threshold = false, .when_below_threshold = true});
+
+    for (float du : {0.1, 0.5, 0.85, 0.9, 0.7, 0.6, 0.93, 0.9, 0.82, 0.81}) {
+        disk_utilization = du;
+        dsm.trigger_poll();
+        poll_barrier.advance_and_await().get();
+    }
+
+    dsm.stop().get();
+    stop_dsm.cancel();
+
+    BOOST_REQUIRE_EQUAL(stats.constant_updates, 10);
+    BOOST_REQUIRE_EQUAL(stats.constant_updates_only_above, 6);
+    BOOST_REQUIRE_EQUAL(stats.constant_updates_only_below, 4);
+
+    BOOST_REQUIRE_EQUAL(stats.crossing_threshold_updates, 3);
+    BOOST_REQUIRE_EQUAL(stats.crossing_threshold_updates_only_above, 2);
+    BOOST_REQUIRE_EQUAL(stats.crossing_threshold_updates_only_below, 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5562,24 +5562,26 @@ SEASTAR_TEST_CASE(check_table_sstable_set_includes_maintenance_sstables) {
 }
 
 // Without commit aba475fe1d24d5c, scylla will fail miserably (either with abort or segfault; depends on the version).
-SEASTAR_THREAD_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
-    abort_source as;
+SEASTAR_TEST_CASE(compaction_manager_stop_and_drain_race_test) {
+    return test_env::do_with_async([] (test_env& env) {
+        abort_source as;
 
-    auto cfg = compaction_manager::config{ .available_memory = 1 };
-    auto task_manager = tasks::task_manager({}, as);
-    auto stop_task_manager = deferred_stop(task_manager);
-    auto cm = compaction_manager(cfg, as, task_manager);
-    auto stop_cm = deferred_stop(cm);
-    cm.enable();
+        auto cfg = compaction_manager::config{ .available_memory = 1 };
+        auto task_manager = tasks::task_manager({}, as);
+        auto stop_task_manager = deferred_stop(task_manager);
+        auto cm = compaction_manager(cfg, as, task_manager);
+        auto stop_cm = deferred_stop(cm);
+        cm.enable();
 
-    testlog.info("requesting abort");
-    as.request_abort();
+        testlog.info("requesting abort");
+        as.request_abort();
 
-    testlog.info("draining compaction manager");
-    cm.drain().get();
+        testlog.info("draining compaction manager");
+        cm.drain().get();
 
-    testlog.info("stopping compaction manager");
-    stop_cm.stop_now();
+        testlog.info("stopping compaction manager");
+        stop_cm.stop_now();
+    });
 }
 
 SEASTAR_TEST_CASE(test_print_shared_sstables_vector) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -681,7 +681,7 @@ private:
                 _db.stop().get();
             });
 
-            _db.invoke_on_all(&replica::database::start, std::ref(_sl_controller)).get();
+            _db.invoke_on_all(&replica::database::start, std::ref(_sl_controller), only_on_shard0(&*_disk_space_monitor_shard0)).get();
 
             smp::invoke_on_all([blocked_reactor_notify_ms] {
                 engine().update_blocked_reactor_notify_ms(blocked_reactor_notify_ms);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -514,6 +514,8 @@ private:
             if (!cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.is_set()) {
                 cfg->view_update_reader_concurrency_semaphore_kill_limit_multiplier.set(std::numeric_limits<uint32_t>::max());
             }
+            cfg->critical_disk_utilization_level.set(1.0f);
+
             tmpdir data_dir;
             auto data_dir_path = data_dir.path().string();
             if (!cfg->data_file_directories.is_set()) {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -642,6 +642,7 @@ private:
             });
             _cm.start(std::move(get_cm_cfg), std::ref(abort_sources), std::ref(_task_manager)).get();
             auto stop_cm = deferred_stop(_cm);
+            _cm.invoke_on_all(&compaction_manager::start, std::ref(*cfg), only_on_shard0(&*_disk_space_monitor_shard0)).get();
 
             _sstm.start(std::ref(*cfg), sstables::storage_manager::config{}).get();
             auto stop_sstm = deferred_stop(_sstm);

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -179,6 +179,8 @@ class PythonTest(Test):
         self.args.append(f"--alluredir={self.allure_dir}")
         if not options.save_log_on_success:
             self.args.append("--allure-no-capture")
+        else:
+            self.args.append('--save-log-on-success')
         if options.markers:
             self.args.append(f"-m={options.markers}")
 

--- a/test/storage/README.md
+++ b/test/storage/README.md
@@ -1,0 +1,6 @@
+Extension of the cluster tests, where all tests require externally mounted volumes
+to be used by scylla cluster nodes. The volumes are passed with --workdir.
+
+The volumes can be of any size. A help generator `space_limited_servers` is provided
+to easily create a cluster of any given number of nodes, where each node operates in
+a separate volume.

--- a/test/storage/__init__.py
+++ b/test/storage/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#

--- a/test/storage/conftest.py
+++ b/test/storage/conftest.py
@@ -1,0 +1,73 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import pytest
+import pathlib
+import shutil
+import subprocess
+import uuid
+
+from typing import Callable
+from contextlib import asynccontextmanager, contextmanager
+
+from test.pylib.manager_client import ManagerClient
+from test.cluster.conftest import *
+
+
+# Mounting volumes outside of the toolchain environment, requires root privileges. To overcome it,
+# `unshare` is used to launch tests in a separate namespace. This is a temporary solution as it
+# works with test.py but breaks the execution of the tests with pytest without test.py.
+# FIXME: Find a more robust solution to ditch unshare.
+@pytest.fixture(scope="function")
+def volumes_factory(pytestconfig, build_mode, request):
+    hash = str(uuid.uuid4())
+    base = pathlib.Path(f"{pytestconfig.getoption("tmpdir")}/{build_mode}/volumes/{hash}")
+    volumes = []
+
+    @contextmanager
+    def wrapper(sizes: list[str]):
+        try:
+            for id, size in enumerate(sizes):
+                path = base / f"scylla-{id}"
+                path.mkdir(parents=True)
+
+                subprocess.run(["sudo", "mount", "-o", f"size={size}", "-t", "tmpfs", "tmpfs", path], check=True)
+                volumes.append(path)
+            yield volumes
+        finally:
+            pass
+    yield wrapper
+
+    # The test in the storage module use unshare -mr as the launcher to be able to mount volumes.
+    # This means that the entire content of the mount is only visible inside the namespace. To keep
+    # the files on a test failure, we need to copy them out of the namespace.
+    #
+    # Copying cannot be done in the finally clause of the wrapper above as at that point test is not
+    # yet marked as failed. So the copy has to be done here.
+    #
+    # Note that since volumes are created within unshare, they will be automatically unmounted and
+    # files will be deleted so no additional cleanup is needed.
+    report = request.node.stash[PHASE_REPORT_KEY]
+    test_failed = report.when == "call" and report.failed
+    preserve_data = test_failed or request.config.getoption("save_log_on_success")
+
+    if preserve_data:
+        for id, path in enumerate(volumes):
+            shutil.copytree(path, base.parent.parent / f"scylla-{hash}-{id}", ignore=shutil.ignore_patterns('commitlog*'))
+
+
+@asynccontextmanager
+async def space_limited_servers(manager: ManagerClient, volumes_factory: Callable, sizes: list[str], **server_args):
+    servers = []
+    cmdline = server_args.pop("cmdline", [])
+    with volumes_factory(sizes) as volumes:
+        try:
+            servers = [await manager.server_add(cmdline = [*cmdline, '--workdir', str(path)],
+                                                property_file={"dc": "dc1", "rack": f"r{id}"},
+                                                **server_args) for id, path in enumerate(volumes)]
+            yield servers
+        finally:
+            pass

--- a/test/storage/suite.yaml
+++ b/test/storage/suite.yaml
@@ -1,0 +1,11 @@
+type: Topology
+pool_size: 4
+cluster:
+  initial_size: 0
+extra_scylla_config_options:
+    authenticator: AllowAllAuthenticator
+    authorizer: AllowAllAuthorizer
+    enable_user_defined_functions: False
+    rf_rack_valid_keyspaces: True
+    tablets_mode_for_new_keyspaces: enabled
+launcher: unshare -mr pytest

--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -1,0 +1,398 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import asyncio
+import logging
+import os
+import pathlib
+import psutil
+import pytest
+import time
+import uuid
+from cassandra.cluster import ConsistencyLevel, EXEC_PROFILE_DEFAULT
+from typing import Callable
+
+from test.cluster.conftest import skip_mode
+from test.cluster.util import get_topology_coordinator, find_server_by_host_id, new_test_keyspace, new_test_table
+from test.pylib.manager_client import ManagerClient
+from test.pylib.tablets import get_tablet_count
+from test.storage.conftest import space_limited_servers
+
+logger = logging.getLogger(__name__)
+
+
+def write_generator(table, size_in_kb: int):
+    for idx in range(size_in_kb):
+        yield f"INSERT INTO {table} (pk, t) VALUES ({idx}, '{'x' * 1020}')"
+
+
+class random_content_file:
+    def __init__(self, path: str, size_in_bytes: int):
+        path = pathlib.Path(path)
+        self.filename = path if path.is_file() else path / str(uuid.uuid4())
+        self.size = size_in_bytes if size_in_bytes > 0 else 0
+
+    def __enter__(self):
+        with open(self.filename, 'wb') as fh:
+            fh.write(os.urandom(self.size))
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        os.unlink(self.filename)
+
+
+# Since we create 100M volumes, we need to reduce the commitlog segment size
+# otherwise we hit out of space.
+global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1",
+                  "--critical-disk-utilization-level", "0.8",
+                  "--commitlog-segment-size-in-mb", "2",
+                  "--schema-commitlog-segment-size-in-mb", "4",
+                  ]
+
+
+@pytest.mark.asyncio
+async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+        cql, hosts = await manager.get_ready_cql(servers)
+
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+            for server in servers:
+                await manager.api.disable_autocompaction(server.ip_addr, ks)
+
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+
+                    logger.info("Write data and verify it did not reach the target node")
+                    query = next(write_generator(cf, 1))
+                    await cql.run_async(query)
+
+                    cl_one_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.ONE)
+                    res = cql.execute(f"SELECT * from {cf} where pk = 0;", host=hosts[0], execution_profile=cl_one_profile)
+                    assert res.one() is None
+
+                    for host in hosts[1:]:
+                        res = cql.execute(f"SELECT * from {cf} where pk = 0;", host=host, execution_profile=cl_one_profile)
+                        assert res.one()
+
+                    logger.info("Restart the node")
+                    mark = await log.mark()
+                    await manager.server_restart(servers[0].server_id)
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+
+                    time.sleep(1) # Let the cluster run for a sec to grep for potential errors
+                    assert await log.grep("database - Setting critical disk utilization mode: false", from_mark=mark) == []
+
+                    try:
+                        cql.execute(f"INSERT INTO {cf} (pk, t) VALUES (-1, 'x')", host=host[0], execution_profile=cl_one_profile).result()
+                    except Exception:
+                        pass
+                    else:
+                        pytest.fail("Expected to fail due to critical disk utilization level")
+
+                logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
+                for _ in range(2):
+                    mark, _ = await log.wait_for("database - Setting critical disk utilization mode: false", from_mark=mark)
+
+                logger.info("Write more data and expect it to succeed")
+                cl_all_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.ALL)
+                cql.execute(next(write_generator(cf, 1)), execution_profile=cl_all_profile)
+
+
+@pytest.mark.asyncio
+async def test_autotoogle_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
+    cmdline = [*global_cmdline,
+               "--logger-log-level", "compaction=debug"]
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=cmdline) as servers:
+        cql, _ = await manager.get_ready_cql(servers)
+
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+            for server in servers:
+                await manager.api.disable_autocompaction(server.ip_addr, ks)
+
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                table = cf.split('.')[-1]
+
+                for _ in range(3):
+                    await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 10)])
+                    await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("compaction_manager - Drained", from_mark=mark)
+
+                    logger.info("Restart the node")
+                    await manager.server_restart(servers[0].server_id)
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("compaction_manager - Drained", from_mark=mark)
+
+                logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
+                for _ in range(2):
+                    mark, _ = await log.wait_for("compaction_manager - Enabled", from_mark=mark)
+
+                await manager.api.keyspace_compaction(servers[0].ip_addr, ks)
+                await log.wait_for(rf"Compact {ks}\.{table} .* Compacted .* sstables to .*", from_mark=mark)
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_reject_split_compaction(manager: ManagerClient, volumes_factory: Callable) -> None:
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+        cql, _ = await manager.get_ready_cql(servers)
+
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                for _ in range(30):
+                    await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 100)])
+                await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+                logger.info("Trigger split compaction")
+                await manager.api.enable_injection(servers[0].ip_addr, "split_sstable_rewrite", one_shot=False)
+                cql.execute_async(f"ALTER KEYSPACE {ks} WITH tablets = {{'initial': 32}}")
+
+                mark, _ = await log.wait_for("split_sstable_rewrite: waiting", from_mark=mark)
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    await log.wait_for(f"Split task .* for table {cf} .* stopped, reason: Compaction for {cf} was stopped due to: drain")
+
+
+@pytest.mark.asyncio
+async def test_split_compaction_not_triggered(manager: ManagerClient, volumes_factory: Callable) -> None:
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline) as servers:
+        cql, _ = await manager.get_ready_cql(servers)
+
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        s1_log = await manager.server_open_log(servers[0].server_id)
+        s1_mark = await s1_log.mark()
+
+        s2_log = await manager.server_open_log(servers[1].server_id)
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                for _ in range(30):
+                    await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 100)])
+                await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        s1_mark, _ = await s1_log.wait_for("compaction_manager - Drained", from_mark=s1_mark)
+
+                    logger.info("Trigger split compaction")
+                    s2_mark = await s2_log.mark()
+                    cql.execute_async(f"ALTER KEYSPACE {ks} WITH tablets = {{'initial': 32}}")
+
+                    s2_log.wait_for(f"compaction .* Split {cf}", from_mark=s2_mark)
+                    assert await s1_log.grep(f"compaction .* Split {cf}", from_mark=s1_mark) == []
+
+
+@pytest.mark.asyncio
+async def test_tablet_repair(manager: ManagerClient, volumes_factory: Callable) -> None:
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        }
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline, config=cfg) as servers:
+        cql, _ = await manager.get_ready_cql(servers)
+
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        host = await manager.get_host_id(servers[0].server_id)
+        mark = await log.mark()
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 4}") as ks:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                table = cf.split('.')[-1]
+
+                for _ in range(2):
+                    await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 100)])
+                    await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+                await manager.server_stop_gracefully(servers[0].server_id)
+                await manager.server_wipe_sstables(servers[0].server_id, ks, table)
+                await manager.server_start(servers[0].server_id)
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("repair - Drained", from_mark=mark)
+
+                    coord = await get_topology_coordinator(manager)
+                    coord_serv = await find_server_by_host_id(manager, servers, coord)
+                    coord_log = await manager.server_open_log(coord_serv.server_id)
+                    coord_mark = await coord_log.mark()
+
+                    logger.info("Schedule tablet repair")
+                    response = await manager.api.tablet_repair(servers[0].ip_addr, ks, table, "all", await_completion=False)
+                    task_id = response['tablet_task_id']
+
+                    for _ in range(await get_tablet_count(manager, servers[1], ks, table)):
+                        coord_mark, matches = await coord_log.wait_for("Initiating tablet repair host=(?P<host>.*) tablet=(?P<tablet>.*)", from_mark=coord_mark)
+                        dst_host, tablet = matches[0][1].group("host"), matches[0][1].group("tablet")
+                        if host == dst_host:
+                            # Tablet repair is triggered on the node with disk utilization above the critical level.
+                            # A local tablet repair task is refused to be created and the tablet repair fails.
+                            error = "Repair service is disabled. No repairs will be started until it's re-enabled"
+                        else:
+                            # Tablet repair is triggered on the node with disk utilization below the critical level.
+                            # A local tablet repair task is created and the row-level repair is executed. It will try
+                            # to send missing rows to the node with critical disk utilization that are rejected.
+                            error = f"put_row_diff: Repair follower={host} failed in put_row_diff handler"
+
+                        await coord_log.wait_for(f"repair for tablet {tablet} failed: seastar::rpc::remote_verb_error.*{error}", from_mark=coord_mark)
+
+                    logger.info("Restart the node")
+                    mark = await log.mark()
+                    await manager.server_restart(servers[0].server_id, wait_others=2)
+                    await manager.driver_connect()
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("repair - Drained", from_mark=mark)
+
+                logger.info("With blob file removed, wait for the tablet repair to succeed")
+                await manager.api.wait_task(servers[0].ip_addr, task_id)
+
+
+@pytest.mark.asyncio
+async def test_autotoogle_reject_incoming_migrations(manager: ManagerClient, volumes_factory: Callable) -> None:
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        }
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline, config=cfg) as servers:
+        await asyncio.gather(*[manager.api.disable_tablet_balancing(server.ip_addr) for server in servers])
+
+        cql, _ = await manager.get_ready_cql(servers)
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                table = cf.split('.')[-1]
+                await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 10)])
+
+                logger.info("Get tablet to migrate")
+                table_id = await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{table}'")
+                table_id = table_id[0].id
+
+                tablet_infos = await cql.run_async(f"SELECT last_token, replicas FROM system.tablets WHERE table_id = {table_id}")
+                tablet_infos = list(tablet_infos)
+
+                assert len(tablet_infos) == 1
+                tablet_info = tablet_infos[0]
+                assert len(tablet_info.replicas) == 1
+
+                hosts = {await manager.get_host_id(server.server_id) : server for server in servers}
+
+                source_host, source_shard = tablet_info.replicas[0]
+                del hosts[str(source_host)]
+                target_host, target_server = list(hosts.items())[0]
+                target_shard = source_shard
+                logger.info(f"Tablet to migrate: {tablet_info.last_token} from {source_host} to {target_host}")
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                workdir = await manager.server_get_workdir(target_server.server_id)
+                log = await manager.server_open_log(target_server.server_id)
+                mark = await log.mark()
+
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+
+                    logger.info("Migrate a tablet to the target node and expect a failure")
+                    await manager.api.move_tablet(node_ip=servers[0].ip_addr, ks=ks, table=table, src_host=source_host,
+                                                src_shard=source_shard, dst_host=target_host, dst_shard=target_shard,
+                                                token=tablet_info.last_token)
+                    mark, _ = await log.wait_for("Streaming for tablet migration .* failed", from_mark=mark)
+
+                logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
+                for _ in range(2):
+                    mark, _ = await log.wait_for("database - Setting critical disk utilization mode: false", from_mark=mark)
+
+                logger.info("Migrate a tablet to the target node and expect a success")
+                await manager.api.move_tablet(node_ip=servers[0].ip_addr, ks=ks, table=table, src_host=source_host,
+                                            src_shard=source_shard, dst_host=target_host, dst_shard=target_shard,
+                                            token=tablet_info.last_token)
+                mark, _ = await log.wait_for("Streaming for tablet migration .* successful", from_mark=mark)
+
+
+@pytest.mark.asyncio
+async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_factory: Callable) -> None:
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        }
+    async with space_limited_servers(manager, volumes_factory, ["100M"]*3, cmdline=global_cmdline, config=cfg) as servers:
+        cql, _ = await manager.get_ready_cql(servers)
+        workdir = await manager.server_get_workdir(servers[0].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        logger.info("Create and populate test table")
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                table = cf.split('.')[-1]
+                table_id = (await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{table}'"))[0].id
+
+                await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 64)])
+                await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+                # Ensure that the topology state update reaches the node. We should never reach 5s timeout here.
+                # But one call to retrieve resize_task_info may not be enough as the entry to system.tablets might
+                # not be there yet.
+                async def assert_resize_task_info(table_id, cb):
+                    async with asyncio.timeout(5):
+                        while (response := await cql.run_async(f"SELECT resize_task_info from system.tablets where table_id = {table_id};")):
+                            try:
+                                assert cb(response)
+                            except AssertionError:
+                                await asyncio.sleep(0.1)
+                            else:
+                                break
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir)
+                with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("compaction_manager - Drained", from_mark=mark)
+
+                    logger.info("Trigger split in table and restart the node")
+                    coord = await get_topology_coordinator(manager)
+                    logger.info(f"Topology coordinator is {coord}")
+                    coord_serv = await find_server_by_host_id(manager, servers, coord)
+                    coord_log = await manager.server_open_log(coord_serv.server_id)
+
+                    await cql.run_async(f"ALTER TABLE {cf} WITH tablets = {{'min_tablet_count': 2}};")
+                    coord_log.wait_for(f"Generating resize decision for table {table_id} of type split")
+
+                    await manager.server_restart(servers[0].server_id, wait_others=2)
+
+                    logger.info("Check if tablet split happened")
+                    await assert_resize_task_info(table_id, lambda response: len(response) == 1 and response[0].resize_task_info is not None)
+
+                    time.sleep(1) # Let the cluster run for a sec to grep for potential errors
+                    assert await log.grep(f"compaction .* Split {cf}", from_mark=mark) == []
+
+                logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
+                for _ in range(2):
+                    mark, _ = await log.wait_for("compaction_manager - Enabled", from_mark=mark)
+                mark, _ = await log.wait_for(f"Detected tablet split for table {cf}, increasing from 1 to 2 tablets", from_mark=mark)
+                await assert_resize_task_info(table_id, lambda response: len(response) == 2 and all(r.resize_task_info is None for r in response))


### PR DESCRIPTION
When a scaling out is delayed or fails, it is crucial to ensure that clusters remain operational
and recoverable even under extreme conditions. To achieve this, the following proactive measures
are implemented:
- reject writes
      - includes: inserts, updates, deletes, counter updates, hints, read+repair and lwt writes
      - applicable to: user tables, views, CDC log, audit, cql tracing
- stop running compactions/repairs and prevent from starting new ones
- reject incoming tablet migrations

The aforementioned mechanisms are automatically enabled when node's disk utilization reaches
the critical level (default: 98%) and disabled when the utilization drop below the threshold.

Apart from that, the series add tests that require mounted volumes to simulate out of space.
The paths to the volumes can be provided using the a pytest argument, i.e.  `--space-limited-dirs`.
When not provided, tests are skipped.

Test scenarios:

1. Start a cluster and write data until one of the nodes reaches 90% of the disk utilization
2. Perform an **operation** that would take the nodes over 100%
3. The nodes should not exceed the critical disk utilization (98% by default)
4. Scale out the cluster by adding one node per rack
5. Retry or wait for the **operation** from step 2

The **operation** is: writing data, running compactions, building materialized views, running repair, 
migrating tablets (caused by RF change, decommission).

The test is successful, if no nodes run out of space, the **operation** from step 2 is
aborted/paused/timed out and the **operation** from step 5 is successful.

`perf-simple-query --smp 1 -m 1G` results obtained for fixed 400MHz frequency:

Read path (before)

```
instructions_per_op:
	mean=   39661.51 standard-deviation=34.53
	median= 39655.39 median-absolute-deviation=23.33
	maximum=39708.71 minimum=39622.61
```

Read path (after)

```
instructions_per_op:
	mean=   39691.68 standard-deviation=34.54
	median= 39683.14 median-absolute-deviation=11.94
	maximum=39749.32 minimum=39656.63
```

Write path (before):

```
instructions_per_op:
	mean=   50942.86 standard-deviation=97.69
	median= 50974.11 median-absolute-deviation=34.25
	maximum=51019.23 minimum=50771.60
```

Write path (after):

```
instructions_per_op:
	mean=   51000.15 standard-deviation=115.04
	median= 51043.93 median-absolute-deviation=52.19
	maximum=51065.81 minimum=50795.00
```

Fixes: https://github.com/scylladb/scylladb/issues/14067
Refs: https://github.com/scylladb/scylladb/issues/2871

No backport, as it is a new feature.