### PR TITLE
treewide: Fix spelling errors

### DIFF
--- a/docs/_utils/redirects.yaml
+++ b/docs/_utils/redirects.yaml
@@ -11,7 +11,7 @@
 /stable/cql/non-reserved-keywords.html: /stable/cql/appendices.html
 /stable/cql/reserved-keywords.html: /stable/cql/appendices.html
 
-# Remove reduntant pages
+# Remove redundant pages
 
 /stable/getting-started/tutorials: https://docs.scylladb.com/stable/get-started/develop-with-scylladb/tutorials-example-projects.html
 /stable/contribute: https://github.com/scylladb/scylladb/blob/master/CONTRIBUTING.md

--- a/docs/operating-scylla/nodetool-commands/restore.rst
+++ b/docs/operating-scylla/nodetool-commands/restore.rst
@@ -52,7 +52,7 @@ Options
 * ``--table`` - Name of the table to load SSTables into
 * ``--nowait`` - Don't wait on the restore process
 * ``--scope <scope>`` - Use specified load-and-stream scope
-* ``--sstables-file-list <file>`` - restore the sstables listed in the given <file>. the list should be new-line seperated.
+* ``--sstables-file-list <file>`` - restore the sstables listed in the given <file>. the list should be new-line separated.
 * ``<sstables>`` - Remainder of keys of the TOC (Table of Contents) components of SSTables to restore, relative to the specified prefix
 
 The `scope` parameter describes the subset of cluster nodes where you want to load data:

--- a/docs/troubleshooting/handling-node-failures.rst
+++ b/docs/troubleshooting/handling-node-failures.rst
@@ -98,7 +98,7 @@ will leave the recovery mode and remove the obsolete internal Raft data.
   :doc:`nodetool status </operating-scylla/nodetool-commands/status>`. If there is a node
   that is joining or leaving, it cannot be recovered. You must permanently stop it. After
   performing the recovery procedure, use
-  :doc:`nodetool status </operating-scylla/nodetool-commands/status>` ony any other node.
+  :doc:`nodetool status </operating-scylla/nodetool-commands/status>` on any other node.
   If the stopped node appears in the output, it means that other nodes still consider it
   a member of the cluster, and you should remove it with the
   :doc:`node removal procedure </operating-scylla/procedures/cluster-management/remove-node/>`.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4792,7 +4792,7 @@ future<> storage_service::do_cluster_cleanup() {
         }
     }
 
-    // The wait above only wait until the comand is processed by the topology coordinator which start cleanup process,
+    // The wait above only wait until the command is processed by the topology coordinator which start cleanup process,
     // but we still need to wait for cleanup to complete here.
     co_await _topology_state_machine.event.when([this] {
         return std::all_of(_topology_state_machine._topology.normal_nodes.begin(), _topology_state_machine._topology.normal_nodes.end(), [] (auto& n) {
@@ -5089,7 +5089,7 @@ future<> storage_service::raft_check_and_repair_cdc_streams() {
                 : std::optional(_topology_state_machine._topology.committed_cdc_generations.back());
 
         if (last_committed_gen == gen) {
-            on_internal_error(rtlogger, "Wrong generation after complation of check and repair cdc stream");
+            on_internal_error(rtlogger, "Wrong generation after completion of check and repair cdc stream");
         }
     } else {
         // Wait until we commit a new CDC generation.
@@ -6086,7 +6086,7 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
     }
 
     rtlogger.info("topology cmd rpc {} completed with status={} index={}",
-        cmd.cmd, (result.status == raft_topology_cmd_result::command_status::success) ? "suceeded" : "failed", cmd_index);
+        cmd.cmd, (result.status == raft_topology_cmd_result::command_status::success) ? "succeeded" : "failed", cmd_index);
     co_return result;
 }
 


### PR DESCRIPTION
Backport: not needed. This is just a cleanup.