### PR TITLE
Reduce Alternator table name length limit to 192 and fix crash when adding stream to table with very long name

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -245,7 +245,17 @@ void executor::supplement_table_info(rjson::value& descr, const schema& schema, 
 // bytes (dash and UUID), and since directory names are limited to 255 bytes,
 // we need to limit table names to 222 bytes, instead of 255.
 // See https://github.com/scylladb/scylla/issues/4480
+// We have two limits here,
+//    max_table_name_length <= max_auxiliary_table_name_length
+// max_table_name_length is the limit we impose on names of new Alternator
+// tables, and max_internal_table_name_length is the potentially higher
+// absolute limit that Scylla imposes on the name of auxiliary tables
+// such as materialized views or CDC log tables. This second limit might
+// mean that it is not possible to add a GSI or Streams to an existing
+// table, because the name of the new auxiliary table may go over the
+// limit.
 static constexpr int max_table_name_length = 222;
+static constexpr int max_auxiliary_table_name_length = 222;
 
 static bool valid_table_name_chars(std::string_view name) {
     for (auto c : name) {
@@ -295,10 +305,10 @@ static std::string view_name(std::string_view table_name, std::string_view index
                 fmt::format("IndexName '{}' must satisfy regular expression pattern: [a-zA-Z0-9_.-]+", index_name));
     }
     std::string ret = std::string(table_name) + delim + std::string(index_name);
-    if (ret.length() > max_table_name_length && validate_len) {
+    if (ret.length() > max_auxiliary_table_name_length && validate_len) {
         throw api_error::validation(
                 fmt::format("The total length of TableName ('{}') and IndexName ('{}') cannot exceed {} characters",
-                        table_name, index_name, max_table_name_length - delim.size()));
+                        table_name, index_name, max_auxiliary_table_name_length - delim.size()));
     }
     return ret;
 }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -287,6 +287,27 @@ static void validate_table_name(const std::string& name) {
     }
 }
 
+// Validate that a CDC log table could be created for the given table name,
+// and if not, throw a user-visible api_error::validation.
+// It is not possible to create a CDC log table if the table name is so long
+// that adding the 15-character suffix "_scylla_cdc_log" (cdc_log_suffix)
+// makes it go over max_auxilliary_table_name_length.
+// Note that if max_table_name_length is set to less than 207 (which is
+// max_auxilliary_table_name_length-15), then this function will never
+// fail. However, it's still important to call it in UpdateTable, in case
+// we have pre-existing tables with names longer than this to avoid #24598.
+static void validate_cdc_log_name_length(std::string_view table_name) {
+    if (cdc::log_name(table_name).length() > max_auxiliary_table_name_length) {
+        // CDC will add cdc_log_suffix ("_scylla_cdc_log") to the table name
+        // to create its log table, and this will exceed the maximum allowed
+        // length. To provide a more helpful error message, we assume that
+        // cdc::log_name() always adds a suffix of the same length.
+        int suffix_len = cdc::log_name(table_name).length() - table_name.length();
+        throw api_error::validation(fmt::format("Streams cannot be added if the table name is longer than {} characters.",
+            max_auxiliary_table_name_length - suffix_len));
+    }
+}
+
 // In DynamoDB index names are local to a table, while in Scylla, materialized
 // view names are global (in a keyspace). So we need to compose a unique name
 // for the view taking into account both the table's name and the index name.
@@ -1571,7 +1592,9 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
 
     rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
     if (stream_specification && stream_specification->IsObject()) {
-        executor::add_stream_options(*stream_specification, builder, sp);
+        if (executor::add_stream_options(*stream_specification, builder, sp)) {
+            validate_cdc_log_name_length(builder.cf_name());
+        }
     }
 
     // Parse the "Tags" parameter early, so we can avoid creating the table
@@ -1769,7 +1792,9 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
             if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
