### PR TITLE
cql, vector_search: implement read path

### DIFF
--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -26,6 +26,7 @@
 #include "cql3/statements/request_validations.hh"
 #include "cql3/functions/token_fct.hh"
 #include "dht/i_partitioner.hh"
+#include "db/schema_tables.hh"
 #include "types/tuple.hh"
 
 namespace {
@@ -1274,14 +1275,16 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
         }
 
         const auto& im = index_opt->metadata();
-        sstring index_table_name = im.name() + "_index";
-        schema_ptr view_schema = db.find_schema(schema->ks_name(), index_table_name);
-        _view_schema = view_schema;
+        if (db::schema_tables::view_should_exist(im)) {
+            sstring index_table_name = im.name() + "_index";
+            schema_ptr view_schema = db.find_schema(schema->ks_name(), index_table_name);
+            _view_schema = view_schema;
 
-        if (im.local()) {
-            prepare_indexed_local(*view_schema);
-        } else {
-            prepare_indexed_global(*view_schema);
+            if (im.local()) {
+                prepare_indexed_local(*view_schema);
+            } else {
+                prepare_indexed_global(*view_schema);
+            }
         }
     }
 }

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -43,9 +43,13 @@ public:
         ascending,
         descending
     };
+    // Vector of floats with dimension the same as the vector indexed column.
+    // This vector is the target for the nearest neighbors in ANN queries.
+    using ann_vector = expr::expression;
+    using ordering_type = std::variant<ordering, ann_vector>;
     class parameters final {
     public:
-        using orderings_type = std::vector<std::pair<shared_ptr<column_identifier::raw>, ordering>>;
+        using orderings_type = std::vector<std::pair<shared_ptr<column_identifier::raw>, ordering_type>>;
         enum class statement_subtype { REGULAR, JSON, PRUNE_MATERIALIZED_VIEW, MUTATION_FRAGMENTS };
     private:
         const orderings_type _orderings;
@@ -75,11 +79,12 @@ public:
     using compare_fn = std::function<bool(const T&, const T&)>;
 
     using result_row_type = std::vector<managed_bytes_opt>;
+    using prepared_ann_ordering_type = std::pair<const column_definition*, expr::expression>;
     using ordering_comparator_type = compare_fn<result_row_type>;
 protected:
     virtual audit::statement_category category() const override;
 private:
-    using prepared_orderings_type = std::vector<std::pair<const column_definition*, ordering>>;
+    using prepared_orderings_type = std::vector<std::pair<const column_definition*, ordering_type>>;
 private:
     lw_shared_ptr<const parameters> _parameters;
     std::vector<::shared_ptr<selection::raw_selector>> _select_clause;

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -131,6 +131,10 @@ private:
 
     void verify_ordering_is_valid(const prepared_orderings_type&, const schema&, const restrictions::statement_restrictions& restrictions) const;
 
+    void verify_ann_ordering_is_valid(const std::optional<expr::expression>& limit, const std::optional<expr::expression>& per_partition_limit, const selection::selection& selection) const;
+
+    prepared_ann_ordering_type prepare_ann_ordering(const schema& schema, prepare_context& ctx, data_dictionary::database db) const;
+
     // Checks whether this ordering reverses all results.
     // We only allow leaving select results unchanged or reversing them.
     bool is_ordering_reversed(const prepared_orderings_type&) const;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -15,6 +15,7 @@
 #include "cql3/cql_statement.hh"
 #include "cql3/stats.hh"
 #include <seastar/core/shared_ptr.hh>
+#include <string_view>
 #include "transport/messages/result_message.hh"
 #include "index/secondary_index_manager.hh"
 #include "exceptions/coordinator_result.hh"
@@ -61,6 +62,7 @@ public:
     using coordinator_result = exceptions::coordinator_result<T>;
     using parameters = raw::select_statement::parameters;
     using ordering_comparator_type = raw::select_statement::ordering_comparator_type;
+    using prepared_ann_ordering_type = raw::select_statement::prepared_ann_ordering_type;
     static constexpr int DEFAULT_COUNT_PAGE_SIZE = 10000;
     bool _may_use_token_aware_routing;
 protected:
@@ -186,10 +188,13 @@ class indexed_table_select_statement : public select_statement {
     secondary_index::index _index;
     expr::expression _used_index_restrictions;
     schema_ptr _view_schema;
+    std::optional<prepared_ann_ordering_type>  _prepared_ann_ordering;
     noncopyable_function<dht::partition_range_vector(const query_options&)> _get_partition_ranges_for_posting_list;
     noncopyable_function<query::partition_slice(const query_options&)> _get_partition_slice_for_posting_list;
 public:
     static constexpr size_t max_base_table_query_concurrency = 4096;
+    static constexpr size_t max_ann_query_limit = 1000;
+    static constexpr std::string_view ann_custom_index_option = "vector_index";
 
     static ::shared_ptr<cql3::statements::select_statement> prepare(data_dictionary::database db,
                                                                     schema_ptr schema,
@@ -200,6 +205,7 @@ public:
                                                                     ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                                                     bool is_reversed,
                                                                     ordering_comparator_type ordering_comparator,
+                                                                    std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                                                     std::optional<expr::expression> limit,
                                                                     std::optional<expr::expression> per_partition_limit,
                                                                     cql_stats &stats,
@@ -213,6 +219,7 @@ public:
                                    ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                    bool is_reversed,
                                    ordering_comparator_type ordering_comparator,
+                                   std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                    std::optional<expr::expression> limit,
                                    std::optional<expr::expression> per_partition_limit,
                                    cql_stats &stats,

--- a/cql3/util.hh
+++ b/cql3/util.hh
@@ -90,6 +90,14 @@ sstring single_quote(const std::string_view s);
 // indicates its incorrectness (for example using other units than microseconds).
 void validate_timestamp(const db::config& config, const query_options& options, const std::unique_ptr<attributes>& attrs);
 
+template<typename T>
+std::vector<T> to_vector(const std::vector<data_value>& values) {
+    std::vector<T> ann_vector;
+    ann_vector.reserve(values.size());
+    std::ranges::transform(values, std::back_inserter(ann_vector), [](const auto& v) { return value_cast<T>(v); });
+    return ann_vector;
+}
+
 } // namespace util
 
 } // namespace cql3

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -306,6 +306,8 @@ utils::chunked_vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_
 
 void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema);
 
