### PR TITLE
sstables: put index_reader behind a virtual interface

### DIFF
--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -26,7 +26,6 @@
 
 namespace sstables {
 
-using use_caching = bool_class<struct use_caching_tag>;
 using promoted_index_block_position_view = std::variant<composite_view, position_in_partition_view>;
 using promoted_index_block_position = std::variant<composite, position_in_partition>;
 

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -891,6 +891,22 @@ public:
         return partition_data_ready(_lower_bound);
     }
 
+    // Advances some internals lower bound (the clustered cursor),
+    // in order to warm up some caches.
+    //
+    // Does not move the lower bound, but counts as a position-changing
+    // call for the "must be called for non-decreasing positions" conditions.
+    //
+    // Must be called only after advanced to some partition and !eof().
+    // Must be called for non-decreasing positions.
+    future<> prefetch_lower_bound(position_in_partition_view pos) {
+        clustered_index_cursor *cur = current_clustered_cursor();
+        if (cur) {
+            return cur->advance_to(pos).discard_result();
+        }
+        return make_ready_future<>();
+    }
+
     // Forwards the cursor to the given position in the current partition.
     //
     // Note that the index within partition, unlike the partition index, doesn't cover all keys.

--- a/sstables/mx/partition_reversing_data_source.cc
+++ b/sstables/mx/partition_reversing_data_source.cc
@@ -365,7 +365,7 @@ static temporary_buffer<char> end_of_partition() {
 class partition_reversing_data_source_impl final : public data_source_impl {
     const schema& _schema;
     shared_sstable _sst;
-    index_reader& _ir;
+    abstract_index_reader& _ir;
     reader_permit _permit;
     tracing::trace_state_ptr _trace_state;
     std::optional<partition_header_context> _partition_header_context;
@@ -453,7 +453,7 @@ private:
 public:
     partition_reversing_data_source_impl(const schema& s,
             shared_sstable sst,
-            index_reader& ir,
+            abstract_index_reader& ir,
             uint64_t partition_start,
             size_t partition_len,
             reader_permit permit,
@@ -603,7 +603,7 @@ public:
     }
 };
 
-partition_reversing_data_source make_partition_reversing_data_source(const schema& s, shared_sstable sst, index_reader& ir, uint64_t pos, size_t len,
+partition_reversing_data_source make_partition_reversing_data_source(const schema& s, shared_sstable sst, abstract_index_reader& ir, uint64_t pos, size_t len,
                                                           reader_permit permit, tracing::trace_state_ptr trace_state) {
     auto source_impl = std::make_unique<partition_reversing_data_source_impl>(
             s, std::move(sst), ir, pos, len, std::move(permit), trace_state);

--- a/sstables/mx/partition_reversing_data_source.hh
+++ b/sstables/mx/partition_reversing_data_source.hh
@@ -44,7 +44,7 @@ struct partition_reversing_data_source {
 //
 // The source must be closed before destruction unless `get()` was never called.
 partition_reversing_data_source make_partition_reversing_data_source(
-    const schema& s, shared_sstable sst, index_reader& ir, uint64_t pos, size_t len,
+    const schema& s, shared_sstable sst, abstract_index_reader& ir, uint64_t pos, size_t len,
     reader_permit permit, tracing::trace_state_ptr trace_state);
 
 }

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1525,10 +1525,7 @@ private:
                 // Even if upper bound is not near, the binary search will populate the cache with blocks
                 // which can be used to narrow down the data file range somewhat.
                 position_in_partition_view lb = get_slice_lower_bound(*_schema, _slice, key);
-                clustered_index_cursor *cur = _index_reader->current_clustered_cursor();
-                if (cur) {
-                    co_await cur->advance_to(lb);
-                }
+                co_await _index_reader->prefetch_lower_bound(lb);
             }
 
             position_in_partition_view pos = get_slice_upper_bound(*_schema, _slice, key);

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -1259,7 +1259,7 @@ class mx_sstable_mutation_reader : public mp_row_consumer_reader_mx {
     bool _will_likely_slice = false;
     bool _read_enabled = true;
     std::unique_ptr<DataConsumeRowsContext> _context;
-    std::unique_ptr<index_reader> _index_reader;
+    std::unique_ptr<abstract_index_reader> _index_reader;
     // We avoid unnecessary lookup for single partition reads thanks to this flag
     bool _single_partition_read = false;
     const dht::partition_range& _pr;
@@ -1324,7 +1324,7 @@ private:
         return (!slice.default_row_ranges().empty() && !slice.default_row_ranges()[0].is_full())
                || slice.get_specific_ranges();
     }
-    index_reader& get_index_reader() {
+    abstract_index_reader& get_index_reader() {
         if (!_index_reader) {
             auto caching = use_caching(global_cache_index_pages && !_slice.options.contains(query::partition_slice::option::bypass_cache));
             _index_reader = std::make_unique<index_reader>(_sst, _consumer.permit(),
@@ -1470,7 +1470,7 @@ private:
                 });
             } else {
                 return get_index_reader().advance_to(pos).then([this] {
-                    index_reader& idx = *_index_reader;
+                    abstract_index_reader& idx = *_index_reader;
                     auto index_position = idx.data_file_positions();
                     if (index_position.start <= _context->position()) {
                         return make_ready_future<>();

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -2104,7 +2104,7 @@ future<uint64_t> validate(
     validating_consumer consumer(schema, permit, sstable, std::move(error_handler));
     auto context = data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer, integrity_check::yes);
 
-    auto idx_reader = std::make_unique<index_reader>(sstable, permit, tracing::trace_state_ptr{}, sstables::use_caching::no, false);
+    auto idx_reader = sstable->make_index_reader(permit, tracing::trace_state_ptr{}, sstables::use_caching::no, false);
     auto big_index_reader = dynamic_cast<index_reader*>(idx_reader.get());
 
     try {

--- a/sstables/sstable_mutation_reader.hh
+++ b/sstables/sstable_mutation_reader.hh
@@ -135,7 +135,7 @@ struct reversed_context {
 // See `sstables::mx::make_partition_reversing_data_source` for documentation.
 template <typename DataConsumeRowsContext>
 inline reversed_context<DataConsumeRowsContext> data_consume_reversed_partition(
-        const schema& s, shared_sstable sst, index_reader& ir,
+        const schema& s, shared_sstable sst, abstract_index_reader& ir,
         typename DataConsumeRowsContext::consumer& consumer, sstable::disk_read_range toread) {
     auto reversing_data_source = sstables::mx::make_partition_reversing_data_source(
             s, sst, ir, toread.start, toread.end - toread.start,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3331,6 +3331,14 @@ gc_clock::time_point sstable::get_gc_before_for_fully_expire(const gc_clock::tim
     return res.knows_entire_range ? res.min_gc_before : gc_clock::time_point::min();
 }
 
+std::unique_ptr<abstract_index_reader> sstable::make_index_reader(
+    reader_permit permit,
+    tracing::trace_state_ptr trace_state,
+    use_caching caching,
+    bool single_partition_read) {
+    return std::make_unique<index_reader>(shared_from_this(), std::move(permit), std::move(trace_state), caching, single_partition_read);
+}
+
 // Returns error code, 0 is success
 static future<int> remove_dir(fs::path dir, bool recursive) {
     std::exception_ptr ex;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -63,6 +63,7 @@ class corrupt_data_handler;
 
 namespace sstables {
 
+struct abstract_index_reader;
 class sstable_directory;
 extern thread_local utils::updateable_value<bool> global_cache_index_pages;
 
@@ -1040,6 +1041,12 @@ public:
             return sst1.total_memory_reclaimed() < sst2.total_memory_reclaimed();
         }
     };
+
+    std::unique_ptr<abstract_index_reader> make_index_reader(
+        reader_permit permit,
+        tracing::trace_state_ptr trace_state = {},
+        use_caching caching = use_caching::yes,
+        bool single_partition_read = false);
 
     // Allow the test cases from sstable_test.cc to test private methods. We use
     // a placeholder to avoid cluttering this class too much. The sstable_test class

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -38,6 +38,8 @@ inline bytes_view to_bytes_view(const temporary_buffer<char>& b) {
 
 namespace sstables {
 
+using use_caching = bool_class<struct use_caching_tag>;
+
 template<typename T>
 concept Writer =
     requires(T& wr, const char* data, size_t size) {

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -4528,8 +4528,8 @@ static sstring get_read_index_test_path(sstring table_name) {
     return format("test/resource/sstables/3.x/uncompressed/read_{}", table_name);
 }
 
-static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit));
+static std::unique_ptr<abstract_index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
+    return sst->make_index_reader(std::move(permit));
 }
 
 shared_sstable make_test_sstable(test_env& env, schema_ptr schema, const sstring& table_name) {

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -2205,8 +2205,8 @@ SEASTAR_TEST_CASE(test_wrong_counter_shard_order) {
       });
 }
 
-static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit));
+static std::unique_ptr<abstract_index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
+    return sst->make_index_reader(std::move(permit));
 }
 
 SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -789,8 +789,8 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
     });
 }
 
-static std::unique_ptr<index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
-    return std::make_unique<index_reader>(sst, std::move(permit));
+static std::unique_ptr<abstract_index_reader> get_index_reader(shared_sstable sst, reader_permit permit) {
+    return sst->make_index_reader(std::move(permit));
 }
 
 SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {


### PR DESCRIPTION
This is a refactoring patch in preparation for BTI indexes. It contains no functional changes (or at least it's not intended to).

In this patch, we modify the sstable readers to use index readers through a new virtual `abstract_index_readers` interface.
Later, we will add BTI indexes which will also implement this interface.

This interface contains the methods of `index_reader` which are needed by sstable readers, and leaves out all other methods, such as `current_clustered_cursor`.

Not all methods of this interface will be implementable by a trie-based index later. For example, a trie-based index can't provide a reliable `get_partition_key()`, because — unlike the current index — it only stores partition keys for partitions which have a row index. So the interface will have to be further restricted later. We don't do that in this patch because that will require changes to sstable reader logic, and this patch is supposed to only include cosmetic changes.

No backports needed, this is a preparation for new functionality.