### PR TITLE
docs: remove API reference redirect

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -163,4 +163,4 @@
 /stable/upgrade/upgrade-opensource/upgrade-guide-from-4.5-to-4.6/metric-update-4.5-to-4.6.html: /stable/upgrade/index.html
 
 # Divice API reference to smaller files
-/stable/reference/api-reference.html: /stable/reference/api/index.html
+# /stable/reference/api-reference.html: /stable/reference/api/index.html


### PR DESCRIPTION
Fix for https://github.com/scylladb/scylladb/pull/24097

The stable branch does not contain the split API reference yet. This change fixes the 404 error raised when accessing the API reference on the stable branch due to the redirect.