### PR TITLE
api: Reserve resulting vector with schema versions

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1796,6 +1796,7 @@ future<json::json_return_type>
 rest_get_schema_versions(sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         return ss.local().describe_schema_versions().then([] (auto result) {
             std::vector<sp::mapper_list> res;
+            res.reserve(result.size());
             for (auto e : result) {
                 sp::mapper_list entry;
                 entry.key = std::move(e.first);


### PR DESCRIPTION
The get_schema_versions handler gets unordered_map from storage service, then converts it to API returning type, which is a vector. This vector can be reserved, the final number of elements is known in advance.
