### PR TITLE
test.py: add the possibility to gather resource metrics for C++ tests

### DIFF
--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -103,7 +103,6 @@ class BoostTestFacade(CppTestFacade):
         root_log_dir = self.temp_dir / mode / 'pytest'
         log_xml = root_log_dir / f"{test_name}.log"
         stdout_file_path = root_log_dir/ f"{test_name}_stdout.log"
-        stderr_file_path = root_log_dir / f"{test_name}_stderr.log"
         report_xml = root_log_dir / f"{test_name}.xml"
         args = [ str(executable),
                  '--output_format=XML',
@@ -121,12 +120,10 @@ class BoostTestFacade(CppTestFacade):
         args.append('--')
         args.extend(test_args)
         os.chdir(self.temp_dir.parent)
-        p, stderr, stdout = run_process(args, timeout)
+        p, stdout = run_process(args, timeout)
 
         with open(stdout_file_path, 'w') as fd:
             fd.write(stdout)
-        with open(stderr_file_path, 'w') as fd:
-            fd.write(stderr)
         log = read_file(log_xml)
         report = read_file(report_xml)
 
@@ -138,7 +135,6 @@ class BoostTestFacade(CppTestFacade):
                 'Internal Error: calling {executable} '
                 'for test {test_id} failed (return_code={return_code}):\n'
                 'output file:{stdout}\n'
-                'std error file:{stderr}\n'
                 'log:{log}\n'
                 'report:{report}\n'
                 'command to repeat:{command}'
@@ -151,7 +147,6 @@ class BoostTestFacade(CppTestFacade):
                     executable=executable,
                     test_id=test_name,
                     stdout=stdout_file_path.absolute(),
-                    stderr=stderr_file_path.absolute(),
                     log=log,
                     report=report,
                     command=' '.join(p.args),

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -34,6 +34,7 @@ from functools import cache
 from pathlib import Path
 from xml.etree import ElementTree
 
+import allure
 from pytest import Config
 from test import BUILD_DIR, COMBINED_TESTS
 from test.pylib.cpp.common_cpp_conftest import get_modes_to_run
@@ -121,6 +122,7 @@ class BoostTestFacade(CppTestFacade):
         results = self._parse_log(log=log)
 
         if not test_passed:
+            allure.attach(stdout_file_path.read_bytes(), name='output', attachment_type=allure.attachment_type.TEXT)
             msg = (
                 'working_dir: {working_dir}\n'
                 'Internal Error: calling {executable} '

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -74,9 +74,10 @@ class BoostTestFacade(CppTestFacade):
             #     _0*
             #     _1*
             #     _2*
-            # however, it's only possible to run test_singular_tree_ptr_sz that executes all test cases
-            # this line catches only test function name ignoring unrelated lines like '_0'
+            # this line catches only test function name ignoring lines like '_0', so it will count test with dataprovider
+            # as one test case.
             # Note: this ignores any test case starting with a '_' symbol
+            # TODO: add support for test cases with dataprovider
             return False, [case[:-1] for case in output.splitlines() if
                          case.endswith('*') and not case.strip().startswith('_')]
 
@@ -203,6 +204,19 @@ def get_combined_tests(config: Config):
                 current_suite = line.strip().rstrip('*')
                 suites[mode][current_suite] = []
             else:
-                case_name = line.strip().rstrip('*')
-                suites[mode][current_suite].append(case_name)
+                # --list_content produces the list of all test cases in the file. When BOOST_DATA_TEST_CASE is used it
+                # additionally produce the lines with numbers for each case preserving the function name like this:
+                # group0_voter_calculator_test *
+                #     existing_voters_are_kept_across_racks *
+                #     leader_is_retained_as_voter *
+                #         _0 *
+                #         _1 *
+                #         _2 *
+                # this line catches only test function name ignoring lines like '_0', so it will count test with dataprovider
+                # as one test case.
+                # Note: this ignores any test case starting with a '_' symbol
+                # TODO: add support for test cases with dataprovider
+                case_name = line.strip()
+                if not case_name.startswith('_'):
+                    suites[mode][current_suite].append(case_name.rstrip('*'))
     return suites

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -99,10 +99,9 @@ class BoostTestFacade(CppTestFacade):
                 return ''
         root_log_dir = self.temp_dir / mode
         log_xml = root_log_dir / f"{test_name}.log"
-        report_xml = root_log_dir / f"{test_name}.xml"
         args = [ str(executable),
+                 '--report_level=no',
                  '--output_format=XML',
-                 f"--report_sink={report_xml}",
                  f"--log_sink={log_xml}",
                  '--catch_system_errors=no',
                  '--color_output=false',
@@ -118,7 +117,6 @@ class BoostTestFacade(CppTestFacade):
         test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env)
 
         log = read_file(log_xml)
-        report = read_file(report_xml)
 
         results = self._parse_log(log=log)
 
@@ -130,7 +128,6 @@ class BoostTestFacade(CppTestFacade):
                 'for test {test_id} failed (return_code={return_code}):\n'
                 'output file:{stdout}\n'
                 'log:{log}\n'
-                'report:{report}\n'
                 'command to repeat:{command}'
             )
             failure = CppTestFailure(
@@ -142,7 +139,6 @@ class BoostTestFacade(CppTestFacade):
                     test_id=test_name,
                     stdout=stdout_file_path.absolute(),
                     log=log,
-                    report=report,
                     command=' '.join(args),
                     return_code=return_code,
                 ),

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -96,7 +96,7 @@ class BoostTestFacade(CppTestFacade):
                     return f.read()
             except IOError:
                 return ''
-        root_log_dir = self.temp_dir / mode / 'pytest'
+        root_log_dir = self.temp_dir / mode
         log_xml = root_log_dir / f"{test_name}.log"
         report_xml = root_log_dir / f"{test_name}.xml"
         args = [ str(executable),
@@ -147,6 +147,9 @@ class BoostTestFacade(CppTestFacade):
                 ),
             )
             return [failure], ''
