### PR TITLE
doc: remove support for Ubuntu 20.04

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -1,6 +1,6 @@
 {
     "Linux Distributions": {
-      "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
+      "Ubuntu": ["22.04", "24.04"],
       "Debian": ["11"],
       "Rocky / CentOS / RHEL": ["8", "9"],
       "Amazon Linux": ["2023"]
@@ -9,7 +9,7 @@
       {
         "version": "ScyllaDB 2025.2",
         "supported_OS": {
-          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
+          "Ubuntu": ["22.04", "24.04"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
@@ -18,7 +18,7 @@
       {
         "version": "ScyllaDB 2025.1",
         "supported_OS": {
-          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
+          "Ubuntu": ["22.04", "24.04"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
@@ -27,7 +27,7 @@
       {
         "version": "Enterprise 2024.2",
         "supported_OS": {
-          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04"],
+          "Ubuntu": ["22.04", "24.04"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": ["2023"]
@@ -36,7 +36,7 @@
       {
         "version": "Enterprise 2024.1",
         "supported_OS": {
-          "Ubuntu": ["20.04 (deprecated)", "22.04", "24.04*"],
+          "Ubuntu": ["22.04", "24.04*"],
           "Debian": ["11"],
           "Rocky / CentOS / RHEL": ["8", "9"],
           "Amazon Linux": []

--- a/docs/getting-started/os-support.rst
+++ b/docs/getting-started/os-support.rst
@@ -4,9 +4,6 @@ OS Support by Linux Distributions and Version
 The following matrix shows which Linux distributions, containers, and images
 are :ref:`supported <os-support-definition>` with which versions of ScyllaDB.
 
-Note that support for Ubuntu 20.04 is deprecated and will be removed in
-a future release.
-
 .. datatemplate:json:: /_static/data/os-support.json
   :template: platforms.tmpl
 


### PR DESCRIPTION
Fixes https://github.com/scylladb/scylladb/issues/24564

No backport, only versions later than 2025.2 are affected.
