### PR TITLE
tablets: stop storage group on deallocation

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2738,7 +2738,17 @@ void tablet_storage_group_manager::update_effective_replication_map(const locato
             _storage_groups[tid.value()] = allocate_storage_group(*new_tablet_map, tid, std::move(range));
             tablet_migrating_in = true;
         } else if (_storage_groups.contains(tid.value()) && locator::is_post_cleanup(this_replica, new_tablet_map->get_tablet_info(tid), transition_info)) {
+            // The storage group should be cleaned up and stopped at this point usually by the tablet cleanup stage,
+            // unless the storage group was allocated after tablet cleanup was completed for this node. This could
+            // happen if the node was restarted after tablet cleanup was run but before moving to the next stage. To
+            // handle this case we stop the storage group here if it's not stopped already.
+            auto sg = _storage_groups[tid.value()];
+
             remove_storage_group(tid.value());
+
+            (void) with_gate(_t.async_gate(), [sg] {
+                return sg->stop("tablet post-cleanup").then([sg] {});
+            });
         }
     }
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1549,6 +1549,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                 return ser::storage_service_rpc_verbs::send_tablet_cleanup(&_messaging,
                                                                                            dst.host, _as, raft::server_id(dst.host.uuid()), gid);
                             });
+                        }).then([] {
+                            return utils::get_local_injector().inject("wait_after_tablet_cleanup", [] (auto& handler) -> future<> {
+                                rtlogger.info("Waiting after tablet cleanup");
+                                return handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds{60});
+                            });
                         });
                     })) {
                         transition_to(locator::tablet_transition_stage::end_migration);

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -469,3 +469,56 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
             if new_tablet_count < old_tablet_count:
                 return True
         await wait_for(tablets_merged, time.time() + 60)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
+    """
+    Migrate a tablet from one node to another, and restart the leaving replica during
+    the tablet cleanup stage, after tablet cleanup is completed.
+    Reproduces issue #24857
+    """
+    cfg = {'error_injections_at_startup': ['short_tablet_stats_refresh_interval']}
+    servers = await manager.servers_add(2, config=cfg)
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
+
+        total_keys = 10
+        for pk in range(total_keys):
+            await cql.run_async(f"INSERT INTO {ks}.test(pk, c) VALUES({pk}, {pk+1})")
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        tablet_token = 0
+
+        s0_host_id = await manager.get_host_id(servers[0].server_id)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+        # Find which server holds the tablet
+        replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+        if replica[0] == s0_host_id:
+            src_server, dst_host_id = servers[0], s1_host_id
+        else:
+            src_server, dst_host_id = servers[1], s0_host_id
+
+        await asyncio.gather(*[manager.api.enable_injection(s.ip_addr, "wait_after_tablet_cleanup", one_shot=False) for s in servers])
+
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        # Start migration - move tablet to other node
+        move_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, ks, 'test', replica[0], replica[1], dst_host_id, 0, tablet_token))
+
+        await log.wait_for("Waiting after tablet cleanup", from_mark=mark, timeout=60)
+
+        # Restart the leaving replica (src_server)
+        await manager.server_stop(src_server.server_id)
+        await manager.server_start(src_server.server_id)
+        await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 30)
+
+        await asyncio.gather(*[manager.api.message_injection(s.ip_addr, "wait_after_tablet_cleanup") for s in servers])
+
+        await manager.api.quiesce_topology(servers[0].ip_addr)


### PR DESCRIPTION
When a tablet transitions to a post-cleanup stage on the leaving replica we deallocate its storage group. Before the storage can be deallocated and destroyed, we must make sure it's cleaned up and stopped properly.

Normally this happens during the tablet cleanup stage, when table::cleanup_table is called, so by the time we transition to the next stage the storage group is already stopped.

However, it's possible that tablet cleanup did not run in some scenario:
1. The topology coordinator runs tablet cleanup on the leaving replica.
2. The leaving replica is restarted.
3. When the leaving replica starts, still in `cleanup` stage, it allocates a storage group for the tablet.
4. The topology coordinator moves to the next stage.
5. The leaving replica deallocates the storage group, but it was not stopped.

To address this scenario, we always stop the storage group when deallocating it. Usually it will be already stopped and complete immediately, and otherwise it will be stopped in the background.

Fixes scylladb/scylladb#24857
Fixes https://github.com/scylladb/scylladb/issues/24828

backport is needed to the relevant releases since it's a bug