### PR TITLE
build: pass the mode-specific compilerf flags to Seastar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ else()
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
     set(Seastar_SCHEDULING_GROUPS_COUNT 19 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
+    set(Seastar_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar
       PRIVATE

--- a/configure.py
+++ b/configure.py
@@ -1952,7 +1952,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON',
         '-DCMAKE_CXX_STANDARD=23',
         '-DCMAKE_CXX_EXTENSIONS=ON',
-        '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags'] + extra_file_prefix_map),
+        '-DSeastar_CXX_FLAGS=SHELL:{}'.format(mode_config['lib_cflags'] + extra_file_prefix_map + mode_config['cxxflags']),
         '-DSeastar_LD_FLAGS={}'.format(semicolon_separated(mode_config['lib_ldflags'], seastar_cxx_ld_flags)),
         '-DSeastar_API_LEVEL=7',
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',


### PR DESCRIPTION
Apparently, Seastar cmake only accepts Seastar_CXX_FLAGS to configure the compiler flags. Otherwise it builds in release mode with -O2 and no lto/pgo.

Fix by passing the mode-specific cflags.

FIXME: the fix for --use-cmake doesn't work.

Need to check if it's a regression to determine if we need to backport it.