### PR TITLE
alternator: update documentation that ttl with tablets does work

### DIFF
--- a/docs/alternator/new-apis.md
+++ b/docs/alternator/new-apis.md
@@ -181,9 +181,6 @@ Alternator table, the following features will not work for this table:
   still change the write isolation mode of the table to a supported mode.
   See <https://github.com/scylladb/scylladb/issues/18068>.
 
-* Enabling TTL with UpdateTableToLive doesn't work (results in an error).
-  See <https://github.com/scylladb/scylla/issues/16567>.
-
 * Enabling Streams with CreateTable or UpdateTable doesn't work
   (results in an error).
   See <https://github.com/scylladb/scylla/issues/16317>.


### PR DESCRIPTION
Our documentation docs/alternator/new-apis.md claims that Alternator TTL does not work with tablets, due to issue #16567. However, we fixed that issue in commit de96c286253cc27977ef65021bf47b02fa863155. So let's drop the outdated statement that it doesn't work.

The pull request that implemented the feature, #23662, was marked with backport/none, so this documentation fix should likewise not be backported.