-                add_stream_options(*stream_specification, builder, p.local());
+                if (add_stream_options(*stream_specification, builder, p.local())) {
+                    validate_cdc_log_name_length(builder.cf_name());
+                }
                 // Alternator Streams doesn't yet work when the table uses tablets (#16317)
                 auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
                 if (stream_enabled && stream_enabled->IsBool()) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -265,6 +265,7 @@ static bool valid_table_name_chars(std::string_view name) {
 // specifies that table names "names must be between 3 and 255 characters long
 // and can contain only the following characters: a-z, A-Z, 0-9, _ (underscore), - (dash), . (dot)
 // validate_table_name throws the appropriate api_error if this validation fails.
+// However, Alternator only allows max_table_name_length characters, not 255.
 static void validate_table_name(const std::string& name) {
     if (name.length() < 3 || name.length() > max_table_name_length) {
         throw api_error::validation(
@@ -816,9 +817,6 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
     elogger.trace("Deleting table {}", request);
 
     std::string table_name = get_table_name(request);
-    // DynamoDB returns validation error even when table does not exist
-    // and the table name is invalid.
-    validate_table_name(table_name);
 
     std::string keyspace_name = executor::KEYSPACE_NAME_PREFIX + table_name;
     tracing::add_table_name(trace_state, keyspace_name, table_name);
@@ -834,6 +832,9 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
 
             std::optional<data_dictionary::table> tbl = p.local().data_dictionary().try_find_table(keyspace_name, table_name);
             if (!tbl) {
+                // DynamoDB returns validation error even when table does not exist
+                // and the table name is invalid.
+                validate_table_name(table_name);
                 throw api_error::resource_not_found(fmt::format("Requested resource not found: Table: {} not found", table_name));
             }
 
@@ -2747,10 +2748,12 @@ future<executor::request_return_type> executor::delete_item(client_state& client
 
 static schema_ptr get_table_from_batch_request(const service::storage_proxy& proxy, const rjson::value::ConstMemberIterator& batch_request) {
     sstring table_name = batch_request->name.GetString(); // JSON keys are always strings
-    validate_table_name(table_name);
     try {
         return proxy.data_dictionary().find_schema(sstring(executor::KEYSPACE_NAME_PREFIX) + table_name, table_name);
     } catch(data_dictionary::no_such_column_family&) {
+        // DynamoDB returns validation error even when table does not exist
+        // and the table name is invalid.
+        validate_table_name(table_name);
         throw api_error::resource_not_found(format("Requested resource not found: Table: {} not found", table_name));
     }
 }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -254,7 +254,7 @@ void executor::supplement_table_info(rjson::value& descr, const schema& schema, 
 // mean that it is not possible to add a GSI or Streams to an existing
 // table, because the name of the new auxiliary table may go over the
 // limit.
-static constexpr int max_table_name_length = 222;
+static constexpr int max_table_name_length = 192;
 static constexpr int max_auxiliary_table_name_length = 222;
 
 static bool valid_table_name_chars(std::string_view name) {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -254,7 +254,7 @@ public:
         uint64_t* item_length_in_bytes = nullptr,
         bool = false);
 
-    static void add_stream_options(const rjson::value& stream_spec, schema_builder&, service::storage_proxy& sp);
+    static bool add_stream_options(const rjson::value& stream_spec, schema_builder&, service::storage_proxy& sp);
     static void supplement_table_info(rjson::value& descr, const schema& schema, service::storage_proxy& sp);
     static void supplement_table_stream_info(rjson::value& descr, const schema& schema, const service::storage_proxy& sp);
 };

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1052,7 +1052,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     });
 }
 
-void executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp) {
+bool executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp) {
     auto stream_enabled = rjson::find(stream_specification, "StreamEnabled");
     if (!stream_enabled || !stream_enabled->IsBool()) {
         throw api_error::validation("StreamSpecification needs boolean StreamEnabled");
@@ -1086,10 +1086,12 @@ void executor::add_stream_options(const rjson::value& stream_specification, sche
                 break;
         }
         builder.with_cdc_options(opts);
+        return true;
     } else {
         cdc::options opts;
         opts.enabled(false);
         builder.with_cdc_options(opts);
+        return false;
     }
 }
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -238,7 +238,17 @@ is different, or can be configured in Alternator:
 
 * DynamoDB limits each BatchWriteItem request to 25 items. In Alternator,
   this limit defaults to 100 but can be changed with 
-  the alternator_max_items_in_batch_write configuration parameter.
+  the `alternator_max_items_in_batch_write` configuration parameter.
+
+* DynamoDB limits the name of tables, GSIs and LSIs, to 255 characters each.
+  In Alternator, the limit is different:
+    * A table's name is limited to 222 characters.
+    * For a GSI, the sum of the length of the table name and the GSI name,
+      plus one, is limited to 222 characters.
+    * For an LSI, the sum of the length of the table name and the LSI name,
+      plus two, is limited to 222 characters.
+  This means that if you create a table whose name's length is close to 222
+  characters, you may not be able to create a GSI or LSI on it.
 
 ## Experimental API features
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -242,13 +242,13 @@ is different, or can be configured in Alternator:
 
 * DynamoDB limits the name of tables, GSIs and LSIs, to 255 characters each.
   In Alternator, the limit is different:
-    * A table's name is limited to 222 characters.
+    * A table's name is limited to 192 characters.
     * For a GSI, the sum of the length of the table name and the GSI name,
       plus one, is limited to 222 characters.
     * For an LSI, the sum of the length of the table name and the LSI name,
       plus two, is limited to 222 characters.
-  This means that if you create a table whose name's length is close to 222
-  characters, you may not be able to create a GSI or LSI on it.
+  So for example, if you create a table whose name 192 characters, you
+  can't create a GSI whose name is longer than 29 characters.
 
 ## Experimental API features
 

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -97,15 +97,14 @@ def test_create_and_delete_table_non_scylla_name(dynamodb):
 # supported in Scylla because we create a directory whose name is the table's
 # name followed by 33 bytes (underscore and UUID). So currently, we only
 # correctly support names with length up to 222.
-def test_create_and_delete_table_very_long_name(dynamodb):
-    # In the future, this should work:
-    #create_and_delete_table(dynamodb, 'n' * 255)
-    # But for now, only 222 works:
+@pytest.mark.xfail(reason="Alternator limits table name length to 222")
+def test_create_and_delete_table_255(dynamodb):
+    create_and_delete_table(dynamodb, 'n' * 255)
+def test_create_and_delete_table_256(dynamodb):
+    with pytest.raises(ClientError, match='ValidationException'):
+       create_and_delete_table(dynamodb, 'n' * 256)
+def test_create_and_delete_table_222(dynamodb):
     create_and_delete_table(dynamodb, 'n' * 222)
-    # We cannot test the following on DynamoDB because it will succeed
-    # (DynamoDB allows up to 255 bytes)
-    #with pytest.raises(ClientError, match='ValidationException'):
-    #   create_table(dynamodb, 'n' * 223)
 
 # Tests creating a table with an invalid schema should return a
 # ValidationException error.

--- a/test/alternator/test_table.py
+++ b/test/alternator/test_table.py
@@ -95,16 +95,16 @@ def test_create_and_delete_table_non_scylla_name(dynamodb):
 
 # names with 255 characters are allowed in Dynamo, but they are not currently
 # supported in Scylla because we create a directory whose name is the table's
-# name followed by 33 bytes (underscore and UUID). So currently, we only
-# correctly support names with length up to 222.
-@pytest.mark.xfail(reason="Alternator limits table name length to 222")
+# name followed by 33 bytes (underscore and UUID). Currently (see #24598),
+# we only support names with length up to 192.
+@pytest.mark.xfail(reason="Alternator limits table name length to 192")
 def test_create_and_delete_table_255(dynamodb):
     create_and_delete_table(dynamodb, 'n' * 255)
 def test_create_and_delete_table_256(dynamodb):
     with pytest.raises(ClientError, match='ValidationException'):
        create_and_delete_table(dynamodb, 'n' * 256)
-def test_create_and_delete_table_222(dynamodb):
-    create_and_delete_table(dynamodb, 'n' * 222)
+def test_create_and_delete_table_192(dynamodb):
+    create_and_delete_table(dynamodb, 'n' * 192)
 
 # Tests creating a table with an invalid schema should return a
 # ValidationException error.

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -136,8 +136,9 @@ def unique_table_name():
     return test_table_prefix + str(current_ms)
 unique_table_name.last_ms = 0
 
-def create_test_table(dynamodb, **kwargs):
-    name = unique_table_name()
+def create_test_table(dynamodb, name=None, **kwargs):
+    if name is None:
+        name = unique_table_name()
     BillingMode = 'PAY_PER_REQUEST'
     if 'BillingMode' in kwargs:
         BillingMode = kwargs['BillingMode']


### PR DESCRIPTION
Before this series, it is possible to crash Scylla (due to an I/O error) by creating an Alternator table close to the maximum name length of 222, and then enabling Alternator Streams. This series fixes this bug in two ways:

1. On a pre-existing table whose name has whatever length, enabling Streams will check if the resulting name is too long, and if it is, report a clear error instead of crashing.
2. For new tables, the limit is lowered to 192. This limit is long enough, but ensures it will be possible to enable streams on such a table. It will also always be possible to add a GSI for such a table with name up to 29 characters (if the table name is shorter, the GSI name can be longer - the sum can be up to 221 characters).

No need to backport, Alternator Streams is still an experimental feature and this patch just improves the unlikely situation of extremely long table names.