### PR TITLE
api: add vector_search api

### DIFF
--- a/api/CMakeLists.txt
+++ b/api/CMakeLists.txt
@@ -50,7 +50,8 @@ set(swagger_files
   api-doc/tasks.json
   api-doc/task_manager.json
   api-doc/task_manager_test.json
-  api-doc/utils.json)
+  api-doc/utils.json
+  api-doc/vector_search.json)
 
 foreach(f ${swagger_files})
   get_filename_component(fname "${f}" NAME_WE)

--- a/api/api-doc/vector_search.def.json
+++ b/api/api-doc/vector_search.def.json
@@ -1,0 +1,22 @@
+"vector_search_status": {
+    "id": "vector_search_status",
+    "summary": "Operational status of the Vector Search feature.",
+    "properties": {
+      "status": {
+        "type": "string",
+        "enum": [
+          "UNAVAILABLE",
+          "INITIALIZING",
+          "SERVING",
+          "INDEXING_EMBEDDINGS"
+        ]
+      },
+      "serving_mode": {
+        "type": "string",
+        "enum": [
+          "PRIMARY",
+          "SECONDARY"
+        ]
+      }
+    }
+}

--- a/api/api-doc/vector_search.json
+++ b/api/api-doc/vector_search.json
@@ -1,0 +1,20 @@
+"/vector_search/status": {
+  "get": {
+    "description": "Returns the current operational status of the Vector Search feature. It is computed based on availability of Vector Store nodes.",
+    "operationId": "get_status",
+    "produces": [
+      "application/json"
+    ],
+    "tags": [
+      "vector_search"
+    ],
+    "responses": {
+      "200": {
+        "schema" : {
+          "$ref": "#/definitions/vector_search_status"
+        },
+        "description": "Successful operation. Returns the current operational status of the Vector Search feature."
+      }
+    }
+  }
+}

--- a/api/api.cc
+++ b/api/api.cc
@@ -31,6 +31,7 @@
 #include "stream_manager.hh"
 #include "system.hh"
 #include "api/config.hh"
+#include "api/vector_search.hh"
 #include "task_manager.hh"
 #include "task_manager_test.hh"
 #include "tasks.hh"
@@ -66,9 +67,11 @@ future<> set_server_init(http_context& ctx) {
         rb->set_api_doc(r);
         rb02->set_api_doc(r);
         rb02->register_api_file(r, "swagger20_header");
+        register_vector_search(rb02, ctx, r);
         rb02->register_api_file(r, "metrics");
         rb->register_function(r, "system",
                 "The system related API");
+        register_vector_search_definitions(rb02, ctx, r);
         rb02->add_definitions_file(r, "metrics");
         set_system(ctx, r);
         rb->register_function(r, "error_injection",

--- a/api/system.cc
+++ b/api/system.cc
@@ -9,6 +9,7 @@
 #include "api/api_init.hh"
 #include "api/api-doc/system.json.hh"
 #include "api/api-doc/metrics.json.hh"
+#include "api/api-doc/vector_search.json.hh"
 #include "replica/database.hh"
 #include "db/sstables-format-selector.hh"
 
@@ -30,6 +31,7 @@ using namespace seastar::httpd;
 
 namespace hs = httpd::system_json;
 namespace hm = httpd::metrics_json;
+namespace vs = httpd::vector_search_json;
 
 extern "C" void __attribute__((weak)) __llvm_profile_dump();
 extern "C" const char * __attribute__((weak)) __llvm_profile_get_filename();
@@ -102,6 +104,12 @@ void set_system(http_context& ctx, routes& r) {
                 return make_ready_future<json::json_return_type>(seastar::json::json_void());
             });
         });
+    });
+
+    vs::get_status.set(r, [](const_req req) {
+        vs::vector_search_status status;
+        status.status = vs::vector_search_status::vector_search_status_status::UNAVAILABLE;
+        return status;
     });
 
     hs::get_system_uptime.set(r, [](const_req req) {

--- a/api/vector_search.cc
+++ b/api/vector_search.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "api/api.hh"
+#include "api/vector_search.hh"
+#include <seastar/core/fstream.hh>
+#include <seastar/http/api_docs.hh>
+
+namespace api {
+using namespace seastar::httpd;
+
+const sstring vector_search_api_filepath = "api/api-doc/vector_search";
+
+void register_vector_search(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, routes& r) {
+    rb->register_function(r, [] (output_stream<char>& os) {
+        return open_file_dma(vector_search_api_filepath + ".json", open_flags::ro).then([&os] (file f) mutable {
+            return do_with(input_stream<char>(make_file_input_stream(std::move(f))), [&os](input_stream<char>& is) {
+                return copy(is, os).then([&is, &os] {
+                    return os.write(",\n").then([&is] {
+                        return is.close();
+                    });
+                });
+            });
+        });
+    });
+}
+
+void register_vector_search_definitions(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, routes& r) {
+    rb->add_definition(r, [] (output_stream<char>& os) {
+        return open_file_dma(vector_search_api_filepath + ".def.json", open_flags::ro).then([&os] (file f) mutable {
+            return do_with(input_stream<char>(make_file_input_stream(std::move(f))), [&os](input_stream<char>& is) {
+                return copy(is, os).then([&is, &os] {
+                    return os.write(",\n").then([&is] {
+                        return is.close();
+                    });
+                });
+            });
+        });
+    });
+}
+
+}
+

--- a/api/vector_search.hh
+++ b/api/vector_search.hh
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "api/api_init.hh"
+#include <seastar/http/api_docs.hh>
+
+namespace api {
+
+void register_vector_search(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, httpd::routes& r);
+void register_vector_search_definitions(std::shared_ptr<httpd::api_registry_builder20> rb, http_context& ctx, httpd::routes& r);
+}

--- a/configure.py
+++ b/configure.py
@@ -1276,6 +1276,8 @@ api = ['api/api.cc',
        'api/cql_server_test.cc',
        'api/service_levels.cc',
        Json2Code('api/api-doc/service_levels.json'),
+       Json2Code('api/api-doc/vector_search.json'),
+       'api/vector_search.cc',
        ]
 
 alternator = [


### PR DESCRIPTION
As we want to introduce the cloud integration for Vector Search, we need to add a new API that would report the status of the service.

This PR adds the `/vector_search/status` endpoint to the existing Scylla API version 2.0.

The endpoint should return one of the following statuses:
  - UNAVAILABLE : there is no connection to any vector node in the current DC.
  - SERVING : there is a connection to the vector node and the last request was completed successfully. Additionally, the serving mode will be reported in a separate field.
  - INDEXING_EMBEDDINGS : there are no vector nodes in the current DC in SERVING state but at least one is in BUILDING state.
  - INITIALIZING : there are no vector nodes in the current DC in SERVING or BUILDING state but at least one is in INITIALIZING state.

Serving modes are defined as follows:
  - PRIMARY : the vector node in the same rack is being used.
  - SECONDARY : the vector node in the same rack is not available, switched to the vector node on different rack.

Fixes: [VECTOR-98](https://scylladb.atlassian.net/browse/VECTOR-98)

[VECTOR-98]: https://scylladb.atlassian.net/browse/VECTOR-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