### PR TITLE
test.py: run boost test in a separate shell

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -94,6 +94,7 @@ class ResourceGather(ABC):
             bufsize=1,
             text=True,
             env=env,
+            shell=True,
             preexec_fn = self.put_process_to_cgroup
         )
         try:


### PR DESCRIPTION
To have information that the test failed because of segmentation fault, since this information produced by the shell. As a caution, all setting related to shell will be used automatically and behavior can differ on end machines depending on what shell is set.

Before fix:
```bash
$ ./test.py --mode=dev test/raft/fsm_test.cc::test_read_barrier
$  cat testlog/dev/test_read_barrier_stdout.1.log

```
After:
```bash
$ ./test.py --mode=dev test/raft/fsm_test.cc::test_read_barrier
$  cat testlog/dev/test_read_barrier_stdout.1.log  
Running 44 test cases...
INFO   raft - Got a vote from unregistered server 00000000-0000-0000-0000-000000000002 during election
INFO   raft - Got a vote from unregistered server 00000000-0000-0000-0000-000000000005 during election
INFO   raft - Got a vote from unregistered server 00000000-0000-0000-0000-000000000005 during election
unknown location(0): fatal error: in "test_leader_ignores_messages_with_current_term": memory access violation at address: 0x1700: no mapping at fault address
test/raft/fsm_test.cc(1418): last checkpoint

*** 1 failure is detected in the test module "raft"
```

Backport needed only for 2025.3, to have better logs for the tests in case of the fail.