### PR TITLE
Add Support for Per-Table Metrics in Alternator

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -105,6 +105,21 @@ static const column_definition& attrs_column(const schema& schema) {
     return *cdef;
 }
 
+
+static lw_shared_ptr<stats> get_stats_from_schema(service::storage_proxy& sp, const schema& schema) {
+    try {
+        replica::table& table = sp.local_db().find_column_family(schema.id());
+        if (!table.get_stats().alternator_stats) {
+            table.get_stats().alternator_stats = seastar::make_shared<table_stats>(schema.ks_name(), schema.cf_name());
+        }
+        return table.get_stats().alternator_stats->_stats;
+    } catch (std::runtime_error&) {
+        // If we're here it means that a table we are currently working on was deleted before the
+        // operation completed, returning a temporary object is fine, if the table get deleted so will its metrics
+        return make_lw_shared<stats>();
+    }
+}
+
 make_jsonable::make_jsonable(rjson::value&& value)
     : _value(std::move(value))
 {}
@@ -720,7 +735,7 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
     elogger.trace("Describing table {}", request);
 
     schema_ptr schema = get_table(_proxy, request);
-
+    get_stats_from_schema(_proxy, *schema)->api_operations.describe_table++;
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
     rjson::value table_description = co_await fill_table_description(schema, table_status::active, _proxy, client_state, trace_state, permit);
@@ -1116,6 +1131,7 @@ future<executor::request_return_type> executor::tag_resource(client_state& clien
         co_return api_error::access_denied("Incorrect resource identifier");
     }
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+    get_stats_from_schema(_proxy, *schema)->api_operations.tag_resource++;
     const rjson::value* tags = rjson::find(request, "Tags");
     if (!tags || !tags->IsArray()) {
         co_return api_error::validation("Cannot parse tags");
@@ -1143,6 +1159,7 @@ future<executor::request_return_type> executor::untag_resource(client_state& cli
     }
 
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
+    get_stats_from_schema(_proxy, *schema)->api_operations.untag_resource++;
     co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
         update_tags_map(*tags, tags_map, update_tags_action::delete_tags);
@@ -1157,7 +1174,7 @@ future<executor::request_return_type> executor::list_tags_of_resource(client_sta
         return make_ready_future<request_return_type>(api_error::access_denied("Incorrect resource identifier"));
     }
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
-
+    get_stats_from_schema(_proxy, *schema)->api_operations.list_tags_of_resource++;
     auto tags_map = get_tags_of_table_or_throw(schema);
     rjson::value ret = rjson::empty_object();
     rjson::add(ret, "Tags", rjson::empty_array());
@@ -2229,7 +2246,8 @@ static future<std::unique_ptr<rjson::value>> get_previous_item(
         const partition_key& pk,
         const clustering_key& ck,
         service_permit permit,
-        alternator::stats& stats);
+        alternator::stats& global_stats,
+        alternator::stats& per_table_stats);
 
 static lw_shared_ptr<query::read_command> previous_item_read_command(service::storage_proxy& proxy,
         schema_ptr schema,
@@ -2386,10 +2404,12 @@ static future<std::unique_ptr<rjson::value>> get_previous_item(
         const partition_key& pk,
         const clustering_key& ck,
         service_permit permit,
-        alternator::stats& stats,
+        alternator::stats& global_stats,
+        alternator::stats& per_table_stats,
         uint64_t& item_length)
 {
-    stats.reads_before_write++;
+    global_stats.reads_before_write++;
+    per_table_stats.reads_before_write++;
     auto selection = cql3::selection::selection::wildcard(schema);
     auto command = previous_item_read_command(proxy, schema, ck, selection);
     command->allow_limit = db::allow_per_partition_rate_limit::yes;
@@ -2410,17 +2430,19 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
         tracing::trace_state_ptr trace_state,
         service_permit permit,
         bool needs_read_before_write,
-        stats& stats,
+        stats& global_stats,
+        stats& per_table_stats,
         uint64_t& wcu_total) {
     if (needs_read_before_write) {
         if (_write_isolation == write_isolation::FORBID_RMW) {
             throw api_error::validation("Read-modify-write operations are disabled by 'forbid_rmw' write isolation policy. Refer to https://github.com/scylladb/scylla/blob/master/docs/alternator/alternator.md#write-isolation-policies for more information.");
         }
-        stats.reads_before_write++;
+        global_stats.reads_before_write++;
+        per_table_stats.reads_before_write++;
         if (_write_isolation == write_isolation::UNSAFE_RMW) {
             // This is the old, unsafe, read before write which does first
             // a read, then a write. TODO: remove this mode entirely.
-            return get_previous_item(proxy, client_state, schema(), _pk, _ck, permit, stats, _consumed_capacity._total_bytes).then(
+            return get_previous_item(proxy, client_state, schema(), _pk, _ck, permit, global_stats, per_table_stats, _consumed_capacity._total_bytes).then(
                     [this, &proxy, &wcu_total, trace_state, permit = std::move(permit)] (std::unique_ptr<rjson::value> previous_item) mutable {
                 std::optional<mutation> m = apply(std::move(previous_item), api::new_timestamp());
                 if (!m) {
@@ -2439,7 +2461,8 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
         });
     }
     // If we're still here, we need to do this write using LWT:
-    stats.write_using_lwt++;
+    global_stats.write_using_lwt++;
+    per_table_stats.write_using_lwt++;
     auto timeout = executor::default_timeout();
     auto selection = cql3::selection::selection::wildcard(schema());
     auto read_command = needs_read_before_write ?
@@ -2586,9 +2609,15 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
             });
         });
     }
