### PR TITLE
sstable: Use fmt::to_string(sstable::filename()) to get component fil…

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3567,10 +3567,10 @@ public:
         if (!_sst) {
             co_return;
         }
-        auto filename = fs::path(_sst->_storage->prefix()) / std::string_view(_sst->component_basename(_type));
+        auto filename = fmt::to_string(_sst->filename(_type));
         // TODO: if we are the last component (or really always), should we remove all component files?
         // For now, this remains the responsibility of calling code (see handle_tablet_migration etc)
-        co_await remove_file(filename.native());
+        co_await remove_file(filename);
     }
 };
 


### PR DESCRIPTION
…e path

The stream sink abort() method wants to remove component file by its path. For that the path is calculated from storage prefix and component basename, but there's a filename() method for it already.

SStable filenames shouldn't be considered as on-disk paths (see #23194), but places that want it should be explicit and format the filename to string by hand.
