### PR TITLE
Do not reference db::config by transport::server

### DIFF
--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -239,6 +239,7 @@ future<> controller::do_start_server() {
               .shard_aware_transport_port_ssl = shard_aware_transport_port_ssl,
               .allow_shard_aware_drivers = cfg.enable_shard_aware_drivers(),
               .bounce_request_smp_service_group = bounce_request_smp_service_group,
+              .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
             };
         });
 

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -245,7 +245,7 @@ future<> controller::do_start_server() {
             };
         });
 
-        cserver->start(std::ref(_qp), std::ref(_auth_service), std::ref(_mem_limiter), std::move(get_cql_server_config), std::ref(cfg), std::ref(_sl_controller), std::ref(_gossiper), _cql_opcode_stats_key, _used_by_maintenance_socket).get();
+        cserver->start(std::ref(_qp), std::ref(_auth_service), std::ref(_mem_limiter), std::move(get_cql_server_config), std::ref(_sl_controller), std::ref(_gossiper), _cql_opcode_stats_key, _used_by_maintenance_socket).get();
         auto on_error = defer([&cserver] { cserver->stop().get(); });
 
         subscribe_server(*cserver).get();

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -240,6 +240,7 @@ future<> controller::do_start_server() {
               .allow_shard_aware_drivers = cfg.enable_shard_aware_drivers(),
               .bounce_request_smp_service_group = bounce_request_smp_service_group,
               .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
+              .cql_duplicate_bind_variable_names_refer_to_same_variable = cfg.cql_duplicate_bind_variable_names_refer_to_same_variable,
             };
         });
 

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -241,6 +241,7 @@ future<> controller::do_start_server() {
               .bounce_request_smp_service_group = bounce_request_smp_service_group,
               .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
               .cql_duplicate_bind_variable_names_refer_to_same_variable = cfg.cql_duplicate_bind_variable_names_refer_to_same_variable,
+              .uninitialized_connections_semaphore_cpu_concurrency = cfg.uninitialized_connections_semaphore_cpu_concurrency,
             };
         });
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -254,7 +254,7 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
         service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
-    : server("CQLServer", clogger, generic_server::config{db_cfg.uninitialized_connections_semaphore_cpu_concurrency})
+    : server("CQLServer", clogger, generic_server::config{std::move(config.uninitialized_connections_semaphore_cpu_concurrency)})
     , _query_processor(qp)
     , _config(std::move(config))
     , _memory_available(ml.get_semaphore())

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -257,7 +257,6 @@ cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& au
     : server("CQLServer", clogger, generic_server::config{db_cfg.uninitialized_connections_semaphore_cpu_concurrency})
     , _query_processor(qp)
     , _config(std::move(config))
-    , _cql_duplicate_bind_variable_names_refer_to_same_variable(db_cfg.cql_duplicate_bind_variable_names_refer_to_same_variable)
     , _memory_available(ml.get_semaphore())
     , _notifier(std::make_unique<event_notifier>(*this))
     , _auth_service(auth_service)
@@ -1334,7 +1333,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
 cql3::dialect
 cql_server::connection::get_dialect() const {
     return cql3::dialect{
-        .duplicate_bind_variable_names_refer_to_same_variable = _server._cql_duplicate_bind_variable_names_refer_to_same_variable,
+        .duplicate_bind_variable_names_refer_to_same_variable = _server._config.cql_duplicate_bind_variable_names_refer_to_same_variable,
     };
 }
 

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -63,7 +63,6 @@
 #include "transport/cql_protocol_extension.hh"
 #include "utils/bit_cast.hh"
 #include "utils/labels.hh"
-#include "db/config.hh"
 #include "utils/reusable_buffer.hh"
 
 template<typename T = void>
@@ -251,7 +250,7 @@ void cql_sg_stats::rename_metrics() {
 }
 
 cql_server::cql_server(distributed<cql3::query_processor>& qp, auth::service& auth_service,
-        service::memory_limiter& ml, cql_server_config config, const db::config& db_cfg,
+        service::memory_limiter& ml, cql_server_config config,
         qos::service_level_controller& sl_controller, gms::gossiper& g, scheduling_group_key stats_key,
         maintenance_socket_enabled used_by_maintenance_socket)
     : server("CQLServer", clogger, generic_server::config{std::move(config.uninitialized_connections_semaphore_cpu_concurrency)})

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -122,6 +122,8 @@ struct cql_server_config {
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
     utils::updateable_value<uint32_t> max_concurrent_requests;
     utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
+
+    utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
 };
 
 /**

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -45,10 +45,6 @@ class query_processor;
 
 }
 
-namespace db {
-class config;
-}
-
 namespace scollectd {
 
 class registrations;
@@ -216,7 +212,6 @@ public:
     cql_server(distributed<cql3::query_processor>& qp, auth::service&,
             service::memory_limiter& ml,
             cql_server_config config,
-            const db::config& db_cfg,
             qos::service_level_controller& sl_controller,
             gms::gossiper& g,
             scheduling_group_key stats_key,

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -120,6 +120,7 @@ struct cql_server_config {
     std::optional<uint16_t> shard_aware_transport_port_ssl;
     bool allow_shard_aware_drivers = true;
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
+    utils::updateable_value<uint32_t> max_concurrent_requests;
 };
 
 /**
@@ -199,7 +200,6 @@ private:
 
     distributed<cql3::query_processor>& _query_processor;
     cql_server_config _config;
-    utils::updateable_value<uint32_t> _max_concurrent_requests;
     utils::updateable_value<bool> _cql_duplicate_bind_variable_names_refer_to_same_variable;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -199,7 +199,6 @@ private:
 
     distributed<cql3::query_processor>& _query_processor;
     cql_server_config _config;
-    size_t _max_request_size;
     utils::updateable_value<uint32_t> _max_concurrent_requests;
     utils::updateable_value<bool> _cql_duplicate_bind_variable_names_refer_to_same_variable;
     semaphore& _memory_available;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -121,6 +121,7 @@ struct cql_server_config {
     bool allow_shard_aware_drivers = true;
     smp_service_group bounce_request_smp_service_group = default_smp_service_group();
     utils::updateable_value<uint32_t> max_concurrent_requests;
+    utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
 };
 
 /**
@@ -200,7 +201,6 @@ private:
 
     distributed<cql3::query_processor>& _query_processor;
     cql_server_config _config;
-    utils::updateable_value<bool> _cql_duplicate_bind_variable_names_refer_to_same_variable;
     semaphore& _memory_available;
     seastar::metrics::metric_groups _metrics;
     std::unique_ptr<event_notifier> _notifier;


### PR DESCRIPTION
The db::config is top-level configuration class that includes options for pretty much everything in Scylla. Instead of messing with this large thing, individual services have their own smaller configs, that are initialized with values from db::config. This PR makes it for transport::server (transport::controller will be next) and its cql_server_config. One bad thing not to step on is that updateable_value is not shard-safe (#7316), but the code in controller that creates cql_server_config is already taking care.