### PR TITLE
tools/scylla-nodetool: backup: add --move-files parameter

### DIFF
--- a/docs/operating-scylla/nodetool-commands/backup.rst
+++ b/docs/operating-scylla/nodetool-commands/backup.rst
@@ -18,13 +18,14 @@ Syntax
                [--snapshot <snapshot>]
                --endpoint <endpoint> --bucket <bucket> --prefix <prefix>
                [--nowait]
+               [--move-files]
 
 Example
 -------
 
 .. code-block:: console
 
-    nodetool backup --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix foo/bar/baz --keyspace ks --table table --snapshot ss
+    nodetool backup --endpoint s3.us-east-2.amazonaws.com  --bucket bucket-foo --prefix foo/bar/baz --keyspace ks --table table --snapshot ss --move-files
 
 Options
 -------
@@ -38,6 +39,7 @@ Options
 * ``--bucket`` - Name of the bucket to backup SSTables to
 * ``--prefix`` - Prefix to backup SSTables to
 * ``--nowait`` - Don't wait on the backup process
+* ``--move-files`` - Move files instead of copying them. This will delete the files from the local disk after they are uploaded to the object storage.
 
 See also
 

--- a/test/nodetool/test_backup.py
+++ b/test/nodetool/test_backup.py
@@ -29,10 +29,10 @@ def test_statusbackup(nodetool):
     assert res.stdout == "running\n"
 
 
-@pytest.mark.parametrize("nowait,task_state,task_error", [(False, "failed", "error"),
-                                                          (False, "done", ""),
-                                                          (True, "", "")])
-def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
+@pytest.mark.parametrize("nowait,task_state,task_error,move_files", [(False, "failed", "error", False),
+                                                          (False, "done", "", True),
+                                                          (True, "", "", True)])
+def test_backup(nodetool, scylla_only, nowait, task_state, task_error, move_files):
     endpoint = "s3.us-east-2.amazonaws.com"
     bucket = "bucket-foo"
     prefix = "foo/bar/baz"
@@ -44,7 +44,8 @@ def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
               "prefix": prefix,
               "keyspace": keyspace,
               "table": table,
-              "snapshot": snapshot}
+              "snapshot": snapshot,
+              "move_files": "true" if move_files else "false"}
     task_id = "2c4a3e5f"
     start_time = "2024-08-08T14:29:25Z"
     end_time = "2024-08-08T14:30:42Z"
@@ -78,6 +79,8 @@ def test_backup(nodetool, scylla_only, nowait, task_state, task_error):
             "--keyspace", keyspace,
             "--table", table,
             "--snapshot", snapshot]
+    if move_files:
+        args.append("--move-files")
     if nowait:
         args.append("--nowait")
         res = nodetool(*args, expected_requests=expected_requests)

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -420,6 +420,7 @@ void backup_operation(scylla_rest_client& client, const bpo::variables_map& vm) 
     if (vm.contains("snapshot")) {
         params["snapshot"] = vm["snapshot"].as<sstring>();
     }
+    params["move_files"] = vm.contains("move-files") ? "true" : "false";
     const auto backup_res = client.post("/storage_service/backup", std::move(params));
     const auto task_id = rjson::to_string_view(backup_res);
     if (vm.contains("nowait")) {
@@ -3577,6 +3578,7 @@ For more information, see: {}"
                     typed_option<sstring>("endpoint", "ID of the configured object storage endpoint to copy SSTables to"),
                     typed_option<sstring>("bucket", "Name of the bucket to backup SSTables to"),
                     typed_option<sstring>("prefix", "The prefix to backup SSTables under"),
+                    typed_option<>("move-files", "Move the SSTable files instead of copying them"),
                     typed_option<>("nowait", "Don't wait on the backup process"),
                 },
             },


### PR DESCRIPTION
Allow opting in for backup to move the files instead of copying them.

Fixes: https://github.com/scylladb/scylladb/issues/24372

Needs backport to 2025.2, as this flag is important to avoid backup causing out-of-space