### PR TITLE
test/cqlpy: fix run-cassandra script to ignore CASSANDRA_HOME

### DIFF
--- a/test/cqlpy/run-cassandra
+++ b/test/cqlpy/run-cassandra
@@ -95,6 +95,7 @@ def run_cassandra_cmd(pid, dir):
     env = { 'CASSANDRA_CONF': confdir,
             'CASSANDRA_LOG_DIR': logsdir,
             'CASSANDRA_INCLUDE': '',
+            'CASSANDRA_HOME': '',
             # Unfortunately, Cassandra's JMX cannot listen only on a specific
             # interface. To allow tests to use JMX (nodetool), we need to
             # have it listen on 0.0.0.0 :-( This is insecure, but arguably


### PR DESCRIPTION
As test/cqlpy/README.md explains, the way to tell the run-cassandra script which version of Cassandra should be run is through the "CASSANDRA" variable, for example:

    CASSANDRA=$HOME/apache-cassandra-4.1.6/bin/cassandra \
    test/cqlpy/run-cassandra test_file.py::test_function

But all the Cassandra scripts, of all versions, have one strange feature: If you set CASSANDRA_HOME, then instead of running the actual Cassandra script you tried to run (in this case, 4.1.6), the Cassandra script goes to run the other Cassandra from CASSANDRA_HOME! This means that if a user happens to have, for some reason, set CASSANDRA_HOME, then the documented "CASSANDRA" variable doesn't work.

The simple fix is to clear CASSANDRA_HOME in the environment that run-cassandra passes to Cassandra.

No need to backport, this is just an improvement for developer experience.