### PR TITLE
doc: add the SBOM page and the download link

### DIFF
--- a/docs/operating-scylla/security/index.rst
+++ b/docs/operating-scylla/security/index.rst
@@ -22,7 +22,7 @@ Security
    encryption-at-rest
    ldap-authentication
    ldap-authorization
-
+   sbom
 .. panel-box::
   :title: Security
   :id: "getting-started"
@@ -57,3 +57,10 @@ Security
   * :doc:`Encryption at Rest </operating-scylla/security/encryption-at-rest>`
 
 Also check out the `Security Features lesson <https://university.scylladb.com/courses/scylla-operations/lessons/security-features/topic/security-features/>`_ on ScyllaDB University.
+
+.. panel-box::
+  :title: Software Bill Of Materials (SBOM)
+  :id: "getting-started"
+  :class: my-panel
+
+  * :doc:`Software Bill Of Materials (SBOM) </operating-scylla/security/sbom/>`

--- a/docs/operating-scylla/security/sbom.rst
+++ b/docs/operating-scylla/security/sbom.rst
@@ -1,0 +1,12 @@
+====================================
+Software Bill Of Materials (SBOM)
+====================================
+
+ScyllaDB's Software Bill Of Materials (SBOM) list of all the software
+components included ScyllaDB, such as third-party libraries or scripts.
+It provides transparency in the software supply chain, facilitates effective
+audits, and helps you ensure compliance with industry standards. 
+
+
+To download an SBOM, go to https://downloads.scylladb.com/downloads/scylla/sbom/
+and choose your ScyllaDB version.


### PR DESCRIPTION
This PR migrates the Software Bill Of Materials (SBOM) page added to the Enterprise docs with https://github.com/scylladb/scylla-enterprise/pull/5067.

The only difference is the link to the SBOM files—in the Enterprise docs, it was the Enterprise SBOM, while here is a link to the ScyllaDB SBOM.

Fixes https://github.com/scylladb/scylladb/issues/24730

Backport reason:
It's a follow-up to migration to Source Available and should be backported to all Source Available versions—2025.1 and later.