### PR TITLE
nodetool: repair: skip tablet keyspaces

### DIFF
--- a/test/nodetool/test_repair.py
+++ b/test/nodetool/test_repair.py
@@ -51,7 +51,7 @@ def _remove_log_timestamp(res):
 
 def test_repair_all_single_keyspace(nodetool):
     res = nodetool("repair", expected_requests=[
-        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy"}, response=["ks1"]),
+        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "vnodes"}, response=["ks1"]),
         expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "tablets"}, response=[]),
         expected_request("GET", "/storage_service/keyspaces", response=["ks1"], multiple=expected_request.ANY),
         JMX_COLUMN_FAMILIES_REQUEST,
@@ -79,7 +79,7 @@ Repair session 1 finished
 
 def test_repair_all_two_keyspaces(nodetool):
     res = nodetool("repair", expected_requests=[
-        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy"},
+        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "vnodes"},
                          response=["ks1", "ks2"]),
         expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "tablets"}, response=[]),
         expected_request("GET", "/storage_service/keyspaces", multiple=expected_request.ANY, response=["ks1", "ks2"]),
@@ -268,7 +268,7 @@ def test_repair_all_three_keyspaces_failed(nodetool):
     """Check that given three keyspaces to repair, if the second one fails, the
     third one isn't even started."""
     expected_requests = [
-        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy"},
+        expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "vnodes"},
                          response=["ks1", "ks2", "ks3"]),
         expected_request("GET", "/storage_service/keyspaces", params={"type": "non_local_strategy", "replication": "tablets"},
                          response=[]),

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1558,9 +1558,9 @@ void repair_operation(scylla_rest_client& client, const bpo::variables_map& vm) 
         keyspaces.push_back(std::move(res.keyspace));
         tables = std::move(res.tables);
     } else {
-        keyspaces = get_keyspaces(client, "non_local_strategy");
+        keyspaces = get_keyspaces(client, "non_local_strategy", "vnodes");
         if (!get_keyspaces(client, "non_local_strategy", "tablets").empty()) {
-            fmt::print("WARNING: Do not use nodetool repair for tablet keyspaces! To repair tablet keyspaces use nodetool cluster repair.");
+            fmt::print("WARNING: nodetool repair does not repair tablet keyspaces! To repair tablet keyspaces use nodetool cluster repair.");
         }
     }
 


### PR DESCRIPTION
Currently, nodetool repair command repairs both vnode and tablet keyspaces if no keyspace is specified. We should use this command to repair only vnode keyspaces, but this isn't easily accessible - we have to explicitly run repair only on vnode keyspaces.

nodetool repair skips tablet keyspaces unless a tablet keyspace is explicitely passed as an argument.

Fixes: #24040.

Needs backport to 2025.1 that introduces nodetool cluster repair