### PR TITLE
sstable: Remove validate argument from sstable::load_metadata()

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -238,7 +238,7 @@ public:
     // load sstable using components shared by a shard
     future<> load(foreign_sstable_open_info info) noexcept;
     // Load metadata components from disk
-    future<> load_metadata(sstable_open_config cfg = {}, bool validate = true) noexcept;
+    future<> load_metadata(sstable_open_config cfg = {}) noexcept;
     // load all components from disk
     // this variant will be useful for testing purposes and also when loading
     // a new sstable from scratch for sharing its components.

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -513,7 +513,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
     auto local = data_dictionary::make_local_options(dir_path);
     auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
-    bootstrap_sst->load_metadata({}, false).get();
+    bootstrap_sst->load_metadata().get();
 
     const auto& serialization_header = bootstrap_sst->get_serialization_header();
     const auto& compression = bootstrap_sst->get_compression();


### PR DESCRIPTION
There are only two callers of the method and the one that wants validation (the sstable::load()) can do it on its own. This helps the other caller (schema loader) being simpler and shorter.
