### PR TITLE
sstables: Move versions static-assertion check to .cc file

### DIFF
--- a/sstables/sstable_version.cc
+++ b/sstables/sstable_version.cc
@@ -6,11 +6,31 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "version.hh"
 #include "sstable_version.hh"
 #include "sstable_version_k_l.hh"
 #include "sstable_version_m.hh"
 
 namespace sstables {
+
+template <size_t S1, size_t S2>
+constexpr bool check_sstable_versions(const std::array<sstable_version_types, S1>& all_sstable_versions,
+        const std::array<sstable_version_types, S2>& writable_sstable_versions, sstable_version_types oldest_writable_sstable_format) {
+    for (auto v : writable_sstable_versions) {
+        if (v < oldest_writable_sstable_format) {
+            return false;
+        }
+    }
+    size_t expected = 0;
+    for (auto v : all_sstable_versions) {
+        if (v >= oldest_writable_sstable_format) {
+            ++expected;
+        }
+    }
+    return expected == S2;
+}
+
+static_assert(check_sstable_versions(all_sstable_versions, writable_sstable_versions, oldest_writable_sstable_format));
 
 const sstring sstable_version_constants::TOC_SUFFIX = "TOC.txt";
 const sstring sstable_version_constants::TEMPORARY_TOC_SUFFIX = "TOC.txt.tmp";

--- a/sstables/version.hh
+++ b/sstables/version.hh
@@ -33,25 +33,6 @@ constexpr std::array<sstable_version_types, 3> writable_sstable_versions = {
 
 constexpr sstable_version_types oldest_writable_sstable_format = sstable_version_types::mc;
 
-template <size_t S1, size_t S2>
-constexpr bool check_sstable_versions(const std::array<sstable_version_types, S1>& all_sstable_versions,
-        const std::array<sstable_version_types, S2>& writable_sstable_versions, sstable_version_types oldest_writable_sstable_format) {
-    for (auto v : writable_sstable_versions) {
-        if (v < oldest_writable_sstable_format) {
-            return false;
-        }
-    }
-    size_t expected = 0;
-    for (auto v : all_sstable_versions) {
-        if (v >= oldest_writable_sstable_format) {
-            ++expected;
-        }
-    }
-    return expected == S2;
-}
-
-static_assert(check_sstable_versions(all_sstable_versions, writable_sstable_versions, oldest_writable_sstable_format));
-
 inline auto get_highest_sstable_version() {
     return all_sstable_versions[all_sstable_versions.size() - 1];
 }
@@ -63,7 +44,7 @@ extern const std::unordered_map<sstable_version_types, seastar::sstring, seastar
 extern const std::unordered_map<sstable_format_types, seastar::sstring, seastar::enum_hash<sstable_format_types>> format_string;
 
 
-inline int operator<=>(sstable_version_types a, sstable_version_types b) {
+constexpr inline int operator<=>(sstable_version_types a, sstable_version_types b) {
     auto to_int = [] (sstable_version_types x) {
         return static_cast<std::underlying_type_t<sstable_version_types>>(x);
     };


### PR DESCRIPTION
Thiss check validates that static values of supported versions are "in sync" with each other. It's enough to do it once when compiling sstable_version.cc, not every time the header is included.

refs: #1 (not that it helps noticeably, but technically it fits)
