### PR TITLE
api: return error from get_host_id_map if gossiper is not enabled yet.

### DIFF
--- a/api/token_metadata.cc
+++ b/api/token_metadata.cc
@@ -74,6 +74,9 @@ void set_token_metadata(http_context& ctx, routes& r, sharded<locator::shared_to
     });
 
     ss::get_host_id_map.set(r, [&tm, &g](const_req req) {
+        if (!g.local().is_enabled()) {
+            throw std::runtime_error("The gossiper is not ready yet");
+        }
         return tm.local().get()->get_host_ids()
             | std::views::transform([&g] (locator::host_id id) {
                 ss::mapper m;


### PR DESCRIPTION
Token metadata api is initialized before gossiper is started. get_host_id_map REST endpoint cannot function without the fully initialized gossiper though. The gossiper is started deep in the join_cluster call chain, but if we move token_metadata api initialization after the call it means that no api will be available during bootstrap. This is not what we want.

Make a simple fix by returning an error from the api if the gossiper is not initialized yet.

Fixes: #24479

Backport since it fixes a crash in tests. 