-    co_return co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, _stats.wcu_total[stats::wcu_types::PUT_ITEM]).finally([op, start_time, this] {
-        _stats.api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
-    });
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.put_item++;
+    uint64_t wcu_total = 0;
+    auto res = co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
+    per_table_stats->wcu_total[stats::wcu_types::PUT_ITEM] += wcu_total;
+    _stats.wcu_total[stats::wcu_types::PUT_ITEM] += wcu_total;
+    per_table_stats->api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    _stats.api_operations.put_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    co_return res;
 }
 
 class delete_item_operation : public rmw_operation {
@@ -2660,6 +2689,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     elogger.trace("delete_item {}", request);
 
     auto op = make_shared<delete_item_operation>(_proxy, std::move(request));
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
@@ -2668,6 +2698,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     if (auto shard = op->shard_for_execute(needs_read_before_write); shard) {
         _stats.api_operations.delete_item--; // uncount on this shard, will be counted in other shard
         _stats.shard_bounce_for_lwt++;
+        per_table_stats->shard_bounce_for_lwt++;
         co_return co_await container().invoke_on(*shard, _ssg,
                 [request = std::move(*op).move_request(), cs = client_state.move_to_other_shard(), gt = tracing::global_trace_state_ptr(trace_state), permit = std::move(permit)]
                 (executor& e) mutable {
@@ -2681,9 +2712,14 @@ future<executor::request_return_type> executor::delete_item(client_state& client
             });
         });
     }
-    co_return co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, _stats.wcu_total[stats::wcu_types::DELETE_ITEM]).finally([op, start_time, this] {
-        _stats.api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
-    });
+    per_table_stats->api_operations.delete_item++;
+    uint64_t wcu_total = 0;
+    auto res = co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
+    per_table_stats->wcu_total[stats::wcu_types::DELETE_ITEM] += wcu_total;
+    _stats.wcu_total[stats::wcu_types::DELETE_ITEM] += wcu_total;
+    per_table_stats->api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    _stats.api_operations.delete_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    co_return res;
 }
 
 static schema_ptr get_table_from_batch_request(const service::storage_proxy& proxy, const rjson::value::ConstMemberIterator& batch_request) {
@@ -2866,15 +2902,23 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
             "maximum is {} (from configuration variable alternator_max_items_in_batch_write)", total_items, maximum_batch_write_size));
     }
     bool should_add_wcu = wcu_consumed_capacity_counter::should_add_capacity(request);
-    size_t wcu_put_units = 0;
-    size_t wcu_delete_units = 0;
+    size_t wcu_put_units;
+    size_t wcu_delete_units;
     rjson::value consumed_capacity = rjson::empty_array();
     std::vector<std::pair<schema_ptr, put_or_delete_item>> mutation_builders;
