### PR TITLE
sstables_loader: Fix load-and-stream vs skip-cleanup check

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -544,7 +544,7 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         load_and_stream_desc = "auto-enabled-for-tablets";
     }
 
-    if (!load_and_stream && skip_cleanup) {
+    if (load_and_stream && skip_cleanup) {
         throw std::runtime_error("Skipping cleanup is not possible when doing load-and-stream");
     }
 


### PR DESCRIPTION
The intention was to fail the REST API call in case --skip-cleanup is requested for --load-and-stream loading. The corresponding if expression is checking something else :( despite log message is correct.
