### PR TITLE
test/boost/sstable_compressor_factory_test: define a test suite name

### DIFF
--- a/test/boost/sstable_compressor_factory_test.cc
+++ b/test/boost/sstable_compressor_factory_test.cc
@@ -14,6 +14,8 @@
 #include "test/lib/log.hh"
 #include "test/lib/random_utils.hh"
 
+BOOST_AUTO_TEST_SUITE(sstable_compressor_factory_test)
+
 // 1. Create a random message.
 // 2. Set this random message as the recommended dict.
 // 3. On all shards, create compressors.
@@ -131,3 +133,5 @@ SEASTAR_THREAD_TEST_CASE(test_numa_awareness) {
         test_one_numa_topology(n_numa_nodes);
     }
 }
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
It seems that tests in test/boost/combined_tests have to define a test suite name, otherwise they aren't picked up by test.py.

Fixes #24199

Should be backported to 2025.2 where this test was added.