### PR TITLE
tools: toolchain: dbuild: support nested containers

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -132,6 +132,9 @@ fedora_packages=(
     fipscheck
     cpp-jwt-devel
 
+    podman
+    buildah
+
     https://github.com/scylladb/cassandra-stress/releases/download/v3.17.5/cassandra-stress-3.17.5-1.noarch.rpm
 )
 

--- a/tools/toolchain/Dockerfile
+++ b/tools/toolchain/Dockerfile
@@ -4,6 +4,7 @@ ARG CLANG_BUILD="SKIP"
 ARG CLANG_ARCHIVES
 
 WORKDIR /mnt
+RUN echo install_weak_deps=False >> /etc/dnf/dnf.conf
 RUN dnf -y update \
     && dnf -y install 'dnf-command(copr)' \
     && dnf -y install ccache \

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -32,6 +32,7 @@ here="$(realpath $(dirname "$0"))"
 toplevel="$(realpath "$here/../..")"
 group_args=()
 docker_args=()
+tmpfiles=()
 image="$(<"$here/image")"
 
 for gid in $(id -G); do
@@ -161,8 +162,22 @@ else
     # --pids-limit is not supported on podman with cgroupsv1
     # detection code from
     #   https://unix.stackexchange.com/questions/617764/how-do-i-check-if-system-is-using-cgroupv1
+    containers_conf="$(mktemp)"
+    tmpfiles+=("$containers_conf")
+    cat > "$containers_conf" <<EOF
+[engine]
+static_dir = "$HOME/.local/share/containers/storage/libpod"
+volume_path = "$HOME/.local/share/containers/storage/libpod"
+
+[containers]
+# netns = private, the default, doesn't work in nested containers,
+# and we don't mind using the host network anyway.
+netns = "host"
+EOF
     if grep -q 'cgroup2.*/sys/fs/cgroup ' /proc/mounts; then
         docker_common_args+=(
+            -v "$HOME/.local/share/containers:$HOME/.local/share/containers"
+            -v "$containers_conf:/etc/containers/containers.conf.d/nested.conf"
             --pids-limit -1
             --annotation run.oci.keep_original_groups=1
         )
@@ -222,6 +237,7 @@ cleanup() {
     if [ -v TMP_PASSWD ]; then
         rm -f "$TMP_PASSWD"
     fi
+    rm -f "${tmpfiles[@]}"
 }
 
 if [[ -n "$interactive" || -n "$is_podman" ]]; then

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-41-20250410
+docker.io/scylladb/scylla-toolchain:fedora-41-20250505


### PR DESCRIPTION
Pass through the local containers directory (it cannot be bind-mounted to /var/lib/containers since podman checks the path hasn't changed) with overrides to the paths. This allows containers to be created inside the dbuild container, so we can enlist pre-packaged software (such as opensearch) in test.py. If the container images are already downloaded in the host, they won't be downloaded again.

It turns out that the container ecosystem doesn't support nested network namespaces well, so we configure the outer container to use host networking for the inner containers. It's useful anyway.

The frozen toolchain now installs podman and buildah so there's something to actually drive those nested containers. We disable weak dnf dependencies to avoid installing qemu.

The frozen toolchain is regenerated with optimized clang from

  https://devpkg.scylladb.com/clang/clang-19.1.7-Fedora-41-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-19.1.7-Fedora-41-x86_64.tar.gz

No backport, nested container support will be used to support new features like opensearch testing.