### PR TITLE
test.py: add a way to provide pytest arguments via test.py

### DIFF
--- a/test.py
+++ b/test.py
@@ -206,6 +206,9 @@ def parse_cmd_line() -> argparse.Namespace:
                         help="Specific byte limit for failure injection (random by default)")
     parser.add_argument('--skip-internet-dependent-tests', action="store_true",
                         help="Skip tests which depend on artifacts from the internet.")
+    parser.add_argument("--pytest-arg", action='store', type=str,
+                        default=None, dest="pytest_arg",
+                        help="Additional command line arguments to pass to pytest, for example ./test.py --pytest-arg=\"-v -x\"")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
@@ -321,6 +324,9 @@ def run_pytest(options: argparse.Namespace, run_id: int) -> tuple[int, list[Simp
             f'--alluredir={report_dir / f"allure_{host_id}"}',
             '-v' if options.verbose else '-q',
         ])
+    if options.pytest_arg:
+        # If pytest_arg is provided, it should be a string with arguments to pass to pytest
+        args.extend(shlex.split(options.pytest_arg))
     if options.gather_metrics:
         args.append('--gather-metrics')
     if len(expression) > 1:

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -10,6 +10,7 @@ import collections
 import logging
 import os
 import pathlib
+import shlex
 from contextlib import asynccontextmanager
 from functools import cache
 from typing import TYPE_CHECKING
@@ -183,6 +184,9 @@ class PythonTest(Test):
             # https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
             no_tests_selected_exit_code = 5
             self.valid_exit_codes = [0, no_tests_selected_exit_code]
+
+        if options.pytest_arg:
+            self.args += shlex.split(options.pytest_arg)
 
         arg = str(self.suite.suite_path / f"{self.shortname}{self.suite.test_file_ext}")
         if self.casename is not None:


### PR DESCRIPTION
Now that we use a single pytest.ini for all tests, different developer preferences collide. There should be an easy way to override pytest.ini defaults from the command line.

Fixes https://github.com/scylladb/scylladb/issues/21800

Extends the usage of test.py. No backport needed. 