+    std::vector<std::tuple<lw_shared_ptr<stats>, size_t, size_t>> per_table_wcu;
     mutation_builders.reserve(request_items.MemberCount());
+    per_table_wcu.reserve(request_items.MemberCount());
     for (auto it = request_items.MemberBegin(); it != request_items.MemberEnd(); ++it) {
+        wcu_put_units = 0;
+        wcu_delete_units = 0;
         schema_ptr schema = get_table_from_batch_request(_proxy, it);
+        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(schema));
+        per_table_stats->api_operations.batch_write_item++;
+        per_table_stats->api_operations.batch_write_item_batch_total += it->value.Size();
+        per_table_stats->api_operations.batch_write_item_histogram.add(it->value.Size());
         tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
-        size_t wcu_units = 0;
+
         std::unordered_set<primary_key, primary_key_hash, primary_key_equal> used_keys(
                 1, primary_key_hash{schema}, primary_key_equal{schema});
         for (auto& request : it->value.GetArray()) {
@@ -2886,9 +2930,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 auto&& put_item = put_or_delete_item(
                         item, schema, put_or_delete_item::put_item{},
                         si_key_attributes(_proxy.data_dictionary().find_table(schema->ks_name(), schema->cf_name())));
-                auto units = wcu_consumed_capacity_counter::get_units(put_item.length_in_bytes());
-                wcu_units += units;
-                wcu_put_units += units;
+                wcu_put_units += wcu_consumed_capacity_counter::get_units(put_item.length_in_bytes());
                 mutation_builders.emplace_back(schema, std::move(put_item));
                 auto mut_key = std::make_pair(mutation_builders.back().second.pk(), mutation_builders.back().second.ck());
                 if (used_keys.contains(mut_key)) {
@@ -2898,7 +2940,6 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
             } else if (r_name == "DeleteRequest") {
                 const rjson::value& key = get_member(r.value, "Key", "DeleteRequest");
                 validate_is_object(key, "Key in DeleteRequest");
-                wcu_units++; // Delete is always 1 unit
                 wcu_delete_units++;
                 mutation_builders.emplace_back(schema, put_or_delete_item(
                         key, schema, put_or_delete_item::delete_item{}));
@@ -2912,15 +2953,24 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 co_return api_error::validation(fmt::format("Unknown BatchWriteItem request type: {}", r_name));
             }
         }
+        per_table_wcu.emplace_back(per_table_stats, wcu_delete_units, wcu_put_units);
         if (should_add_wcu) {
             rjson::value entry = rjson::empty_object();
             rjson::add(entry, "TableName", rjson::from_string(rjson::to_string_view(it->name)));
-            rjson::add(entry, "CapacityUnits", wcu_units);
+            rjson::add(entry, "CapacityUnits", wcu_delete_units + wcu_put_units);
             rjson::push_back(consumed_capacity, std::move(entry));
         }
     }
     for (const auto& b : mutation_builders) {
         co_await verify_permission(_enforce_authorization, client_state, b.first, auth::permission::MODIFY);
+    }
+    wcu_put_units = 0;
+    wcu_delete_units = 0;
+    for (const auto& w : per_table_wcu) {
+        std::get<0>(w)->wcu_total[stats::DELETE_ITEM] += std::get<1>(w);
+        std::get<0>(w)->wcu_total[stats::PUT_ITEM] += std::get<2>(w);
+        wcu_delete_units += std::get<1>(w);
+        wcu_put_units += std::get<2>(w);
     }
     _stats.wcu_total[stats::PUT_ITEM] += wcu_put_units;
     _stats.wcu_total[stats::DELETE_ITEM] += wcu_delete_units;
@@ -4084,9 +4134,15 @@ future<executor::request_return_type> executor::update_item(client_state& client
             });
         });
     }
