### PR TITLE
test.py: add coverage for boost with pytest execution

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,6 +66,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                            "Will route the profiles to `tmpdir`/mode/coverage/`suite` and post process them in order to generate "
                            "lcov file per suite, lcov file per mode, and an lcov file for the entire run, "
                            "The lcov files can eventually be used for generating coverage reports")
+    parser.addoption("--coverage-mode", action='append', type=str, dest="coverage_modes",
+                        help="Collect and process coverage only for the modes specified. implies: --coverage, default: All built modes")
     parser.addoption("--cluster-pool-size", type=int,
                      help="Set the pool_size for PythonTest and its descendants.  Alternatively environment variable "
                           "CLUSTER_POOL_SIZE can be used to achieve the same")

--- a/test/pylib/cpp/item.py
+++ b/test/pylib/cpp/item.py
@@ -25,6 +25,9 @@
 #
 from __future__ import annotations
 
+from collections import namedtuple
+
+from scripts import coverage as coverage_script
 from pathlib import Path
 from typing import Sequence, Any, Iterator
 
@@ -34,6 +37,8 @@ from _pytest._io import TerminalWriter
 
 from test import COMBINED_TESTS, BUILD_DIR
 from test.pylib.cpp.facade import CppTestFailure, CppTestFailureList, CppTestFacade
+
+coverage = namedtuple('coverage', ['global_coverage_flag', 'suite_coverage_flag', 'coverage_modes'])
 
 
 class CppFailureRepr(object):
@@ -122,8 +127,8 @@ class CppFile(pytest.File):
     Represents the C++ test file with all necessary information for test execution
     """
     def __init__(self, *, no_parallel_run: bool = False, modes: list[str], disabled_tests: dict[str, set[str]],
-                 run_id=None, facade: CppTestFacade, arguments: Sequence[str], parameters: list[str] = None,
-                 env: dict = None, **kwargs: Any) -> None:
+                 run_id=None, facade: CppTestFacade, arguments: Sequence[str], coverage_config: coverage,
+                 parameters: list[str] = None, env: dict = None, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.facade = facade
         self.modes = modes
@@ -133,6 +138,7 @@ class CppFile(pytest.File):
         self.parameters = parameters
         self.env = env
         self._arguments = arguments
+        self.coverage_config = coverage_config
 
     def collect(self) -> Iterator[CppTestFunction]:
         for mode in self.modes:
@@ -144,6 +150,8 @@ class CppFile(pytest.File):
             combined, tests = self.facade.list_tests(executable, self.no_parallel_run, mode)
             if combined:
                 executable = executable.parent / COMBINED_TESTS.stem
+            if mode == "coverage":
+                self.env.update(coverage_script.env(executable))
             for test_name in tests:
                 if '/' in test_name:
                     test_name = test_name.replace('/', '_')

--- a/test/pylib/cpp/item.py
+++ b/test/pylib/cpp/item.py
@@ -137,7 +137,7 @@ class CppFile(pytest.File):
     def collect(self) -> Iterator[CppTestFunction]:
         for mode in self.modes:
             test_name = self.path.stem
-            self.env['TMPDIR'] = Path(self.parent.config.getoption('tmpdir'), mode).absolute()
+            self.env['TMPDIR'] = (self.facade.temp_dir / mode).absolute()
             if test_name in self.disabled_tests[mode]:
                 continue
             executable = Path(f'{BUILD_DIR}/{mode}/test/{self.path.parent.name}/{test_name}')


### PR DESCRIPTION
This PR adds the possibility to gather coverage for the boost tests when they're executed with pytest. Since the pytest will be used as the main runner for boost tests as well, we need this before switching the runners.