### PR TITLE
replica/database: memtable_list: save ref to memtable_table_shared_data

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -193,7 +193,7 @@ private:
     seal_immediate_fn_type _seal_immediate_fn;
     std::function<schema_ptr()> _current_schema;
     replica::dirty_memory_manager* _dirty_memory_manager;
-    memtable_table_shared_data _table_shared_data;
+    memtable_table_shared_data& _table_shared_data;
     std::optional<shared_future<>> _flush_coalescing;
     seastar::scheduling_group _compaction_scheduling_group;
     replica::table_stats& _table_stats;


### PR DESCRIPTION
This is passed by reference to the constructor, but a copy is saved into the _table_shared_data member. A reference to this member is passed down to all memtable readers. Because of the copy, the memtable readers save a reference to the memtable_list's member, which goes away together with the memtable_list when the storage_group is destroyed.
This causes use-after-free when a storage group is destroyed while a memtable read is still ongoing. The memtable reader keeps the memtable alive, but its reference to the memtable_table_shared_data becomes stale.
Fix by saving a reference in the memtable_list too, so memtable readers receive a reference pointing to the original replica::table member, which is stable accross tablet migrations and merges. The copy was introduced by https://github.com/scylladb/scylladb/commit/2a76065e3d3b2e9bc8cc18d2436bec0aa8d98d14. There was a copy even before this commit, but in the previous vnode-only world this was fine -- there was one memtable_list per table and it was
around until the table itself was. In the tablet world, this is no longer given, but the above commit didn't account for this.

A test is included, which reproduces the use-after-free on memtable migration. The test is somewhat artificial in that the use-after-free would be prevented by holding on to an ERM, but this is done intentionaly to keep the test simple. Migration -- unlike merge where this use-after-free was originally observed -- is easy to trigger from unit tests.

Fixes: #23762

Need backports to all versions which use tablets.