### PR TITLE
cdc: add a log for vector search changes 

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -960,8 +960,11 @@ public:
     // Given a reference to such a column from the base schema, this function sets the corresponding column
     // in the log to the given value for the given row.
     void set_value(const clustering_key& log_ck, const column_definition& base_cdef, const managed_bytes_view& value) {
-        auto& log_cdef = *_log_schema.get_column_definition(log_data_column_name_bytes(base_cdef.name()));
-        _log_mut.set_cell(log_ck, log_cdef, atomic_cell::make_live(*base_cdef.type, _ts, value, _ttl));
+        auto log_cdef_ptr = _log_schema.get_column_definition(log_data_column_name_bytes(base_cdef.name()));
+        if (!log_cdef_ptr) {
+            return;
+        }
+        _log_mut.set_cell(log_ck, *log_cdef_ptr, atomic_cell::make_live(*base_cdef.type, _ts, value, _ttl));
     }
 
     // Each regular and static column in the base schema has a corresponding column in the log schema
@@ -978,7 +981,11 @@ public:
     // Given a reference to such a column from the base schema, this function sets the corresponding column
     // in the log to the given set of keys for the given row.
     void set_deleted_elements(const clustering_key& log_ck, const column_definition& base_cdef, const managed_bytes& deleted_elements) {
-        auto& log_cdef = *_log_schema.get_column_definition(log_data_column_deleted_elements_name_bytes(base_cdef.name()));
+        auto log_cdef_ptr = _log_schema.get_column_definition(log_data_column_deleted_elements_name_bytes(base_cdef.name()));
+        if (!log_cdef_ptr) {
+            return;
+        }
+        auto& log_cdef = *log_cdef_ptr;
         _log_mut.set_cell(log_ck, log_cdef, atomic_cell::make_live(*log_cdef.type, _ts, deleted_elements, _ttl));
     }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -105,8 +105,10 @@ bool is_log_for_some_table(const replica::database& db, const sstring& ks_name, 
 
 schema_ptr get_base_table(const replica::database&, const schema&);
 schema_ptr get_base_table(const replica::database&, std::string_view, std::string_view);
+schema_ptr get_vsc_base_table(const replica::database&, std::string_view, std::string_view);
 
 seastar::sstring base_name(std::string_view log_name);
+seastar::sstring vsc_base_name(std::string_view table_name);
 seastar::sstring log_name(std::string_view table_name);
 seastar::sstring vsc_log_name(std::string_view table_name);
 seastar::sstring log_data_column_name(std::string_view column_name);

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -108,6 +108,7 @@ schema_ptr get_base_table(const replica::database&, std::string_view, std::strin
 
 seastar::sstring base_name(std::string_view log_name);
 seastar::sstring log_name(std::string_view table_name);
+seastar::sstring vsc_log_name(std::string_view table_name);
 seastar::sstring log_data_column_name(std::string_view column_name);
 seastar::sstring log_meta_column_name(std::string_view column_name);
 bytes log_data_column_name_bytes(const bytes& column_name);

--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -93,6 +93,9 @@ class custom_index {
 public:
     virtual ~custom_index() = default;
     virtual void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) = 0;
+    virtual bool is_vector_index() const {
+        return false;
+    }
 };
 
 class secondary_index_manager {

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -24,8 +24,10 @@ public:
     vector_index() = default;
     ~vector_index() override = default;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
+    bool is_vector_index() const override;
 };
 
 std::unique_ptr<secondary_index::custom_index> vector_index_factory();
-
+bool has_vector_index(const schema& s);
+std::unordered_set<sstring> get_vector_indexed_columns(const schema& s);
 }

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -77,7 +77,7 @@ void mutation::set_cell(const clustering_key_prefix& prefix, const bytes& name, 
         api::timestamp_type timestamp, ttl_opt ttl) {
     auto column_def = schema()->get_column_definition(name);
     if (!column_def) {
-        throw std::runtime_error(format("no column definition found for '{}'", name));
+        return;
     }
     return set_cell(prefix, *column_def, atomic_cell::make_live(*column_def->type, timestamp, column_def->type->decompose(value), ttl));
 }

