### PR TITLE
logalloc_test: don't test performance in test background_reclaim

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -406,7 +406,7 @@ class background_reclaimer {
     promise<>* _main_loop_wait = nullptr;
     future<> _done;
     bool _stopping = false;
-    static constexpr size_t free_memory_threshold = 60'000'000;
+    static constexpr size_t free_memory_threshold = background_reclaim_free_memory_threshold;
 private:
     bool have_work() const {
 #ifndef SEASTAR_DEFAULT_ALLOCATOR

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -29,6 +29,8 @@ constexpr int segment_size_shift = 17; // 128K; see #151, #152
 constexpr size_t segment_size = 1 << segment_size_shift;
 constexpr size_t max_zone_segments = 256;
 
+constexpr size_t background_reclaim_free_memory_threshold = 60'000'000;
+
 //
 // Frees some amount of objects from the region to which it's attached.
 //


### PR DESCRIPTION
The test is failing in CI sometimes due to performance reasons.

There are at least two problems:
1. The initial 500ms (wall time) sleep might be too short. If the reclaimer
   doesn't manage to evict enough memory during this time, the test will fail.
2. During the 100ms (thread CPU time) window given by the test to background
   reclaim, the `background_reclaim` scheduling group isn't actually
   guaranteed to get any CPU, regardless of shares. If the process is
   switched out inside the `background_reclaim` group, it might
   accumulate so much vruntime that it won't get any more CPU again
   for a long time.

We have seen both.

This kind of timing test can't be run reliably on overcommitted machines
without modifying the Seastar scheduler to support that (by e.g. using
thread clock instead of wall time clock in the scheduler), and that would
require an amount of effort disproportionate to the value of the test.

So for now, to unflake the test, this patch removes the performance test
part. (And the tradeoff is a weakening of the test). After the patch,
we only check that the background reclaim happens *eventually*.

Fixes https://github.com/scylladb/scylladb/issues/15677

Backporting this is optional. The test is flaky even in stable branches, but the failure is rare.