### PR TITLE
dist: rpm: override %_sbindir for Fedora 42

### DIFF
--- a/dist/redhat/scylla.spec
+++ b/dist/redhat/scylla.spec
@@ -21,6 +21,11 @@ Obsoletes:      scylla-enterprise < 2025.1.0
 %global __brp_python_bytecompile %{nil}
 %global __brp_mangle_shebangs %{nil}
 
+# On Fedora 42, _sbindir was redefined to /usr/bin; redefine it back
+# Eventually we should migrate to /usr/bin too, but let's not touch
+# it until it becomes widely used in RHEL.
+%global _sbindir /usr/sbin
+
 %undefine _find_debuginfo_dwz_opts
 
 # Prevent find-debuginfo.sh from tempering with scylla's build-id (#5881)


### PR DESCRIPTION
Fedora 42 merged /usr/sbin into /usr/bin [1]. As part of that change the rpm macro %_sbindir was redefined from /usr/sbin to /usr/bin. As a result RPM build on Fedora 42 fails: install.sh places some files into /usr/sbin, while rpmbuild looks for them in /usr/bin.

We could resolve this either by following the change and moving the files to /usr/bin as well, or fixing the spec to place the files in /usr/sbin. The former is more difficult:
 - what about Debian/Ubuntu?
 - what about older RPM-based distributions (like all RHEL distributions)?
 - what about scripts that hard-code /usr/sbin/<scylla utility>?

So we pick the latter, and redefine %_sbindir to /usr/sbin. Since that directory still exists (as a symlink), installation on systems with merged /usr/bin and /usr/sbin will work.

We'll have to address the problem later (likely by installing to either /usr/bin or /usr/sbin depending on context), but for now, this is a simple solution that works everywhere.

[1] https://fedoraproject.org/wiki/Changes/Unify_bin_and_sbin

No backport - all branches build on Fedora 41 or earlier and so aren't affected.