### PR TITLE
tablets: prevent accidental copy of tablets_map

### DIFF
--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -676,7 +676,6 @@ public:
     // Allow mutating a tablet_map
     // Uses the copy-modify-swap idiom.
     // If func throws, no changes are done to the tablet map.
-    void mutate_tablet_map(table_id, noncopyable_function<void(tablet_map&)> func);
     future<> mutate_tablet_map_async(table_id, noncopyable_function<future<>(tablet_map&)> func);
 
     future<> clear_gently();

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -449,16 +449,28 @@ class tablet_map {
 public:
     using tablet_container = utils::chunked_vector<tablet_info>;
 private:
+    using transitions_map = std::unordered_map<tablet_id, tablet_transition_info>;
     // The implementation assumes that _tablets.size() is a power of 2:
     //
     //   _tablets.size() == 1 << _log2_tablets
     //
     tablet_container _tablets;
     size_t _log2_tablets; // log_2(_tablets.size())
-    std::unordered_map<tablet_id, tablet_transition_info> _transitions;
+    transitions_map _transitions;
     resize_decision _resize_decision;
     tablet_task_info _resize_task_info;
     repair_scheduler_config _repair_scheduler_config;
+
+    // Internal constructor, used by clone() and clone_gently().
+    tablet_map(tablet_container tablets, size_t log2_tablets, transitions_map transitions,
+        resize_decision resize_decision, tablet_task_info resize_task_info, repair_scheduler_config repair_scheduler_config)
+        : _tablets(std::move(tablets))
+        , _log2_tablets(log2_tablets)
+        , _transitions(std::move(transitions))
+        , _resize_decision(resize_decision)
+        , _resize_task_info(std::move(resize_task_info))
+        , _repair_scheduler_config(std::move(repair_scheduler_config))
+    {}
 
     /// Returns the largest token owned by tablet_id when the tablet_count is `1 << log2_tablets`.
     dht::token get_last_token(tablet_id id, size_t log2_tablets) const;
@@ -471,6 +483,15 @@ public:
     ///
     /// \param tablet_count The desired tablets to allocate. Must be a power of two.
     explicit tablet_map(size_t tablet_count);
+
+    tablet_map(tablet_map&&) = default;
+    tablet_map(const tablet_map&) = delete;
+
+    tablet_map& operator=(tablet_map&&) = default;
+    tablet_map& operator=(const tablet_map&) = delete;
+
+    tablet_map clone() const;
+    future<tablet_map> clone_gently() const;
 
     /// Returns tablet_id of a tablet which owns a given token.
     tablet_id get_tablet_id(token) const;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -957,10 +957,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             // the base table will coordinate the transition for the entire group.
                             continue;
                         }
-                        locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
+                        locator::tablet_map old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
-                        new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
+                        new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, std::move(old_tablets));
                     } catch (const std::exception& e) {
                         error = e.what();
                         rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"

--- a/test/boost/locator_topology_test.cc
+++ b/test/boost/locator_topology_test.cc
@@ -287,7 +287,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_sketch) {
         node3_shards[1]++;
 
         auto table = table_id(utils::make_random_uuid());
-        tab_meta.set_tablet_map(table, tmap);
+        tab_meta.set_tablet_map(table, std::move(tmap));
         tm.set_tablets(std::move(tab_meta));
         return make_ready_future<>();
     }).get();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -209,7 +209,7 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
             verify_tablet_metadata_persistence(e, tm, ts);
 
             // Increase RF of table2
-            tm.mutate_tablet_map(table2, [&] (tablet_map& tmap) {
+            tm.mutate_tablet_map_async(table2, [&] (tablet_map& tmap) {
                 auto tb = tmap.first_tablet();
                 tb = *tmap.next_tablet(tb);
 
@@ -234,7 +234,8 @@ SEASTAR_TEST_CASE(test_tablet_metadata_persistence) {
                     tablet_replica {h1, 4},
                     session_id(utils::UUID_gen::get_time_UUID())
                 });
-            });
+                return make_ready_future();
+            }).get();
 
             verify_tablet_metadata_persistence(e, tm, ts);
 
@@ -1440,11 +1441,12 @@ SEASTAR_THREAD_TEST_CASE(test_token_ownership_splitting) {
 }
 
 static
