### PR TITLE
docs: fix \t (tab) is not rendered correctly

### DIFF
--- a/docs/_ext/utils.py
+++ b/docs/_ext/utils.py
@@ -22,6 +22,8 @@ def readable_desc_rst(description):
 
         cleaned_line = line.replace('\\n', '\n')
 
+        cleaned_line = cleaned_line.replace('\\t', '\n' + indent * 2)
+        
         if line.endswith('"'):
             cleaned_line = cleaned_line[:-1] + ' '
 


### PR DESCRIPTION
Closes https://github.com/scylladb/scylladb/issues/22423

Before:

<img width="774" alt="image" src="https://github.com/user-attachments/assets/ae95d88c-d1d6-413d-8844-e0806eae1d2c" />

Now:

<img width="752" alt="image" src="https://github.com/user-attachments/assets/0a5d760c-06dd-4193-86cd-d059ad819b53" />
