### PR TITLE
tablets: fix missing data after tablet merge 

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2748,7 +2748,7 @@ void tablet_storage_group_manager::update_effective_replication_map(const locato
     //  Also serves as a protection for clearing the cache on the new range, although it shouldn't be a
     //  problem as fresh node won't have any data in new range and migration cleanup invalidates the
     //  range being moved away.
-    if (tablet_migrating_in) {
+    if (tablet_migrating_in || old_tablet_count != new_tablet_count) {
         refresh_mutation_source();
     }
 }

--- a/sstables/sstable_set.cc
+++ b/sstables/sstable_set.cc
@@ -805,6 +805,14 @@ class incremental_reader_selector : public reader_selector {
         tracing::trace(_trace_state, "Reading partition range {} from sstable {}", *_pr, seastar::value_of([&sst] { return sst->get_filename(); }));
         return _fn(sst, *_pr);
     }
+
+    dht::ring_position_view pr_end() const {
+        return dht::ring_position_view::for_range_end(*_pr);
+    }
+
+    bool end_of_stream() const {
+        return _selector_position.is_max() || dht::ring_position_tri_compare(*_s, _selector_position, pr_end()) > 0;
+    }
 public:
     explicit incremental_reader_selector(schema_ptr s,
             lw_shared_ptr<const sstable_set> sstables,
@@ -839,8 +847,8 @@ public:
             auto selection = _selector->select({_selector_position, _pr});
             _selector_position = selection.next_position;
 
-            irclogger.trace("{}: {} sstables to consider, advancing selector to {}", fmt::ptr(this), selection.sstables.size(),
-                    _selector_position);
+            irclogger.trace("{}: {} sstables to consider, advancing selector to {}, eos={}", fmt::ptr(this), selection.sstables.size(),
+                    _selector_position, end_of_stream());
 
             readers.clear();
             for (auto& sst : selection.sstables) {
@@ -848,7 +856,7 @@ public:
                     readers.push_back(create_reader(sst));
                 }
             }
-        } while (!_selector_position.is_max() && readers.empty() && (!pos || dht::ring_position_tri_compare(*_s, *pos, _selector_position) >= 0));
+        } while (!end_of_stream() && readers.empty() && (!pos || dht::ring_position_tri_compare(*_s, *pos, _selector_position) >= 0));
 
         irclogger.trace("{}: created {} new readers", fmt::ptr(this), readers.size());
 
@@ -865,8 +873,14 @@ public:
         _pr = &pr;
 
         auto pos = dht::ring_position_view::for_range_start(*_pr);
+
         if (dht::ring_position_tri_compare(*_s, pos, _selector_position) >= 0) {
             return create_new_readers(pos);
+        }
+        // If selector position Y is contained in new range [X, Z], then we should try selecting new
+        // sstables since it might have sstables that overlap with that range.
+        if (!_selector_position.is_max() && dht::ring_position_tri_compare(*_s, _selector_position, pr_end()) <= 0) {
+            return create_new_readers(std::nullopt);
         }
 
         return {};

--- a/test/boost/sstable_set_test.cc
+++ b/test/boost/sstable_set_test.cc
@@ -22,6 +22,7 @@
 #include "test/lib/simple_schema.hh"
 #include "test/lib/sstable_utils.hh"
 #include "readers/from_mutations.hh"
+#include "service/storage_service.hh"
 
 BOOST_AUTO_TEST_SUITE(sstable_set_test)
 
