### PR TITLE
streaming: Avoid deadlock by running view checks in a separate scheduling group

### DIFF
--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -7,6 +7,7 @@
  */
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/with_scheduling_group.hh>
 
 #include "consumer.hh"
 #include "replica/database.hh"
@@ -35,7 +36,9 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
 
             auto cf = db.local().find_column_family(reader.schema()).shared_from_this();
             auto guard = service::topology_guard(frozen_guard);
-            auto use_view_update_path = co_await db::view::check_needs_view_update_path(vb.local(), db.local().get_token_metadata_ptr(), *cf, reason);
+            bool use_view_update_path = co_await with_scheduling_group(db.local().get_gossip_scheduling_group(), [&] {
+                return db::view::check_needs_view_update_path(vb.local(), db.local().get_token_metadata_ptr(), *cf, reason);
+            });
             //FIXME: for better estimations this should be transmitted from remote
             auto metadata = mutation_source_metadata{};
             auto& cs = cf->get_compaction_strategy();

--- a/test/cluster/test_streaming_deadlock.py
+++ b/test/cluster/test_streaming_deadlock.py
@@ -1,0 +1,51 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import asyncio
+import logging
+import pytest
+import time
+from cassandra.cluster import ConsistencyLevel
+
+from test.cluster.dtest.alternator_utils import random_string
+from test.cluster.util import new_test_keyspace
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_streaming_deadlock_removenode(request, manager: ManagerClient):
+    # Force removenode to exercise range_streamer and not repair.
+    # The bug is in the streaming, and when senders are on different nodes,
+    # and receivers are cross-located (B->C, C->B).
+    cfg = {
+        'rf_rack_valid_keyspaces': False,
+        'tablets_mode_for_new_keyspaces': 'disabled',
+        'maintenance_reader_concurrency_semaphore_count_limit': 1,
+        'enable_repair_based_node_ops': False,
+        'enable_cache': False, # Force IO
+    }
+
+    cmdline = [
+        '--logger-log-level', 'stream_session=trace',
+        '--logger-log-level', 'query_processor=trace'
+    ]
+
+    servers = await manager.servers_add(3, config=cfg, cmdline=cmdline)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int, v text);")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv AS SELECT * FROM {ks}.test "
+                            "WHERE c IS NOT NULL and pk IS NOT NULL PRIMARY KEY (c, pk)")
+
+        keys = range(10240)
+        val = random_string(10240)
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c, v) VALUES (?, ?, '{val}')")
+        await asyncio.gather(*[cql.run_async(stmt, [k, k]) for k in keys])
+
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.remove_node(servers[1].server_id, servers[0].server_id)


### PR DESCRIPTION
This issue happens with removenode, when RBNO is disabled, so range
streamer is used.

The deadlock happens in a scenario like this:
1. Start 3 nodes: {A, B, C}, RF=2
2. Node A is lost
3. removenode A
4. Both B and C gain ownership of ranges.
5. Streaming sessions are started with crossed directions: B->C, C->B

Readers created by sender side exhaust streaming semaphore on B and C.
Receiver side attempts to obtain a permit indirectly by calling
check_needs_view_update_path(), which reads local tables. That read is
blocked and times-out, causing streaming to fail. The streaming writer
is already using a tracking-only permit.

Even if we didn't deadlock, and the streaming semaphore was simply exhausted
by other receiving sessions (via tracking-only permit), the query may still time-out due to starvation. 

To avoid that, run the query under a different scheduling group, which
translates to the system semaphore instead of the maintenance
semaphore, to break the dependency. The gossip group was chosen
because it shouldn't be contended and this change should not interfere
with it much.

Fixes #24807
Fixes #24925