### PR TITLE
test.py: change pattern for cleaning .log files in testlog directory

### DIFF
--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -517,7 +517,7 @@ def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
     dirname.mkdir(parents=True, exist_ok=True)
 
     # Remove old artifacts.
-    for p in dirname.rglob(pattern):
+    for p in dirname.glob(pattern):
         p.unlink()
 
 


### PR DESCRIPTION
Currently, test.py will delete recursively all .log files under the testlog directory instead of cleaning only on testlog directory. With this change, it will not go deeper to delete log files. We still have a method for cleaning the log files in modes directories. The downside of this solution, that we will need to explicitly tell all directories that we want to clean.

Fixes: https://github.com/scylladb/scylladb/issues/24001

