### PR TITLE
s3_client: parse multipart response XML defensively

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -711,6 +711,14 @@ public:
 };
 
 sstring parse_multipart_upload_id(sstring& body) {
+    auto get_node_safe = []<typename T>(const T* node, const std::string_view node_name) {
+        auto child = node->first_node(node_name.data());
+        if (!child) {
+            throw std::runtime_error(seastar::format("'{}' node is missing in InitiateMultipartUploadResult response", node_name));
+        }
+        return child;
+    };
+
     auto doc = std::make_unique<rapidxml::xml_document<>>();
     try {
         doc->parse<0>(body.data());
@@ -720,8 +728,8 @@ sstring parse_multipart_upload_id(sstring& body) {
         // and handle the error the way it prefers
         return "";
     }
-    auto root_node = doc->first_node("InitiateMultipartUploadResult");
-    auto uploadid_node = root_node->first_node("UploadId");
+    auto root_node = get_node_safe(doc.get(), "InitiateMultipartUploadResult");
+    auto uploadid_node = get_node_safe(root_node, "UploadId");
     return uploadid_node->value();
 }
 


### PR DESCRIPTION
Ensure robust handling of XML responses when initiating multipart uploads. Check for the existence of required nodes before access, and throw an exception if the XML is empty or malformed.

Fixes: https://github.com/scylladb/scylladb/issues/25009

Backport to 2025.2 and  2025.3 to prevent these crashes in case anyone runs tests using these versions