### PR TITLE
repair: row_level: unstall to_repair_rows_on_wire() destroying its input

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1448,7 +1448,9 @@ private:
         size_t row_bytes = co_await get_repair_rows_size(row_list);
         _metrics.tx_row_nr += row_list.size();
         _metrics.tx_row_bytes += row_bytes;
-        for (repair_row& r : row_list) {
+        while (!row_list.empty()) {
+            repair_row r = std::move(row_list.front());
+            row_list.pop_front();
             const auto& dk_with_hash = r.get_dk_with_hash();
             // No need to search from the beginning of the rows. Look at the end of repair_rows_on_wire is enough.
             if (rows.empty()) {


### PR DESCRIPTION
to_repair_rows_on_wire() moves the contents of its input std::list and is careful to yield after each element, but the final destruction of the input list still deals with all of the list elements without yielding. This is expensive as not all contents of repair_row are moved (_dk_with_hash is of type lw_shared_ptr<const decorated_key_with_hash>).

To fix, destroy each row element as we move along. This is safe as we own the input and don't reference row_list other than for the iteration.

Fixes #24725.

While not a regression, it fixes a user problem in repair an is a safe fix, so nominating for backport.