### PR TITLE
topology_coordinator: silence ERROR messages on abort

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2021,6 +2021,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             throw;
                         } catch (group0_concurrent_modification&) {
                             throw;
+                        } catch (raft::request_aborted&) {
+                            throw;
                         } catch (...) {
                             rtlogger.error("transition_state::join_group0, "
                                             "global_token_metadata_barrier failed, error {}",
@@ -2157,6 +2159,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (group0_concurrent_modification&) {
                     throw;
+                } catch (raft::request_aborted&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("transition_state::commit_cdc_generation, "
                                     "raft_topology_cmd::command::barrier failed, error {}", std::current_exception());
@@ -2236,6 +2240,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     throw;
                 } catch (group0_concurrent_modification&) {
                     throw;
+                } catch (raft::request_aborted&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("tablets draining failed with {}. Aborting the topology operation", std::current_exception());
                     _rollback = fmt::format("Failed to drain tablets: {}", std::current_exception());
@@ -2250,6 +2256,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (term_changed_error&) {
                     throw;
                 } catch (group0_concurrent_modification&) {
+                    throw;
+                } catch (raft::request_aborted&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::write_both_read_old, "
@@ -2297,6 +2305,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
                 } catch (term_changed_error&) {
                     throw;
+                } catch (raft::request_aborted&) {
+                    throw;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
                                     " (node state is {}): {}", state, std::current_exception());
@@ -2326,6 +2336,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (term_changed_error&) {
                     throw;
                 } catch (group0_concurrent_modification&) {
+                    throw;
+                } catch (raft::request_aborted&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::write_both_read_new, "
@@ -2465,6 +2477,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 } catch (term_changed_error&) {
                     throw;
                 } catch (group0_concurrent_modification&) {
+                    throw;
+                } catch (raft::request_aborted&) {
                     throw;
                 } catch (...) {
                     rtlogger.error("transition_state::left_token_ring, "


### PR DESCRIPTION
When the topology coordinator is shut down while doing a long-running operation, the current operation might throw a raft::request_aborted exception. This is not a critical issue and should not be logged with ERROR verbosity level.

Make sure that all the try..catch blocks in the topology coordinator which:

- May try to acquire a new group0 guard in the `try` part
- Have a `catch (...)` block that print an ERROR-level message

...have a pass-through `catch (raft::request_aborted&)` block which does not log the exception.

Fixes: scylladb/scylladb#22649

Looks like 2025.1 and 6.2 might be prone to this as well, so marking for backport to those versions.