### PR TITLE
config, main: make cpu scheduling mandatory

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1238,7 +1238,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
     , enable_sstable_key_validation(this, "enable_sstable_key_validation", value_status::Used, ENABLE_SSTABLE_KEY_VALIDATION, "Enable validation of partition and clustering keys monotonicity"
         " Performance is affected to some extent as a result. Useful to help debugging problems that may arise at another layers.")
-    , cpu_scheduler(this, "cpu_scheduler", value_status::Used, true, "Enable cpu scheduling.")
+    , cpu_scheduler(this, "cpu_scheduler", value_status::Unused, true, "Enable cpu scheduling.")
     , view_building(this, "view_building", value_status::Used, true, "Enable view building; should only be set to false when the node is experience issues due to view building.")
     , enable_sstables_mc_format(this, "enable_sstables_mc_format", value_status::Unused, true, "Enable SSTables 'mc' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")
     , enable_sstables_md_format(this, "enable_sstables_md_format", value_status::Unused, true, "Enable SSTables 'md' format to be used as the default file format.  Deprecated, please use \"sstable_format\" instead.")

--- a/main.cc
+++ b/main.cc
@@ -884,15 +884,9 @@ sharded<locator::shared_token_metadata> token_metadata;
             //});
 
             schema::set_default_partitioner(cfg->partitioner(), cfg->murmur3_partitioner_ignore_msb_bits());
-            auto make_sched_group = [&] (sstring name, sstring short_name, unsigned shares) {
-                if (cfg->cpu_scheduler()) {
-                    return seastar::create_scheduling_group(name, short_name, shares).get();
-                } else {
-                    return seastar::scheduling_group();
-                }
-            };
-            auto background_reclaim_scheduling_group = make_sched_group("background_reclaim", "bgre", 50);
-            auto maintenance_scheduling_group = make_sched_group("streaming", "strm", 200);
+
+            auto background_reclaim_scheduling_group = create_scheduling_group("background_reclaim", "bgre", 50).get();
+            auto maintenance_scheduling_group = create_scheduling_group("streaming", "strm", 200).get();
 
             smp::invoke_on_all([&cfg, background_reclaim_scheduling_group] {
                 logalloc::tracker::config st_cfg;
@@ -1128,15 +1122,15 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             // Note: changed from using a move here, because we want the config object intact.
             replica::database_config dbcfg;
-            dbcfg.compaction_scheduling_group = make_sched_group("compaction", "comp", 1000);
-            dbcfg.memory_compaction_scheduling_group = make_sched_group("mem_compaction", "mcmp", 1000);
+            dbcfg.compaction_scheduling_group = create_scheduling_group("compaction", "comp", 1000).get();
+            dbcfg.memory_compaction_scheduling_group = create_scheduling_group("mem_compaction", "mcmp", 1000).get();
             dbcfg.streaming_scheduling_group = maintenance_scheduling_group;
-            dbcfg.statement_scheduling_group = make_sched_group("statement", "stmt", 1000);
-            dbcfg.memtable_scheduling_group = make_sched_group("memtable", "mt", 1000);
-            dbcfg.memtable_to_cache_scheduling_group = make_sched_group("memtable_to_cache", "mt2c", 200);
-            dbcfg.gossip_scheduling_group = make_sched_group("gossip", "gms", 1000);
-            dbcfg.commitlog_scheduling_group = make_sched_group("commitlog", "clog", 1000);
-            dbcfg.schema_commitlog_scheduling_group = make_sched_group("schema_commitlog", "sclg", 1000);
+            dbcfg.statement_scheduling_group = create_scheduling_group("statement", "stmt", 1000).get();
+            dbcfg.memtable_scheduling_group = create_scheduling_group("memtable", "mt", 1000).get();
+            dbcfg.memtable_to_cache_scheduling_group = create_scheduling_group("memtable_to_cache", "mt2c", 200).get();
+            dbcfg.gossip_scheduling_group = create_scheduling_group("gossip", "gms", 1000).get();
+            dbcfg.commitlog_scheduling_group = create_scheduling_group("commitlog", "clog", 1000).get();
+            dbcfg.schema_commitlog_scheduling_group = create_scheduling_group("schema_commitlog", "sclg", 1000).get();
             dbcfg.available_memory = memory::stats().total_memory();
 
             // Make sure to initialize the scheduling group keys at a point where we are sure


### PR DESCRIPTION
CPU scheduling has been with us since 641aaba12c6854c7fe729fcca74aee33a9da6d2d (2017), and no one ever disables it. Likely nothing really works without it.

Make it mandatory and mark the option unused.

Small cleanup, not marking for backport.