### PR TITLE
tools/scylla-sstable: scrub: use UUID sstable identifiers

### DIFF
--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -1172,13 +1172,6 @@ def test_scrub_output_dir(scylla_path, scrub_workdir, scrub_schema_file, scrub_g
         subprocess.check_call([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, "--unsafe-accept-nonempty-output-dir", scrub_good_sstable])
 
 
-def test_scrub_output_dir_sstable_clash(scylla_path, scrub_workdir, scrub_schema_file, scrub_good_sstable):
-    with tempfile.TemporaryDirectory(prefix="test_scrub_output_dir_sstable_clash", dir=scrub_workdir) as tmp_dir:
-        subprocess.check_call([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, "--unsafe-accept-nonempty-output-dir", scrub_good_sstable])
-        check_scrub_output_dir(tmp_dir, 1)
-        subprocess_check_error([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, "--unsafe-accept-nonempty-output-dir", scrub_good_sstable], "cannot create output sstable .*, file already exists")
-
-
 def test_scrub_abort_mode(scylla_path, scrub_workdir, scrub_schema_file, scrub_good_sstable, scrub_bad_sstable):
     with tempfile.TemporaryDirectory(prefix="test_scrub_abort_mode", dir=scrub_workdir) as tmp_dir:
         subprocess.check_call([scylla_path, "sstable", "scrub", "--schema-file", scrub_schema_file, "--scrub-mode", "abort", "--output-dir", tmp_dir, scrub_good_sstable])

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -923,7 +923,7 @@ private:
     sstables::shared_sstable do_make_sstable() const {
         const auto format = sstables::sstable_format_types::big;
         const auto version = sstables::get_highest_sstable_version();
-        auto generation = _generation_generator();
+        auto generation = _generation_generator(uuid_identifiers::yes);
         auto sst_name = sstables::sstable::filename(_output_dir, _schema->ks_name(), _schema->cf_name(), version, generation, format, component_type::Data);
         if (file_exists(sst_name).get()) {
             throw std::runtime_error(fmt::format("cannot create output sstable {}, file already exists", sst_name));


### PR DESCRIPTION
Much easier to avoid sstable collisions. Makes it possible to scrub multiple sstables, with multiple calls to scylla-sstable, reusing the same output directory. Previously, each new call to scylla-sstable scrub, would start from generation 0, guaranteeing collision.

Refs: #21387

Improvement targeted at making test's lifes easier, no backport needed