### PR TITLE
vector_index: do not create a view when creating a vector index

### DIFF
--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -231,6 +231,17 @@ description index(const data_dictionary::database& db, const sstring& ks, const 
     if (!schema) {
         throw exceptions::invalid_request_exception(format("Table for existing index '{}' not found in '{}'", name, ks));
     }
+    
+    index_metadata im = schema->all_indices().find(name)->second;
+
+    auto custom_class = secondary_index::secondary_index_manager::get_custom_class(im);
+
+    if (custom_class) {
+        auto desc = (*custom_class)->describe(im, *schema);
+        if (desc) {
+            return std::move(*desc);
+        }
+    }
 
     std::optional<view_ptr> idx;
     auto views = db.find_table(ks, schema->cf_name()).views();

--- a/cql3/statements/index_target.cc
+++ b/cql3/statements/index_target.cc
@@ -20,7 +20,6 @@ namespace statements {
 using db::index::secondary_index;
 
 const sstring index_target::target_option_name = "target";
-const sstring index_target::custom_index_option_name = "class_name";
 const boost::regex index_target::target_regex("^(keys|entries|values|full)\\((.+)\\)$");
 
 sstring index_target::column_name() const {

--- a/cql3/statements/index_target.hh
+++ b/cql3/statements/index_target.hh
@@ -21,7 +21,6 @@ namespace statements {
 
 struct index_target {
     static const sstring target_option_name;
-    static const sstring custom_index_option_name;
     static const boost::regex target_regex;
 
     enum class target_type {

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -19,7 +19,6 @@
 #include "index/secondary_index.hh"
 #include "index/vector_index.hh"
 
-#include "cql3/statements/index_target.hh"
 #include "cql3/expr/expression.hh"
 #include "index/target_parser.hh"
 #include "schema/schema.hh"
@@ -373,6 +372,18 @@ std::optional<std::function<std::unique_ptr<custom_index>()>> secondary_index_ma
     } else {
         return std::nullopt;
     }
+}
+
+std::optional<std::unique_ptr<custom_index>> secondary_index_manager::get_custom_class(const index_metadata& im) {
+    auto it = im.options().find(db::index::secondary_index::custom_index_option_name);
+    if (it == im.options().end()) {
+        return std::nullopt;
+    }
+    auto custom_class_factory = secondary_index::secondary_index_manager::get_custom_class_factory(it->second);
+    if (!custom_class_factory) {
+        return std::nullopt;
+    }
+    return (*custom_class_factory)();
 }
 
 }

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -16,6 +16,7 @@
 #include <unordered_map>
 
 #include "index/secondary_index_manager.hh"
+#include "index/secondary_index.hh"
 #include "index/vector_index.hh"
 
 #include "cql3/statements/index_target.hh"
@@ -352,10 +353,10 @@ std::optional<sstring> secondary_index_manager::custom_index_class(const schema&
 
     auto idx = _indices.find(index_name_from_table_name(s.cf_name()));
 
-    if (idx == _indices.end() || !(*idx).second.metadata().options().contains(cql3::statements::index_target::custom_index_option_name)) {
+    if (idx == _indices.end() || !(*idx).second.metadata().options().contains(db::index::secondary_index::custom_index_option_name)) {
         return std::nullopt;
     } else {
-        return (*idx).second.metadata().options().at(cql3::statements::index_target::custom_index_option_name);
+        return (*idx).second.metadata().options().at(db::index::secondary_index::custom_index_option_name);
     }
 }
 

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -94,6 +94,7 @@ public:
     virtual ~custom_index() = default;
     /// Returns a custom description of the index, or std::nullopt if the default index description logic should be used instead.
     virtual std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const = 0;
+    virtual bool should_create_view() const = 0;
     virtual void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) = 0;
 };
 
@@ -112,6 +113,7 @@ public:
     bool is_global_index(const schema& s) const;
     std::optional<sstring> custom_index_class(const schema& s) const;
     static std::optional<std::function<std::unique_ptr<custom_index>()>> get_custom_class_factory(const sstring& class_name);
+    static std::optional<std::unique_ptr<custom_index>> get_custom_class(const index_metadata& im);
 private:
     void add_index(const index_metadata& im);
 };

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -92,6 +92,8 @@ public:
 class custom_index {
 public:
     virtual ~custom_index() = default;
+    /// Returns a custom description of the index, or std::nullopt if the default index description logic should be used instead.
+    virtual std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const = 0;
     virtual void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) = 0;
 };
 

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -8,10 +8,12 @@
 
 
 #include "cql3/statements/index_target.hh"