-void apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
+future<> apply_resize_plan(token_metadata& tm, const migration_plan& plan) {
     for (auto [table_id, resize_decision] : plan.resize_plan().resize) {
-        tm.tablets().mutate_tablet_map(table_id, [&] (tablet_map& tmap) {
+        co_await tm.tablets().mutate_tablet_map_async(table_id, [&] (tablet_map& tmap) {
             resize_decision.sequence_number = tmap.resize_decision().sequence_number + 1;
             tmap.set_resize_decision(resize_decision);
+            return make_ready_future();
         });
     }
 }
@@ -1485,28 +1487,30 @@ future<> handle_resize_finalize(cql_test_env& e, group0_guard& guard, const migr
 
 // Reflects the plan in a given token metadata as if the migrations were fully executed.
 static
-void apply_plan(token_metadata& tm, const migration_plan& plan) {
+future<> apply_plan(token_metadata& tm, const migration_plan& plan) {
     for (auto&& mig : plan.migrations()) {
-        tm.tablets().mutate_tablet_map(mig.tablet.table, [&] (tablet_map& tmap) {
+        co_await tm.tablets().mutate_tablet_map_async(mig.tablet.table, [&] (tablet_map& tmap) {
             auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
             testlog.trace("Replacing tablet {} replica from {} to {}", mig.tablet.tablet, mig.src, mig.dst);
             tinfo.replicas = replace_replica(tinfo.replicas, mig.src, mig.dst);
             tmap.set_tablet(mig.tablet.tablet, tinfo);
+            return make_ready_future();
         });
     }
-    apply_resize_plan(tm, plan);
+    co_await apply_resize_plan(tm, plan);
 }
 
 // Reflects the plan in a given token metadata as if the migrations were started but not yet executed.
 static
-void apply_plan_as_in_progress(token_metadata& tm, const migration_plan& plan) {
+future<> apply_plan_as_in_progress(token_metadata& tm, const migration_plan& plan) {
     for (auto&& mig : plan.migrations()) {
-        tm.tablets().mutate_tablet_map(mig.tablet.table, [&] (tablet_map& tmap) {
+        co_await tm.tablets().mutate_tablet_map_async(mig.tablet.table, [&] (tablet_map& tmap) {
             auto tinfo = tmap.get_tablet_info(mig.tablet.tablet);
             tmap.set_tablet_transition_info(mig.tablet.tablet, migration_to_transition_info(tinfo, mig));
+            return make_ready_future();
         });
     }
-    apply_resize_plan(tm, plan);
+    co_await apply_resize_plan(tm, plan);
 }
 
 static
@@ -1548,8 +1552,7 @@ void do_rebalance_tablets(cql_test_env& e,
             return;
         }
         stm.mutate_token_metadata([&] (token_metadata& tm) {
-            apply_plan(tm, plan);
-            return make_ready_future<>();
+            return apply_plan(tm, plan);
         }).get();
 
         if (auto_split && load_stats) {
@@ -1612,8 +1615,7 @@ void rebalance_tablets_as_in_progress(tablet_allocator& talloc, shared_token_met
             break;
         }
         stm.mutate_token_metadata([&] (token_metadata& tm) {
-            apply_plan_as_in_progress(tm, plan);
-            return make_ready_future<>();
+            return apply_plan_as_in_progress(tm, plan);
         }).get();
     }
 }
@@ -1621,18 +1623,18 @@ void rebalance_tablets_as_in_progress(tablet_allocator& talloc, shared_token_met
 // Completes any in progress tablet migrations.
 static
 void execute_transitions(shared_token_metadata& stm) {
-    stm.mutate_token_metadata([&] (token_metadata& tm) {
+    stm.mutate_token_metadata([&] (token_metadata& tm) -> future<> {
         for (auto&& [table, tables] : tm.tablets().all_table_groups()) {
-            tm.tablets().mutate_tablet_map(table, [&] (tablet_map& tmap) {
+            co_await tm.tablets().mutate_tablet_map_async(table, [&] (tablet_map& tmap) {
                 for (auto&& [tablet, trinfo]: tmap.transitions()) {
                     auto ti = tmap.get_tablet_info(tablet);
                     ti.replicas = trinfo.next;
                     tmap.set_tablet(tablet, ti);
                 }
                 tmap.clear_transitions();
+                return make_ready_future();
             });
         }
-        return make_ready_future<>();
     }).get();
 }
 


### PR DESCRIPTION
As they are wasteful in many cases, it is better
to move the tablet_map if possible, or clone
it gently in an async fiber.

Add clone() and clone_gently() methods to
allow explicit copies.

* minor optimization, no backport needed