+bool view_should_exist(const index_metadata& im);
+
 sstring serialize_kind(column_kind kind);
 column_kind deserialize_kind(sstring kind);
 data_type parse_type(sstring str);

--- a/index/secondary_index_manager.cc
+++ b/index/secondary_index_manager.cc
@@ -362,12 +362,14 @@ std::optional<sstring> secondary_index_manager::custom_index_class(const schema&
 // This function returns a factory, as the custom index class should be lightweight, preferably not holding any state.
 // We prefer this over a static custom index class instance, as it allows us to avoid any issues with thread safety.
 std::optional<std::function<std::unique_ptr<custom_index>()>> secondary_index_manager::get_custom_class_factory(const sstring& class_name) {
+    sstring lower_class_name = class_name;
+    std::transform(lower_class_name.begin(), lower_class_name.end(), lower_class_name.begin(), ::tolower);
 
     const static std::unordered_map<std::string_view, std::function<std::unique_ptr<custom_index>()>> classes = {
         {"vector_index", vector_index_factory},
     };
 
-    if (auto class_it = classes.find(class_name); class_it != classes.end()) {
+    if (auto class_it = classes.find(lower_class_name); class_it != classes.end()) {
         return class_it->second;
     } else {
         return std::nullopt;

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -94,7 +94,7 @@ public:
     virtual ~custom_index() = default;
     /// Returns a custom description of the index, or std::nullopt if the default index description logic should be used instead.
     virtual std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const = 0;
-    virtual bool should_create_view() const = 0;
+    virtual bool view_should_exist() const = 0;
     virtual void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) = 0;
 };
 

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -50,7 +50,7 @@ const static std::unordered_map<sstring, std::function<void(const sstring&)>> su
         {"search_beam_width", validate_unsigned_option<4096>},
     };
 
-bool vector_index::should_create_view() const {
+bool vector_index::view_should_exist() const {
     return false;
 }
 

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -38,7 +38,9 @@ static void validate_unsigned_option(const sstring& value) {
 }
 
 static void validate_similarity_function(const sstring& value) {
-    if (value != "COSINE" && value != "EUCLIDEAN" && value != "DOT_PRODUCT") {
+    sstring similarity_function = value;
+    std::transform(similarity_function.begin(), similarity_function.end(), similarity_function.begin(), ::tolower);
+    if (similarity_function != "cosine" && similarity_function != "euclidean" && similarity_function != "dot_product") {
         throw exceptions::invalid_request_exception(format("Unsupported similarity function: {}", value));
     }
 }

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -24,7 +24,7 @@ public:
     vector_index() = default;
     ~vector_index() override = default;
     std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
-    bool should_create_view() const override;
+    bool view_should_exist() const override;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
 };
 

--- a/service/vector_store_client.hh
+++ b/service/vector_store_client.hh
@@ -70,6 +70,27 @@ public:
 
     using ann_error = std::variant<disabled, aborted, addr_unavailable, service_unavailable, service_error, service_reply_format_error>;
 
+    struct ann_error_visitor {
+        sstring operator()(service::vector_store_client::service_error e) const {
+            return fmt::format("Vector Store error: HTTP status {}", e.status);
+        }
+        sstring operator()(service::vector_store_client::disabled) const {
+            return fmt::format("Vector Store is disabled");
+        }
+        sstring operator()(service::vector_store_client::aborted) const {
+            return fmt::format("Vector Store request was aborted");
+        }
+        sstring operator()(service::vector_store_client::addr_unavailable) const {
+            return fmt::format("Vector Store service address could not be fetched from DNS");
+        }
+        sstring operator()(service::vector_store_client::service_unavailable) const {
+            return fmt::format("Vector Store service is unavailable");
+        }
+        sstring operator()(service::vector_store_client::service_reply_format_error) const {
+            return fmt::format("Vector Store returned an invalid JSON");
+        }
+    };
+
     explicit vector_store_client(config const& cfg);
     ~vector_store_client();
 

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -1,0 +1,393 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit bb66561142788270ab450c02de836b3952ed37b4
+#
+# The original Apache Cassandra license:
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .porting import *
+
+# public class VectorInvalidQueryTest extends SAITester
+# {
+#     @BeforeClass
+#     public static void setupClass()
+#     {
+#         requireNetwork();
+#     }
+
+#     @Test
+#     public void cannotCreateEmptyVectorColumn()
+#     {
+#         assertThatThrownBy(() -> execute(String.format("CREATE TABLE %s.%s (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))",
+#                                                        KEYSPACE, createTableName())))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("vectors may only have positive dimensions; given 0");
+#     }
+
+#     @Test
+#     public void cannotQueryEmptyVectorColumn()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+#         assertThatThrownBy(() -> execute("SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("vectors may only have positive dimensions; given 0");
+#     }
+
+#     @Test
+#     public void cannotIndex1DWithCosine()
+#     {
+#         createTable("CREATE TABLE %s (pk int, v vector<float, 1>, PRIMARY KEY(pk))");
+#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'cosine'}"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasRootCauseMessage(StorageAttachedIndex.VECTOR_1_DIMENSION_COSINE_ERROR);
+#     }
+
+#     @Test
+#     public void cannotInsertWrongNumberOfDimensions()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0])"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
+#     }
+
+#     @Test
+#     public void cannotQueryWrongNumberOfDimensions()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5] LIMIT 5"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
+#     }
+
+#     @Test
+#     public void testMultiVectorOrderingsNotAllowed() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("Cannot specify more than one ANN ordering",
+#                              "SELECT * FROM %s ORDER BY val1 ann of [2.5, 3.5, 4.5], val2 ann of [2.1, 3.2, 4.0] LIMIT 2");
+#     }
+
+#     @Test
+#     public void testDescendingVectorOrderingIsNotAllowed() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("Descending ANN ordering is not supported",
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2");
+#     }
+
+#     @Test
+#     public void testVectorOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("ANN ordering does not support any other ordering",
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2");
+#     }
+
+#     @Test
+#     public void testVectorOrderingIsNotAllowedWithoutIndex() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void testInvalidColumnNameWithAnn() throws Throwable
+#     {
+#         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
+#         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + '.' + table),
+#                              "SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1");
+#     }
+
+#     @Test
+#     public void cannotPerformNonANNQueryOnVectorIndex() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage(StatementRestrictions.VECTOR_INDEXES_ANN_ONLY_MESSAGE,
+#                              "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]");
+#     }
+
+#     @Test
+#     public void cannotOrderWithAnnOnNonVectorColumn() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int, v int, primary key(k))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1");
+#     }
+
+#     @Test
+#     public void disallowZeroVectorsWithCosineSimilarity()
+#     {
+#         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'cosine'}");
+
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, [0.0, 0.0])")).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(0.0f, 0.0f))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1.0f, Float.NaN))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1.0f, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(Float.NEGATIVE_INFINITY, 1.0f))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
+#     }
+
+#     @Test
+#     public void mustHaveLimitSpecifiedAndWithinMaxAllowed()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_LIMIT_ERROR);
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(String.format(StorageAttachedIndex.ANN_LIMIT_ERROR, IndexWriterConfig.MAX_TOP_K, 1001));
+#     }
+
+#     @Test
+#     public void mustHaveLimitWithinPageSize()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 3>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (k, v) VALUES (1, [1.0, 2.0, 3.0])");
+#         execute("INSERT INTO %s (k, v) VALUES (2, [2.0, 3.0, 4.0])");
+#         execute("INSERT INTO %s (k, v) VALUES (3, [3.0, 4.0, 5.0])");
+
+#         ClientWarn.instance.captureWarnings();
+#         ResultSet result = execute("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [2.0, 3.0, 4.0] LIMIT 10", 9);
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_PAGE_SIZE_WARNING, 9, 10, 10), ClientWarn.instance.getWarnings().get(0));
+#         assertEquals(1, result.size());
+
+#         ClientWarn.instance.captureWarnings();
+#         result = execute("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [2.0, 3.0, 4.0] LIMIT 10", 11);
+#         assertNull(ClientWarn.instance.getWarnings());
+#         assertEquals(1, result.size());
+#     }
+
+#     @Test
+#     public void cannotHaveAggregationOnANNQuery()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+
+#         assertThatThrownBy(() -> executeNet("SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_AGGREGATION_ERROR);
+#     }
+
+#     @Test
+#     public void multipleVectorColumnsInQueryFailCorrectlyTest() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void annOrderingIsNotAllowedWithoutIndexWhereIndexedColumnExistsInQueryTest() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void cannotPostFilterOnNonIndexedColumnWithAnnOrdering() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void cannotHavePerPartitionLimitWithAnnOrdering()
+#     {
+#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_PARTITION_LIMIT_ERROR);
+#     }
+
+#     @Test
+#     public void cannotCreateIndexOnNonFloatVector()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<int, 1>)");
+
+#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'"))
+#             .isInstanceOf(InvalidRequestException.class).hasRootCauseMessage(StorageAttachedIndex.VECTOR_NON_FLOAT_ERROR);
+#     }
+
+#     @Test
+#     public void canOrderWithWhereOnPrimaryColumns() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (a int, b int, c int, d int, v vector<float, 2>, PRIMARY KEY ((a,b),c,d))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (a, b, c, d, v) VALUES (1, 2, 1, 2, [6.0,1.0])");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE v > [5.0,1.0] ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage("v cannot be restricted by more than one relation in an ANN ordering");
+
+#         ResultSet result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE);
+
+#         createIndex("CREATE CUSTOM INDEX c_idx ON %s(c) USING 'StorageAttachedIndex'");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE);
+
+#         dropIndex("DROP INDEX %s.c_idx");
+#         createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
+
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c > 0 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#     }
+
+#     @Test
+#     public void canOnlyExecuteWithCorrectConsistencyLevel()
+#     {
+#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
+
+#         ClientWarn.instance.captureWarnings();
+#         ResultSet result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.ONE);
+#         assertEquals(3, result.size());
+#         assertNull(ClientWarn.instance.getWarnings());
+
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_ONE);
+#         assertEquals(3, result.size());
+#         assertNull(ClientWarn.instance.getWarnings());
+
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.QUORUM);
+#         assertEquals(3, result.size());
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_WARNING, ConsistencyLevel.QUORUM, ConsistencyLevel.ONE),
+#                      ClientWarn.instance.getWarnings().get(0));
+
+#         ClientWarn.instance.captureWarnings();
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_QUORUM);
+#         assertEquals(3, result.size());
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_WARNING, ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_ONE),
+#                      ClientWarn.instance.getWarnings().get(0));
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.SERIAL))
+#             .isInstanceOf(InvalidRequestException.class)
+#             .hasMessage(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_ERROR, ConsistencyLevel.SERIAL));
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_SERIAL))
+#             .isInstanceOf(InvalidRequestException.class)
+#             .hasMessage(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_ERROR, ConsistencyLevel.LOCAL_SERIAL));
+#     }
+
+#     protected ResultSet execute(String query, ConsistencyLevel consistencyLevel)
+#     {
+#         return execute(query, consistencyLevel, -1);
+#     }
+
+#     protected ResultSet execute(String query, int pageSize)
+#     {
+#         return execute(query, ConsistencyLevel.ONE, pageSize);
+#     }
+
+#     protected ResultSet execute(String query, ConsistencyLevel consistencyLevel, int pageSize)
+#     {
+#         ClientState state = ClientState.forInternalCalls();
+#         QueryState queryState = new QueryState(state);
+
+#         CQLStatement statement = QueryProcessor.parseStatement(formatQuery(query), queryState.getClientState());
+#         statement.validate(state);
+
+#         QueryOptions options = QueryOptions.withConsistencyLevel(QueryOptions.forInternalCalls(Collections.emptyList()), consistencyLevel);
+#         options = QueryOptions.withPageSize(options, pageSize);
+
+#         return ((ResultMessage.Rows)statement.execute(queryState, options, Dispatcher.RequestTime.forImmediateExecution())).result;
+#     }
+# }

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -6,32 +6,33 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .porting import *
+from ..util import is_scylla
 
