### PR TITLE
Add table size bytes to describe table

### DIFF
--- a/alternator/controller.hh
+++ b/alternator/controller.hh
@@ -15,6 +15,7 @@
 
 namespace service {
 class storage_proxy;
+class storage_service;
 class migration_manager;
 class memory_limiter;
 }
@@ -57,6 +58,7 @@ class server;
 class controller : public protocol_server {
     sharded<gms::gossiper>& _gossiper;
     sharded<service::storage_proxy>& _proxy;
+    sharded<service::storage_service>& _ss;
     sharded<service::migration_manager>& _mm;
     sharded<db::system_distributed_keyspace>& _sys_dist_ks;
     sharded<cdc::generation_service>& _cdc_gen_svc;
@@ -74,6 +76,7 @@ public:
     controller(
         sharded<gms::gossiper>& gossiper,
         sharded<service::storage_proxy>& proxy,
+        sharded<service::storage_service>& ss,
         sharded<service::migration_manager>& mm,
         sharded<db::system_distributed_keyspace>& sys_dist_ks,
         sharded<cdc::generation_service>& cdc_gen_svc,

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -624,12 +624,30 @@ static future<bool> is_view_built(
 
 }
 
-static future<rjson::value> fill_table_description(schema_ptr schema, table_status tbl_status, service::storage_proxy& proxy, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit)
+static future<> fill_table_size(rjson::value &table_description, schema_ptr schema, service::storage_service &ss, service::storage_proxy& proxy) {
+    auto &table = schema->table();
+    std::uint64_t total_size = 0;
+    if (auto val = table.table_size_in_bytes().get()) {
+        total_size = *val;
+    }
+    else {
+        total_size = co_await ss.estimate_total_sstable_volume(schema->id(), service::storage_service::ignore_errors::yes);
+        auto now = table.table_size_in_bytes().set_now(total_size, std::chrono::hours{ 6 });
+        (void)proxy.get_db().invoke_on_others(
+            [cfid = schema->id(), total_size, now] (replica::database& db) {
+                db.find_column_family(cfid).table_size_in_bytes().set(total_size, now);
+            });
+    }
+    rjson::add(table_description, "TableSizeBytes", total_size);
+}
+
+static future<rjson::value> fill_table_description(schema_ptr schema, table_status tbl_status, service::storage_proxy& proxy, service::storage_service &ss, service::client_state& client_state, tracing::trace_state_ptr trace_state, service_permit permit)
 {
     rjson::value table_description = rjson::empty_object();
     auto tags_ptr = db::get_tags_of_table(schema);
 
     rjson::add(table_description, "TableName", rjson::from_string(schema->cf_name()));
+    auto fill_table_size_job = fill_table_size(table_description, schema, ss, proxy);
 
     auto creation_timestamp = get_table_creation_time(*schema);
     
@@ -743,6 +761,8 @@ static future<rjson::value> fill_table_description(schema_ptr schema, table_stat
     executor::supplement_table_stream_info(table_description, *schema, proxy);
 
     // FIXME: still missing some response fields (issue #5026)
+    co_await std::move(fill_table_size_job);
+
     co_return table_description;
 }
 
@@ -762,7 +782,7 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
     get_stats_from_schema(_proxy, *schema)->api_operations.describe_table++;
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
-    rjson::value table_description = co_await fill_table_description(schema, table_status::active, _proxy, client_state, trace_state, permit);
+    rjson::value table_description = co_await fill_table_description(schema, table_status::active, _proxy, _ss, client_state, trace_state, permit);
     rjson::value response = rjson::empty_object();
     rjson::add(response, "Table", std::move(table_description));
     elogger.trace("returning {}", response);
@@ -827,7 +847,7 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
     auto& p = _proxy.container();
 
     schema_ptr schema = get_table(_proxy, request);
-    rjson::value table_description = co_await fill_table_description(schema, table_status::deleting, _proxy, client_state, trace_state, permit);
+    rjson::value table_description = co_await fill_table_description(schema, table_status::deleting, _proxy, _ss, client_state, trace_state, permit);
     co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::DROP);
     co_await _mm.container().invoke_on(0, [&, cs = client_state.move_to_other_shard()] (service::migration_manager& mm) -> future<> {
         size_t retries = mm.get_concurrent_ddl_retries();

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -194,12 +194,14 @@ static const rjson::value::Member& get_single_member(const rjson::value& v, cons
 
 executor::executor(gms::gossiper& gossiper,
          service::storage_proxy& proxy,
+         service::storage_service& ss,
          service::migration_manager& mm,
          db::system_distributed_keyspace& sdks,
          cdc::metadata& cdc_metadata,
          smp_service_group ssg,
          utils::updateable_value<uint32_t> default_timeout_in_ms)
     : _gossiper(gossiper),
+      _ss(ss),
       _proxy(proxy),
       _mm(mm),
       _sdks(sdks),

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -40,6 +40,7 @@ namespace cql3::selection {
 
 namespace service {
     class storage_proxy;
+    class storage_service;
 }
 
 namespace cdc {
@@ -158,6 +159,7 @@ using attrs_to_get = attribute_path_map<std::monostate>;
 
 class executor : public peering_sharded_service<executor> {
     gms::gossiper& _gossiper;
+    service::storage_service& _ss;
     service::storage_proxy& _proxy;
     service::migration_manager& _mm;
     db::system_distributed_keyspace& _sdks;
@@ -180,6 +182,7 @@ public:
 
     executor(gms::gossiper& gossiper,
              service::storage_proxy& proxy,
+             service::storage_service& ss,
              service::migration_manager& mm,
              db::system_distributed_keyspace& sdks,
              cdc::metadata& cdc_metadata,

--- a/main.cc
+++ b/main.cc
@@ -2414,7 +2414,7 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             api::set_server_service_levels(ctx, cql_server_ctl, qp).get();
 
-            alternator::controller alternator_ctl(gossiper, proxy, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, auth_service, sl_controller, *cfg, dbcfg.statement_scheduling_group);
+            alternator::controller alternator_ctl(gossiper, proxy, ss, mm, sys_dist_ks, cdc_generation_service, service_memory_limiter, auth_service, sl_controller, *cfg, dbcfg.statement_scheduling_group);
             redis::controller redis_ctl(proxy, auth_service, mm, *cfg, gossiper, dbcfg.statement_scheduling_group);
 
             // Register at_exit last, so that storage_service::drain_on_shutdown will be called first

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -768,22 +768,26 @@ public:
     template <typename T> class simple_value_with_expiry {
         std::chrono::nanoseconds expire_when;
         std::optional<T> value;
+
+        static auto now() {
+            return std::chrono::high_resolution_clock::now();
+        }
     public:
         std::optional<T> get() const {
-            auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(lowres_clock::now().time_since_epoch());
-            if (now <= expire_when) {
+            auto n = std::chrono::duration_cast<std::chrono::nanoseconds>(now().time_since_epoch());
+            if (n <= expire_when) {
                 return value;
             }
             return std::nullopt;
         }
         std::chrono::nanoseconds set_now(T v, std::chrono::nanoseconds ttl) {
-            auto now = std::chrono::duration_cast<std::chrono::nanoseconds>((lowres_clock::now() + ttl).time_since_epoch());
-            if (now <= expire_when) {
-                now = expire_when + std::chrono::nanoseconds{ 1 };
+            auto n = std::chrono::duration_cast<std::chrono::nanoseconds>((now() + ttl).time_since_epoch());
+            if (n <= expire_when) {
+                n = expire_when + std::chrono::nanoseconds{ 1 };
             }
             value = std::move(v);
-            expire_when = now;
-            return now;
+            expire_when = n;
+            return n;
             
         }
         void set(std::uint64_t v, std::chrono::nanoseconds expiry) {
@@ -793,6 +797,14 @@ public:
             }
         }
     };
+
+private:
+    simple_value_with_expiry<std::uint64_t> _table_size_in_bytes;
+
+public:
+    auto &table_size_in_bytes() {
+        return _table_size_in_bytes;
+    }
 
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -762,6 +762,38 @@ private:
              mutation_reader::forwarding fwd_mr,
              std::function<void(size_t)> reserve_fn) const;
 public:
+    // note: there's nothing synchronizing value between shards, so it's absolutely possible
+    // to get different values on different shards - we don't care that much, because the value
+    // will close in on "real thing" over time.
+    template <typename T> class simple_value_with_expiry {
+        std::chrono::nanoseconds expire_when;
+        std::optional<T> value;
+    public:
+        std::optional<T> get() const {
+            auto now = std::chrono::duration_cast<std::chrono::nanoseconds>(lowres_clock::now().time_since_epoch());
+            if (now <= expire_when) {
+                return value;
+            }
+            return std::nullopt;
+        }
+        std::chrono::nanoseconds set_now(T v, std::chrono::nanoseconds ttl) {
+            auto now = std::chrono::duration_cast<std::chrono::nanoseconds>((lowres_clock::now() + ttl).time_since_epoch());
+            if (now <= expire_when) {
+                now = expire_when + std::chrono::nanoseconds{ 1 };
+            }
+            value = std::move(v);
+            expire_when = now;
+            return now;
+            
+        }
+        void set(std::uint64_t v, std::chrono::nanoseconds expiry) {
+            if (expiry > expire_when) {
+                expire_when = expiry;
+                value = v;
+            }
+        }
+    };
+
     const storage_options& get_storage_options() const noexcept { return *_storage_opts; }
     lw_shared_ptr<const storage_options> get_storage_options_ptr() const noexcept { return _storage_opts; }
     future<> init_storage();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2532,6 +2532,11 @@ table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_optio
         tlogger.warn("Writes disabled, column family no durable.");
     }
 
+    // we initialize 0 for 30 seconds, because those values are used in DescribeTable
+    // which is used on start to check if table is created and we don't want to increment response time
+    // on startup, when table is empty anyway
+    table_size_in_bytes().set_now(0, std::chrono::seconds{ 30 });
+
     recalculate_tablet_count_stats();
     set_metrics();
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4780,11 +4780,23 @@ semaphore& storage_service::get_do_sample_sstables_concurrency_limiter() {
     return _do_sample_sstables_concurrency_limiter;
 }
 
-future<uint64_t> storage_service::estimate_total_sstable_volume(table_id t) {
+future<uint64_t> storage_service::estimate_total_sstable_volume(table_id t, ignore_errors errors) {
     co_return co_await seastar::map_reduce(
         _db.local().get_token_metadata().get_host_ids(),
         [&] (auto h) -> future<uint64_t> {
-            return ser::storage_service_rpc_verbs::send_estimate_sstable_volume(&_messaging.local(), h, t);
+            try {
+                co_return co_await ser::storage_service_rpc_verbs::send_estimate_sstable_volume(&_messaging.local(), h, t);
+            }
+            catch(...) {
+                if (errors == ignore_errors::yes) {
+                    // If the call failed we just return 0 for this one
+                    cdc_log.info("call failed for table {} and host {}, returning 0", t, h);
+                    co_return 0;
+                } else {
+                    cdc_log.error("call failed for table {} and host {}", t, h);
+                    throw;
+                }
+            }
         },
         uint64_t(0),
         std::plus<uint64_t>()

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -1034,7 +1034,9 @@ private:
     using byte_vector = std::vector<std::byte>;
     std::function<future<byte_vector>(std::vector<byte_vector>)> _train_dict;
 public:
-    future<uint64_t> estimate_total_sstable_volume(table_id);
+    struct ignore_errors_tag;
+    using ignore_errors = seastar::bool_class<ignore_errors_tag>;
+    future<uint64_t> estimate_total_sstable_volume(table_id, ignore_errors = ignore_errors::no);
     future<std::vector<std::byte>> train_dict(utils::chunked_vector<temporary_buffer<char>> sample);
     future<> publish_new_sstable_dict(table_id, std::span<const std::byte>, service::raft_group0_client&);
     void set_train_dict_callback(decltype(_train_dict));

--- a/test/alternator/test_describe_table.py
+++ b/test/alternator/test_describe_table.py
@@ -114,10 +114,10 @@ def test_describe_table_item_count(test_table):
 
 # Similar test for estimated size in bytes - TableSizeBytes - which again,
 # may reflect the size as long as six hours ago.
-@pytest.mark.xfail(reason="DescribeTable does not return table size")
 def test_describe_table_size(test_table):
     got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']
     assert 'TableSizeBytes' in got
+    assert got['TableSizeBytes'] >= 0
 
 # Test the ProvisionedThroughput attribute returned by DescribeTable.
 # This is a very partial test: Our test table is configured without


### PR DESCRIPTION
Add a placeholder for a value (table's size in bytes) and expiry time in table object.
On every DescribeTable call:
- if table's size is not cached - updates cached size
- gets cached size and returns it as TableSizeBytes field.

Fixes #7551 