--- a/test/cql/vsc_enable_disable_test.cql
+++ b/test/cql/vsc_enable_disable_test.cql
@@ -1,0 +1,41 @@
+-- Important: using the same partition key for each row so the results of select from log table
+-- do not depend on how stream IDs are assigned to partition keys.
+
+-- Error messages contain a keyspace name. Make the output stable.
+-- CDC and tablets are not working together yet, turn them off.
+CREATE KEYSPACE ks
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
+    tablets = {'enabled': false};
+
+-- create table with vector column
+create table ks.t (pk int, ck int, v vector<float, 3>, primary key(pk, ck));
+
+-- create index on vector column using 'vector_index' custom class
+-- this enables VSC automatically
+create index on ks.t (v) using 'vector_index';
+
+-- this write goes to the log
+insert into ks.t (pk, ck, v) values (0, 1, [100.0, 101.0, 102.0]);
+
+-- drop index disable VSC. should retain the log
+drop index ks.t_v_idx;
+
+-- add more data to base - should not generate log
+insert into ks.t (pk, ck, v) values (0, 2, [200.0, 201.0, 202.0]);
+
+-- should still work, and give one row (0, 1, [100.0, 101.0, 102.0])
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_vsc_log;
+
+-- add more data
+insert into ks.t (pk, ck, v) values (0, 3, [300.0, 301.0, 302.0]);
+
+-- recreate the index
+create index on ks.t (v) using 'vector_index';
+
+-- more data - this should also go to log.
+insert into ks.t (pk, ck, v) values (0, 4, [400.0, 401.0, 402.0]);
+
+-- gives two rows (0, 1, [100.0, 101.0, 102.0])+(0, 4, [400.0, 401.0, 402.0])
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_vsc_log;
+
+DROP KEYSPACE ks;

