### PR TITLE
test: Use test sched groups, not database ones

### DIFF
--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -551,7 +551,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_deadlock) {
         sst->open_data().get();
         t->add_sstable_and_update_cache(sst).get();
 
-        auto& sem = *with_scheduling_group(e.local_db().get_streaming_scheduling_group(), [&] () {
+        auto& sem = *with_scheduling_group(get_scheduling_groups().get().streaming_scheduling_group, [&] () {
             return &e.local_db().get_reader_concurrency_semaphore();
         }).get();
 


### PR DESCRIPTION
Some tests want to switch between sched groups. For that there's cql-test-env facility to create and use them. However, there's a test that uses replica::database as sched groups provider, which is not nice. Fix it.
