### PR TITLE
scylla-gdb: Don't show io_queue executing and queued resources

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -3802,8 +3802,6 @@ class scylla_io_queues(gdb.Command):
         Capacity tail:       Ticket(weight: 73168384, size: 100561888)
         Capacity head:       Ticket(weight: 77360511, size: 104242143)
 
-        Resources executing: Ticket(weight: 2176, size: 514048)
-        Resources queued:    Ticket(weight: 384, size: 98304)
         Handles: (1)
             Class 0x6000005d7278:
                 Ticket(weight: 128, size: 32768)
@@ -3922,8 +3920,6 @@ class scylla_io_queues(gdb.Command):
                     gdb.write("\tCapacity head:       {}\n".format(self.ticket(std_atomic(fg['_capacity_head']).get())))
                     gdb.write("\n")
 
-                gdb.write("\tResources executing: {}\n".format(self.ticket(fq['_resources_executing'])))
-                gdb.write("\tResources queued:    {}\n".format(self.ticket(fq['_resources_queued'])))
                 handles = std_priority_queue(fq['_handles'])
                 gdb.write("\tHandles: ({})\n".format(len(handles)))
                 for pclass_ptr in handles:


### PR DESCRIPTION
These counters are no longer accounted by io-queue code and are always zero. Even more -- accounting removal happened years ago and we don't have Scylla versions built with seastar older than that.

It can be backported, but since seastar update that would drop those fields won't happen there, it doesn't make much sense to backport it either.