### PR TITLE
test: kmip: Fix segfault from premature destruction of port_promise

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -319,6 +319,9 @@ static future<> kmip_test_helper(const std::function<future<>(const kmip_test_in
 
     std::future<void> pykmip_status;
 
+    std::promise<int> port_promise;
+    auto fut = port_promise.get_future();
+
     static const char* def_resourcedir = "./test/resource/certs";
     const char* resourcedir = std::getenv("KMIP_RESOURCE_DIR");
     if (resourcedir == nullptr) {
@@ -382,9 +385,6 @@ database_path={}/pykmip.db
             bp::env["TMPDIR"]=tmp.path().string()
         );
 
-        std::promise<int> port_promise;
-        auto f = port_promise.get_future();
-
         pykmip_status = std::async([&] {
             static std::regex port_ex("Listening on (\\d+)");
 
@@ -407,10 +407,10 @@ database_path={}/pykmip.db
             }
         });
         // arbitrary timeout of 20s for the server to make some output. Very generous.
-        if (f.wait_for(20s) == std::future_status::timeout) {
+        if (fut.wait_for(20s) == std::future_status::timeout) {
             throw std::runtime_error("Could not start pykmip");
         }
-        auto port = f.get();
+        auto port = fut.get();
         if (port <= 0) {
             throw std::runtime_error("Invalid port");
         }


### PR DESCRIPTION
`kmip_test_helper()` is a utility function to spawn a dedicated PyKMIP server for a particular Boost test case. The function runs the server as an external process and uses a thread to parse the port from the server's logs. The thread communicates the port to the main thread via a promise.

The current implementation has a bug where the thread may set a value to the promise after its destruction, causing a segfault. The scenario is the following:

1. The main thread spawns the server, it starts the thread, and waits for the future to resolve (i.e., for the thread to report the server's port).

2. The server never reports the port within 20 seconds, but it is still running. This causes the future to time out.

3. The main thread assumes the server is "dead" and throws a runtime error.

4. C++ destructs the promise (reverse declaration order).

5. C++ runs the deferred cleanup action, during which it stops the server and waits for the thread to terminate.

6. The thread gets unblocked from its while loop because the server is no longer running, and attempts to set a value to the promise that was destroyed in step (4).

Fix the bug by declaring the promise before the cleanup action.

It's not clear yet what causes the server to malfunction (server logs are missing), but the situation has been encountered multiple times in CI and the segfault is a legitimate bug on its own.

Fixes #24574.

Improves CI stability, backport is needed.