### PR TITLE
docs: fix md redirections for multiversion support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,7 @@ extensions = [
 ]
 
 # The suffix(es) of source filenames.
-source_suffix = ['.rst']
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = "index"


### PR DESCRIPTION
## Motivation

This change resolves an issue where selecting a version from the multiversion dropdown on Markdown pages (e.g. https://docs.scylladb.com/manual/stable/alternator/getting-started.html) incorrectly redirected users to the main page instead of the corresponding versioned page.

![image](https://github.com/user-attachments/assets/c0317a20-89dc-4d38-bebc-a9bf40b420a4)

The underlying cause was that the `multiversion` extension relies on `source_suffix` to identify available pages for URL mapping. Without this configuration, proper redirection fails for `.md` files.

**IMPORTANT:** This fix should be backported to `2025.1` to ensure correct behavior. Otherwise, the fix will only take effect in future releases.

### How to test

Testing locally is non-trivial. I've tested it already, so the best next step is to merge and confirm that it works as expected in the live environment. For reference, here are the instructions:

1. Clone the repository.
2. Checkout each branch, update each `conf.py`file, commit the changes.
3. Go back to the master branch and set `smv_remote_whitelist` to "".
4. Run `make multiversionpreview`.
5. Open an alternator/getting-started page and switch between versions in the dropdown to verify behavior. 

Fixes https://github.com/scylladb/scylladb/issues/23960 
