### PR TITLE
sstable: add more complete schema to scylla component

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1860,6 +1860,16 @@ sstable::read_scylla_metadata() noexcept {
     });
 }
 
+static sstable_column_kind to_sstable_column_kind(column_kind k) {
+    switch (k) {
+        case column_kind::partition_key: return sstable_column_kind::partition_key;
+        case column_kind::clustering_key: return sstable_column_kind::clustering_key;
+        case column_kind::static_column: return sstable_column_kind::static_column;
+        case column_kind::regular_column: return sstable_column_kind::regular_column;
+    }
+    on_internal_error(sstlog, format("to_sstable_column_kind(): unknown column kind {}", static_cast<std::underlying_type_t<column_kind>>(k)));
+}
+
 void
 sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats) {
@@ -1925,6 +1935,16 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         sstlog.info("SSTable {} has numerical generation. SSTable identifier in scylla_metadata set to {}", get_filename(), sid);
     }
     _components->scylla_metadata->data.set<scylla_metadata_type::SSTableIdentifier>(scylla_metadata::sstable_identifier{sid});
+
+    sstable_schema_type sstable_schema;
+    sstable_schema.id = _schema->id();
+    sstable_schema.version = _schema->version();
+    sstable_schema.keyspace_name.value = to_bytes(_schema->ks_name());
+    sstable_schema.table_name.value = to_bytes(_schema->cf_name());
+    for (const auto& col : _schema->all_columns()) {
+        sstable_schema.columns.elements.push_back(sstable_column_description{to_sstable_column_kind(col.kind), {col.name()}, {to_bytes(col.type->name())}});
+    }
+    _components->scylla_metadata->data.set<scylla_metadata_type::Schema>(std::move(sstable_schema));
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata);
 }

--- a/test/lib/random_schema.hh
+++ b/test/lib/random_schema.hh
@@ -178,6 +178,12 @@ public:
     /// make sure to honor this guarantee.
     random_schema(uint32_t seed, random_schema_specification& spec);
 
+    /// Create random schema object from an existing schema.
+    ///
+    /// Allows using random data generation facilities on an existing schema.
+    random_schema(schema_ptr schema) : _schema(std::move(schema)) {
+    }
+
     schema_ptr schema() const {
         return _schema;
     }


### PR DESCRIPTION
Sstables store a basic schema in the statistics component. The scylla-sstable tool uses this to be able to read and dump sstables in a self-contained manner, without requiring an external schema source.
The problem is that the schema stored int he statistics component is incomplete: it doesn't store column names for key columns, so these have placeholder names in dump outputs where column names are visible.
This is not a disaster but it is confusing and it can cause errors in scripts which want to check the content of sstables, while also knowing the schema and expecting the proper names for key columns.

To make sstables truly self-contained w.r.t. the schema, add a complete schema to the scylla component. This schema contains the names and types of all columns, as well as some basic information about the schema: keyspace name, table name, id and version.
When available, scylla-sstable's schema loader will use this new more complete schema and fall-back to the old method of loading the (incomplete) schema from the statistics component otherwise.

New feature, no backport required.