### PR TITLE
utils: chunked_vector: add some modifiers

### DIFF
--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -30,7 +30,7 @@ using deque = std::deque<int>;
 
 BOOST_AUTO_TEST_CASE(test_random_walk) {
     auto rand = std::default_random_engine();
-    auto op_gen = std::uniform_int_distribution<unsigned>(0, 12);
+    auto op_gen = std::uniform_int_distribution<unsigned>(0, 13);
     auto nr_dist = std::geometric_distribution<size_t>(0.7);
     deque d;
     disk_array c;
@@ -123,6 +123,15 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             auto end = std::uniform_int_distribution<size_t>(start, d.size())(rand);
             c.erase(c.begin() + start, c.begin() + end);
             d.erase(d.begin() + start, d.begin() + end);
+            break;
+        }
+        case 13: {
+            auto start = std::uniform_int_distribution<size_t>(0, d.size())(rand);
+            auto nr = std::uniform_int_distribution<size_t>(0, 20)(rand);
+            auto n = rand();
+            auto data = std::views::iota(n, n + nr);
+            c.insert(c.begin() + start, data.begin(), data.end());
+            d.insert(d.begin() + start, data.begin(), data.end());
             break;
         }
         default:
@@ -549,4 +558,15 @@ BOOST_AUTO_TEST_CASE(test_erase_single) {
     BOOST_REQUIRE_EQUAL(r3 - std::begin(vec), 1);
     BOOST_REQUIRE_EQUAL(vec[0], 2);
     BOOST_REQUIRE_EQUAL(vec[1], 8);
+}
+
+BOOST_AUTO_TEST_CASE(test_insert_range) {
+    auto vec = utils::chunked_vector<int, 8>();
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+    vec.push_back(4);
+    auto data = std::views::iota(8, 12);
+    vec.insert(vec.begin() + 2, data.begin(), data.end());
+    BOOST_REQUIRE(std::ranges::equal(vec, std::array{1, 2, 8, 9, 10, 11, 3, 4}));
 }

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -570,3 +570,15 @@ BOOST_AUTO_TEST_CASE(test_insert_range) {
     vec.insert(vec.begin() + 2, data.begin(), data.end());
     BOOST_REQUIRE(std::ranges::equal(vec, std::array{1, 2, 8, 9, 10, 11, 3, 4}));
 }
+
+BOOST_AUTO_TEST_CASE(test_swap) {
+    auto v1 = utils::chunked_vector<int, 8>();
+    auto v2 = utils::chunked_vector<int, 8>();
+
+    v1.push_back(1);
+    v2.push_back(2);
+    v2.push_back(4);
+    v1.swap(v2);
+    BOOST_REQUIRE(std::ranges::equal(v1, std::array{2, 4}));
+    BOOST_REQUIRE(std::ranges::equal(v2, std::array{1}));
+}

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -30,7 +30,7 @@ using deque = std::deque<int>;
 
 BOOST_AUTO_TEST_CASE(test_random_walk) {
     auto rand = std::default_random_engine();
-    auto op_gen = std::uniform_int_distribution<unsigned>(0, 10);
+    auto op_gen = std::uniform_int_distribution<unsigned>(0, 12);
     auto nr_dist = std::geometric_distribution<size_t>(0.7);
     deque d;
     disk_array c;
@@ -108,6 +108,21 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             auto n = rand();
             c.insert(c.begin() + pos, n);
             d.insert(d.begin() + pos, n);
+            break;
+        }
+        case 11: {
+            if (!c.empty()) {
+                auto pos = std::uniform_int_distribution<size_t>(0, d.size() - 1)(rand);
+                c.erase(c.begin() + pos);
+                d.erase(d.begin() + pos);
+            }
+            break;
+        }
+        case 12: {
+            auto start = std::uniform_int_distribution<size_t>(0, d.size())(rand);
+            auto end = std::uniform_int_distribution<size_t>(start, d.size())(rand);
+            c.erase(c.begin() + start, c.begin() + end);
+            d.erase(d.begin() + start, d.begin() + end);
             break;
         }
         default:
