### PR TITLE
doc: add a link to the previous Enterprise documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,4 +74,5 @@ In addition, you can read our `blog <https://www.scylladb.com/blog/>`_ and atten
   reference/index
   faq
   Contribute to ScyllaDB <contribute>
+  2024.2 and earlier documentation <https://enterprise.docs.scylladb.com/branch-2024.2/>
 


### PR DESCRIPTION
This PR adds a link to the docs for previous Enterprise versions at https://enterprise.docs.scylladb.com/ to the left menu.

As we still support versions 2024.1 and 2024.2, we need to ensure easier access to those docs sets.

Fixes https://github.com/scylladb/scylladb/issues/23870

Please backport this PR to branch-2025.1 as it's relevant and requested for ScyllaDB 2025.1.