### PR TITLE
api: Make us of datablse::get_all_keyspaces()

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -67,17 +67,6 @@ T map_sum(T&& dest, const S& src) {
     return std::move(dest);
 }
 
-template <typename MAP>
-std::vector<sstring> map_keys(const MAP& map) {
-    std::vector<sstring> res;
-    res.reserve(std::size(map));
-
-    for (const auto& i : map) {
-        res.push_back(fmt::to_string(i.first));
-    }
-    return res;
-}
-
 /**
  * General sstring splitting function
  */

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -360,13 +360,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
         });
 
     cf::get_column_family_name_keyspace.set(r, [&ctx] (const_req req){
-        std::vector<sstring> res;
-        const flat_hash_map<sstring, replica::keyspace>& keyspaces = ctx.db.local().get_keyspaces();
-        res.reserve(keyspaces.size());
-        for (const auto& i : keyspaces) {
-            res.push_back(i.first);
-        }
-        return res;
+        return ctx.db.local().get_all_keyspaces();
     });
 
     cf::get_memtable_columns_count.set(r, [&ctx] (std::unique_ptr<http::request> req) {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1027,7 +1027,7 @@ rest_get_keyspaces(http_context& ctx, const_req req) {
         } else if (type == "non_local_strategy") {
             keyspaces = ctx.db.local().get_non_local_strategy_keyspaces();
         } else {
-            keyspaces = map_keys(ctx.db.local().get_keyspaces());
+            keyspaces = ctx.db.local().get_all_keyspaces();
         }
         if (replication.empty() || replication == "all") {
             return keyspaces;


### PR DESCRIPTION
There are two places in the API that want to get the list of keyspace names. For that they call database::get_keyspaces() and then extract keys from the returned name to class keyspace map.

There's a database::get_all_keyspaces() method that does exactly that.

Remove the map_keys helper from the api/api.hh that becomes unused.
