### PR TITLE
sstables_loader: Extend logging with recently added skip-cleanup

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -548,8 +548,8 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         throw std::runtime_error("Skipping cleanup is not possible when doing load-and-stream");
     }
 
-    llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}",
-            ks_name, cf_name, load_and_stream_desc, primary_replica_only);
+    llog.info("Loading new SSTables for keyspace={}, table={}, load_and_stream={}, primary_replica_only={}, skip_cleanup={}",
+            ks_name, cf_name, load_and_stream_desc, primary_replica_only, skip_cleanup);
     try {
         if (load_and_stream) {
             ::table_id table_id;


### PR DESCRIPTION
When starting, the loader prints all its arguments into logs. Recently added skip-cleanup one is not included, but it's good to have one too.

refs: #24139
