### PR TITLE
Update seastar submodule for http request retry on ECONNRESET

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "seastar"]
 	path = seastar
-	url = ../seastar
+	url = ../scylla-seastar
 	ignore = dirty
 [submodule "swagger-ui"]
 	path = swagger-ui


### PR DESCRIPTION
 Update seastar submodule

* seastar d7ff58f2...9f0034a0 (1):
  > http_client: Add ECONNRESET to retryable errors

And switch to 2025.2 branch from scylla-seastar for backports

Fixes #24445