### PR TITLE
Fix for cassandra role gets recreated after DROP ROLE

### DIFF
--- a/auth/common.cc
+++ b/auth/common.cc
@@ -119,6 +119,11 @@ future<> create_legacy_metadata_table_if_missing(
     return qs;
 }
 
+::service::raft_timeout get_raft_timeout() noexcept {
+    auto dur = internal_distributed_query_state().get_client_state().get_timeout_config().other_timeout;
+    return ::service::raft_timeout{.value = lowres_clock::now() + dur};
+}
+
 static future<> announce_mutations_with_guard(
         ::service::raft_group0_client& group0_client,
         std::vector<canonical_mutation> muts,

--- a/auth/common.hh
+++ b/auth/common.hh
@@ -17,6 +17,7 @@
 
 #include "types/types.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "timeout_config.hh"
 
 using namespace std::chrono_literals;
 
@@ -76,6 +77,8 @@ future<> create_legacy_metadata_table_if_missing(
 /// Time-outs for internal, non-local CQL queries.
 ///
 ::service::query_state& internal_distributed_query_state() noexcept;
+
+::service::raft_timeout get_raft_timeout() noexcept;
 
 // Execute update query via group0 mechanism, mutations will be applied on all nodes.
 // Use this function when need to perform read before write on a single guard or if

--- a/auth/ldap_role_manager.cc
+++ b/auth/ldap_role_manager.cc
@@ -338,8 +338,7 @@ future<std::vector<cql3::description>> ldap_role_manager::describe_role_grants()
 }
 
 future<> ldap_role_manager::ensure_superuser_is_created() {
-    // ldap is responsible for users
-    co_return;
+    return _std_mgr.ensure_superuser_is_created();
 }
 
 } // namespace auth

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -142,7 +142,7 @@ future<> password_authenticator::maybe_create_default_password() {
         const sstring query = seastar::format("SELECT * FROM {}.{} WHERE is_superuser = true ALLOW FILTERING", get_auth_ks_name(_qp), meta::roles_table::name);
         auto results = co_await _qp.execute_internal(query,
                 db::consistency_level::LOCAL_ONE,
-                internal_distributed_query_state(), cql3::query_processor::cache_internal::no);
+                internal_distributed_query_state(), cql3::query_processor::cache_internal::yes);
         // Don't add default password if
         // - there is no default superuser
         // - there is a superuser with a password.

--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -117,7 +117,8 @@ future<> password_authenticator::migrate_legacy_metadata() const {
     });
 }
 
