### PR TITLE
test.py: refactor test facades for better error handling

### DIFF
--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -123,25 +123,17 @@ class BoostTestFacade(CppTestFacade):
         if not test_passed:
             allure.attach(stdout_file_path.read_bytes(), name='output', attachment_type=allure.attachment_type.TEXT)
             msg = (
-                'working_dir: {working_dir}\n'
-                'Internal Error: calling {executable} '
-                'for test {test_id} failed (return_code={return_code}):\n'
-                'output file:{stdout}\n'
-                'log:{log}\n'
-                'command to repeat:{command}'
+                f'working_dir: {os.getcwd()}\n'
+                f'Internal Error: calling {executable} '
+                f'for test {test_name} failed ({return_code=}):\n'
+                f'output file:{stdout_file_path.absolute()}\n'
+                f'log:{log}\n'
+                f'command to repeat:{" ".join(args)}\n'
             )
             failure = CppTestFailure(
                 file_name.name,
                 line_num=results[0].line_num,
-                contents=msg.format(
-                    working_dir=os.getcwd(),
-                    executable=executable,
-                    test_id=test_name,
-                    stdout=stdout_file_path.absolute(),
-                    log=log,
-                    command=' '.join(args),
-                    return_code=return_code,
-                ),
+                contents=msg
             )
             return [failure], ''
 

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -39,23 +39,16 @@ class UnitTestFacade(CppTestFacade):
         if not test_passed:
             allure.attach(stdout_file_path.read_bytes(), name='output', attachment_type=allure.attachment_type.TEXT)
             msg = (
-                'working_dir: {working_dir}\n'
-                'Internal Error: calling {executable} '
-                'for test {test_id} failed (returncode={returncode}):\n'
-                'output:{stdout}\n'
-                'command to repeat:{command}'
+                f'working_dir: {os.getcwd()}\n'
+                f'Internal Error: calling {executable} '
+                f'for test {test_name} failed ({return_code=}):\n'
+                f'output:{stdout_file_path.absolute()}\n'
+                f'command to repeat:{" ".join(args)}'
             )
             failure = CppTestFailure(
                 file_name.name,
                 line_num=0,
-                contents=msg.format(
-                    working_dir=os.getcwd(),
-                    executable=executable,
-                    test_id=test_name,
-                    stdout=stdout_file_path.absolute(),
-                    command=' '.join(args),
-                    returncode=return_code,
-                ),
+                contents=msg
             )
             return [failure], ''
         stdout_file_path.unlink(missing_ok=True)


### PR DESCRIPTION
Switching to f-string formatting to simplify the code and to unify it with a general approach for formatting strings.
If the log file absent or empty test fails with an error regarding a missing boost log file, however, it's not helpful since it's not a root cause of the fail. Adding logic to log this issue as a warning in a pytest's log file and continue with providing results to the pytest itself. 