### PR TITLE
doc: fix the product name for version 2025.1

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -7,7 +7,7 @@
     },
     "ScyllaDB Versions": [
       {
-        "version": "Enterprise 2025.1",
+        "version": "ScyllaDB 2025.1",
         "supported_OS": {
           "Ubuntu": ["20.04", "22.04", "24.04"],
           "Debian": ["11"],


### PR DESCRIPTION
Starting with 2025.1, ScyllaDB versions are no longer called "Enterprise", but the OS support page still uses that label.
This commit fixes that by replacing "Enterprise" with "ScyllaDB".

This update is required since we've removed "Enterprise" from everywhere else, including the commands, so having it here is confusing.

Fixes https://github.com/scylladb/scylladb/issues/24179

This PR must be backported to all branches where the bug exists, which is branch-2025.1 and branch-2025.2.