### PR TITLE
s3_client: Fix hang in get() on EOF by signaling condition variable

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1189,6 +1189,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                             if (buff_size == 0 && _range->len == 0) {
                                 s3l.trace("Fiber for object '{}' signals EOS", _object_name);
                                 _buffers.emplace_back(std::move(buf), co_await _client->claim_memory(buff_size));
+                                _get_cv.signal();
                                 _is_finished = true;
                                 break;
                             }


### PR DESCRIPTION
* Ensure _get_cv.signal() is called when an empty buffer received
* Prevents `get()` from stalling indefinitely while waiting on EOF
* Found when testing https://github.com/scylladb/scylladb/pull/23695

No backport needed since the class being fixed is available only in master