-# public class VectorInvalidQueryTest extends SAITester
-# {
-#     @BeforeClass
-#     public static void setupClass()
-#     {
-#         requireNetwork();
-#     }
+ANN_LIMIT_ERROR = "Use of ANN OF in an ORDER BY clause requires a LIMIT that is not greater than %s. LIMIT was %s"
+ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE = "ANN ordering is only supported on float vector indexes"
+ANN_REQUIRES_INDEX_MESSAGE = "ANN ordering by vector requires the column to be indexed"
+SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = "ANN ordering by vector does not support filtering"
+CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = "ANN ordering by vector requires all restricted column(s) to be indexed"
+TOPK_AGGREGATION_ERROR = "can not be run with aggregation"
+TOPK_LIMIT_ERROR = "queries must have a limit specified"
+VECTOR_INDEXES_ANN_ONLY_MESSAGE = "Vector indexes only support ANN queries"
 
-#     @Test
-#     public void cannotCreateEmptyVectorColumn()
-#     {
-#         assertThatThrownBy(() -> execute(String.format("CREATE TABLE %s.%s (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))",
-#                                                        KEYSPACE, createTableName())))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("vectors may only have positive dimensions; given 0");
-#     }
+def test_cannot_create_empty_vector_column(cql, test_keyspace):
+        assert_invalid_message(
+            cql,
+            "",
+            "dimension",
+            f"CREATE TABLE {test_keyspace}.test_table (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))"
+        )
 
