### PR TITLE
audit: introduce debug level logs on happy path

### DIFF
--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -63,6 +63,8 @@ class AuditTester(Tester):
 
         cluster = self.cluster
 
+        cluster.set_configuration_options(values={"logger_log_level": {"audit": "debug"}})
+
         if helper is None:
             self.helper = AuditBackendTable()
         else:


### PR DESCRIPTION
Audit component defines `audit` logger which it uses only for `error` and `info` logs,
regarding `audit` module initialization and errors during audit log writing.
This change introduces `debug` level logs on the happy path of audit log writes.

Fixes: https://github.com/scylladb/scylladb/issues/23773

No backport needed - this is a small quality-of-life improvement.