### PR TITLE
[backport 2025.2]sstables_loader: Fix load-and-stream vs skip-cleanup check

### DIFF
--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -548,7 +548,7 @@ future<> sstables_loader::load_new_sstables(sstring ks_name, sstring cf_name,
         throw std::runtime_error("Skipping reshape is not possible when doing load-and-stream");
     }
     
-    if (!load_and_stream && skip_cleanup) {
+    if (load_and_stream && skip_cleanup) {
         throw std::runtime_error("Skipping cleanup is not possible when doing load-and-stream");
     }
 


### PR DESCRIPTION
The intention was to fail the REST API call in case --skip-cleanup is requested for --load-and-stream loading. The corresponding if expression is checking something else :( despite log message is correct.

Fixes: https://github.com/scylladb/scylladb/issues/24913

(cherry picked from commit f14e1c1a8a071d434bba28da3f16ba32b9a52a01)