-#     @Test
-#     public void cannotQueryEmptyVectorColumn()
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-#         assertThatThrownBy(() -> execute("SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("vectors may only have positive dimensions; given 0");
-#     }
+@pytest.mark.xfail(reason="similarity_cosine not implemented yet")
+def test_cannot_query_empty_vector_column(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        assert_invalid_message(
+            cql, table,
+            "dimension",
+            "SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"
+        )
 
 #     @Test
 #     public void cannotIndex1DWithCosine()
@@ -52,93 +53,88 @@ from .porting import *
 #         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
 #     }
 
-#     @Test
-#     public void cannotQueryWrongNumberOfDimensions()
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+def test_cannot_query_wrong_number_of_dimensions(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(val) USING '{custom_index}'")
 
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])")
 
-#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5] LIMIT 5"))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
-#     }
+        assert_invalid_message(
+            cql, table,
+            "Invalid vector literal",
+            "SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5] LIMIT 5"
+        )
 
-#     @Test
-#     public void testMultiVectorOrderingsNotAllowed() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
+def test_multi_vector_orderings_not_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))") as table:
 
-#         assertInvalidMessage("Cannot specify more than one ANN ordering",
-#                              "SELECT * FROM %s ORDER BY val1 ann of [2.5, 3.5, 4.5], val2 ann of [2.1, 3.2, 4.0] LIMIT 2");
-#     }
+        # Scylla doesnt support custom indexes on text columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX ON %s(str_val)")
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(val1) USING '{custom_index}'")
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(val2) USING '{custom_index}'")
 