@@ -505,4 +520,33 @@ BOOST_AUTO_TEST_CASE(test_insert_single) {
     BOOST_REQUIRE_EQUAL(vec[2], 6);
     BOOST_REQUIRE_EQUAL(vec[3], 1);
     BOOST_REQUIRE_EQUAL(vec[4], 3);
+}
+
+BOOST_AUTO_TEST_CASE(test_erase_single) {
+    auto vec = utils::chunked_vector<int, 8>();
+    vec.push_back(1);
+    vec.push_back(2);
+    vec.push_back(3);
+    vec.push_back(4);
+    BOOST_REQUIRE_EQUAL(vec.size(), 4);
+    auto r1 = vec.erase(vec.begin());
+    BOOST_REQUIRE_EQUAL(vec.size(), 3);
+    BOOST_REQUIRE_EQUAL(r1 - std::begin(vec), 0);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 3);
+    BOOST_REQUIRE_EQUAL(vec[2], 4);
+    auto r2 = vec.erase(vec.begin() + 1);
+    BOOST_REQUIRE_EQUAL(vec.size(), 2);
+    BOOST_REQUIRE_EQUAL(r2 - std::begin(vec), 1);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 4);
+    vec.push_back(5);
+    vec.push_back(6);
+    vec.push_back(7);
+    vec.push_back(8);
+    auto r3 = vec.erase(vec.begin() + 1, vec.end() - 1);
+    BOOST_REQUIRE_EQUAL(vec.size(), 2);
+    BOOST_REQUIRE_EQUAL(r3 - std::begin(vec), 1);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 8);
 }

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -30,7 +30,7 @@ using deque = std::deque<int>;
 
 BOOST_AUTO_TEST_CASE(test_random_walk) {
     auto rand = std::default_random_engine();
-    auto op_gen = std::uniform_int_distribution<unsigned>(0, 9);
+    auto op_gen = std::uniform_int_distribution<unsigned>(0, 10);
     auto nr_dist = std::geometric_distribution<size_t>(0.7);
     deque d;
     disk_array c;
@@ -101,6 +101,13 @@ BOOST_AUTO_TEST_CASE(test_random_walk) {
             auto nr = nr_dist(rand);
             c.resize(nr);
             d.resize(nr);
+            break;
+        }
+        case 10: {
+            auto pos = std::uniform_int_distribution<size_t>(0, d.size())(rand);
+            auto n = rand();
+            c.insert(c.begin() + pos, n);
+            d.insert(d.begin() + pos, n);
             break;
         }
         default:
@@ -464,4 +471,38 @@ BOOST_AUTO_TEST_CASE(test_value_init_ctor) {
     for (auto it = vec.begin(); it != vec.end(); ++it) {
         BOOST_REQUIRE_EQUAL(*it, v);
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_insert_single) {
+    auto vec = utils::chunked_vector<int, 8>();
+    auto r1 = vec.insert(vec.begin(), 1);
+    BOOST_REQUIRE_EQUAL(vec.size(), 1);
+    BOOST_REQUIRE_EQUAL(r1 - std::begin(vec), 0);
+    BOOST_REQUIRE_EQUAL(vec[0], 1);
+    auto r2 = vec.insert(vec.begin(), 2);
+    BOOST_REQUIRE_EQUAL(vec.size(), 2);
+    BOOST_REQUIRE_EQUAL(r2 - std::begin(vec), 0);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 1);
+    auto r3 = vec.insert(vec.end(), 3);
+    BOOST_REQUIRE_EQUAL(vec.size(), 3);
+    BOOST_REQUIRE_EQUAL(r3 - std::begin(vec), 2);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 1);
+    BOOST_REQUIRE_EQUAL(vec[2], 3);
+    auto r4 = vec.insert(vec.end() - 2, 4);
+    BOOST_REQUIRE_EQUAL(vec.size(), 4);
+    BOOST_REQUIRE_EQUAL(r4 - std::begin(vec), 1);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 4);
+    BOOST_REQUIRE_EQUAL(vec[2], 1);
+    BOOST_REQUIRE_EQUAL(vec[3], 3);
+    auto r5 = vec.emplace(vec.end() - 2, 6);
+    BOOST_REQUIRE_EQUAL(vec.size(), 5);
+    BOOST_REQUIRE_EQUAL(r5 - std::begin(vec), 2);
+    BOOST_REQUIRE_EQUAL(vec[0], 2);
+    BOOST_REQUIRE_EQUAL(vec[1], 4);
+    BOOST_REQUIRE_EQUAL(vec[2], 6);
+    BOOST_REQUIRE_EQUAL(vec[3], 1);
+    BOOST_REQUIRE_EQUAL(vec[4], 3);
 }

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -331,6 +331,7 @@ public:
     iterator erase(const_iterator pos);
     iterator erase(iterator first, iterator last);
     iterator erase(const_iterator first, const_iterator last);
+    void swap(chunked_vector& x) noexcept;
 };
 
 template<typename T, size_t max_contiguous_allocation>
