### PR TITLE
storage_service: cancel all write requests after stopping transports

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -6955,7 +6955,7 @@ future<> storage_proxy::drain_on_shutdown() {
     //NOTE: the thread is spawned here because there are delicate lifetime issues to consider
     // and writing them down with plain futures is error-prone.
     return async([this] {
-        cancel_write_handlers([] (const abstract_write_response_handler&) { return true; });
+        cancel_all_write_response_handlers().get();
         _hints_resource_manager.stop().get();
     });
 }
@@ -6979,4 +6979,13 @@ future<utils::chunked_vector<dht::token_range_endpoints>> storage_proxy::describ
     return locator::describe_ring(_db.local(), _remote->gossiper(), keyspace, include_only_local_dc);
 }
 
+future<> storage_proxy::cancel_all_write_response_handlers() {
+    while (!_response_handlers.empty()) {
+        _response_handlers.begin()->second->timeout_cb();
+
+        if (!_response_handlers.empty()) {
+            co_await maybe_yield();
+        }
+    }
+}
 }

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -600,6 +600,8 @@ private:
         ++p->get_stats().received_mutations;
         p->get_stats().forwarded_mutations += forward_host_id.size();
 
+        co_await utils::get_local_injector().inject("storage_proxy_write_response_pause", utils::wait_for_message(5min));
+
         if (auto stale = _sp.apply_fence(fence, src_addr)) {
             errors.count += (forward_host_id.size() + 1);
             errors.local = std::move(*stale);

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -521,6 +521,8 @@ public:
     bool is_me(gms::inet_address addr) const noexcept;
     bool is_me(const locator::effective_replication_map& erm, locator::host_id id) const noexcept;
 
+    future<> cancel_all_write_response_handlers();
+
 private:
     bool only_me(const locator::effective_replication_map& erm, const host_id_vector_replica_set& replicas) const noexcept;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5816,6 +5816,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
             }
             break;
             case raft_topology_cmd::command::barrier_and_drain: {
+                co_await utils::get_local_injector().inject("pause_before_barrier_and_drain", utils::wait_for_message(std::chrono::minutes(5)));
                 if (_topology_state_machine._topology.tstate == topology::transition_state::write_both_read_old) {
                     for (auto& n : _topology_state_machine._topology.transition_nodes) {
                         if (!_address_map.find(locator::host_id{n.first.uuid()})) {

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -1,0 +1,110 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import logging
+import threading
+import pytest
+import asyncio
+import time
+
+from cassandra import ConsistencyLevel  # type: ignore
+from cassandra.query import SimpleStatement  # type: ignore
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.cluster.util import check_token_ring_and_group0_consistency, new_test_keyspace
+from test.pylib.util import wait_for
+from test.cluster.test_tablets2 import inject_error_on
+from test.pylib.scylla_cluster import ReplaceConfig
+from test.cluster.util import get_topology_coordinator
+from cassandra.cluster import ConnectionException, NoHostAvailable  # type: ignore
+from test.cluster.conftest import skip_mode
+
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="#23665")
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    """ Test a simultaneous topology change and write query during shutdown, which may cause the node to get stuck (see https://github.com/scylladb/scylladb/issues/23665).
+
+     1. Create a keyspace with replication factor 3
+     2. Start 3 servers
+     3. Use error injection to pause the 3rd node on a topology change (`barrier_and_drain`)
+     4  Trigger a topology change by adding a new node to the cluster.
+     5. Make sure the topology change was paused on the node 3 (`barrier_and_drain`)
+     6. Now with error injection, make sure node 2 will pause before sending a write acknowledgment.
+     7. Send a write query to the node 3. (which already should be paused on the topology change operation)
+     8. The query should have completed, but one write to node 2 should be remaining, making write_response_handler block the topology change in node 3
+     9. Start node 3 shutdown. The shutdown should hang since the one of the replicas did not send the response and therefore the response write handler still holds the ERM.
+    """
+    logger.info("Creating a new cluster")
+
+    cmdline = [
+        '--logger-log-level', 'debug_error_injection=debug',
+    ]
+
+    servers = await manager.servers_add(3, auto_rack_dc="dc1", cmdline=cmdline)
+
+    cql, hosts = await manager.get_ready_cql(servers)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3};") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
+        target_host = hosts[2]
+        target_server = servers[2]
+
+        # Make the target node stop before locking the ERM
+        logger.info(
+            f"Enabling injection 'pause_before_barrier_and_drain' on the target server {target_server}")
+        target_server_log = await manager.server_open_log(target_server.server_id)
+        await manager.api.enable_injection(target_server.ip_addr, "pause_before_barrier_and_drain", one_shot=True)
+
+        async def do_add_node():
+            logger.info("Adding a node to the cluster")
+            try:
+                await manager.server_add(property_file={"dc": "dc1", "rack": "rack4"})
+            except Exception as exc:
+                logger.error(f"Failed to add a new node: {exc}")
+
+        # Start adding a new node to the cluster, causing a topology change that will issue a barrier and drain
+        add_last_node_task = asyncio.create_task(do_add_node())
+
+        # Wait for the topology change to start
+        logger.info("Waiting for a topology change to start")
+        await target_server_log.wait_for("pause_before_barrier_and_drain: waiting for message")
+
+        # Now make sure responses on one of the replicas will be delayed
+        server_to_pause = servers[1]
+        await inject_error_on(manager, "storage_proxy_write_response_pause", [server_to_pause])
+        logger.info(
+            f"Pausing responses on one of the replicas {server_to_pause}")
+        paused_server_logs = await manager.server_open_log(server_to_pause.server_id)
+
+        # Now send a write query to the target node that will be shut down.
+        await cql.run_async(f"insert into {ks}.t (pk, v) values ({32765}, {17777})", host=target_host)
+
+        # Make sure the node that's response is paused, got the write request.
+        await paused_server_logs.wait_for("storage_proxy_write_response_pause: waiting for message")
+
+        # Start shutdown of the query coordinator
+        async def do_shutdown():
+            logger.info(f"Starting shutdown of node {target_server.server_id}")
+            await manager.server_stop_gracefully(target_server.server_id)
+
+        shutdown_task = asyncio.create_task(do_shutdown())
+
+        # Wait for the shutdown to start
+        await target_server_log.wait_for("Stop transport: done")
+
+        # Unpause the coordinator to make it now continue with `barrier_and_drain` shutdown
+        await manager.api.message_injection(target_server.ip_addr, 'pause_before_barrier_and_drain')
+
+        logger.info(f"Unblocking writes on the node {server_to_pause}")
+        await manager.api.message_injection(server_to_pause.ip_addr, 'storage_proxy_write_response_pause')
+
+        logger.info("Waiting for the shutdown to complete")
+        await shutdown_task
+
+        logger.info("Cancelling addnode task")
+        add_last_node_task.cancel()

--- a/test/cluster/test_unfinished_writes_during_shutdown.py
+++ b/test/cluster/test_unfinished_writes_during_shutdown.py
@@ -24,7 +24,6 @@ from test.cluster.conftest import skip_mode
 logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="#23665")
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_unfinished_writes_during_shutdown(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
     """ Test a simultaneous topology change and write query during shutdown, which may cause the node to get stuck (see https://github.com/scylladb/scylladb/issues/23665).


### PR DESCRIPTION
When a node shuts down, in storage service, after storage_proxy RPCs are stopped, some write handlers within storage_proxy may still be waiting for background writes to complete. These handlers hold appropriate ERMs to block schema changes before the write finishes. After the RPCs are stopped, these writes cannot receive the replies anymore.
 
If, at the same time, there are RPC commands executing `barrier_and_drain`, they may get stuck waiting for these ERM holders to finish, potentially blocking node shutdown until the writes time out.
  
This change introduces cancellation of all outstanding write handlers from storage_service after the storage proxy RPCs were stopped. 
    
Fixes scylladb/scylladb#23665

Backport: since this fixes an issue that frequently causes issues in CI, backport to 2025.1, 2025.2, and 2025.3. 
