### PR TITLE
test_tablet_tasks: use injection to revoke resize

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -556,6 +556,9 @@ class load_balancer {
         // If we cancel a split, that's because average size dropped so much a merge would be
         // required post completion, and vice-versa.
         bool table_needs_resize_cancellation(const table_size_desc& d) const {
+            if (utils::get_local_injector().enter("force_resize_cancellation")) {
+                return true;
+            }
             return d.resize_decision.split_or_merge() && to_resize_decision(d).way != d.resize_decision.way;
         }
 

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -520,9 +520,8 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
 
         async def revoke_resize(log, mark):
             await log.wait_for('tablet_virtual_task: wait until tablet operation is finished', from_mark=mark)
-            await asyncio.gather(*[cql.run_async(f"DELETE FROM {keyspace}.{table1} WHERE pk={k};") for k in keys])
-
-            await manager.api.flush_keyspace(servers[0].ip_addr, keyspace)
+            revoke_injection = "force_resize_cancellation"
+            await enable_injection(manager, servers, revoke_injection)
 
         async def wait_for_task(task_id):
             status = await tm.wait_for_task(servers[0].ip_addr, task_id)


### PR DESCRIPTION
Currently, test_tablet_resize_revoked tries to trigger split revoke by deleting some rows. This method isn't deterministic and so a test is flaky.

Use error injection to trigger resize revoke.

Fixes: #22570.

Needs backport to 2025.1 as it introduces the test.