### PR TITLE
[Backport 6.2] utils/lsa/chunked_managed_vector: fix the calculation of max_chunk_capacity()

### DIFF
--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -648,7 +648,6 @@ struct alignas(segment_size) segment {
     static void operator delete(void* ptr) = delete;
 };
 
-static constexpr size_t max_managed_object_size = segment_size * 0.1;
 static constexpr auto max_used_space_ratio_for_compaction = 0.85;
 static constexpr size_t max_used_space_for_compaction = segment_size * max_used_space_ratio_for_compaction;
 static constexpr size_t min_free_space_for_compaction = segment_size - max_used_space_for_compaction;

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -32,6 +32,7 @@ class allocating_section;
 constexpr int segment_size_shift = 17; // 128K; see #151, #152
 constexpr size_t segment_size = 1 << segment_size_shift;
 constexpr size_t max_zone_segments = 256;
+constexpr size_t max_managed_object_size = segment_size * 0.1;
 
 //
 // Frees some amount of objects from the region to which it's attached.

--- a/utils/lsa/chunked_managed_vector.hh
+++ b/utils/lsa/chunked_managed_vector.hh
@@ -28,16 +28,17 @@ namespace lsa {
 
 template <typename T>
 class chunked_managed_vector {
-    static const size_t max_contiguous_allocation = logalloc::segment_size * 0.1;
-    static_assert(std::is_nothrow_move_constructible<T>::value, "T must be nothrow move constructible");
     using chunk_ptr = managed_vector<T>;
+    static constexpr size_t max_contiguous_allocation = logalloc::max_managed_object_size - chunk_ptr::metadata_size();
+    static_assert(std::is_nothrow_move_constructible<T>::value, "T must be nothrow move constructible");
     // Each chunk holds max_chunk_capacity() items, except possibly the last
     managed_vector<chunk_ptr, 1> _chunks;
     size_t _size = 0;
     size_t _capacity = 0;
 public:
     static size_t max_chunk_capacity() {
-        return std::max(max_contiguous_allocation / sizeof(T), size_t(1));
+        static_assert(max_contiguous_allocation >= sizeof(T));
+        return max_contiguous_allocation / sizeof(T);
     }
 private:
     void reserve_for_push_back() {

--- a/utils/managed_vector.hh
+++ b/utils/managed_vector.hh
@@ -164,6 +164,11 @@ public:
             pop_back();
         }
     }
+    // If the user of `managed_vector` wants to fit within n bytes,
+    // the `managed_vector` must have at most `(n - metadata_size()) / sizeof(T)` elements.
+    constexpr static size_t metadata_size() {
+        return sizeof(external);
+    }
     void reserve(size_type new_capacity) {
         if (new_capacity <= _capacity) {
             return;


### PR DESCRIPTION
`chunked_managed_vector` is a vector-like container which splits its contents into multiple contiguous allocations if necessary, in order to fit within LSA's max preferred contiguous allocation limits.

Each limited-size chunk is stored in a `managed_vector`. `managed_vector` is unaware of LSA's size limits.
It's up to the user of `managed_vector` to pick a size which is small enough.

This happens in `chunked_managed_vector::max_chunk_capacity()`. But the calculation is wrong, because it doesn't account for the fact that `managed_vector` has to place some metadata (the backreference pointer) inside the allocation. In effect, the chunks allocated by `chunked_managed_vector` are just a tiny bit larger than the limit, and the limit is violated.

Fix this by accounting for the metadata.

Also, before the patch `chunked_managed_vector::max_contiguous_allocation`, repeats the definition of logalloc::max_managed_object_size. This is begging for a bug if `logalloc::max_managed_object_size` changes one day. Adjust it so that `chunked_managed_vector` looks directly at `logalloc::max_managed_object_size`, as it means to.

Fixes scylladb/scylladb#23854

(cherry picked from commit 7f9152babc4a39c8b176a97ce221b2b289f9f1a9)