### PR TITLE
test/boost/mutation_reader_test: fix a use-after-free in `test_fast_forwarding_combined_reader_is_consistent_with_slicing`

### DIFF
--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1108,7 +1108,8 @@ SEASTAR_TEST_CASE(test_fast_forwarding_combined_reader_is_consistent_with_slicin
         };
 
         check_next_partition(combined[0]);
-        rd.fast_forward_to(dht::partition_range::make_singular(keys[2])).get();
+        auto prange = dht::partition_range::make_singular(keys[2]);
+        rd.fast_forward_to(prange).get();
         check_next_partition(combined[2]);
     });
 }


### PR DESCRIPTION
The contract in mutation_reader.hh says:

```
// pr needs to be valid until the reader is destroyed or fast_forward_to()
// is called again.
    future<> fast_forward_to(const dht::partition_range& pr) {
```

`test_fast_forwarding_combined_reader_is_consistent_with_slicing` violates this by passing a temporary to `fast_forward_to`.

Fix that.

Fixes scylladb/scylladb#24542

The problem is minor but it should be backported to all active branches because there's no risk. (Because it's a test-only change).