### PR TITLE
mutation/mutation_compactor: cache regular/shadowable max-purgable in separate members

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -150,7 +150,8 @@ class compact_mutation_state {
     gc_clock::time_point _query_time;
     max_purgeable_fn _get_max_purgeable;
     can_gc_fn _can_gc;
-    max_purgeable _max_purgeable;
+    max_purgeable _max_purgeable_regular;
+    max_purgeable _max_purgeable_shadowable;
     std::optional<gc_clock::time_point> _gc_before;
     const query::partition_slice& _slice;
     uint64_t _row_limit{};
@@ -318,12 +319,13 @@ private:
         if (!t) {
             return std::make_pair(false, max_purgeable::timestamp_source::none);
         }
-        if (!_max_purgeable) {
-            _max_purgeable = _get_max_purgeable(*_dk, is_shadowable);
+        auto& max_purgeable = is_shadowable ? _max_purgeable_shadowable : _max_purgeable_regular;
+        if (!max_purgeable) {
+            max_purgeable = _get_max_purgeable(*_dk, is_shadowable);
         }
-        auto ret = t.timestamp < _max_purgeable.timestamp;
-        mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, _max_purgeable.timestamp, ret);
-        return std::make_pair(ret, _max_purgeable.source);
+        auto ret = t.timestamp < max_purgeable.timestamp;
+        mclog.debug("can_gc: t={} is_shadowable={} max_purgeable={}: ret={}", t, is_shadowable, max_purgeable.timestamp, ret);
+        return std::make_pair(ret, max_purgeable.source);
     };
 
 public:
@@ -379,7 +381,8 @@ public:
         _static_row_live = false;
         _partition_tombstone = {};
         _current_partition_limit = std::min(_row_limit, _partition_row_limit);
-        _max_purgeable = {};
+        _max_purgeable_regular = {};
+        _max_purgeable_shadowable = {};
         _gc_before = std::nullopt;
         _last_static_row.reset();
         _last_pos = position_in_partition::for_partition_start();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -4023,3 +4023,109 @@ SEASTAR_THREAD_TEST_CASE(test_to_data_query_results_with_distinct_and_per_partit
         BOOST_REQUIRE_EQUAL(result.row_count(), pkeys.size() * 2);
     }
 }
