### PR TITLE
docs: remove [errno X] prefix from metrics logger

### DIFF
--- a/docs/_ext/scylladb_metrics.py
+++ b/docs/_ext/scylladb_metrics.py
@@ -38,7 +38,11 @@ class MetricsProcessor:
             except SystemExit:
                 LOGGER.info(f'Skipping file: {file_path}')
             except Exception as error:
-                LOGGER.info(error)
+                # Remove [Errno X] prefix from error message
+                error_msg = str(error)
+                if '[Errno' in error_msg:
+                    error_msg = error_msg.split('] ', 1)[1]
+                LOGGER.info(error_msg)
 
     def _process_metrics_files(self, repo_dir, output_directory, metrics_config_path):
         for root, _, files in os.walk(repo_dir):


### PR DESCRIPTION
## Motivation
 
This PR improves the clarity of logs in the metrics processing extension by removing the `[Errno X]` prefix from error messages. These messages are actually informative logs rather than critical errors.
 
## Before

>  INFO: [Errno 2] No such file or directory: '/path/to/file'

## After

> INFO: No such file or directory: '/path/to/file'

## How to test

1. Build the docs.
2. Open Reference > Metrics
3. Make sure it renders without errors

Fixes https://github.com/scylladb/scylladb/issues/24251 

