### PR TITLE
tools: toolchain: clear .cache and .cargo directories

### DIFF
--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -9,6 +9,7 @@ RUN dnf -y update \
     && dnf -y install ccache \
     && dnf -y install devscripts debhelper fakeroot file rpm-build \
     && ./install-dependencies.sh && dnf clean all \
+    && rm -rf /root/.cache /root/.cargo \
     && echo 'ALL ALL=(ALL:ALL) NOPASSWD: ALL' >> /etc/sudoers \
     && cp ./tools/toolchain/system-auth /etc/pam.d \
     && echo 'Defaults !requiretty' >> /etc/sudoers


### PR DESCRIPTION
The .cache and .cargo directories are used during pip and rust builds when preparing the toolchain, but aren't useful afterwards. Remove them to save a bit of space.

Small space optimization that isn't worthwhile to backport to release branches.