### PR TITLE
cql: extend IF clause in LWT statements to match WHERE clause

### DIFF
--- a/cql3/statements/raw/insert_statement.hh
+++ b/cql3/statements/raw/insert_statement.hh
@@ -42,6 +42,7 @@ public:
                   std::unique_ptr<attributes::raw> attrs,
                   std::vector<::shared_ptr<column_identifier::raw>> column_names,
                   std::vector<expr::expression> column_values,
+                  std::optional<expr::expression> cond_opt,
                   bool if_not_exists);
 
     virtual ::shared_ptr<cql3::statements::modification_statement> prepare_internal(data_dictionary::database db, schema_ptr schema,
@@ -63,7 +64,8 @@ public:
      * @param json_value JSON string representing names and values
      * @param attrs additional attributes for statement (CL, timestamp, timeToLive)
      */
-    insert_json_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, expr::expression json_value, bool if_not_exists, bool default_unset);
+    insert_json_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, expr::expression json_value,
+                  std::optional<expr::expression> cond_opt, bool if_not_exists, bool default_unset);
 
     virtual ::shared_ptr<cql3::statements::modification_statement> prepare_internal(data_dictionary::database db, schema_ptr schema,
                 prepare_context& ctx, std::unique_ptr<attributes> attrs, cql_stats& stats) const override;

--- a/cql3/statements/update_statement.cc
+++ b/cql3/statements/update_statement.cc
@@ -34,6 +34,7 @@
 #include "validation.hh"
 #include "dht/i_partitioner.hh"
 #include <optional>
+#include <utility>
 
 namespace cql3 {
 
@@ -372,8 +373,9 @@ insert_statement::insert_statement(cf_name name,
                                    std::unique_ptr<attributes::raw> attrs,
                                    std::vector<::shared_ptr<column_identifier::raw>> column_names,
                                    std::vector<expr::expression> column_values,
+                                   std::optional<expr::expression> cond_opt,
                                    bool if_not_exists)
-    : raw::modification_statement{std::move(name), std::move(attrs), std::nullopt /* condition */, if_not_exists, false}
+    : raw::modification_statement{std::move(name), std::move(attrs), std::move(cond_opt), if_not_exists, false}
     , _column_names{std::move(column_names)}
     , _column_values{std::move(column_values)}
 { }
@@ -429,9 +431,10 @@ insert_statement::prepare_internal(data_dictionary::database db, schema_ptr sche
 insert_json_statement::insert_json_statement(cf_name name,
                                              std::unique_ptr<attributes::raw> attrs,
                                              expr::expression json_value,
+                                             std::optional<expr::expression> cond_opt,
                                              bool if_not_exists,
                                              bool default_unset)
-    : raw::modification_statement{name, std::move(attrs), std::nullopt /* condition */, if_not_exists, false}
+    : raw::modification_statement{name, std::move(attrs), cond_opt, if_not_exists, false}
     , _name(name)
     , _json_value(std::move(json_value))
     , _if_not_exists(if_not_exists)

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -1119,7 +1119,7 @@ SEASTAR_TEST_CASE(test_user_function_filtering) {
         // Expect error until UDFs can be used for filtering.
         // See #5607
         BOOST_REQUIRE_EXCEPTION(e.execute_cql("SELECT val FROM my_table WHERE my_func(val) > 10;").get(),
-                                exceptions::syntax_exception, message_equals("line 1:31 no viable alternative at input 'my_func'"));
+                                exceptions::syntax_exception, message_equals("line 1:38 no viable alternative at input '('"));
 
         // Reproduce #7977 and verify the internal error exception
         e.execute_cql("CREATE FUNCTION minutesAgo(ago int, now bigint) \

--- a/test/cql/lwt_test.result
+++ b/test/cql/lwt_test.result
@@ -1084,16 +1084,24 @@ OK
 +-------------+-----+
 > -- list contains
 > update lwt set c=0 where a = 1 if listint contains null;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:42 no viable alternative at input 'contains'">
++-------------+-----------+
+| [applied]   | listint   |
+|-------------+-----------|
+| False       | null      |
++-------------+-----------+
 > -- map contains
 > update lwt set c=0 where a = 1 if mapint contains key 1;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:41 no viable alternative at input 'contains'">
++-------------+----------+
+| [applied]   | mapint   |
+|-------------+----------|
+| False       | null     |
++-------------+----------+
 > -- set contains
 > update lwt set c=0 where a = 1 if setint contains key 1;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:41 no viable alternative at input 'contains'">
+Error from server: code=2200 [Invalid query] message="Cannot use CONTAINS KEY on non-map column setint"
 > -- multi-value set contaias
 > update lwt set c=0 where a = 1 if setint contains key 1;
-<Error from server: code=2000 [Syntax error in CQL query] message="line 1:41 no viable alternative at input 'contains'">
+Error from server: code=2200 [Invalid query] message="Cannot use CONTAINS KEY on non-map column setint"
 > -- addressing map element
 > update lwt set c=0 where a = 1 if mapint[2] = 3;
 +-------------+----------+


### PR DESCRIPTION
Previously, the IF clause of UPDATE, INSERT, and DELETE supported fewer
conditional expressions than those available in WHERE clause. This patch
extends the grammar of IF conditions to support the same set of conditional
expressions as WHERE clause by reusing WHERE's expressions rules.

Fixes: https://github.com/scylladb/scylladb/issues/25255

It's a minor CQL language enhancement that doesn't need to be backported.