### PR TITLE
test.py: dtest: few fixes missed in the initial implementation

### DIFF
--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -47,7 +47,10 @@ class ScyllaCluster:
         return {node.name: node for node in self.nodelist()}
 
     def nodelist(self) -> list[ScyllaNode]:
-        return [ScyllaNode(cluster=self, server=server) for server in self._sorted_nodes(self.manager.all_servers())]
+        return [
+            ScyllaNode(cluster=self, server=server, name=f"node{n}")
+            for n, server in enumerate(self._sorted_nodes(self.manager.all_servers()), start=1)
+        ]
 
     def populate(self, nodes: int | list[int]) -> ScyllaCluster:
         if self._config_options.get("alternator_enforce_authorization"):

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -84,9 +84,10 @@ NodetoolError = ToolError
 
 
 class ScyllaNode:
-    def __init__(self, cluster: ScyllaCluster, server: ServerInfo):
+    def __init__(self, cluster: ScyllaCluster, server: ServerInfo, name: str):
         self.cluster = cluster
         self.server_id = server.server_id
+        self.name = name
         self.pid = None
         self.all_pids = []
         self.network_interfaces = {
@@ -134,10 +135,6 @@ class ScyllaNode:
 
     def set_mem_mb_per_cpu(self, mem: int) -> None:  # not used in scylla-dtest
         raise NotImplementedError("setting memory per CPU during a test is not supported")
-
-    @property
-    def name(self) -> str:
-        return f"node{self.server_id}"
 
     def address(self) -> str:
         """Return the IP use by this node for internal communication."""

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -300,6 +300,8 @@ class ScyllaNode:
                            wait_seconds: int | None = None,
                            marks: list[tuple[ScyllaNode, int]] | None = None,
                            dump_core: bool = True) -> None:  # not implemented
+        if wait_seconds is None:
+            wait_seconds = 127 if self.scylla_mode() != "debug" else 600
         if not wait_for(func=lambda: not self.is_running(), timeout=wait_seconds):
             raise NodeError(f"Problem stopping node {self.name}")
 

--- a/test/cluster/dtest/conftest.py
+++ b/test/cluster/dtest/conftest.py
@@ -90,6 +90,8 @@ def fixture_dtest_setup(request: FixtureRequest,
         for name, value in cluster_options.kwargs.items():
             dtest_setup.cluster_options.setdefault(name, value)
 
+    dtest_setup.init_default_config()
+
     # at this point we're done with our setup operations in this fixture
     # yield to allow the actual test to run
     yield dtest_setup


### PR DESCRIPTION
There are few problems found in the dtest shim code after #21580 was merged:

- The call of `init_default_config()` method was missed in https://github.com/scylladb/scylladb/pull/21580 .  It is required to handle dtest options and markers.
- The implementation of dtest shim uses `server_id` to format a name of a node in a cluster. This is a difference in behavior with dtest. Some of dtests use code like `cluster.nodes()["node1"]` to get access to a node object.
- Default timeout was missed in `ScyllaNode.wait_until_stopped()` method. Set it to 600 for debug mode or to 127 otherwise.