### PR TITLE
test_sstable_compression_dictionaries_autotrain: raise the timeout

### DIFF
--- a/test/cluster/test_sstable_compression_dictionaries_autotrain.py
+++ b/test/cluster/test_sstable_compression_dictionaries_autotrain.py
@@ -15,7 +15,7 @@ from test.pylib.rest_client import ScyllaMetrics
 
 logger = logging.getLogger(__name__)
 
-TIMEOUT = 30
+TIMEOUT = 600
 
 async def get_metrics(manager: ManagerClient, servers: list[ServerInfo]) -> list[ScyllaMetrics]:
     return await asyncio.gather(*[manager.metrics.query(s.ip_addr) for s in servers])


### PR DESCRIPTION
There were CI runs in which the training happened as planned, but it was too slow to fit within the timeout.

Raise the timeout to pacify the CI.

Fixes scylladb/scylladb#23964

No backport, AFAIK the test isn't in any stable branch yet. (It's scheduled for 2025.2).