-#     @Test
-#     public void testDescendingVectorOrderingIsNotAllowed() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        assert_invalid_message(
+            cql, table, "Cannot specify more than one ANN ordering",
+            "SELECT * FROM %s ORDER BY val1 ANN OF [2.5, 3.5, 4.5], val2 ANN OF [2.1, 3.2, 4.0] LIMIT 2"
+        )
 
-#         assertInvalidMessage("Descending ANN ordering is not supported",
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2");
-#     }
+def test_descending_vector_ordering_is_not_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE INDEX c_index ON %s(val) USING '{custom_index}'")
 
-#     @Test
-#     public void testVectorOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        assert_invalid_message(cql, table, "Descending ANN ordering is not supported",
+                               "SELECT val FROM %s where val=[1.2, 1.2, 1.2] ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2")
 
-#         assertInvalidMessage("ANN ordering does not support any other ordering",
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2");
-#     }
+def test_vector_ordering_is_not_allowed_with_clustering_ordering(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX c_index ON %s (val) USING '{custom_index}'")
 
-#     @Test
-#     public void testVectorOrderingIsNotAllowedWithoutIndex() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        assert_invalid_message(cql, table, "ANN ordering does not support any other ordering",
+                               "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5");
+def test_vector_ordering_is_not_allowed_without_index(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING");
-#     }
+def test_invalid_column_name_with_ann(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
+        assert_invalid_message(
+            cql, table,
+            f"Undefined column name",
+            "SELECT k FROM %s ORDER BY bad_col ANN OF [1.0] LIMIT 1"
+        )
 
-#     @Test
-#     public void testInvalidColumnNameWithAnn() throws Throwable
-#     {
-#         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
-#         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + '.' + table),
-#                              "SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1");
-#     }
+def test_cannot_perform_non_ann_query_on_vector_index(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX c_index ON %s (val) USING '{custom_index}'")
+        assert_invalid_message(
+            cql, table, VECTOR_INDEXES_ANN_ONLY_MESSAGE,
+            "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]"
+        )
 
-#     @Test
-#     public void cannotPerformNonANNQueryOnVectorIndex() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-
-#         assertInvalidMessage(StatementRestrictions.VECTOR_INDEXES_ANN_ONLY_MESSAGE,
-#                              "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]");
-#     }
-
-#     @Test
-#     public void cannotOrderWithAnnOnNonVectorColumn() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int, v int, primary key(k))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1");
-#     }
+def test_cannot_order_with_ann_on_non_vector_column(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, v int, PRIMARY KEY(k))") as table:
+        # Scylla doesn't support custom indexes on int columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX c_index ON %s (v)")
+        assert_invalid_message(
+            cql, table, ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
+            "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1"
+        )
 
 #     @Test
 #     public void disallowZeroVectorsWithCosineSimilarity()
@@ -154,18 +150,20 @@ from .porting import *
 #         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
 #     }
 
-#     @Test
-#     public void mustHaveLimitSpecifiedAndWithinMaxAllowed()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_must_have_limit_specified_and_within_max_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>)") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX c_index ON %s (v) USING '{custom_index}' WITH OPTIONS = {{'similarity_function': 'euclidean'}}")
 
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_LIMIT_ERROR);
+        assert_invalid_message(
+            cql, table, TOPK_LIMIT_ERROR,
+            "SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"
+        )
 
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(String.format(StorageAttachedIndex.ANN_LIMIT_ERROR, IndexWriterConfig.MAX_TOP_K, 1001));
-#     }
+        assert_invalid_message(
+            cql, table, ANN_LIMIT_ERROR % (1000, 1001),
+            f"SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"
+        )
 
 #     @Test
 #     public void mustHaveLimitWithinPageSize()
@@ -189,103 +187,116 @@ from .porting import *
 #         assertEquals(1, result.size());
 #     }
 
-#     @Test
-#     public void cannotHaveAggregationOnANNQuery()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_cannot_have_aggregation_on_ann_query(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>, c int)") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(v) USING '{custom_index}' WITH OPTIONS = {{'similarity_function' : 'euclidean'}}")
 
-#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (2, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (3, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)")
 
-#         assertThatThrownBy(() -> executeNet("SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_AGGREGATION_ERROR);
-#     }
+        assert_invalid_message(
+            cql, table, TOPK_AGGREGATION_ERROR,
+            "SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"
+        )
 
-#     @Test
-#     public void multipleVectorColumnsInQueryFailCorrectlyTest() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_multiple_vector_columns_in_query_fail_correctly(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(v1) USING '{custom_index}' WITH OPTIONS = {{'similarity_function' : 'euclidean'}}")
 
-#         execute("INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])");
+        execute(cql, table, "INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] ALLOW FILTERING");
-#     }
+        # Added a LIMIT here to account for differences in the sequence of validation checks between Scylla and Cassandra.
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] LIMIT 3 ALLOW FILTERING"
+        )
 
