### PR TITLE
cql3: Represent create_statement using managed_bytes

### DIFF
--- a/auth/service.cc
+++ b/auth/service.cc
@@ -47,6 +47,7 @@
 #include "data_dictionary/keyspace_metadata.hh"
 #include "service/storage_service.hh"
 #include "service_permit.hh"
+#include "utils/managed_string.hh"
 
 using namespace std::chrono_literals;
 
@@ -475,12 +476,14 @@ future<std::vector<cql3::description>> service::describe_roles(bool with_hashed_
         const bool can_login = co_await _role_manager->can_login(role);
         const bool is_superuser = co_await _role_manager->is_superuser(role);
 
+        sstring create_statement = produce_create_statement(formatted_role_name, maybe_hashed_password, can_login, is_superuser);
+
         result.push_back(cql3::description {
             // Roles do not belong to any keyspace.
             .keyspace = std::nullopt,
             .type = "role",
             .name = role,
-            .create_statement = produce_create_statement(formatted_role_name, maybe_hashed_password, can_login, is_superuser)
+            .create_statement = managed_string(create_statement)
         });
     }
 
@@ -621,19 +624,21 @@ future<std::vector<cql3::description>> service::describe_permissions() const {
 
     for (const auto& permissions : permission_list) {
         for (const auto& permission : permissions.permissions) {
+            sstring create_statement = describe_resource_kind(permission, permissions.resource, permissions.role_name);
+
             result.push_back(cql3::description {
                 // Permission grants do not belong to any keyspace.
                 .keyspace = std::nullopt,
                 .type = "grant_permission",
                 .name = permissions.role_name,
-                .create_statement = describe_resource_kind(permission, permissions.resource, permissions.role_name)
+                .create_statement = managed_string(create_statement)
             });
         }
 
         co_await coroutine::maybe_yield();
     }
 
-    std::ranges::sort(result, std::less<>{}, [] (const cql3::description& desc) noexcept {
+    std::ranges::sort(result, std::less<>{}, [] (const cql3::description& desc) {
         return std::make_tuple(std::ref(desc.name), std::ref(*desc.create_statement));
     });
 

--- a/cql3/description.cc
+++ b/cql3/description.cc
@@ -32,7 +32,7 @@ std::vector<managed_bytes_opt> description::serialize(bool serialize_create_stat
     result.push_back(to_managed_bytes(cql3::util::maybe_quote(name)));
 
     if (serialize_create_statement && create_statement) {
-        result.push_back(to_managed_bytes(*create_statement));
+        result.push_back(create_statement.value().as_managed_bytes());
     } else if (serialize_create_statement) {
         on_internal_error(dlogger, "create_statement field is empty");
     }

--- a/cql3/description.cc
+++ b/cql3/description.cc
@@ -18,7 +18,7 @@ static logging::logger dlogger{"description"};
 
 namespace cql3 {
 
-std::vector<managed_bytes_opt> description::serialize(bool serialize_create_statement) const {
+std::vector<managed_bytes_opt> description::serialize(bool serialize_create_statement) && {
     std::vector<managed_bytes_opt> result{};
     result.reserve(serialize_create_statement ? 4 : 3);
 
@@ -32,7 +32,7 @@ std::vector<managed_bytes_opt> description::serialize(bool serialize_create_stat
     result.push_back(to_managed_bytes(cql3::util::maybe_quote(name)));
 
     if (serialize_create_statement && create_statement) {
-        result.push_back(create_statement.value().as_managed_bytes());
+        result.push_back(std::move(create_statement.value()).as_managed_bytes());
     } else if (serialize_create_statement) {
         on_internal_error(dlogger, "create_statement field is empty");
     }

--- a/cql3/description.cc
+++ b/cql3/description.cc
@@ -18,21 +18,21 @@ static logging::logger dlogger{"description"};
 
 namespace cql3 {
 
-std::vector<bytes_opt> description::serialize(bool serialize_create_statement) const {
-    std::vector<bytes_opt> result{};
+std::vector<managed_bytes_opt> description::serialize(bool serialize_create_statement) const {
+    std::vector<managed_bytes_opt> result{};
     result.reserve(serialize_create_statement ? 4 : 3);
 
     if (keyspace) {
-        result.push_back(to_bytes(cql3::util::maybe_quote(*keyspace)));
+        result.push_back(to_managed_bytes(cql3::util::maybe_quote(*keyspace)));
     } else {
-        result.push_back(data_value::make_null(utf8_type).serialize());
+        result.push_back(to_managed_bytes_opt(data_value::make_null(utf8_type).serialize()));
     }
 
-    result.push_back(to_bytes(type));
-    result.push_back(to_bytes(cql3::util::maybe_quote(name)));
+    result.push_back(to_managed_bytes(type));
+    result.push_back(to_managed_bytes(cql3::util::maybe_quote(name)));
 
     if (serialize_create_statement && create_statement) {
-        result.push_back(to_bytes(*create_statement));
+        result.push_back(to_managed_bytes(*create_statement));
     } else if (serialize_create_statement) {
         on_internal_error(dlogger, "create_statement field is empty");
     }

--- a/cql3/description.hh
+++ b/cql3/description.hh
@@ -11,7 +11,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
-#include "bytes_fwd.hh"
+#include "utils/managed_bytes.hh"
 
 #include <optional>
 #include <vector>
@@ -80,7 +80,7 @@ struct description {
     ///
     /// Precondition: if `serialize_create_statement` is true, then `create_statement.has_value()`
     ///               is also true.
-    std::vector<bytes_opt> serialize(bool serialize_create_statement = true) const;
+    std::vector<managed_bytes_opt> serialize(bool serialize_create_statement = true) const;
 };
 
 } // namespace cql3

--- a/cql3/description.hh
+++ b/cql3/description.hh
@@ -90,7 +90,7 @@ struct description {
     ///
     /// Precondition: if `serialize_create_statement` is true, then `create_statement.has_value()`
     ///               is also true.
-    std::vector<managed_bytes_opt> serialize(bool serialize_create_statement = true) const;
+    std::vector<managed_bytes_opt> serialize(bool serialize_create_statement = true) &&;
 };
 
 } // namespace cql3

--- a/cql3/functions/aggregate_fcts.cc
+++ b/cql3/functions/aggregate_fcts.cc
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <optional>
 #include <type_traits>
+#include "utils/managed_string.hh"
 
 using namespace cql3;
 using namespace functions;
@@ -357,7 +358,7 @@ user_aggregate::user_aggregate(function_name fname, bytes_opt initcond, ::shared
 bool user_aggregate::has_finalfunc() const { return _agg.state_to_result_function != nullptr; }
 
 description user_aggregate::describe(with_create_statement with_stmt) const {
-    auto maybe_create_statement = std::invoke([&] -> std::optional<sstring> {
+    auto maybe_create_statement = std::invoke([&] -> std::optional<managed_string> {
         if (!with_stmt) {
             return std::nullopt;
         }
@@ -365,7 +366,7 @@ description user_aggregate::describe(with_create_statement with_stmt) const {
         auto ks = cql3::util::maybe_quote(name().keyspace);
         auto na = cql3::util::maybe_quote(name().name);
 
-        std::ostringstream os;
+        fragmented_ostringstream os;
 
         os << "CREATE AGGREGATE " << ks << "." << na << "(";
         auto a = arg_types();
@@ -390,7 +391,7 @@ description user_aggregate::describe(with_create_statement with_stmt) const {
         }
         os << ";";
 
-        return std::move(os).str();
+        return std::move(os).to_managed_string();
     });
 
     return description {

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -16,6 +16,7 @@
 #include "cql3/functions/function_name.hh"
 #include "cql3/statements/prepared_statement.hh"
 #include "exceptions/exceptions.hh"
+#include <ranges>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/exception.hh>
@@ -459,8 +460,8 @@ std::vector<lw_shared_ptr<column_specification>> get_element_column_specificatio
 }
 
 std::vector<std::vector<managed_bytes_opt>> serialize_descriptions(std::vector<description>&& descs, bool serialize_create_statement = true) {
-    return descs | std::views::transform([serialize_create_statement] (const description& desc) {
-        return desc.serialize(serialize_create_statement);
+    return descs | std::views::as_rvalue | std::views::transform([serialize_create_statement] (description desc) {
+        return std::move(desc).serialize(serialize_create_statement);
     }) | std::ranges::to<std::vector>();
 }
 

--- a/cql3/statements/describe_statement.hh
+++ b/cql3/statements/describe_statement.hh
@@ -47,7 +47,7 @@ protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications(replica::database& db, const service::client_state& client_state) const {
         return get_column_specifications();
     }
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const = 0;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const = 0;
 public:
     virtual uint32_t get_bound_terms() const override;
     virtual bool depends_on(std::string_view ks_name, std::optional<std::string_view> cf_name) const override;
@@ -61,12 +61,12 @@ public:
 class cluster_describe_statement : public describe_statement {
 private:
     bool should_add_range_ownership(replica::database& db, const service::client_state& client_state) const;
-    future<bytes_opt> range_ownership(const service::storage_proxy& proxy, const sstring& ks) const;
+    future<managed_bytes_opt> range_ownership(const service::storage_proxy& proxy, const sstring& ks) const;
 
 protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications() const override;
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications(replica::database& db, const service::client_state& client_state) const override;
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
     cluster_describe_statement();
@@ -88,7 +88,7 @@ private:
 
 protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications() const override;
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
     schema_describe_statement(bool full_schema, bool with_hashed_passwords, bool with_internals);
@@ -102,7 +102,7 @@ private:
 
 protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications() const override;
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
     listing_describe_statement(element_type element, bool with_internals);
@@ -118,7 +118,7 @@ private:
 
 protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications() const override;
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
     element_describe_statement(element_type element, std::optional<sstring> keyspace, sstring name, bool with_internals);
@@ -132,7 +132,7 @@ private:
 
 protected:
     virtual std::vector<lw_shared_ptr<column_specification>> get_column_specifications() const override;
-    virtual seastar::future<std::vector<std::vector<bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
+    virtual seastar::future<std::vector<std::vector<managed_bytes_opt>>> describe(cql3::query_processor& qp, const service::client_state& client_state) const override;
 
 public:
     generic_describe_statement(std::optional<sstring> keyspace, sstring name, bool with_internals);

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -404,12 +404,12 @@ no_such_column_family::no_such_column_family(std::string_view ks_name, const tab
 }
 
 cql3::description keyspace_metadata::describe(const replica::database& db, cql3::with_create_statement with_create_statement) const {
-    auto maybe_create_statement = std::invoke([&] -> std::optional<sstring> {
+    auto maybe_create_statement = std::invoke([&] -> std::optional<managed_string> {
         if (!with_create_statement) {
             return std::nullopt;
         }
 
-        std::ostringstream os;
+        fragmented_ostringstream os;
 
         os << "CREATE KEYSPACE " << cql3::util::maybe_quote(_name)
            << " WITH replication = {'class': " << cql3::util::single_quote(_strategy_name);
@@ -422,7 +422,7 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
                 os << ", " << cql3::util::single_quote(e.first) << ": " << cql3::util::single_quote(e.second);
             }
         }
-        os << "} AND durable_writes = " << std::boolalpha << _durable_writes << std::noboolalpha;
+        os << "} AND durable_writes = " << fmt::to_string(_durable_writes);
         if (db.features().tablets) {
             if (!_initial_tablets.has_value()) {
                 os << " AND tablets = {'enabled': false}";
@@ -432,7 +432,7 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
         }
         os << ";";
 
-        return std::move(os).str();
+        return std::move(os).to_managed_string();
     });
 
     return cql3::description {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -30,6 +30,7 @@
 #include "utils/assert.hh"
 #include "utils/logalloc.hh"
 #include "utils/checked-file-impl.hh"
+#include "utils/managed_bytes.hh"
 #include "view_info.hh"
 #include "db/data_listeners.hh"
 #include "memtable-sstable.hh"
@@ -2916,8 +2917,13 @@ future<> table::write_schema_as_cql(database& db, sstring dir) const {
     auto out = co_await make_file_output_stream(std::move(f));
     std::exception_ptr ex;
 
+    auto view = managed_bytes_view(schema_description.as_managed_bytes());
+
     try {
-        co_await out.write(schema_description.c_str(), schema_description.size());
+        for (auto&& fragment : fragment_range(view)) {
+            auto sv = to_string_view(fragment);
+            co_await out.write(sv.data(), sv.size());
+        }
         co_await out.flush();
     } catch (...) {
         ex = std::current_exception();

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -8,6 +8,7 @@
 
 #include <seastar/core/on_internal_error.hh>
 #include <map>
+#include "bytes_ostream.hh"
 #include "cql3/description.hh"
 #include "db/tablet_options.hh"
 #include "db/view/view.hh"
@@ -37,6 +38,7 @@
 #include "utils/hashing.hh"
 #include "utils/hashers.hh"
 #include "alternator/extract_from_attrs.hh"
+#include "utils/managed_string.hh"
 
 #include <boost/lexical_cast.hpp>
 
@@ -911,7 +913,8 @@ auto fmt::formatter<schema>::format(const schema& s, fmt::format_context& ctx) c
     return fmt::format_to(out, "]");
 }
 
-static std::ostream& map_as_cql_param(std::ostream& os, const std::map<sstring, sstring>& map, bool first = true) {
+template <typename Stream>
+static Stream& map_as_cql_param(Stream& os, const std::map<sstring, sstring>& map, bool first = true) {
     for (auto i: map) {
         if (first) {
             first = false;
@@ -939,7 +942,7 @@ std::string schema_extension::options_to_string() const {
     return ss.str();
 }
 
-static std::ostream& column_definition_as_cql_key(std::ostream& os, const column_definition & cd) {
+static fragmented_ostringstream& column_definition_as_cql_key(fragmented_ostringstream& os, const column_definition & cd) {
     os << cd.name_as_cql_string();
     os << " " << cd.type->cql3_type_name();
 
@@ -949,7 +952,7 @@ static std::ostream& column_definition_as_cql_key(std::ostream& os, const column
     return os;
 }
 
-static void describe_index_columns(std::ostream& os, bool is_local, const schema& index_schema, schema_ptr base_schema) {
+static void describe_index_columns(fragmented_ostringstream& os, bool is_local, const schema& index_schema, schema_ptr base_schema) {
     auto index_name = secondary_index::index_name_from_table_name(index_schema.cf_name());
     if (!base_schema->all_indices().contains(index_name)) {
         on_internal_error(dblog, format("Couldn't find index {} on table {}", index_name, base_schema->cf_name()));
@@ -999,8 +1002,8 @@ static void describe_index_columns(std::ostream& os, bool is_local, const schema
     os << ")";
 }
 
-sstring schema::get_create_statement(const schema_describe_helper& helper, bool with_internals) const {
-    std::ostringstream os;
+managed_string schema::get_create_statement(const schema_describe_helper& helper, bool with_internals) const {
+    fragmented_ostringstream os;
 
     os << "CREATE ";
     int n = 0;
@@ -1025,7 +1028,7 @@ sstring schema::get_create_statement(const schema_describe_helper& helper, bool 
 
             os << ";\n";
 
-            return std::move(os).str();
+            return std::move(os).to_managed_string();
         } else {
             os << "MATERIALIZED VIEW " << cql3::util::maybe_quote(ks_name()) << "." << cql3::util::maybe_quote(cf_name()) << " AS\n";
             if (view_info()->include_all_columns()) {
@@ -1095,7 +1098,7 @@ sstring schema::get_create_statement(const schema_describe_helper& helper, bool 
     }
     os << "WITH ";
     if (with_internals) {
-        os << "ID = " << id() << "\nAND ";
+        os << "ID = " << id().to_sstring() << "\nAND ";
     }
     if (!clustering_key_columns().empty()) {
         // Adding clustering key order can be optional, but there's no harm in doing so.
@@ -1123,7 +1126,7 @@ sstring schema::get_create_statement(const schema_describe_helper& helper, bool 
     if (with_internals) {
         for (auto& cdef : dropped_columns()) {
             os << "\nALTER TABLE " << cql3::util::maybe_quote(ks_name()) << "." << cql3::util::maybe_quote(cf_name())
-               << " DROP " << cql3::util::maybe_quote(cdef.first) << " USING TIMESTAMP " << cdef.second.timestamp << ";";
+               << " DROP " << cql3::util::maybe_quote(cdef.first) << " USING TIMESTAMP " << fmt::to_string(cdef.second.timestamp) << ";";
 
             auto column = get_column_definition(to_bytes(cdef.first));
             if (column) {
@@ -1135,7 +1138,7 @@ sstring schema::get_create_statement(const schema_describe_helper& helper, bool 
         }
     }
 
-    return std::move(os).str();
+    return std::move(os).to_managed_string();
 }
 
 cql3::description schema::describe(const schema_describe_helper& helper, cql3::describe_option desc_opt) const {
@@ -1158,8 +1161,8 @@ cql3::description schema::describe(const schema_describe_helper& helper, cql3::d
     };
 }
 
-std::ostream& schema::schema_properties(const schema_describe_helper& helper, std::ostream& os) const {
-    os << "bloom_filter_fp_chance = " << bloom_filter_fp_chance();
+fragmented_ostringstream& schema::schema_properties(const schema_describe_helper& helper, fragmented_ostringstream& os) const {
+    os << "bloom_filter_fp_chance = " << fmt::to_string(bloom_filter_fp_chance());
     os << "\n    AND caching = {";
     map_as_cql_param(os, caching_options().to_map());
     os << "}";
@@ -1170,12 +1173,12 @@ std::ostream& schema::schema_properties(const schema_describe_helper& helper, st
     map_as_cql_param(os,  get_compressor_params().get_options());
     os << "}";
 
-    os << "\n    AND crc_check_chance = " << crc_check_chance();
-    os << "\n    AND default_time_to_live = " << default_time_to_live().count();
-    os << "\n    AND gc_grace_seconds = " << gc_grace_seconds().count();
-    os << "\n    AND max_index_interval = " << max_index_interval();
-    os << "\n    AND memtable_flush_period_in_ms = " << memtable_flush_period();
-    os << "\n    AND min_index_interval = " << min_index_interval();
+    os << "\n    AND crc_check_chance = " << fmt::to_string(crc_check_chance());
+    os << "\n    AND default_time_to_live = " << fmt::to_string(default_time_to_live().count());
+    os << "\n    AND gc_grace_seconds = " << fmt::to_string(gc_grace_seconds().count());
+    os << "\n    AND max_index_interval = " << fmt::to_string(max_index_interval());
+    os << "\n    AND memtable_flush_period_in_ms = " << fmt::to_string(memtable_flush_period());
+    os << "\n    AND min_index_interval = " << fmt::to_string(min_index_interval());
     os << "\n    AND speculative_retry = '" << speculative_retry().to_sstring() << "'";
 
     if (has_tablet_options()) {
@@ -1196,7 +1199,7 @@ std::ostream& schema::schema_properties(const schema_describe_helper& helper, st
     return os;
 }
 
-std::ostream& schema::describe_alter_with_properties(const schema_describe_helper& helper, std::ostream& os) const {
+fragmented_ostringstream& schema::describe_alter_with_properties(const schema_describe_helper& helper, fragmented_ostringstream& os) const {
     os << "ALTER "; 
     if (is_view()) {
         if (helper.is_index(view_info()->base_id(), *this)) {

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -925,7 +925,7 @@ public:
 
     // Generate ALTER TABLE/MATERIALIZED VIEW statement containing all properties with current values.
     // The method cannot be used on index, as indexes don't support alter statement.
-    std::ostream& describe_alter_with_properties(const schema_describe_helper& helper, std::ostream& os) const;
+    fragmented_ostringstream& describe_alter_with_properties(const schema_describe_helper& helper, fragmented_ostringstream& os) const;
     friend bool operator==(const schema&, const schema&);
     const column_mapping& get_column_mapping() const;
     friend class schema_registry_entry;
@@ -946,9 +946,9 @@ public:
     static table_schema_version calculate_digest(const raw_schema& r);
 private:
     // Print all schema properties in CQL syntax
-    std::ostream& schema_properties(const schema_describe_helper& helper, std::ostream& os) const;
+    fragmented_ostringstream& schema_properties(const schema_describe_helper& helper, fragmented_ostringstream& os) const;
 
-    sstring get_create_statement(const schema_describe_helper& helper, bool with_internals) const;
+    managed_string get_create_statement(const schema_describe_helper& helper, bool with_internals) const;
 public:
     const v3_columns& v3() const {
         return _v3_columns;

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -33,6 +33,7 @@
 #include "service/topology_state_machine.hh"
 #include "utils/sorting.hh"
 #include <seastar/core/reactor.hh>
+#include "utils/managed_string.hh"
 
 namespace qos {
 static logging::logger sl_logger("service_level_controller");
@@ -966,12 +967,14 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
             continue;
         }
 
+        sstring create_statement = describe_service_level(sl_name, sl.slo);
+
         result.push_back(cql3::description {
             // Service levels do not belong to any keyspace.
             .keyspace = std::nullopt,
             .type = "service_level",
             .name = sl_name,
-            .create_statement = describe_service_level(sl_name, sl.slo)
+            .create_statement = managed_string(create_statement)
         });
 
         co_await coroutine::maybe_yield();
@@ -992,21 +995,22 @@ future<std::vector<cql3::description>> service_level_controller::describe_attach
         const auto formatted_role = cql3::util::maybe_quote(role);
         const auto formatted_sl = cql3::util::maybe_quote(service_level);
 
+        sstring create_statement = seastar::format("ATTACH SERVICE LEVEL {} TO {};", formatted_sl, formatted_role);
+
         result.push_back(cql3::description {
             // Attaching a service level doesn't belong to any keyspace.
             .keyspace = std::nullopt,
             .type = "service_level_attachment",
             .name = service_level,
-            .create_statement = seastar::format("ATTACH SERVICE LEVEL {} TO {};", formatted_sl, formatted_role)
+            .create_statement = managed_string(create_statement)
         });
 
         co_await coroutine::maybe_yield();
     }
 
-    std::ranges::sort(result, std::less<>{}, [] (const cql3::description& desc) noexcept {
+    std::ranges::sort(result, std::less<>{}, [] (const cql3::description& desc) {
         return std::make_tuple(std::ref(desc.name), std::ref(*desc.create_statement));
     });
-
 
     co_return result;
 }

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -4362,7 +4362,7 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
             auto schema = e.local_db().find_schema("ks", ct.first);
             auto schema_desc = schema->describe(describe_helper, cql3::describe_option::STMTS);
 
-            BOOST_CHECK_EQUAL(normalize_white_space(*schema_desc.create_statement), normalize_white_space(ct.second));
+            BOOST_CHECK_EQUAL(normalize_white_space(schema_desc.create_statement.value().linearize()), normalize_white_space(ct.second));
         }
     }, describe_test_config());
 }
@@ -4431,12 +4431,12 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
             auto schema = e.local_db().find_schema("KS", ct.first);
             auto schema_desc = schema->describe(describe_helper, cql3::describe_option::STMTS);
 
-            BOOST_CHECK_EQUAL(normalize_white_space(*schema_desc.create_statement), normalize_white_space(ct.second));
+            BOOST_CHECK_EQUAL(normalize_white_space(schema_desc.create_statement.value().linearize()), normalize_white_space(ct.second));
 
             auto base_schema = e.local_db().find_schema("KS", "cF");
             auto base_schema_desc = base_schema->describe(describe_helper, cql3::describe_option::STMTS);
 
-            BOOST_CHECK_EQUAL(normalize_white_space(*base_schema_desc.create_statement), normalize_white_space(base_table));
+            BOOST_CHECK_EQUAL(normalize_white_space(base_schema_desc.create_statement.value().linearize()), normalize_white_space(base_table));
         }
     }, describe_test_config());
 }

--- a/test/cluster/test_describe.py
+++ b/test/cluster/test_describe.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import asyncio
+import pytest
+from test.cluster.util import new_test_keyspace, new_test_table
+from test.pylib.manager_client import ManagerClient
+
+# The following test verifies that Scylla avoids making an oversized allocation
+# when generating a large create statement when performing a DESCRIBE statement.
+# The threshold for generating a warning about an oversized allocation is set
+# to 128 * 2^10 bytes.
+#
+# Reproducer for issue scylladb/scylladb#24018.
+@pytest.mark.asyncio
+async def test_large_create_statement(manager: ManagerClient):
+    cmdline = ["--logger-log-level", "describe=trace"]
+    srv = await manager.server_add(cmdline=cmdline)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY") as table:
+            # CQL will not accept identifiers longers than ~2^16.
+            col_name_len = 60_000
+            # An oversized allocation warning is issued for allocations bigger than 128 * 2^10.
+            target_size_threshold = 128 * (2 ** 10)
+
+            async def add_and_drop(col_name: str) -> None:
+                await cql.run_async(f"ALTER TABLE {table} ADD {col_name} int")
+                await cql.run_async(f"ALTER TABLE {table} DROP {col_name}")
+
+            # Let's get ourselves a little bit more room with the size just
+            # to make sure an oversized allocation will be triggered.
+            col_count = 2 * (target_size_threshold // col_name_len) + 1
+            col_name_prefix = "a" * col_name_len
+
+            await asyncio.gather(*[add_and_drop(f"{col_name_prefix}{idx}") for idx in range(col_count)])
+
+            log = await manager.server_open_log(srv.server_id)
+            marker = await log.mark()
+
+            await cql.run_async("DESCRIBE SCHEMA WITH INTERNALS")
+
+            matches = await log.grep("oversized allocation", from_mark=marker)
+            assert len(matches) == 0

--- a/test/lib/random_schema.cc
+++ b/test/lib/random_schema.cc
@@ -849,7 +849,7 @@ schema_ptr build_random_schema(uint32_t seed, random_schema_specification& spec)
 
 sstring udt_to_str(const user_type_impl& udt) {
     auto udt_desc = udt.describe(cql3::with_create_statement::yes);
-    return *udt_desc.create_statement;
+    return udt_desc.create_statement.value().linearize();
 }
 
 struct udt_list {
@@ -1155,7 +1155,8 @@ future<> random_schema::create_with_cql(cql_test_env& env) {
         replica::schema_describe_helper describe_helper{db.as_data_dictionary()};
         auto schema_desc = _schema->describe(describe_helper, cql3::describe_option::STMTS);
 
-        env.execute_cql(*schema_desc.create_statement).get();
+        sstring create_statement = schema_desc.create_statement.value().linearize();
+        env.execute_cql(create_statement).get();
         auto& tbl = db.find_column_family(ks_name, tbl_name);
 
         _schema = tbl.schema();

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2982,15 +2982,18 @@ void query_operation(schema_ptr sstable_schema, reader_permit permit, const std:
         const auto original_schema_description = sstable_schema->describe(describe_helper, cql3::describe_option::STMTS_AND_INTERNALS);
         const auto schema_description = schema->describe(describe_helper, cql3::describe_option::STMTS_AND_INTERNALS);
 
+        const sstring original_create_statement = original_schema_description.create_statement.value().linearize();
+        const sstring schema_create_statement = schema_description.create_statement.value().linearize();
+
         sst_log.debug("\noriginal schema:\n{}\nreplacement schema:\n{}\n\nNote: original keyspace name of {} was replaced with {}, original id of {} was replaced with {} and all properties were dropped!\n",
-                original_schema_description.create_statement.value(),
-                schema_description.create_statement.value(),
+                original_create_statement,
+                schema_create_statement,
                 sstable_schema->ks_name(),
                 keyspace_name,
                 sstable_schema->id(),
                 schema->id());
 
-        co_await env.execute_cql(schema_description.create_statement.value());
+        co_await env.execute_cql(schema_create_statement);
 
         auto& table = db.find_column_family(keyspace_name, table_name);
 

--- a/types/types.cc
+++ b/types/types.cc
@@ -44,6 +44,7 @@
 #include "utils/ascii.hh"
 #include "utils/fragment_range.hh"
 #include "utils/managed_bytes.hh"
+#include "utils/managed_string.hh"
 
 #include "types/user.hh"
 #include "types/tuple.hh"
@@ -3415,12 +3416,12 @@ sstring user_type_impl::get_name_as_cql_string() const {
 }
 
 cql3::description user_type_impl::describe(cql3::with_create_statement with_create_statement) const {
-    auto maybe_create_statement = std::invoke([&] -> std::optional<sstring> {
+    auto maybe_create_statement = std::invoke([&] -> std::optional<managed_string> {
         if (!with_create_statement) {
             return std::nullopt;
         }
 
-        std::ostringstream os;
+        fragmented_ostringstream os;
 
         os << "CREATE TYPE " << cql3::util::maybe_quote(_keyspace) << "." << get_name_as_cql_string() << " (\n";
         for (size_t i = 0; i < _string_field_names.size(); i++) {
@@ -3432,7 +3433,7 @@ cql3::description user_type_impl::describe(cql3::with_create_statement with_crea
         }
         os << ");";
 
-        return std::move(os).str();
+        return std::move(os).to_managed_string();
     });
 
     return cql3::description {

--- a/utils/managed_string.hh
+++ b/utils/managed_string.hh
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "utils/fragment_range.hh"
+#include "utils/managed_bytes.hh"
+#include "bytes_ostream.hh"
+
+// A thin wrapper over `managed_bytes` representing a fragmented UTF-8 encoded string.
+class managed_string {
+private:
+    managed_bytes _impl;
+
+private:
+    managed_string(managed_bytes mb) : _impl(std::move(mb)) {}
+
+public:
+    managed_string(managed_string&&) noexcept = default;
+    managed_string(std::string_view sv)
+        : _impl(bytes_view(reinterpret_cast<const int8_t*>(sv.data()), sv.size()))
+    {}
+    managed_string& operator=(managed_string&&) noexcept = default;
+
+    // Precondition: the passed argument must represent a valid UTF-8 string.
+    static managed_string from_managed_bytes_unsafe(managed_bytes mb) {
+        return managed_string(std::move(mb));
+    }
+
+    bool operator==(const managed_string&) const = default;
+
+    std::strong_ordering operator<=>(const managed_string& other) const {
+        auto lv = managed_bytes_view(_impl);
+        auto rv = managed_bytes_view(other._impl);
+        return compare_unsigned(lv, rv);
+    }
+
+    template <typename Self>
+    decltype(auto) as_managed_bytes(this Self&& self) {
+        return std::forward_like<Self>(self._impl);
+    }
+
+    sstring linearize() const {
+        sstring result(sstring::initialized_later{}, _impl.size());
+        size_t offset = 0;
+
+        for (auto&& fragment : fragment_range(managed_bytes_view(_impl))) {
+            std::string_view char_view = to_string_view(fragment);
+            std::ranges::copy(char_view, result.begin() + offset);
+            offset += fragment.size();
+        }
+
+        return result;
+    }
+};
+
+template <> struct fmt::formatter<managed_string> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const managed_string& b, FormatContext& ctx) const {
+        auto view = managed_bytes_view(b.as_managed_bytes());
+        auto out = ctx.out();
+
+        for (auto&& fragment : fragment_range(view)) {
+            std::string_view sv = to_string_view(fragment);
+            out = fmt::format_to(out, "{}", sv);
+        }
+
+        return out;
+    }
+};
+inline std::ostream& operator<<(std::ostream& os, const managed_string& b) {
+    fmt::print(os, "{}", b);
+    return os;
+}
+
+// A thin wrapper over `bytes_ostream` with a promise that it corresponds
+// to actual UTF-8 characters, not just generic bytes.
+class fragmented_ostringstream {
+private:
+    bytes_ostream _impl;
+
+public:
+    struct iter {
+        fragmented_ostringstream& stream;
+
+        iter& operator=(char c) {
+            stream.write(c);
+            return *this;
+        }
+
+        iter& operator*() { return *this; }
+        iter& operator++() { return *this; }
+        iter& operator++(int) { return *this; }
+    };
+
+public:
+    [[gnu::always_inline]]
+    void write(std::string_view sv) {
+        _impl.write(sv.data(), sv.size());
+    }
+    [[gnu::always_inline]]
+    void write(char c) {
+        _impl.write(bytes_view(reinterpret_cast<typename bytes_ostream::value_type*>(&c), 1));
+    }
+
+    fragmented_ostringstream& operator<<(std::string sv) {
+        write(sv);
+        return *this;
+    }
+    fragmented_ostringstream& operator<<(char c) {
+        write(c);
+        return *this;
+    }
+    fragmented_ostringstream& operator<<(const managed_string& ms) {
+        for (auto&& fragment : fragment_range(managed_bytes_view(ms.as_managed_bytes()))) {
+            _impl.write(fragment);
+        }
+        return *this;
+    }
+
+    iter to_iter() noexcept {
+        return iter {*this};
+    }
+
+    managed_string to_managed_string() && {
+        return managed_string::from_managed_bytes_unsafe(std::move(_impl).to_managed_bytes());
+    }
+};


### PR DESCRIPTION
When describing a table, we need to do it carefully: if some
columns were dropped, we must specify that explicitly by

```
ALTER TABLE {table} DROP {column} USING TIMESTAMP ...
```

in the result of the DESCRIBE statement. Failing to do so
could lead to data resurrection.

However, if a table has been altered many, many times,
we might end up with a huge create statement. Constructing
it could, in turn, trigger an oversized allocation.
Some tests ran into that very problem in fact.

In this commit, we want to mitigate the problem: instead of
allocating a contiguous chunk of memory for the create
statement, we use `bytes_ostream` and `managed_bytes` to
possibly keep data scattered in memory. It makes handling
`cql3::description` less convenient in the code, but since
the struct is pretty much immediately serialized after
creating it, it's a very good trade-off.

A reproducer is intentionally not provided by this commit:
it's easy to test the change, but adding and dropping
a huge number of columns would take a really long amount
of time, so we need to omit it.

Fixes scylladb/scylladb#24018

Backport: all of the supported versions are affected, so we want to backport the changes there.