### PR TITLE
S3 chunked download source bug fixes

### DIFF
--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -48,6 +48,6 @@ custom_args:
     bloom_filter_test:
         - '-c1'
     s3_test:
-        - '-c2 -m2G --logger-log-level s3=trace --logger-log-level http=trace'
+        - '-c2 -m2G --logger-log-level s3=trace --logger-log-level http=trace --logger-log-level default_retry_strategy=trace'
 run_in_debug:
     - logalloc_standard_allocator_segment_pool_backend_test

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1163,7 +1163,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                         if (_range == s3::full_range && reply.get_header("Content-Range").empty()) {
                             auto content_range_header = parse_content_range(reply.get_header("Content-Range"));
                             _range = range{content_range_header.start, content_range_header.total};
-                            s3l.trace("No range for object '{}' was provided. Setting the range to {} form the Content-Range header",
+                            s3l.trace("No range for object '{}' was provided. Setting the range to {} from the Content-Range header",
                                       _object_name,
                                       _range);
                         }

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1144,12 +1144,12 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                               _object_name,
                               current_range);
                 } else if (_is_contiguous_mode) {
-                    s3l.trace("Setting contiguous download mode for '{}'", _object_name);
                     current_range = _range;
+                    s3l.trace("Setting contiguous download mode for '{}', range: {}", _object_name, current_range);
                 } else {
                     // In non-contiguous mode we download the object in chunks of _max_buffers_size
-                    s3l.trace("Setting ranged download mode for '{}'", _object_name);
                     current_range = {_range.offset(), std::min(_range.length(), _max_buffers_size - _buffers_size)};
+                    s3l.trace("Setting ranged download mode for '{}', range: {}", _object_name, current_range);
                 }
                 req._headers["Range"] = current_range.to_header_string();
                 s3l.trace("Fiber for object '{}' will make HTTP request within range {}", _object_name, current_range);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1160,7 +1160,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                             s3l.warn("Fiber for object '{}' failed: {}. Exiting", _object_name, reply._status);
                             throw httpd::unexpected_status_error(reply._status);
                         }
-                        if (_range == s3::full_range && reply.get_header("Content-Range").empty()) {
+                        if (_range == s3::full_range && !reply.get_header("Content-Range").empty()) {
                             auto content_range_header = parse_content_range(reply.get_header("Content-Range"));
                             _range = range{content_range_header.start, content_range_header.total};
                             s3l.trace("No range for object '{}' was provided. Setting the range to {} from the Content-Range header",

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1180,6 +1180,10 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                         std::exception_ptr ex;
                         try {
                             while (_buffers_size < _max_buffers_size && !_is_finished) {
+                                utils::get_local_injector().inject("kill_s3_inflight_req", [] {
+                                    // Inject non-retryable error to emulate source failure
+                                    throw aws::aws_exception(aws::aws_error::get_errors().at("ResourceNotFound"));
+                                });
                                 auto start = s3_clock::now();
                                 s3l.trace("Fiber for object '{}' will try to read within range {}", _object_name, _range);
                                 auto buf = co_await in.read();

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -90,6 +90,10 @@ struct stats {
     std::time_t last_modified;
 };
 
+struct filler_exception final : std::runtime_error {
+    explicit filler_exception(const char* msg) : std::runtime_error(msg) {}
+};
+
 future<> ignore_reply(const http::reply& rep, input_stream<char>&& in_);
 [[noreturn]] void map_s3_client_exception(std::exception_ptr ex);
 


### PR DESCRIPTION
- Fix missing negation in the `if` in the background downloading fiber
- Add test to catch this case
- Improve the s3 proxy to inject errors if the same resource requested more than once
- Suppress client retry since retrying the same request when each produces multiple buffers may lead to the same data appear more than once in the buffer deque
- Inject exception from the test to simulate response callback failure in the middle

No need to backport anything since this class in not used yet
