### PR TITLE
test.py: Fix start 3rd party services

### DIFF
--- a/test.py
+++ b/test.py
@@ -418,11 +418,11 @@ async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) ->
                 console.print_progress(result)
         return failed
 
-    await start_3rd_party_services(tempdir_base=pathlib.Path(options.tmpdir), toxiproxy_byte_limit=options.byte_limit)
     total_tests = 0
     max_failures = options.max_failures
     failed = 0
     try:
+        await start_3rd_party_services(tempdir_base=pathlib.Path(options.tmpdir), toxiproxy_byte_limit=options.byte_limit)
         for i in range(1, options.repeat + 1):
             result = run_pytest(options, run_id=i)
             total_tests += result[0]

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -546,7 +546,7 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
     TestSuite.artifacts.add_exit_artifact(None, make_async_finalize)
     ms = MinioServer(
         tempdir_base=str(tempdir_base),
-        address="127.0.0.1",
+        address=await hosts.lease_host(),
         logger=LogPrefixAdapter(logger=logging.getLogger("minio"), extra={"prefix": "minio"}),
     )
     await ms.start()


### PR DESCRIPTION
Move 3rd party services starting under `try` clause to avoid situation that main process is collapses without going stopping services.
Without this, if something wrong during start it will not trigger execution exit artifacts, so the process will stay forever.

This functionality in 2025.2 and can potentially affect jobs, so backport needed.