+#include "cql3/util.hh"
 #include "exceptions/exceptions.hh"
 #include "schema/schema.hh"
 #include "index/vector_index.hh"
 #include "concrete_types.hh"
+#include "utils/managed_string.hh"
 #include <seastar/core/sstring.hh>
 
 
@@ -47,6 +49,22 @@ const static std::unordered_map<sstring, std::function<void(const sstring&)>> su
         {"construction_beam_width", validate_unsigned_option<4096>},
         {"search_beam_width", validate_unsigned_option<4096>},
     };
+
+
+std::optional<cql3::description> vector_index::describe(const index_metadata& im, const schema& base_schema) const {
+    fragmented_ostringstream os;
+    os << "CREATE CUSTOM INDEX " << cql3::util::maybe_quote(im.name()) << " ON "
+       << cql3::util::maybe_quote(base_schema.ks_name()) << "." << cql3::util::maybe_quote(base_schema.cf_name())
+       << "(" << cql3::util::maybe_quote(im.options().at(cql3::statements::index_target::target_option_name)) << ")"
+       << " USING 'vector_index'";
+
+    return cql3::description{
+        .keyspace = base_schema.ks_name(),
+        .type = "index",
+        .name = im.name(),
+        .create_statement = std::move(os).to_managed_string(),
+    };
+}
 
 void vector_index::validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) {
     if (targets.size() != 1) {

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -50,6 +50,9 @@ const static std::unordered_map<sstring, std::function<void(const sstring&)>> su
         {"search_beam_width", validate_unsigned_option<4096>},
     };
 
+bool vector_index::should_create_view() const {
+    return false;
+}
 
 std::optional<cql3::description> vector_index::describe(const index_metadata& im, const schema& base_schema) const {
     fragmented_ostringstream os;

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -24,6 +24,7 @@ public:
     vector_index() = default;
     ~vector_index() override = default;
     std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
+    bool should_create_view() const override;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
 };
 

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -23,6 +23,7 @@ class vector_index: public custom_index {
 public:
     vector_index() = default;
     ~vector_index() override = default;
+    std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
 };
 

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -2738,6 +2738,7 @@ def test_desc_restore(cql):
         cql.execute(f"CREATE TYPE {ks}.my_type (value int)")
         cql.execute(f"""CREATE TABLE {ks}.some_other_table (c1 frozen<my_type>, c2 double, c3 int, c4 set<int>,
                         PRIMARY KEY ((c1, c2), c3)) WITH comment = 'some comment'""")
+        cql.execute(f"CREATE TABLE {ks}.vector_table (pk int PRIMARY KEY, v vector<float, 3>)")
 
         cql.execute(f"""CREATE MATERIALIZED VIEW {ks}.mv AS
                             SELECT pk FROM {ks}.my_table
@@ -2746,6 +2747,7 @@ def test_desc_restore(cql):
                             WITH comment='some other comment'""")
 
         cql.execute(f"CREATE INDEX myindex ON {ks}.some_other_table (c1)")
+        cql.execute(f"CREATE INDEX custom_index ON {ks}.vector_table (v) USING 'vector_index'")
 
         cql.execute(f"""CREATE FUNCTION {ks}.my_udf(val1 int, val2 int)
                         RETURNS NULL ON NULL INPUT


### PR DESCRIPTION
This PR adds a way for custom indexes to decide whether a view should be created for them, as for the vector_index the view is not needed, because we store it in the external service. To allow this, custom logic for describing indexes using custom classes was added (as it used to depend on the view corresponding to an index).

Fixes: VECTOR-10