### PR TITLE
[DO NOT REVIEW] Introduce a separate limit for max table name length

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -60,11 +60,11 @@ Keyspace and table names are defined by the following grammar:
    keyspace_name: `name`
    table_name: [ `keyspace_name` '.' ] `name`
    name: `unquoted_name` | `quoted_name`
-   unquoted_name: re('[a-zA-Z_0-9]{1, 48}')
+   unquoted_name: re('[a-zA-Z_0-9]{1, 218}')
    quoted_name: '"' `unquoted_name` '"'
 
 Both keyspace and table names consist of only alphanumeric characters, cannot be empty, and are limited in
-size to 48 characters (that limit exists mostly to avoid filenames, which may include the keyspace and table name, to go
+size to 218 characters (that limit exists mostly to avoid filenames, which may include the keyspace and table name, to go
 over the limits of certain file systems). By default, keyspace and table names are case insensitive (``myTable`` is
 equivalent to ``mytable``), but case sensitivity can be forced by using double-quotes (``"myTable"`` is different from
 ``mytable``).

--- a/docs/reference/limits.rst
+++ b/docs/reference/limits.rst
@@ -54,10 +54,10 @@ CQL Limits
        Hundreds of kilobytes (good latency) or megabytes (mediocre latency)
    * - Key length
      - 65533
-   * - Table / CF name length
-     - 48 characters
+   * - Table / CF / View / Index name length
+     - 218 characters
    * - Keyspace name length
-     - 48 characters
+     - 218 characters
    * - Query parameters in a query
      - 65535 (2^16-1)
    * - Statements in a batch

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -1921,7 +1921,8 @@ SEASTAR_TEST_CASE(test_select_multiple_ranges) {
 SEASTAR_TEST_CASE(test_validate_keyspace) {
     return do_with_cql_env([] (cql_test_env& e) {
         return make_ready_future<>().then([&e] {
-            return e.execute_cql("create keyspace kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkssssssssssssssssssssssssssssssssssssssssssssss with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };");
+            sstring keyspace_name(220, 'k');
+            return e.execute_cql(format("create keyspace {} with replication = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }};", keyspace_name));
         }).then_wrapped([&e] (future<shared_ptr<cql_transport::messages::result_message>> f) {
             assert_that_failed(f);
             return e.execute_cql("create keyspace ks3-1 with replication = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 };");
@@ -1943,7 +1944,8 @@ SEASTAR_TEST_CASE(test_validate_keyspace) {
 SEASTAR_TEST_CASE(test_validate_table) {
     return do_with_cql_env([] (cql_test_env& e) {
         return make_ready_future<>().then([&e] {
-            return e.execute_cql("create table ttttttttttttttttttttttttttttttttttttttttbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb (foo text PRIMARY KEY, bar text);");
+            sstring table_name(220, 't');
+            return e.execute_cql(format("create table {} (foo text PRIMARY KEY, bar text);", table_name));
         }).then_wrapped([&e] (future<shared_ptr<cql_transport::messages::result_message>> f) {
             assert_that_failed(f);
             return e.execute_cql("create table tb (foo text PRIMARY KEY, foo text);");

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -295,8 +295,9 @@ def testKeyspace(cql):
 
     execute(cql, n, "CREATE KEYSPACE %s WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
     execute(cql, n, "DROP KEYSPACE %s")
+    too_long_keyspace_name = "k" * 219
     assertInvalid(cql, "", 
-         "CREATE KEYSPACE My_much_much_too_long_identifier_that_should_not_work WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
+         "CREATE KEYSPACE " + too_long_keyspace_name + " WITH replication = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
 
     # FIXME: Cassandra throws InvalidRequest here, but Scylla uses
     # ConfigurationException. We shouldn't have done that... But I consider

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -39,14 +39,14 @@ def test_create_keyspace_missing_with(cql):
     with pytest.raises(SyntaxException):
         cql.execute("CREATE KEYSPACE test_create_and_drop_keyspace")
 
-# The documentation states that "Keyspace names can have up to 48 alpha-
+# The documentation states that "Keyspace names can have up to 218 alpha-
 # numeric characters and contain underscores; only letters and numbers are
 # supported as the first character.". This is not accurate. Test what is actually
 # enforced:
 def test_create_keyspace_invalid_name(cql, this_dc):
     rep = " WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }"
-    with pytest.raises(InvalidRequest, match='48'):
-        cql.execute('CREATE KEYSPACE ' + 'x'*49 + rep)
+    with pytest.raises(InvalidRequest, match='218'):
+        cql.execute('CREATE KEYSPACE ' + 'x'*219 + rep)
     # The name xyz!123, unquoted, is a syntax error. With quotes it's valid
     # syntax, but an illegal name.
     with pytest.raises(SyntaxException):

--- a/test/cqlpy/test_utf8.py
+++ b/test/cqlpy/test_utf8.py
@@ -84,7 +84,7 @@ def test_unicode_equivalence_like(scylla_only, cql, table1):
 # ambiguous - are various Unicode letters (e.g., Hebrew letters) allowed, or
 # not, in table names? The Apache Cassandra and Scylla DDL documentation is
 # more explicit  - table names must match the regular expression
-# [a-zA-Z_0-9]{1, 48} - so must use the Latin alphabet and nothing else.
+# [a-zA-Z_0-9]{1, 218} - so must use the Latin alphabet and nothing else.
 # Let's confirm this in a test.
 def test_unicode_in_table_names(cql, test_keyspace):
     n = unique_name()


### PR DESCRIPTION
Currently the table name length is limited to 48 characters, same way as all the other names. This was compatible with Cassandra 3 but due to a bug the validation of this constraint was removed in Cassandra 4 and 5 (see CASSANDRA-20389). Nowadays, some of the usage scenarios depends on the lack of limitation in Cassandra, such as some feature store workflows generating long table names.

This path introduces the behavior that is compatible with Cassandra 4 and 5. It limits table name to 222 characters because when the existing code creates a directory to store the new table, this directory's name is created by sstables::init_table_storage(), which takes the table's full name, a dash (-), and a 32-byte UUID string. Because most Linux filesystems limit filename components to 255 bytes, this means that any table name longer than 222 bytes will attempt to mkdir() a directory name longer than the allowed 255 bytes, and fail.

Exactly the same limit (222 characters) is proposed in the patch fixing directory creation failures in Cassandra 4 and 5 (see apache/cassandra/pull/4038, SchemaConstants.java).

Closes scylladb/scylladb#4480, scylladb/scylladb#10984.

New issue scylladb/scylla-drivers#75 was created to track the updates needed in drivers.

Backport: 2025.2 as this is a compatibility bug fix that is needed to make ScyllaDB work with some of the AI workflows.