### PR TITLE
Update seastar submodule

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3618,8 +3618,15 @@ class chunked_vector(object):
 
 def get_local_task_queues():
     """ Return a list of task pointers for the local reactor. """
-    for tq_ptr in static_vector(gdb.parse_and_eval('\'seastar\'::local_engine._task_queues')):
-        yield std_unique_ptr(tq_ptr).dereference()
+    tq = gdb.parse_and_eval('\'seastar\'::local_engine._task_queues')
+    try:
+        task_queues = std_array(tq)
+    except gdb.error:
+        task_queues = static_vector(tq)
+    for tq_ptr in task_queues:
+        tq_uptr = std_unique_ptr(tq_ptr)
+        if (tq_uptr):
+            yield tq_uptr.dereference()
 
 def get_local_io_queues():
     """ Return a list of io queues for the local reactor. """


### PR DESCRIPTION
* seastar d7ff58f2...26badcb1 (22):
  > http/client: Skip HEAD reply body processing
  > httpd: Remove unused connection::_req member
  > httpd: Don't write body for HEAD replies
  > http: Move trailing chunk write into reply.cc
  > http_client: Add ECONNRESET to retryable errors
  > stall_detector: no backtrace if exception
  > http: Add test for "aborted" client
  > http: in the client, fix malforming of requests with zero-sized bodies
  > http: Track bytes read from a response
  > http: Add test for improper client handling of aborted requests
  > aio_storage_context: Rename iocb_pool::_iocb_pool to _all_iocbs
  > resource: Add some debug-level logging to memory allocation
  > resource: Rework sysconf memory fallback
  > resource: Indentation fix after previous patch
  > resource: Calculate available memory from NUMA nodes
  > resource: Move NUMA nodes vector evaluation up
  > reactor: Drop _reuseport boolean
  > reactor: Simplify network stack creation and initialization
  > reactor: Remove write-only _thread_id
  > reactor: Keep task-queues in std::array instead of static_vector
  > reactor: Mark _id and task_queue::_id const
  > memory: Report oversized alloc count as metric
