### PR TITLE
Remove sstables::storage::absolute_path type

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1006,7 +1006,7 @@ public:
 private:
     using snapshot_file_set = foreign_ptr<std::unique_ptr<std::unordered_set<sstring>>>;
 
-    future<snapshot_file_set> take_snapshot(sstring jsondir);
+    future<snapshot_file_set> snapshot_sstables(sstring name);
     // Writes the table schema and the manifest of all files in the snapshot directory.
     future<> finalize_snapshot(database& db, sstring jsondir, std::vector<snapshot_file_set> file_sets);
     static future<> seal_snapshot(sstring jsondir, std::vector<snapshot_file_set> file_sets);

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -872,7 +872,7 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
 }
 
 future<entry_descriptor> sstable::clone(generation_type new_generation) const {
-    co_await _storage->snapshot(*this, _storage->prefix(), storage::absolute_path::yes, new_generation);
+    co_await _storage->snapshot(*this, "", storage::absolute_path::no, new_generation);
     co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2270,7 +2270,7 @@ std::vector<std::pair<component_type, sstring>> sstable::all_components() const 
 }
 
 future<> sstable::snapshot(const sstring& dir) const {
-    return _storage->snapshot(*this, dir, storage::absolute_path::yes);
+    return _storage->snapshot(*this, fmt::format("{}/{}", snapshots_dir, dir), storage::absolute_path::no);
 }
 
 future<> sstable::change_state(sstable_state to, delayed_commit_changes* delay_commit) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -872,7 +872,7 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
 }
 
 future<entry_descriptor> sstable::clone(generation_type new_generation) const {
-    co_await _storage->snapshot(*this, "", storage::absolute_path::no, new_generation);
+    co_await _storage->snapshot(*this, "", new_generation);
     co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
 }
 
@@ -1909,7 +1909,7 @@ future<> sstable::seal_sstable(bool backup)
         _marked_for_deletion = mark_for_deletion::none;
     }
     if (backup) {
-        co_await _storage->snapshot(*this, "backups", storage::absolute_path::no);
+        co_await _storage->snapshot(*this, "backups");
     }
 }
 
@@ -2270,7 +2270,7 @@ std::vector<std::pair<component_type, sstring>> sstable::all_components() const 
 }
 
 future<> sstable::snapshot(const sstring& dir) const {
-    return _storage->snapshot(*this, fmt::format("{}/{}", snapshots_dir, dir), storage::absolute_path::no);
+    return _storage->snapshot(*this, fmt::format("{}/{}", snapshots_dir, dir));
 }
 
 future<> sstable::change_state(sstable_state to, delayed_commit_changes* delay_commit) {

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -82,7 +82,7 @@ public:
     {}
 
     virtual future<> seal(const sstable& sst) override;
-    virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen) const override;
+    virtual future<> snapshot(const sstable& sst, sstring dir, std::optional<generation_type> gen) const override;
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
@@ -381,13 +381,8 @@ future<> filesystem_storage::create_links(const sstable& sst, const std::filesys
     return create_links_common(sst, dir.native(), sst._generation, mark_for_removal::no);
 }
 
-future<> filesystem_storage::snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen) const {
-    std::filesystem::path snapshot_dir;
-    if (abs) {
-        snapshot_dir = dir;
-    } else {
-        snapshot_dir = _dir.path() / dir;
-    }
+future<> filesystem_storage::snapshot(const sstable& sst, sstring dir, std::optional<generation_type> gen) const {
+    std::filesystem::path snapshot_dir = _dir.path() / dir;
     co_await sst.sstable_touch_directory_io_check(snapshot_dir);
     co_await create_links_common(sst, snapshot_dir, std::move(gen));
 }
@@ -563,7 +558,7 @@ public:
     }
 
     virtual future<> seal(const sstable& sst) override;
-    virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type>) const override;
+    virtual future<> snapshot(const sstable& sst, sstring dir, std::optional<generation_type>) const override;
     virtual future<> change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) override;
     // runs in async context
     virtual void open(sstable& sst) override;
@@ -707,7 +702,7 @@ future<> s3_storage::remove_by_registry_entry(entry_descriptor desc) {
     co_await _client->delete_object(prefix + "/" + sstable_version_constants::TOC_SUFFIX);
 }
 
-future<> s3_storage::snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen) const {
+future<> s3_storage::snapshot(const sstable& sst, sstring dir, std::optional<generation_type> gen) const {
     on_internal_error(sstlog, "Snapshotting S3 objects not implemented");
     co_return;
 }

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -95,11 +95,10 @@ class storage {
 public:
     virtual ~storage() {}
 
-    using absolute_path = bool_class<class absolute_path_tag>; // FIXME -- should go away eventually
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
     virtual future<> seal(const sstable& sst) = 0;
-    virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen = {}) const = 0;
+    virtual future<> snapshot(const sstable& sst, sstring dir, std::optional<generation_type> gen = {}) const = 0;
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;


### PR DESCRIPTION
The type is used to differentiate between three distinct calls of storage::snapshot() by:
- sstable::snapshot() uses absolute path, because this is how table::take_snapshot() calls it
- sstable::clone() uses relative path, because it just clones the sstable in whatever directory it's in
- sstable::seal_sstable() uses absolute path in vain, because it snapshots into local directory anyway and can use relative path (see #22959)

In fact, even the first invocation can use relative paths -- the target directory for the snapshot is sstable datadir anyway, the caller of it can just pass the snapshot name and let sstable prepend "datadir/snapshots/" prefix on its own.

Once all callers use relative paths, the differentiator can be removed.

While fixing it, a tiny IO optimization for snapshot directory creation is applied.