### PR TITLE
test: close logfile/socket_dir for stopped servers in recycle_cluster

### DIFF
--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -55,7 +55,7 @@ class PythonTestSuite(TestSuite):
                which would delete the log file and directory - we might want to preserve
                these if it came from a failed test.
             """
-            for srv in cluster.running.values():
+            for srv in cluster.servers.values():
                 srv.log_file.close()
                 srv.maintenance_socket_dir.cleanup()
             await cluster.stop()


### PR DESCRIPTION
PythonTestSuite::recycle_cluster is a function that releases resources of an old, dirty cluster to make it reusable. It closes log_file and maintenance_socket_dir for running nodes in a dirty cluster, however it doesn't do the same for stopped nodes. It leads to leakage of file descriptors of stopped nodes, which in turn can lead to hitting ulimit of open files (that is often 1024) if the leaking test is repeated with `./test.py --repeat ...`. The problem was detected when tests from `test/cluster/dtest/` directory were executed with high `repeat` value.

This commit extends `recycle_cluster` to close and cleanup logfile and `socket_dir` for nodes that are stopped.

No backport needed, as it's just a minor improvement in the testing framework.