### PR TITLE
docs: enable ai chatbot

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,6 +168,7 @@ html_css_files = [
 html_theme_options = {
     "conf_py_path": "docs/",
     'hide_banner': 'true',
+    "hide_ai_chatbot": "false",
     "hide_edit_this_page_button": "false",
     "hide_feedback_buttons": 'false',
     "github_issues_repository": "scylladb/scylladb",
@@ -180,7 +181,6 @@ html_theme_options = {
     'banner_title_text': 'ScyllaDB University LIVE, FREE Virtual Training Event | March 21',
     "collapse_navigation": 'true',
     "brand": "open-source" if FLAG == 'opensource' else "self-hosted",
-
 }
 
 # Last updated format


### PR DESCRIPTION
Adds an AI chatbot to ScyllaDB docs powered by [Biel.ai](https://biel.ai).

**Details:** https://sphinx-theme.scylladb.com/stable/configuration/ai-chatbot.html