### PR TITLE
generic server: 2 step shutdown

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -942,6 +942,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The default timeout for other, miscellaneous operations.\n"
         "\n"
         "Related information: About hinted handoff writes")
+    , request_timeout_on_shutdown_in_seconds(this, "request_timeout_on_shutdown_in_seconds", value_status::Used, 30,
+        "Timeout for CQL server requests on shutdown. After this timeout the server will shutdown all connections.")
     , group0_raft_op_timeout_in_ms(this, "group0_raft_op_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 60000,
             "The time in milliseconds that group0 allows a Raft operation to complete.")
     /**

--- a/db/config.hh
+++ b/db/config.hh
@@ -322,6 +322,7 @@ public:
     named_value<uint32_t> truncate_request_timeout_in_ms;
     named_value<uint32_t> write_request_timeout_in_ms;
     named_value<uint32_t> request_timeout_in_ms;
+    named_value<uint32_t> request_timeout_on_shutdown_in_seconds;
     named_value<uint32_t> group0_raft_op_timeout_in_ms;
     named_value<bool> cross_node_timeout;
     named_value<uint32_t> internode_send_buff_size_in_bytes;

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -276,10 +276,6 @@ server::server(const sstring& server_name, logging::logger& logger, config cfg)
 {
 }
 
-server::~server()
-{
-}
-
 future<> server::stop() {
     co_await shutdown();
     co_await std::exchange(_all_connections_stopped, make_ready_future<>());

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -236,6 +236,26 @@ void connection::shutdown()
     }
 }
 
+bool connection::shutdown_input() {
+    try {
+        _fd.shutdown_input();
+    } catch (...) {
+        _server._logger.warn("Error shutting down input side of connection {}->{}, exception: {}", _fd.remote_address(), _fd.local_address(), std::current_exception());
+        return false;
+    }
+    return true;
+}
+
+bool connection::shutdown_output() {
+    try {
+        _fd.shutdown_output();
+    } catch (...) {
+        _server._logger.warn("Error shutting down output side of connection {}->{}, exception: {}", _fd.remote_address(), _fd.local_address(), std::current_exception());
+        return false;
+    }
+    return true;
+}
+
 server::server(const sstring& server_name, logging::logger& logger, config cfg)
     : _server_name{server_name}
     , _logger{logger}

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -229,11 +229,8 @@ void connection::on_connection_ready()
 
 void connection::shutdown()
 {
-    try {
-        _fd.shutdown_input();
-        _fd.shutdown_output();
-    } catch (...) {
-    }
+    shutdown_input();
+    shutdown_output();
 }
 
 bool connection::shutdown_input() {

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -8,7 +8,6 @@
 
 #include "generic_server.hh"
 
-
 #include <exception>
 #include <fmt/ranges.h>
 #include <seastar/core/when_all.hh>
@@ -273,6 +272,7 @@ server::server(const sstring& server_name, logging::logger& logger, config cfg)
     }))
     , _prev_conns_cpu_concurrency(_conns_cpu_concurrency)
     , _conns_cpu_concurrency_semaphore(_conns_cpu_concurrency, named_semaphore_exception_factory{"connections cpu concurrency semaphore"})
+    , _shutdown_timeout(std::chrono::seconds{cfg.shutdown_timeout_in_seconds})
 {
 }
 
@@ -285,7 +285,11 @@ future<> server::shutdown() {
     if (_gate.is_closed()) {
         co_return;
     }
-    _all_connections_stopped = _gate.close();
+
+    shared_future<> connections_stopped{_gate.close()};
+    _all_connections_stopped = connections_stopped.get_future();
+
+     // Stop all listeners.
     size_t nr = 0;
     size_t nr_total = _listeners.size();
     _logger.debug("abort accept nr_total={}", nr_total);
@@ -293,14 +297,35 @@ future<> server::shutdown() {
         l.abort_accept();
         _logger.debug("abort accept {} out of {} done", ++nr, nr_total);
     }
+     co_await std::move(_listeners_stopped);
+
+    // Shutdown RX side of the connections, so no new requests could be received.
+    // Leave the TX side so the responses to ongoing requests could be sent.
+    _logger.debug("Shutting down RX side of {} connections", _connections_list.size());
+    co_await for_each_gently([](auto& connection) {
+        if (!connection.shutdown_input()) {
+            // If failed to shutdown the input side, then attempt to shutdown the output side which should do a complete shutdown of the connection.
+            connection.shutdown_output();
+        }
+    });
+
+    // Wait for the remaining requests to finish.
+    _logger.debug("Waiting for connections to stop");
+    try {
+        co_await connections_stopped.get_future(seastar::lowres_clock::now() + _shutdown_timeout);
+    } catch (const timed_out_error& _) {
+        _logger.info("Timed out waiting for connections shutdown.");
+    }
+
+    // Either all requests stopped or a timeout occurred, do the full shutdown of the connections.
     size_t nr_conn = 0;
     auto nr_conn_total = _connections_list.size();
     _logger.debug("shutdown connection nr_total={}", nr_conn_total);
-    for (auto& c : _connections_list) {
+    co_await for_each_gently([&nr_conn, nr_conn_total, this](connection& c) {
         c.shutdown();
         _logger.debug("shutdown connection {} out of {} done", ++nr_conn, nr_conn_total);
-    }
-    co_await std::move(_listeners_stopped);
+    });
+
     _abort_source.request_abort();
 }
 

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -39,6 +39,7 @@ class server;
 // member function to perform request processing. This base class provides a
 // `_read_buf` and a `_write_buf` for reading requests and writing responses.
 class connection : public boost::intrusive::list_base_hook<> {
+    friend class server;
 public:
     using connection_process_loop = noncopyable_function<future<> ()>;
     using execute_under_tenant_type = noncopyable_function<future<> (connection_process_loop)>;
@@ -84,6 +85,7 @@ public:
 
 struct config {
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
+    utils::updateable_value<uint32_t> shutdown_timeout_in_seconds;
 };
 
 // A generic TCP socket server.
@@ -128,6 +130,7 @@ private:
     utils::observer<uint32_t> _conns_cpu_concurrency_observer;
     uint32_t _prev_conns_cpu_concurrency;
     named_semaphore _conns_cpu_concurrency_semaphore;
+    std::chrono::seconds _shutdown_timeout;
 public:
     server(const sstring& server_name, logging::logger& logger, config cfg);
 

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -142,9 +142,9 @@ public:
     future<> shutdown();
     future<> stop();
 
-    future<> listen(socket_address addr, 
-        std::shared_ptr<seastar::tls::credentials_builder> creds, 
-        bool is_shard_aware, bool keepalive, 
+    future<> listen(socket_address addr,
+        std::shared_ptr<seastar::tls::credentials_builder> creds,
+        bool is_shard_aware, bool keepalive,
         std::optional<file_permissions> unix_domain_socket_permissions,
         std::function<server&()> get_shard_instance = {}
         );

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -61,6 +61,8 @@ protected:
 
 private:
     future<> process_until_tenant_switch();
+    bool shutdown_input();
+    bool shutdown_output();
 public:
     connection(server& server, connected_socket&& fd, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units);
     virtual ~connection();

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -131,7 +131,7 @@ private:
 public:
     server(const sstring& server_name, logging::logger& logger, config cfg);
 
-    virtual ~server();
+    virtual ~server() = default;
 
     // Makes sure listening sockets no longer generate new connections and aborts the
     // connected sockets, so that new requests are not served and existing requests don't

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -177,7 +177,7 @@ def default_timeout(mode):
     if mode == "dev":
         return "30s"
     elif mode == "debug":
-        return "3m"
+        return "1m30s"
     else:
         # this branch shouldn't be reached
         assert False

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -59,7 +59,12 @@ async def test_long_query_timeout_erm(request, manager: ManagerClient, query_typ
 
     logger.info("Start four nodes cluster")
     # FIXME: Adjust this test to run with `rf_rack_valid_keyspaces` set to `True`.
-    servers = await manager.servers_add(4, config={"rf_rack_valid_keyspaces": False})
+    if should_wait_for_timeout and shutdown_nodes:
+        # Overriding the `request_timeout_on_shutdown_in_seconds` for this test to avoid excessive delays, since after PR 24499
+        # all queries (non-completed) are always waited for `request_timeout_on_shutdown_in_seconds` time.
+        servers = await manager.servers_add(4, config={"rf_rack_valid_keyspaces": False, "request_timeout_on_shutdown_in_seconds": 30})
+    else:
+        servers = await manager.servers_add(4, config={"rf_rack_valid_keyspaces": False})
 
     selected_server = servers[0]
     logger.info(f"Creating a client with selected_server: {selected_server}")

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -1,0 +1,97 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import logging
+import pytest
+import asyncio
+import time
+
+from cassandra import ConsistencyLevel  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.cluster.util import new_test_keyspace
+from test.cluster.test_tablets2 import inject_error_on
+from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
+from test.cluster.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="#24481")
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """
+    Test query execution during cql connections shutdown.
+
+     1. Start 3 servers
+     2. Create a keyspace with replication factor 3
+     3. Use error injection to pause write responses on 2 nodes of the cluster.
+     4  Send a write query through the remaining node.
+     5. Make sure the query coordinator started shutting down.
+     6. Unpause the write responses from 2 nodes.
+     7. Make sure request is completed successfully.
+    """
+
+    logger.info("Creating a new cluster")
+
+    cmdline = [
+        '--logger-log-level', 'debug_error_injection=debug',
+    ]
+
+    servers = await manager.servers_add(3, auto_rack_dc="dc1", cmdline=cmdline)
+
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        target_host = hosts[2]
+        target_server = servers[2]
+
+        target_server_log = await manager.server_open_log(target_server.server_id)
+
+        # Make sure responses on the other replicas will be delayed.
+        servers_to_pause = [servers[1], servers[0]]
+        await inject_error_on(manager, "storage_proxy_write_response_pause", servers_to_pause)
+        logger.info(
+            f"Pausing write responses on the replicas {servers_to_pause}")
+
+        # Send a write query to the target node that will be shut down.
+        async def do_send_query():
+            logger.info(f"Sending a write query to the target node {target_server.server_id}")
+            await cql.run_async(f"insert into {ks}.t (pk, v) values ({32765}, {17777})", host=target_host)
+
+        write_task = asyncio.create_task(do_send_query())
+
+        # Make sure nodes that have to pause the request response, got the write request and started waiting.
+        for server in servers_to_pause:
+            paused_server_logs = await manager.server_open_log(server.server_id)
+            await paused_server_logs.wait_for("storage_proxy_write_response_pause: waiting for message")
+
+        # Start shutdown of the query coordinator node
+        async def do_shutdown():
+            logger.info(f"Starting shutdown of node {target_server.server_id}")
+            await manager.server_stop_gracefully(target_server.server_id)
+
+        shutdown_task = asyncio.create_task(do_shutdown())
+
+        # Wait for the shutdown to start
+        await target_server_log.wait_for("init - Shutting down local storage")
+        await asyncio.sleep(1)
+
+        logger.info(f"Unblocking writes on the nodes {servers_to_pause}")
+        for server in servers_to_pause:
+            await manager.api.message_injection(server.ip_addr, 'storage_proxy_write_response_pause')
+
+        logger.info("Waiting for write query to complete")
+        await write_task
+
+        logger.info("Waiting for the shutdown to complete")
+        await shutdown_task
+
+

--- a/test/cluster/test_write_query_during_cql_server_shutdown.py
+++ b/test/cluster/test_write_query_during_cql_server_shutdown.py
@@ -20,7 +20,6 @@ from test.cluster.conftest import skip_mode
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="#24481")
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_write_query_during_cql_server_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -234,8 +234,6 @@ class ManagerClient:
         logger.debug("ManagerClient stopping %s", server_id)
         await self.client.put_json(f"/cluster/server/{server_id}/stop")
 
-    # FIXME: change timeout back to 60 once we fix the slow flushing of tables during shutdown
-    # (see https://github.com/scylladb/scylladb/issues/12028).
     async def server_stop_gracefully(self, server_id: ServerNum, timeout: float = 180) -> None:
         """Stop specified server gracefully"""
         logger.debug("ManagerClient stopping gracefully %s", server_id)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -82,7 +82,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
     # reason, so we increase the timeouts according to each mode's needs. The client
     # should avoid timing out its requests before the server times out - for this reason
     # we increase the CQL driver's client-side timeout in conftest.py.
-    request_timeout_in_ms = 180000 if mode in {'debug', 'sanitize'} else 30000
+    request_timeout_in_ms = 90000 if mode in {'debug', 'sanitize'} else 30000
 
     return {
         'cluster_name': cluster_name,
@@ -123,6 +123,7 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'truncate_request_timeout_in_ms': request_timeout_in_ms,
         'write_request_timeout_in_ms': request_timeout_in_ms,
         'request_timeout_in_ms': request_timeout_in_ms,
+        'request_timeout_on_shutdown_in_seconds': int(request_timeout_in_ms/1000),
         'group0_raft_op_timeout_in_ms': 300000,
         'user_defined_function_time_limit_ms': 1000,
 

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -242,6 +242,7 @@ future<> controller::do_start_server() {
               .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
               .cql_duplicate_bind_variable_names_refer_to_same_variable = cfg.cql_duplicate_bind_variable_names_refer_to_same_variable,
               .uninitialized_connections_semaphore_cpu_concurrency = cfg.uninitialized_connections_semaphore_cpu_concurrency,
+              .request_timeout_on_shutdown_in_seconds = cfg.request_timeout_on_shutdown_in_seconds
             };
         });
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -256,7 +256,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         service::memory_limiter& ml, cql_server_config config,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
-    : server("CQLServer", clogger, generic_server::config{std::move(config.uninitialized_connections_semaphore_cpu_concurrency)})
+    : server("CQLServer", clogger, generic_server::config{std::move(config.uninitialized_connections_semaphore_cpu_concurrency), config.request_timeout_on_shutdown_in_seconds})
     , _query_processor(qp)
     , _config(std::move(config))
     , _memory_available(ml.get_semaphore())

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -121,6 +121,7 @@ struct cql_server_config {
     utils::updateable_value<uint32_t> max_concurrent_requests;
     utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
+    utils::updateable_value<uint32_t> request_timeout_on_shutdown_in_seconds;
 };
 
 /**

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -120,7 +120,6 @@ struct cql_server_config {
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
     utils::updateable_value<uint32_t> max_concurrent_requests;
     utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
-
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
 };
 


### PR DESCRIPTION
This PR implements solution proposed in scylladb/scylladb#24481 

### Two-step connections shutdown for `generic_server`: 
Instead of terminating connections immediately, the shutdown now proceeds in two stages: first closing the receive (input) side to stop new requests, then waiting for all active requests to complete before fully closing the connections.

The updated shutdown process is as follows:

1. Initial Shutdown Phase
   * Close the accept gate to block new incoming connections.
   * Abort all accept() calls.
   * For all active connections:
      * Close only the input side of the connection to prevent new requests.
      * Keep the output side open to allow responses to be sent.

2. Drain Phase
   * Wait for all in-progress requests to either complete or fail.

3. Final Shutdown Phase
   * Fully close all connections.

Fixes scylladb/scylladb#24481