+
+// Max-purgeable has two values: one for regular and one for shadowable
+// tombstones. Check that the value is not sticky -- if a shadowable is requested
+// first, it won't apply to regular tombstones and vice-versa.
+SEASTAR_THREAD_TEST_CASE(test_mutation_compactor_sticky_max_purgeable) {
+    simple_schema ss;
+    auto s = ss.schema();
+
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto permit = semaphore.make_permit();
+
+    auto dk = ss.make_pkey(1);
+
+    const auto& v_def = *s->get_column_definition(to_bytes("v"));
+    const auto value = serialized("v");
+
+    const auto deletion_time = gc_clock::now() - std::chrono::hours(1) - s->gc_grace_seconds();
+    const auto compaction_time = gc_clock::now();
+    const api::timestamp_type shadowable_max_purgeable = 110;
+    const api::timestamp_type regular_max_purgeable = 50;
+    const api::timestamp_type timestamp = 100;
+
+    class mutation_rebuilding_consumer {
+        mutation_rebuilder_v2 _mr;
+
+    public:
+        explicit mutation_rebuilding_consumer(schema_ptr s) : _mr(std::move(s)) { }
+        void consume_new_partition(dht::decorated_key dk) { _mr.consume_new_partition(std::move(dk)); }
+        void consume(tombstone t) { _mr.consume(t); }
+        stop_iteration consume(static_row&& sr, tombstone, bool) { return _mr.consume(std::move(sr)); }
+        stop_iteration consume(clustering_row&& cr, row_tombstone, bool) { return _mr.consume(std::move(cr)); }
+        stop_iteration consume(range_tombstone_change&& rtc) { return _mr.consume(std::move(rtc)); }
+        stop_iteration consume_end_of_partition() { return _mr.consume_end_of_partition(); }
+        mutation_opt consume_end_of_stream() { return _mr.consume_end_of_stream(); }
+    };
+
+    auto get_max_purgeable = [] (const dht::decorated_key&, is_shadowable is) {
+        const auto ts = is == is_shadowable::yes ? shadowable_max_purgeable : regular_max_purgeable;
+        return max_purgeable{ts, max_purgeable::timestamp_source::none};
+    };
+
+    auto compact_and_expire = [&] (mutation mut) {
+        auto reader = make_mutation_reader_from_mutations(s, permit, std::move(mut));
+        auto close_reader = deferred_close(reader);
+
+        auto compactor = compact_for_compaction<mutation_rebuilding_consumer>(
+                *s,
+                compaction_time,
+                get_max_purgeable,
+                tombstone_gc_state(nullptr),
+                mutation_rebuilding_consumer(s));
+        auto mut_opt = reader.consume(std::move(compactor)).get();
+
+        BOOST_REQUIRE(mut_opt);
+
+        return *mut_opt;
+    };
+
+    // max-purgeable returned for shadowable tombstone becomes sticky and applies to row tombstone after it
+    {
+        mutation mut(s, dk);
+        mutation mut_compacted(s, dk);
+
+        auto row1 = clustering_row(ss.make_ckey(1));
+        row1.apply(shadowable_tombstone(timestamp, deletion_time));
+
+        auto row2 = clustering_row(ss.make_ckey(2));
+        row2.apply(tombstone(timestamp, deletion_time));
+
+        auto row3 = clustering_row(ss.make_ckey(3));
+        row3.cells().apply(v_def, atomic_cell::make_live(*v_def.type, timestamp, value));
+
+        mut_compacted.apply(mutation_fragment(*s, permit, clustering_row(*s, row2)));
+        mut_compacted.apply(mutation_fragment(*s, permit, clustering_row(*s, row3)));
+
+        mut.apply(mutation_fragment(*s, permit, std::move(row1)));
+        mut.apply(mutation_fragment(*s, permit, std::move(row2)));
+        mut.apply(mutation_fragment(*s, permit, std::move(row3)));
+
+        assert_that(compact_and_expire(std::move(mut))).is_equal_to(mut_compacted);
+    }
+
+    // max-purgeable returned for regular tombstone becomes sticky and applies to shadowable tombstone after it
+    {
+        mutation mut(s, dk);
+        mutation mut_compacted(s, dk);
+
+        auto row1 = clustering_row(ss.make_ckey(1));
+        row1.apply(tombstone(timestamp, deletion_time));
+
+        auto row2 = clustering_row(ss.make_ckey(2));
+        row2.apply(shadowable_tombstone(timestamp, deletion_time));
+
+        auto row3 = clustering_row(ss.make_ckey(3));
+        row3.cells().apply(v_def, atomic_cell::make_live(*v_def.type, timestamp, value));
+
+        mut_compacted.apply(mutation_fragment(*s, permit, clustering_row(*s, row1)));
+        mut_compacted.apply(mutation_fragment(*s, permit, clustering_row(*s, row3)));
+
+        mut.apply(mutation_fragment(*s, permit, std::move(row1)));
+        mut.apply(mutation_fragment(*s, permit, std::move(row2)));
+        mut.apply(mutation_fragment(*s, permit, std::move(row3)));
+
+        assert_that(compact_and_expire(std::move(mut))).is_equal_to(mut_compacted);
+    }
+}


### PR DESCRIPTION
Max purgeable has two possible values for each partition: one for regular tombstones and one for shadowable ones. Yet currently a single member is used to cache the max-purgeable value for the partition, so whichever kind of tombstone is checked first, its max-purgeable will become sticky and apply to the other kind of tombstones too. E.g. if the first can_gc() check is for a regular tombstone, its max-purgeable will apply to shadowable tombstones in the partition too, meaning they might not be purged, even though they are purgeable, as the shadowable max-purgeable is expected to be more lenient. The other way around is worse, as it will result in regular tombstone being incorrectly purged, permitted by the more lenient shadowable tombstone max-purgeable. Fix this by caching the two possible values in two separate members. A reproducer unit test is also added.

Fixes: scylladb/scylladb#23272

Needs backport to all release which have https://github.com/scylladb/scylladb/commit/7d893a5ed9a55e85adc66a079f7d3f18da73c7ec (>=6.2)