@@ -199,6 +200,226 @@ SEASTAR_TEST_CASE(test_tablet_sstable_set_copy_ctor) {
         BOOST_REQUIRE(*tablet_sstable_set->all() == *tablet_sstable_set_copy.all());
         BOOST_REQUIRE_EQUAL(tablet_sstable_set->size(), tablet_sstable_set_copy.size());
         BOOST_REQUIRE_EQUAL(tablet_sstable_set->bytes_on_disk(), tablet_sstable_set_copy.bytes_on_disk());
+
+    }, std::move(cfg));
+}
+
+SEASTAR_TEST_CASE(test_sstable_set_fast_forward_by_cache_reader_simulation) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        auto pks = tests::generate_partition_keys(6, s);
+        std::vector<mutation> muts;
+        for (auto pk : pks) {
+            auto mut = mutation(s, pk);
+            ss.add_row(mut, ss.make_ckey(0), "val");
+            muts.push_back(std::move(mut));
+        }
+
+        sstable_writer_config cfg = env.manager().configure_writer("");
+
+        std::vector<sstables::shared_sstable> ssts;
+
+        {
+            auto mr = make_mutation_reader_from_mutations(s, env.make_reader_permit(), {muts[0], muts[1], muts[2]});
+            auto sst = make_sstable_easy(env, std::move(mr), cfg);
+            testlog.info("sstable [{}, {}]", sst->get_first_decorated_key().token(), sst->get_last_decorated_key().token());
+            ssts.push_back(std::move(sst));
+        }
+
+        {
+            auto mr = make_mutation_reader_from_mutations(s, env.make_reader_permit(), {muts[4], muts[5]});
+            auto sst = make_sstable_easy(env, std::move(mr), cfg);
+            testlog.info("sstable [{}, {}]", sst->get_first_decorated_key().token(), sst->get_last_decorated_key().token());
+            ssts.push_back(std::move(sst));
+        }
+        auto token_range = dht::token_range::make(dht::first_token(), dht::last_token());
+        auto set = make_lw_shared<sstable_set>(std::make_unique<partitioned_sstable_set>(ss.schema(), token_range));
+        for (auto& sst : ssts) {
+            set->insert(sst);
+        }
+
+        // simulation of full scan on range [0, 5]
+        // cache reader fetches [0, 1] -> next [4]
+        // [2] consumed from cache
+        // fast forward to [3, 5]
+
+        auto first_range = dht::partition_range::make({pks[0]}, {pks[1]});
+        auto reader = set->make_range_sstable_reader(s, env.make_reader_permit(),
+                                                     first_range,
+                                                     s->full_slice(),
+                                                     nullptr,
+                                                     ::streamed_mutation::forwarding::no,
+                                                     ::mutation_reader::forwarding::yes);
+        auto close_r = deferred_close(reader);
+
+        auto mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE(mopt && mopt->decorated_key().equal(*s, pks[0]));
+
+        mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE(mopt && mopt->decorated_key().equal(*s, pks[1]));
+
+        auto second_range = dht::partition_range::make({pks[3]}, {pks[5]});
+
+        reader.fast_forward_to(second_range).get();
+
+        mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE(mopt && mopt->decorated_key().equal(*s, pks[4]));
+
+        mopt = read_mutation_from_mutation_reader(reader).get();
+        BOOST_REQUIRE(mopt && mopt->decorated_key().equal(*s, pks[5]));
+        // EOS
+        BOOST_REQUIRE(!read_mutation_from_mutation_reader(reader).get());
+    });
+}
+
+static future<> guarantee_all_tablet_replicas_on_shard0(cql_test_env& env) {
+    auto& ss = env.get_storage_service().local();
+    auto& stm = env.get_shared_token_metadata().local();
+    auto my_host_id = ss.get_token_metadata_ptr()->get_topology().my_host_id();
+
+    co_await ss.set_tablet_balancing_enabled(false);
+    co_await stm.mutate_token_metadata([&] (locator::token_metadata& tm) -> future<> {
+        tm.update_topology(my_host_id, locator::endpoint_dc_rack::default_location, locator::node::state::normal, 1);
+        return make_ready_future<>();
+    });
+}
+
+SEASTAR_TEST_CASE(test_tablet_sstable_set_fast_forward_across_tablet_ranges) {
+    // enable tablets, to get access to tablet_storage_group_manager
+    cql_test_config cfg;
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+
+    return do_with_cql_env_thread([&](cql_test_env& env) {
+        guarantee_all_tablet_replicas_on_shard0(env).get();
+
+        env.execute_cql("CREATE KEYSPACE test_tablet_sstable_set"
+                        " WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1} AND TABLETS = {'enabled': true, 'initial': 2};").get();
+        env.execute_cql("CREATE TABLE test_tablet_sstable_set.test (pk int PRIMARY KEY)").get();
+
+        auto& table = env.local_db().find_column_family("test_tablet_sstable_set", "test");
+        auto s = table.schema();
+        auto& sgm = column_family_test::get_storage_group_manager(table);
+        auto erm = table.get_effective_replication_map();
+        auto& tmap = erm->get_token_metadata().tablets().get_tablet_map(s->id());
+
+        std::unordered_map<locator::tablet_id, std::vector<dht::decorated_key>> keys_per_tablet;
+
+        table.disable_auto_compaction().get();
+        for (int i = 0; i < 10; i++) {
+            env.execute_cql(fmt::format("INSERT INTO test_tablet_sstable_set.test (pk) VALUES ({})", i)).get();
+            auto key = dht::decorate_key(*s, partition_key::from_singular(*s, i));
+            keys_per_tablet[tmap.get_tablet_id(key.token())].push_back(key);
+            // produces single-partition sstables, to stress incremental selector.
+            table.flush().get();
+        }
+
+        for (auto& [_, keys] : keys_per_tablet) {
+            auto cmp = dht::decorated_key::less_comparator(s);
+            std::ranges::sort(keys, cmp);
+        }
+
+        auto set = replica::make_tablet_sstable_set(s, *sgm.get(), tmap);
+
+        utils::get_local_injector().enable("enable_read_debug_log");
+        testlog.info("first tablet range: {}", tmap.get_token_range(locator::tablet_id(0)));
+        testlog.info("second tablet range: {}", tmap.get_token_range(locator::tablet_id(1)));
+
+        auto& keys_for_first_tablet = keys_per_tablet.at(locator::tablet_id(0));
+        auto& keys_for_second_tablet = keys_per_tablet.at(locator::tablet_id(1));
+
+        auto create_reader = [&] (const dht::partition_range& range) {
+            return set->make_range_sstable_reader(s, make_reader_permit(env),
+                                           range,
+                                           s->full_slice(),
+                                           nullptr,
+                                           ::streamed_mutation::forwarding::no,
+                                           ::mutation_reader::forwarding::yes);
+        };
+
+        auto read_and_check = [&] (auto& reader, const dht::decorated_key& expected) {
+            auto mopt = read_mutation_from_mutation_reader(reader).get();
+            BOOST_REQUIRE(mopt && mopt->decorated_key().equal(*s, expected));
+        };
+        auto end_of_stream_check = [&] (auto& reader) {
+            BOOST_REQUIRE(!read_mutation_from_mutation_reader(reader).get());
+        };
+
+        // simulation of full scan on tablet ranges
+        // cache reader fetches range of first tablet
+        // fast forward to range of second tablet
+        {
+            auto first_range = dht::partition_range::make({keys_for_first_tablet.front()}, {keys_for_first_tablet.back()});
+            auto reader = create_reader(first_range);
+            auto close_r = deferred_close(reader);
+
+            for (auto& k : keys_for_first_tablet) {
+                read_and_check(reader, k);
+            }
+
+            auto second_range = dht::partition_range::make({keys_for_second_tablet.front()}, {keys_for_second_tablet.back()});
+            reader.fast_forward_to(second_range).get();
+
+            for (auto& k: keys_for_second_tablet) {
+                read_and_check(reader, k);
+            }
+            end_of_stream_check(reader);
+        }
+
+        // verify that fast forward will be able to create reader when the new range goes across tablet boundaries.
+        {
+            auto first_range = dht::partition_range::make({keys_for_first_tablet[0]}, {keys_for_first_tablet[0]});
+            auto reader = create_reader(first_range);
+            auto close_r = deferred_close(reader);
+
+            for (auto& k : std::span{keys_for_first_tablet.begin(), 1}) {
+                read_and_check(reader, k);
+            }
+
+            auto second_range = dht::partition_range::make({keys_for_first_tablet[1]}, {keys_for_second_tablet.back()});
+            reader.fast_forward_to(second_range).get();
+
+            for (auto& k : std::span{keys_for_first_tablet.begin() + 1, keys_for_first_tablet.size() - 1}) {
+                read_and_check(reader, k);
+            }
+            for (auto& k: keys_for_second_tablet) {
+                read_and_check(reader, k);
+            }
+            end_of_stream_check(reader);
+        }
+
+        // Reproduces a scenario of range scan where fast forward will overlap with next position returned by selector
+        // full scan: [0, 20]
+        // 1) cache reader emits [0, 10) (position 10 is cached)
+        // 2) incremental selector returns 0 sstables, next position of 16 (the start of a sstable)
+        // 3) fast forward to range [14, 20]
+        // fast forward might expect new range to be after next position (16), but [14, 20] is before and overlaps with next position.
+        // the incremental selector must be called also when new range overlaps with next position. otherwise, there's chance of
+        // missing data.
+        {
+            auto first_token = tmap.get_first_token(locator::tablet_id(0));
+            auto first_range = dht::partition_range::make({dht::ring_position::starting_at(first_token)},
+                                                          {dht::ring_position::ending_at(first_token)});
+            auto reader = create_reader(first_range);
+            auto close_r = deferred_close(reader);
+
+            end_of_stream_check(reader);
+
+            auto& keys_for_second_tablet = keys_per_tablet.at(locator::tablet_id(1));
+            auto second_range = dht::partition_range::make({dht::ring_position::starting_at(dht::next_token(first_token))},
+                                                           {keys_for_second_tablet.back()});
+
+            reader.fast_forward_to(second_range).get();
+
+            for (auto& k : keys_for_first_tablet) {
+                read_and_check(reader, k);
+            }
+            for (auto& k: keys_for_second_tablet) {
+                read_and_check(reader, k);
+            }
+            end_of_stream_check(reader);
+        }
 
     }, std::move(cfg));
 }


