### PR TITLE
dist/docker/debian/build_docker.sh: add scylla-server-dbg

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -83,6 +83,7 @@ fi
 packages=(
     "build/dist/$config/debian/${product}_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-server_$version-$release-1_$arch.deb"
+    "build/dist/$config/debian/$product-server-dbg_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-kernel-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-node-exporter_$version-$release-1_$arch.deb"


### PR DESCRIPTION
Adding missing scylla-server-dbg package, to enable debug symbols in our container


Fixes: https://github.com/scylladb/scylladb/issues/24271


**Since in `master` and `2025.2` we are using UBI for our container, making this change directly on 2025.1, I assume we don't need to backport this to older enterprise releases**