+
+        log_xml.unlink(missing_ok=True)
+        stdout_file_path.unlink(missing_ok=True)
 
         if results:
             return results, ''

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from xml.etree import ElementTree
 
 from pytest import Config
-from test import BUILD_DIR, COMBINED_TESTS
+from test import BUILD_DIR, COMBINED_TESTS, TOP_SRC_DIR
 from test.pylib.cpp.common_cpp_conftest import get_modes_to_run
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure, run_process
 
@@ -119,7 +119,7 @@ class BoostTestFacade(CppTestFacade):
         # Tests are written in the way that everything after '--' passes to the test itself rather than to the test framework
         args.append('--')
         args.extend(test_args)
-        os.chdir(self.temp_dir.parent)
+        os.chdir(TOP_SRC_DIR)
         p, stdout = run_process(args, timeout)
 
         with open(stdout_file_path, 'w') as fd:

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -9,6 +9,7 @@ import os
 from pathlib import Path
 from typing import Sequence
 
+from test import TOP_SRC_DIR
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure, run_process
 
 TIMEOUT = 60 * 10 # seconds
@@ -34,7 +35,7 @@ class UnitTestFacade(CppTestFacade):
         env: dict = None,
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         args = [str(executable), *test_args]
-        os.chdir(self.temp_dir.parent)
+        os.chdir(TOP_SRC_DIR)
         p, stdout = run_process(args, TIMEOUT)
 
         if p.returncode != 0:

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -58,4 +58,5 @@ class UnitTestFacade(CppTestFacade):
                 ),
             )
             return [failure], ''
+        stdout_file_path.unlink(missing_ok=True)
         return None, ''

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -9,10 +9,7 @@ import os
 from pathlib import Path
 from typing import Sequence
 
-from test import TOP_SRC_DIR
-from test.pylib.cpp.facade import CppTestFacade, CppTestFailure, run_process
-
-TIMEOUT = 60 * 10 # seconds
+from test.pylib.cpp.facade import CppTestFacade, CppTestFailure
 
 class UnitTestFacade(CppTestFacade):
 
@@ -35,10 +32,9 @@ class UnitTestFacade(CppTestFacade):
         env: dict = None,
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         args = [str(executable), *test_args]
-        os.chdir(TOP_SRC_DIR)
-        p, stdout = run_process(args, TIMEOUT)
+        test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env)
 
-        if p.returncode != 0:
+        if not test_passed:
             msg = (
                 'working_dir: {working_dir}\n'
                 'Internal Error: calling {executable} '
@@ -53,10 +49,10 @@ class UnitTestFacade(CppTestFacade):
                     working_dir=os.getcwd(),
                     executable=executable,
                     test_id=test_name,
-                    stdout=stdout,
-                    command=' '.join(p.args),
-                    returncode=p.returncode,
+                    stdout=stdout_file_path.absolute(),
+                    command=' '.join(args),
+                    returncode=return_code,
                 ),
             )
-            return [failure], stdout
-        return None, stdout
+            return [failure], ''
+        return None, ''

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -9,6 +9,8 @@ import os
 from pathlib import Path
 from typing import Sequence
 
+import allure
+
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure
 
 class UnitTestFacade(CppTestFacade):
@@ -35,6 +37,7 @@ class UnitTestFacade(CppTestFacade):
         test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env)
 
         if not test_passed:
