### PR TITLE
[Backport 2025.1] replica: Fix truncate assert failure

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -2638,6 +2638,7 @@ future<> database::truncate_table_on_all_shards(sharded<database>& sharded_db, s
         st.truncated_at = truncated_at_opt.value_or(db_clock::now());
         st.did_flush = should_flush;
     });
+    co_await utils::get_local_injector().inject("database_truncate_wait", utils::wait_for_message(1min));
 
     if (with_snapshot) {
         auto truncated_at = truncated_at_opt.value_or(db_clock::now());
@@ -2677,7 +2678,9 @@ future<> database::truncate(db::system_keyspace& sys_ks, column_family& cf, cons
     // What we want to assert is that only data generated until truncation time was included,
     // since we don't want to leave behind data on disk with RP lower than the one we set
     // in the truncation table.
-    SCYLLA_ASSERT(!st.did_flush || rp == db::replay_position() || st.low_mark >= rp);
+    if (st.did_flush && rp != db::replay_position() && st.low_mark < rp) {
+        on_internal_error(dblog, "Data written after truncation time was incorrectly truncated. Truncate is known to not work well with concurrent writes. Retry!");
+    }
     if (rp == db::replay_position()) {
         // If this shard had no mutations, st.low_mark will be an empty, default constructed
         // replay_position. This is a problem because an empty replay_position has the shard_id

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -195,7 +195,7 @@ distributed_loader::process_upload_dir(distributed<replica::database>& db, shard
             }).get();
             return sstm.make_sstable(global_table->schema(), global_table->get_storage_options(),
                                      generation, sstables::sstable_state::upload, sstm.get_highest_supported_format(),
-                                     sstables::sstable_format_types::big, gc_clock::now(), &error_handler_gen_for_upload_dir);
+                                     sstables::sstable_format_types::big, db_clock::now(), &error_handler_gen_for_upload_dir);
         };
         // Pass owned_ranges_ptr to reshard to piggy-back cleanup on the resharding compaction.
         // Note that needs_cleanup() is inaccurate and may return false positives,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3170,7 +3170,6 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
     co_await _cache.invalidate(row_cache::external_updater([this, &rp, &remove, truncated_at] {
         // FIXME: the following isn't exception safe.
         for_each_compaction_group([&] (compaction_group& cg) {
-            auto gc_trunc = to_gc_clock(truncated_at);
 
             auto pruned = make_lw_shared<sstables::sstable_set>(_compaction_strategy.make_sstable_set(_schema));
             auto maintenance_pruned = make_maintenance_sstable_set();
@@ -3179,7 +3178,7 @@ future<db::replay_position> table::discard_sstables(db_clock::time_point truncat
                                             const lw_shared_ptr<sstables::sstable_set>& pruning,
                                             replica::enable_backlog_tracker enable_backlog_tracker) mutable {
                 pruning->for_each_sstable([&] (const sstables::shared_sstable& p) mutable {
-                    if (p->max_data_age() <= gc_trunc) {
+                    if (p->max_data_age() <= truncated_at) {
                         if (p->originated_on_this_node().value_or(false) && p->get_stats_metadata().position.shard_id() == this_shard_id()) {
                             rp = std::max(p->get_stats_metadata().position, rp);
                         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6055,7 +6055,7 @@ future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id
     auto load_sstable = [] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
         auto& mng = t.get_sstables_manager();
         auto sst = mng.make_sstable(t.schema(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
-                                    d.version, d.format, gc_clock::now(), default_io_error_handler_gen());
+                                    d.version, d.format, db_clock::now(), default_io_error_handler_gen());
         // The loader will consider current shard as sstable owner, despite the tablet sharder
         // will still point to leaving replica at this stage in migration. If node goes down,
         // SSTables will be loaded at pending replica and migration is retried, so correctness

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -226,7 +226,7 @@ void sstable_directory::validate(sstables::shared_sstable sst, process_flags fla
 
 future<sstables::shared_sstable> sstable_directory::load_sstable(sstables::entry_descriptor desc,
         const data_dictionary::storage_options& storage_opts, sstables::sstable_open_config cfg) const {
-    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
+    shared_sstable sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load(_sharder, cfg);
     co_return sst;
 }
@@ -504,7 +504,7 @@ sstable_directory::move_foreign_sstables(sharded<sstable_directory>& source_dire
 }
 
 future<shared_sstable> sstable_directory::load_foreign_sstable(foreign_sstable_open_info& info) {
-    auto sst = _manager.make_sstable(_schema, *_storage_opts, info.generation, _state, info.version, info.format, gc_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, *_storage_opts, info.generation, _state, info.version, info.format, db_clock::now(), _error_handler_gen);
     co_await sst->load(std::move(info));
     co_return sst;
 }
@@ -521,7 +521,7 @@ sstable_directory::load_foreign_sstables(sstable_entry_descriptor_vector info_ve
 
 future<std::vector<shard_id>> sstable_directory::get_shards_for_this_sstable(
         const sstables::entry_descriptor& desc, const data_dictionary::storage_options& storage_opts, process_flags flags) const {
-    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, gc_clock::now(), _error_handler_gen);
+    auto sst = _manager.make_sstable(_schema, storage_opts, desc.generation, _state, desc.version, desc.format, db_clock::now(), _error_handler_gen);
     co_await sst->load_owner_shards(_sharder);
     validate(sst, flags);
     co_return sst->get_shards_for_this_sstable();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3237,7 +3237,7 @@ sstable::sstable(schema_ptr schema,
         db::large_data_handler& large_data_handler,
         db::corrupt_data_handler& corrupt_data_handler,
         sstables_manager& manager,
-        gc_clock::time_point now,
+        db_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size)
     : sstable_buffer_size(buffer_size)

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -202,7 +202,7 @@ public:
             db::large_data_handler& large_data_handler,
             db::corrupt_data_handler& corrupt_data_handler,
             sstables_manager& manager,
-            gc_clock::time_point now,
+            db_clock::time_point now,
             io_error_handler_gen error_handler_gen,
             size_t buffer_size);
     sstable& operator=(const sstable&) = delete;
@@ -457,7 +457,7 @@ public:
      * max_data_age, which is load time. This could maybe
      * be improved upon.
      */
-    gc_clock::time_point max_data_age() const {
+    db_clock::time_point max_data_age() const {
         return _now;
     }
     std::vector<sstring> component_filenames() const;
@@ -590,7 +590,7 @@ private:
     } _marked_for_deletion = mark_for_deletion::none;
     bool _active = true;
 
-    gc_clock::time_point _now;
+    db_clock::time_point _now;
 
     io_error_handler _read_error_handler;
     io_error_handler _write_error_handler;

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -130,7 +130,7 @@ shared_sstable sstables_manager::make_sstable(schema_ptr schema,
         sstable_state state,
         sstable_version_types v,
         sstable_format_types f,
-        gc_clock::time_point now,
+        db_clock::time_point now,
         io_error_handler_gen error_handler_gen,
         size_t buffer_size) {
     return make_lw_shared<sstable>(std::move(schema), storage, generation, state, v, f, get_large_data_handler(), get_corrupt_data_handler(), *this, now, std::move(error_handler_gen), buffer_size);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -14,7 +14,7 @@
 
 #include "utils/assert.hh"
 #include "utils/disk-error-handler.hh"
-#include "gc_clock.hh"
+#include "db_clock.hh"
 #include "sstables/sstables.hh"
 #include "sstables/shareable_components.hh"
 #include "sstables/shared_sstable.hh"
@@ -152,7 +152,7 @@ public:
             sstable_state state = sstable_state::normal,
             sstable_version_types v = get_highest_sstable_version(),
             sstable_format_types f = sstable_format_types::big,
-            gc_clock::time_point now = gc_clock::now(),
+            db_clock::time_point now = db_clock::now(),
             io_error_handler_gen error_handler_gen = default_io_error_handler_gen(),
             size_t buffer_size = default_sstable_buffer_size);
 

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -25,10 +25,14 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
+static db_clock::time_point to_db_clock(gc_clock::time_point tp) {
+    return db_clock::from_time_t(gc_clock::to_time_t(tp));
+}
+
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, std::vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
-    auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, query_time);
+    auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, to_db_clock(query_time));
     auto mt = make_memtable(s, mutations);
     auto mr = mt->make_flat_reader(s, env.make_reader_permit());
     sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -349,7 +349,7 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, std::vector<mutation> mutations,
-        sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
+        sstables::sstable::version_types version, db_clock::time_point query_time = db_clock::now()) {
     return make_sstable_easy(env, make_memtable(s, mutations), env.manager().configure_writer(), version, mutations.size(), query_time)->as_mutation_source();
 }
 

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -121,13 +121,13 @@ public:
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
-            size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now());
+            size_t buffer_size = default_sstable_buffer_size, db_clock::time_point now = db_clock::now());
 
     shared_sstable make_sstable(schema_ptr schema, sstring dir, sstable::version_types v = sstables::get_highest_sstable_version());
 
     shared_sstable make_sstable(schema_ptr schema, sstables::generation_type generation,
             sstable::version_types v = sstables::get_highest_sstable_version(), sstable::format_types f = sstable::format_types::big,
-            size_t buffer_size = default_sstable_buffer_size, gc_clock::time_point now = gc_clock::now());
+            size_t buffer_size = default_sstable_buffer_size, db_clock::time_point now = db_clock::now());
 
     shared_sstable make_sstable(schema_ptr schema, sstable::version_types v = sstables::get_highest_sstable_version());
 

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -93,7 +93,7 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, s
 }
 
 shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition, gc_clock::time_point query_time) {
+        sstables::generation_type gen, const sstables::sstable::version_types version, int expected_partition, db_clock::time_point query_time) {
     auto s = rd.schema();
     auto sst = env.make_sstable(s, gen, version, sstable_format_types::big, default_sstable_buffer_size, query_time);
     sst->write_components(std::move(rd), expected_partition, s, cfg, encoding_stats{}).get();
@@ -102,7 +102,7 @@ shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writ
 }
 
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types v, int estimated_partitions, gc_clock::time_point query_time) {
+        sstables::generation_type gen, const sstable::version_types v, int estimated_partitions, db_clock::time_point query_time) {
     return make_sstable_easy(env, mt->make_flat_reader(mt->schema(), env.make_reader_permit()), std::move(cfg), gen, v, estimated_partitions, query_time);
 }
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -19,7 +19,7 @@
 #include "test/lib/test_services.hh"
 #include "test/lib/sstable_test_env.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
-#include "gc_clock.hh"
+#include "db_clock.hh"
 #include <seastar/core/coroutine.hh>
 
 using namespace sstables;
@@ -232,9 +232,9 @@ future<compaction_result> compact_sstables(test_env& env, sstables::compaction_d
                  can_purge_tombstones can_purge = can_purge_tombstones::yes);
 
 shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, gc_clock::time_point = gc_clock::now());
+        sstables::generation_type gen, const sstable::version_types version = sstables::get_highest_sstable_version(), int expected_partition = 1, db_clock::time_point = db_clock::now());
 shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
-        sstables::generation_type gen, const sstable::version_types v = sstables::get_highest_sstable_version(), int estimated_partitions = 1, gc_clock::time_point = gc_clock::now());
+        sstables::generation_type gen, const sstable::version_types v = sstables::get_highest_sstable_version(), int estimated_partitions = 1, db_clock::time_point = db_clock::now());
 
 
 inline shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
