### PR TITLE
repair: Speed up ranges calculation when small table optimization is on

### DIFF
--- a/test/cluster/test_boot_nodes.py
+++ b/test/cluster/test_boot_nodes.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import pytest
+import time
+import logging
+logger = logging.getLogger(__name__)
+
+@pytest.mark.asyncio
+async def test_boot(manager):
+    rbno = True
+    cfg = {'enable_repair_based_node_ops': rbno, 'num_tokens': 256}
+    nr_nodes = 3
+    for i in range(nr_nodes):
+        logger.info(f"booting node {i+1}")
+        start = time.time()
+        await manager.server_add(config=cfg)
+        end = time.time()
+        logger.info(f"node {i+1} took {end - start}ms to boot")


### PR DESCRIPTION
repair: Speed up ranges calculation when small table optimization is on

Normally, during bootstrap, in repair_service::bootstrap_with_repair, we
need to calculate which range to sync data from carefully for the new
node. With small table optimization on, we pass a single full range and
all peer nodes to row level repair to sync data with. Now that we only
need to pass a single range and full peers, there is no need to calculate
the ranges and peers in repair_service::bootstrap_with_repair and drop
it later. The calculation takes time which slows down bootstrap, e.g.,

```
Jul 08 22:01:41.927785 cluster-scale-50-200-test-scayle-t-db-node-51209daa-93 scylla[5326]:
[shard 0:strm] repair - bootstrap_with_repair: started with
keyspace=system_distributed_everywhere, nr_ranges=23809

Jul 08 22:01:57.883797 cluster-scale-50-200-test-scayle-t-db-node-51209daa-93 scylla[5326]:
[shard 0:strm] repair - repair[79eac1a1-5d5b-4028-ae1c-06e68bec2d50]:
sync data for keyspace=system_distributed_everywhere, status=started,
reason=bootstrap, small_table_optimization=true
```

The range calculation took 15 seconds for system_distributed_everywhere
table.

To fix, the ranges calculation is skipped if small table optimization is
on for the keyspace.

Before:
cluster    dev   [ PASS ] cluster.test_boot_nodes.1 104.59s

After:
cluster    dev   [ PASS ] cluster.test_boot_nodes.1 89.23s

A 15% improvement to bootstrap 30 node cluster was observed.

Fixes #24817
