### PR TITLE
replica: hold compaction group gate during flush

### DIFF
--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -57,6 +57,8 @@ class compaction_group {
     seastar::condition_variable _staging_done_condition;
     // Gates async operations confined to a single group.
     seastar::named_gate _async_gate;
+    // Gates flushes.
+    seastar::named_gate _flush_gate;
     bool _tombstone_gc_enabled = true;
 private:
     // Adds new sstable to the set of sstables
@@ -188,6 +190,10 @@ public:
 
     seastar::named_gate& async_gate() noexcept {
         return _async_gate;
+    }
+
+    seastar::named_gate& flush_gate() noexcept {
+        return _flush_gate;
     }
 
     compaction_manager& get_compaction_manager() noexcept;


### PR DESCRIPTION
Destructor of database_sstable_write_monitor, which is created
in table::try_flush_memtable_to_sstable, tries to get the compaction
state of the processed compaction group. If at this point
the compaction group is already stopped (and the compaction state
is removed), e.g. due to concurrent tablet merge, an exception is
thrown and a node coredumps.

Add flush gate to compaction group to wait for flushes in
compaction_group::stop. Hold the gate in seal function in
table::make_memtable_list. seal function is turned into
a coroutine to ensure it won't throw.

Wait until async_gate is closed before flushing, to ensure that
all data is written into sstables. Stop ongoing compactions
beforehand.

Remove unnecessary flush in tablet_storage_group_manager::merge_completion_fiber.
Stop method already flushes the compaction group.

Fixes: https://github.com/scylladb/scylladb/issues/23911.

Needs backport to all live versions, as all are vulnerable