### PR TITLE
Drop v2 and flat from reader and related names

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -897,7 +897,7 @@ private:
     // if the derived compaction wants to opt in for this behavior, in addition
     // to overriding `make_interposer_consumer()`, it would have to override
     // `use_interposer_consumer()` so it returns true.
-    virtual reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) {
+    virtual mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) {
         return _table_s.get_compaction_strategy().make_interposer_consumer(_ms_metadata, std::move(end_consumer));
     }
 
@@ -1388,7 +1388,7 @@ public:
     {
     }
 
-    reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) override {
+    mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
         return [this, end_consumer = std::move(end_consumer)] (mutation_reader reader) mutable -> future<> {
             return mutation_writer::segregate_by_token_group(std::move(reader),
                     _options.classifier,
@@ -1682,7 +1682,7 @@ public:
         }
     }
 
-    reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) override {
+    mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
         if (!use_interposer_consumer()) {
             return end_consumer;
         }
@@ -1778,7 +1778,7 @@ public:
 
     }
 
-    reader_consumer_v2 make_interposer_consumer(reader_consumer_v2 end_consumer) override {
+    mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
         return [end_consumer = std::move(end_consumer)] (mutation_reader reader) mutable -> future<> {
             return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
         };

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -762,7 +762,7 @@ private:
             return dht::to_partition_range(*r);
         };
 
