### PR TITLE
gossiper: do not assume that id->ip mapping is available in failure_d…

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -963,8 +963,8 @@ future<> gossiper::failure_detector_loop_for_node(locator::host_id host_id, gene
     auto diff = gossiper::clk::duration(0);
     auto echo_interval = std::chrono::seconds(2);
     auto max_duration = echo_interval + std::chrono::milliseconds(_gcfg.failure_detector_timeout_ms());
-    auto node = _address_map.get(host_id);
     while (is_enabled() && !_abort_source.abort_requested()) {
+        auto node = _address_map.find(host_id);
         bool failed = false;
         try {
             logger.debug("failure_detector_loop: Send echo to node {}/{}, status = started", host_id, node);


### PR DESCRIPTION
…etector_loop_for_node

failure_detector_loop_for_node may be started on a shard before id->ip mapping is available there. Currently the code treats missing mapping as an internal error, but it uses its result for debug output only, so lets relax the code to not assume the mapping is available.

Fixes #23407

Backport to scylla-2025.2.0 since this is the only version where the bug exists.