### PR TITLE
encryption: remove default case from component_type switch

### DIFF
--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -823,7 +823,16 @@ public:
         case sstables::component_type::TemporaryTOC:
         case sstables::component_type::TOC:
             co_return sink;
-        default:
+        case sstables::component_type::Data:
+        case sstables::component_type::Index:
+        case sstables::component_type::CompressionInfo:
+        case sstables::component_type::Summary:
+        case sstables::component_type::Digest:
+        case sstables::component_type::CRC:
+        case sstables::component_type::Filter:
+        case sstables::component_type::Statistics:
+        case sstables::component_type::TemporaryStatistics:
+        case sstables::component_type::Unknown:
             break;
         }
         co_await wrap_writeonly(sst, type, [&sink](shared_ptr<symmetric_key> k) { 


### PR DESCRIPTION
Do not use default, instead list all fall-through components explicitely, so if we add a new one, the developer doing that will be forced to consider what to do here.

Eliminate the `default` case from the switch in
`encryption_file_io_extension::wrap_sink`, and explicitly handle all `component_type` values within the switch statement.

fixes: https://github.com/scylladb/scylladb/issues/23724

No backport is needed since it does not introduce any new functionality