### PR TITLE
test: pylib: preserve correct expected server start state

### DIFF
--- a/test/pylib/internal_types.py
+++ b/test/pylib/internal_types.py
@@ -6,7 +6,7 @@
 """Internal types for handling Scylla test servers.
 """
 
-from enum import Enum, auto
+from enum import IntEnum, auto
 from typing import NewType, NamedTuple
 
 
@@ -33,7 +33,7 @@ class ServerInfo(NamedTuple):
         return {"dc": self.datacenter, "rack": self.rack}
 
 
-class ServerUpState(Enum):
+class ServerUpState(IntEnum):
     PROCESS_STARTED = auto()
     HOST_ID_QUERIED = auto()
     CQL_CONNECTED = auto()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1292,7 +1292,7 @@ class ScyllaCluster:
         # Starting may fail and if we didn't add it now it might leak.
         self.running[server_id] = server
         if not connect_driver:
-            expected_server_up_state = ServerUpState.HOST_ID_QUERIED
+            expected_server_up_state = min(expected_server_up_state, ServerUpState.HOST_ID_QUERIED)
 
         def instance_auth_provider(desc: dict):
             module_path, class_name = desc["authenticator"].rsplit('.', 1)


### PR DESCRIPTION
When server_start is called with connect_driver=False
the expected state should be adjusted to HOST_ID_QUERIED
since a connection to CQL is not guaranteed. However,
if the caller expects an earlier state, we preserve
that state due to similar reasoning.