-#     @Test
-#     public void annOrderingIsNotAllowedWithoutIndexWhereIndexedColumnExistsInQueryTest() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_query(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>, c int)") as table:
+        # Scylla doesn't support custom indexes on int columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX c_index ON %s (c)")
 
-#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (2, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (3, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-#     }
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
 
-#     @Test
-#     public void cannotPostFilterOnNonIndexedColumnWithAnnOrdering() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
+    ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
+        SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE
+    )
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))"
+    ) as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(v) USING '{custom_index}' WITH OPTIONS = {{'similarity_function': 'euclidean'}}")
 
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+def test_cannot_have_per_partition_limit_with_ann_ordering(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        execute(cql, table, f"CREATE CUSTOM INDEX ON %s(v) USING '{custom_index}' WITH OPTIONS = {{'similarity_function' : 'euclidean'}}")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 1, [1])")
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 2, [2])")
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 3, [3])")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        assert_invalid_message(
+            cql, table, "do not support per-partition limits",
+            "SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-#     }
-
-#     @Test
-#     public void cannotHavePerPartitionLimitWithAnnOrdering()
-#     {
-#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
-
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"))
-#             .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_PARTITION_LIMIT_ERROR);
-#     }
-
-#     @Test
-#     public void cannotCreateIndexOnNonFloatVector()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<int, 1>)");
-
-#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'"))
-#             .isInstanceOf(InvalidRequestException.class).hasRootCauseMessage(StorageAttachedIndex.VECTOR_NON_FLOAT_ERROR);
-#     }
+def test_cannot_create_index_on_non_float_vector(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<int, 1>)") as table:
+        custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
+        assert_invalid_message(
+            cql, table, "float",
+            f"CREATE CUSTOM INDEX ON %s(v) USING '{custom_index}'"
+        )
 
 #     @Test
 #     public void canOrderWithWhereOnPrimaryColumns() throws Throwable

