### PR TITLE
[DO NOT REVIEW] cql3/statements/create_index_statement.cc: Change change type to CREATED

### DIFF
--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -400,7 +400,7 @@ create_index_statement::prepare_schema_mutations(query_processor& qp, const quer
         m = co_await service::prepare_column_family_update_announcement(qp.proxy(), std::move(res->schema), {}, ts);
 
         ret = ::make_shared<event::schema_change>(
-                event::schema_change::change_type::UPDATED,
+                event::schema_change::change_type::CREATED,
                 event::schema_change::target_type::TABLE,
                 keyspace(),
                 column_family());


### PR DESCRIPTION
Before these changes, the type of the schema change for creating an index was set to UPDATED. However, it makes much less sense than using CREATED instead, similarly to CREATE TABLE/MATERIALIZED VIEW/etc.

Backport: TBD if we should backport this change. Probably not since it doesn't seem to have affected anything.