-future<> password_authenticator::create_default_if_missing() {
+future<> password_authenticator::legacy_create_default_if_missing() {
+    SCYLLA_ASSERT(legacy_mode(_qp));
     const auto exists = co_await default_role_row_satisfies(_qp, &has_salted_hash, _superuser);
     if (exists) {
         co_return;
@@ -127,18 +128,75 @@ future<> password_authenticator::create_default_if_missing() {
         salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt);
     }
     const auto query = update_row_query();
-    if (legacy_mode(_qp)) {
-        co_await _qp.execute_internal(
+    co_await _qp.execute_internal(
             query,
             db::consistency_level::QUORUM,
             internal_distributed_query_state(),
             {salted_pwd, _superuser},
             cql3::query_processor::cache_internal::no);
-        plogger.info("Created default superuser authentication record.");
-    } else {
-        co_await announce_mutations(_qp, _group0_client, query,
-            {salted_pwd, _superuser}, _as, ::service::raft_timeout{});
-        plogger.info("Created default superuser authentication record.");
+    plogger.info("Created default superuser authentication record.");
+}
+
+future<> password_authenticator::maybe_create_default_password() {
+    auto needs_password = [this] () -> future<bool> {
+        const sstring query = seastar::format("SELECT * FROM {}.{} WHERE is_superuser = true ALLOW FILTERING", get_auth_ks_name(_qp), meta::roles_table::name);
+        auto results = co_await _qp.execute_internal(query,
+                db::consistency_level::LOCAL_ONE,
+                internal_distributed_query_state(), cql3::query_processor::cache_internal::no);
+        // Don't add default password if
+        // - there is no default superuser
+        // - there is a superuser with a password.
+        bool has_default = false;
+        bool has_superuser_with_password = false;
+        for (auto& result : *results) {
+            if (result.get_as<sstring>(meta::roles_table::role_col_name) == _superuser) {
+                has_default = true;
+            }
+            if (has_salted_hash(result)) {
+                has_superuser_with_password = true;
+            }
+        }
+        co_return has_default && !has_superuser_with_password;
+    };
+    if (!co_await needs_password()) {
+        co_return;
+    }
+    // We don't want to start operation earlier to avoid quorum requirement in
+    // a common case.
+    ::service::group0_batch batch(
+            co_await _group0_client.start_operation(_as, get_raft_timeout()));
+    // Check again as the state may have changed before we took the guard (batch).
+    if (!co_await needs_password()) {
+        co_return;
+    }
+    // Set default superuser's password.
+    std::string salted_pwd(get_config_value(_qp.db().get_config().auth_superuser_salted_password(), ""));
+    if (salted_pwd.empty()) {
+        salted_pwd = passwords::hash(DEFAULT_USER_PASSWORD, rng_for_salt);
+    }
+    const auto update_query = update_row_query();
+    co_await collect_mutations(_qp, batch, update_query, {salted_pwd, _superuser});
+    co_await std::move(batch).commit(_group0_client, _as, get_raft_timeout());
+    plogger.info("Created default superuser authentication record.");
+}
+
+future<> password_authenticator::maybe_create_default_password_with_retries() {
+    size_t retries = _migration_manager.get_concurrent_ddl_retries();
+    while (true)  {
+        try {
+            co_return co_await maybe_create_default_password();
+        } catch (const ::service::group0_concurrent_modification& ex) {
+            plogger.warn("Failed to execute maybe_create_default_password due to guard conflict.{}.", retries ? " Retrying" : " Number of retries exceeded, giving up");
+            if (retries--) {
+                continue;
+            }
+            // Log error but don't crash the whole node startup sequence.
+            plogger.error("Failed to create default superuser password due to guard conflict.");
+            co_return;
+        } catch (const ::service::raft_operation_timeout_error& ex) {
+            plogger.error("Failed to create default superuser password due to exception: {}", ex.what());
+            co_return;
+        }
     }
 }
 
@@ -164,10 +222,11 @@ future<> password_authenticator::start() {
                         migrate_legacy_metadata().get();
                         return;
                     }
+                    legacy_create_default_if_missing().get();
                 }
                 utils::get_local_injector().inject("password_authenticator_start_pause", utils::wait_for_message(5min)).get();
-                create_default_if_missing().get();
                 if (!legacy_mode(_qp)) {
+                    maybe_create_default_password_with_retries().get();
                     _superuser_created_promise.set_value();
                 }
             });

--- a/auth/password_authenticator.hh
+++ b/auth/password_authenticator.hh
@@ -41,7 +41,7 @@ class password_authenticator : public authenticator {
     ::service::migration_manager& _migration_manager;
     future<> _stopped;
     abort_source _as;
-    std::string _superuser;
+    std::string _superuser; // default superuser name from the config (may or may not be present in roles table)
     shared_promise<> _superuser_created_promise;
 
 public:
@@ -89,7 +89,10 @@ private:
 
     future<> migrate_legacy_metadata() const;
 
-    future<> create_default_if_missing();
+    future<> legacy_create_default_if_missing();
+
+    future<> maybe_create_default_password();
+    future<> maybe_create_default_password_with_retries();
 
     sstring update_row_query() const;
 };

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -240,6 +240,13 @@ future<> service::start(::service::migration_manager& mm, db::system_keyspace& s
         });
     }
     co_await _role_manager->start();
