### PR TITLE
Replace container_to_vec with std::ranges

### DIFF
--- a/api/api.hh
+++ b/api/api.hh
@@ -24,17 +24,6 @@
 namespace api {
 
 template<class T>
-std::vector<sstring> container_to_vec(const T& container) {
-    std::vector<sstring> res;
-    res.reserve(std::size(container));
-
-    for (const auto& i : container) {
-        res.push_back(fmt::to_string(i));
-    }
-    return res;
-}
-
-template<class T>
 std::vector<T> map_to_key_value(const std::map<sstring, sstring>& map) {
     std::vector<T> res;
     res.reserve(map.size());

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1050,7 +1050,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<db::system_keyspace
             a.merge(b);
             return a;
         }).then([](const std::unordered_set<sstring>& res) {
-            return make_ready_future<json::json_return_type>(container_to_vec(res));
+            return make_ready_future<json::json_return_type>(res | std::ranges::to<std::vector>());
         });
     });
 

--- a/api/config.cc
+++ b/api/config.cc
@@ -187,7 +187,7 @@ void set_config(std::shared_ptr < api_registry_builder20 > rb, http_context& ctx
     });
 
     ss::get_all_data_file_locations.set(r, [&cfg](const_req req) {
-        return container_to_vec(cfg.data_file_directories());
+        return cfg.data_file_directories();
     });
 
     ss::get_saved_caches_location.set(r, [&cfg](const_req req) {

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -25,10 +25,9 @@ void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
     });
 
 
-    httpd::gossiper_json::get_live_endpoint.set(r, [&g] (std::unique_ptr<request> req) {
-        return g.get_live_members_synchronized().then([] (auto res) {
-            return make_ready_future<json::json_return_type>(container_to_vec(res));
-        });
+    httpd::gossiper_json::get_live_endpoint.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+        auto res = co_await g.get_live_members_synchronized();
+        co_return json::json_return_type(container_to_vec(res));
     });
 
     httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {

--- a/api/gossiper.cc
+++ b/api/gossiper.cc
@@ -21,13 +21,13 @@ using namespace json;
 void set_gossiper(http_context& ctx, routes& r, gms::gossiper& g) {
     httpd::gossiper_json::get_down_endpoint.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
         auto res = co_await g.get_unreachable_members_synchronized();
-        co_return json::json_return_type(container_to_vec(res));
+        co_return json::json_return_type(res | std::views::transform([] (auto& ep) { return fmt::to_string(ep); }) | std::ranges::to<std::vector>());
     });
 
 
     httpd::gossiper_json::get_live_endpoint.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
         auto res = co_await g.get_live_members_synchronized();
-        co_return json::json_return_type(container_to_vec(res));
+        co_return json::json_return_type(res | std::views::transform([] (auto& ep) { return fmt::to_string(ep); }) | std::ranges::to<std::vector>());
     });
 
     httpd::gossiper_json::get_endpoint_downtime.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -719,8 +719,8 @@ static
 json::json_return_type
 rest_get_natural_endpoints(http_context& ctx, sharded<service::storage_service>& ss, const_req req) {
         auto keyspace = validate_keyspace(ctx, req);
-        return container_to_vec(ss.local().get_natural_endpoints(keyspace, req.get_query_param("cf"),
-                req.get_query_param("key")));
+        auto res = ss.local().get_natural_endpoints(keyspace, req.get_query_param("cf"), req.get_query_param("key"));
+        return res | std::views::transform([] (auto& ep) { return fmt::to_string(ep); }) | std::ranges::to<std::vector>();
 }
 
 static

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -59,7 +59,7 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
 
     ss::get_moving_nodes.set(r, [](const_req req) {
         std::unordered_set<sstring> addr;
-        return container_to_vec(addr);
+        return addr | std::ranges::to<std::vector>();
     });
 
     ss::get_joining_nodes.set(r, [&tm, &g](const_req req) {

--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -54,7 +54,7 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
         for (const auto host_id: leaving_host_ids) {
             eps.insert(g.local().get_address_map().get(host_id));
         }
-        return container_to_vec(eps);
+        return eps | std::views::transform([] (auto& i) { return fmt::to_string(i); }) | std::ranges::to<std::vector>();
     });
 
     ss::get_moving_nodes.set(r, [](const_req req) {
@@ -70,7 +70,7 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
         for (const auto& [token, host_id]: points) {
             eps.insert(g.local().get_address_map().get(host_id));
         }
-        return container_to_vec(eps);
+        return eps | std::views::transform([] (auto& i) { return fmt::to_string(i); }) | std::ranges::to<std::vector>();
     });
 
     ss::get_host_id_map.set(r, [&tm, &g](const_req req) {


### PR DESCRIPTION
The helper in question converts an iterable collection to a vector of fmt::to_string()-s of the collection elements.
Patch the caller to use standard library and remove the helper.