### PR TITLE
test/alternator: make tests runnable on DynamoDB Local

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -204,7 +204,12 @@ def dynamodb_test_connection(dynamodb, request, optional_rest_api):
         # URL is the fastest one.
         url = dynamodb.meta.client._endpoint.host
         response = requests.get(url, verify=False)
-        assert response.ok
+        # We don't check response: In Alternator and DynamoDB, we expect
+        # response.ok (200), but in recent versions of DynamoDB Local we can
+        # get error code 400 because it only allows signed health requests
+        # and gives an invalid signature error on an unsigned get().
+        # In any case, any HTTP response (as opposed to exception in get())
+        # means that the server is still alive.
     except:
         dynamodb_test_connection.scylla_crashed = True
         pytest.fail(f'Scylla appears to have crashed in test {request.node.parent.name}::{request.node.name}')

--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -107,7 +107,7 @@ def get_valid_alternator_role():
             pass
         # If we couldn't find a valid role, let's hope that
         # alternator-enforce-authorization is not enabled so anything will work
-        return ('unknown_user', 'unknown_secret')
+        return ('unknownuser', 'unknownsecret')
 
     return _get_valid_alternator_role
 


### PR DESCRIPTION
The Alternator tests should pass on Alternator (of course), and almost always also on DynamoDB to verify that the tests themselves are correct and don't just enshrine Alternator's incorrect behavior. Although much less important, it is sometimes useful to be able to check if the test also pass on other DynamoDB clones, especially "DynamoDB Local" - Amazon's DynamoDB mock written in Java.

In issue https://github.com/scylladb/scylladb/issues/7775 we noted that some of our tests don't actually pass on DynamoDB Local, for different reasons, but at the time that issue was created most of the tests did work. However, checking now on a newer version of DynamoDB Local (2.6.1), I notice that _all_ tests failed because of some silly reasons that are easy to fix - and this is what the two patches in this series fix. After these fixes, most of the Alternator tests pass on DynamoDB Local. But not all of them - #7775 is still open.

No backport needed - these are just test framework improvements for developers.