### PR TITLE
test: Use in-memory SQLite for PyKMIP server

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -344,8 +344,8 @@ auth_suite=TLS1.2
 policy_path={}
 enable_tls_client_auth=False
 logging_level=DEBUG
-database_path={}/pykmip.db
-        )foo", info.cert, info.key, info.ca, tmp.path().string(), tmp.path().string());
+database_path=:memory:
+        )foo", info.cert, info.key, info.ca, tmp.path().string());
 
         auto cfgfile = fmt::format("{}/pykmip.conf", tmp.path().string());
         auto log = fmt::format("{}/pykmip.log", tmp.path().string());


### PR DESCRIPTION
The PyKMIP server uses an SQLite database to store artifacts such as encryption keys. By default, SQLite performs a full journal and data flush to disk on every CREATE TABLE operation. Each operation triggers three fdatasync(2) calls. If we multiply this by 16, that is the number of tables created by the server, we get a significant number of file syncs, which can last for several seconds on slow machines.

This behavior has led to CI stability issues from KMIP unit tests where the server failed to complete its schema creation within the 20-second timeout (observed on spider9 and spider11).

Fix this by configuring the server to use an in-memory SQLite.

Fixes #24842.

Improves CI stability, backport is needed.