### PR TITLE
db/corrupt_data_handler: guard stop() against null _fragment_semaphore

### DIFF
--- a/db/corrupt_data_handler.cc
+++ b/db/corrupt_data_handler.cc
@@ -126,7 +126,9 @@ void system_table_corrupt_data_handler::unplug_system_keyspace() noexcept {
 
 future<> system_table_corrupt_data_handler::stop() noexcept {
     co_await _gate.close();
-    co_await _fragment_semaphore->stop();
+    if (_fragment_semaphore) {
+        co_await _fragment_semaphore->stop();
+    }
 }
 
 future<corrupt_data_handler::entry_id> nop_corrupt_data_handler::do_record_corrupt_clustering_row(const schema& s, const partition_key& pk,


### PR DESCRIPTION
If the server shuts down early (e.g., due to an invalid config parameter), `_fragment_semaphore` may not be initialized. In such cases, calling `stop()` on it leads to a segfault. Fix this by checking for null before invoking stop.

Although `corrupt_data_handler` was backported to 2025.1, this issue does not occur in 2025.2 and master. The recent versions include #23113, which changes how the system keyspace is stopped and PR #24492, which originally introduced `corrupt_data_handler`, builds on that change to ensure `_fragment_semaphore` is stopped only if it has been created.

Fixes #24920