--- a/test/cqlpy/test_invalid_ann_queries.py
+++ b/test/cqlpy/test_invalid_ann_queries.py
@@ -1,0 +1,53 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+###############################################################################
+# Tests to check if invalid ANN queries are handled correctly.
+# These tests ensure that queries that do not meet the requirements for ANN
+# indexing throw the appropriate exceptions.
+###############################################################################
+
+import pytest
+import re
+from .util import new_test_table, is_scylla
+from cassandra.protocol import InvalidRequest
+
+ANN_REQUIRES_INDEX_MESSAGE = "ANN ordering by vector requires the column to be indexed"
+SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = "ANN ordering by vector does not support filtering"
+CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = "ANN ordering by vector requires all restricted column(s) to be indexed"
+
+
+def test_ann_query_without_index(cql, test_keyspace):
+    schema = 'p int primary key, v vector<float, 3>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match=re.escape(ANN_REQUIRES_INDEX_MESSAGE)):
+            cql.execute(f"SELECT * FROM {table} ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5")
+
+
+def test_ann_query_with_ck_filtering(cql, test_keyspace):
+    ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
+        SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE
+    )
+    schema = 'p int, v vector<float, 3>, ck int, primary key (p, ck)'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        custom_index = 'vector_index' if is_scylla(cql) else 'sai'
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING '{custom_index}'")
+        with pytest.raises(InvalidRequest, match=re.escape(ANN_REQUIRES_INDEXED_FILTERING_MESSAGE)):
+            cql.execute(f"SELECT * FROM {table} WHERE ck = 1 ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5")
+        with pytest.raises(InvalidRequest, match=re.escape(ANN_REQUIRES_INDEXED_FILTERING_MESSAGE)):
+            cql.execute(f"SELECT * FROM {table} WHERE ck = 1 ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5 ALLOW FILTERING")
+
+
+# Although Cassandra allows for such queries, these queries fail with assertion error.
+# In Scylla, such queries are not allowed, as it is unclear if the filtering should happen pre or post ANN search.
+def test_ann_query_not_allow_any_filtering(scylla_only, cql, test_keyspace):
+    schema = 'p int primary key, c int, v vector<float, 3>'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
+
+        cql.execute(f"CREATE INDEX ON {table}(c)")
+        with pytest.raises(InvalidRequest, match=re.escape(SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE)):
+            cql.execute(f"SELECT * FROM {table} WHERE c = 1 ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5")
+        with pytest.raises(InvalidRequest, match=re.escape(SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE)):
+            cql.execute(f"SELECT * FROM {table} WHERE c = 1 ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5 ALLOW FILTERING")


### PR DESCRIPTION
This pull request is an addition of ANN OF queries.

The patch contains:

- CQL syntax for ORDER BY `vector_column_name` ANN OF `vector_literal` clause of SELECT statements.
- implementation of external ANN queries (using vector-store service)
- tests

Example syntax:

```
SELECT comment
    FROM cycling.comments_vs
    ORDER BY comment_vector ANN OF [0.1, 0.15, 0.3, 0.12, 0.05]
    LIMIT 3;
```
Limit can be between 1 and 1000 - same as for Cassandra.

Co-authored-by: @janpiotrlakomy @smoczy123 
Fixes: VECTOR-48
Fixes: VECTOR-46
