### PR TITLE
alternator: improve, document and test table/index name lengths

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -238,7 +238,17 @@ is different, or can be configured in Alternator:
 
 * DynamoDB limits each BatchWriteItem request to 25 items. In Alternator,
   this limit defaults to 100 but can be changed with 
-  the alternator_max_items_in_batch_write configuration parameter.
+  the `alternator_max_items_in_batch_write` configuration parameter.
+
+* DynamoDB limits the name of tables, GSIs and LSIs, to 255 characters each.
+  In Alternator, the limit is different:
+    * A table's name is limited to 222 characters.
+    * For a GSI, the sum of the length of the table name and the GSI name,
+      plus one, is limited to 222 characters.
+    * For an LSI, the sum of the length of the table name and the LSI name,
+      plus two, is limited to 222 characters.
+  This means that if you create a table whose name's length is close to 222
+  characters, you may not be able to create a GSI or LSI on it.
 
 ## Experimental API features
 

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -97,15 +97,14 @@ def test_create_and_delete_table_non_scylla_name(dynamodb):
 # supported in Scylla because we create a directory whose name is the table's
 # name followed by 33 bytes (underscore and UUID). So currently, we only
 # correctly support names with length up to 222.
-def test_create_and_delete_table_very_long_name(dynamodb):
-    # In the future, this should work:
-    #create_and_delete_table(dynamodb, 'n' * 255)
-    # But for now, only 222 works:
+@pytest.mark.xfail(reason="Alternator limits table name length to 222")
+def test_create_and_delete_table_255(dynamodb):
+    create_and_delete_table(dynamodb, 'n' * 255)
+def test_create_and_delete_table_256(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException'):
+       create_and_delete_table(dynamodb, 'n' * 256)
+def test_create_and_delete_table_222(dynamodb):
     create_and_delete_table(dynamodb, 'n' * 222)
-    # We cannot test the following on DynamoDB because it will succeed
-    # (DynamoDB allows up to 255 bytes)
-    #with pytest.raises(ClientError, match='ValidationException'):
-    #   create_table(dynamodb, 'n' * 223)
 
 # Tests creating a table with an invalid schema should return a
 # ValidationException error.

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -136,8 +136,9 @@ def unique_table_name():
     return test_table_prefix + str(current_ms)
 unique_table_name.last_ms = 0
 
-def create_test_table(dynamodb, **kwargs):
-    name = unique_table_name()
+def create_test_table(dynamodb, name=None, **kwargs):
+    if name is None:
+        name = unique_table_name()
     BillingMode = 'PAY_PER_REQUEST'
     if 'BillingMode' in kwargs:
         BillingMode = kwargs['BillingMode']


### PR DESCRIPTION
Whereas DynamoDB limits the names of tables, LSIs and GSIs to 255 characters each, Alternator currently has different (and lower) limitations:
 1. A table name must be up to 222 characters.
 2. For a GSI, the sum of the table's and GSI's name length, plus 1, must be up to 222 characters.
 3. For an LSI, the sum of the table's and LSI's name length, plus 2, must be up to 222 characters.

The first patch documents these existing limitations, improves their testing, and fixes a tiny bug found by one of the tests (where UpdateTable adding a GSI's limit testing is off by one).

The second patch unfortunately shows with a reproducer (issue #24598) this limit of 222 is problematic and we may need to lower it: If a user creates a table of length 222 and then enables Alternator streams, Scylla shuts down on an IO error. This will need to be fixed later, but at least this patch properly documents the existing behavior.

No need to backport this patch - it is a very minor improvement that it is unlikely users care about and there is no potential for harm.