### PR TITLE
main: check if current process group controls stdin tty

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -696,7 +696,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
     // If --version is requested, print it out and exit immediately to avoid
     // Seastar-specific warnings that may occur when running the app
-    if (!isatty(fileno(stdin))) {
+    if (!isatty(fileno(stdin)) || tcgetpgrp(fileno(stdin)) != getpgrp()) {
         auto parsed_opts = bpo::command_line_parser(ac, av).options(app.get_options_description()).allow_unregistered().run();
         print_starting_message(ac, av, parsed_opts);
     }


### PR DESCRIPTION
`test.py` doesn't override stdin when starting Scylla, so when tests are run from a terminal, `isatty()` returns true and parsed command line output is not printed, which is inconvenient.

In this commit we add a check if the current process group controls the stdin terminal. This serves two purposes:
* improves the "interactive mode" check from #scylladb/scylladb#18309, as only the controlling process group can interact with the terminal.
* solves the `test.py` problem above, because `test.py` runs scylla in a new session/process group (it calls `setsid` after fork), and is now correctly not considered interactive.

Backport: not needed, since it's minor inconvenience, not a real issue.