### PR TITLE
api/failure_detector.cc: stream endpoints

### DIFF
--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -40,7 +40,9 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
                 }
                 res.emplace_back(std::move(val));
             });
-            return make_ready_future<json::json_return_type>(res);
+            return make_ready_future<json::json_return_type>(json::stream_range_as_array(res, [](const fd::endpoint_state& i){
+                return i;
+            }));
         });
     });
 


### PR DESCRIPTION
Previously, get_all_endpoint_states accumulated all results in memory, which could lead to large allocations when dealing with many endpoints.

This change uses the stream_range_as_array helper to stream the results.

Fixes #24386

**Backport to prevent large allocation errors in the test**