-        return make_flat_multi_range_reader(_schema, _permit, std::move(source),
+        return make_multi_range_reader(_schema, _permit, std::move(source),
                                             std::move(owned_range_generator),
                                             _schema->full_slice(),
                                             tracing::trace_state_ptr());

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -859,7 +859,7 @@ private:
                 auto close_reader = deferred_close(reader);
 
                 if (enable_garbage_collected_sstable_writer()) {
-                    using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, compacted_fragments_writer>;
+                    using compact_mutations = compact_for_compaction<compacted_fragments_writer, compacted_fragments_writer>;
                     auto cfc = compact_mutations(*schema(), now,
                         max_purgeable_func(),
                         get_tombstone_gc_state(),
@@ -869,7 +869,7 @@ private:
                     reader.consume_in_thread(std::move(cfc));
                     return;
                 }
-                using compact_mutations = compact_for_compaction_v2<compacted_fragments_writer, noop_compacted_fragments_consumer>;
+                using compact_mutations = compact_for_compaction<compacted_fragments_writer, noop_compacted_fragments_consumer>;
                 auto cfc = compact_mutations(*schema(), now,
                     max_purgeable_func(),
                     get_tombstone_gc_state(),

--- a/compaction/compaction_strategy.cc
+++ b/compaction/compaction_strategy.cc
@@ -77,7 +77,7 @@ uint64_t compaction_strategy_impl::adjust_partition_estimate(const mutation_sour
     return partition_estimate;
 }
 
-reader_consumer_v2 compaction_strategy_impl::make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const {
+mutation_reader_consumer compaction_strategy_impl::make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const {
     return end_consumer;
 }
 
@@ -741,7 +741,7 @@ uint64_t compaction_strategy::adjust_partition_estimate(const mutation_source_me
     return _compaction_strategy_impl->adjust_partition_estimate(ms_meta, partition_estimate, std::move(schema));
 }
 
-reader_consumer_v2 compaction_strategy::make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const {
+mutation_reader_consumer compaction_strategy::make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const {
     return _compaction_strategy_impl->make_interposer_consumer(ms_meta, std::move(end_consumer));
 }
 

--- a/compaction/compaction_strategy.hh
+++ b/compaction/compaction_strategy.hh
@@ -111,7 +111,7 @@ public:
 
     uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate, schema_ptr) const;
 
-    reader_consumer_v2 make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const;
+    mutation_reader_consumer make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const;
 
     // Returns whether or not interposer consumer is used by a given strategy.
     bool use_interposer_consumer() const;

--- a/compaction/compaction_strategy_impl.hh
+++ b/compaction/compaction_strategy_impl.hh
@@ -82,7 +82,7 @@ public:
     /// @return A new functor that wraps the end consumer with additional processing capabilities
     /// @note The returned functor preserves the original consumer's semantics while allowing
     ///       preprocessing of data
-    virtual reader_consumer_v2 make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const;
+    virtual mutation_reader_consumer make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const;
 
     virtual bool use_interposer_consumer() const {
         return false;

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -208,7 +208,7 @@ uint64_t time_window_compaction_strategy::adjust_partition_estimate(const mutati
     return partition_estimate / std::max(1UL, uint64_t(estimated_window_count));
 }
 
-reader_consumer_v2 time_window_compaction_strategy::make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const {
+mutation_reader_consumer time_window_compaction_strategy::make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const {
     if (ms_meta.min_timestamp && ms_meta.max_timestamp
             && get_window_for(_options, *ms_meta.min_timestamp) == get_window_for(_options, *ms_meta.max_timestamp)) {
         return end_consumer;

--- a/compaction/time_window_compaction_strategy.hh
+++ b/compaction/time_window_compaction_strategy.hh
@@ -156,7 +156,7 @@ public:
 
     virtual uint64_t adjust_partition_estimate(const mutation_source_metadata& ms_meta, uint64_t partition_estimate, schema_ptr s) const override;
 
-    virtual reader_consumer_v2 make_interposer_consumer(const mutation_source_metadata& ms_meta, reader_consumer_v2 end_consumer) const override;
+    virtual mutation_reader_consumer make_interposer_consumer(const mutation_source_metadata& ms_meta, mutation_reader_consumer end_consumer) const override;
 
     virtual bool use_interposer_consumer() const override {
         return true;

--- a/db/row_cache.cc
+++ b/db/row_cache.cc
@@ -49,7 +49,7 @@ static schema_ptr to_query_domain(const query::partition_slice& slice, schema_pt
 mutation_reader
 row_cache::create_underlying_reader(read_context& ctx, mutation_source& src, const dht::partition_range& pr) {
     schema_ptr entry_schema = to_query_domain(ctx.slice(), _schema);
-    auto reader = src.make_reader_v2(entry_schema, ctx.permit(), pr, ctx.slice(), ctx.trace_state(), streamed_mutation::forwarding::yes);
+    auto reader = src.make_mutation_reader(entry_schema, ctx.permit(), pr, ctx.slice(), ctx.trace_state(), streamed_mutation::forwarding::yes);
     ctx.on_underlying_created();
     return reader;
 }

--- a/db/view/build_progress_virtual_reader.hh
+++ b/db/view/build_progress_virtual_reader.hh
@@ -63,7 +63,7 @@ class build_progress_virtual_reader {
                 , _legacy_generation_number_col(_schema->get_column_definition("generation_number")->id)
                 , _legacy_slice(slice)
                 , _slice(adjust_partition_slice())
-                , _underlying(scylla_views_build_progress.make_reader_v2(
+                , _underlying(scylla_views_build_progress.make_mutation_reader(
                         scylla_views_build_progress.schema(),
                         std::move(permit),
                         range,

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -2975,7 +2975,7 @@ void view_builder::init_virtual_table() {
 
         auto& table_v2 = _db.find_column_family(db::system_keyspace::view_build_status_v2());
 
-        mutation_reader ms_reader = make_multishard_combining_reader_v2(
+        mutation_reader ms_reader = make_multishard_combining_reader(
                 seastar::make_shared<streaming_reader_lifecycle_policy>(_db.container(), table_v2.schema()->id(), gc_clock::now()),
                 table_v2.schema(),
                 table_v2.get_effective_replication_map(),

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3214,13 +3214,13 @@ public:
 // Called in the context of a seastar::thread.
 void view_builder::execute(build_step& step, exponential_backoff_retry r) {
     gc_clock::time_point now = gc_clock::now();
-    auto compaction_state = make_lw_shared<compact_for_query_state_v2>(
+    auto compaction_state = make_lw_shared<compact_for_query_state>(
             *step.reader.schema(),
             now,
             step.pslice,
             batch_size,
             query::max_partitions);
-    auto consumer = compact_for_query_v2<view_builder::consumer>(compaction_state, view_builder::consumer{*this, _vug.shared_from_this(), step, now});
+    auto consumer = compact_for_query<view_builder::consumer>(compaction_state, view_builder::consumer{*this, _vug.shared_from_this(), step, now});
     auto built = step.reader.consume_in_thread(std::move(consumer));
     if (auto ds = std::move(*compaction_state).detach_state()) {
         if (ds->current_tombstone) {

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -3420,7 +3420,7 @@ void view_updating_consumer::maybe_flush_buffer_mid_partition() {
 }
 
 view_updating_consumer::view_updating_consumer(view_update_generator& gen, schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
-        evictable_reader_handle_v2& staging_reader_handle)
+        evictable_reader_handle& staging_reader_handle)
     : view_updating_consumer(std::move(schema), std::move(permit), as, staging_reader_handle,
             [table = table.shared_from_this(), excluded_sstables = std::move(excluded_sstables), gen = gen.shared_from_this()] (mutation m) mutable {
         auto s = m.schema();

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -165,7 +165,7 @@ future<> view_update_generator::start() {
                                 mutation_reader::forwarding fwd_mr) {
                         return ssts->make_range_sstable_reader(s, std::move(permit), pr, ps, std::move(ts), fwd_ms, fwd_mr, *_progress_tracker);
                     });
-                    auto [staging_sstable_reader, staging_sstable_reader_handle] = make_manually_paused_evictable_reader_v2(
+                    auto [staging_sstable_reader, staging_sstable_reader_handle] = make_manually_paused_evictable_reader(
                             std::move(ms),
                             s,
                             permit,

--- a/db/view/view_updating_consumer.hh
+++ b/db/view/view_updating_consumer.hh
@@ -19,7 +19,6 @@
 #include "mutation/mutation_rebuilder.hh"
 
 class evictable_reader_handle;
-class evictable_reader_handle_v2;
 
 namespace db::view {
 
@@ -50,7 +49,7 @@ private:
     schema_ptr _schema;
     reader_permit _permit;
     const seastar::abort_source* _as;
-    evictable_reader_handle_v2& _staging_reader_handle;
+    evictable_reader_handle& _staging_reader_handle;
     circular_buffer<mutation> _buffer;
     std::optional<mutation_rebuilder_v2> _mut_builder;
     size_t _buffer_size{0};
@@ -64,7 +63,7 @@ private:
 
 public:
     // Push updates with a custom pusher. Mainly for tests.
-    view_updating_consumer(schema_ptr schema, reader_permit permit, const seastar::abort_source& as, evictable_reader_handle_v2& staging_reader_handle,
+    view_updating_consumer(schema_ptr schema, reader_permit permit, const seastar::abort_source& as, evictable_reader_handle& staging_reader_handle,
             noncopyable_function<future<row_locker::lock_holder>(mutation)> view_update_pusher)
             : _schema(std::move(schema))
             , _permit(std::move(permit))
@@ -74,7 +73,7 @@ public:
     { }
 
     view_updating_consumer(view_update_generator& gen, schema_ptr schema, reader_permit permit, replica::table& table, std::vector<sstables::shared_sstable> excluded_sstables, const seastar::abort_source& as,
-            evictable_reader_handle_v2& staging_reader_handle);
+            evictable_reader_handle& staging_reader_handle);
 
     view_updating_consumer(view_updating_consumer&&) = default;
 

--- a/db/virtual_table.cc
+++ b/db/virtual_table.cc
@@ -63,7 +63,7 @@ mutation_source memtable_filling_virtual_table::as_mutation_source() {
             };
 
             return execute(mutation_sink, permit).then([this, mt, s, units, &range, &slice, &trace_state, &fwd, &fwd_mr] () {
-                auto rd = mt->as_data_source().make_reader_v2(s, units->units.permit(), range, slice, trace_state, fwd, fwd_mr);
+                auto rd = mt->as_data_source().make_mutation_reader(s, units->units.permit(), range, slice, trace_state, fwd, fwd_mr);
 
                 if (!_shard_aware) {
                     rd = make_filtering_reader(std::move(rd), [this] (const dht::decorated_key& dk) -> bool {

--- a/index/built_indexes_virtual_reader.hh
+++ b/index/built_indexes_virtual_reader.hh
@@ -113,7 +113,7 @@ class built_indexes_virtual_reader {
                 , _db(db)
                 , _schema(std::move(schema))
                 , _view_names_slice(index_slice_to_view_slice(slice, *built_views.schema(), *_schema))
-                , _underlying(built_views.make_reader_v2(
+                , _underlying(built_views.make_mutation_reader(
                         built_views.schema(),
                         std::move(permit),
                         range,

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -55,7 +55,7 @@ using foreign_unique_ptr = foreign_ptr<std::unique_ptr<T>>;
 /// 3) Both, `read_context::lookup_readers()` and `read_context::save_readers()`
 ///    knows to do nothing when the query is not stateful and just short
 ///    circuit.
-class read_context : public reader_lifecycle_policy_v2 {
+class read_context : public reader_lifecycle_policy {
 
     //              ( )    (O)
     //               |      ^
@@ -718,7 +718,7 @@ future<page_consume_result<ResultBuilder>> read_page(
     auto compaction_state = make_lw_shared<compact_for_query_state_v2>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
             cmd.partition_limit);
 
-    auto reader = make_multishard_combining_reader_v2(ctx, s, ctx->erm(), ctx->permit(), ranges.front(), cmd.slice,
+    auto reader = make_multishard_combining_reader(ctx, s, ctx->erm(), ctx->permit(), ranges.front(), cmd.slice,
             trace_state, mutation_reader::forwarding(ranges.size() > 1));
     if (ranges.size() > 1) {
         reader = make_mutation_reader<multi_range_reader>(s, ctx->permit(), std::move(reader), ranges);

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -363,7 +363,7 @@ mutation_reader read_context::create_reader(
 
     rm.state = reader_state::used;
 
-    return table.as_mutation_source().make_reader_v2(std::move(schema), rm.rparts->permit, *rm.rparts->range, *rm.rparts->slice,
+    return table.as_mutation_source().make_mutation_reader(std::move(schema), rm.rparts->permit, *rm.rparts->range, *rm.rparts->slice,
             std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
 }
 

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -647,7 +647,7 @@ struct page_consume_result {
 // A special-purpose multi-range reader for multishard reads
 //
 // It is different from the "stock" multi-range reader
-// (make_flat_multi_range_reader()) in the following ways:
+// (make_multi_range_reader()) in the following ways:
 // * It guarantees that a buffer never crosses two ranges.
 // * It guarantees that after calling `fill_buffer()` the underlying reader's
 //   buffer's *entire* content is moved into its own buffer. In other words,

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -634,10 +634,10 @@ requires std::is_nothrow_move_constructible_v<typename ResultBuilder::result_typ
 struct page_consume_result {
     typename ResultBuilder::result_type result;
     mutation_reader::tracked_buffer unconsumed_fragments;
-    lw_shared_ptr<compact_for_query_state_v2> compaction_state;
+    lw_shared_ptr<compact_for_query_state> compaction_state;
 
     page_consume_result(typename ResultBuilder::result_type&& result, mutation_reader::tracked_buffer&& unconsumed_fragments,
-            lw_shared_ptr<compact_for_query_state_v2>&& compaction_state) noexcept
+            lw_shared_ptr<compact_for_query_state>&& compaction_state) noexcept
         : result(std::move(result))
         , unconsumed_fragments(std::move(unconsumed_fragments))
         , compaction_state(std::move(compaction_state)) {
@@ -715,7 +715,7 @@ future<page_consume_result<ResultBuilder>> read_page(
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         noncopyable_function<ResultBuilder()> result_builder_factory) {
-    auto compaction_state = make_lw_shared<compact_for_query_state_v2>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
+    auto compaction_state = make_lw_shared<compact_for_query_state>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
             cmd.partition_limit);
 
     auto reader = make_multishard_combining_reader(ctx, s, ctx->erm(), ctx->permit(), ranges.front(), cmd.slice,

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -2385,7 +2385,7 @@ future<mutation_opt> counter_write_query(schema_ptr s, const mutation_source& so
                          const query::partition_slice& slice,
                          tracing::trace_state_ptr trace_ptr)
             : range(dht::partition_range::make_singular(dk))
-            , reader(source.make_reader_v2(s, std::move(permit), range, slice,
+            , reader(source.make_mutation_reader(s, std::move(permit), range, slice,
                                                       std::move(trace_ptr), streamed_mutation::forwarding::no,
                                                       mutation_reader::forwarding::no))
         { }

--- a/mutation_writer/feed_writers.cc
+++ b/mutation_writer/feed_writers.cc
@@ -10,13 +10,13 @@
 
 namespace mutation_writer {
 
-bucket_writer::bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer)
+bucket_writer::bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, mutation_reader_consumer& consumer)
     : _schema(schema)
     , _handle(std::move(queue_reader.second))
     , _consume_fut(consumer(std::move(queue_reader.first)))
 { }
 
-bucket_writer::bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
+bucket_writer::bucket_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer& consumer)
     : bucket_writer(schema, make_queue_reader(schema, std::move(permit)), consumer)
 { }
 

--- a/mutation_writer/feed_writers.cc
+++ b/mutation_writer/feed_writers.cc
@@ -10,17 +10,17 @@
 
 namespace mutation_writer {
 
-bucket_writer_v2::bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer)
+bucket_writer::bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer)
     : _schema(schema)
     , _handle(std::move(queue_reader.second))
     , _consume_fut(consumer(std::move(queue_reader.first)))
 { }
 
-bucket_writer_v2::bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
-    : bucket_writer_v2(schema, make_queue_reader(schema, std::move(permit)), consumer)
+bucket_writer::bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
+    : bucket_writer(schema, make_queue_reader(schema, std::move(permit)), consumer)
 { }
 
-future<> bucket_writer_v2::consume(mutation_fragment_v2 mf) {
+future<> bucket_writer::consume(mutation_fragment_v2 mf) {
     if (_handle.is_terminated()) {
         // When the handle is terminated, it was aborted
         // or associated reader was closed prematurely.
@@ -38,15 +38,15 @@ future<> bucket_writer_v2::consume(mutation_fragment_v2 mf) {
     return _handle.push(std::move(mf));
 }
 
-void bucket_writer_v2::consume_end_of_stream() {
+void bucket_writer::consume_end_of_stream() {
     _handle.push_end_of_stream();
 }
 
-void bucket_writer_v2::abort(std::exception_ptr ep) noexcept {
+void bucket_writer::abort(std::exception_ptr ep) noexcept {
     _handle.abort(std::move(ep));
 }
 
-future<> bucket_writer_v2::close() noexcept {
+future<> bucket_writer::close() noexcept {
     return std::move(_consume_fut);
 }
 

--- a/mutation_writer/feed_writers.cc
+++ b/mutation_writer/feed_writers.cc
@@ -10,14 +10,14 @@
 
 namespace mutation_writer {
 
-bucket_writer_v2::bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader, reader_consumer_v2& consumer)
+bucket_writer_v2::bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer)
     : _schema(schema)
     , _handle(std::move(queue_reader.second))
     , _consume_fut(consumer(std::move(queue_reader.first)))
 { }
 
 bucket_writer_v2::bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
-    : bucket_writer_v2(schema, make_queue_reader_v2(schema, std::move(permit)), consumer)
+    : bucket_writer_v2(schema, make_queue_reader(schema, std::move(permit)), consumer)
 { }
 
 future<> bucket_writer_v2::consume(mutation_fragment_v2 mf) {
@@ -29,7 +29,7 @@ future<> bucket_writer_v2::consume(mutation_fragment_v2 mf) {
         auto ex = _handle.get_exception();
         if (!ex) {
             // shouldn't really happen
-            ex = make_exception_ptr(std::runtime_error("queue_reader_handle_v2 is terminated"));
+            ex = make_exception_ptr(std::runtime_error("queue_reader_handle is terminated"));
         }
         return std::exchange(_consume_fut, make_exception_future<>(ex)).then([ex = std::move(ex)] () mutable {
             return make_exception_future<>(std::move(ex));

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -14,16 +14,16 @@
 
 namespace mutation_writer {
 
-class bucket_writer_v2 {
+class bucket_writer {
     schema_ptr _schema;
     queue_reader_handle _handle;
     future<> _consume_fut;
 
 private:
-    bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer);
+    bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer);
 
 public:
-    bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer);
+    bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer);
 
     future<> consume(mutation_fragment_v2 mf);
 

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -20,10 +20,10 @@ class bucket_writer {
     future<> _consume_fut;
 
 private:
-    bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer);
+    bucket_writer(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, mutation_reader_consumer& consumer);
 
 public:
-    bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer);
+    bucket_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer& consumer);
 
     future<> consume(mutation_fragment_v2 mf);
 

--- a/mutation_writer/feed_writers.hh
+++ b/mutation_writer/feed_writers.hh
@@ -16,11 +16,11 @@ namespace mutation_writer {
 
 class bucket_writer_v2 {
     schema_ptr _schema;
-    queue_reader_handle_v2 _handle;
+    queue_reader_handle _handle;
     future<> _consume_fut;
 
 private:
-    bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle_v2> queue_reader_v2, reader_consumer_v2& consumer);
+    bucket_writer_v2(schema_ptr schema, std::pair<mutation_reader, queue_reader_handle> queue_reader, reader_consumer_v2& consumer);
 
 public:
     bucket_writer_v2(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer);

--- a/mutation_writer/multishard_writer.cc
+++ b/mutation_writer/multishard_writer.cc
@@ -47,7 +47,7 @@ private:
     const dht::sharder& _sharder;
     std::vector<foreign_ptr<std::unique_ptr<shard_writer>>> _shard_writers;
     std::vector<future<>> _pending_consumers;
-    std::vector<std::optional<queue_reader_handle_v2>> _queue_reader_handles;
+    std::vector<std::optional<queue_reader_handle>> _queue_reader_handles;
     dht::shard_replica_set _current_shards;
     uint64_t _consumed_partitions = 0;
     mutation_reader _producer;
@@ -112,7 +112,7 @@ multishard_writer::multishard_writer(
 }
 
 future<> multishard_writer::make_shard_writer(unsigned shard) {
-    auto [reader, handle] = make_queue_reader_v2(_s, _producer.permit());
+    auto [reader, handle] = make_queue_reader(_s, _producer.permit());
     _queue_reader_handles[shard] = std::move(handle);
     return smp::submit_to(shard, [gs = global_schema_ptr(_s),
             consumer = _consumer,

--- a/mutation_writer/multishard_writer.hh
+++ b/mutation_writer/multishard_writer.hh
@@ -33,7 +33,7 @@ namespace mutation_writer {
 future<uint64_t> distribute_reader_and_consume_on_shards(schema_ptr s,
     const dht::sharder& sharder,
     mutation_reader producer,
-    reader_consumer_v2 consumer,
+    mutation_reader_consumer consumer,
     utils::phased_barrier::operation&& op = {});
 
 } // namespace mutation_writer

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -21,7 +21,7 @@ class partition_sorting_mutation_writer {
     reader_permit _permit;
     reader_consumer_v2 _consumer;
     size_t _max_memory;
-    bucket_writer_v2 _bucket_writer;
+    bucket_writer _bucket_writer;
     std::optional<dht::decorated_key> _last_bucket_key;
     lw_shared_ptr<replica::memtable> _memtable;
     future<> _background_memtable_flush = make_ready_future<>();

--- a/mutation_writer/partition_based_splitting_writer.cc
+++ b/mutation_writer/partition_based_splitting_writer.cc
@@ -19,7 +19,7 @@ namespace mutation_writer {
 class partition_sorting_mutation_writer {
     schema_ptr _schema;
     reader_permit _permit;
-    reader_consumer_v2 _consumer;
+    mutation_reader_consumer _consumer;
     size_t _max_memory;
     bucket_writer _bucket_writer;
     std::optional<dht::decorated_key> _last_bucket_key;
@@ -72,7 +72,7 @@ private:
     }
 
 public:
-    partition_sorting_mutation_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2 consumer, const segregate_config& cfg)
+    partition_sorting_mutation_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer consumer, const segregate_config& cfg)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
         , _consumer(std::move(consumer))
@@ -130,7 +130,7 @@ public:
     }
 };
 
-future<> segregate_by_partition(mutation_reader producer, segregate_config cfg, reader_consumer_v2 consumer) {
+future<> segregate_by_partition(mutation_reader producer, segregate_config cfg, mutation_reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
   try {

--- a/mutation_writer/partition_based_splitting_writer.hh
+++ b/mutation_writer/partition_based_splitting_writer.hh
@@ -25,6 +25,6 @@ struct segregate_config {
 // streams that honor it.
 // This is useful for scrub compaction to split sstables containing out-of-order
 // and/or duplicate partitions into sstables that honor the partition ordering.
-future<> segregate_by_partition(mutation_reader producer, segregate_config cfg, reader_consumer_v2 consumer);
+future<> segregate_by_partition(mutation_reader producer, segregate_config cfg, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -15,7 +15,7 @@
 namespace mutation_writer {
 
 class shard_based_splitting_mutation_writer {
-    using shard_writer = bucket_writer_v2;
+    using shard_writer = bucket_writer;
 
 private:
     schema_ptr _schema;

--- a/mutation_writer/shard_based_splitting_writer.cc
+++ b/mutation_writer/shard_based_splitting_writer.cc
@@ -20,7 +20,7 @@ class shard_based_splitting_mutation_writer {
 private:
     schema_ptr _schema;
     reader_permit _permit;
-    reader_consumer_v2 _consumer;
+    mutation_reader_consumer _consumer;
     unsigned _current_shard;
     std::vector<std::optional<shard_writer>> _shards;
 
@@ -29,7 +29,7 @@ private:
         return writer.consume(std::move(mf));
     }
 public:
-    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2 consumer)
+    shard_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer consumer)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
         , _consumer(std::move(consumer))
@@ -81,7 +81,7 @@ public:
     }
 };
 
-future<> segregate_by_shard(mutation_reader producer, reader_consumer_v2 consumer) {
+future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
     return feed_writer(

--- a/mutation_writer/shard_based_splitting_writer.hh
+++ b/mutation_writer/shard_based_splitting_writer.hh
@@ -16,6 +16,6 @@ namespace mutation_writer {
 // manner. This is useful, for instance, in the resharding process where a user changes
 // the amount of CPU assigned to Scylla and we have to rewrite the SSTables to their new
 // owners.
-future<> segregate_by_shard(mutation_reader producer, reader_consumer_v2 consumer);
+future<> segregate_by_shard(mutation_reader producer, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -95,12 +95,12 @@ small_flat_map<Key, Value, Size>::find(const key_type& k) {
 class timestamp_based_splitting_mutation_writer {
     using bucket_id = int64_t;
 
-    class timestamp_bucket_writer : public bucket_writer_v2 {
+    class timestamp_bucket_writer : public bucket_writer {
         bool _has_current_partition = false;
 
     public:
         timestamp_bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
-            : bucket_writer_v2(schema, std::move(permit), consumer) {
+            : bucket_writer(schema, std::move(permit), consumer) {
         }
         void set_has_current_partition() {
             _has_current_partition = true;

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -99,7 +99,7 @@ class timestamp_based_splitting_mutation_writer {
         bool _has_current_partition = false;
 
     public:
-        timestamp_bucket_writer(schema_ptr schema, reader_permit permit, reader_consumer_v2& consumer)
+        timestamp_bucket_writer(schema_ptr schema, reader_permit permit, mutation_reader_consumer& consumer)
             : bucket_writer(schema, std::move(permit), consumer) {
         }
         void set_has_current_partition() {
@@ -117,7 +117,7 @@ private:
     schema_ptr _schema;
     reader_permit _permit;
     classify_by_timestamp _classifier;
-    reader_consumer_v2 _consumer;
+    mutation_reader_consumer _consumer;
     partition_start _current_partition_start;
     std::unordered_map<bucket_id, timestamp_bucket_writer> _buckets;
     std::vector<bucket_id> _buckets_used_for_current_partition;
@@ -137,7 +137,7 @@ private:
     future<> write_marker_and_tombstone(const clustering_row& cr);
 
 public:
-    timestamp_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, classify_by_timestamp classifier, reader_consumer_v2 consumer)
+    timestamp_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, classify_by_timestamp classifier, mutation_reader_consumer consumer)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
         , _classifier(std::move(classifier))
@@ -441,7 +441,7 @@ future<> timestamp_based_splitting_mutation_writer::consume(partition_end&& pe) 
     });
 }
 
-future<> segregate_by_timestamp(mutation_reader producer, classify_by_timestamp classifier, reader_consumer_v2 consumer) {
+future<> segregate_by_timestamp(mutation_reader producer, classify_by_timestamp classifier, mutation_reader_consumer consumer) {
     //FIXME: make this into a consume() variant?
     auto schema = producer.schema();
     auto permit = producer.permit();

--- a/mutation_writer/timestamp_based_splitting_writer.hh
+++ b/mutation_writer/timestamp_based_splitting_writer.hh
@@ -15,6 +15,6 @@
 namespace mutation_writer {
 
 using classify_by_timestamp = noncopyable_function<int64_t(api::timestamp_type)>;
-future<> segregate_by_timestamp(mutation_reader producer, classify_by_timestamp classifier, reader_consumer_v2 consumer);
+future<> segregate_by_timestamp(mutation_reader producer, classify_by_timestamp classifier, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/mutation_writer/token_group_based_splitting_writer.cc
+++ b/mutation_writer/token_group_based_splitting_writer.cc
@@ -21,7 +21,7 @@ class token_group_based_splitting_mutation_writer {
     schema_ptr _schema;
     reader_permit _permit;
     classify_by_token_group _classify;
-    reader_consumer_v2 _consumer;
+    mutation_reader_consumer _consumer;
     token_group_id _current_group_id = 0;
     std::optional<bucket_writer> _current_writer;
 private:
@@ -63,7 +63,7 @@ private:
         return make_ready_future<>();
     }
 public:
-    token_group_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, classify_by_token_group classify, reader_consumer_v2 consumer)
+    token_group_based_splitting_mutation_writer(schema_ptr schema, reader_permit permit, classify_by_token_group classify, mutation_reader_consumer consumer)
         : _schema(std::move(schema))
         , _permit(std::move(permit))
         , _classify(std::move(classify))
@@ -107,7 +107,7 @@ public:
     }
 };
 
-future<> segregate_by_token_group(mutation_reader producer, classify_by_token_group classify, reader_consumer_v2 consumer) {
+future<> segregate_by_token_group(mutation_reader producer, classify_by_token_group classify, mutation_reader_consumer consumer) {
     auto schema = producer.schema();
     auto permit = producer.permit();
     return feed_writer(

--- a/mutation_writer/token_group_based_splitting_writer.cc
+++ b/mutation_writer/token_group_based_splitting_writer.cc
@@ -23,7 +23,7 @@ class token_group_based_splitting_mutation_writer {
     classify_by_token_group _classify;
     reader_consumer_v2 _consumer;
     token_group_id _current_group_id = 0;
-    std::optional<bucket_writer_v2> _current_writer;
+    std::optional<bucket_writer> _current_writer;
 private:
     future<> write(mutation_fragment_v2&& mf) {
         return _current_writer->consume(std::move(mf));
@@ -31,7 +31,7 @@ private:
 
     inline void allocate_new_writer_if_needed() {
         if (!_current_writer) [[unlikely]] {
-            _current_writer = bucket_writer_v2(_schema, _permit, _consumer);
+            _current_writer = bucket_writer(_schema, _permit, _consumer);
         }
     }
 

--- a/mutation_writer/token_group_based_splitting_writer.hh
+++ b/mutation_writer/token_group_based_splitting_writer.hh
@@ -23,6 +23,6 @@ using classify_by_token_group = std::function<token_group_id(dht::token)>;
 // Therefore, it's guaranteed that the segregator will emit data for only
 // one group at a time. When moving to the next group, we're guaranteed
 // that producer won't longer emit data for the previous group.
-future<> segregate_by_token_group(mutation_reader producer, classify_by_token_group classify, reader_consumer_v2 consumer);
+future<> segregate_by_token_group(mutation_reader producer, classify_by_token_group classify, mutation_reader_consumer consumer);
 
 } // namespace mutation_writer

--- a/querier.hh
+++ b/querier.hh
@@ -88,7 +88,7 @@ public:
         , _permit(std::move(permit))
         , _range(make_lw_shared<const dht::partition_range>(std::move(range)))
         , _slice(std::make_unique<const query::partition_slice>(std::move(slice)))
-        , _reader(ms.make_reader_v2(_schema, _permit, *_range, *_slice, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
+        , _reader(ms.make_mutation_reader(_schema, _permit, *_range, *_slice, std::move(trace_ptr), streamed_mutation::forwarding::no, mutation_reader::forwarding::no))
         , _query_ranges(*_range)
         , _qr_config(std::move(config))
     { }

--- a/readers/delegating_impl.hh
+++ b/readers/delegating_impl.hh
@@ -8,14 +8,14 @@
 
 #include "readers/mutation_reader.hh"
 
-class delegating_reader_v2 : public mutation_reader::impl {
+class delegating_reader : public mutation_reader::impl {
     mutation_reader_opt _underlying_holder;
     mutation_reader* _underlying;
 public:
     // when passed a lvalue reference to the reader
     // we don't own it and the caller is responsible
     // for evenetually closing the reader.
-    delegating_reader_v2(mutation_reader& r)
+    delegating_reader(mutation_reader& r)
         : impl(r.schema(), r.permit())
         , _underlying_holder()
         , _underlying(&r)
@@ -23,7 +23,7 @@ public:
     // when passed a rvalue reference to the reader
     // we assume ownership of it and will close it
     // in close().
-    delegating_reader_v2(mutation_reader&& r)
+    delegating_reader(mutation_reader&& r)
         : impl(r.schema(), r.permit())
         , _underlying_holder(std::move(r))
         , _underlying(&*_underlying_holder)

--- a/readers/evictable.hh
+++ b/readers/evictable.hh
@@ -36,7 +36,7 @@ class partition_slice;
 /// transparent to its user.
 /// Parameters passed by reference have to be kept alive while the reader is
 /// alive.
-mutation_reader make_auto_paused_evictable_reader_v2(
+mutation_reader make_auto_paused_evictable_reader(
         mutation_source ms,
         schema_ptr schema,
         reader_permit permit,
@@ -45,17 +45,17 @@ mutation_reader make_auto_paused_evictable_reader_v2(
         tracing::trace_state_ptr trace_state,
         mutation_reader::forwarding fwd_mr);
 
-class evictable_reader_v2;
+class evictable_reader;
 
-class evictable_reader_handle_v2 {
-    friend std::pair<mutation_reader, evictable_reader_handle_v2> make_manually_paused_evictable_reader_v2(mutation_source, schema_ptr, reader_permit,
+class evictable_reader_handle {
+    friend std::pair<mutation_reader, evictable_reader_handle> make_manually_paused_evictable_reader(mutation_source, schema_ptr, reader_permit,
             const dht::partition_range&, const query::partition_slice&, tracing::trace_state_ptr, mutation_reader::forwarding);
 
 private:
-    evictable_reader_v2* _r;
+    evictable_reader* _r;
 
 private:
-    explicit evictable_reader_handle_v2(evictable_reader_v2& r);
+    explicit evictable_reader_handle(evictable_reader& r);
 
 public:
     void pause();
@@ -72,7 +72,7 @@ public:
 /// transparent to its user.
 /// Parameters passed by reference have to be kept alive while the reader is
 /// alive.
-std::pair<mutation_reader, evictable_reader_handle_v2> make_manually_paused_evictable_reader_v2(
+std::pair<mutation_reader, evictable_reader_handle> make_manually_paused_evictable_reader(
         mutation_source ms,
         schema_ptr schema,
         reader_permit permit,

--- a/readers/multi_range.hh
+++ b/readers/multi_range.hh
@@ -36,7 +36,7 @@ namespace query {
 ///     ranges. Otherwise the reader is created with
 ///     mutation_reader::forwarding::yes.
 mutation_reader
-make_flat_multi_range_reader(
+make_multi_range_reader(
         schema_ptr s, reader_permit permit, mutation_source source, const dht::partition_range_vector& ranges,
         const query::partition_slice& slice,
         tracing::trace_state_ptr trace_state = nullptr,
@@ -47,7 +47,7 @@ make_flat_multi_range_reader(
 /// Generator overload. The ranges returned by the generator have to satisfy the
 /// same requirements as the `ranges` param of the vector overload.
 mutation_reader
-make_flat_multi_range_reader(
+make_multi_range_reader(
         schema_ptr s,
         reader_permit permit,
         mutation_source source,

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -25,12 +25,12 @@ extern logger mrlog;
 
 namespace {
 
-struct remote_fill_buffer_result_v2 {
+struct remote_fill_buffer_result {
     foreign_ptr<std::unique_ptr<const mutation_reader::tracked_buffer>> buffer;
     bool end_of_stream = false;
 
-    remote_fill_buffer_result_v2() = default;
-    remote_fill_buffer_result_v2(mutation_reader::tracked_buffer&& buffer, bool end_of_stream)
+    remote_fill_buffer_result() = default;
+    remote_fill_buffer_result(mutation_reader::tracked_buffer&& buffer, bool end_of_stream)
         : buffer(make_foreign(std::make_unique<const mutation_reader::tracked_buffer>(std::move(buffer))))
         , end_of_stream(end_of_stream) {
     }
@@ -122,9 +122,9 @@ future<> foreign_reader::fill_buffer() {
     return forward_operation([reader = _reader.get()] () {
         auto f = reader->is_buffer_empty() ? reader->fill_buffer() : make_ready_future<>();
         return f.then([=] {
-            return make_ready_future<remote_fill_buffer_result_v2>(remote_fill_buffer_result_v2(reader->detach_buffer(), reader->is_end_of_stream()));
+            return make_ready_future<remote_fill_buffer_result>(remote_fill_buffer_result(reader->detach_buffer(), reader->is_end_of_stream()));
         });
-    }).then([this] (remote_fill_buffer_result_v2 res) mutable {
+    }).then([this] (remote_fill_buffer_result res) mutable {
         _end_of_stream = res.end_of_stream;
         for (const auto& mf : *res.buffer) {
             // Need a copy since the mf is on the remote shard.
@@ -711,9 +711,9 @@ struct buffer_fill_hint {
 // Although it implements the mutation_reader:impl interface it cannot be
 // wrapped into a mutation_reader, as it needs to be managed by a shared
 // pointer.
-class shard_reader_v2 : public mutation_reader::impl {
+class shard_reader : public mutation_reader::impl {
 private:
-    shared_ptr<reader_lifecycle_policy_v2> _lifecycle_policy;
+    shared_ptr<reader_lifecycle_policy> _lifecycle_policy;
     const unsigned _shard;
     foreign_ptr<lw_shared_ptr<const dht::partition_range>> _pr;
     const query::partition_slice& _ps;
@@ -723,14 +723,14 @@ private:
     foreign_ptr<std::unique_ptr<evictable_reader>> _reader;
 
 private:
-    future<remote_fill_buffer_result_v2> fill_reader_buffer(evictable_reader& reader, std::optional<buffer_fill_hint> hint);
+    future<remote_fill_buffer_result> fill_reader_buffer(evictable_reader& reader, std::optional<buffer_fill_hint> hint);
     future<> do_fill_buffer(std::optional<buffer_fill_hint> hint);
 
 public:
-    shard_reader_v2(
+    shard_reader(
             schema_ptr schema,
             reader_permit permit,
-            shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+            shared_ptr<reader_lifecycle_policy> lifecycle_policy,
             unsigned shard,
             const dht::partition_range& pr,
             const query::partition_slice& ps,
@@ -745,11 +745,11 @@ public:
         , _fwd_mr(fwd_mr) {
     }
 
-    shard_reader_v2(shard_reader_v2&&) = delete;
-    shard_reader_v2& operator=(shard_reader_v2&&) = delete;
+    shard_reader(shard_reader&&) = delete;
+    shard_reader& operator=(shard_reader&&) = delete;
 
-    shard_reader_v2(const shard_reader_v2&) = delete;
-    shard_reader_v2& operator=(const shard_reader_v2&) = delete;
+    shard_reader(const shard_reader&) = delete;
+    shard_reader& operator=(const shard_reader&) = delete;
 
     const mutation_fragment_v2& peek_buffer() const {
         return buffer().front();
@@ -771,7 +771,7 @@ public:
     }
 };
 
-future<> shard_reader_v2::close() noexcept {
+future<> shard_reader::close() noexcept {
     if (_read_ahead) {
         try {
             co_await *std::exchange(_read_ahead, std::nullopt);
@@ -811,14 +811,14 @@ future<> shard_reader_v2::close() noexcept {
     }
 }
 
-future<remote_fill_buffer_result_v2> shard_reader_v2::fill_reader_buffer(evictable_reader& reader, std::optional<buffer_fill_hint> hint) {
+future<remote_fill_buffer_result> shard_reader::fill_reader_buffer(evictable_reader& reader, std::optional<buffer_fill_hint> hint) {
     evictable_reader::auto_pause_disable_guard auto_pause_guard{reader};
     reader_permit::need_cpu_guard ncpu_guard{reader.permit()};
 
     co_await reader.fill_buffer();
 
     if (!hint) {
-        co_return remote_fill_buffer_result_v2(reader.detach_buffer(), reader.is_end_of_stream());
+        co_return remote_fill_buffer_result(reader.detach_buffer(), reader.is_end_of_stream());
     }
 
     mutation_reader::tracked_buffer buffer(reader.permit());
@@ -841,16 +841,16 @@ future<remote_fill_buffer_result_v2> shard_reader_v2::fill_reader_buffer(evictab
         co_await reader.fill_buffer();
     }
 
-    co_return remote_fill_buffer_result_v2(std::move(buffer), reader.is_end_of_stream());
+    co_return remote_fill_buffer_result(std::move(buffer), reader.is_end_of_stream());
 }
 
-future<> shard_reader_v2::do_fill_buffer(std::optional<buffer_fill_hint> hint) {
+future<> shard_reader::do_fill_buffer(std::optional<buffer_fill_hint> hint) {
     struct reader_and_buffer_fill_result {
         foreign_ptr<std::unique_ptr<evictable_reader>> reader;
-        remote_fill_buffer_result_v2 result;
+        remote_fill_buffer_result result;
     };
 
-    auto res = co_await std::invoke([&] () -> future<remote_fill_buffer_result_v2> {
+    auto res = co_await std::invoke([&] () -> future<remote_fill_buffer_result> {
         if (!_reader) {
             reader_and_buffer_fill_result res = co_await smp::submit_to(_shard, coroutine::lambda([this, gs = global_schema_ptr(_schema), hint] () -> future<reader_and_buffer_fill_result> {
                 auto ms = mutation_source([lifecycle_policy = _lifecycle_policy.get()] (
@@ -906,7 +906,7 @@ future<> shard_reader_v2::do_fill_buffer(std::optional<buffer_fill_hint> hint) {
             _reader = std::move(res.reader);
             co_return std::move(res.result);
         } else {
-            co_return co_await smp::submit_to(_shard, coroutine::lambda([this, hint] () -> future<remote_fill_buffer_result_v2>  {
+            co_return co_await smp::submit_to(_shard, coroutine::lambda([this, hint] () -> future<remote_fill_buffer_result>  {
                 return fill_reader_buffer(*_reader, hint);
             }));
         }
@@ -920,7 +920,7 @@ future<> shard_reader_v2::do_fill_buffer(std::optional<buffer_fill_hint> hint) {
     _end_of_stream = res.end_of_stream;
 }
 
-future<> shard_reader_v2::fill_buffer(std::optional<buffer_fill_hint> hint) {
+future<> shard_reader::fill_buffer(std::optional<buffer_fill_hint> hint) {
     // FIXME: want to move this to the inner scopes but it makes clang miscompile the code.
     reader_permit::awaits_guard guard(_permit);
     if (_read_ahead) {
@@ -933,7 +933,7 @@ future<> shard_reader_v2::fill_buffer(std::optional<buffer_fill_hint> hint) {
     co_await do_fill_buffer(hint);
 }
 
-future<> shard_reader_v2::next_partition() {
+future<> shard_reader::next_partition() {
     if (!_reader) {
         co_return;
     }
@@ -953,7 +953,7 @@ future<> shard_reader_v2::next_partition() {
     });
 }
 
-future<> shard_reader_v2::fast_forward_to(const dht::partition_range& pr) {
+future<> shard_reader::fast_forward_to(const dht::partition_range& pr) {
     if (!_reader && !_read_ahead) {
         // No need to fast-forward uncreated readers, they will be passed the new
         // range when created.
@@ -977,11 +977,11 @@ future<> shard_reader_v2::fast_forward_to(const dht::partition_range& pr) {
     });
 }
 
-future<> shard_reader_v2::fast_forward_to(position_range) {
+future<> shard_reader::fast_forward_to(position_range) {
     return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
 }
 
-void shard_reader_v2::read_ahead() {
+void shard_reader::read_ahead() {
     if (_read_ahead || is_end_of_stream() || !is_buffer_empty()) {
         return;
     }
@@ -992,7 +992,7 @@ void shard_reader_v2::read_ahead() {
 } // anonymous namespace
 
 // See make_multishard_combining_reader() for description.
-class multishard_combining_reader_v2 : public mutation_reader::impl {
+class multishard_combining_reader : public mutation_reader::impl {
     struct shard_and_token {
         shard_id shard;
         dht::token token;
@@ -1005,7 +1005,7 @@ class multishard_combining_reader_v2 : public mutation_reader::impl {
 
     std::any _keep_alive_sharder;
     const dht::sharder& _sharder;
-    std::vector<std::unique_ptr<shard_reader_v2>> _shard_readers;
+    std::vector<std::unique_ptr<shard_reader>> _shard_readers;
     // Contains the position of each shard with token granularity, organized
     // into a min-heap. Used to select the shard with the smallest token each
     // time a shard reader produces a new partition.
@@ -1022,10 +1022,10 @@ class multishard_combining_reader_v2 : public mutation_reader::impl {
     future<> handle_empty_reader_buffer();
 
 public:
-    multishard_combining_reader_v2(
+    multishard_combining_reader(
             const dht::sharder& sharder,
             std::any keep_alive_sharder,
-            shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+            shared_ptr<reader_lifecycle_policy> lifecycle_policy,
             schema_ptr s,
             reader_permit permit,
             const dht::partition_range& pr,
@@ -1036,10 +1036,10 @@ public:
             read_ahead read_ahead);
 
     // this is captured.
-    multishard_combining_reader_v2(const multishard_combining_reader_v2&) = delete;
-    multishard_combining_reader_v2& operator=(const multishard_combining_reader_v2&) = delete;
-    multishard_combining_reader_v2(multishard_combining_reader_v2&&) = delete;
-    multishard_combining_reader_v2& operator=(multishard_combining_reader_v2&&) = delete;
+    multishard_combining_reader(const multishard_combining_reader&) = delete;
+    multishard_combining_reader& operator=(const multishard_combining_reader&) = delete;
+    multishard_combining_reader(multishard_combining_reader&&) = delete;
+    multishard_combining_reader& operator=(multishard_combining_reader&&) = delete;
 
     virtual future<> fill_buffer() override;
     virtual future<> next_partition() override;
@@ -1048,7 +1048,7 @@ public:
     virtual future<> close() noexcept override;
 };
 
-void multishard_combining_reader_v2::on_partition_range_change(const dht::partition_range& pr) {
+void multishard_combining_reader::on_partition_range_change(const dht::partition_range& pr) {
     _shard_selection_min_heap.clear();
     _shard_selection_min_heap.reserve(_sharder.shard_count());
 
@@ -1068,7 +1068,7 @@ void multishard_combining_reader_v2::on_partition_range_change(const dht::partit
     }
 }
 
-bool multishard_combining_reader_v2::maybe_move_to_next_shard(const dht::token* const t) {
+bool multishard_combining_reader::maybe_move_to_next_shard(const dht::token* const t) {
     if (_shard_selection_min_heap.empty() || (t && *t < _shard_selection_min_heap.front().token)) {
         return false;
     }
@@ -1087,7 +1087,7 @@ bool multishard_combining_reader_v2::maybe_move_to_next_shard(const dht::token* 
     return true;
 }
 
-future<> multishard_combining_reader_v2::handle_empty_reader_buffer() {
+future<> multishard_combining_reader::handle_empty_reader_buffer() {
     auto& reader = *_shard_readers[_current_shard];
 
     if (reader.is_end_of_stream()) {
@@ -1128,10 +1128,10 @@ future<> multishard_combining_reader_v2::handle_empty_reader_buffer() {
     }
 }
 
-multishard_combining_reader_v2::multishard_combining_reader_v2(
+multishard_combining_reader::multishard_combining_reader(
         const dht::sharder& sharder,
         std::any keep_alive_sharder,
-        shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+        shared_ptr<reader_lifecycle_policy> lifecycle_policy,
         schema_ptr s,
         reader_permit permit,
         const dht::partition_range& pr,
@@ -1161,11 +1161,11 @@ multishard_combining_reader_v2::multishard_combining_reader_v2(
 
     _shard_readers.reserve(_sharder.shard_count());
     for (unsigned i = 0; i < _sharder.shard_count(); ++i) {
-        _shard_readers.emplace_back(std::make_unique<shard_reader_v2>(_schema, _permit, lifecycle_policy, i, pr, ps, trace_state, fwd_mr));
+        _shard_readers.emplace_back(std::make_unique<shard_reader>(_schema, _permit, lifecycle_policy, i, pr, ps, trace_state, fwd_mr));
     }
 }
 
-future<> multishard_combining_reader_v2::fill_buffer() {
+future<> multishard_combining_reader::fill_buffer() {
     _crossed_shards = false;
     return do_until([this] { return is_buffer_full() || is_end_of_stream(); }, [this] {
         auto& reader = *_shard_readers[_current_shard];
@@ -1184,7 +1184,7 @@ future<> multishard_combining_reader_v2::fill_buffer() {
     });
 }
 
-future<> multishard_combining_reader_v2::next_partition() {
+future<> multishard_combining_reader::next_partition() {
     clear_buffer_to_next_partition();
     if (is_buffer_empty()) {
         return _shard_readers[_current_shard]->next_partition();
@@ -1192,27 +1192,27 @@ future<> multishard_combining_reader_v2::next_partition() {
     return make_ready_future<>();
 }
 
-future<> multishard_combining_reader_v2::fast_forward_to(const dht::partition_range& pr) {
+future<> multishard_combining_reader::fast_forward_to(const dht::partition_range& pr) {
     clear_buffer();
     _end_of_stream = false;
     on_partition_range_change(pr);
-    return parallel_for_each(_shard_readers, [&pr] (std::unique_ptr<shard_reader_v2>& sr) {
+    return parallel_for_each(_shard_readers, [&pr] (std::unique_ptr<shard_reader>& sr) {
         return sr->fast_forward_to(pr);
     });
 }
 
-future<> multishard_combining_reader_v2::fast_forward_to(position_range pr) {
+future<> multishard_combining_reader::fast_forward_to(position_range pr) {
     return make_exception_future<>(make_backtraced_exception_ptr<std::bad_function_call>());
 }
 
-future<> multishard_combining_reader_v2::close() noexcept {
-    return parallel_for_each(_shard_readers, [] (std::unique_ptr<shard_reader_v2>& sr) {
+future<> multishard_combining_reader::close() noexcept {
+    return parallel_for_each(_shard_readers, [] (std::unique_ptr<shard_reader>& sr) {
         return sr->close();
     });
 }
 
-mutation_reader make_multishard_combining_reader_v2(
-        shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+mutation_reader make_multishard_combining_reader(
+        shared_ptr<reader_lifecycle_policy> lifecycle_policy,
         schema_ptr schema,
         locator::effective_replication_map_ptr erm,
         reader_permit permit,
@@ -1223,13 +1223,13 @@ mutation_reader make_multishard_combining_reader_v2(
         multishard_reader_buffer_hint buffer_hint,
         read_ahead read_ahead) {
     auto& sharder = erm->get_sharder(*schema);
-    return make_mutation_reader<multishard_combining_reader_v2>(sharder, std::any(std::move(erm)), std::move(lifecycle_policy),
+    return make_mutation_reader<multishard_combining_reader>(sharder, std::any(std::move(erm)), std::move(lifecycle_policy),
             std::move(schema), std::move(permit), pr, ps, std::move(trace_state), fwd_mr, buffer_hint, read_ahead);
 }
 
-mutation_reader make_multishard_combining_reader_v2_for_tests(
+mutation_reader make_multishard_combining_reader_for_tests(
         const dht::sharder& sharder,
-        shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+        shared_ptr<reader_lifecycle_policy> lifecycle_policy,
         schema_ptr schema,
         reader_permit permit,
         const dht::partition_range& pr,
@@ -1238,6 +1238,6 @@ mutation_reader make_multishard_combining_reader_v2_for_tests(
         mutation_reader::forwarding fwd_mr,
         multishard_reader_buffer_hint buffer_hint,
         read_ahead read_ahead) {
-    return make_mutation_reader<multishard_combining_reader_v2>(sharder, std::any(),
+    return make_mutation_reader<multishard_combining_reader>(sharder, std::any(),
             std::move(lifecycle_policy), std::move(schema), std::move(permit), pr, ps, std::move(trace_state), fwd_mr, buffer_hint, read_ahead);
 }

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -397,7 +397,7 @@ mutation_reader evictable_reader::recreate_reader() {
         _reader_recreated = true;
     }
 
-    return _ms.make_reader_v2(
+    return _ms.make_mutation_reader(
             _schema,
             _permit,
             *range,

--- a/readers/multishard.hh
+++ b/readers/multishard.hh
@@ -28,7 +28,7 @@
 /// parameters because although client code is required to keep them alive as
 /// long as the top level reader lives, the shard readers might outlive the
 /// multishard reader itself.
-class reader_lifecycle_policy_v2 {
+class reader_lifecycle_policy {
 public:
     struct stopped_reader {
         reader_concurrency_semaphore::inactive_read_handle handle;
@@ -125,8 +125,8 @@ using read_ahead = bool_class<struct read_ahead_tag>;
 /// semaphore, and the avoidance of evictions is more important than low latencies.
 ///
 /// The readers' life-cycles are managed through the supplied lifecycle policy.
-mutation_reader make_multishard_combining_reader_v2(
-        shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+mutation_reader make_multishard_combining_reader(
+        shared_ptr<reader_lifecycle_policy> lifecycle_policy,
         schema_ptr schema,
         locator::effective_replication_map_ptr erm,
         reader_permit permit,
@@ -137,9 +137,9 @@ mutation_reader make_multishard_combining_reader_v2(
         multishard_reader_buffer_hint buffer_hint = multishard_reader_buffer_hint::no,
         read_ahead read_ahead = read_ahead::yes);
 
-mutation_reader make_multishard_combining_reader_v2_for_tests(
+mutation_reader make_multishard_combining_reader_for_tests(
         const dht::sharder& sharder,
-        shared_ptr<reader_lifecycle_policy_v2> lifecycle_policy,
+        shared_ptr<reader_lifecycle_policy> lifecycle_policy,
         schema_ptr schema,
         reader_permit permit,
         const dht::partition_range& pr,

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -762,4 +762,4 @@ future<> consume_partitions(mutation_reader& reader, Consumer consumer) {
 /// A consumer function that is passed a mutation_reader to be consumed from
 /// and returns a future<> resolved when the reader is fully consumed, and closed.
 /// Note: the function assumes ownership of the reader and must close it in all cases.
-using reader_consumer_v2 = std::function<future<> (mutation_reader)>;
+using mutation_reader_consumer = std::function<future<> (mutation_reader)>;

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -519,7 +519,7 @@ public:
             tracing::trace_state_ptr trace_state)
         : impl(s, std::move(permit))
         , _generator(std::move(generator))
-        , _reader(source.make_reader_v2(s, _permit, first_range, slice, trace_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes))
+        , _reader(source.make_mutation_reader(s, _permit, first_range, slice, trace_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::yes))
     {
     }
 
@@ -607,7 +607,7 @@ public:
     }
     virtual future<> fast_forward_to(const dht::partition_range& pr) override {
         if (!_reader) {
-            _reader = _source.make_reader_v2(_schema, _permit, pr, _slice, std::move(_trace_state), streamed_mutation::forwarding::no,
+            _reader = _source.make_mutation_reader(_schema, _permit, pr, _slice, std::move(_trace_state), streamed_mutation::forwarding::no,
                     mutation_reader::forwarding::yes);
             _end_of_stream = false;
             return make_ready_future<>();
@@ -663,7 +663,7 @@ make_multi_range_reader(schema_ptr s, reader_permit permit, mutation_source sour
             return make_empty_mutation_reader(std::move(s), std::move(permit));
         }
     } else if (ranges.size() == 1) {
-        return source.make_reader_v2(std::move(s), std::move(permit), ranges.front(), slice, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
+        return source.make_mutation_reader(std::move(s), std::move(permit), ranges.front(), slice, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
     } else {
         return make_mutation_reader<multi_range_mutation_reader<adapter>>(std::move(s), std::move(permit), std::move(source),
                 ranges.front(), adapter(std::next(ranges.cbegin()), ranges.cend()), slice, std::move(trace_state));
@@ -1215,7 +1215,7 @@ mutation_source make_combined_mutation_source(std::vector<mutation_source> adden
         std::vector<mutation_reader> rd;
         rd.reserve(addends.size());
         for (auto&& ms : addends) {
-            rd.emplace_back(ms.make_reader_v2(s, permit, pr, slice, tr, fwd_sm, fwd_mr));
+            rd.emplace_back(ms.make_mutation_reader(s, permit, pr, slice, tr, fwd_sm, fwd_mr));
         }
         return make_combined_reader(s, std::move(permit), std::move(rd), fwd_sm, fwd_mr);
     });

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -87,9 +87,9 @@ public:
 };
 } //anon namespace
 
-class empty_flat_reader_v2 final : public mutation_reader::impl {
+class empty_mutation_reader final : public mutation_reader::impl {
 public:
-    empty_flat_reader_v2(schema_ptr s, reader_permit permit) : impl(std::move(s), std::move(permit)) { _end_of_stream = true; }
+    empty_mutation_reader(schema_ptr s, reader_permit permit) : impl(std::move(s), std::move(permit)) { _end_of_stream = true; }
     virtual future<> fill_buffer() override { return make_ready_future<>(); }
     virtual future<> next_partition() override { return make_ready_future<>(); }
     virtual future<> fast_forward_to(const dht::partition_range& pr) override { return make_ready_future<>(); };
@@ -98,7 +98,7 @@ public:
 };
 
 mutation_reader make_empty_mutation_reader(schema_ptr s, reader_permit permit) {
-    return make_mutation_reader<empty_flat_reader_v2>(std::move(s), std::move(permit));
+    return make_mutation_reader<empty_mutation_reader>(std::move(s), std::move(permit));
 }
 
 mutation_reader make_forwardable(mutation_reader m) {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -720,10 +720,10 @@ make_multi_range_reader(
  * This reader takes a get_next_fragment generator that produces mutation_fragment_opt which is returned by
  * generating_reader.
  */
-class generating_reader_v2 final : public mutation_reader::impl {
+class generating_reader final : public mutation_reader::impl {
     noncopyable_function<future<mutation_fragment_v2_opt> ()> _get_next_fragment;
 public:
-    generating_reader_v2(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_v2_opt> ()> get_next_fragment)
+    generating_reader(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_v2_opt> ()> get_next_fragment)
         : impl(std::move(s), std::move(permit)), _get_next_fragment(std::move(get_next_fragment))
     { }
     virtual future<> fill_buffer() override {
@@ -752,7 +752,7 @@ public:
 };
 
 mutation_reader make_generating_reader(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_v2_opt> ()> get_next_fragment) {
-    return make_mutation_reader<generating_reader_v2>(std::move(s), std::move(permit), std::move(get_next_fragment));
+    return make_mutation_reader<generating_reader>(std::move(s), std::move(permit), std::move(get_next_fragment));
 }
 
 mutation_reader make_generating_reader_v1(schema_ptr s, reader_permit permit, noncopyable_function<future<mutation_fragment_opt> ()> get_next_fragment) {
@@ -788,7 +788,7 @@ mutation_reader make_generating_reader_v1(schema_ptr s, reader_permit permit, no
             co_return mf;
         }
     };
-    return make_mutation_reader<generating_reader_v2>(s, permit, adaptor(s, permit, std::move(get_next_fragment)));
+    return make_mutation_reader<generating_reader>(s, permit, adaptor(s, permit, std::move(get_next_fragment)));
 }
 
 class reader_from_mutation_base : public mutation_reader::impl {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -36,7 +36,7 @@
 extern logging::logger mrlog;
 
 mutation_reader make_delegating_reader(mutation_reader& r) {
-    return make_mutation_reader<delegating_reader_v2>(r);
+    return make_mutation_reader<delegating_reader>(r);
 }
 
 namespace {

--- a/readers/mutation_readers.cc
+++ b/readers/mutation_readers.cc
@@ -497,7 +497,7 @@ mutation_reader make_nonforwardable(mutation_reader r, bool single_partition) {
 }
 
 template<typename Generator>
-class flat_multi_range_mutation_reader : public mutation_reader::impl {
+class multi_range_mutation_reader : public mutation_reader::impl {
     std::optional<Generator> _generator;
     mutation_reader _reader;
 
@@ -509,7 +509,7 @@ class flat_multi_range_mutation_reader : public mutation_reader::impl {
     }
 
 public:
-    flat_multi_range_mutation_reader(
+    multi_range_mutation_reader(
             schema_ptr s,
             reader_permit permit,
             mutation_source source,
@@ -635,7 +635,7 @@ public:
     }
 };
 mutation_reader
-make_flat_multi_range_reader(schema_ptr s, reader_permit permit, mutation_source source, const dht::partition_range_vector& ranges,
+make_multi_range_reader(schema_ptr s, reader_permit permit, mutation_source source, const dht::partition_range_vector& ranges,
                         const query::partition_slice& slice,
                         tracing::trace_state_ptr trace_state,
                         mutation_reader::forwarding fwd_mr)
@@ -665,13 +665,13 @@ make_flat_multi_range_reader(schema_ptr s, reader_permit permit, mutation_source
     } else if (ranges.size() == 1) {
         return source.make_reader_v2(std::move(s), std::move(permit), ranges.front(), slice, std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr);
     } else {
-        return make_mutation_reader<flat_multi_range_mutation_reader<adapter>>(std::move(s), std::move(permit), std::move(source),
+        return make_mutation_reader<multi_range_mutation_reader<adapter>>(std::move(s), std::move(permit), std::move(source),
                 ranges.front(), adapter(std::next(ranges.cbegin()), ranges.cend()), slice, std::move(trace_state));
     }
 }
 
 mutation_reader
-make_flat_multi_range_reader(
+make_multi_range_reader(
         schema_ptr s,
         reader_permit permit,
         mutation_source source,
@@ -710,7 +710,7 @@ make_flat_multi_range_reader(
             return make_empty_mutation_reader(std::move(s), std::move(permit));
         }
     } else {
-        return make_mutation_reader<flat_multi_range_mutation_reader<adapter>>(std::move(s), std::move(permit), std::move(source),
+        return make_mutation_reader<multi_range_mutation_reader<adapter>>(std::move(s), std::move(permit), std::move(source),
                 *first_range, std::move(adapted_generator), slice, std::move(trace_state));
     }
 }

--- a/readers/mutation_source.hh
+++ b/readers/mutation_source.hh
@@ -131,7 +131,7 @@ public:
     // All parameters captured by reference must remain live as long as returned
     // mutation_reader or streamed_mutation obtained through it are alive.
     mutation_reader
-    make_reader_v2(
+    make_mutation_reader(
             schema_ptr s,
             reader_permit permit,
             partition_range range,
@@ -144,13 +144,13 @@ public:
     }
 
     mutation_reader
-    make_reader_v2(
+    make_mutation_reader(
             schema_ptr s,
             reader_permit permit,
             partition_range range = query::full_partition_range) const
     {
         auto& full_slice = s->full_slice();
-        return make_reader_v2(std::move(s), std::move(permit), range, full_slice);
+        return make_mutation_reader(std::move(s), std::move(permit), range, full_slice);
     }
 
     partition_presence_checker make_partition_presence_checker() {

--- a/readers/mutation_source.hh
+++ b/readers/mutation_source.hh
@@ -41,7 +41,7 @@ partition_presence_checker make_default_partition_presence_checker() {
 // Partition-range forwarding is not yet supported in reverse mode.
 class mutation_source {
     using partition_range = const dht::partition_range&;
-    using flat_reader_v2_factory_type = std::function<mutation_reader(schema_ptr,
+    using mutation_reader_factory = std::function<mutation_reader(schema_ptr,
                                                                         reader_permit,
                                                                         partition_range,
                                                                         const query::partition_slice&,
@@ -51,15 +51,15 @@ class mutation_source {
     // We could have our own version of std::function<> that is nothrow
     // move constructible and save some indirection and allocation.
     // Probably not worth the effort though.
-    lw_shared_ptr<flat_reader_v2_factory_type> _fn;
+    lw_shared_ptr<mutation_reader_factory> _fn;
     lw_shared_ptr<std::function<partition_presence_checker()>> _presence_checker_factory;
 private:
     mutation_source() = default;
     explicit operator bool() const { return bool(_fn); }
     friend class optimized_optional<mutation_source>;
 public:
-    mutation_source(flat_reader_v2_factory_type fn, std::function<partition_presence_checker()> pcf = [] { return make_default_partition_presence_checker(); })
-        : _fn(make_lw_shared<flat_reader_v2_factory_type>(std::move(fn)))
+    mutation_source(mutation_reader_factory fn, std::function<partition_presence_checker()> pcf = [] { return make_default_partition_presence_checker(); })
+        : _fn(make_lw_shared<mutation_reader_factory>(std::move(fn)))
         , _presence_checker_factory(make_lw_shared<std::function<partition_presence_checker()>>(std::move(pcf)))
     { }
 

--- a/readers/queue.hh
+++ b/readers/queue.hh
@@ -10,31 +10,31 @@
 
 #include "readers/mutation_reader.hh"
 
-class queue_reader_v2;
+class queue_reader;
 
 /// Calls to different methods cannot overlap!
 /// The handle can be used only while the reader is still alive. Once
 /// `push_end_of_stream()` is called, the reader and the handle can be destroyed
 /// in any order. The reader can be destroyed at any time.
-class queue_reader_handle_v2 {
-    friend std::pair<mutation_reader, queue_reader_handle_v2> make_queue_reader_v2(schema_ptr, reader_permit);
-    friend class queue_reader_v2;
+class queue_reader_handle {
+    friend std::pair<mutation_reader, queue_reader_handle> make_queue_reader(schema_ptr, reader_permit);
+    friend class queue_reader;
 
 private:
-    queue_reader_v2* _reader = nullptr;
+    queue_reader* _reader = nullptr;
     std::exception_ptr _ex;
 
 private:
-    explicit queue_reader_handle_v2(queue_reader_v2& reader) noexcept;
+    explicit queue_reader_handle(queue_reader& reader) noexcept;
 
     void abandon() noexcept;
 
     [[nodiscard]] std::exception_ptr check_abort() const noexcept;
 
 public:
-    queue_reader_handle_v2(queue_reader_handle_v2&& o) noexcept;
-    ~queue_reader_handle_v2();
-    queue_reader_handle_v2& operator=(queue_reader_handle_v2&& o);
+    queue_reader_handle(queue_reader_handle&& o) noexcept;
+    ~queue_reader_handle();
+    queue_reader_handle& operator=(queue_reader_handle&& o);
 
     future<> push(mutation_fragment_v2 mf);
 
@@ -55,5 +55,5 @@ public:
     std::exception_ptr get_exception() const noexcept;
 };
 
-std::pair<mutation_reader, queue_reader_handle_v2> make_queue_reader_v2(schema_ptr s, reader_permit permit);
+std::pair<mutation_reader, queue_reader_handle> make_queue_reader(schema_ptr s, reader_permit permit);
 

--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -28,7 +28,7 @@ private:
     // Only needed for local readers, the multishard reader takes care
     // of pinning tables on used shards.
     std::optional<utils::phased_barrier::operation> _local_read_op;
-    std::optional<evictable_reader_handle_v2> _reader_handle;
+    std::optional<evictable_reader_handle> _reader_handle;
     // Fragment stream of either local or multishard reader for the range
     mutation_fragment_v1_stream _reader;
     // Current partition read from disk

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -464,9 +464,9 @@ future<> repair_writer::write_start_and_mf(lw_shared_ptr<const decorated_key_wit
 };
 
 class queue_reader_handle_adapter : public mutation_fragment_queue::impl {
-    queue_reader_handle_v2 _handle;
+    queue_reader_handle _handle;
 public:
-    queue_reader_handle_adapter(queue_reader_handle_v2 handle)
+    queue_reader_handle_adapter(queue_reader_handle handle)
         : _handle(std::move(handle))
     {}
 
@@ -483,7 +483,7 @@ public:
     }
 };
 
-mutation_fragment_queue make_mutation_fragment_queue(schema_ptr s, reader_permit permit, queue_reader_handle_v2 handle) {
+mutation_fragment_queue make_mutation_fragment_queue(schema_ptr s, reader_permit permit, queue_reader_handle handle) {
     return mutation_fragment_queue(std::move(s), std::move(permit), seastar::make_shared<queue_reader_handle_adapter>(std::move(handle)));
 }
 
@@ -548,7 +548,7 @@ lw_shared_ptr<repair_writer> make_repair_writer(
             sharded<replica::database>& db,
             db::view::view_builder& view_builder,
             service::frozen_topology_guard topo_guard) {
-    auto [queue_reader, queue_handle] = make_queue_reader_v2(schema, permit);
+    auto [queue_reader, queue_handle] = make_queue_reader(schema, permit);
     auto queue = make_mutation_fragment_queue(schema, permit, std::move(queue_handle));
     auto i = std::make_unique<repair_writer_impl>(schema, permit, db, view_builder, reason, std::move(queue), std::move(queue_reader), topo_guard);
     return make_lw_shared<repair_writer>(schema, permit, std::move(i));

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -286,7 +286,7 @@ mutation_reader repair_reader::make_reader(
                 return cf.make_streaming_reader(std::move(s), std::move(permit), pr, ps, fwd_mr, compaction_time);
             });
             mutation_reader rd(nullptr);
-            std::tie(rd, _reader_handle) = make_manually_paused_evictable_reader_v2(
+            std::tie(rd, _reader_handle) = make_manually_paused_evictable_reader(
                 std::move(ms),
                 _schema,
                 _permit,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3092,7 +3092,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
         return rd;
     });
     auto&& full_slice = schema->full_slice();
-    return make_flat_multi_range_reader(schema, std::move(permit), std::move(ms),
+    return make_multi_range_reader(schema, std::move(permit), std::move(ms),
             std::move(range_generator), std::move(full_slice), {}, mutation_reader::forwarding::no);
 }
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3084,7 +3084,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
             mutation_reader::forwarding fwd_mr) {
         auto table_id = s->id();
         const auto buffer_hint = multishard_reader_buffer_hint(multishard_reader_buffer_size.has_value());
-        auto rd = make_multishard_combining_reader_v2(seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
+        auto rd = make_multishard_combining_reader(seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
                 std::move(s), erm, std::move(permit), pr, ps, std::move(trace_state), fwd_mr, buffer_hint, read_ahead);
         if (multishard_reader_buffer_size) {
             rd.set_max_buffer_size(*multishard_reader_buffer_size);
@@ -3107,7 +3107,7 @@ mutation_reader make_multishard_streaming_reader(distributed<replica::database>&
     const auto table_id = schema->id();
     const auto& full_slice = schema->full_slice();
     auto erm = db.local().find_column_family(schema).get_effective_replication_map();
-    auto rd = make_multishard_combining_reader_v2(
+    auto rd = make_multishard_combining_reader(
         seastar::make_shared<streaming_reader_lifecycle_policy>(db, table_id, compaction_time),
         std::move(schema),
         std::move(erm),

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -780,14 +780,14 @@ public:
     // Note: for data queries use query() instead.
     // The 'range' parameter must be live as long as the reader is used.
     // Mutations returned by the reader will all have given schema.
-    mutation_reader make_reader_v2(schema_ptr schema,
+    mutation_reader make_mutation_reader(schema_ptr schema,
             reader_permit permit,
             const dht::partition_range& range,
             const query::partition_slice& slice,
             tracing::trace_state_ptr trace_state = nullptr,
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) const;
-    mutation_reader make_reader_v2_excluding_staging(schema_ptr schema,
+    mutation_reader make_mutation_reader_excluding_staging(schema_ptr schema,
             reader_permit permit,
             const dht::partition_range& range,
             const query::partition_slice& slice,
@@ -795,9 +795,9 @@ public:
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes) const;
 
-    mutation_reader make_reader_v2(schema_ptr schema, reader_permit permit, const dht::partition_range& range = query::full_partition_range) const {
+    mutation_reader make_mutation_reader(schema_ptr schema, reader_permit permit, const dht::partition_range& range = query::full_partition_range) const {
         auto& full_slice = schema->full_slice();
-        return make_reader_v2(std::move(schema), std::move(permit), range, full_slice);
+        return make_mutation_reader(std::move(schema), std::move(permit), range, full_slice);
     }
 
     // The streaming mutation reader differs from the regular mutation reader in that:

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2016,7 +2016,7 @@ future<> start_large_data_handler(sharded<replica::database>& db);
 // Opt-in for compacting the output by passing `compaction_time`, see
 // make_streaming_reader() for more details.
 // Setting multishard_reader_buffer_size enables the multishard reader's buffer
-// size optimization (see make_multishard_combining_reader_v2()), using the
+// size optimization (see make_multishard_combining_reader()), using the
 // given size.
 mutation_reader make_multishard_streaming_reader(
         distributed<replica::database>& db,
@@ -2039,7 +2039,7 @@ mutation_reader make_multishard_streaming_reader(
 bool is_internal_keyspace(std::string_view name);
 
 class streaming_reader_lifecycle_policy
-    : public reader_lifecycle_policy_v2
+    : public reader_lifecycle_policy
         , public enable_shared_from_this<streaming_reader_lifecycle_policy> {
 
     template <typename T>

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -385,7 +385,7 @@ protected:
                                     const query::partition_slice& slice,
                                     streamed_mutation::forwarding fwd,
                                     mutation_reader::forwarding fwd_mr) {
-        auto ret = _memtable->_underlying->make_reader_v2(_schema, std::move(permit), delegate, slice, nullptr, fwd, fwd_mr);
+        auto ret = _memtable->_underlying->make_mutation_reader(_schema, std::move(permit), delegate, slice, nullptr, fwd, fwd_mr);
         _last = {};
         return ret;
     }

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -346,7 +346,7 @@ private:
             auto ms_begin = _underlying_mutation_sources.begin();
 
             if (!_underlying_reader) {
-                _underlying_reader = ms_begin->second.ms.make_reader_v2(_underlying_schema, _permit, _underlying_pr, ms_begin->second.slice,
+                _underlying_reader = ms_begin->second.ms.make_mutation_reader(_underlying_schema, _permit, _underlying_pr, ms_begin->second.slice,
                         _ts, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
             }
 

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -605,12 +605,12 @@ future<foreign_ptr<lw_shared_ptr<query::result>>> dump_mutations(
     auto accounter = co_await db.local().get_result_memory_limiter().new_data_read(permit.max_result_size(), short_read_allowed);
     query_state qs(output_schema, cmd, opts, prs, std::move(accounter));
 
-    auto compaction_state = make_lw_shared<compact_for_query_state_v2>(*output_schema, qs.cmd.timestamp, qs.cmd.slice, qs.remaining_rows(), qs.remaining_partitions());
+    auto compaction_state = make_lw_shared<compact_for_query_state>(*output_schema, qs.cmd.timestamp, qs.cmd.slice, qs.remaining_rows(), qs.remaining_partitions());
     auto partition_key_generator = make_partition_key_generator(db, underlying_schema, prs, ts, timeout);
 
     auto dk_opt = co_await partition_key_generator();
     while (dk_opt) {
-        auto reader_consumer = compact_for_query_v2<query_result_builder>(compaction_state, query_result_builder(*output_schema, qs.builder));
+        auto reader_consumer = compact_for_query<query_result_builder>(compaction_state, query_result_builder(*output_schema, qs.builder));
         auto reader = co_await make_partition_mutation_dump_reader(output_schema, underlying_schema, permit, db, *dk_opt, cmd.slice, ts, timeout);
 
         std::exception_ptr ex;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -304,7 +304,7 @@ table::make_streaming_reader(schema_ptr s, reader_permit permit,
     });
 
     return maybe_compact_for_streaming(
-            make_flat_multi_range_reader(s, std::move(permit), std::move(source), ranges, slice, nullptr, mutation_reader::forwarding::no),
+            make_multi_range_reader(s, std::move(permit), std::move(source), ranges, slice, nullptr, mutation_reader::forwarding::no),
             get_compaction_manager(),
             compaction_time,
             _config.enable_compacting_data_for_streaming_and_repair(),

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -212,7 +212,7 @@ table::make_mutation_reader(schema_ptr s,
                            streamed_mutation::forwarding fwd,
                            mutation_reader::forwarding fwd_mr) const {
     if (_virtual_reader) [[unlikely]] {
-        return (*_virtual_reader).make_reader_v2(s, std::move(permit), range, slice, trace_state, fwd, fwd_mr);
+        return (*_virtual_reader).make_mutation_reader(s, std::move(permit), range, slice, trace_state, fwd, fwd_mr);
     }
 
     std::vector<mutation_reader> readers;
@@ -3869,7 +3869,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     auto lock = co_await std::move(lockf);
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
-    auto reader = source.make_reader_v2(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
+    auto reader = source.make_mutation_reader(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());
     // return the local partition/row lock we have taken so it

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -18,7 +18,7 @@
 
 namespace streaming {
 
-reader_consumer_v2 make_streaming_consumer(sstring origin,
+mutation_reader_consumer make_streaming_consumer(sstring origin,
         sharded<replica::database>& db,
         db::view::view_builder& vb,
         uint64_t estimated_partitions,
@@ -42,7 +42,7 @@ reader_consumer_v2 make_streaming_consumer(sstring origin,
             // Data segregation is postponed to happen during off-strategy if latter is enabled, which
             // means partition estimation shouldn't be adjusted.
             const auto adjusted_estimated_partitions = (offstrategy) ? estimated_partitions : cs.adjust_partition_estimate(metadata, estimated_partitions, cf->schema());
-            reader_consumer_v2 consumer =
+            mutation_reader_consumer consumer =
                     [cf = std::move(cf), adjusted_estimated_partitions, use_view_update_path, &vb, origin = std::move(origin), offstrategy] (mutation_reader reader) {
                 sstables::shared_sstable sst;
                 try {

--- a/streaming/consumer.hh
+++ b/streaming/consumer.hh
@@ -24,7 +24,7 @@ class view_builder;
 
 namespace streaming {
 
-reader_consumer_v2 make_streaming_consumer(sstring origin,
+mutation_reader_consumer make_streaming_consumer(sstring origin,
     sharded<replica::database>& db,
     db::view::view_builder& vb,
     uint64_t estimated_partitions,

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -169,7 +169,7 @@ public:
 
     shared_ptr<stream_session> get_session(streaming::plan_id plan_id, locator::host_id from, const char* verb, std::optional<table_id> cf_id = {});
 
-    reader_consumer_v2 make_streaming_consumer(
+    mutation_reader_consumer make_streaming_consumer(
             uint64_t estimated_partitions, stream_reason, service::frozen_topology_guard);
 public:
     virtual future<> on_dead(inet_address endpoint, locator::host_id id, endpoint_state_ptr state, gms::permit_id) override;

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -84,7 +84,7 @@ public:
     }
 };
 
-reader_consumer_v2
+mutation_reader_consumer
 stream_manager::make_streaming_consumer(uint64_t estimated_partitions, stream_reason reason, service::frozen_topology_guard topo_guard) {
     return streaming::make_streaming_consumer("streaming", _db, _view_builder, estimated_partitions, reason, is_offstrategy_supported(reason), topo_guard);
 }

--- a/test/boost/cache_mutation_reader_test.cc
+++ b/test/boost/cache_mutation_reader_test.cc
@@ -88,7 +88,7 @@ struct expected_fragment {
     expected_fragment(range_tombstone_change rtc) : f(std::move(rtc)) { }
     expected_fragment(position_in_partition_view pos, tombstone tomb) : expected_fragment(range_tombstone_change(pos, tomb)) { }
 
-    void check(flat_reader_assertions_v2& r) {
+    void check(mutation_reader_assertions& r) {
         if (f.index() == 0) {
             r.produces_row_with_key(make_ck(std::get<int>(f)));
         } else {

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -328,7 +328,7 @@ static void test_database(void (*run_tests)(populate_fn_ex, bool), unsigned cgs)
                     tracing::trace_state_ptr trace_state,
                     streamed_mutation::forwarding fwd,
                     mutation_reader::forwarding fwd_mr) {
-                return cf.make_reader_v2(s, std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr);
+                return cf.make_mutation_reader(s, std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr);
             });
         }, true);
     }).get();

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -39,7 +39,7 @@
 using namespace sstables;
 
 static mutation_reader sstable_reader(reader_permit permit, shared_sstable sst, schema_ptr s) {
-    return sst->as_mutation_source().make_reader_v2(s, std::move(permit), query::full_partition_range, s->full_slice());
+    return sst->as_mutation_source().make_mutation_reader(s, std::move(permit), query::full_partition_range, s->full_slice());
 
 }
 

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -1543,7 +1543,7 @@ SEASTAR_TEST_CASE(memtable_reader_after_tablet_migration) {
 
             testlog.info("create reader -- first buffer fill");
 
-            auto reader = tbl.make_reader_v2(schema, co_await db.obtain_reader_permit(tbl, "read", db::no_timeout, {}), query::full_partition_range, schema->full_slice());
+            auto reader = tbl.make_mutation_reader(schema, co_await db.obtain_reader_permit(tbl, "read", db::no_timeout, {}), query::full_partition_range, schema->full_slice());
 
             std::exception_ptr ex;
             try {

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -381,17 +381,17 @@ SEASTAR_TEST_CASE(test_partition_version_consistency_after_lsa_compaction_happen
         m3.set_clustered_cell(ck3, to_bytes("col"), data_value(bytes(bytes::initialized_later(), 8)), next_timestamp());
 
         mt->apply(m1);
-        std::optional<flat_reader_assertions_v2> rd1 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
+        std::optional<mutation_reader_assertions> rd1 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
         rd1->set_max_buffer_size(1);
         rd1->fill_buffer().get();
 
         mt->apply(m2);
-        std::optional<flat_reader_assertions_v2> rd2 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
+        std::optional<mutation_reader_assertions> rd2 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
         rd2->set_max_buffer_size(1);
         rd2->fill_buffer().get();
 
         mt->apply(m3);
-        std::optional<flat_reader_assertions_v2> rd3 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
+        std::optional<mutation_reader_assertions> rd3 = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
         rd3->set_max_buffer_size(1);
         rd3->fill_buffer().get();
 

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -998,7 +998,7 @@ SEASTAR_TEST_CASE(memtable_flush_compresses_mutations) {
 
         // Treat the table as mutation_source and SCYLLA_ASSERT we get the expected mutation and end of stream
         mutation_source ms = t.as_mutation_source();
-        assert_that(ms.make_reader_v2(s, semaphore.make_permit()))
+        assert_that(ms.make_mutation_reader(s, semaphore.make_permit()))
             .produces(m2)
             .produces_end_of_stream();
     }, db_config);
@@ -1043,7 +1043,7 @@ SEASTAR_TEST_CASE(memtable_flush_period) {
 
         // Check mutation presents in the table
         mutation_source ms = t.as_mutation_source();
-        assert_that(ms.make_reader_v2(s2, semaphore.make_permit()))
+        assert_that(ms.make_mutation_reader(s2, semaphore.make_permit()))
             .produces(m)
             .produces_end_of_stream();
     }, db_config);

--- a/test/boost/multishard_combining_reader_as_mutation_source_test.cc
+++ b/test/boost/multishard_combining_reader_as_mutation_source_test.cc
@@ -93,7 +93,7 @@ static auto make_populate(bool evict_paused_readers, bool single_fragment_buffer
             };
 
             auto lifecycle_policy = seastar::make_shared<test_reader_lifecycle_policy>(std::move(factory), std::make_unique<evicting_semaphore_factory>(evict_paused_readers));
-            auto mr = make_multishard_combining_reader_v2_for_tests(keep_alive_sharder.back(), std::move(lifecycle_policy), s,
+            auto mr = make_multishard_combining_reader_for_tests(keep_alive_sharder.back(), std::move(lifecycle_policy), s,
                     std::move(permit), range, slice, trace_state, fwd_mr);
             if (fwd_sm == streamed_mutation::forwarding::yes) {
                 return make_forwardable(std::move(mr));

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -801,7 +801,7 @@ SEASTAR_THREAD_TEST_CASE(test_make_nonforwardable) {
 
     // next_partition()
     {
-        auto check = [&] (flat_reader_assertions_v2 rd) {
+        auto check = [&] (mutation_reader_assertions rd) {
             rd.produces_partition_start(m1.decorated_key(), m1.partition().partition_tombstone());
             rd.next_partition();
             rd.produces_partition_start(m2.decorated_key(), m2.partition().partition_tombstone());

--- a/test/boost/mutation_reader_another_test.cc
+++ b/test/boost/mutation_reader_another_test.cc
@@ -415,14 +415,14 @@ SEASTAR_THREAD_TEST_CASE(test_multi_range_reader) {
     // Generator ranges are single pass, so we need a new range each time they are used.
     auto run_test = [&] (auto make_empty_ranges, auto make_single_ranges, auto make_multiple_ranges) {
         testlog.info("empty ranges");
-        assert_that(make_flat_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_empty_ranges(), s.schema()->full_slice()))
+        assert_that(make_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_empty_ranges(), s.schema()->full_slice()))
                 .produces_end_of_stream()
                 .fast_forward_to(fft_range)
                 .produces(ms[9])
                 .produces_end_of_stream();
 
         testlog.info("single range");
-        assert_that(make_flat_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_single_ranges(), s.schema()->full_slice()))
+        assert_that(make_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_single_ranges(), s.schema()->full_slice()))
                 .produces(ms[1])
                 .produces(ms[2])
                 .produces_end_of_stream()
@@ -431,7 +431,7 @@ SEASTAR_THREAD_TEST_CASE(test_multi_range_reader) {
                 .produces_end_of_stream();
 
         testlog.info("read full partitions and fast forward");
-        assert_that(make_flat_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_multiple_ranges(), s.schema()->full_slice()))
+        assert_that(make_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_multiple_ranges(), s.schema()->full_slice()))
                 .produces(ms[1])
                 .produces(ms[2])
                 .produces(ms[4])
@@ -441,7 +441,7 @@ SEASTAR_THREAD_TEST_CASE(test_multi_range_reader) {
                 .produces_end_of_stream();
 
         testlog.info("read, skip partitions and fast forward");
-        assert_that(make_flat_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_multiple_ranges(), s.schema()->full_slice()))
+        assert_that(make_multi_range_reader(s.schema(), semaphore.make_permit(), source, make_multiple_ranges(), s.schema()->full_slice()))
                 .produces_partition_start(keys[1])
                 .next_partition()
                 .produces_partition_start(keys[2])

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -785,7 +785,7 @@ SEASTAR_TEST_CASE(combined_mutation_reader_test) {
         sstable_set->insert(sst);
 
         sstable_mutation_readers.emplace_back(
-            sst->as_mutation_source().make_reader_v2(
+            sst->as_mutation_source().make_mutation_reader(
                 s.schema(),
                 list_permit,
                 query::full_partition_range,
@@ -1061,7 +1061,7 @@ SEASTAR_TEST_CASE(test_fast_forwarding_combined_reader_is_consistent_with_slicin
             }
             mutation_source ds = make_sstable_containing(env.make_sstable(s), muts)->as_mutation_source();
             reader_ranges.push_back(dht::partition_range::make({keys[0]}, {keys[0]}));
-            readers.push_back(ds.make_reader_v2(s,
+            readers.push_back(ds.make_mutation_reader(s,
                 permit,
                 reader_ranges.back(),
                 s->full_slice(), nullptr,
@@ -1138,8 +1138,8 @@ SEASTAR_TEST_CASE(test_combined_reader_slicing_with_overlapping_range_tombstones
         {
             auto permit = env.make_reader_permit();
             auto slice = partition_slice_builder(*s).with_range(range).build();
-            readers.push_back(ds1.make_reader_v2(s, permit, query::full_partition_range, slice));
-            readers.push_back(ds2.make_reader_v2(s, permit, query::full_partition_range, slice));
+            readers.push_back(ds1.make_mutation_reader(s, permit, query::full_partition_range, slice));
+            readers.push_back(ds2.make_mutation_reader(s, permit, query::full_partition_range, slice));
 
             auto rd = mutation_fragment_v1_stream(make_combined_reader(s, permit, std::move(readers),
                 streamed_mutation::forwarding::no, mutation_reader::forwarding::no));
@@ -1162,9 +1162,9 @@ SEASTAR_TEST_CASE(test_combined_reader_slicing_with_overlapping_range_tombstones
         // Check fast_forward_to()
         {
             auto permit = env.make_reader_permit();
-            readers.push_back(ds1.make_reader_v2(s, permit, query::full_partition_range, s->full_slice(),
+            readers.push_back(ds1.make_mutation_reader(s, permit, query::full_partition_range, s->full_slice(),
                 nullptr, streamed_mutation::forwarding::yes));
-            readers.push_back(ds2.make_reader_v2(s, permit, query::full_partition_range, s->full_slice(),
+            readers.push_back(ds2.make_mutation_reader(s, permit, query::full_partition_range, s->full_slice(),
                 nullptr, streamed_mutation::forwarding::yes));
 
             auto rd = mutation_fragment_v1_stream(make_combined_reader(s, permit, std::move(readers),
@@ -2253,7 +2253,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_next_partition) {
                 tracing::trace_state_ptr trace_state,
                 mutation_reader::forwarding fwd_mr) {
             auto& table = db->local().find_column_family(schema);
-            auto reader = table.as_mutation_source().make_reader_v2(
+            auto reader = table.as_mutation_source().make_mutation_reader(
                     schema,
                     std::move(permit),
                     range,
@@ -2340,7 +2340,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
                 tracing::trace_state_ptr trace_state,
                 mutation_reader::forwarding fwd_mr) mutable {
             auto& table = db->local().find_column_family(s);
-            return table.as_mutation_source().make_reader_v2(std::move(s), std::move(permit), range, slice, std::move(trace_state),
+            return table.as_mutation_source().make_mutation_reader(std::move(s), std::move(permit), range, slice, std::move(trace_state),
                     streamed_mutation::forwarding::no, fwd_mr);
         };
         auto& table = env.db().local().find_column_family(schema);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2392,7 +2392,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
             });
         };
 
-        auto write_all = [&semaphore] (queue_reader_handle_v2& handle, const std::vector<mutation>& muts) {
+        auto write_all = [&semaphore] (queue_reader_handle& handle, const std::vector<mutation>& muts) {
             return async([&] {
                 auto reader = make_mutation_reader_from_mutations(muts.front().schema(), semaphore.make_permit(), muts);
                 auto close_reader = deferred_close(reader);
@@ -2406,7 +2406,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         auto actual_muts = std::vector<mutation>{};
         actual_muts.reserve(20);
 
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
@@ -2419,7 +2419,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // abort() -- check that consumer is aborted
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
@@ -2441,7 +2441,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // abort() -- check that producer is aborted
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
@@ -2466,7 +2466,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // Detached handle
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto fill_buffer_fut = reader.fill_buffer();
@@ -2483,7 +2483,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // Abandoned handle aborts, move-assignment
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
@@ -2497,7 +2497,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
         BOOST_REQUIRE(!fill_buffer_fut.available());
 
         {
-            auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+            auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
             auto& throwaway_reader = std::get<0>(p);
             auto& throwaway_handle = std::get<1>(p);
             auto close_throwaway_reader = deferred_close(throwaway_reader);
@@ -2511,7 +2511,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // Abandoned handle aborts, destructor
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
@@ -2526,7 +2526,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
         {
             // Destroy handle
-            queue_reader_handle_v2 throwaway_handle(std::move(handle));
+            queue_reader_handle throwaway_handle(std::move(handle));
         }
 
         BOOST_REQUIRE_THROW(fill_buffer_fut.get(), std::runtime_error);
@@ -2535,19 +2535,19 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 
     // Life-cycle, relies on ASAN for error reporting
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);
         {
-            auto throwaway_p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+            auto throwaway_p = make_queue_reader(gen.schema(), semaphore.make_permit());
             auto& throwaway_reader = std::get<0>(throwaway_p);
             auto& throwaway_handle = std::get<1>(throwaway_p);
             auto close_throwaway_reader = deferred_close(throwaway_reader);
             // Overwrite handle
             handle = std::move(throwaway_handle);
 
-            auto another_throwaway_p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+            auto another_throwaway_p = make_queue_reader(gen.schema(), semaphore.make_permit());
             auto& another_throwaway_reader = std::get<0>(another_throwaway_p);
             auto& another_throwaway_handle = std::get<1>(another_throwaway_p);
             auto close_another_throwaway_reader = deferred_close(another_throwaway_reader);
@@ -2556,13 +2556,13 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
             another_throwaway_handle = std::move(throwaway_handle);
 
             // Overwrite with moved-from handle (move constructor)
-            queue_reader_handle_v2 yet_another_throwaway_handle(std::move(throwaway_handle));
+            queue_reader_handle yet_another_throwaway_handle(std::move(throwaway_handle));
         }
     }
 
     // push_end_of_stream() detaches handle from reader, relies on ASAN for error reporting
     {
-        auto p = make_queue_reader_v2(gen.schema(), semaphore.make_permit());
+        auto p = make_queue_reader(gen.schema(), semaphore.make_permit());
         auto& reader = std::get<0>(p);
         auto& handle = std::get<1>(p);
         auto close_reader = deferred_close(reader);

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3449,14 +3449,14 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
         ref_mut.partition().compact_for_query(*s, pk, query_time, {query::clustering_range::make_open_ended_both_sides()}, true, max_rows);
     }
 
-    struct consumer_v2 {
+    struct consumer {
         reader_permit permit;
         mutation& mut;
         const uint64_t row_limit;
         uint64_t rows = 0;
         mutation_rebuilder_v2 builder;
 
-        consumer_v2(reader_permit permit, mutation& mut, uint64_t row_limit, uint64_t rows = 0)
+        consumer(reader_permit permit, mutation& mut, uint64_t row_limit, uint64_t rows = 0)
             : permit(std::move(permit)), mut(mut), row_limit(row_limit), rows(rows), builder(mut.schema())
         { }
 
@@ -3494,7 +3494,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
     testlog.info("non-paged v2");
     {
         mutation res_mut(s, pk);
-        auto c = compact_for_query<consumer_v2>(*s, query_time, s->full_slice(), max_rows, max_partitions, consumer_v2{permit, res_mut, max_rows});
+        auto c = compact_for_query<consumer>(*s, query_time, s->full_slice(), max_rows, max_partitions, consumer{permit, res_mut, max_rows});
         auto reader = make_mutation_reader_from_fragments(s, permit, make_frags());
         auto close_reader = deferred_close(reader);
 
@@ -3511,9 +3511,9 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
         auto close_reader = deferred_close(reader);
 
         while (!reader.is_buffer_empty() || !reader.is_end_of_stream()) {
-            auto c = consumer_v2{permit, res_mut, max_rows};
+            auto c = consumer{permit, res_mut, max_rows};
             compaction_state->start_new_page(1, max_partitions, query_time, reader.peek().get()->position().region(), c);
-            reader.consume(compact_for_query<consumer_v2>(compaction_state, std::move(c))).get();
+            reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
         }
 
         BOOST_REQUIRE_EQUAL(res_mut, ref_mut);
@@ -3527,9 +3527,9 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
         auto close_reader = deferred_close(reader);
 
         while (!reader.is_buffer_empty() || !reader.is_end_of_stream()) {
-            auto c = consumer_v2{permit, res_mut, 2};
+            auto c = consumer{permit, res_mut, 2};
             compaction_state->start_new_page(max_rows, max_partitions, query_time, reader.peek().get()->position().region(), c);
-            reader.consume(compact_for_query<consumer_v2>(compaction_state, std::move(c))).get();
+            reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
         }
 
         BOOST_REQUIRE_EQUAL(res_mut, ref_mut);
@@ -3548,8 +3548,8 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
                 restore_state(reader, std::move(*detached_state));
             }
             auto compaction_state = make_lw_shared<compact_mutation_state<compact_for_sstables::no>>(*s, query_time, s->full_slice(), 1, max_partitions);
-            auto c = consumer_v2{permit, res_mut, max_rows};
-            reader.consume(compact_for_query<consumer_v2>(compaction_state, std::move(c))).get();
+            auto c = consumer{permit, res_mut, max_rows};
+            reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
             detached_state = std::move(*compaction_state).detach_state();
         }
 
@@ -3569,8 +3569,8 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
                 restore_state(reader, std::move(*detached_state));
             }
             auto compaction_state = make_lw_shared<compact_mutation_state<compact_for_sstables::no>>(*s, query_time, s->full_slice(), max_rows, max_partitions);
-            auto c = consumer_v2{permit, res_mut, 2};
-            reader.consume(compact_for_query<consumer_v2>(compaction_state, std::move(c))).get();
+            auto c = consumer{permit, res_mut, 2};
+            reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
             detached_state = std::move(*compaction_state).detach_state();
         }
 
@@ -3622,12 +3622,12 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_detach_state) {
         return frags;
     };
 
-    struct consumer_v2 {
+    struct consumer {
         uint64_t frags = 0;
         const uint64_t frag_limit;
         const bool final_stop;
 
-        consumer_v2(uint64_t stop_at, bool final_stop) : frag_limit(stop_at + 1), final_stop(final_stop) { }
+        consumer(uint64_t stop_at, bool final_stop) : frag_limit(stop_at + 1), final_stop(final_stop) { }
         void consume_new_partition(const dht::decorated_key& dk) { }
         void consume(const tombstone& t) { }
         stop_iteration consume(static_row&& sr, tombstone, bool) {
@@ -3660,7 +3660,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_detach_state) {
         auto compaction_state = make_lw_shared<compact_mutation_state<compact_for_sstables::no>>(*s, query_time, s->full_slice(), max_rows, max_partitions);
         auto reader = make_mutation_reader_from_fragments(s, permit, make_frags());
         auto close_reader = deferred_close(reader);
-        reader.consume(compact_for_query<consumer_v2>(compaction_state, consumer_v2(stop_at, final_stop))).get();
+        reader.consume(compact_for_query<consumer>(compaction_state, consumer(stop_at, final_stop))).get();
         const auto has_detached_state = bool(std::move(*compaction_state).detach_state());
         if (stop_at < inter_partition_frag_count) {
             BOOST_CHECK_EQUAL(has_detached_state, final_stop);
@@ -3718,7 +3718,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_validator) {
     mutation_fragment_v2 rtc_end(*s, permit, range_tombstone_change(position_in_partition::after_key(*s, cks[2]), tombstone{}));
     mutation_fragment_v2 pe(*s, permit, partition_end());
 
-    struct consumer_v2 {
+    struct consumer {
         void consume_new_partition(const dht::decorated_key& dk) { }
         void consume(const tombstone& t) { }
         stop_iteration consume(static_row&& sr, tombstone, bool) {
@@ -3751,7 +3751,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_validator) {
         auto close_reader = deferred_close(reader);
         bool is_valid = true;
         try {
-            reader.consume(compact_for_query<consumer_v2>(compaction_state, consumer_v2{})).get();
+            reader.consume(compact_for_query<consumer>(compaction_state, consumer{})).get();
         } catch (invalid_mutation_fragment_stream& ex) {
             is_valid = false;
         }

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -605,15 +605,15 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
             std::sort(mutations.begin(), mutations.end(), mutation_decorated_key_less_comparator());
 
             // Flush will happen in the middle of reading for this scanner
-            auto assert_that_scanner1 = assert_that(cf.make_reader_v2(s, env.make_reader_permit(),
+            auto assert_that_scanner1 = assert_that(cf.make_mutation_reader(s, env.make_reader_permit(),
                         query::full_partition_range));
 
             // Flush will happen before it is invoked
-            auto assert_that_scanner2 = assert_that(cf.make_reader_v2(s, env.make_reader_permit(),
+            auto assert_that_scanner2 = assert_that(cf.make_mutation_reader(s, env.make_reader_permit(),
                         query::full_partition_range));
 
             // Flush will happen after all data was read, but before EOS was consumed
-            auto assert_that_scanner3 = assert_that(cf.make_reader_v2(s, env.make_reader_permit(),
+            auto assert_that_scanner3 = assert_that(cf.make_mutation_reader(s, env.make_reader_permit(),
                         query::full_partition_range));
 
             assert_that_scanner1.produces(mutations[0]);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -5045,12 +5045,12 @@ void test_cache_tombstone_gc_overlap_checks_concurrent_singular_reads_scenario(c
 
     db.apply({ freeze(mut_v2) }, db::no_timeout).get();
 
-    auto reader1 = tbl.make_reader_v2(schema, db.obtain_reader_permit(tbl, "read1", db::no_timeout, {}).get(), pr, schema->full_slice());
+    auto reader1 = tbl.make_mutation_reader(schema, db.obtain_reader_permit(tbl, "read1", db::no_timeout, {}).get(), pr, schema->full_slice());
     const auto close_reader1 = deferred_close(reader1);
 
     reader1.fill_buffer().get();
 
-    auto reader2 = tbl.make_reader_v2(schema, db.obtain_reader_permit(tbl, "read2", db::no_timeout, {}).get(), pr, schema->full_slice());
+    auto reader2 = tbl.make_mutation_reader(schema, db.obtain_reader_permit(tbl, "read2", db::no_timeout, {}).get(), pr, schema->full_slice());
     const auto close_reader2 = deferred_close(reader2);
 
     reader2.fill_buffer().get();
@@ -5118,7 +5118,7 @@ void test_cache_tombstone_gc_overlap_checks_concurrent_scanning_reads_scenario(c
     assert_that(env.execute_cql(format("SELECT * FROM ks.{} WHERE pk = {} AND ck1 = {} and ck2 = {}", table_name, pk2, ck1, 0)).get()).is_rows();
 
     testlog.info("read 1");
-    auto reader1 = tbl.make_reader_v2(
+    auto reader1 = tbl.make_mutation_reader(
             schema,
             db.obtain_reader_permit(tbl, "read1", db::no_timeout, {}).get(),
             query::full_partition_range,
@@ -5128,7 +5128,7 @@ void test_cache_tombstone_gc_overlap_checks_concurrent_scanning_reads_scenario(c
     reader1.fill_buffer().get();
 
     testlog.info("read 2");
-    auto reader2 = tbl.make_reader_v2(
+    auto reader2 = tbl.make_mutation_reader(
             schema,
             db.obtain_reader_permit(tbl, "read2", db::no_timeout, {}).get(),
             query::full_partition_range,

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -52,14 +52,14 @@ future <> test_schema_changes_int(sstable_version_types sstable_vtype) {
         const auto pr = dht::partition_range::make_open_ended_both_sides();
 
         auto mr = assert_that(created_with_base_schema->as_mutation_source()
-                    .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
+                    .make_mutation_reader(changed, env.make_reader_permit(), pr, changed->full_slice()));
         for (auto& m : changed_mutations) {
             mr.produces(m);
         }
         mr.produces_end_of_stream();
 
         mr = assert_that(created_with_changed_schema->as_mutation_source()
-                .make_reader_v2(changed, env.make_reader_permit(), pr, changed->full_slice()));
+                .make_mutation_reader(changed, env.make_reader_permit(), pr, changed->full_slice()));
         for (auto& m : changed_mutations) {
             mr.produces(m);
         }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3017,7 +3017,7 @@ static mutation_reader compacted_sstable_reader(test_env& env, schema_ptr s,
     compaction_progress_monitor progress_monitor;
     sstables::compact_sstables(std::move(desc), cdata, cf->try_get_table_state_with_static_sharding(), progress_monitor).get();
 
-    return compacted_sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
+    return compacted_sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
 }
 
 SEASTAR_TEST_CASE(compact_deleted_row) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -190,7 +190,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_read) {
     BOOST_REQUIRE(val_cdef);
 
     auto to_expected = [val_cdef] (int val) {
-        return std::vector<flat_reader_assertions_v2::expected_column>{{val_cdef, int32_type->decompose(int32_t(val))}};
+        return std::vector<mutation_reader_assertions::expected_column>{{val_cdef, int32_type->decompose(int32_t(val))}};
     };
 
     // Sequential read
@@ -441,7 +441,7 @@ SEASTAR_TEST_CASE(test_uncompressed_skip_using_index_rows) {
     BOOST_REQUIRE(rc_cdef);
 
     auto to_expected = [rc_cdef] (sstring val) {
-        return std::vector<flat_reader_assertions_v2::expected_column>{{rc_cdef, utf8_type->decompose(val)}};
+        return std::vector<mutation_reader_assertions::expected_column>{{rc_cdef, utf8_type->decompose(val)}};
     };
     sstring rc_base(1024, 'b');
 
@@ -703,7 +703,7 @@ SEASTAR_TEST_CASE(test_uncompressed_filtering_and_forwarding_range_tombstones_re
     BOOST_REQUIRE(rc_cdef);
 
     auto to_expected = [rc_cdef] (int val) {
-        return std::vector<flat_reader_assertions_v2::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
+        return std::vector<mutation_reader_assertions::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
     };
 
     // Sequential read
@@ -999,7 +999,7 @@ SEASTAR_TEST_CASE(test_uncompressed_slicing_interleaved_rows_and_rts_read) {
     BOOST_REQUIRE(rc_cdef);
 
     auto to_expected = [rc_cdef] (int val) {
-        return std::vector<flat_reader_assertions_v2::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
+        return std::vector<mutation_reader_assertions::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
     };
 
     // Sequential read
@@ -1292,7 +1292,7 @@ SEASTAR_TEST_CASE(test_uncompressed_compound_static_row_read) {
     BOOST_REQUIRE(val_cdef);
 
     auto generate = [&] (int int_val, std::string_view text_val, std::string_view inet_val) {
-        std::vector<flat_reader_assertions_v2::expected_column> columns;
+        std::vector<mutation_reader_assertions::expected_column> columns;
 
         columns.push_back({s_int_cdef, int32_type->decompose(int_val)});
         columns.push_back({s_text_cdef, utf8_type->from_string(text_val)});
@@ -1508,7 +1508,7 @@ SEASTAR_TEST_CASE(test_uncompressed_counters_read) {
     BOOST_REQUIRE(cdef);
 
     auto generate = [&] (api::timestamp_type timestamp, int64_t value, int64_t clock) {
-        std::vector<flat_reader_assertions_v2::assert_function> assertions;
+        std::vector<mutation_reader_assertions::assert_function> assertions;
 
         assertions.push_back([&, timestamp, value, clock] (const column_definition& def,
                                                            const atomic_cell_or_collection* cell) {
@@ -1654,7 +1654,7 @@ static future<> test_partition_key_with_values_of_different_types_read(const sst
     auto generate = [&] (bool bool_val, double double_val, float float_val, int int_val, long long_val,
                          std::string_view timestamp_val, std::string_view timeuuid_val, std::string_view uuid_val,
                          std::string_view text_val) {
-        std::vector<flat_reader_assertions_v2::expected_column> columns;
+        std::vector<mutation_reader_assertions::expected_column> columns;
 
         columns.push_back({bool_cdef, boolean_type->decompose(bool_val)});
         columns.push_back({double_cdef, double_type->decompose(double_val)});
@@ -1784,7 +1784,7 @@ SEASTAR_TEST_CASE(test_zstd_compression) {
         return dht::decorate_key(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, pk);
     };
 
-    flat_reader_assertions_v2 assertions(sst.make_reader());
+    mutation_reader_assertions assertions(sst.make_reader());
     assertions.produces_partition_start(to_key(0));
     for (int i = 1; i <= 2000; ++i) {
         assertions.produces_row_with_key(clustering_key::from_exploded(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, {int32_type->decompose(i)}));
@@ -1893,7 +1893,7 @@ SEASTAR_TEST_CASE(test_uncompressed_subset_of_columns_read) {
                          std::optional<float> float_val, std::optional<int> int_val, std::optional<long> long_val,
                          std::optional<std::string_view> timestamp_val, std::optional<std::string_view> timeuuid_val,
                          std::optional<std::string_view> uuid_val, std::optional<std::string_view> text_val) {
-        std::vector<flat_reader_assertions_v2::expected_column> columns;
+        std::vector<mutation_reader_assertions::expected_column> columns;
 
         if (bool_val) {
             columns.push_back({bool_cdef, boolean_type->decompose(*bool_val)});
@@ -2100,7 +2100,7 @@ SEASTAR_TEST_CASE(test_uncompressed_large_subset_of_columns_sparse_read) {
     }
 
     auto generate = [&] (const std::vector<std::pair<int, int>>& column_values) {
-        std::vector<flat_reader_assertions_v2::expected_column> columns;
+        std::vector<mutation_reader_assertions::expected_column> columns;
 
         for (auto& p : column_values) {
             columns.push_back({column_defs[p.first - 1], int32_type->decompose(p.second)});
@@ -2318,7 +2318,7 @@ SEASTAR_TEST_CASE(test_uncompressed_large_subset_of_columns_dense_read) {
     }
 
     auto generate = [&] (const std::vector<std::pair<int, int>>& column_values) {
-        std::vector<flat_reader_assertions_v2::expected_column> columns;
+        std::vector<mutation_reader_assertions::expected_column> columns;
 
         for (auto& p : column_values) {
             columns.push_back({column_defs[p.first - 1], int32_type->decompose(p.second)});
@@ -2424,7 +2424,7 @@ SEASTAR_TEST_CASE(test_uncompressed_deleted_cells_read) {
     BOOST_REQUIRE(int_cdef);
 
     auto generate = [&] (uint64_t timestamp, uint64_t deletion_time) {
-        std::vector<flat_reader_assertions_v2::assert_function> assertions;
+        std::vector<mutation_reader_assertions::assert_function> assertions;
 
         assertions.push_back([timestamp, deletion_time] (const column_definition& def,
                                  const atomic_cell_or_collection* cell) {
@@ -2893,7 +2893,7 @@ SEASTAR_TEST_CASE(test_uncompressed_collections_read) {
     BOOST_REQUIRE(map_cdef);
 
     auto generate = [&] (std::vector<int> set_val, std::vector<sstring> list_val, std::vector<std::pair<int, sstring>> map_val) {
-        std::vector<flat_reader_assertions_v2::assert_function> assertions;
+        std::vector<mutation_reader_assertions::assert_function> assertions;
 
         assertions.push_back([val = std::move(set_val)] (const column_definition& def,
                                                          const atomic_cell_or_collection* cell) {
@@ -4733,7 +4733,7 @@ SEASTAR_TEST_CASE(test_uncompressed_read_two_rows_fast_forwarding) {
     BOOST_REQUIRE(rc_cdef);
 
     auto to_expected = [rc_cdef] (int val) {
-        return std::vector<flat_reader_assertions_v2::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
+        return std::vector<mutation_reader_assertions::expected_column>{{rc_cdef, int32_type->decompose(int32_t(val))}};
     };
 
     auto r = assert_that(sst.make_reader(query::full_partition_range,
@@ -5587,7 +5587,7 @@ SEASTAR_TEST_CASE(test_compression_premature_eof) {
             return dht::decorate_key(*ZSTD_MULTIPLE_CHUNKS_SCHEMA, pk);
         };
 
-        flat_reader_assertions_v2 assertions(sst.make_reader());
+        mutation_reader_assertions assertions(sst.make_reader());
         try {
             assertions.produces_partition_start(to_key(0));
             BOOST_FAIL("produces_partition_start unexpectedly");

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -3725,7 +3725,7 @@ SEASTAR_TEST_CASE(purged_tombstone_consumer_sstable_test) {
             auto gc_now = gc_clock::now();
             gc_before = gc_now - s->gc_grace_seconds();
 
-            auto cfc = compact_for_compaction_v2<compacting_sstable_writer_test, compacting_sstable_writer_test>(
+            auto cfc = compact_for_compaction<compacting_sstable_writer_test, compacting_sstable_writer_test>(
                 *s, gc_now, max_purgeable_func, tombstone_gc_state(nullptr), std::move(cr), std::move(purged_cr));
 
             auto cs = sstables::make_compaction_strategy(sstables::compaction_strategy_type::size_tiered, s->compaction_strategy_options());

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -263,12 +263,12 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                 auto prange = dht::partition_range::make_singular(m.decorated_key());
 
                 {
-                    auto r1 = source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
+                    auto r1 = source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                             slice, nullptr,
                             streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
                     auto close_r1 = deferred_action([&r1] { r1.close().get(); });
 
-                    auto r2 = rev_source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
+                    auto r2 = rev_source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                             rev_slice, nullptr,
                             streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
                     close_r1.cancel();
@@ -276,12 +276,12 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_reversing_reader_random_schema) {
                     compare_readers(*query_schema, std::move(r1), std::move(r2), true);
                 }
 
-                auto r1 = source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
+                auto r1 = source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                         query_schema->full_slice(), nullptr,
                         streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
                 auto close_r1 = deferred_action([&r1] { r1.close().get(); });
 
-                auto r2 = rev_source.make_reader_v2(query_schema, semaphore.make_permit(), prange,
+                auto r2 = rev_source.make_mutation_reader(query_schema, semaphore.make_permit(), prange,
                         rev_full_slice, nullptr,
                         streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
                 close_r1.cancel();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -288,12 +288,12 @@ SEASTAR_TEST_CASE(datafile_generation_16_s3, *boost::unit_test::precondition(tes
 }
 
 // mutation_reader for sstable keeping all the required objects alive.
-static mutation_reader sstable_reader_v2(shared_sstable sst, schema_ptr s, reader_permit permit) {
+static mutation_reader sstable_mutation_reader(shared_sstable sst, schema_ptr s, reader_permit permit) {
     return sst->as_mutation_source().make_mutation_reader(s, std::move(permit), query::full_partition_range, s->full_slice());
 
 }
 
-static mutation_reader sstable_reader_v2(shared_sstable sst, schema_ptr s, reader_permit permit, const dht::partition_range& pr) {
+static mutation_reader sstable_mutation_reader(shared_sstable sst, schema_ptr s, reader_permit permit, const dht::partition_range& pr) {
     return sst->as_mutation_source().make_mutation_reader(s, std::move(permit), pr, s->full_slice());
 }
 
@@ -409,7 +409,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(512*1024, 'a')));
 
         auto sstp = make_sstable_containing(env.make_sstable(s), {std::move(m)});
-        auto reader = sstable_reader_v2(sstp, s, env.make_reader_permit());
+        auto reader = sstable_mutation_reader(sstp, s, env.make_reader_permit());
         auto close_reader = deferred_close(reader);
         while (reader().get()) {
         }
@@ -452,7 +452,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
         m.set_clustered_cell(c_key2, r1_col, make_dead_atomic_cell(1));
 
         auto sstp = make_sstable_containing(env.make_sstable(s), {m});
-        assert_that(sstable_reader_v2(sstp, s, env.make_reader_permit()))
+        assert_that(sstable_mutation_reader(sstp, s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
     });
@@ -511,7 +511,7 @@ SEASTAR_TEST_CASE(check_multi_schema) {
                 auto s = builder.build();
 
                 auto sst = env.reusable_sst(s, get_test_dir("multi_schema_test", s), 1, version).get();
-                auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
+                auto reader = sstable_mutation_reader(sst, s, env.make_reader_permit());
                 auto close_reader = deferred_close(reader);
                 std::invoke([&] {
                     mutation_opt m = read_mutation_from_mutation_reader(reader).get();
@@ -702,7 +702,7 @@ SEASTAR_TEST_CASE(test_wrong_range_tombstone_order) {
         auto dkey = dht::decorate_key(*s, std::move(pkey));
 
         auto sst = env.reusable_sst(s, get_test_dir("wrong_range_tombstone_order", s), 1, version).get();
-        auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
+        auto reader = sstable_mutation_reader(sst, s, env.make_reader_permit());
 
         using kind = mutation_fragment_v2::kind;
         assert_that(std::move(reader))
@@ -769,7 +769,7 @@ SEASTAR_TEST_CASE(test_counter_read) {
             auto node2 = counter_id(utils::UUID("b8a6c3f3-e222-433f-9ce9-de56a8466e07"));
 
             auto sst = env.reusable_sst(s, get_test_dir("counter_test", s), 5, version).get();
-            auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
+            auto reader = sstable_mutation_reader(sst, s, env.make_reader_permit());
             auto close_reader = deferred_close(reader);
 
             auto mfopt = reader().get();
@@ -897,7 +897,7 @@ SEASTAR_TEST_CASE(test_promoted_index_read) {
         auto ck2 = clustering_key::from_exploded(*s, {int32_type->decompose(0), int32_type->decompose(0)});
         auto ck3 = clustering_key::from_exploded(*s, {int32_type->decompose(0), int32_type->decompose(1)});
 
-        auto rd = sstable_reader_v2(sst, s, env.make_reader_permit());
+        auto rd = sstable_mutation_reader(sst, s, env.make_reader_permit());
         using kind = mutation_fragment_v2::kind;
         assert_that(std::move(rd))
                 .produces_partition_start(dkey)
@@ -1575,10 +1575,10 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
         dht::decorated_key::less_comparator cmp(s);
         std::sort(keys.begin(), keys.end(), cmp);
 
-        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit())).produces(keys);
+        assert_that(sstable_mutation_reader(sst, s, env.make_reader_permit())).produces(keys);
 
         auto pr = dht::partition_range::make(dht::ring_position(keys[0]), dht::ring_position(keys[1]));
-        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_mutation_reader(sst, s, env.make_reader_permit(), pr))
             .produces(keys[0])
             .produces(keys[1])
             .produces_end_of_stream()
@@ -1588,7 +1588,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream();
 
         pr = dht::partition_range::make(dht::ring_position(keys[1]), dht::ring_position(keys[1]));
-        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_mutation_reader(sst, s, env.make_reader_permit(), pr))
             .produces(keys[1])
             .produces_end_of_stream()
             .fast_forward_to(dht::partition_range::make(dht::ring_position(keys[3]), dht::ring_position(keys[4])))
@@ -1608,7 +1608,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream();
 
         pr = dht::partition_range::make({ dht::ring_position(keys[0]), false }, { dht::ring_position(keys[1]), false});
-        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_mutation_reader(sst, s, env.make_reader_permit(), pr))
             .produces_end_of_stream()
             .fast_forward_to(dht::partition_range::make(dht::ring_position(keys[6]), dht::ring_position(keys[6])))
             .produces(keys[6])
@@ -1617,7 +1617,7 @@ SEASTAR_TEST_CASE(test_partition_skipping) {
             .produces_end_of_stream();
 
         pr = dht::partition_range::make(dht::ring_position(keys[0]), dht::ring_position(keys[1]));
-        assert_that(sstable_reader_v2(sst, s, env.make_reader_permit(), pr))
+        assert_that(sstable_mutation_reader(sst, s, env.make_reader_permit(), pr))
             .fast_forward_to(dht::partition_range::make(dht::ring_position::starting_at(keys[0].token()), dht::ring_position::ending_at(keys[1].token())))
             .produces(keys[0])
             .produces(keys[1])
@@ -2150,7 +2150,7 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
                     .build();
 
             auto sst = env.reusable_sst(s, get_test_dir("wrong_counter_shard_order", s), 2, version).get();
-            auto reader = sstable_reader_v2(sst, s, env.make_reader_permit());
+            auto reader = sstable_mutation_reader(sst, s, env.make_reader_permit());
             auto close_reader = deferred_close(reader);
 
             auto verify_row = [&s] (mutation_fragment_v2_opt mfopt, int64_t expected_value) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -448,7 +448,7 @@ SEASTAR_TEST_CASE(broken_ranges_collection) {
     return test_env::do_with_async([] (test_env& env) {
         auto sstp = env.reusable_sst(peers_schema(), "test/resource/sstables/broken_ranges", generation_type{2}).get();
         auto s = peers_schema();
-        auto reader = sstp->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), query::full_partition_range);
+        auto reader = sstp->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), query::full_partition_range);
         auto close_r = deferred_close(reader);
         while (true) {
             mutation_opt mut = read_mutation_from_mutation_reader(reader).get();
@@ -915,7 +915,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
 
         {
             auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck1})).build();
-            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m, slice.get_all_ranges())
                     .produces_end_of_stream();
         }
@@ -964,7 +964,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
 
         {
             auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck1})).build();
-            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m)
                     .produces_end_of_stream();
         }
@@ -1006,7 +1006,7 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
 
             {
                 auto slice = partition_slice_builder(*s).with_range(query::clustering_range::make_starting_with({ck})).build();
-                assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+                assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                         .produces(m, slice.get_all_ranges())
                         .produces_end_of_stream();
             }
@@ -1041,7 +1041,7 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
 
         {
             auto slice = partition_slice_builder(*s).build();
-            assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
+            assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), dht::partition_range::make_singular(dk), slice))
                     .produces(m)
                     .produces_end_of_stream();
         }
@@ -1104,7 +1104,7 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
             mt1->make_mutation_reader(s, combined_permit), mt2->make_mutation_reader(s, combined_permit));
         auto sst = make_sstable_easy(env, std::move(mr), env.manager().configure_writer(), version);
 
-        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
+        assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit()))
             .produces(m1 + m2)
             .produces_end_of_stream();
       }
@@ -1141,7 +1141,7 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
             auto before = index_accesses();
 
             {
-                assert_that(ms.make_reader_v2(s, env.make_reader_permit()))
+                assert_that(ms.make_mutation_reader(s, env.make_reader_permit()))
                     .produces(m1)
                     .produces(m2)
                     .produces_end_of_stream();
@@ -1281,7 +1281,7 @@ SEASTAR_TEST_CASE(test_large_index_pages_do_not_cause_large_allocations) {
 
     auto t0 = std::chrono::steady_clock::now();
     auto large_allocs_before = memory::stats().large_allocations();
-    mutation actual = *with_closeable(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit(), pr), [] (auto& sst_reader) {
+    mutation actual = *with_closeable(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit(), pr), [] (auto& sst_reader) {
         return read_mutation_from_mutation_reader(sst_reader);
     }).get();
     auto large_allocs_after = memory::stats().large_allocations();
@@ -1425,7 +1425,7 @@ SEASTAR_TEST_CASE(test_counter_header_size) {
     auto mt = make_memtable(s, {m});
     for (const auto version : writable_sstable_versions) {
         auto sst = make_sstable_easy(env, mt, env.manager().configure_writer(), version);
-        assert_that(sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()))
+        assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
     }
@@ -1460,7 +1460,7 @@ SEASTAR_TEST_CASE(test_static_compact_tables_are_read) {
 
             auto ms = make_sstable_mutation_source(env, s, muts, version);
 
-            assert_that(ms.make_reader_v2(s, env.make_reader_permit()))
+            assert_that(ms.make_mutation_reader(s, env.make_reader_permit()))
                 .produces(muts[0])
                 .produces(muts[1])
                 .produces_end_of_stream();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -718,7 +718,7 @@ SEASTAR_TEST_CASE(buffer_overflow) {
                 mutation_fragment_v2(*s, env.make_reader_permit(), partition_start(dk1, rt1_before.tombstone())).memory_usage()
                     + mutation_fragment_v2(*s, env.make_reader_permit(), range_tombstone_change(rt1_before)).memory_usage(),
                 mutation_fragment_v2(*s, env.make_reader_permit(), clustering_row(ck1)).memory_usage()));
-    flat_reader_assertions_v2 rd(std::move(r));
+    mutation_reader_assertions rd(std::move(r));
     rd.produces_partition_start(dk1)
         .produces_range_tombstone_change(rt1_before)
         .produces_row_with_key(ck1)

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -127,7 +127,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
         BOOST_REQUIRE(processed_shards.insert(shard).second == true); // check resharding created one sstable per shard.
         assert_sstable_computes_correct_owners(env, new_sst).get();
 
-        auto rd = assert_that(new_sst->as_mutation_source().make_reader_v2(s, env.make_reader_permit()));
+        auto rd = assert_that(new_sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit()));
         BOOST_REQUIRE(muts[shard].size() == keys_per_shard);
         for (auto k : std::views::iota(0u, keys_per_shard)) {
             rd.produces(muts[shard][k]);

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -831,7 +831,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
         auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
 
         auto mt = make_memtable(schema, muts);
-        auto p = make_manually_paused_evictable_reader_v2(
+        auto p = make_manually_paused_evictable_reader(
                 mt->as_data_source(),
                 schema,
                 permit,
@@ -930,7 +930,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     const abort_source as;
     auto mt = make_memtable(schema, {mut});
     auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
-    auto p = make_manually_paused_evictable_reader_v2(
+    auto p = make_manually_paused_evictable_reader(
             mt->as_data_source(),
             schema,
             permit,
@@ -993,7 +993,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_empty_mutatio
     auto stop_sem = deferred_stop(sem);
     auto permit = sem.make_tracking_only_permit(schema, "test", db::no_timeout, {});
     abort_source as;
-    auto [staging_reader, staging_reader_handle] = make_manually_paused_evictable_reader_v2(make_empty_mutation_source(), schema, permit,
+    auto [staging_reader, staging_reader_handle] = make_manually_paused_evictable_reader(make_empty_mutation_source(), schema, permit,
             query::full_partition_range, schema->full_slice(), {}, mutation_reader::forwarding::no);
     auto close_staging_reader = deferred_close(staging_reader);
     bool buffer_flushed = false;

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -69,7 +69,7 @@ SEASTAR_THREAD_TEST_CASE(test_streaming_vt_as_mutation_source) {
                 tracing::trace_state_ptr trace_state,
                 streamed_mutation::forwarding stream_fwd,
                 mutation_reader::forwarding) {
-            return ms.make_reader_v2(s, permit, pr, slice, trace_state, stream_fwd, mutation_reader::forwarding::no);
+            return ms.make_mutation_reader(s, permit, pr, slice, trace_state, stream_fwd, mutation_reader::forwarding::no);
         });
     }, false /* with_partition_range_forwarding */);
 }

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -170,7 +170,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                 auto test_common = [&] (const query::partition_slice& slice) {
                     testlog.info("Read whole partitions at once");
                     auto pranges_walker = partition_range_walker(pranges);
-                    auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                    auto mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
                                                 nullptr, streamed_mutation::forwarding::no, fwd_mr);
                     auto actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
@@ -197,7 +197,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
                     testlog.info("Read partitions with fast-forwarding to each individual row");
                     pranges_walker = partition_range_walker(pranges);
-                    mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                    mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
                                            nullptr, streamed_mutation::forwarding::yes, fwd_mr);
                     actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
@@ -233,14 +233,14 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                 test_common(slice);
 
                 testlog.info("Test monotonic positions");
-                auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
+                auto mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
                                             nullptr, streamed_mutation::forwarding::no, fwd_mr);
                 assert_that(std::move(mr)).has_monotonic_positions();
 
                 if (range_size != 1) {
                     testlog.info("Read partitions fast-forwarded to the range of interest");
                     auto pranges_walker = partition_range_walker(pranges);
-                    mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                    mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
                                            nullptr, streamed_mutation::forwarding::yes, fwd_mr);
                     auto actual = assert_that(std::move(mr));
                     for (auto& expected : mutations) {
@@ -280,7 +280,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
 
                 testlog.info("Read partitions with just static rows");
                 auto pranges_walker = partition_range_walker(pranges);
-                mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
+                mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pranges_walker.initial_range(), slice,
                                        nullptr, streamed_mutation::forwarding::no, fwd_mr);
                 auto actual = assert_that(std::move(mr));
                 for (auto& expected : mutations) {
@@ -307,7 +307,7 @@ static void test_slicing_and_fast_forwarding(tests::reader_concurrency_semaphore
                     test_common(slice);
 
                     testlog.info("Test monotonic positions");
-                    auto mr = ms.make_reader_v2(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
+                    auto mr = ms.make_mutation_reader(s.schema(), semaphore.make_permit(), query::full_partition_range, slice,
                                                 nullptr, streamed_mutation::forwarding::no, fwd_mr);
                     assert_that(std::move(mr)).has_monotonic_positions();
                 }
@@ -377,11 +377,11 @@ static void test_streamed_mutation_forwarding_is_consistent_with_slicing(tests::
 
         mutation_source ms = populate(m.schema(), {m}, gc_clock::now());
 
-        auto sliced_reader = ms.make_reader_v2(m.schema(), semaphore.make_permit(), prange, slice_with_ranges);
+        auto sliced_reader = ms.make_mutation_reader(m.schema(), semaphore.make_permit(), prange, slice_with_ranges);
         auto close_sliced_reader = deferred_close(sliced_reader);
 
         auto fwd_reader =
-            ms.make_reader_v2(m.schema(), semaphore.make_permit(), prange, full_slice, nullptr, streamed_mutation::forwarding::yes);
+            ms.make_mutation_reader(m.schema(), semaphore.make_permit(), prange, full_slice, nullptr, streamed_mutation::forwarding::yes);
         std::vector<position_range> position_ranges;
         for (auto& r: ranges) {
             position_ranges.emplace_back(r);
@@ -423,7 +423,7 @@ static void test_streamed_mutation_forwarding_guarantees(tests::reader_concurren
 
     auto new_stream = [&ms, s, &semaphore, &m] () -> flat_reader_assertions_v2 {
         testlog.info("Creating new streamed_mutation");
-        auto res = assert_that(ms.make_reader_v2(s,
+        auto res = assert_that(ms.make_mutation_reader(s,
             semaphore.make_permit(),
             query::full_partition_range,
             s->full_slice(),
@@ -558,7 +558,7 @@ static void test_fast_forwarding_across_partitions_to_empty_range(tests::reader_
     mutation_source ms = populate(s, partitions, gc_clock::now());
 
     auto pr = dht::partition_range::make({keys[0]}, {keys[1]});
-    auto rd = assert_that(ms.make_reader_v2(s,
+    auto rd = assert_that(ms.make_mutation_reader(s,
         semaphore.make_permit(),
         pr,
         s->full_slice(),
@@ -660,7 +660,7 @@ static void test_streamed_mutation_slicing_returns_only_relevant_tombstones(test
             ))
             .build();
 
-        auto rd = assert_that(ms.make_reader_v2(s, semaphore.make_permit(), pr, slice));
+        auto rd = assert_that(ms.make_mutation_reader(s, semaphore.make_permit(), pr, slice));
 
         auto rt3_trimmed = rt3; trim_range_tombstone(*s, rt3_trimmed, slice.row_ranges(*s, m.key()));
         auto rt4_trimmed = rt4; trim_range_tombstone(*s, rt4_trimmed, slice.row_ranges(*s, m.key()));
@@ -684,7 +684,7 @@ static void test_streamed_mutation_slicing_returns_only_relevant_tombstones(test
             ))
             .build();
 
-        auto rd = assert_that(ms.make_reader_v2(s, semaphore.make_permit(), pr, slice));
+        auto rd = assert_that(ms.make_mutation_reader(s, semaphore.make_permit(), pr, slice));
 
         auto rt3_trimmed = rt3; trim_range_tombstone(*s, rt3_trimmed, slice.row_ranges(*s, m.key()));
         auto rt4_trimmed = rt4; trim_range_tombstone(*s, rt4_trimmed, slice.row_ranges(*s, m.key()));
@@ -747,7 +747,7 @@ static void test_streamed_mutation_forwarding_across_range_tombstones(tests::rea
     auto rt5 = table.delete_range(m, rt5_range);
 
     mutation_source ms = populate(s, std::vector<mutation>({m}), gc_clock::now());
-    auto rd = assert_that(ms.make_reader_v2(s,
+    auto rd = assert_that(ms.make_mutation_reader(s,
         semaphore.make_permit(),
         query::full_partition_range,
         s->full_slice(),
@@ -847,7 +847,7 @@ static void test_range_queries(tests::reader_concurrency_semaphore_wrapper& sema
 
     auto test_slice = [&] (dht::partition_range r) {
         testlog.info("Testing range {}", r);
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), r))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), r))
             .produces(slice(partitions, r))
             .produces_end_of_stream();
     };
@@ -951,7 +951,7 @@ void test_all_data_is_read_back(tests::reader_concurrency_semaphore_wrapper& sem
         auto ms = populate(m.schema(), {m}, query_time);
         mutation copy(m);
         copy.partition().compact_for_compaction(*copy.schema(), always_gc, copy.decorated_key(), query_time, tombstone_gc_state(nullptr));
-        assert_that(ms.make_reader_v2(m.schema(), semaphore.make_permit())).produces_compacted(copy, query_time);
+        assert_that(ms.make_mutation_reader(m.schema(), semaphore.make_permit())).produces_compacted(copy, query_time);
     });
 }
 
@@ -961,7 +961,7 @@ void test_mutation_reader_fragments_have_monotonic_positions(tests::reader_concu
     for_each_mutation([&semaphore, &populate] (const mutation& m) {
         auto ms = populate(m.schema(), {m}, gc_clock::now());
 
-        auto rd = ms.make_reader_v2(m.schema(), semaphore.make_permit());
+        auto rd = ms.make_mutation_reader(m.schema(), semaphore.make_permit());
         assert_that(std::move(rd)).has_monotonic_positions();
     });
 }
@@ -990,7 +990,7 @@ static void test_time_window_clustering_slicing(tests::reader_concurrency_semaph
             .with_range(ss.make_ckey_range(1, 2))
             .build();
         auto prange = dht::partition_range::make_singular(pkey);
-        assert_that(ms.make_reader_v2(s, semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s, semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s, pkey.key()))
             .produces_end_of_stream();
     }
@@ -1000,7 +1000,7 @@ static void test_time_window_clustering_slicing(tests::reader_concurrency_semaph
             .with_range(query::clustering_range::make_singular(ss.make_ckey(0)))
             .build();
         auto prange = dht::partition_range::make_singular(pkey);
-        assert_that(ms.make_reader_v2(s, semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s, semaphore.make_permit(), prange, slice))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1079,14 +1079,14 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(0)))
             .build();
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice))
             .produces_eos_or_empty_mutation();
     }
 
     {
         auto slice = partition_slice_builder(*s)
             .build();
-        auto rd = assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice, nullptr, streamed_mutation::forwarding::yes));
+        auto rd = assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice, nullptr, streamed_mutation::forwarding::yes));
         rd.produces_partition_start(pk)
           .fast_forward_to(position_range(position_in_partition::for_key(ck1), position_in_partition::after_key(*s, ck2)))
           .produces_row_with_key(ck1)
@@ -1097,7 +1097,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
     {
         auto slice = partition_slice_builder(*s)
             .build();
-        auto rd = assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice, nullptr, streamed_mutation::forwarding::yes));
+        auto rd = assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice, nullptr, streamed_mutation::forwarding::yes));
         rd.produces_partition_start(pk)
           .produces_end_of_stream()
           .fast_forward_to(position_range(position_in_partition::for_key(ck1), position_in_partition::after_key(*s, ck2)))
@@ -1109,7 +1109,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(1)))
             .build();
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice))
             .produces(row1 + row2 + row3 + row4 + row5 + del_1, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1117,7 +1117,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(2)))
             .build();
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice))
             .produces(row6 + row7 + del_1 + del_2, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1126,7 +1126,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(1, 2)))
             .build();
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice))
             .produces(row3 + row4 + del_1, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1135,7 +1135,7 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
         auto slice = partition_slice_builder(*s)
             .with_range(query::clustering_range::make_singular(make_ck(3)))
             .build();
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, slice))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, slice))
             .produces(row8 + del_3, slice.row_ranges(*s, pk.key()))
             .produces_end_of_stream();
     }
@@ -1143,12 +1143,12 @@ static void test_clustering_slices(tests::reader_concurrency_semaphore_wrapper& 
     // Test out-of-range partition keys
     {
         auto pr = dht::partition_range::make_singular(keys[0]);
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, s->full_slice()))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, s->full_slice()))
             .produces_eos_or_empty_mutation();
     }
     {
         auto pr = dht::partition_range::make_singular(keys[2]);
-        assert_that(ds.make_reader_v2(s, semaphore.make_permit(), pr, s->full_slice()))
+        assert_that(ds.make_mutation_reader(s, semaphore.make_permit(), pr, s->full_slice()))
             .produces_eos_or_empty_mutation();
     }
 }
@@ -1171,7 +1171,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
     // fully populate cache
     {
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1182,7 +1182,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1193,7 +1193,7 @@ static void test_query_only_static_row(tests::reader_concurrency_semaphore_wrapp
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_singular(m1.decorated_key());
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1215,7 +1215,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
 
     {
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, s.schema()->full_slice()))
             .produces(m1)
             .produces_end_of_stream();
     }
@@ -1226,7 +1226,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_ending_with(dht::ring_position(m1.decorated_key()));
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1237,7 +1237,7 @@ static void test_query_no_clustering_ranges_no_static_columns(tests::reader_conc
             .with_ranges({})
             .build();
         auto prange = dht::partition_range::make_singular(m1.decorated_key());
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), prange, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), prange, slice))
             .produces(m1, slice.row_ranges(*s.schema(), m1.key()))
             .produces_end_of_stream();
     }
@@ -1254,7 +1254,7 @@ void test_streamed_mutation_forwarding_succeeds_with_no_data(tests::reader_concu
     s.add_row(m, cks[0], "data");
 
     auto source = populate(s.schema(), {m}, gc_clock::now());
-    assert_that(source.make_reader_v2(s.schema(),
+    assert_that(source.make_mutation_reader(s.schema(),
                 semaphore.make_permit(),
                 query::full_partition_range,
                 s.schema()->full_slice(),
@@ -1305,7 +1305,7 @@ void test_slicing_with_overlapping_range_tombstones(tests::reader_concurrency_se
 
     {
         auto slice = partition_slice_builder(*s).with_range(range).build();
-        auto rd = ds.make_reader_v2(s, semaphore.make_permit(), query::full_partition_range, slice);
+        auto rd = ds.make_mutation_reader(s, semaphore.make_permit(), query::full_partition_range, slice);
         auto close_rd = deferred_close(rd);
 
         auto prange = position_range(range);
@@ -1385,7 +1385,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
     auto ms = populate(s.schema(), mutations, gc_clock::now());
     auto pr = dht::partition_range::make_singular(pkey);
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit()))
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit()))
             .next_partition() // Does nothing before first partition
             .produces_partition_start(pkey)
             .produces_row_with_key(s.make_ckey(0))
@@ -1399,7 +1399,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_partition_end()
             .produces_end_of_stream();
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1422,7 +1422,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_range_tombstone_change(range_tombstone_change(position_in_partition::after_key(*s.schema(), s.make_ckey(5)), {}))
             .produces_end_of_stream();
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1436,7 +1436,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_range_tombstone_change(range_tombstone_change(position_in_partition_view::before_key(s.make_ckey(2)), {}))
             .produces_end_of_stream();
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1458,7 +1458,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_end_of_stream();
 
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1474,7 +1474,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_range_tombstone_change({position_in_partition_view::before_key(s.make_ckey(6)), {}})
             .produces_end_of_stream();
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1489,7 +1489,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
             .produces_range_tombstone_change({position_in_partition_view::before_key(s.make_ckey(7)), {}})
             .produces_end_of_stream();
 
-    assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr,
+    assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr,
                                   s.schema()->full_slice(),
                                   nullptr,
                                   streamed_mutation::forwarding::yes,
@@ -1537,7 +1537,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
         auto slice = partition_slice_builder(*s.schema())
                 .with_range(s.make_ckey_range(16, 18))
                 .build();
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr, slice))
                 .produces_partition_start(pkey)
                 .produces_range_tombstone_change({position_in_partition_view::before_key(s.make_ckey(17)), t3})
                 .produces_range_tombstone_change({position_in_partition::after_key(*s.schema(), s.make_ckey(18)), {}})
@@ -1550,7 +1550,7 @@ void test_range_tombstones_v2(tests::reader_concurrency_semaphore_wrapper& semap
                 .with_range(s.make_ckey_range(0, 3))
                 .with_range(s.make_ckey_range(8, 11))
                 .build();
-        assert_that(ms.make_reader_v2(s.schema(), semaphore.make_permit(), pr, slice))
+        assert_that(ms.make_mutation_reader(s.schema(), semaphore.make_permit(), pr, slice))
                 .produces_partition_start(pkey)
                 .produces_row_with_key(s.make_ckey(0))
                 .produces_range_tombstone_change(range_tombstone_change(position_in_partition_view::before_key(s.make_ckey(1)), t1))
@@ -1643,7 +1643,7 @@ void test_next_partition(tests::reader_concurrency_semaphore_wrapper& semaphore,
         mutations.push_back(std::move(m));
     }
     auto source = populate(s.schema(), mutations, gc_clock::now());
-    assert_that(source.make_reader_v2(s.schema(), semaphore.make_permit()))
+    assert_that(source.make_mutation_reader(s.schema(), semaphore.make_permit()))
         .next_partition() // Does nothing before first partition
         .produces_partition_start(pkeys[0])
         .produces_static_row()
@@ -1731,7 +1731,7 @@ static mutation_source make_mutation_source(populate_fn_ex populate, schema_ptr 
         reversed_slices.emplace_back(partition_slice_builder(*table_schema, slice)
                 .with_option<query::partition_slice::option::reversed>()
                 .build());
-        return ms.make_reader_v2(query_schema, std::move(permit), pr, reversed_slices.back(), tr, fwd, mr_fwd);
+        return ms.make_mutation_reader(query_schema, std::move(permit), pr, reversed_slices.back(), tr, fwd, mr_fwd);
     });
 }
 

--- a/test/lib/reader_lifecycle_policy.hh
+++ b/test/lib/reader_lifecycle_policy.hh
@@ -13,7 +13,7 @@
 #include <seastar/core/gate.hh>
 
 class test_reader_lifecycle_policy
-        : public reader_lifecycle_policy_v2
+        : public reader_lifecycle_policy
         , public enable_shared_from_this<test_reader_lifecycle_policy> {
 public:
     using reader_factory_function = std::function<mutation_reader(

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -82,7 +82,7 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, s
         }
 
         // validate the sstable
-        auto rd = assert_that(sst->as_mutation_source().make_reader_v2(s, semaphore.make_permit()));
+        auto rd = assert_that(sst->as_mutation_source().make_mutation_reader(s, semaphore.make_permit()));
         for (auto&& m : merged) {
             rd.produces(m);
         }

--- a/test/perf/perf_fast_forward.cc
+++ b/test/perf/perf_fast_forward.cc
@@ -811,7 +811,7 @@ public:
 // cf should belong to ks.test
 static test_result scan_rows_with_stride(replica::column_family& cf, clustered_ds& ds, int n_rows, int n_read = 1, int n_skip = 0) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    auto rd = cf.make_reader_v2(cf.schema(),
+    auto rd = cf.make_mutation_reader(cf.schema(),
         semaphore.make_permit(),
         query::full_partition_range,
         cf.schema()->full_slice(),
@@ -858,7 +858,7 @@ static test_result scan_with_stride_partitions(replica::column_family& cf, int n
     int pk = 0;
     auto pr = n_skip ? dht::partition_range::make_ending_with(dht::partition_range::bound(keys[0], false)) // covering none
                      : query::full_partition_range;
-    auto rd = cf.make_reader_v2(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice());
+    auto rd = cf.make_mutation_reader(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice());
     auto close_rd = deferred_close(rd);
 
     metrics_snapshot before;
@@ -881,7 +881,7 @@ static test_result scan_with_stride_partitions(replica::column_family& cf, int n
 
 static test_result slice_rows(replica::column_family& cf, clustered_ds& ds, int offset = 0, int n_read = 1) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
-    auto rd = cf.make_reader_v2(cf.schema(),
+    auto rd = cf.make_mutation_reader(cf.schema(),
         semaphore.make_permit(),
         query::full_partition_range,
         cf.schema()->full_slice(),
@@ -913,7 +913,7 @@ static test_result slice_rows_by_ck(replica::column_family& cf, clustered_ds& ds
             ds.make_ck(*cf.schema(), offset + n_read - 1)))
         .build();
     auto pr = dht::partition_range::make_singular(dht::decorate_key(*cf.schema(), ds.make_pk(*cf.schema())));
-    auto rd = cf.make_reader_v2(cf.schema(), semaphore.make_permit(), pr, slice);
+    auto rd = cf.make_mutation_reader(cf.schema(), semaphore.make_permit(), pr, slice);
     auto close_rd = deferred_close(rd);
 
     return test_reading_all(rd);
@@ -928,7 +928,7 @@ static test_result select_spread_rows(replica::column_family& cf, clustered_ds& 
 
     auto slice = sb.build();
     auto pr = dht::partition_range::make_singular(make_pkey(*cf.schema(), 0));
-    auto rd = cf.make_reader_v2(cf.schema(),
+    auto rd = cf.make_mutation_reader(cf.schema(),
         semaphore.make_permit(),
         pr,
         slice);
@@ -944,7 +944,7 @@ static test_result select_missing_row(replica::column_family& cf, clustered_ds& 
 
     auto pr = dht::partition_range::make_singular(dht::decorate_key(*cf.schema(), ds.make_pk(*cf.schema())));
     auto slice = sb.build();
-    auto rd = cf.make_reader_v2(cf.schema(),
+    auto rd = cf.make_mutation_reader(cf.schema(),
         semaphore.make_permit(),
         pr,
         slice);
@@ -961,7 +961,7 @@ static test_result test_slicing_using_restrictions(replica::column_family& cf, c
         }))
         .build();
     auto pr = dht::partition_range::make_singular(make_pkey(*cf.schema(), 0));
-    auto rd = cf.make_reader_v2(cf.schema(), semaphore.make_permit(), pr, slice, nullptr,
+    auto rd = cf.make_mutation_reader(cf.schema(), semaphore.make_permit(), pr, slice, nullptr,
                              streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
     auto close_rd = deferred_close(rd);
 
@@ -971,7 +971,7 @@ static test_result test_slicing_using_restrictions(replica::column_family& cf, c
 static test_result slice_rows_single_key(replica::column_family& cf, clustered_ds& ds, int offset = 0, int n_read = 1) {
     tests::reader_concurrency_semaphore_wrapper semaphore;
     auto pr = dht::partition_range::make_singular(make_pkey(*cf.schema(), 0));
-    auto rd = cf.make_reader_v2(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice(), nullptr, streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
+    auto rd = cf.make_mutation_reader(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice(), nullptr, streamed_mutation::forwarding::yes, mutation_reader::forwarding::no);
     auto close_rd = deferred_close(rd);
 
     metrics_snapshot before;
@@ -992,7 +992,7 @@ static test_result slice_partitions(replica::column_family& cf, const std::vecto
         dht::partition_range::bound(keys[std::min<size_t>(keys.size(), offset + n_read) - 1], true)
     );
 
-    auto rd = cf.make_reader_v2(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice());
+    auto rd = cf.make_mutation_reader(cf.schema(), semaphore.make_permit(), pr, cf.schema()->full_slice());
     auto close_rd = deferred_close(rd);
     metrics_snapshot before;
 
@@ -1156,7 +1156,7 @@ static test_result test_forwarding_with_restriction(replica::column_family& cf, 
         .build();
 
     auto pr = single_partition ? dht::partition_range::make_singular(make_pkey(*cf.schema(), 0)) : query::full_partition_range;
-    auto rd = cf.make_reader_v2(cf.schema(),
+    auto rd = cf.make_mutation_reader(cf.schema(),
         semaphore.make_permit(),
         pr,
         slice,


### PR DESCRIPTION
Following a number of similar code cleanup PR, this one aims to be the last one, definitely dropping flat from all reader and related names.
Similarly, v2 is also dropped from reader names, although it still persists in mutation_fragment_v2, mutation_v2 and related names. This won't change in the foreseeable future, as we don't have plans to drop mutation (the v1 variant).
The changes in this PR are entirely mechanical, mostly just search-and-replace.

Code cleanup, no backport required.