@@ -242,7 +242,7 @@ inline shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstab
     return make_sstable_easy(env, std::move(rd), std::move(cfg), env.new_generation(), version, expected_partition);
 }
 inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::memtable> mt, sstable_writer_config cfg,
-        const sstable::version_types version = sstables::get_highest_sstable_version(), int estimated_partitions = 1, gc_clock::time_point query_time = gc_clock::now()) {
+        const sstable::version_types version = sstables::get_highest_sstable_version(), int estimated_partitions = 1, db_clock::time_point query_time = db_clock::now()) {
     return make_sstable_easy(env, std::move(mt), std::move(cfg), env.new_generation(), version, estimated_partitions, query_time);
 }
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -362,7 +362,7 @@ test_env::new_generation() noexcept {
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstring dir, sstables::generation_type generation,
         sstable::version_types v, sstable::format_types f,
-        size_t buffer_size, gc_clock::time_point now) {
+        size_t buffer_size, db_clock::time_point now) {
     // FIXME -- most of the callers work with _impl->dir's path, so
     // test_env can initialize the .dir/.prefix only once, when constructed
     auto storage = _impl->storage;
@@ -381,7 +381,7 @@ test_env::make_sstable(schema_ptr schema, sstring dir, sstable::version_types v)
 shared_sstable
 test_env::make_sstable(schema_ptr schema, sstables::generation_type generation,
         sstable::version_types v, sstable::format_types f,
-        size_t buffer_size, gc_clock::time_point now) {
+        size_t buffer_size, db_clock::time_point now) {
     return make_sstable(std::move(schema), _impl->dir.path().native(), generation, std::move(v), std::move(f), buffer_size, now);
 }
 


### PR DESCRIPTION
Truncate doesn't really go well with concurrent writes. The fix (#23560) exposed a preexisting fragility which I missed.

1) truncate gets RP mark X, truncated_at = second T 2) new sstable written during snapshot or later, also at second T (difference of MS) 3) discard_sstables() get RP Y > saved RP X, since creation time of sstable with RP Y is equal to truncated_at = second T.

So the problem is that truncate is using a clock of second granularity for filtering out sstables written later, and after we got low mark and truncate time, it can happen that a sstable is flushed later within the same second, but at a different millisecond.
By switching to a millisecond clock (db_clock), we allow sstables written later within the same second from being filtered out. It's not perfect but extremely unlikely a new write lands and get flushed in the same millisecond we recorded truncated_at timepoint. In practice, truncate will not be used concurrently to writes, so this should be enough for our tests performing such concurrent actions.
We're moving away from gc_clock which is our cheap lowres_clock, but time is only retrieved when creating sstable objects, which frequency of creation is low enough for not having significant consequences, and also db_clock should be cheap enough since it's usually syscall-less.

Fixes #23771.



Closes scylladb/scylladb#24426

(cherry picked from commit 2d716f3ffe92d88942c23f22085abbeb77b0684c)

