### PR TITLE
mutation: check key of inserted rows

### DIFF
--- a/compound.hh
+++ b/compound.hh
@@ -255,6 +255,9 @@ public:
     // Returns true iff given prefix has no missing components
     bool is_full(managed_bytes_view v) const {
         SCYLLA_ASSERT(AllowPrefixes == allow_prefixes::yes);
+        if (_types.size() == 0) {
+            return v.empty();
+        }
         return std::distance(begin(v), end(v)) == (ssize_t)_types.size();
     }
     bool is_empty(managed_bytes_view v) const {

--- a/mutation/mutation_partition_v2.cc
+++ b/mutation/mutation_partition_v2.cc
@@ -614,6 +614,7 @@ mutation_partition_v2::find_row(const schema& s, const clustering_key& key) cons
 deletable_row&
 mutation_partition_v2::clustered_row(const schema& s, clustering_key&& key) {
     check_schema(s);
+    check_row_key(s, key, is_dummy::no);
     auto i = _rows.find(key, rows_entry::tri_compare(s));
     if (i == _rows.end()) {
         auto e = alloc_strategy_unique_ptr<rows_entry>(
@@ -626,6 +627,7 @@ mutation_partition_v2::clustered_row(const schema& s, clustering_key&& key) {
 deletable_row&
 mutation_partition_v2::clustered_row(const schema& s, const clustering_key& key) {
     check_schema(s);
+    check_row_key(s, key, is_dummy::no);
     auto i = _rows.find(key, rows_entry::tri_compare(s));
     if (i == _rows.end()) {
         auto e = alloc_strategy_unique_ptr<rows_entry>(
@@ -638,6 +640,7 @@ mutation_partition_v2::clustered_row(const schema& s, const clustering_key& key)
 deletable_row&
 mutation_partition_v2::clustered_row(const schema& s, clustering_key_view key) {
     check_schema(s);
+    check_row_key(s, key, is_dummy::no);
     auto i = _rows.find(key, rows_entry::tri_compare(s));
     if (i == _rows.end()) {
         auto e = alloc_strategy_unique_ptr<rows_entry>(
@@ -650,6 +653,7 @@ mutation_partition_v2::clustered_row(const schema& s, clustering_key_view key) {
 rows_entry&
 mutation_partition_v2::clustered_rows_entry(const schema& s, position_in_partition_view pos, is_dummy dummy, is_continuous continuous) {
     check_schema(s);
+    check_row_key(s, pos, dummy);
     auto i = _rows.find(pos, rows_entry::tri_compare(s));
     if (i == _rows.end()) {
         auto e = alloc_strategy_unique_ptr<rows_entry>(
@@ -667,6 +671,7 @@ mutation_partition_v2::clustered_row(const schema& s, position_in_partition_view
 rows_entry&
 mutation_partition_v2::clustered_row(const schema& s, position_in_partition_view pos, is_dummy dummy) {
     check_schema(s);
+    check_row_key(s, pos, dummy);
     auto cmp = rows_entry::tri_compare(s);
     auto i = _rows.lower_bound(pos, cmp);
     if (i == _rows.end() || cmp(i->position(), pos) != 0) {
@@ -684,6 +689,7 @@ mutation_partition_v2::clustered_row(const schema& s, position_in_partition_view
 deletable_row&
 mutation_partition_v2::append_clustered_row(const schema& s, position_in_partition_view pos, is_dummy dummy, is_continuous continuous) {
     check_schema(s);
+    check_row_key(s, pos, dummy);
     const auto cmp = rows_entry::tri_compare(s);
     auto i = _rows.end();
     if (!_rows.empty() && (cmp(*std::prev(i), pos) >= 0)) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -4129,3 +4129,174 @@ SEASTAR_THREAD_TEST_CASE(test_mutation_compactor_sticky_max_purgeable) {
         assert_that(compact_and_expire(std::move(mut))).is_equal_to(mut_compacted);
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(test_serialized_mutation_empty_and_nonfull_keys) {
+    auto random_spec = tests::make_random_schema_specification(
+            get_name(),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(2, 8),
+            std::uniform_int_distribution<size_t>(2, 8));
+    auto random_schema = tests::random_schema(tests::random::get_int<uint32_t>(), *random_spec);
+
+    auto schema = random_schema.schema();
+
+    auto updated_schema = schema_builder(schema)
+        .remove_column(schema->regular_column_at(0).name())
+        .build();
+
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+
+    testlog.info("Random schema:\n{}", random_schema.cql());
+
+    const auto mutations = tests::generate_random_mutations(random_schema, 1).get();
+
+    {
+        const auto& mut = mutations.back();
+        frozen_mutation fm(mut);
+
+        assert_that(fm.unfreeze(schema)).is_equal_to(mut);
+    }
+
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+        set_abort_on_internal_error(abort);
+    });
+
+    auto check = [&] (const clustering_key& ckey) {
+        testlog.info("Adding row with bad key: {}", ckey);
+
+        auto mut = mutations.back();
+
+        // Need to sneak in the bad key via the back-door, the mutation_partition
+        // will rejects it via the regular insert/update methods.
+        auto& rows = mut.partition().mutable_clustered_rows();
+        auto e = alloc_strategy_unique_ptr<rows_entry>(current_allocator().construct<rows_entry>(ckey, deletable_row(*schema, mut.partition().clustered_rows().begin()->row())));
+        rows.insert_before_hint(rows.end(), std::move(e), rows_entry::tri_compare(*schema));
+
+        frozen_mutation fm(mut);
+        BOOST_REQUIRE_THROW(fm.unfreeze(schema), std::runtime_error);
+        BOOST_REQUIRE_THROW(fm.unfreeze(updated_schema), std::runtime_error);
+
+        canonical_mutation cm(mut);
+        BOOST_REQUIRE_THROW(cm.to_mutation(schema), std::runtime_error);
+        BOOST_REQUIRE_THROW(cm.to_mutation(updated_schema), std::runtime_error);
+    };
+
+    check(clustering_key::make_empty());
+
+    if (schema->clustering_key_size() > 1) {
+        auto full_ckey = random_schema.make_ckey(0);
+        full_ckey.erase(full_ckey.end() - 1);
+        check(clustering_key::from_exploded(*schema, full_ckey));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_mutation_empty_and_nonfull_keys) {
+    auto random_spec = tests::make_random_schema_specification(
+            get_name(),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(2, 8),
+            std::uniform_int_distribution<size_t>(2, 8));
+    auto random_schema = tests::random_schema(tests::random::get_int<uint32_t>(), *random_spec);
+
+    auto schema = random_schema.schema();
+
+    testlog.info("Random schema:\n{}", random_schema.cql());
+
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+        set_abort_on_internal_error(abort);
+    });
+
+    auto check = [&] (const clustering_key& ckey) {
+        testlog.info("Adding row with bad key: {}", ckey);
+
+        mutation_partition mp(*schema);
+
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, ckey), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, clustering_key(ckey)), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, clustering_key_view(ckey)), std::runtime_error);
+
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    };
+
+    check(clustering_key::make_empty());
+
+    if (schema->clustering_key_size() > 1) {
+        auto full_ckey = random_schema.make_ckey(0);
+        full_ckey.erase(full_ckey.end() - 1);
+        check(clustering_key::from_exploded(*schema, full_ckey));
+    }
+
+    mutation_partition mp(*schema);
+    const auto ckey = clustering_key::from_exploded(*schema, random_schema.make_ckey(0));
+
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_mutation_partition_v2_empty_and_nonfull_keys) {
+    auto random_spec = tests::make_random_schema_specification(
+            get_name(),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(1, 1),
+            std::uniform_int_distribution<size_t>(1, 1));
+    auto random_schema = tests::random_schema(tests::random::get_int<uint32_t>(), *random_spec);
+
+    auto schema = random_schema.schema();
+
+    testlog.info("Random schema:\n{}", random_schema.cql());
+
+    auto reset_abort = defer([abort = set_abort_on_internal_error(false)] {
+        set_abort_on_internal_error(abort);
+    });
+
+    auto check = [&] (const clustering_key& ckey) {
+        testlog.info("Adding row with bad key: {}", ckey);
+
+        mutation_partition_v2 mp(*schema);
+
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, ckey), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, clustering_key(ckey)), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, clustering_key_view(ckey)), std::runtime_error);
+
+        BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+        BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::for_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    };
+
+    check(clustering_key::make_empty());
+
+    if (schema->clustering_key_size() > 1) {
+        auto full_ckey = random_schema.make_ckey(0);
+        full_ckey.erase(full_ckey.end() - 1);
+        check(clustering_key::from_exploded(*schema, full_ckey));
+    }
+
+    mutation_partition_v2 mp(*schema);
+    const auto ckey = clustering_key::from_exploded(*schema, random_schema.make_ckey(0));
+
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_row(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.clustered_rows_entry(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::before_key(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::after_all_prefixed(ckey), is_dummy::no, is_continuous::no), std::runtime_error);
+    BOOST_REQUIRE_THROW(mp.append_clustered_row(*schema, position_in_partition_view::for_static_row(), is_dummy::no, is_continuous::no), std::runtime_error);
+}

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4325,6 +4325,7 @@ SEASTAR_TEST_CASE(test_reading_of_nonfull_keys) {
                     .with_column("ck1", utf8_type, column_kind::clustering_key)
                     .with_column("ck2", utf8_type, column_kind::clustering_key)
                     .with_column("v", utf8_type)
+                    .with(schema_builder::compact_storage::yes)
                     .build();
 
             auto pkey = dht::decorate_key(*s, partition_key::from_single_value(*s, serialized("pk1")));


### PR DESCRIPTION
Make sure the keys are full prefixes as it is expected to be the case for rows. At severeal occasions we have seen empty row keys make their ways into the sstables, despite the fact that they are not allowed by the CQL frontend. This means that such empty keys are possibly results of memory corruption or use-after-{free,copy} errors. The source of the corruption is impossible to pinpoint when the empty key is discovered in the sstable. So this patch adds checks for such keys to places where mutations are built: when building or unserializing mutations.

Fixes: https://github.com/scylladb/scylladb/issues/24506

Not a typical backport candidate (not a bugfix or regression fix), but we should still backport so we have the additional checks deployed to existing production clusters.