### PR TITLE
mv: take read pressure into account when throttling view updates

### DIFF
--- a/db/view/view_update_backlog.hh
+++ b/db/view/view_update_backlog.hh
@@ -50,11 +50,11 @@ public:
         return float(_current) / float(_max) / admission_control_threshold;
     }
 
-    const size_t& get_current_bytes() const {
+    const size_t& get_current_size() const {
         return _current;
     }
 
-    const size_t& get_max_bytes() const {
+    const size_t& get_max_size() const {
         return _max;
     }
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -454,7 +454,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
 
             co_await seastar::sleep(throttle_delay);
 
-            if (utils::get_local_injector().enter("view_update_limit") && _db.view_update_sem().current() == 0) {
+            if (utils::get_local_injector().enter("pending_view_updates_memory_admission_limit") && _db.view_update_sem().current() == 0) {
                 err = std::make_exception_ptr(std::runtime_error("View update backlog exceeded the limit"));
                 break;
             }

--- a/idl/view.idl.hh
+++ b/idl/view.idl.hh
@@ -9,8 +9,8 @@
 namespace db {
 namespace view {
 class update_backlog {
-    size_t get_current_bytes();
-    size_t get_max_bytes();
+    size_t get_current_size();
+    size_t get_max_size();
 };
 }
 }

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -264,7 +264,6 @@ private:
     future<> execution_loop() noexcept;
 
     uint64_t get_serialize_limit() const;
-    uint64_t get_kill_limit() const;
 
     // Throws std::bad_alloc if memory consumed is oom_kill_limit_multiply_threshold more than the memory limit.
     void consume(reader_permit::impl& permit, resources r);
@@ -486,6 +485,8 @@ public:
         return _initial_resources == reader_resources{std::numeric_limits<int>::max(), std::numeric_limits<ssize_t>::max()};
     }
 
+    uint64_t get_kill_limit() const;
+
     const resources available_resources() const {
         return _resources;
     }
@@ -504,6 +505,10 @@ public:
 
     void set_max_queue_length(size_t size) {
         _max_queue_length = size;
+    }
+
+    size_t get_max_queue_length() const {
+        return _max_queue_length;
     }
 
     uint64_t active_reads() const noexcept {

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -61,6 +61,16 @@ reader_concurrency_semaphore* reader_concurrency_semaphore_group::get_or_null(sc
         return &(it->second.sem);
     }
 }
+
+const reader_concurrency_semaphore* reader_concurrency_semaphore_group::get_or_null(scheduling_group sg) const {
+    auto it = _semaphores.find(sg);
+    if (it == _semaphores.end()) {
+        return nullptr;
+    } else {
+        return &(it->second.sem);
+    }
+}
+
 reader_concurrency_semaphore& reader_concurrency_semaphore_group::add_or_update(scheduling_group sg, size_t shares) {
     auto result = _semaphores.try_emplace(
             sg,

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -74,6 +74,7 @@ public:
     future<> stop() noexcept;
     reader_concurrency_semaphore& get(scheduling_group sg);
     reader_concurrency_semaphore* get_or_null(scheduling_group sg);
+    const reader_concurrency_semaphore* get_or_null(scheduling_group sg) const;
     reader_concurrency_semaphore& add_or_update(scheduling_group sg, size_t shares);
     future<> remove(scheduling_group sg);
     size_t size();

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1496,11 +1496,11 @@ private:
     static constexpr size_t max_count_system_concurrent_reads{10};
     size_t max_memory_system_concurrent_reads() { return _dbcfg.available_memory * 0.02; };
     size_t max_memory_pending_view_updates() const {
-        auto ret = _dbcfg.available_memory * 0.1;
-        utils::get_local_injector().inject("view_update_limit", [&ret] {
-            ret = 250000;
-        });
-        return ret;
+        if (const auto limit = utils::get_local_injector().inject_parameter<size_t>("pending_view_updates_memory_admission_limit"); limit) {
+            // The limit for admission is 80% of the kill limit.
+            return *limit / 0.8;
+        }
+        return _dbcfg.available_memory * 0.1;
     }
 
     struct db_stats {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1489,7 +1489,12 @@ private:
     size_t max_memory_concurrent_view_update_reads() { return _dbcfg.available_memory * 0.01; }
     // Assume a queued read takes up 1kB of memory, and allow 2% of memory to be filled up with such reads.
     size_t max_inactive_queue_length() { return _dbcfg.available_memory * 0.02 / 1000; }
-    size_t max_inactive_view_update_queue_length() { return _dbcfg.available_memory * 0.01 / 1000; }
+    size_t max_inactive_view_update_queue_length() {
+        if (const auto max = utils::get_local_injector().inject_parameter<size_t>("max_view_update_read_queue"); max) {
+            return *max;
+        }
+        return _dbcfg.available_memory * 0.01 / 1000;
+    }
     // They're rather heavyweight, so limit more
     static constexpr size_t max_count_streaming_concurrent_reads{10};
     size_t max_memory_streaming_concurrent_reads() { return _dbcfg.available_memory * 0.02; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1938,9 +1938,7 @@ public:
         return _querier_cache;
     }
 
-    db::view::update_backlog get_view_update_backlog() const {
-        return {max_memory_pending_view_updates() - _view_update_concurrency_sem.current(), max_memory_pending_view_updates()};
-    }
+    db::view::update_backlog get_view_update_backlog() const;
 
     db::data_listeners& data_listeners() const {
         return *_data_listeners;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3864,6 +3864,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     auto lock = co_await std::move(lockf);
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
+    co_await utils::get_local_injector().inject("prolong_view_reads_100ms", std::chrono::milliseconds(100));
     auto reader = source.make_reader_v2(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());

--- a/service/misc_services.cc
+++ b/service/misc_services.cc
@@ -252,7 +252,7 @@ future<> view_update_backlog_broker::start() {
                 //FIXME: discarded future.
                 (void)_gossiper.add_local_application_state(
                         gms::application_state::VIEW_BACKLOG,
-                        gms::versioned_value(seastar::format("{}:{}:{}", backlog->get_current_bytes(), backlog->get_max_bytes(), now)));
+                        gms::versioned_value(seastar::format("{}:{}:{}", backlog->get_current_size(), backlog->get_max_size(), now)));
                 sleep_abortable(gms::gossiper::INTERVAL, _as).get();
             }
         }).handle_exception_type([] (const seastar::sleep_aborted& ignored) { });

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -1758,7 +1758,7 @@ public:
             ++stats().throttled_base_writes;
             ++stats().total_throttled_base_writes;
             tracing::trace(trace, "Delaying user write due to view update backlog {}/{} by {}us",
-                          _view_backlog.get_current_bytes(), _view_backlog.get_max_bytes(), delay.count());
+                          _view_backlog.get_current_size(), _view_backlog.get_max_size(), delay.count());
             // Waited on indirectly.
             (void)sleep_abortable<seastar::steady_clock_type>(delay).finally([self = shared_from_this(), on_resume = std::forward<Func>(on_resume)] {
                 --self->stats().throttled_base_writes;
@@ -3120,7 +3120,7 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::
                        sm::description("number of currently throttled write requests"))(basic_level),
     });
     _metrics.add_group(storage_proxy_stats::REPLICA_STATS_CATEGORY, {
-        sm::make_current_bytes("view_update_backlog", [this] { return _max_view_update_backlog.fetch_shard(this_shard_id()).get_current_bytes(); },
+        sm::make_gauge("view_update_backlog", [this] { return _max_view_update_backlog.fetch_shard(this_shard_id()).relative_size(); },
                        sm::description("Tracks the size of scylla_database_view_update_backlog and is used instead of that one to calculate the "
                                         "max backlog across all shards, which is then used by other nodes to calculate appropriate throttling delays "
                                         "if it grows too large. If it's notably different from scylla_database_view_update_backlog, it means "

--- a/test/cluster/mv/test_mv_admission_control.py
+++ b/test/cluster/mv/test_mv_admission_control.py
@@ -29,7 +29,11 @@ logger = logging.getLogger(__name__)
 @skip_mode('release', "error injections aren't enabled in release mode")
 async def test_mv_admission_control_exception(manager: ManagerClient) -> None:
     node_count = 2
-    config = {'error_injections_at_startup': ['view_update_limit', 'update_backlog_immediately'], 'tablets_mode_for_new_keyspaces': 'enabled'}
+    config = {'error_injections_at_startup': [{
+                'name': 'pending_view_updates_memory_admission_limit',
+                'value': 200000,
+            }, 'update_backlog_immediately'
+        ], 'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(node_count, config=config)
     cql, hosts = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
@@ -68,7 +72,11 @@ async def test_mv_admission_control_exception(manager: ManagerClient) -> None:
 async def test_mv_retried_writes_reach_all_replicas(manager: ManagerClient) -> None:
     node_count = 4
     cfg = {'error_injections_at_startup': ['update_backlog_immediately'], 'tablets_mode_for_new_keyspaces': 'enabled'}
-    cfg_slow = {'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update', 'update_backlog_immediately'], 'tablets_mode_for_new_keyspaces': 'enabled'}
+    cfg_slow = {'error_injections_at_startup': [{
+                'name': 'pending_view_updates_memory_admission_limit',
+                'value': 200000,
+            }, 'delay_before_remote_view_update', 'update_backlog_immediately'
+        ], 'tablets_mode_for_new_keyspaces': 'enabled'}
     servers = await manager.servers_add(node_count - 1, config=cfg, auto_rack_dc="dc1")
     server = await manager.server_add(config=cfg_slow, property_file={"dc": servers[0].datacenter, "rack": servers[0].rack})
 

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -57,7 +57,11 @@ async def test_view_backlog_increased_after_write(manager: ManagerClient) -> Non
 @skip_mode('release', "error injections aren't enabled in release mode")
 async def test_gossip_same_backlog(manager: ManagerClient) -> None:
     node_count = 2
-    servers = await manager.servers_add(node_count, config={'error_injections_at_startup': ['view_update_limit', 'update_backlog_immediately'], 'tablets_mode_for_new_keyspaces': 'enabled'})
+    servers = await manager.servers_add(node_count, config={'error_injections_at_startup': [{
+                'name': 'pending_view_updates_memory_admission_limit',
+                'value': 200000,
+            }, 'update_backlog_immediately'
+        ], 'tablets_mode_for_new_keyspaces': 'enabled'})
     cql, hosts = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
@@ -101,8 +105,12 @@ async def test_gossip_same_backlog(manager: ManagerClient) -> None:
 @skip_mode('release', "error injections aren't enabled in release mode")
 async def test_configurable_mv_control_flow_delay(manager: ManagerClient) -> None:
     node_count = 2
-    servers = await manager.servers_add(node_count,
-                                        config={'error_injections_at_startup': ['update_backlog_immediately', 'view_update_limit', 'skip_updating_local_backlog_via_view_update_backlog_broker'], 'tablets_mode_for_new_keyspaces': 'enabled'},
+    servers = await manager.servers_add(node_count, config={'error_injections_at_startup': [
+            'update_backlog_immediately', {
+                'name': 'pending_view_updates_memory_admission_limit',
+                'value': 200000,
+            }, 'skip_updating_local_backlog_via_view_update_backlog_broker'
+        ], 'tablets_mode_for_new_keyspaces': 'enabled'},
                                         cmdline=['--smp=1'])
     cql, hosts = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:


### PR DESCRIPTION
Currently, we throttle view updates by delaying the responses to write requests that generate view updates based on the amount of memory used by view updates that have been sent but no response was received yet.
There's also another area which we've seen overloaded by the view update path - the reads before writes.
In the scenario where there's a large concurrency of writes generating view updates (which can happen particularly often when 
a node is slow and we're not waiting for its responses to writes by using consistency level lower than ALL), all the writes may 
need to perform a read before sending the view update. These reads are controlled by the view_update reader_concurrency_semaphore, which limits the number and memory used by concurrent reads, queues reads 
that do not fit in these limits, and kills reads when the queue becomes too long. We want to avoid the killed writes as it can 
introduce inconsistencies between replicas and it also needs to be fixed later by repair, wasting the work of the initial write attempt.
In this patch we avoid this by extending the view update throttling and view update admission control to take into account the 
reader_concurrency_semaphore status.
For that, we change the meaning of the view_update backlog:
* it used to refer only to the memory used for pending view updates
* now it's referring to the memory used for pending view updates, the memory used for reads, or the read queue, whatever is closest to its limit
By changing only the view_update backlog, we reuse the existing delay-based throttling and admission control that we were already using depending on the pending view update memory usage.

Fixes https://github.com/scylladb/scylladb/issues/21553
Fixes https://github.com/scylladb/scylladb/issues/23319