### PR TITLE
main: don't start maintenance auth service if not enabled

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2027,22 +2027,23 @@ sharded<locator::shared_token_metadata> token_metadata;
                 });
             };
 
-            checkpoint(stop_signal, "starting maintenance auth service");
-            auth::service_config maintenance_auth_config;
-            maintenance_auth_config.authorizer_java_name = sstring{auth::allow_all_authorizer_name};
-            maintenance_auth_config.authenticator_java_name = sstring{auth::allow_all_authenticator_name};
-            maintenance_auth_config.role_manager_java_name = sstring{auth::maintenance_socket_role_manager_name};
-
-            maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(group0_client),  std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, maintenance_socket_enabled::yes).get();
-
-            cql_transport::controller cql_maintenance_server_ctl(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, maintenance_cql_sg_stats_key, maintenance_socket_enabled::yes, dbcfg.statement_scheduling_group);
-
+            std::optional<cql_transport::controller> cql_maintenance_server_ctl;
             std::any stop_maintenance_auth_service;
             std::any stop_maintenance_cql;
 
             if (cfg->maintenance_socket() != "ignore") {
+                checkpoint(stop_signal, "starting maintenance auth service");
+                auth::service_config maintenance_auth_config;
+                maintenance_auth_config.authorizer_java_name = sstring{auth::allow_all_authorizer_name};
+                maintenance_auth_config.authenticator_java_name = sstring{auth::allow_all_authenticator_name};
+                maintenance_auth_config.role_manager_java_name = sstring{auth::maintenance_socket_role_manager_name};
+
+                maintenance_auth_service.start(perm_cache_config, std::ref(qp), std::ref(group0_client),  std::ref(mm_notifier), std::ref(mm), maintenance_auth_config, maintenance_socket_enabled::yes).get();
+
+                cql_maintenance_server_ctl.emplace(maintenance_auth_service, mm_notifier, gossiper, qp, service_memory_limiter, sl_controller, lifecycle_notifier, *cfg, maintenance_cql_sg_stats_key, maintenance_socket_enabled::yes, dbcfg.statement_scheduling_group);
+
                 start_auth_service(maintenance_auth_service, stop_maintenance_auth_service, "maintenance auth service");
-                start_cql(cql_maintenance_server_ctl, stop_maintenance_cql, "maintenance native server");
+                start_cql(*cql_maintenance_server_ctl, stop_maintenance_cql, "maintenance native server");
             }
 
             checkpoint(stop_signal, "starting REST API");

--- a/test/cluster/test_config_live_updates.py
+++ b/test/cluster/test_config_live_updates.py
@@ -1,0 +1,21 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import pytest
+from test.pylib.util import wait_for
+
+
+@pytest.mark.asyncio
+async def test_config_live_updates(manager):
+    config = {
+        "maintenance_socket": "ignore"  # bring back the default value
+    }
+    server = await manager.server_add(config=config)
+    server_log = await manager.server_open_log(server.server_id)
+
+    await manager.server_update_config(server.server_id, "permissions_validity_in_ms", 20000)
+    await server_log.wait_for("Updating loading cache; max_size: 1000, expiry: 20000ms, refresh: 100ms")
+
+    await manager.server_update_config(server.server_id, "permissions_update_interval_in_ms", 30000)
+    await server_log.wait_for("Updating loading cache; max_size: 1000, expiry: 20000ms, refresh: 30000ms")


### PR DESCRIPTION
In https://github.com/scylladb/scylladb/commit/f96d30c2b50856aefca8aff28eb0f23e3d21b5d8
we introduced the maintenance service, which is an additional
instance of auth::service. But this service has a somewhat
confusing 2-level startup mechanism: it's initialized with
sharded<Service>::start and then auth::service::start
(different method with the same name to confuse even more).

When maintenance_socket was disabled (default setting), the code
did only the first part of the startup. This registered a config
observer but didn't create a permission_cache instance.
As a result, a crash on SIGHUP when config is reloaded can occur.

Fixes: https://github.com/scylladb/scylladb/issues/24528
Backport: all not eol versions since 6.0 and 2025.1