### PR TITLE
replica: Fix take_storage_snapshot() running concurrently to merge completion

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -357,12 +357,12 @@ public:
     virtual void update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) = 0;
 
     virtual compaction_group& compaction_group_for_token(dht::token token) const = 0;
-    virtual utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const = 0;
     virtual compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const = 0;
     virtual compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const = 0;
 
     virtual size_t log2_storage_groups() const = 0;
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
+    virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
 
     virtual locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
     virtual bool all_storage_groups_split() = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -654,14 +654,23 @@ private:
 
     // Select a storage group from a given token.
     storage_group& storage_group_for_token(dht::token token) const;
+    // Return storage groups, present in this shard, that own a particular token range.
+    // This is a much safer interface to view all data belonging to a tablet replica since data can be
+    // moved across compaction groups belonging to the same replica. So data could escape an iteration
+    // on compaction groups. Iterating on storage groups instead, allows the caller to see all the
+    // data at any point in time. In short, writes can operate on compaction group level, but reads
+    // must operate on storage group level.
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const;
     storage_group& storage_group_for_id(size_t i) const;
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();
     compaction_group* get_compaction_group(size_t id) const;
+    // NOTE: all readers must only operate on storage groups, which can provide all data belonging to
+    // a given tablet replica. Interfaces below should only be used in the context of writes, for
+    // example, to append data to memtable. Iterating on compaction groups is susceptible to races
+    // since sstables might move across compaction groups in background.
     // Select a compaction group from a given token.
     compaction_group& compaction_group_for_token(dht::token token) const;
-    // Return compaction groups, present in this shard, that own a particular token range.
-    utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const;
     // Select a compaction group from a given key.
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const;
     // Select a compaction group from a given sstable based on its token range.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -199,10 +199,12 @@ table::add_memtables_to_reader_list(std::vector<mutation_reader>& readers,
         return;
     }
     auto token_range = range.transform(std::mem_fn(&dht::ring_position::token));
-    auto cgs = compaction_groups_for_token_range(token_range);
-    reserve_fn(std::ranges::fold_left(cgs | std::views::transform(std::mem_fn(&compaction_group::memtable_count)), uint64_t(0), std::plus{}));
-    for (auto& cg : cgs) {
-        add_memtables_from_cg(*cg);
+    auto sgs = storage_groups_for_token_range(token_range);
+    reserve_fn(std::ranges::fold_left(sgs | std::views::transform(std::mem_fn(&storage_group::memtable_count)), uint64_t(0), std::plus{}));
+    for (auto& sg : sgs) {
+        for (auto& cg : sg->compaction_groups()) {
+            add_memtables_from_cg(*cg);
+        }
     }
 }
 