-    co_return co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, _stats.wcu_total[stats::wcu_types::UPDATE_ITEM]).finally([op, start_time, this] {
-        _stats.api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
-    });
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *(op->schema()));
+    per_table_stats->api_operations.update_item++;
+    uint64_t wcu_total = 0;
+    auto res = co_await op->execute(_proxy, client_state, trace_state, std::move(permit), needs_read_before_write, _stats, *per_table_stats, wcu_total);
+    per_table_stats->wcu_total[stats::wcu_types::UPDATE_ITEM] += wcu_total;
+    _stats.wcu_total[stats::wcu_types::UPDATE_ITEM] += wcu_total;
+    per_table_stats->api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    _stats.api_operations.update_item_latency.mark(std::chrono::steady_clock::now() - start_time);
+    co_return res;
 }
 
 // Check according to the request's "ConsistentRead" field, which consistency
@@ -4134,7 +4190,8 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     elogger.trace("Getting item {}", request);
 
     schema_ptr schema = get_table(_proxy, request);
-
+    lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *schema);
+    per_table_stats->api_operations.get_item++;
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
     rjson::value& query_key = request["Key"];
@@ -4171,11 +4228,15 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT);
     co_return co_await _proxy.query(schema, std::move(command), std::move(partition_ranges), cl,
             service::storage_proxy::coordinator_query_options(executor::default_timeout(), std::move(permit), client_state, trace_state)).then(
-            [this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time), add_capacity=std::move(add_capacity)] (service::storage_proxy::coordinator_query_result qr) mutable {
+            [per_table_stats, this, schema, partition_slice = std::move(partition_slice), selection = std::move(selection), attrs_to_get = std::move(attrs_to_get), start_time = std::move(start_time), add_capacity=std::move(add_capacity)] (service::storage_proxy::coordinator_query_result qr) mutable {
 
+        per_table_stats->api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);
         _stats.api_operations.get_item_latency.mark(std::chrono::steady_clock::now() - start_time);
-
-        return make_ready_future<executor::request_return_type>(make_jsonable(describe_item(schema, partition_slice, *selection, *qr.query_result, std::move(attrs_to_get), add_capacity, _stats.rcu_half_units_total)));
+        uint64_t rcu_half_units = 0;
+        auto res = make_ready_future<executor::request_return_type>(make_jsonable(describe_item(schema, partition_slice, *selection, *qr.query_result, std::move(attrs_to_get), add_capacity, rcu_half_units)));
+        per_table_stats->rcu_half_units_total += rcu_half_units;
+        _stats.rcu_half_units_total += rcu_half_units;
+        return res;
     });
 }
 
