### PR TITLE
locator/production_snitch_base: Reduce log level when property file incomplete

### DIFF
--- a/locator/production_snitch_base.cc
+++ b/locator/production_snitch_base.cc
@@ -112,19 +112,19 @@ void production_snitch_base::parse_property_file(std::string contents) {
 
 [[noreturn]]
 void production_snitch_base::throw_double_declaration(const sstring& key) const {
-    logger().error("double \"{}\" declaration in {}", key, _prop_file_name);
+    logger().warn("double \"{}\" declaration in {}", key, _prop_file_name);
     throw bad_property_file_error();
 }
 
 [[noreturn]]
 void production_snitch_base::throw_bad_format(const sstring& line) const {
-    logger().error("Bad format in properties file {}: {}", _prop_file_name, line);
+    logger().warn("Bad format in properties file {}: {}", _prop_file_name, line);
     throw bad_property_file_error();
 }
 
 [[noreturn]]
 void production_snitch_base::throw_incomplete_file() const {
-    logger().error("Property file {} is incomplete. Some obligatory fields are missing.", _prop_file_name);
+    logger().warn("Property file {} is incomplete. Some obligatory fields are missing.", _prop_file_name);
     throw bad_property_file_error();
 }
 


### PR DESCRIPTION
We're reducing the log level in case the provided property file is incomplete. The rationale behind this change is related to how CCM interacts with Scylla:

* The `GossipingPropertyFileSnitch` reloads the `cassandra-rackdc.properties` configuration every 60 seconds.
* When a new node is added to the cluster, CCM recreates the `cassandra-rackdc.properties` file for EVERY node.

If those two processes start happening at about the same time, it may lead to Scylla trying to read a not-completely-recreated file, and an error will be produced.

Although we would normally fix this issue and try to avoid the race, that behavior will be no longer relevant as we're making the rack and DC values immutable (cf. scylladb/scylladb#23278). What's more, trying to fix the problem in the older versions of Scylla could bring a more serious regression. Having that in mind, this commit is a compromise between making CI less flaky and having minimal impact when backported.

Fixes scylladb/scylladb#20092

Backport: backporting to all maintained versions. The PR makes CI less flaky, while having no impact on how Scylla behaves.