### PR TITLE
test.py: allow cmake configuration and ./configure.py configuration to coexist

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -30,7 +30,10 @@ DEBUG_MODES = {"debug", "sanitize"}
 def path_to(mode: str, *components: str) -> str:
     """Resolve path to built executable."""
 
-    if BUILD_DIR.joinpath("build.ninja").exists():
+    # cmake places build.ninja in build/, traditional is in ./.
+    # We choose to test for traditional, not cmake, because IDEs may
+    # invoke cmake to learn the configuration and generate false positives
+    if not TOP_SRC_DIR.joinpath("build.ninja").exists():
         *dir_components, basename = components
         return str(BUILD_DIR.joinpath(*dir_components, ALL_MODES[mode], basename))
     return str(BUILD_DIR.joinpath(mode, *components))

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -273,7 +273,10 @@ def ninja(target: str) -> str:
     """Build specified target using ninja."""
 
     return subprocess.Popen(
-        args=["ninja", *(["-C", str(BUILD_DIR)] if BUILD_DIR.joinpath("build.ninja").exists() else []), target],
+        # cmake places build.ninja in build/, traditional is in ./.
+        # We choose to test for traditional, not cmake, because IDEs may
+        # invoke cmake to learn the configuration and generate false positives
+        args=["ninja", *(["-C", str(BUILD_DIR)] if not TOP_SRC_DIR.joinpath("build.ninja").exists() else []), target],
         stdout=subprocess.PIPE,
         cwd=TOP_SRC_DIR,
     ).communicate()[0].decode()


### PR DESCRIPTION

Cmake emits its build.ninja into build/, while configure.py emits build.ninja into ./. test.py uses this difference to choose the directory structure to test.

The problem is that vscode will randomly call cmake to understand the directory structure, so we end up with both build.ninja set up.

Invert the logic to look for ./build.ninja to determine the mode (instead of build/build.ninja which can exist even if the user uses traditional configuration).

It can still happen that a stray ./build.ninja exists (for example due to switching branches), but that is rarer than having vscode auto-create it.

Minor DX improvement, no need for backport.