### PR TITLE
api: unregister raft_topology_get_cmd_status on shutdown

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1996,6 +1996,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::reload_raft_topology_state.unset(r);
     ss::upgrade_to_raft_topology.unset(r);
     ss::raft_topology_upgrade_status.unset(r);
+    ss::raft_topology_get_cmd_status.unset(r);
     ss::move_tablet.unset(r);
     ss::add_tablet_replica.unset(r);
     ss::del_tablet_replica.unset(r);


### PR DESCRIPTION
In c8ce9d1c60edd3cb3a3f8133117488b9036dc300 we introduced raft_topology_get_cmd_status REST api but the commit forgot to unregister the handler during shutdown.

Fixes #24910

Need to be backported everywhere the commit above was backported to.