### PR TITLE
test.py: skip cleaning testlog

### DIFF
--- a/test.py
+++ b/test.py
@@ -157,7 +157,7 @@ def parse_cmd_line() -> argparse.Namespace:
                         help="Number of jobs to use for running the tests")
     parser.add_argument('--save-log-on-success', "-s", default=False,
                         dest="save_log_on_success", action="store_true",
-                        help="Save test log output on success.")
+                        help="Save test log output on success and skip cleanup before the run.")
     parser.add_argument('--list', dest="list_tests", action="store_true", default=False,
                         help="Print list of tests instead of executing them")
     parser.add_argument('--skip',
@@ -261,7 +261,7 @@ def parse_cmd_line() -> argparse.Namespace:
         args.coverage = True
 
     args.tmpdir = os.path.abspath(args.tmpdir)
-    prepare_dirs(tempdir_base=pathlib.Path(args.tmpdir), modes=args.modes, gather_metrics=args.gather_metrics)
+    prepare_dirs(tempdir_base=pathlib.Path(args.tmpdir), modes=args.modes, gather_metrics=args.gather_metrics, save_log_on_success=args.save_log_on_success)
 
     if args.extra_scylla_cmdline_options:
         args.extra_scylla_cmdline_options = args.extra_scylla_cmdline_options.split()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -60,7 +60,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     # Options for compatibility with test.py
     parser.addoption('--save-log-on-success', default=False,
                         dest="save_log_on_success", action="store_true",
-                        help="Save test log output on success.")
+                        help="Save test log output on success and skip cleanup before the run.")
     parser.addoption('--coverage', action='store_true', default=False,
                       help="When running code instrumented with coverage support"
                            "Will route the profiles to `tmpdir`/mode/coverage/`suite` and post process them in order to generate "
@@ -180,7 +180,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     # Run stuff just once for the pytest session even running under xdist.
     if "xdist" not in sys.modules or not sys.modules["xdist"].is_xdist_worker(request_or_session=session):
         temp_dir = Path(session.config.getoption("--tmpdir")).absolute()
-        prepare_dirs(tempdir_base=temp_dir, modes=session.config.getoption("--mode") or get_configured_modes(), gather_metrics=session.config.getoption("--gather-metrics"))
+        prepare_dirs(tempdir_base=temp_dir, modes=session.config.getoption("--mode") or get_configured_modes(), gather_metrics=session.config.getoption("--gather-metrics"), save_log_on_success=session.config.getoption("save_log_on_success"),)
         start_3rd_party_services(tempdir_base=temp_dir, toxiproxy_byte_limit=session.config.getoption('byte_limit'))
 
 

--- a/test/pylib/ldap_server.py
+++ b/test/pylib/ldap_server.py
@@ -109,7 +109,7 @@ def make_saslauthd_conf(ip, port, instance_path):
 def start_ldap(host: Host, port: int, instance_root: Path, toxiproxy_byte_limit: int):
     tp_port = 8474
 
-    tp_log_file = open(instance_root.parent / 'toxiproxy_server.log', 'x')
+    tp_log_file = open(instance_root.parent / 'toxiproxy_server.log', 'w')
     tp_server = subprocess.Popen(
         ['toxiproxy-server', '-host', host, '-port', str(tp_port)],
         stdout=tp_log_file,

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -503,32 +503,33 @@ async def run_test(test: Test, options: argparse.Namespace, gentle_kill=False, e
     return False
 
 
-def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
+def prepare_dir(dirname: pathlib.Path, pattern: str, save_log_on_success: bool) -> None:
     # Ensure the dir exists.
     dirname.mkdir(parents=True, exist_ok=True)
 
-    # Remove old artifacts.
-    if pattern == '*':
-        shutil.rmtree(dirname, ignore_errors=True)
-    else:
-        for p in dirname.glob(pattern):
-            p.unlink()
+    if not save_log_on_success:
+        # Remove old artifacts.
+        if pattern == '*':
+            shutil.rmtree(dirname, ignore_errors=True)
+        else:
+            for p in dirname.glob(pattern):
+                p.unlink()
 
 
-def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool) -> None:
-    prepare_dir(tempdir_base, "*.log")
+def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool, save_log_on_success: bool = False) -> None:
     setup_cgroup(gather_metrics)
+    prepare_dir(tempdir_base, "*.log", save_log_on_success)
     for directory in ['report', 'ldap_instances']:
         full_path_directory = tempdir_base / directory
-        prepare_dir(full_path_directory, '*')
+        prepare_dir(full_path_directory, '*', save_log_on_success)
     for mode in modes:
-        prepare_dir(tempdir_base / mode, "*.log")
-        prepare_dir(tempdir_base / mode, "*.reject")
-        prepare_dir(tempdir_base / mode / "xml", "*.xml")
-        prepare_dir(tempdir_base / mode / "failed_test", "*")
-        prepare_dir(tempdir_base / mode / "allure", "*.xml")
+        prepare_dir(tempdir_base / mode, "*.log", save_log_on_success)
+        prepare_dir(tempdir_base / mode, "*.reject", save_log_on_success)
+        prepare_dir(tempdir_base / mode / "xml", "*.xml", save_log_on_success)
+        prepare_dir(tempdir_base / mode / "failed_test", "*", save_log_on_success)
+        prepare_dir(tempdir_base / mode / "allure", "*.xml", save_log_on_success)
         if TEST_RUNNER != "pytest":
-            prepare_dir(tempdir_base / mode / "pytest", "*")
+            prepare_dir(tempdir_base / mode / "pytest", "*", save_log_on_success)
 
 
 @universalasync.async_to_sync_wraps

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -508,8 +508,11 @@ def prepare_dir(dirname: pathlib.Path, pattern: str) -> None:
     dirname.mkdir(parents=True, exist_ok=True)
 
     # Remove old artifacts.
-    for p in dirname.glob(pattern):
-        p.unlink()
+    if pattern == '*':
+        shutil.rmtree(dirname, ignore_errors=True)
+    else:
+        for p in dirname.glob(pattern):
+            p.unlink()
 
 
 def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool) -> None:
@@ -517,17 +520,14 @@ def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: b
     setup_cgroup(gather_metrics)
     for directory in ['report', 'ldap_instances']:
         full_path_directory = tempdir_base / directory
-        shutil.rmtree(full_path_directory, ignore_errors=True)
         prepare_dir(full_path_directory, '*')
     for mode in modes:
         prepare_dir(tempdir_base / mode, "*.log")
         prepare_dir(tempdir_base / mode, "*.reject")
         prepare_dir(tempdir_base / mode / "xml", "*.xml")
-        shutil.rmtree(tempdir_base / mode / "failed_test", ignore_errors=True)
         prepare_dir(tempdir_base / mode / "failed_test", "*")
         prepare_dir(tempdir_base / mode / "allure", "*.xml")
         if TEST_RUNNER != "pytest":
-            shutil.rmtree(tempdir_base / mode / "pytest", ignore_errors=True)
             prepare_dir(tempdir_base / mode / "pytest", "*")
 
 


### PR DESCRIPTION
Skip removing any artifacts when -s provided between test.py invocation.
Logs from the previous run will be overridden if tests were executed one
more time. Fox example:
1. Execute tests A, B, C with parameter -s
2. All logs are present even if tests are passed
3. Execute test B with parameter -s
4. Logs for A and C are from the first run
5. Logs for B are from the most recent run

Backport is not needed, since it framework enhancement.