### PR DESCRIPTION
Consider the following scenario:

1) let's assume tablet 0 has range [1, 5] (pre merge)
2) tablet merge happens, tablet 0 has now range [1, 10]
3) tablet_sstable_set isn't refreshed, so holds a stale state, thinks tablet 0 still has range [1, 5]
4) during a full scan, forward service will intersect the full range with tablet ranges and consume one tablet at a time
5) replica service is asked to consume range [1, 10] of tablet 0 (post merge)

We have two possible outcomes:

With cache bypass:

1) cache reader is bypassed
2) sstable reader is created on range [1, 10]
3) unrefreshed tablet_sstable_set holds stale state, but select correctly all sstables intersecting with range [1, 10]

With cache:

1) cache reader is created
2) finds partition with token 5 is cached
3) sstable reader is created on range [1, 4] (later would fast forward to range [6, 10]; also belongs to tablet 0)
4) incremental selector consumes the pre-merge sstable spanning range [1, 5]
4.1) since the partitioned_sstable_set pre-merge contains only that sstable, EOS is reached
4.2) since EOS is reached, the fast forward to range [6, 10] is not allowed.
So with the set refreshed, sstable set is aligned with tablet ranges, and no premature EOS is signalled, otherwise preventing fast forward to from happening and all data from being properly captured in the read.

This change fixes the bug and triggers a mutation source refresh whenever the number of tablets for the table has changed, not only when we have incoming tablets.

Additionally, includes a fix for range reads that span more than one tablet, which can happen during split execution.

Fixes: https://github.com/scylladb/scylladb/issues/23313

This change needs to be backported to all supported versions which implement tablet merge.