### PR TITLE
topology coordinator: make decommissioning node non voter before comp…

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2481,6 +2481,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     node = retake_node(co_await start_operation(), node.id);
                 }
 
+                // Make decommissioning node a non voter before reporting operation completion below.
+                // Otherwise the decommissioned node may see the completion and exit before it is removed from
+                // the config at which point the removal from the config will hang if the cluster had only two
+                // nodes before the decommission.
+                co_await _voter_handler.on_node_removed(node.id, _as);
+
                 topology_request_tracking_mutation_builder rtbuilder(node.rs->request_id);
 
                 rtbuilder.done();


### PR DESCRIPTION
…leting the operation

A decommissioned node is removed from a raft config after operation is marked as completed. This is required since otherwise the decommissioned node will not see that decommission has completed (the status is propagated through raft). But right after the decommission is marked as completed a decommissioned node may terminate, so in case of a two node cluster, the configuration change that removes it from the raft will fail, because there will no be quorum.

The solution is to mark the decommissioning node as non voter before reporting the operation as completed.

Fixes: #24026

Backport to 2025.2 because it fixes a potential hang. Don't backport to branches older than 2025.2 because they don't have 8b186ab0ff9ebd1e3844752eb092021522d8f143, which caused this issue.