### PR TITLE
server: check if `_gate` is open before using.

### DIFF
--- a/generic_server.cc
+++ b/generic_server.cc
@@ -338,7 +338,7 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
 }
 
 future<> server::do_accepts(int which, bool keepalive, socket_address server_addr) {
-    for (;;) {
+    while (!_gate.is_closed()) {
         seastar::gate::holder holder(_gate);
         bool shed = false;
         try {


### PR DESCRIPTION
Add a check in `server::do_accepts` to ensure `_gate` is not accessed after it has been closed. Previously, this led to errors in the logs when a node was shutting down, such as: "seastar - Exceptional future ignored".

Fixes scylladb/scylladb#23991

No backport needed, this is a minor issue.