### PR TITLE
s3_client: Refactor `range` class for state validation

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -651,7 +651,7 @@ void test_download_data_source(const client_maker_function& client_maker, bool i
     }
 
     testlog.info("Download object");
-    auto in = is_chunked ? input_stream<char>(cln->make_chunked_download_source(name, {})) : input_stream<char>(cln->make_download_source(name, {}));
+    auto in = is_chunked ? input_stream<char>(cln->make_chunked_download_source(name, s3::full_range)) : input_stream<char>(cln->make_download_source(name, s3::full_range));
     auto close = seastar::deferred_close(in);
     for (unsigned ch = 0; ch < chunks; ch++) {
         auto buf = in.read_exactly(chunk_size).get();

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -34,6 +34,7 @@
 #include <seastar/util/lazy.hh>
 #include <seastar/http/request.hh>
 #include <seastar/http/exception.hh>
+#include "s3_retry_strategy.hh"
 #include "db/config.hh"
 #include "utils/assert.hh"
 #include "utils/s3/aws_error.hh"

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/queue.hh>
+#include <seastar/core/units.hh>
 #include <seastar/http/client.hh>
 #include <filesystem>
 #include "utils/lister.hh"
@@ -30,10 +31,54 @@ namespace s3 {
 
 using s3_clock = std::chrono::steady_clock;
 
-struct range {
-    uint64_t off;
-    size_t len;
+class range {
+    friend struct fmt::formatter<range>;
+
+public:
+    range() = delete;
+    constexpr range(uint64_t offset, uint64_t len) : _offset(offset), _length(len) {
+        uint64_t t;
+        if (__builtin_add_overflow(_offset, len, &t)) [[unlikely]] {
+            throw std::overflow_error(fmt::format("Range offset {} + length {} exceeds maximum uint64_t", _offset, len));
+        }
+        if (_offset + len > _max_object_size) [[unlikely]] {
+            throw std::overflow_error(fmt::format("Range offset {} + length {} exceeds maximum object size {}", _offset, len, _max_object_size));
+        }
+    }
+    explicit constexpr range(uint64_t offset) : _offset(offset) {}
+    constexpr range& operator+=(uint64_t offset) {
+        uint64_t t;
+        if (__builtin_add_overflow(_offset, offset, &t)) [[unlikely]] {
+            throw std::overflow_error(fmt::format("Range offset {} + length {} exceeds maximum uint64_t", _offset, offset));
+        }
+        if (_offset + offset > _max_object_size) [[unlikely]] {
+            throw std::overflow_error(fmt::format("Range offset {} + length {} exceeds maximum object size {}", _offset, offset, _max_object_size));
+        }
+
+        _offset += offset;
+        if (_length != _max_object_size) [[unlikely]] {
+            if (__builtin_sub_overflow(_length, offset, &t)) {
+                throw std::underflow_error(fmt::format("Range length {} - offset {} exceeds minimum uint64_t", _length, offset));
+            }
+            _length -= offset;
+        }
+        return *this;
+    }
+    std::partial_ordering operator<=>(const range& other) const noexcept = default;
+    [[nodiscard]] sstring to_header_string() const noexcept {
+        return fmt::format("bytes={}-{}", _offset, _length != _max_object_size ? fmt::format("{}", _offset + _length - 1) : "");
+    }
+    [[nodiscard]] uint64_t offset() const noexcept { return _offset; }
+    [[nodiscard]] uint64_t length() const noexcept { return _length; }
+
+    // 5TiB is the largest object size supported by S3
+    static constexpr uint64_t _max_object_size{5_TiB};
+
+private:
+    uint64_t _offset;
+    uint64_t _length{_max_object_size};
 };
+static constexpr range full_range{0};
 
 struct tag {
     std::string key;
@@ -114,7 +159,7 @@ public:
     future<tag_set> get_object_tagging(sstring object_name, seastar::abort_source* = nullptr);
     future<> put_object_tagging(sstring object_name, tag_set tagging, seastar::abort_source* = nullptr);
     future<> delete_object_tagging(sstring object_name, seastar::abort_source* = nullptr);
-    future<temporary_buffer<char>> get_object_contiguous(sstring object_name, std::optional<range> range = {}, seastar::abort_source* = nullptr);
+    future<temporary_buffer<char>> get_object_contiguous(sstring object_name, range download_range = s3::full_range, seastar::abort_source* = nullptr);
     future<> put_object(sstring object_name, temporary_buffer<char> buf, seastar::abort_source* = nullptr);
     future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* = nullptr);
     future<> copy_object(sstring source_object, sstring target_object, std::optional<size_t> part_size = {}, std::optional<tag> tag = {}, seastar::abort_source* = nullptr);
@@ -123,8 +168,8 @@ public:
     file make_readable_file(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_sink(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_jumbo_sink(sstring object_name, std::optional<unsigned> max_parts_per_piece = {}, seastar::abort_source* = nullptr);
-    data_source make_chunked_download_source(sstring object_name, std::optional<range> range = {}, seastar::abort_source* = nullptr);
-    data_source make_download_source(sstring object_name, std::optional<range> range = {}, seastar::abort_source* = nullptr);
+    data_source make_download_source(sstring object_name, range download_range = s3::full_range, seastar::abort_source* = nullptr);
+    data_source make_chunked_download_source(sstring object_name, range range = s3::full_range, seastar::abort_source* = nullptr);
     /// upload a file with specified path to s3
     ///
     /// @param path the path to the file
@@ -180,4 +225,12 @@ public:
     future<> close();
 };
 
-} // s3 namespace
+} // namespace s3
+
+template <>
+struct fmt::formatter<s3::range> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(const s3::range& range, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}-{}", range._offset, range._length != s3::range::_max_object_size ? fmt::format("{}", range._length) : "∞");
+    }
+};

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -19,8 +19,6 @@
 #include "utils/lister.hh"
 #include "utils/s3/creds.hh"
 #include "credentials_providers/aws_credentials_provider_chain.hh"
-#include "s3_retry_strategy.hh"
-#include "utils/exceptions.hh"
 #include "retryable_http_client.hh"
 #include "utils/s3/client_fwd.hh"
 


### PR DESCRIPTION
Revamped the `range` class to actively manage its state by enforcing validation on all modifications. This prevents overflow, invalid states, and ensures the object size does not exceed the 5TiB limit in S3. This should address and prevent future problems related to this issue https://github.com/minio/minio/issues/21333

No backport needed since this problem related only to this change https://github.com/scylladb/scylladb/pull/23880
