### PR TITLE
sstable: Move update_info_for_opened_data() method to private: block

### DIFF
--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -244,7 +244,6 @@ public:
     // a new sstable from scratch for sharing its components.
     future<> load(const dht::sharder& sharder, sstable_open_config cfg = {}) noexcept;
     future<> open_data(sstable_open_config cfg = {}) noexcept;
-    future<> update_info_for_opened_data(sstable_open_config cfg = {});
 
     // Load set of shards that own the SSTable, while reading the minimum
     // from disk to achieve that.
@@ -664,6 +663,8 @@ private:
     // filter initialisation was not good.
     // This should be called only before an sstable is sealed.
     void maybe_rebuild_filter_from_index(uint64_t num_partitions);
+
+    future<> update_info_for_opened_data(sstable_open_config cfg = {});
 
     future<> read_toc() noexcept;
     future<> read_summary() noexcept;


### PR DESCRIPTION
The method is internally called by ssatble itself to refresh its state after opening or assigning (from foreign info) data and index files.
