### PR TITLE
test/cqlpy: fix "run --release 2025.1"

### DIFF
--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -386,7 +386,7 @@ def run_precompiled_scylla_cmd(exe, pid, dir):
         cmd.remove('--kernel-page-cache=1')
         cmd.remove('--flush-schema-tables-after-modification=false')
         cmd.remove('--strict-allow-filtering=true')
-    if major <= [6,2] or (enterprise and major <= [2025,1]):
+    if major <= [6,2] or (enterprise and major < [2025,1]):
         cmd.remove('--experimental-features=views-with-tablets')
     if major <= [4,5]:
         cmd.remove('--max-networking-io-control-blocks=1000')


### PR DESCRIPTION
This patch fixes "test/cqlpy/run --release 2025.1" which fails as follows on all tests with indexes or views:

        Secondary indexes are not supported on base tables with tablets

test/cqlpy/run can run cqlpy (and alternator) tests on various official releases of Scylla which it knows how to download. When running old versions of Scylla, we need to change the configuration options to those that were needed on specific versions.

On new versions of Scylla we need to pass
        --experimental-features=views-with-tablets
to be able to test materialized views, but in older versions we need to remove that parameter because it didn't exist. We incorrectly removed it for any versions 2025.1 or earlier, but that's incorrect - it just needs to be removed for versions strictly earlier than 2025.1 - it is needed for 2025.1 (I tested it is indeed needed even in the earliers RCs).

No need to backport this patch - it is only useful for developers running tests manually, and this always happens on master.