### PR TITLE
test.py: enhance allure reporting

### DIFF
--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -78,7 +78,7 @@ class CppTestFacade(ABC):
                     env: dict = None) -> \
             tuple[bool, Path, int]:
         root_log_dir = self.temp_dir / mode
-        stdout_file_path = root_log_dir / f"{test_name}_stdout.log"
+        stdout_file_path = root_log_dir / f"{test_name}_stdout.{self.run_id}.log"
         test = make_test_object(test_name, file_name.parent.name, self.run_id, mode, log_dir=self.temp_dir)
 
         resource_gather = get_resource_gather(self.gather_metrics, test=test)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -27,6 +27,7 @@ from cassandra.cluster import Cluster as CassandraCluster  # type: ignore # pyli
 from cassandra.auth import AuthProvider
 import aiohttp
 import asyncio
+import allure
 
 import universalasync
 
@@ -177,7 +178,9 @@ class ManagerClient:
         for server in await self.all_servers():
             log_file = await self.server_open_log(server_id=server.server_id)
             shutil.copyfile(log_file.file, failed_test_path_dir / f"{pathlib.Path(log_file.file).name}")
+            allure.attach(log_file.file.read_bytes(), name=log_file.file.name, attachment_type=allure.attachment_type.TEXT)
         for name, log in logs.items():
+            allure.attach(log.read_bytes(), name=name, attachment_type=allure.attachment_type.TEXT) if name != "pytest.log" else None
             shutil.copyfile(log, failed_test_path_dir / name)
 
     async def is_manager_up(self) -> bool:


### PR DESCRIPTION
Add run ID for process output file to be not overwritten in the next case: first run failed, second passed. They are using the same name, so the second run will overwrite and delete the file. This will help to investigate in case of C++ test fails
Add attaching Scylla log files to allure report in case test failed. This is an alternative for link in JUnit report that exists in CI. That change will help to investigate the cluster tests fails. Example can be found in the failed [job](https://jenkins.scylladb.com/job/scylla-master/job/byo/job/byo_build_tests_dtest/2980/allure/).

Backport is not needed, this is only framework enhancements