### PR TITLE
repair: Reduce max row buf size when small table optimization is on

### DIFF
--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -2764,7 +2764,12 @@ private:
 
     size_t get_max_row_buf_size(row_level_diff_detect_algorithm algo) {
         // Max buffer size per repair round
-        return is_rpc_stream_supported(algo) ?  repair::task_manager_module::max_repair_memory_per_range : 256 * 1024;
+        size_t size = is_rpc_stream_supported(algo) ? repair::task_manager_module::max_repair_memory_per_range : 256 * 1024;
+        if (_small_table_optimization) {
+            // For small table optimization, we reduce the buffer size to reduce memory consumption.
+            size /= _all_live_peer_nodes.size();
+        }
+        return size;
     }
 
     // Step A: Negotiate sync boundary to use
@@ -3098,7 +3103,7 @@ public:
 
             auto& mem_sem = _shard_task.rs.memory_sem();
             auto max = _shard_task.rs.max_repair_memory();
-            auto wanted = (_all_live_peer_nodes.size() + 1) * repair::task_manager_module::max_repair_memory_per_range;
+            auto wanted = (_all_live_peer_nodes.size() + 1) * max_row_buf_size;
             wanted = std::min(max, wanted);
             rlogger.trace("repair[{}]: Started to get memory budget, wanted={}, available={}, max_repair_memory={}",
                     _shard_task.global_repair_id.uuid(), wanted, mem_sem.current(), max);


### PR DESCRIPTION
If small_table_optimization is on, a repair works on a whole table simultaneously. It may be distributed across the whole cluster and all nodes might participate in repair.

On a repair master, row buffer is copied for each repair peer. This means that the memory scales with the number of peers.

In large clusters, repair with small_table_optimization leads to OOM.

Divide the max_row_buf_size by the number of repair peers if small_table_optimization is on.

Fixes: https://github.com/scylladb/scylladb/issues/22244.

The issue was reproduced with both dtest (#22244) - update_cluster_layout_tests.TestLargeScaleCluster.test_add_many_nodes_under_load - 
and SCT (#24727) - longevity_test.LongevityTest.test_scale_empty_cluster.
Both tests were run on current master (https://github.com/scylladb/scylladb/commit/d4efefbd9cfd46e4a5a54e2daa42d193bddac038) with applied fix.

- test_add_many_nodes_under_load (50 nodes) - https://jenkins.scylladb.com/job/scylla-master/job/byo/job/dtest-byo/1490/ - passed

Needs backport to all live versions