### PR TITLE
compaction_manager: drop gratuitous conversion from interval to wrapped_interval

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1939,7 +1939,7 @@ bool needs_cleanup(const sstables::shared_sstable& sst,
     dht::token_range sst_token_range = dht::token_range::make(first_token, last_token);
 
     auto r = std::lower_bound(sorted_owned_ranges.begin(), sorted_owned_ranges.end(), first_token,
-            [] (const wrapping_interval<dht::token>& a, const dht::token& b) {
+            [] (const interval<dht::token>& a, const dht::token& b) {
         // check that range a is before token b.
         return a.after(b, dht::token_comparator());
     });


### PR DESCRIPTION

The conversion is unnecessary and likely dates back from before the split between interval and wrapped_interval. It gets in the way of making the conversion explicit.

Minor improvement, no backport needed.