--- a/test/cql/vsc_enable_disable_test.result
+++ b/test/cql/vsc_enable_disable_test.result
@@ -1,0 +1,62 @@
+> -- Important: using the same partition key for each row so the results of select from log table
+> -- do not depend on how stream IDs are assigned to partition keys.
+> 
+> -- Error messages contain a keyspace name. Make the output stable.
+> -- CDC and tablets are not working together yet, turn them off.
+> CREATE KEYSPACE ks
+>     WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
+>     tablets = {'enabled': false};
+OK
+> 
+> -- create table with vector column
+> create table ks.t (pk int, ck int, v vector<float, 3>, primary key(pk, ck));
+OK
+> 
+> -- create index on vector column using 'vector_index' custom class
+> -- this enables VSC automatically
+> create index on ks.t (v) using 'vector_index';
+OK
+> 
+> -- this write goes to the log
+> insert into ks.t (pk, ck, v) values (0, 1, [100.0, 101.0, 102.0]);
+OK
+> 
+> -- drop index disable VSC. should retain the log
+> drop index ks.t_v_idx;
+OK
+> 
+> -- add more data to base - should not generate log
+> insert into ks.t (pk, ck, v) values (0, 2, [200.0, 201.0, 202.0]);
+OK
+> 
+> -- should still work, and give one row (0, 1, [100.0, 101.0, 102.0])
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_vsc_log;
++--------------------+-----------------+-----------+------+------+-----------------------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v                     |
+|--------------------+-----------------+-----------+------+------+-----------------------|
+|                  0 |               2 | null      |    0 |    1 | [100.0, 101.0, 102.0] |
++--------------------+-----------------+-----------+------+------+-----------------------+
+> 
+> -- add more data
+> insert into ks.t (pk, ck, v) values (0, 3, [300.0, 301.0, 302.0]);
+OK
+> 
+> -- recreate the index
+> create index on ks.t (v) using 'vector_index';
+OK
+> 
+> -- more data - this should also go to log.
+> insert into ks.t (pk, ck, v) values (0, 4, [400.0, 401.0, 402.0]);
+OK
+> 
+> -- gives two rows (0, 1, [100.0, 101.0, 102.0])+(0, 4, [400.0, 401.0, 402.0])
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_vsc_log;
++--------------------+-----------------+-----------+------+------+-----------------------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v                     |
+|--------------------+-----------------+-----------+------+------+-----------------------|
+|                  0 |               2 | null      |    0 |    1 | [100.0, 101.0, 102.0] |
+|                  0 |               2 | null      |    0 |    4 | [400.0, 401.0, 402.0] |
++--------------------+-----------------+-----------+------+------+-----------------------+
+> 
+> DROP KEYSPACE ks;
+OK

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -10,14 +10,18 @@ import pytest
 from .util import new_test_table, is_scylla
 from cassandra.protocol import InvalidRequest, ConfigurationException
 
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
 
 
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_without_custom_keyword(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -28,6 +32,9 @@ def test_create_vector_search_index_without_custom_keyword(cql, test_keyspace):
         
         cql.execute(f"CREATE INDEX ON {table}(v) USING '{custom_class}'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_custom_index_with_invalid_class(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -35,24 +42,36 @@ def test_create_custom_index_with_invalid_class(cql, test_keyspace):
         with pytest.raises((InvalidRequest, ConfigurationException), match=r"Non-supported custom class|Unable to find"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING '{invalid_custom_class}'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_custom_index_without_custom_class(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises((InvalidRequest, ConfigurationException), match=r"CUSTOM index requires specifying|Unable to find"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v)")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_on_nonvector_column(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v int'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Vector indexes are only supported on columns of vectors of floats"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_options(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Unsupported option"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'bad_option': 'bad_value'}}")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_numeric_value(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -65,19 +84,27 @@ def test_create_vector_search_index_with_bad_numeric_value(cql, test_keyspace, s
         with pytest.raises(InvalidRequest, match="out of valid range"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'construction_beam_width': '5000' }}") 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_similarity_value(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Unsupported similarity function"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'similarity_function': 'bad_similarity_function'}}") 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_on_nonfloat_vector_column(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<int, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Vector indexes are only supported on columns of vectors of floats"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
         
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_describe_custom_index(cql, test_keyspace):
     schema = 'p int primary key, v1 vector<float, 3>, v2 vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_vsc.py
+++ b/test/cqlpy/test_vsc.py
@@ -1,0 +1,194 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+from cassandra.protocol import InvalidRequest
+
+from .cassandra_tests.porting import assert_rows_ignoring_order
+from .util import new_test_table, unique_name
+from .nodetool import flush
+import pytest
+import time
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_vsc_add_drop_index(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v1 vector<float, 3>, v2 vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE INDEX ON {table} (v1) USING 'vector_index'")
+        with pytest.raises(InvalidRequest, match="Unrecognized name v2"):
+            cql.execute(f"SELECT pk, v1, v2 FROM {table}_scylla_vsc_log")
+        cql.execute(f"SELECT pk, v1 FROM {table}_scylla_vsc_log")
+
+        cql.execute(f"CREATE INDEX ON {table} (v2) USING 'vector_index'")
+        cql.execute(f"SELECT pk, v1, v2 FROM {table}_scylla_vsc_log")
+
+        cql.execute(f"DROP INDEX {table}_v1_idx")
+        with pytest.raises(InvalidRequest, match="Unrecognized name v1"):
+            cql.execute(f"SELECT pk, v1, v2 FROM {table}_scylla_vsc_log")
+        cql.execute(f"SELECT pk, v2 FROM {table}_scylla_vsc_log")
+
+# For a table named "xyz", the VSC table is always named "xyz_scylla_vsc_log".
+# Check what happens if a table called "xyz_scylla_vsc_log" already exists
+# (as a normal table), and then we try to create index on "xyz"'s vector column
+# using 'vector_index' custom index class.
+# Unlike the secondary-index code which tries to find a different name to
+# use for its backing view, the VSC code doesn't do that, but creating the
+# index using 'vector_index' custom class should fail gracefully with a clear
+# error message, and this test verifies that.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_vsc_taken_log_name(scylla_only, cql, test_keyspace):
+    name = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {name}_scylla_vsc_log (p int PRIMARY KEY)")
+    try:
+        schema = "pk int primary key, v vector<float, 3>"
+        # We can't create an index using 'vector_index' on vector column of table {name}:
+        with pytest.raises(InvalidRequest, match=f"{name}_scylla_vsc_log already exists"):
+            cql.execute(f"CREATE TABLE {name} ({schema})")
+            cql.execute(f"CREATE INDEX ON {name} (v) USING 'vector_index'")
+            cql.execute(f"DROP TABLE {name}")
+    finally:
+        cql.execute(f"DROP TABLE {name}_scylla_vsc_log")
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_both_cdc_vsc_enabled(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v vector<float, 3>"
+    extra = " with cdc = {'enabled': true}"
+    with new_test_table(cql, test_keyspace, schema, extra) as table:
+        cql.execute(f"CREATE INDEX ON {table} (v) USING 'vector_index'")
+
+        # Log to both tables
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, [1.0, 2.0, 3.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+        )
+
+        # Change CDC options and check if it affects VSC
+
+        # Disable CDC
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : false}}")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (2, [4.0, 5.0, 6.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+        )
+        # Enable CDC with TTL set to 2 seconds
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : true, 'ttl' : 2}}")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (3, [7.0, 8.0, 9.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+        )
+        # Wait for TTL to expire
+        time.sleep(3)
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+        )
+        # Enable CDC with delta set to keys only
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : true, 'delta' : 'keys'}}")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (4, [10.0, 11.0, 12.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 4, None],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+            [2, 4, [10.0, 11.0, 12.0]],
+        )
+        # Enable CDC with preimage
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : true, 'preimage' : true}}")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, [0.0, 0.0, 0.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 4, None],
+            [0, 1, [1.0, 2.0, 3.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+            [2, 4, [10.0, 11.0, 12.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+        )
+        # Enable CDC with postimage
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : true, 'postimage' : true}}")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (1, [1.0, 2.0, 3.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 4, None],
+            [0, 1, [1.0, 2.0, 3.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+            [2, 1, [1.0, 2.0, 3.0]],
+            [9, 1, [1.0, 2.0, 3.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+            [2, 4, [10.0, 11.0, 12.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+            [2, 1, [1.0, 2.0, 3.0]],
+        )
+        # Alter back to default cdc options
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled' : true}}")
+
+        # Drop index
+        cql.execute(f"DROP INDEX {table}_v_idx")
+        cql.execute(f"INSERT INTO {table} (pk, v) VALUES (5, [13.0, 14.0, 15.0])")
+        cdc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_cdc_log")
+        vsc_results = cql.execute(f"SELECT \"cdc$operation\", pk, v FROM {table}_scylla_vsc_log")
+        assert_rows_ignoring_order(cdc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 4, None],
+            [0, 1, [1.0, 2.0, 3.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+            [2, 1, [1.0, 2.0, 3.0]],
+            [9, 1, [1.0, 2.0, 3.0]],
+            [2, 5, [13.0, 14.0, 15.0]],
+        )
+        assert_rows_ignoring_order(vsc_results,
+            [2, 1, [1.0, 2.0, 3.0]],
+            [2, 2, [4.0, 5.0, 6.0]],
+            [2, 3, [7.0, 8.0, 9.0]],
+            [2, 4, [10.0, 11.0, 12.0]],
+            [2, 1, [0.0, 0.0, 0.0]],
+            [2, 1, [1.0, 2.0, 3.0]],
+        )


### PR DESCRIPTION
Currently, Vector Store service uses the CDC log to sync up the vector indexes with the database. This, however, conflicts with user changes to the CDC setup. If the user turns off the CDC or changes the CDC settings, the service might behave unexpectedly or just stop working. To fix this issue we introduce a copy of the CDC table, Vector Search Changes, suffixed by "_scylla_vsc_log". 

This log is created only for tables with vector search indexes and behaves exactly the same as the CDC log, except for settings, which are hardcoded and do not interfere with the user's CDC settings.

This PR adds the support for this table with appropriate tests.



Coauthored by: @QuerthDP 

Fixes: VECTOR-27
Fixes: VECTOR-83
Fixes: VECTOR-25
