### PR TITLE
table: Touch and sync snapshot directory only once

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2941,11 +2941,13 @@ future<> table::snapshot_on_all_shards(sharded<database>& sharded_db, const glob
         std::vector<table::snapshot_file_set> file_sets;
         file_sets.reserve(smp::count);
 
+        co_await io_check([&jsondir] { return recursive_touch_directory(jsondir); });
         co_await coroutine::parallel_for_each(smp::all_cpus(), [&] (unsigned shard) -> future<> {
             file_sets.emplace_back(co_await smp::submit_to(shard, [&] {
                 return table_shards->take_snapshot(jsondir);
             }));
         });
+        co_await io_check(sync_directory, jsondir);
 
         co_await t.finalize_snapshot(sharded_db.local(), std::move(jsondir), std::move(file_sets));
     });
@@ -2959,14 +2961,12 @@ future<table::snapshot_file_set> table::take_snapshot(sstring jsondir) {
     auto tables = *_sstables->all() | std::ranges::to<std::vector<sstables::shared_sstable>>();
     auto table_names = std::make_unique<std::unordered_set<sstring>>();
 
-    co_await io_check([&jsondir] { return recursive_touch_directory(jsondir); });
     co_await _sstables_manager.dir_semaphore().parallel_for_each(tables, [&jsondir, &table_names] (sstables::shared_sstable sstable) {
         table_names->insert(sstable->component_basename(sstables::component_type::Data));
         return io_check([sstable, &dir = jsondir] {
             return sstable->snapshot(dir);
         });
     });
-    co_await io_check(sync_directory, jsondir);
     co_return make_foreign(std::move(table_names));
 }
 


### PR DESCRIPTION
The table::take_snapshot() touches the snapshot directory, which is good. It happens on all shards, which is not that good, because all shards just step on each other toes when doing it, the directory is not sharded. Same for post-snapshot directory sync -- it can happen once, after all shards finish creating snapshot links.

Move both, touching and syncing up one level. There's only one caller of the method, so only one caller to update.