+    if (this_shard_id() == 0) {
+        // Role manager and password authenticator have this odd startup
+        // mechanism where they asynchronously create the superuser role
+        // in the background. Correct password creation depends on role
+        // creation therefore we need to wait here.
+        co_await _role_manager->ensure_superuser_is_created();
+    }
     co_await when_all_succeed(_authorizer->start(), _authenticator->start()).discard_result();
     _permissions_cache = std::make_unique<permissions_cache>(_loading_cache_config, *this, log);
     co_await once_among_shards([this] {

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -206,7 +206,7 @@ future<> standard_role_manager::maybe_create_default_role() {
     auto has_superuser = [this] () -> future<bool> {
         const sstring query = seastar::format("SELECT * FROM {}.{} WHERE is_superuser = true ALLOW FILTERING", get_auth_ks_name(_qp), meta::roles_table::name);
         auto results = co_await _qp.execute_internal(query, db::consistency_level::LOCAL_ONE,
-                internal_distributed_query_state(), cql3::query_processor::cache_internal::no);
+                internal_distributed_query_state(), cql3::query_processor::cache_internal::yes);
         for (const auto& result : *results) {
             if (has_can_login(result)) {
                 co_return true;

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -178,7 +178,8 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
                     _migration_manager)).discard_result();
 }
 
-future<> standard_role_manager::create_default_role_if_missing() {
+future<> standard_role_manager::legacy_create_default_role_if_missing() {
+    SCYLLA_ASSERT(legacy_mode(_qp));
     try {
         const auto exists = co_await default_role_row_satisfies(_qp, &has_can_login, _superuser);
         if (exists) {
@@ -188,20 +189,70 @@ future<> standard_role_manager::create_default_role_if_missing() {
                 get_auth_ks_name(_qp),
                 meta::roles_table::name,
                 meta::roles_table::role_col_name);
-        if (legacy_mode(_qp)) {
-            co_await _qp.execute_internal(
-                    query,
-                    db::consistency_level::QUORUM,
-                    internal_distributed_query_state(),
-                    {_superuser},
-                    cql3::query_processor::cache_internal::no).discard_result();
-        } else {
-            co_await announce_mutations(_qp, _group0_client, query, {_superuser}, _as, ::service::raft_timeout{});
-        }
+        co_await _qp.execute_internal(
+                query,
+                db::consistency_level::QUORUM,
+                internal_distributed_query_state(),
+                {_superuser},
+                cql3::query_processor::cache_internal::no).discard_result();
         log.info("Created default superuser role '{}'.", _superuser);
     } catch(const exceptions::unavailable_exception& e) {
         log.warn("Skipped default role setup: some nodes were not ready; will retry");
         throw e;
+    }
+}
+
+future<> standard_role_manager::maybe_create_default_role() {
+    auto has_superuser = [this] () -> future<bool> {
+        const sstring query = seastar::format("SELECT * FROM {}.{} WHERE is_superuser = true ALLOW FILTERING", get_auth_ks_name(_qp), meta::roles_table::name);
+        auto results = co_await _qp.execute_internal(query, db::consistency_level::LOCAL_ONE,
+                internal_distributed_query_state(), cql3::query_processor::cache_internal::no);
+        for (const auto& result : *results) {
+            if (has_can_login(result)) {
+                co_return true;
+            }
+        }
+        co_return false;
+    };
+    if (co_await has_superuser()) {
+        co_return;
+    }
+    // We don't want to start operation earlier to avoid quorum requirement in
+    // a common case.
+    ::service::group0_batch batch(
+            co_await _group0_client.start_operation(_as, get_raft_timeout()));
+    // Check again as the state may have changed before we took the guard (batch).
+    if (co_await has_superuser()) {
+        co_return;
+    }
+    // There is no superuser which has can_login field - create default role.
+    // Note that we don't check if can_login is set to true.
+    const sstring insert_query = seastar::format("INSERT INTO {}.{} ({}, is_superuser, can_login) VALUES (?, true, true)",
+            get_auth_ks_name(_qp),
+            meta::roles_table::name,
+            meta::roles_table::role_col_name);
+    co_await collect_mutations(_qp, batch, insert_query, {_superuser});
+    co_await std::move(batch).commit(_group0_client, _as, get_raft_timeout());
+    log.info("Created default superuser role '{}'.", _superuser);
+}
+
+future<> standard_role_manager::maybe_create_default_role_with_retries() {
+    size_t retries = _migration_manager.get_concurrent_ddl_retries();
+    while (true)  {
+        try {
+            co_return co_await maybe_create_default_role();
+        } catch (const ::service::group0_concurrent_modification& ex) {
+            log.warn("Failed to execute maybe_create_default_role due to guard conflict.{}.", retries ? " Retrying" : " Number of retries exceeded, giving up");
+            if (retries--) {
+                continue;
+            }
+            // Log error but don't crash the whole node startup sequence.
+            log.error("Failed to create default superuser role due to guard conflict.");
+            co_return;
+        } catch (const ::service::raft_operation_timeout_error& ex) {
+            log.error("Failed to create default superuser role due to exception: {}", ex.what());
+            co_return;
+        }
     }
 }
 
@@ -266,9 +317,10 @@ future<> standard_role_manager::start() {
                     co_await migrate_legacy_metadata();
                     co_return;
                 }
+                co_await legacy_create_default_role_if_missing();
             }
-            co_await create_default_role_if_missing();
             if (!legacy) {
+                co_await maybe_create_default_role_with_retries();
                 _superuser_created_promise.set_value();
             }
         };

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -95,7 +95,10 @@ private:
 
     future<> migrate_legacy_metadata();
 
-    future<> create_default_role_if_missing();
+    future<> legacy_create_default_role_if_missing();
+
+    future<> maybe_create_default_role();
+    future<> maybe_create_default_role_with_retries();
 
     future<> create_or_replace(std::string_view role_name, const role_config&, ::service::group0_batch&);
 

--- a/test/cluster/auth_cluster/test_auth_after_reset.py
+++ b/test/cluster/auth_cluster/test_auth_after_reset.py
@@ -1,0 +1,50 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import pytest
+import logging
+import asyncio
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+from cassandra.auth import PlainTextAuthProvider
+from test.pylib.util import wait_for
+
+
+async def repeat_until_success(f):
+    async def try_execute(f):
+        try:
+            await f()
+            return True
+        except:
+            return None
+    return await wait_for(lambda: try_execute(f), time.time() + 60)
+
+"""
+Test if superuser is recreated after manual sstable delete (password reset procedure).
+"""
+@pytest.mark.asyncio
+async def test_auth_after_reset(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
+    await cql.run_async("ALTER ROLE cassandra WITH PASSWORD = 'forgotten_pwd'")
+
+    logging.info("Stopping cluster")
+    await asyncio.gather(*[manager.server_stop_gracefully(server.server_id) for server in servers])
+
+    logging.info("Deleting sstables")
+    for table in ["roles", "role_members", "role_attributes", "role_permissions"]:
+        await asyncio.gather(*[manager.server_wipe_sstables(server.server_id, "system", table) for server in servers])
+
+    logging.info("Starting cluster")
+    # Don't try connect to the servers yet, with deleted superuser it will be possible only after
+    # quorum is reached.
+    await asyncio.gather(*[manager.server_start(server.server_id, connect_driver=False) for server in servers])
+
+    logging.info("Waiting for CQL connection")
+    await repeat_until_success(lambda: manager.driver_connect(auth_provider=PlainTextAuthProvider(username="cassandra", password="cassandra")))
+    await manager.get_ready_cql(servers)

--- a/test/cluster/auth_cluster/test_auth_default_superuser_replaced.py
+++ b/test/cluster/auth_cluster/test_auth_default_superuser_replaced.py
@@ -1,0 +1,64 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import pytest
+import logging
+
+from cassandra.cluster import NoHostAvailable
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import unique_name
+from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
+from cassandra.auth import PlainTextAuthProvider
+
+
+"""
+Checks whether the default superuser is replaced by a custom one,
+and that the default superuser is not present in the system.
+"""
+async def test_auth_default_superuser_replaced(manager: ManagerClient) -> None:
+    servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logging.info("Creating non default superuser")
+    role = "r" + unique_name()
+    await cql.run_async(f"CREATE ROLE {role} WITH SUPERUSER = true AND PASSWORD = '{role}' AND LOGIN = true")
+
+    logging.info("Removing default superuser")
+    await manager.driver_connect(auth_provider=PlainTextAuthProvider(username=role, password=role))
+    cql = manager.get_cql()
+    await cql.run_async(f"DROP ROLE cassandra")
+
+    logging.info("Rolling restart")
+    await manager.rolling_restart(servers, wait_for_cql=False)
+
+    logging.info("Non-rolling restart")
+    for s in servers:
+        logging.info(f"Stopping server {s.server_id}")
+        await manager.server_stop_gracefully(s.server_id)
+    for s in servers:
+        logging.info(f"Starting server {s.server_id}")
+        await manager.server_start(s.server_id, auth_provider={
+            "authenticator": "cassandra.auth.PlainTextAuthProvider",
+            "kwargs": {
+                "username": role,
+                "password": role
+            }}
+        )
+
+    logging.info("Waiting for CQL")
+    await manager.driver_connect(auth_provider=PlainTextAuthProvider(username=role, password=role))
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logging.info("Checking for expected roles")
+    for s in servers:
+        logging.info(f"Checking if default removed superuser is not present on server {s.server_id}")
+        with pytest.raises(NoHostAvailable, match="Bad credentials"):
+            await manager.driver_connect(server=s,
+                auth_provider=PlainTextAuthProvider(username='cassandra', password='cassandra'))
+
+        logging.info(f"Checking if added superuser works on server {s.server_id}")
+        await manager.driver_connect(server=s,
+            auth_provider=PlainTextAuthProvider(username=role, password=role))

--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -6,7 +6,7 @@
 """Internal types for handling Scylla test servers.
 """
 
-from enum import Enum, auto
+from enum import IntEnum, auto
 from typing import NewType, NamedTuple
 
 
@@ -33,7 +33,7 @@ class ServerInfo(NamedTuple):
         return {"dc": self.datacenter, "rack": self.rack}
 
 
-class ServerUpState(Enum):
+class ServerUpState(IntEnum):
     PROCESS_STARTED = auto()
     HOST_ID_QUERIED = auto()
     CQL_CONNECTED = auto()

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -246,7 +246,8 @@ class ManagerClient:
                            connect_driver: bool = True,
                            expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED,
                            cmdline_options_override: list[str] | None = None,
-                           append_env_override: dict[str, str] | None = None) -> None:
+                           append_env_override: dict[str, str] | None = None,
+                           auth_provider: dict[str, str] | None = None) -> None:
         """Start specified server and optionally wait for it to learn of other servers.
 
         Replace CLI options and environment variables with `cmdline_options_override` and `append_env_override`
@@ -260,6 +261,7 @@ class ManagerClient:
             "expected_server_up_state": expected_server_up_state.name,
             "cmdline_options_override": cmdline_options_override,
             "append_env_override": append_env_override,
+            "auth_provider": auth_provider,
         }
         await self.client.put_json(f"/cluster/server/{server_id}/start", data, timeout=timeout)
         await self.server_sees_others(server_id, wait_others, interval = wait_interval)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1261,6 +1261,7 @@ class ScyllaCluster:
                            server_id: ServerNum,
                            expected_error: str | None = None,
                            seeds: list[IPAddress] | None = None,
+                           connect_driver = True,
                            expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED,
                            cmdline_options_override: list[str] | None = None,
                            append_env_override: dict[str, str] | None = None) -> None:
@@ -1286,6 +1287,8 @@ class ScyllaCluster:
         # Put the server in `running` before starting it.
         # Starting may fail and if we didn't add it now it might leak.
         self.running[server_id] = server
+        if not connect_driver:
+            expected_server_up_state = min(expected_server_up_state, ServerUpState.HOST_ID_QUERIED)
         await server.start(
             api=self.api,
             expected_error=expected_error,
@@ -1717,6 +1720,7 @@ class ScyllaClusterManager:
             server_id=server_id,
             expected_error=data.get("expected_error"),
             seeds=data.get("seeds"),
+            connect_driver=data.get("connect_driver"),
             expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "CQL_QUERIED")),
             cmdline_options_override=data.get("cmdline_options_override"),
             append_env_override=data.get("append_env_override"),

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -24,6 +24,7 @@ from typing import Any, Optional, Dict, List, Set, Tuple, Callable, AsyncIterato
     Awaitable
 import uuid
 from io import BufferedWriter
+import importlib
 
 from test import TOP_SRC_DIR, TEST_DIR
 from test.pylib.host_registry import Host, HostRegistry
@@ -48,7 +49,7 @@ import psutil
 
 from cassandra import InvalidRequest                    # type: ignore
 from cassandra import OperationTimedOut                 # type: ignore
-from cassandra.auth import PlainTextAuthProvider        # type: ignore
+from cassandra.auth import PlainTextAuthProvider, AuthProvider # type: ignore
 from cassandra.cluster import Cluster           # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import NoHostAvailable   # type: ignore # pylint: disable=no-name-in-module
 from cassandra.cluster import Session           # pylint: disable=no-name-in-module
@@ -388,6 +389,7 @@ class ScyllaServer:
         self.cluster_name = cluster_name
         self.ip_addr = IPAddress(ip_addr)
         self.seeds = seeds
+        self.auth_provider: Optional[AuthProvider] = None
         self.cmd: Optional[Process] = None
         self.start_stop_lock = asyncio.Lock()
         self.stop_event = asyncio.Event()
@@ -621,7 +623,8 @@ class ScyllaServer:
         oldlevel = caslog.getEffectiveLevel()
         # Be quiet about connection failures.
         caslog.setLevel('CRITICAL')
-        auth = PlainTextAuthProvider(username='cassandra', password='cassandra')
+        if self.auth_provider is None:
+            self.auth_provider = PlainTextAuthProvider(username='cassandra', password='cassandra')
         # auth::standard_role_manager creates "cassandra" role in an
         # async loop auth::do_after_system_ready(), which retries
         # role creation with an exponential back-off. In other
@@ -652,7 +655,7 @@ class ScyllaServer:
                          # This is the latest version Scylla supports
                          protocol_version=4,
                          control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                         auth_provider=auth) as cluster:
+                         auth_provider=self.auth_provider) as cluster:
                 with cluster.connect() as session:
                     connected = True
                     # See the comment above about `auth::standard_role_manager`. We execute
@@ -662,7 +665,7 @@ class ScyllaServer:
                                                         {EXEC_PROFILE_DEFAULT: profile},
                                                    contact_points=contact_points,
                                                    control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                                                   auth_provider=auth)
+                                                   auth_provider=self.auth_provider)
                     self.control_connection = self.control_cluster.connect()
                     return ServerUpState.CQL_QUERIED
         except (NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:
@@ -1264,7 +1267,8 @@ class ScyllaCluster:
                            connect_driver = True,
                            expected_server_up_state: ServerUpState = ServerUpState.CQL_QUERIED,
                            cmdline_options_override: list[str] | None = None,
-                           append_env_override: dict[str, str] | None = None) -> None:
+                           append_env_override: dict[str, str] | None = None,
+                           auth_provider: dict[str, str] | None = None) -> None:
         """Start a server.
 
         Replace CLI options and environment variables with `cmdline_options_override` and `append_env_override`
@@ -1289,6 +1293,15 @@ class ScyllaCluster:
         self.running[server_id] = server
         if not connect_driver:
             expected_server_up_state = min(expected_server_up_state, ServerUpState.HOST_ID_QUERIED)
+
+        def instance_auth_provider(desc: dict):
+            module_path, class_name = desc["authenticator"].rsplit('.', 1)
+            module = importlib.import_module(module_path)
+            auth_class = getattr(module, class_name)
+            return auth_class(**desc["kwargs"])
+
+        if auth_provider is not None:
+            server.auth_provider = instance_auth_provider(auth_provider)
         await server.start(
             api=self.api,
             expected_error=expected_error,
@@ -1724,6 +1737,7 @@ class ScyllaClusterManager:
             expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "CQL_QUERIED")),
             cmdline_options_override=data.get("cmdline_options_override"),
             append_env_override=data.get("append_env_override"),
+            auth_provider=data.get("auth_provider"),
         )
 
     async def _cluster_server_pause(self, request) -> None:


### PR DESCRIPTION
This patchset fixes regression introduced by https://github.com/scylladb/scylla-enterprise/commit/7e749cd848f8c7590f6297f98c6aa39afa36346c when we started re-creating default superuser role and password from the config, even if new custom superuser was created by the user.

Now we'll check, first with CL LOCAL_ONE if there is a need to create default superuser role or password, confirm
it with CL QUORUM and only then atomically create role or password.

If server is started without cluster quorum we'll skip creating role or password.

Fixes https://github.com/scylladb/scylladb/issues/24469
Backport: all versions since 2024.2