### PR TITLE
Add ability to skip SSTables cleanup when loading them

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2144,6 +2144,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"skip_cleanup",
+                     "description":"Don't cleanup keys from loaded sstables. Invalid if load_and_stream is true",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -453,11 +453,12 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         auto cf = req->get_query_param("cf");
         auto stream = req->get_query_param("load_and_stream");
         auto primary_replica = req->get_query_param("primary_replica_only");
+        auto skip_cleanup_p = req->get_query_param("skip_cleanup");
         boost::algorithm::to_lower(stream);
         boost::algorithm::to_lower(primary_replica);
         bool load_and_stream = stream == "true" || stream == "1";
         bool primary_replica_only = primary_replica == "true" || primary_replica == "1";
-        bool skip_cleanup = false;
+        bool skip_cleanup = skip_cleanup_p == "true" || skip_cleanup_p == "1";
         // No need to add the keyspace, since all we want is to avoid always sending this to the same
         // CPU. Even then I am being overzealous here. This is not something that happens all the time.
         auto coordinator = std::hash<sstring>()(cf) % smp::count;

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -457,13 +457,14 @@ void set_sstables_loader(http_context& ctx, routes& r, sharded<sstables_loader>&
         boost::algorithm::to_lower(primary_replica);
         bool load_and_stream = stream == "true" || stream == "1";
         bool primary_replica_only = primary_replica == "true" || primary_replica == "1";
+        bool skip_cleanup = false;
         // No need to add the keyspace, since all we want is to avoid always sending this to the same
         // CPU. Even then I am being overzealous here. This is not something that happens all the time.
         auto coordinator = std::hash<sstring>()(cf) % smp::count;
         return sst_loader.invoke_on(coordinator,
                 [ks = std::move(ks), cf = std::move(cf),
-                load_and_stream, primary_replica_only] (sstables_loader& loader) {
-            return loader.load_new_sstables(ks, cf, load_and_stream, primary_replica_only, sstables_loader::stream_scope::all);
+                load_and_stream, primary_replica_only, skip_cleanup] (sstables_loader& loader) {
+            return loader.load_new_sstables(ks, cf, load_and_stream, primary_replica_only, skip_cleanup, sstables_loader::stream_scope::all);
         }).then_wrapped([] (auto&& f) {
             if (f.failed()) {
                 auto msg = fmt::format("Failed to load new sstables: {}", f.get_exception());

--- a/docs/operating-scylla/nodetool-commands/cleanup.rst
+++ b/docs/operating-scylla/nodetool-commands/cleanup.rst
@@ -1,3 +1,5 @@
+.. _nodetool-cleanup-cmd:
+
 Nodetool cleanup
 ================
 **cleanup** ``[<keyspace> <tablename ...>]``- triggers the immediate removal of data from node(s) that "lose" part of their token range due to a range movement operation (node addition or node replacement).

--- a/docs/operating-scylla/nodetool-commands/refresh.rst
+++ b/docs/operating-scylla/nodetool-commands/refresh.rst
@@ -40,4 +40,14 @@ Load and Stream make restores and migrations much easier:
 * No need to run nodetool cleanup to remove unused data
 
 
+Skip cleanup
+---------------
+
+.. code::
+
+   nodetool refresh <my_keyspace> <my_table> [--skip-cleanup]
+
+When loading an SSTable, Scylla will cleanup it from keys that the node is not responsible for. To skip this step, use the `--skip-cleanup` option.
+See :ref:`nodetool cleanup <nodetool-cleanup-cmd>`.
+
 .. include:: nodetool-index.rst

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -167,7 +167,7 @@ distributed_loader::make_sstables_available(sstables::sstable_directory& dir, sh
 }
 
 future<>
-distributed_loader::process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks, sstring cf) {
+distributed_loader::process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks, sstring cf, bool skip_cleanup) {
     const auto& rs = db.local().find_keyspace(ks).get_replication_strategy();
     if (rs.is_per_table()) {
         on_internal_error(dblog, "process_upload_dir is not supported with tablets");

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -91,7 +91,7 @@ public:
             get_sstables_from_upload_dir(distributed<replica::database>& db, sstring ks, sstring cf, sstables::sstable_open_config cfg);
     static future<std::tuple<table_id, std::vector<std::vector<sstables::shared_sstable>>>>
             get_sstables_from_object_store(distributed<replica::database>& db, sstring ks, sstring cf, std::vector<sstring> sstables, sstring endpoint, sstring bucket, sstring prefix, sstables::sstable_open_config cfg, std::function<seastar::abort_source*()> = {});
-    static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name);
+    static future<> process_upload_dir(distributed<replica::database>& db, sharded<db::view::view_builder>& vb, sstring ks_name, sstring cf_name, bool skip_cleanup);
 };
 
 future<sstables::generation_type> highest_generation_seen(sharded<sstables::sstable_directory>& directory);

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -544,6 +544,10 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         load_and_stream_desc = "auto-enabled-for-tablets";
     }
 
+    if (!load_and_stream && skip_cleanup) {
+        throw std::runtime_error("Skipping cleanup is not possible when doing load-and-stream");
+    }
+
     llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}",
             ks_name, cf_name, load_and_stream_desc, primary_replica_only);
     try {

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -528,7 +528,7 @@ future<> sstables_loader::load_and_stream(sstring ks_name, sstring cf_name,
 // All the global operations are going to happen here, and just the reloading happens
 // in there.
 future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
-    bool load_and_stream, bool primary_replica_only, stream_scope scope) {
+    bool load_and_stream, bool primary_replica_only, bool skip_cleanup, stream_scope scope) {
     if (_loading_new_sstables) {
         throw std::runtime_error("Already loading SSTables. Try again later");
     } else {
@@ -560,7 +560,7 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
                 co_await loader.load_and_stream(ks_name, cf_name, table_id, std::move(sstables_on_shards[this_shard_id()]), primary_replica_only, true, scope, {});
             });
         } else {
-            co_await replica::distributed_loader::process_upload_dir(_db, _view_builder, ks_name, cf_name);
+            co_await replica::distributed_loader::process_upload_dir(_db, _view_builder, ks_name, cf_name, skip_cleanup);
         }
     } catch (...) {
         llog.warn("Done loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, status=failed: {}",

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -107,7 +107,7 @@ public:
      * @return a future<> when the operation finishes.
      */
     future<> load_new_sstables(sstring ks_name, sstring cf_name,
-            bool load_and_stream, bool primary_replica_only, stream_scope scope);
+            bool load_and_stream, bool primary_replica_only, bool skip_cleanup, stream_scope scope);
 
     /**
      * Download new SSTables not currently tracked by the system from object store

--- a/test/nodetool/test_refresh.py
+++ b/test/nodetool/test_refresh.py
@@ -53,3 +53,16 @@ def test_refresh_primary_replica_only(nodetool, scylla_only):
             ("refresh", "ks", "tbl", "--primary-replica-only"),
             {"expected_requests": []},
             ["error processing arguments: --primary-replica-only|-pro takes no effect without --load-and-stream|-las"])
+
+
+def test_refresh_skip_cleanup(nodetool, scylla_only):
+    nodetool("refresh", "ks", "tbl", "--skip-cleanup", expected_requests=[
+        expected_request("POST", "/storage_service/sstables/ks", params={"cf": "tbl", "skip_cleanup": "true"})])
+
+
+def test_refresh_skip_cleanup_load_and_stream(nodetool, scylla_only):
+    check_nodetool_fails_with(
+            nodetool,
+            ("refresh", "ks", "tbl", "--load-and-stream", "--skip-cleanup"),
+            {"expected_requests": []},
+            ["error processing arguments: --skip-cleanup takes no effect with --load-and-stream|-las"])

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -1491,6 +1491,12 @@ void refresh_operation(scylla_rest_client& client, const bpo::variables_map& vm)
         }
         params["primary_replica_only"] = "true";
     }
+    if (vm.contains("skip-cleanup")) {
+        if (vm.contains("load-and-stream")) {
+            throw std::invalid_argument("--skip-cleanup takes no effect with --load-and-stream|-las");
+        }
+        params["skip_cleanup"] = "true";
+    }
     client.post(format("/storage_service/sstables/{}", vm["keyspace"].as<sstring>()), std::move(params));
 }
 
@@ -4051,6 +4057,7 @@ For more information, see: {}"
                 {
                     typed_option<>("load-and-stream", "Allows loading sstables that do not belong to this node, in which case they are automatically streamed to the owning nodes"),
                     typed_option<>("primary-replica-only", "Load the sstables and stream to primary replica node that owns the data. Repair is needed after the load and stream process"),
+                    typed_option<>("skip-cleanup", "Do not perform keys cleanup when loading sstables."),
                 },
                 {
                     typed_option<sstring>("keyspace", "The keyspace to load sstable(s) into", 1),


### PR DESCRIPTION
The non-streaming loading of sstables performs cleanup since recently [1]. For vnodes, unfortunately, cleanup is almost unavoidable, because of the nature of vnodes sharding, even if sstable is already clean. This leads to waste of IO and CPU for nothing. Skipping the cleanup in a smart way is possible, but requires too many changes in the code and in the on-disk data. However, the effort will not help existing SSTables and it's going to be obsoleted by tablets some time soon.

Said that, the easiest way to skip cleanup is the explicit --skip-cleanup option for nodetool and respective skip_cleanup parameter for API handler.

New feature, no backport

fixes #24136
refs #12422 [1]