### PR TITLE
transport/server: silence the oversized allocation warning in snappy_compress

### DIFF
--- a/compress.cc
+++ b/compress.cc
@@ -768,6 +768,8 @@ size_t snappy_processor::uncompress(const char* input, size_t input_len,
 
 size_t snappy_processor::compress(const char* input, size_t input_len,
                 char* output, size_t output_len) const {
+    // FIXME: snappy internally performs allocations greater than 128 kiB.
+    const memory::scoped_large_allocation_warning_threshold slawt{256*1024};
     auto ret = snappy_compress(input, input_len, output, &output_len);
     if (ret != SNAPPY_OK) {
         throw std::runtime_error("snappy compression failure: snappy_compress() failed");

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1727,6 +1727,8 @@ void cql_server::response::compress_snappy()
     auto in = input_buffer.get_linearized_view(_body);
     size_t output_len = snappy_max_compressed_length(in.size());
     _body = output_buffer.make_bytes_ostream(output_len, [&in] (bytes_mutable_view out) {
+        // FIXME: snappy internally performs allocations greater than 128 kiB.
+        const memory::scoped_large_allocation_warning_threshold slawt{256*1024};
         size_t actual_len = out.size();
         if (snappy_compress(reinterpret_cast<const char*>(in.data()), in.size(), reinterpret_cast<char*>(out.data()), &actual_len) != SNAPPY_OK) {
             throw std::runtime_error("CQL frame Snappy compression failure");


### PR DESCRIPTION
It has been observed to generate ~200 kiB allocations.

Since we have already been made aware of that, we can silence the warning to clean up the logs.

We might want to backport it to 2025.2, where we lowered the default allocation size threshold for warnings.

Refs https://github.com/scylladb/scylladb/issues/24116