### PR TITLE
[workflow]: add conflict_reminder to PRs based against `master`

### DIFF
--- a/.github/workflows/conflict_reminder.yaml
+++ b/.github/workflows/conflict_reminder.yaml
@@ -1,9 +1,16 @@
 name: Notify PR Authors of Conflicts
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
+  push:
+    branches:
+      - 'master'
+      - 'branch-*'
   schedule:
     - cron: '0 10 * * 1,4'  # Runs every Monday and Thursday at 10:00am
-  workflow_dispatch:      # Manual trigger for testing
 
 jobs:
   notify_conflict_prs:
@@ -14,32 +21,95 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            console.log("Starting conflict reminder script...");
+            // Print trigger event
+            if (process.env.GITHUB_EVENT_NAME) {
+              console.log(`Workflow triggered by: ${process.env.GITHUB_EVENT_NAME}`);
+            } else {
+              console.log("Could not determine workflow trigger event.");
+            }
+            const isPushEvent = process.env.GITHUB_EVENT_NAME === 'push';
+            console.log(`isPushEvent: ${isPushEvent}`);
+            const twoMonthsAgo = new Date();
+            twoMonthsAgo.setMonth(twoMonthsAgo.getMonth() - 2);
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               per_page: 100
             });
+            console.log(`Fetched ${prs.length} open PRs`);
+            const recentPrs = prs.filter(pr => new Date(pr.created_at) >= twoMonthsAgo);
+            const validBaseBranches = ['master'];
             const branchPrefix = 'branch-';
             const threeDaysAgo = new Date();
-            const conflictLabel = 'conflicts';          
+            const conflictLabel = 'conflicts';
             threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
-            for (const pr of prs) {
-              if (!pr.base.ref.startsWith(branchPrefix)) continue;
-              const hasConflictLabel = pr.labels.some(label => label.name === conflictLabel);
-              if (!hasConflictLabel) continue;
+            console.log(`Three days ago: ${threeDaysAgo.toISOString()}`);
+
+            for (const pr of recentPrs) {
+              console.log(`Checking PR #${pr.number} on base branch '${pr.base.ref}'`);
+              const isBranchX = pr.base.ref.startsWith(branchPrefix);
+              const isMaster = validBaseBranches.includes(pr.base.ref);
+              if (!(isBranchX || isMaster)) {
+                console.log(`PR #${pr.number} skipped: base branch is not 'master' or does not start with '${branchPrefix}'`);
+                continue;
+              }
               const updatedDate = new Date(pr.updated_at);
-              if (updatedDate >= threeDaysAgo) continue;
-              if (pr.assignee === null) continue;
-              const assignee = pr.assignee.login;
-              if (assignee) {
-                await github.rest.issues.createComment({
+              console.log(`PR #${pr.number} last updated at: ${updatedDate.toISOString()}`);
+              if (!isPushEvent && updatedDate >= threeDaysAgo) {
+                console.log(`PR #${pr.number} skipped: updated within last 3 days`);
+                continue;
+              }
+              if (pr.assignee === null) {
+                console.log(`PR #${pr.number} skipped: no assignee`);
+                continue;
+              }
+
+              // Fetch PR details to check mergeability
+              let { data: prDetails } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+              });
+              console.log(`PR #${pr.number} mergeable: ${prDetails.mergeable}`);
+
+              // Wait and re-fetch if mergeable is null
+              if (prDetails.mergeable === null) {
+                console.log(`PR #${pr.number} mergeable is null, waiting 2 seconds and retrying...`);
+                await new Promise(resolve => setTimeout(resolve, 2000)); // wait 2 seconds
+                prDetails = (await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  issue_number: pr.number,
-                  body: `@${assignee}, this PR has been open with conflicts. Please resolve the conflicts so we can merge it.`,
-                });
-                console.log(`Notified @${assignee} for PR #${pr.number}`);
-              } 
+                  pull_number: pr.number,
+                })).data;
+                console.log(`PR #${pr.number} mergeable after retry: ${prDetails.mergeable}`);
+              }
+
+              if (prDetails.mergeable === false) {
+                const hasConflictLabel = pr.labels.some(label => label.name === conflictLabel);
+                console.log(`PR #${pr.number} has conflict label: ${hasConflictLabel}`);
+                if (!hasConflictLabel) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    labels: [conflictLabel],
+                  });
+                  console.log(`Added 'conflicts' label to PR #${pr.number}`);
+                }
+                const assignee = pr.assignee.login;
+                if (assignee) {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: `@${assignee}, this PR has merge conflicts with the base branch. Please resolve the conflicts so we can merge it.`,
+                  });
+                  console.log(`Notified @${assignee} for PR #${pr.number}`);
+                }
+              } else {
+                console.log(`PR #${pr.number} is mergeable, no action needed.`);
+              }
             }
             console.log(`Total PRs checked: ${prs.length}`);


### PR DESCRIPTION
Today we send a reminder to PR's author when backport PRs has conflicts. Often, PR authors wait for their PR to be reviewed/merged, but the merge is not happening because the PR now conflicts with master and so maintainers won't merge it. This can lead to a stall, where maintainers wait for the author to rebase and authors are waiting for merge.

In this PR we added the ability to notify the PR author as soon as base branch moved forward and rebase is required

Fixes: https://github.com/scylladb/scylla-pkg/issues/4955

**PR automation improvements,  no backport is needed**

### Testing
- [x] https://github.com/yaronkaikov/trigger/actions/runs/15051660860/job/42307686374
![image](https://github.com/user-attachments/assets/93f814e4-88aa-4a7c-88d8-574c3c5ba1da)
