### PR TITLE
test.py: handle cancellation gracefully to avoid TypeError

### DIFF
--- a/test.py
+++ b/test.py
@@ -447,8 +447,6 @@ async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) ->
             if max_failures != 0 and max_failures <= failed:
                 print("Too much failures, stopping")
                 await cancel(pending, "Too much failures, stopping")
-    except asyncio.CancelledError:
-        return
     finally:
         await TestSuite.artifacts.cleanup_before_exit()
 
@@ -521,6 +519,9 @@ async def main() -> int:
         stop_event.set()
         async with asyncio.timeout(5):
             await resource_watcher
+    except asyncio.CancelledError:
+        print('\ntests cancelled by signal')
+        return 1
     except Exception as e:
         print(palette.fail(e))
         raise


### PR DESCRIPTION
Previously, if test execution was cancelled, `run_all_tests()` could return `None`. This caused a `TypeError` when the result was unconditionally unpacked into `total_tests_pytest, failed_pytest_tests`.

This commit updates the code to handle the cancellation appropriately, preventing the confusing `TypeError` exception and ensuring clean cancellation behavior.

No backport: This is test framework change, the problem also exists in branches, but is not causing any real issue, just a confusing exception message. Therefore it seems enough to fix just in the master.