### PR TITLE
service: tablet_allocator: avoid large contiguous vector in make_repair_plan()

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -871,7 +871,7 @@ public:
             db_clock::duration repair_time_diff;
         };
 
-        std::vector<repair_plan> plans;
+        utils::chunked_vector<repair_plan> plans;
         auto migration_tablet_ids = co_await mplan.get_migration_tablet_ids();
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
             const auto& tmap = _tm->tablets().get_tablet_map(table);


### PR DESCRIPTION
make_repair_plan() allocates a temporary vector which can grow larger than our 128k basic allocation unit. Use a chunked vector to avoid stalls due to large allocations.

Fixes #24713.

While a minor issue, it will cause bug reports in 2025.3 which has lower threshold for reporting large allocations, so backport it there. Older releases have a higher threshold.