### PR TITLE
encryption_test: Catch exact exception

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -25,6 +25,7 @@
 #include "ent/encryption/encryption.hh"
 #include "ent/encryption/symmetric_key.hh"
 #include "ent/encryption/local_file_provider.hh"
+#include "ent/encryption/encryption_exceptions.hh"
 #include "test/lib/tmpdir.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/cql_test_env.hh"
@@ -649,10 +650,20 @@ SEASTAR_TEST_CASE(test_kms_provider_with_master_key_in_cf, *check_run_test_decor
         );
 
         // should fail
-        BOOST_REQUIRE_THROW(
-            co_await test_provider("'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'kms_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml)
-            , std::exception
-        );
+        try {
+            try {
+                co_await test_provider("'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'kms_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', "
+                                       "'secret_key_strength': 128",
+                        tmp, yaml);
+            } catch (std::nested_exception& ex) {
+                std::rethrow_if_nested(ex);
+            }
+            BOOST_FAIL("Required an exception to be re-thrown");
+        } catch (encryption::configuration_error&) {
+            // EXPECTED
+        } catch (...) {
+            BOOST_FAIL(format("Unexpected exception: {}", std::current_exception()));
+        }
 
         // should be ok
         co_await test_provider(fmt::format("'key_provider': 'KmsKeyProviderFactory', 'kms_host': 'kms_test', 'master_key': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", kms_key_alias)
@@ -949,10 +960,21 @@ SEASTAR_TEST_CASE(test_gcp_provider_with_master_key_in_cf, *check_run_test_decor
         );
 
         // should fail
-        BOOST_REQUIRE_THROW(
-            co_await test_provider("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", tmp, yaml)
-            , std::exception
-        );
+        try {
+            try {
+                co_await test_provider(
+                    "'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128",
+                    tmp,
+                    yaml);
+            } catch (std::nested_exception& ex) {
+                std::rethrow_if_nested(ex);
+            }
+            BOOST_FAIL("Required an exception to be re-thrown");
+        } catch (encryption::configuration_error&) {
+            // EXPECTED
+        } catch (...) {
+            BOOST_FAIL(format("Unexpected exception: {}", std::current_exception()));
+        }
 
         // should be ok
         co_await test_provider(fmt::format("'key_provider': 'GcpKeyProviderFactory', 'gcp_host': 'gcp_test', 'master_key': '{}', 'cipher_algorithm':'AES/CBC/PKCS5Padding', 'secret_key_strength': 128", gcp.key_name)
@@ -1072,7 +1094,7 @@ static future<> network_error_test_helper(const tmpdir& tmp, const std::string& 
 
     BOOST_REQUIRE_THROW(
         co_await test_broken_encrypted_commitlog(args, scopts);
-        , std::exception
+        , exceptions::mutation_write_timeout_exception
     );
 
     co_await proxy.stop();


### PR DESCRIPTION
Apparently `test_kms_network_error` will succeed at any circumstances since most of our exceptions derive from `std::exception`, so whatever happens to the test, for whatever reason it will throw, the test will be marked as passed.

Start catching the exact exception that we expect to be thrown.

Maybe somewhat related to https://github.com/scylladb/scylladb/issues/22628

I think this fix should be backported, but not sure to what releases,  @scylladb/scylla-maint your assistance is needed