### PR TITLE
build: add p11-kit's cflags to user_cflags instead of args.user_cflags

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2087,7 +2087,7 @@ libs = ' '.join([maybe_static(args.staticyamlcpp, '-lyaml-cpp'), '-latomic', '-l
                  '-ldeflate',
                 ])
 
-args.user_cflags += " " + pkg_config('p11-kit-1', '--cflags')
+user_cflags += " " + pkg_config('p11-kit-1', '--cflags')
 
 if not args.staticboost:
     user_cflags += ' -DBOOST_ALL_DYN_LINK'


### PR DESCRIPTION
Fix an issue introduced in commit 083f7353 where p11-kit's compiler flags were incorrectly added to `args.user_cflags` instead of `user_cflags`. This created the following problem:

When using CMake generation mode, these flags were added to `CMAKE_CXX_FLAGS`, causing them to be passed to all compiler invocations including linking stages where they were irrelevant.

This change moves p11-kit's cflags to `user_cflags`, which ensures the flags are correctly included in compilation commands but not in linking commands. This maintains the proper behavior in the ninja build system while fixing the issue in the CMake build system.

`args.user_cflags` is preserved for its intended purpose of storing user-specified compiler flags passed via command line options.

---

it's a build-related cleanup, and it changes the behavior of the cmake-generated building system,  hence no need to backport.