+            allure.attach(stdout_file_path.read_bytes(), name='output', attachment_type=allure.attachment_type.TEXT)
             msg = (
                 'working_dir: {working_dir}\n'
                 'Internal Error: calling {executable} '

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -35,7 +35,7 @@ class UnitTestFacade(CppTestFacade):
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         args = [str(executable), *test_args]
         os.chdir(self.temp_dir.parent)
-        p, stderr, stdout = run_process(args, TIMEOUT)
+        p, stdout = run_process(args, TIMEOUT)
 
         if p.returncode != 0:
             msg = (
@@ -43,7 +43,6 @@ class UnitTestFacade(CppTestFacade):
                 'Internal Error: calling {executable} '
                 'for test {test_id} failed (returncode={returncode}):\n'
                 'output:{stdout}\n'
-                'std error:{stderr}\n'
                 'command to repeat:{command}'
             )
             failure = CppTestFailure(
@@ -54,7 +53,6 @@ class UnitTestFacade(CppTestFacade):
                     executable=executable,
                     test_id=test_name,
                     stdout=stdout,
-                    stderr=stderr,
                     command=' '.join(p.args),
                     returncode=p.returncode,
                 ),

--- a/test/pylib/cpp/util.py
+++ b/test/pylib/cpp/util.py
@@ -1,0 +1,27 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def make_test_object(test_name: str, suite: str, run_id: int, mode: str = 'no_mode', log_dir: Path = None) -> SimpleNamespace:
+    """
+    Returns object that used in resource gathering.
+    It needed to not change the logic of writing metrics to DB that used in test types from test.py.
+    """
+    test = SimpleNamespace()
+    test.time_end = 0
+    test.time_start = 0
+    test.id = run_id
+    test.mode = mode
+    test.success = False
+    test.shortname = test_name
+
+    test.suite = SimpleNamespace()
+    test.suite.log_dir = log_dir / mode
+    test.suite.name = suite
+
+    return test

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -68,7 +68,7 @@ class ResourceGather(ABC):
             self.loop = asyncio.new_event_loop()
             self.own_loop = True
         self.test = test
-        self.db_path = self.test.suite.log_dir.parent / DEFAULT_DB_NAME
+        self.db_path = self.test.suite.log_dir / DEFAULT_DB_NAME
         standardized_name = self.test.shortname.replace("/", "_")
         self.cgroup_path = Path(
             f"{CGROUP_TESTS}/{self.test.suite.name}.{standardized_name}.{self.test.mode}.{self.test.id}"

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -69,7 +69,7 @@ class ResourceGather(ABC):
         self.db_path = self.test.suite.log_dir / DEFAULT_DB_NAME
         standardized_name = self.test.shortname.replace("/", "_")
         self.cgroup_path = Path(
-            f"{CGROUP_TESTS}/{self.test.suite.name}.{standardized_name}.{self.test.suite.mode}.{self.test.id}"
+            f"{CGROUP_TESTS}/{self.test.suite.name}.{standardized_name}.{self.test.mode}.{self.test.id}"
         )
         self.logger = logging.getLogger(__name__)
 

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -11,11 +11,13 @@ import getpass
 import logging
 import os
 import platform
+import shlex
 import subprocess
 from abc import ABC
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import psutil
@@ -66,7 +68,7 @@ class ResourceGather(ABC):
             self.loop = asyncio.new_event_loop()
             self.own_loop = True
         self.test = test
-        self.db_path = self.test.suite.log_dir / DEFAULT_DB_NAME
+        self.db_path = self.test.suite.log_dir.parent / DEFAULT_DB_NAME
         standardized_name = self.test.shortname.replace("/", "_")
         self.cgroup_path = Path(
             f"{CGROUP_TESTS}/{self.test.suite.name}.{standardized_name}.{self.test.mode}.{self.test.id}"
@@ -76,6 +78,33 @@ class ResourceGather(ABC):
     def __del__(self):
         if self.own_loop:
             self.loop.close()
+
+    def  run_process(self, args: list[str], timeout: float, env: dict = None) -> tuple[subprocess.Popen[str], str]:
+
+        args = shlex.split(' '.join(args))
+        if env:
+            env.update(os.environ)
+        else:
+            env = os.environ.copy()
+        p = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+            text=True,
+            env=env,
+            preexec_fn = self.put_process_to_cgroup
+        )
+        try:
+            stdout, stderr = p.communicate(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.critical(f"Process {args} timed out")
+            stdout = p.stdout.read()
+            p.kill()
+        except KeyboardInterrupt:
+            p.kill()
+            raise
+        return p, stdout
 
     def make_cgroup(self) -> None:
         pass
@@ -185,7 +214,7 @@ class ResourceGatherOn(ResourceGather):
                 setattr(metrics, stats[stat], float(value) / 1_000_000)
 
 
-def get_resource_gather(is_switched_on: bool, test: TestPyTest) -> ResourceGather:
+def get_resource_gather(is_switched_on: bool, test: TestPyTest | SimpleNamespace) -> ResourceGather:
     if is_switched_on:
         return ResourceGatherOn(test)
     else:


### PR DESCRIPTION
Move the run_process method to resource gather instance, since we need to start a monitor to check memory consumption in the cgroup. Pytest has concept of the test, but it is completely different from test.py. Resource gather instance take test instance to save and extract information about the test. Additional method emulating test.py test instance added not to rewrite the resource gather instance. Finally, combining all these changes to have ability to get metrics for test in both runners: test.py and pytest.

