### PR TITLE
docs: exclude OS and ENT from search engines

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "!layout.html" %}
+
+{% block scripts %}
+    {# Add noindex meta tag for non-manual builds (opensource/enterprise) to exclude them from search engines #}
+    {% if flag != 'manual' %}
+    <meta name="robots" content="noindex">
+    {% endif %}
+    {{ super() }}
+{% endblock %} 


### PR DESCRIPTION
## Motivation

Excludes `opensource` and `enterprise` builds from Google's index while keeping `manual` pages indexable.

**Note:** This change may have a short-term negative impact on SEO and page visits.

This change only applies to pages that exist.  Pages that return a 404 (not found) are not affected by this logic. They may still appear in search results until Google re-crawls and drops them.  

To speed up removal of 404 pages, it's best to either set up redirects to preserve any SEO value or exclude them using [Google Search Console](https://support.google.com/webmasters/answer/9689846?hl=en).

## How to test

1. Clone this PR.

2. Build the documentation using the `manual` flag:

   ```bash
   make FLAG=manual preview
   ```

3. Open `http://127.0.0.1:5500/` in your browser.

4. Open the browser inspector and verify that the `<meta name="robots" content="noindex">` tag is **NOT** present in the `<head>`.

   ![image](https://github.com/user-attachments/assets/6d703e4b-bc7e-4a35-b44d-cbaa509c363a)

5. Build the documentation again using the `opensource` flag:

   ```bash
   make FLAG=opensource preview
   ```

6. Open the inspector and confirm that the `<meta name="robots" content="noindex">` tag is present in the `<head>`.

   ![image](https://github.com/user-attachments/assets/dacf596c-62ed-4d45-85cc-b83bc93487a1)
