### PR TITLE
test: actually wait for tablets to distribute across nodes

### DIFF
--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -51,7 +51,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
             return len(set(base_replicas) & set(view_replicas)) == 0 or None
         # There's 4 nodes and 4 tablets, so even if the initial placement is not balanced,
         # each node should get 1 replica after some time.
-        wait_for(replicas_balanced, time.time() + 60)
+        await wait_for(replicas_balanced, time.time() + 60)
 
         # Disable migrations concurrent with replace since we don't handle nodes going down during migration yet.
         # See https://github.com/scylladb/scylladb/issues/16527


### PR DESCRIPTION
In test_tablet_mv_replica_pairing_during_replace, after we create the tables, we want to wait for their tablets to distribute evenly across nodes and we have a wait_for for that.
But we don't await this wait_for, so it's a no-op. This patch fixes it by adding the missing await.

Refs https://github.com/scylladb/scylladb/issues/23982
Refs https://github.com/scylladb/scylladb/issues/23997