@@ -4307,6 +4368,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     for (const auto& rs : requests) {
         responses_sizes[responses_sizes_pos].resize(rs.requests.size());
         size_t pos = 0;
+        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
+        per_table_stats->api_operations.batch_get_item_histogram.add(rs.requests.size());
         for (const auto &r : rs.requests) {
             auto& pk = r.first;
             auto& cks = r.second;
@@ -4397,6 +4460,8 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
             pos++;
         }
         _stats.rcu_half_units_total += rcu_half_units;
+        lw_shared_ptr<stats> per_table_stats = get_stats_from_schema(_proxy, *rs.schema);
+        per_table_stats->rcu_half_units_total += rcu_half_units;
         if (should_add_rcu) {
             rjson::value entry = rjson::empty_object();
             rjson::add(entry, "TableName", table);
@@ -4842,7 +4907,7 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
     elogger.trace("Scanning {}", request);
 
     auto [schema, table_type] = get_table_or_view(_proxy, request);
-
+    get_stats_from_schema(_proxy, *schema)->api_operations.scan++;
     auto segment = get_int_attribute(request, "Segment");
     auto total_segments = get_int_attribute(request, "TotalSegments");
     if (segment || total_segments) {
@@ -5319,7 +5384,7 @@ future<executor::request_return_type> executor::query(client_state& client_state
     elogger.trace("Querying {}", request);
 
     auto [schema, table_type] = get_table_or_view(_proxy, request);
-
+    get_stats_from_schema(_proxy, *schema)->api_operations.query++;
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
     rjson::value* exclusive_start_key = rjson::find(request, "ExclusiveStartKey");

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -192,6 +192,7 @@ executor::executor(gms::gossiper& gossiper,
       _ssg(ssg)
 {
     s_default_timeout_in_ms = std::move(default_timeout_in_ms);
+    register_metrics(_metrics, _stats);
 }
 
 

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -171,6 +171,9 @@ public:
     using client_state = service::client_state;
     using request_return_type = std::variant<json::json_return_type, api_error>;
     stats _stats;
+    // The metric_groups object holds this stat object's metrics registered
+    // as long as the stats object is alive.
+    seastar::metrics::metric_groups _metrics;
     static constexpr auto ATTRS_COLUMN_NAME = ":attrs";
     static constexpr auto KEYSPACE_NAME_PREFIX = "alternator_";
     static constexpr std::string_view INTERNAL_TABLE_PREFIX = ".scylla.alternator.";

--- a/alternator/rmw_operation.hh
+++ b/alternator/rmw_operation.hh
@@ -118,7 +118,8 @@ public:
             tracing::trace_state_ptr trace_state,
             service_permit permit,
             bool needs_read_before_write,
-            stats& stats,
+            stats& global_stats,
+            stats& per_table_stats,
             uint64_t& wcu_total);
     std::optional<shard_id> shard_for_execute(bool needs_read_before_write);
 };

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -28,27 +28,43 @@ static seastar::metrics::histogram estimated_histogram_to_metrics(const utils::e
     }
     return res;
 }
-stats::stats() : api_operations{} {
+
+static seastar::metrics::label column_family_label("cf");
+static seastar::metrics::label keyspace_label("ks");
+
+
+static void register_metrics_with_optional_table(seastar::metrics::metric_groups& metrics, const stats& stats, const sstring& ks, const sstring& table) {
+
     // Register the
     seastar::metrics::label op("op");
-
-    _metrics.add_group("alternator", {
+    bool has_table = table.length();
+    std::vector<seastar::metrics::label> aggregate_labels;
+    std::vector<seastar::metrics::label_instance> labels = {alternator_label};
+    if (has_table) {
+        labels.push_back(column_family_label(table));
+        labels.push_back(keyspace_label(ks));
+        aggregate_labels.push_back(seastar::metrics::shard_label);
+    }
+    metrics.add_group((has_table)? "alternator_table" : "alternator", {
 #define OPERATION(name, CamelCaseName) \
-                seastar::metrics::make_total_operations("operation", api_operations.name, \
-                        seastar::metrics::description("number of operations via Alternator API"), {op(CamelCaseName), alternator_label, basic_level}).set_skip_when_empty(),
+                seastar::metrics::make_total_operations("operation", stats.api_operations.name, \
+                        seastar::metrics::description("number of operations via Alternator API"), labels)(basic_level)(op(CamelCaseName)).aggregate(aggregate_labels).set_skip_when_empty(),
 #define OPERATION_LATENCY(name, CamelCaseName) \
+		metrics.add_group((has_table)? "alternator_table" : "alternator", { \
                 seastar::metrics::make_histogram("op_latency", \
-                        seastar::metrics::description("Latency histogram of an operation via Alternator API"), {op(CamelCaseName), alternator_label, basic_level}, [this]{return to_metrics_histogram(api_operations.name.histogram());}).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(), \
+                        seastar::metrics::description("Latency histogram of an operation via Alternator API"), labels, [&stats]{return to_metrics_histogram(stats.api_operations.name.histogram());})(op(CamelCaseName))(basic_level).aggregate({seastar::metrics::shard_label}).set_skip_when_empty()}); \
+            if (!has_table) {\
+            	metrics.add_group("alternator", { \
 				seastar::metrics::make_summary("op_latency_summary", \
-						                        seastar::metrics::description("Latency summary of an operation via Alternator API"), [this]{return to_metrics_summary(api_operations.name.summary());})(op(CamelCaseName))(basic_level)(alternator_label).set_skip_when_empty(),
+						                        seastar::metrics::description("Latency summary of an operation via Alternator API"), [&stats]{return to_metrics_summary(stats.api_operations.name.summary());})(op(CamelCaseName))(basic_level)(alternator_label).set_skip_when_empty()}); \
+            }
+
             OPERATION(batch_get_item, "BatchGetItem")
             OPERATION(batch_write_item, "BatchWriteItem")
             OPERATION(create_backup, "CreateBackup")
             OPERATION(create_global_table, "CreateGlobalTable")
-            OPERATION(create_table, "CreateTable")
             OPERATION(delete_backup, "DeleteBackup")
             OPERATION(delete_item, "DeleteItem")
-            OPERATION(delete_table, "DeleteTable")
             OPERATION(describe_backup, "DescribeBackup")
             OPERATION(describe_continuous_backups, "DescribeContinuousBackups")
             OPERATION(describe_endpoints, "DescribeEndpoints")
@@ -77,59 +93,74 @@ stats::stats() : api_operations{} {
             OPERATION(update_item, "UpdateItem")
             OPERATION(update_table, "UpdateTable")
             OPERATION(update_time_to_live, "UpdateTimeToLive")
-            OPERATION_LATENCY(put_item_latency, "PutItem")
-            OPERATION_LATENCY(get_item_latency, "GetItem")
-            OPERATION_LATENCY(delete_item_latency, "DeleteItem")
-            OPERATION_LATENCY(update_item_latency, "UpdateItem")
-            OPERATION_LATENCY(batch_write_item_latency, "BatchWriteItem")
-            OPERATION_LATENCY(batch_get_item_latency, "BatchGetItem")
             OPERATION(list_streams, "ListStreams")
             OPERATION(describe_stream, "DescribeStream")
             OPERATION(get_shard_iterator, "GetShardIterator")
             OPERATION(get_records, "GetRecords")
-            OPERATION_LATENCY(get_records_latency, "GetRecords")
     });
-    _metrics.add_group("alternator", {
-            seastar::metrics::make_total_operations("unsupported_operations", unsupported_operations,
-                    seastar::metrics::description("number of unsupported operations via Alternator API"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("total_operations", total_operations,
-                    seastar::metrics::description("number of total operations via Alternator API"))(basic_level)(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("reads_before_write", reads_before_write,
-                    seastar::metrics::description("number of performed read-before-write operations"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("write_using_lwt", write_using_lwt,
-                    seastar::metrics::description("number of writes that used LWT"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("shard_bounce_for_lwt", shard_bounce_for_lwt,
-                    seastar::metrics::description("number writes that had to be bounced from this shard because of LWT requirements"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("requests_blocked_memory", requests_blocked_memory,
-                    seastar::metrics::description("Counts a number of requests blocked due to memory pressure."))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("requests_shed", requests_shed,
-                    seastar::metrics::description("Counts a number of requests shed due to overload."))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("filtered_rows_read_total", cql_stats.filtered_rows_read_total,
-                    seastar::metrics::description("number of rows read during filtering operations"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("filtered_rows_matched_total", cql_stats.filtered_rows_matched_total,
-                    seastar::metrics::description("number of rows read and matched during filtering operations")),
-            seastar::metrics::make_counter("rcu_total", [this]{return 0.5 * rcu_half_units_total;},
-                    seastar::metrics::description("total number of consumed read units"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("wcu_total", wcu_total[wcu_types::PUT_ITEM],
-                    seastar::metrics::description("total number of consumed write units"),{op("PutItem")})(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("wcu_total", wcu_total[wcu_types::DELETE_ITEM],
-                    seastar::metrics::description("total number of consumed write units"),{op("DeleteItem")})(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("wcu_total", wcu_total[wcu_types::UPDATE_ITEM],
-                    seastar::metrics::description("total number of consumed write units"),{op("UpdateItem")})(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("wcu_total", wcu_total[wcu_types::INDEX],
-                    seastar::metrics::description("total number of consumed write units"),{op("Index")})(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_total_operations("filtered_rows_dropped_total", [this] { return cql_stats.filtered_rows_read_total - cql_stats.filtered_rows_matched_total; },
-                    seastar::metrics::description("number of rows read and dropped during filtering operations"))(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("batch_item_count", seastar::metrics::description("The total number of items processed across all batches"),{op("BatchWriteItem")},
-                    api_operations.batch_write_item_batch_total)(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_counter("batch_item_count", seastar::metrics::description("The total number of items processed across all batches"),{op("BatchGetItem")},
-                    api_operations.batch_get_item_batch_total)(alternator_label).set_skip_when_empty(),
-            seastar::metrics::make_histogram("batch_item_count_histogram", seastar::metrics::description("Histogram of the number of items in a batch request"),{op("BatchGetItem")},
-                    [this]{ return estimated_histogram_to_metrics(api_operations.batch_get_item_histogram);})(alternator_label).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
-            seastar::metrics::make_histogram("batch_item_count_histogram", seastar::metrics::description("Histogram of the number of items in a batch request"),{op("BatchWriteItem")},
-                    [this]{ return estimated_histogram_to_metrics(api_operations.batch_write_item_histogram);})(alternator_label).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+    OPERATION_LATENCY(put_item_latency, "PutItem")
+    OPERATION_LATENCY(get_item_latency, "GetItem")
+    OPERATION_LATENCY(delete_item_latency, "DeleteItem")
+    OPERATION_LATENCY(update_item_latency, "UpdateItem")
+    OPERATION_LATENCY(batch_write_item_latency, "BatchWriteItem")
+    OPERATION_LATENCY(batch_get_item_latency, "BatchGetItem")
+    OPERATION_LATENCY(get_records_latency, "GetRecords")
+    if (!has_table) {
+        // Create and delete operations are not applicable to a per-table metrics
+        // only register it for the global metrics
+        metrics.add_group("alternator", {
+            OPERATION(create_table, "CreateTable")
+            OPERATION(delete_table, "DeleteTable")
+
+        });
+    }
+    metrics.add_group((has_table)? "alternator_table" : "alternator", {
+            seastar::metrics::make_total_operations("unsupported_operations", stats.unsupported_operations,
+                    seastar::metrics::description("number of unsupported operations via Alternator API"), labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("total_operations", stats.total_operations,
+                    seastar::metrics::description("number of total operations via Alternator API"), labels)(basic_level).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("reads_before_write", stats.reads_before_write,
+                    seastar::metrics::description("number of performed read-before-write operations"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("write_using_lwt", stats.write_using_lwt,
+                    seastar::metrics::description("number of writes that used LWT"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("shard_bounce_for_lwt", stats.shard_bounce_for_lwt,
+                    seastar::metrics::description("number writes that had to be bounced from this shard because of LWT requirements"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("requests_blocked_memory", stats.requests_blocked_memory,
+                    seastar::metrics::description("Counts a number of requests blocked due to memory pressure."), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("requests_shed", stats.requests_shed,
+                    seastar::metrics::description("Counts a number of requests shed due to overload."), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("filtered_rows_read_total", stats.cql_stats.filtered_rows_read_total,
+                    seastar::metrics::description("number of rows read during filtering operations"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("filtered_rows_matched_total", stats.cql_stats.filtered_rows_matched_total,
+                    seastar::metrics::description("number of rows read and matched during filtering operations"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("rcu_total", [&stats]{return 0.5 * stats.rcu_half_units_total;},
+                    seastar::metrics::description("total number of consumed read units"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("wcu_total", stats.wcu_total[stats::wcu_types::PUT_ITEM],
+                    seastar::metrics::description("total number of consumed write units"), labels)(op("PutItem")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("wcu_total", stats.wcu_total[stats::wcu_types::DELETE_ITEM],
+                    seastar::metrics::description("total number of consumed write units"), labels)(op("DeleteItem")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("wcu_total", stats.wcu_total[stats::wcu_types::UPDATE_ITEM],
+                    seastar::metrics::description("total number of consumed write units"), labels)(op("UpdateItem")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("wcu_total", stats.wcu_total[stats::wcu_types::INDEX],
+                    seastar::metrics::description("total number of consumed write units"), labels)(op("Index")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("filtered_rows_dropped_total", [&stats] { return stats.cql_stats.filtered_rows_read_total - stats.cql_stats.filtered_rows_matched_total; },
+                    seastar::metrics::description("number of rows read and dropped during filtering operations"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("batch_item_count", seastar::metrics::description("The total number of items processed across all batches"), labels,
+                    stats.api_operations.batch_write_item_batch_total)(op("BatchWriteItem")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_counter("batch_item_count", seastar::metrics::description("The total number of items processed across all batches"), labels,
+                    stats.api_operations.batch_get_item_batch_total)(op("BatchGetItem")).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_histogram("batch_item_count_histogram", seastar::metrics::description("Histogram of the number of items in a batch request"), labels,
+                    [&stats]{ return estimated_histogram_to_metrics(stats.api_operations.batch_get_item_histogram);})(op("BatchGetItem")).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+            seastar::metrics::make_histogram("batch_item_count_histogram", seastar::metrics::description("Histogram of the number of items in a batch request"), labels,
+                    [&stats]{ return estimated_histogram_to_metrics(stats.api_operations.batch_write_item_histogram);})(op("BatchWriteItem")).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
     });
 }
 
-
+void register_metrics(seastar::metrics::metric_groups& metrics, const stats& stats) {
+    register_metrics_with_optional_table(metrics, stats, "", "");
+}
+table_stats::table_stats(const sstring& ks, const sstring& table) {
+    _stats = make_lw_shared<stats>();
+    register_metrics_with_optional_table(_metrics, *_stats, ks, table);
+}
 }

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -108,4 +108,10 @@ private:
     seastar::metrics::metric_groups _metrics;
 };
 
+struct table_stats {
+    table_stats(const sstring& ks, const sstring& table);
+    seastar::metrics::metric_groups _metrics;
+    lw_shared_ptr<stats> _stats;
+};
+
 }

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -22,7 +22,6 @@ namespace alternator {
 // visible by the metrics REST API, with the "alternator" prefix.
 class stats {
 public:
-    stats();
     // Count of DynamoDB API operations by types
     struct {
         uint64_t batch_get_item = 0;
@@ -102,10 +101,6 @@ public:
     uint64_t wcu_total[NUM_TYPES] = {0};
     // CQL-derived stats
     cql3::cql_stats cql_stats;
-private:
-    // The metric_groups object holds this stat object's metrics registered
-    // as long as the stats object is alive.
-    seastar::metrics::metric_groups _metrics;
 };
 
 struct table_stats {
@@ -113,5 +108,6 @@ struct table_stats {
     seastar::metrics::metric_groups _metrics;
     lw_shared_ptr<stats> _stats;
 };
+void register_metrics(seastar::metrics::metric_groups& metrics, const stats& stats);
 
 }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -96,6 +96,9 @@ namespace gms {
 class feature_service;
 }
 
+namespace alternator {
+class table_stats;
+}
 namespace sstables {
 
 enum class sstable_state;
@@ -391,6 +394,7 @@ struct table_stats {
     utils::timed_rate_moving_average_and_histogram tombstone_scanned;
     utils::timed_rate_moving_average_and_histogram live_scanned;
     utils::estimated_histogram estimated_coordinator_read;
+    shared_ptr<alternator::table_stats> alternator_stats;
 };
 
 using storage_options = data_dictionary::storage_options;


### PR DESCRIPTION
This series introduces per-table metrics support for Alternator. It includes the following commits:

Add optional per-table metrics for Alternator
Introduces a shared_ptr-based mechanism that allows Alternator to register per-table metrics. These metrics follow the table's lifecycle, similar to how CQL metrics are handled. The use of shared_ptr ensures no direct dependency between table stats and Alternator.

Enable registration of stats objects per table
Adds support for registering a stats object using a keyspace and table name. Per-table metrics are prefixed with alternator_table to differentiate them from per-shard metrics. Metrics are reported once per node, and those not meaningful at the table level (e.g. create/delete) are excluded. All metrics use the skip_when_empty flag.

Update per-table metrics handling
Adds a helper function to retrieve the stats object from a table schema. Updates both per-shard and per-table metrics, resulting in some code duplication.

Add tests for per-table metrics
Extends existing tests to also validate the per-table metrics. These tests ensure that the new metrics are correctly registered and updated.

This series improves observability in Alternator by enabling fine-grained per-table metrics without disrupting existing per-shard metrics.
**No need to backport**

Fixes #19824