@@ -675,6 +676,15 @@ template <typename T, size_t max_contiguous_allocation>
 typename chunked_vector<T, max_contiguous_allocation>::iterator
 chunked_vector<T, max_contiguous_allocation>::erase(iterator pos) {
     return erase(const_iterator(pos));
+}
+
+template <typename T, size_t max_contiguous_allocation>
+void
+chunked_vector<T, max_contiguous_allocation>::swap(chunked_vector& x) noexcept {
+    using std::swap;
+    swap(_chunks, x._chunks);
+    swap(_size, x._size);
+    swap(_capacity, x._capacity);
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -323,6 +323,8 @@ public:
 public:
     iterator insert(const_iterator pos, const T& x);
     iterator insert(const_iterator pos, T&& x);
+    template <typename Iterator>
+    iterator insert(const_iterator post, Iterator first, Iterator last);
     template <typename... Args>
     iterator emplace(const_iterator pos, Args&&... args);
     iterator erase(iterator pos);
@@ -622,6 +624,18 @@ chunked_vector<T, max_contiguous_allocation>::insert(const_iterator pos, T&& x) 
     auto insert_idx = pos - begin();
     push_back(std::move(x));
     std::rotate(begin() + insert_idx, end() - 1, end());
+    return begin() + insert_idx;
+}
+
+template <typename T, size_t max_contiguous_allocation>
+template <typename Iterator>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::insert(const_iterator pos, Iterator first, Iterator last) {
+    auto insert_idx = pos - begin();
+    auto n_insert = std::distance(first, last);
+    reserve(size() + n_insert);
+    std::copy(first, last, std::back_inserter(*this));
+    std::rotate(begin() + insert_idx, end() - n_insert, end());
     return begin() + insert_idx;
 }
 

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -326,6 +326,10 @@ public:
     iterator insert(const_iterator pos, T&& x);
     template <typename... Args>
     iterator emplace(const_iterator pos, Args&&... args);
+    iterator erase(iterator pos);
+    iterator erase(const_iterator pos);
+    iterator erase(iterator first, iterator last);
+    iterator erase(const_iterator first, const_iterator last);
 };
 
 template<typename T, size_t max_contiguous_allocation>
@@ -626,6 +630,34 @@ chunked_vector<T, max_contiguous_allocation>::emplace(const_iterator pos, Args&&
     emplace_back(std::forward<Args>(args)...);
     std::rotate(begin() + insert_idx, end() - 1, end());
     return begin() + insert_idx;
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::erase(const_iterator first, const_iterator last) {
+    auto erase_idx = first - begin();
+    auto n_erase = last - first;
+    std::rotate(begin() + erase_idx, begin() + erase_idx + n_erase, end());
+    resize(size() - n_erase);
+    return begin() + erase_idx;
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::erase(const_iterator pos) {
+    return erase(pos, pos + 1);
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::erase(iterator first, iterator last) {
+    return erase(const_iterator(first), const_iterator(last));
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::erase(iterator pos) {
+    return erase(const_iterator(pos));
 }
 
 template <typename T, size_t max_contiguous_allocation>

--- a/utils/chunked_vector.hh
+++ b/utils/chunked_vector.hh
@@ -321,6 +321,11 @@ public:
     bool operator==(const chunked_vector& x) const {
         return std::ranges::equal(*this, x);
     }
+public:
+    iterator insert(const_iterator pos, const T& x);
+    iterator insert(const_iterator pos, T&& x);
+    template <typename... Args>
+    iterator emplace(const_iterator pos, Args&&... args);
 };
 
 template<typename T, size_t max_contiguous_allocation>
@@ -593,6 +598,34 @@ chunked_vector<T, max_contiguous_allocation>::clear() {
         pop_back();
     }
     shrink_to_fit();
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::insert(const_iterator pos, const T& x) {
+    auto insert_idx = pos - begin();
+    push_back(x);
+    std::rotate(begin() + insert_idx, end() - 1, end());
+    return begin() + insert_idx;
+}
+
+template <typename T, size_t max_contiguous_allocation>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::insert(const_iterator pos, T&& x) {
+    auto insert_idx = pos - begin();
+    push_back(std::move(x));
+    std::rotate(begin() + insert_idx, end() - 1, end());
+    return begin() + insert_idx;
+}
+
+template <typename T, size_t max_contiguous_allocation>
+template <typename... Args>
+typename chunked_vector<T, max_contiguous_allocation>::iterator
+chunked_vector<T, max_contiguous_allocation>::emplace(const_iterator pos, Args&&... args) {
+    auto insert_idx = pos - begin();
+    emplace_back(std::forward<Args>(args)...);
+    std::rotate(begin() + insert_idx, end() - 1, end());
+    return begin() + insert_idx;
 }
 
 template <typename T, size_t max_contiguous_allocation>


### PR DESCRIPTION
chunked_vector is a replacement for std::vector that avoids large contiguous
allocations.

In this series, we add some missing modifiers and improve quality-of-life for
chunked_vector users (the static_assert patch).

Those modifiers were generally unused since they have O(n) complexity
and therefore not useful for hot paths, but they are used in some
control plane code on vectors which we'd like to replace with chunked_vectors.

A candidate for such a replacement is token_range_vector (see #3335).

This is a prerequisite for fixing some minor stalls; I don't expect we'll backport
fixes to those stalls.