@@ -669,7 +671,7 @@ storage_group* storage_group_manager::maybe_storage_group_for_id(const schema_pt
 
 class single_storage_group_manager final : public storage_group_manager {
     replica::table& _t;
-    storage_group* _single_sg;
+    storage_group_ptr _single_sg;
     compaction_group* _single_cg;
 
     compaction_group& get_compaction_group() const noexcept {
@@ -683,7 +685,7 @@ public:
         auto cg = make_lw_shared<compaction_group>(_t, size_t(0), dht::token_range::make_open_ended_both_sides());
         _single_cg = cg.get();
         auto sg = make_lw_shared<storage_group>(std::move(cg));
-        _single_sg = sg.get();
+        _single_sg = sg;
         r[0] = std::move(sg);
         _storage_groups = std::move(r);
     }
@@ -697,9 +699,9 @@ public:
     compaction_group& compaction_group_for_token(dht::token token) const override {
         return get_compaction_group();
     }
-    utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const override {
-        utils::chunked_vector<compaction_group*> ret;
-        ret.push_back(&get_compaction_group());
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const override {
+        utils::chunked_vector<storage_group_ptr> ret;
+        ret.push_back(_single_sg);
         return ret;
     }
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override {
@@ -842,7 +844,7 @@ public:
     void update_effective_replication_map(const locator::effective_replication_map& erm, noncopyable_function<void()> refresh_mutation_source) override;
 
     compaction_group& compaction_group_for_token(dht::token token) const override;
-    utils::chunked_vector<compaction_group*> compaction_groups_for_token_range(dht::token_range tr) const override;
+    utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const override;
     compaction_group& compaction_group_for_key(partition_key_view key, const schema_ptr& s) const override;
     compaction_group& compaction_group_for_sstable(const sstables::shared_sstable& sst) const override;
 
@@ -1148,8 +1150,8 @@ compaction_group& table::compaction_group_for_token(dht::token token) const {
     return _sg_manager->compaction_group_for_token(token);
 }
 
-utils::chunked_vector<compaction_group*> tablet_storage_group_manager::compaction_groups_for_token_range(dht::token_range tr) const {
-    utils::chunked_vector<compaction_group*> ret;
+utils::chunked_vector<storage_group_ptr> tablet_storage_group_manager::storage_groups_for_token_range(dht::token_range tr) const {
+    utils::chunked_vector<storage_group_ptr> ret;
     auto cmp = dht::token_comparator();
 
     size_t candidate_start = tr.start() ? tablet_id_for_token(tr.start()->value()) : size_t(0);
@@ -1161,18 +1163,16 @@ utils::chunked_vector<compaction_group*> tablet_storage_group_manager::compactio
             continue;
         }
         auto& sg = it->second;
-        for (auto& cg : sg->compaction_groups()) {
-            if (cg && tr.overlaps(cg->token_range(), cmp)) {
-                ret.push_back(cg.get());
-            }
+        if (sg && tr.overlaps(sg->token_range(), cmp)) {
+            ret.push_back(sg);
         }
     }
 
     return ret;
 }
 
-utils::chunked_vector<compaction_group*> table::compaction_groups_for_token_range(dht::token_range tr) const {
-    return _sg_manager->compaction_groups_for_token_range(tr);
+utils::chunked_vector<storage_group_ptr> table::storage_groups_for_token_range(dht::token_range tr) const {
+    return _sg_manager->storage_groups_for_token_range(tr);
 }
 
 compaction_group& tablet_storage_group_manager::compaction_group_for_key(partition_key_view key, const schema_ptr& s) const {
@@ -1254,20 +1254,24 @@ const storage_group_map& table::storage_groups() const {
 future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_storage_snapshot(dht::token_range tr) {
     utils::chunked_vector<sstables::sstable_files_snapshot> ret;
 
-    for (auto& cg : compaction_groups_for_token_range(tr)) {
+    for (auto& sg : storage_groups_for_token_range(tr)) {
+        co_await utils::get_local_injector().inject("take_storage_snapshot", utils::wait_for_message(60s));
+
         // We don't care about sstables in snapshot being unlinked, as the file
         // descriptors remain opened until last reference to them are gone.
         // Also, we should be careful with taking a deletion lock here as a
         // deadlock might occur due to memtable flush backpressure waiting on
         // compaction to reduce the backlog.
 
-        co_await cg->flush();
+        co_await sg->flush();
 
         // The sstable set must be obtained *after* the deletion lock is taken,
         // otherwise components of sstables in the set might be unlinked from the filesystem
         // by compaction while we are waiting for the lock.
         auto deletion_guard = co_await get_sstable_list_permit();
-        co_await cg->make_sstable_set()->for_each_sstable_gently([&] (const sstables::shared_sstable& sst) -> future<> {
+        // It's vital that we build a set on the storage group level, since sstables
+        // might move across compaction groups in the background.
+        co_await sg->make_sstable_set()->for_each_sstable_gently([&] (const sstables::shared_sstable& sst) -> future<> {
            ret.push_back({
                .sst = sst,
                .files = co_await sst->readable_file_for_all_components(),
@@ -2607,6 +2611,8 @@ future<> tablet_storage_group_manager::merge_completion_fiber() {
 
     while (!_t.async_gate().is_closed()) {
         try {
+            co_await utils::get_local_injector().inject("merge_completion_fiber", utils::wait_for_message(60s));
+
             co_await for_each_storage_group_gently([] (storage_group& sg) -> future<> {
                 auto main_group = sg.main_compaction_group();
                 for (auto& group : sg.merging_groups()) {


### PR DESCRIPTION
Some background:
When merge happens, a background fiber wakes up to merge compaction groups of sibling tablets into main one. It cannot happen when rebuilding the storage group list, since token metadata update is not preemptable. So a storage group, post merge, has the main compaction group and two other groups to be merged into the main. When the merge happens, those two groups are empty and will be freed.

Consider this scenario:
1) merge happens, from 2 to 1 tablet
2) produces a single storage group, containing main and two other compaction groups to be merged into main.
3) take_storage_snapshot(), triggered by migration post merge, gets a list of pointer to all compaction groups.
4) t__s__s() iterates first on main group, yields.
5) background fiber wakes up, moves the data into main and frees the two groups
6) t__s__s() advances to other groups that are now freed, since step 5.
7) segmentation fault

In addition to memory corruption, there's also a potential for data to escape the iteration in take_storage_snapshot(), since data can be moved across compaction groups in background, all belonging to the same storage group. That could result in data loss.

Readers should all operate on storage group level since it can provide a view on all the data owned by a tablet replica. The movement of sstable from group A to B is atomic, but iteration first on A, then later on B, might miss data that was moved from B to A, before the iteration reached B. By switching to storage group in the interface that retrieves groups by token range, we guarantee that all data of a given replica can be found regardless of which compaction group they sit on.

Fixes #23162.

It's a critical fix, with little risk, so must be backported as soon as possible.