### PR TITLE
streaming: use host_id in file streaming

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -210,7 +210,6 @@ private:
     // when both of which sit on the same node. So all the movement is local.
     future<> clone_locally_tablet_storage(locator::global_tablet_id, locator::tablet_replica leaving, locator::tablet_replica pending);
     future<> cleanup_tablet(locator::global_tablet_id);
-    inet_address host2ip(locator::host_id) const;
     // Handler for table load stats RPC.
     future<locator::load_stats> load_stats_for_tablet_based_tables();
     future<> process_tablet_split_candidate(table_id) noexcept;

--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -116,13 +116,13 @@ struct stream_blob_info {
 };
 
 // The handler for the STREAM_BLOB verb.
-seastar::future<> stream_blob_handler(replica::database& db, netw::messaging_service& ms, gms::inet_address from, streaming::stream_blob_meta meta, rpc::sink<streaming::stream_blob_cmd_data> sink, rpc::source<streaming::stream_blob_cmd_data> source);
+seastar::future<> stream_blob_handler(replica::database& db, netw::messaging_service& ms, locator::host_id from, streaming::stream_blob_meta meta, rpc::sink<streaming::stream_blob_cmd_data> sink, rpc::source<streaming::stream_blob_cmd_data> source);
 
 // Exposed mainly for testing
 
 future<> stream_blob_handler(replica::database& db,
         netw::messaging_service& ms,
-        gms::inet_address from,
+        locator::host_id from,
         streaming::stream_blob_meta meta,
         rpc::sink<streaming::stream_blob_cmd_data> sink,
         rpc::source<streaming::stream_blob_cmd_data> source,
@@ -163,11 +163,9 @@ public:
     size_t stream_bytes = 0;
 };
 
-using host2ip_t = std::function<future<gms::inet_address> (locator::host_id)>;
-
 // The handler for the TABLET_STREAM_FILES verb. The receiver of this verb will
 // stream sstables files specified by the stream_files_request req.
-future<stream_files_response> tablet_stream_files_handler(replica::database& db, netw::messaging_service& ms, streaming::stream_files_request req, host2ip_t host2ip);
+future<stream_files_response> tablet_stream_files_handler(replica::database& db, netw::messaging_service& ms, streaming::stream_files_request req);
 
 // Ask the src node to stream sstables to dst node for table in the given token range using TABLET_STREAM_FILES verb.
 future<stream_files_response> tablet_stream_files(const file_stream_id& ops_id, replica::table& table, const dht::token_range& range, const locator::host_id& src, const locator::host_id& dst, seastar::shard_id dst_shard_id, netw::messaging_service& ms, abort_source& as, service::frozen_topology_guard topo_guard);
@@ -178,7 +176,6 @@ future<size_t> tablet_stream_files(netw::messaging_service& ms,
     std::vector<node_and_shard> targets,
     table_id table,
     file_stream_id ops_id,
-    host2ip_t host2ip,
     service::frozen_topology_guard topo_guard,
     bool may_inject_errors = false
     );

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -294,7 +294,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
         }
     });
     ms.register_stream_blob([this] (const rpc::client_info& cinfo, streaming::stream_blob_meta meta, rpc::source<streaming::stream_blob_cmd_data> source) {
-        auto from = netw::messaging_service::get_source(cinfo).addr;
+        const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
         auto sink = _ms.local().make_sink_for_stream_blob(source);
         (void)stream_blob_handler(_db.local(), _ms.local(), from, meta, sink, source).handle_exception([ms = _ms.local().shared_from_this()] (std::exception_ptr eptr) {
             sslog.warn("Failed to run stream blob handler: {}", eptr);


### PR DESCRIPTION
Use host ids instead of ips in file-streaming.

Fixes: #22421.

Requires backport to 2025.1 (that introduces [file-streaming in scylladb.git](https://github.com/scylladb/scylladb/pull/22034)) and 2025.2