### PR TITLE
compaction_manager: cancel submission timer on drain

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1147,6 +1147,7 @@ future<> compaction_manager::drain() {
     }
     // Stop ongoing compactions, if the request has not been sent already and wait for them to stop.
     co_await stop_ongoing_compactions("drain");
+    _compaction_submission_timer.cancel();
     cmlog.info("Drained");
 }
 


### PR DESCRIPTION
The `drain` method, cancels all running compactions and moves the compaction manager into the disabled state. To move it back to the enabled state, the `enable` method shall be called.

This, however, throws an assertion error as the submission time is not cancelled and re-enabling the manager tries to arm the armed timer.

Thus, cancel the timer, when calling the drain method to disable the compaction manager.

Fixes https://github.com/scylladb/scylladb/issues/24504

All versions are affected. So it's a good candidate for a backport.