### PR TITLE
LWT: Revert "paxos_state: read repair for intranode_migration"

### DIFF
--- a/service/paxos/paxos_state.hh
+++ b/service/paxos/paxos_state.hh
@@ -75,10 +75,6 @@ private:
     static future<replica_guard> get_replica_lock(const dht::token& key, clock_type::time_point timeout,
         const dht::shard_replica_set& shards);
 
-    static future<paxos_state> load_and_repair_paxos_state(db::system_keyspace& sys_ks,
-        partition_key_view key, schema_ptr s, gc_clock::time_point now,
-        db::timeout_clock::time_point timeout, const dht::shard_replica_set& shards);
-
     utils::UUID _promised_ballot = utils::UUID_gen::min_time_UUID();
     std::optional<proposal> _accepted_proposal;
     std::optional<proposal> _most_recent_commit;

--- a/service/paxos/proposal.hh
+++ b/service/paxos/proposal.hh
@@ -46,10 +46,6 @@ inline bool operator>(const proposal& lhs, const proposal& rhs) {
     return lhs.ballot.timestamp() > rhs.ballot.timestamp();
 }
 
-inline bool operator==(const proposal& lhs, const proposal& rhs) {
-    return lhs.ballot.timestamp() == rhs.ballot.timestamp();
-}
-
 } // end of namespace "paxos"
 } // end of namespace "service"
 


### PR DESCRIPTION
This PR reverts commit 45f5efb9badbb6c1722423c642a591fcb9f4bcd8.

The `load_and_repair_paxos_state` function was introduced in scylladb/scylladb#24478, but it has never been tested or proven useful.

One set of problems stems from its use of local data structures from a remote shard. In particular, `system_keyspace` and `schema_ptr` cannot be directly accessed from another shard — doing so is a bug.

More importantly, `load_paxos_state` on different shards can't ever return different values. The actual shard from which data is read is determined by `sharder.shard_for_reads`, and `storage_proxy` will jump back to the appropriate shard if the current one doesn't match. This means `load_and_repair_paxos_state` can't observe paxos state from write-but-not-read shard, and therefore will never be able to repair anything.

We believe this explicit Paxos state read-repair is not needed at all.

Any paxos state read which drives some paxos round forward is already accompanied by a paxos state write. Suppose we wrote the state to the old shard but not to the new shard (because of some error) when streaming is already finished. The RPC call (prepare or accept) will return an error to the coordinator, such replica response won't affect the current round. This write won't affect any subsequent paxos rounds either, unless in those rounds the write actually succeeds on both shards, effectively 'auto-repairing' paxos state.

Same holds if we managed to write to the new shard but not to the old shard. Any subsequent reads will observe either the old state or the new state (if the tablet already switched reads to the new shard). In any case, we'll have to write the state to all relevant shards from `sharder.shard_for_writes` (one or two) before sending rpc response, making this state visible for all subsequent reads.

Thus, the monotonicity property ("once observed, the state must always be observed") appears to hold without requiring explicit read-repair and `load_and_repair_paxos_state` is not needed.

References
[1] - [LWT over tablets design](https://docs.google.com/document/d/1CPm0N9XFUcZ8zILpTkfP5O4EtlwGsXg_TU4-1m7dTuM/edit?tab=t.0#heading=h.goufx7gx24yu)

backport: not needed, `load_and_repair_paxos_state` did nothing for LWT over vnodes, and LWT for tablets is not released yet.