### PR TITLE
test.py: handle max failures for pytest repeats

### DIFF
--- a/test.py
+++ b/test.py
@@ -427,6 +427,9 @@ async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) ->
             result = run_pytest(options, run_id=i)
             total_tests += result[0]
             failed_tests.extend(result[1])
+            if len(failed_tests) >= max_failures != 0:
+                print("Too much failures, stopping")
+                break
         console.print_start_blurb()
         TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
         for test in TestSuite.all_tests():


### PR DESCRIPTION
Pytest can handle max failures, but inside one run, and it was not affecting the repeats. Repeats for pytest is just another execution of the process, so there is no connection between them. With additional check, it will respect max fails.

This issue in 2025.2 and in 2025.3. It's a minor enhancement of the test framework, that mostly will impact local run or custom CI run that is executed only for master.