### PR TITLE
test: wait for normal state propagation in test_auth_v2_migration

### DIFF
--- a/test/cluster/auth_cluster/test_auth_v2_migration.py
+++ b/test/cluster/auth_cluster/test_auth_v2_migration.py
@@ -14,7 +14,8 @@ from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name
 from cassandra.cluster import ConsistencyLevel
 from test.cluster.util import wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
-        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes
+        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
+        wait_for_token_ring_and_group0_consistency
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
 
@@ -162,6 +163,8 @@ async def test_auth_v2_migration(request, manager: ManagerClient):
 
     logging.info("Waiting until driver connects to every server")
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     logging.info("Checking the upgrade state on all nodes")
     for host in hosts:


### PR DESCRIPTION
By default, cluster tests have skip_wait_for_gossip_to_settle=0 and ring_delay_ms=0. In tests with gossip topology, it may lead to a race, where nodes see different state of each other.

In case of test_auth_v2_migration, there are three nodes. If the first node already knows that the third node is NORMAL, and the second node does not, the system_auth tables can return incomplete results.

To avoid such a race, this commit adds a check that all nodes see other nodes as NORMAL before any writes are done.

Refs: #24163

Only a test fix, I don't think backports in scylladb repo are necessary, as I haven't seen any related CI failures