### PR TITLE
[Backport 6.2] cql: create default superuser if it doesn't exist

### DIFF
--- a/auth/maintenance_socket_role_manager.cc
+++ b/auth/maintenance_socket_role_manager.cc
@@ -43,6 +43,10 @@ future<> maintenance_socket_role_manager::stop() {
     return make_ready_future<>();
 }
 
+future<> maintenance_socket_role_manager::ensure_superuser_is_created() {
+    return make_ready_future<>();
+}
+
 template<typename T = void>
 future<T> operation_not_supported_exception(std::string_view operation) {
     return make_exception_future<T>(

--- a/auth/maintenance_socket_role_manager.hh
+++ b/auth/maintenance_socket_role_manager.hh
@@ -39,6 +39,8 @@ public:
 
     virtual future<> stop() override;
 
+    virtual future<> ensure_superuser_is_created() override;
+
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) override;
 
     virtual future<> drop(std::string_view role_name, ::service::group0_batch& mc) override;

--- a/auth/role_manager.hh
+++ b/auth/role_manager.hh
@@ -107,6 +107,13 @@ public:
     virtual future<> stop() = 0;
 
     ///
+    /// Ensure that superuser role exists.
+    ///
+    /// \returns a future once it is ensured that the superuser role exists.
+    ///
+    virtual future<> ensure_superuser_is_created() = 0;
+
+    ///
     /// \returns an exceptional future with \ref role_already_exists for a role that has previously been created.
     ///
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) = 0;

--- a/auth/service.cc
+++ b/auth/service.cc
@@ -257,6 +257,10 @@ future<> service::stop() {
     });
 }
 
+future<> service::ensure_superuser_is_created() {
+    return _role_manager->ensure_superuser_is_created();
+}
+
 void service::update_cache_config() {
     auto db = _qp.db();
 

--- a/auth/service.hh
+++ b/auth/service.hh
@@ -131,6 +131,8 @@ public:
 
     future<> stop();
 
+    future<> ensure_superuser_is_created();
+
     void update_cache_config();
 
     void reset_authorization_cache();

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -278,6 +278,10 @@ future<> standard_role_manager::stop() {
     return _stopped.handle_exception_type([] (const sleep_aborted&) { }).handle_exception_type([](const abort_requested_exception&) {});;
 }
 
+future<> standard_role_manager::ensure_superuser_is_created() {
+    co_return;
+}
+
 future<> standard_role_manager::create_or_replace(std::string_view role_name, const role_config& c, ::service::group0_batch& mc) {
     const sstring query = seastar::format("INSERT INTO {}.{} ({}, is_superuser, can_login) VALUES (?, ?, ?)",
             get_auth_ks_name(_qp),

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -37,6 +37,7 @@ class standard_role_manager final : public role_manager {
     future<> _stopped;
     abort_source _as;
     std::string _superuser;
+    shared_promise<> _superuser_created_promise;
 
 public:
     standard_role_manager(cql3::query_processor&, ::service::raft_group0_client&, ::service::migration_manager&);

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -49,6 +49,8 @@ public:
 
     virtual future<> stop() override;
 
+    virtual future<> ensure_superuser_is_created() override;
+
     virtual future<> create(std::string_view role_name, const role_config&, ::service::group0_batch&) override;
 
     virtual future<> drop(std::string_view role_name, ::service::group0_batch& mc) override;

--- a/main.cc
+++ b/main.cc
@@ -2133,6 +2133,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 ss.local().drain_on_shutdown().get();
             });
 
+            auth_service.local().ensure_superuser_is_created().get();
             ss.local().register_protocol_server(cql_server_ctl, cfg->start_native_transport()).get();
             api::set_transport_controller(ctx, cql_server_ctl).get();
             auto stop_transport_controller = defer_verbose_shutdown("transport controller API", [&ctx] {

--- a/test/topology_experimental_raft/test_restart_cluster.py
+++ b/test/topology_experimental_raft/test_restart_cluster.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+"""
+Test clusters can restart fine after all nodes are stopped gracefully
+"""
+
+import logging
+import time
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_restart_cluster(manager: ManagerClient) -> None:
+    """Test that cluster can restart fine after all nodes are stopped gracefully"""
+    servers = await manager.servers_add(3)
+    cql = manager.get_cql()
+
+    logger.info(f"Servers {servers}, gracefully stopping servers {[s.server_id for s in servers]} to check if all will go up")
+    for s in servers:
+        await manager.server_stop_gracefully(s.server_id)
+
+    logger.info(f"Starting servers {[s.server_id for s in servers]}")
+    for s in servers:
+        await manager.server_start(s.server_id)
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)


### PR DESCRIPTION
Backport of https://github.com/scylladb/scylladb/pull/20137 is needed for another backport https://github.com/scylladb/scylladb/pull/24690 to work correctly.

Fixes https://github.com/scylladb/scylladb/issues/24712