### PR TITLE
[Backport 2025.2] test: test_raft_recovery_user_data: disable hinted handoff

### DIFF
--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -47,6 +47,8 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
     # and adjusting this test to working with it may require significant changes in the test.
     # Let's disable the option explicitly until we do that.
     rf_rack_cfg = {'rf_rack_valid_keyspaces': False}
+    # Workaround for flakiness from https://github.com/scylladb/scylladb/issues/23565.
+    hints_cfg = {'hinted_handoff_enabled': False}
     # Decrease failure_detector_timeout_in_ms from the default 20 s to speed up some graceful shutdowns in the test.
     # Shutting down the CQL server can hang for failure_detector_timeout_in_ms in the presence of dead nodes and
     # CQL requests.
@@ -54,7 +56,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
         'endpoint_snitch': 'GossipingPropertyFileSnitch',
         'tablets_mode_for_new_keyspaces': 'enabled',
         'failure_detector_timeout_in_ms': 2000,
-    } | rf_rack_cfg
+    } | rf_rack_cfg | hints_cfg
 
     property_file_dc1 = {'dc': 'dc1', 'rack': 'rack1'}
     property_file_dc2 = {'dc': 'dc2', 'rack': 'rack2'}
@@ -155,7 +157,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
         for i, being_replaced in enumerate(dead_servers):
             replace_cfg = ReplaceConfig(replaced_id=being_replaced.server_id, reuse_ip_addr=False, use_host_id=True,
                                         ignore_dead_nodes=[dead_srv.ip_addr for dead_srv in dead_servers[i + 1:]])
-            new_servers.append(await manager.server_add(replace_cfg=replace_cfg, config=rf_rack_cfg, property_file=property_file_dc2))
+            new_servers.append(await manager.server_add(replace_cfg=replace_cfg, config=cfg, property_file=property_file_dc2))
 
     logging.info(f'Unsetting the recovery_leader config option on {live_servers}')
     for srv in live_servers:


### PR DESCRIPTION
The test is currently flaky, writes can fail with "Too many in flight
hints: 10485936". See scylladb/scylladb#23565 for more details.

We suspect that scylladb/scylladb#23565 is caused by an infrastructure
issue - slow disks on some machines we run CI jobs on.

Since the test fails often and investigation doesn't seem to be easy,
we first deflake the test in this patch by disabling hinted handoff.

For replacing nodes, we provide `cfg` because there should have been
`cfg` in the first place. The test was correct anyway because:
- `tablets_mode_for_new_keyspaces` is set to `true` by default in
  test/cluster/suite.yaml,
- `endpoint_snitch` is set to `GossipingPropertyFileSnitch` by default
  if the property file is provided in `ScyllaServer.__init__`.

Ref scylladb/scylladb#23565

We should backport this patch to 2025.2 because this test is also flaky
on CI jobs using 2025.2. Older branches don't have this test.

Closes scylladb/scylladb#24364

(cherry picked from commit 8756c233e063478ec18b62527cf13fe8c0efd22e)

Parent PR: #24364

Fixes #24756