### PR TITLE
raft_sys_table_storage: avoid temp buffer when  deserializing log_entry

### DIFF
--- a/serializer_impl.hh
+++ b/serializer_impl.hh
@@ -769,6 +769,12 @@ utils::input_stream as_input_stream(const bytes_ostream& b) {
     return utils::input_stream::fragmented(b.fragments().begin(), b.size());
 }
 
+template<FragmentedView View>
+inline
+auto as_input_stream(View v) {
+    return fragmented_memory_input_stream(fragment_range(v).begin(), v.size_bytes());
+}
+
 template<typename Output, typename ...T>
 void serialize(Output& out, const boost::variant<T...>& v) {}
 


### PR DESCRIPTION
The get_blob method linearizes data by copying it into a single buffer, which can cause 'oversized allocation' warnings.

In this commit we avoid copying by creating input stream on top of the original fragmened managed bytes, returned by untyped_result_set_row::get_view.

fixes scylladb/scylladb#23903

backport: no need, not a critical issue.