### PR TITLE
locator/token_metadata.cc: use utils::chunked_vector to store `_sorted_tokens`

### DIFF
--- a/dht/token.cc
+++ b/dht/token.cc
@@ -78,7 +78,7 @@ static float ratio_helper(int64_t a, int64_t b) {
 }
 
 std::map<token, float>
-token::describe_ownership(const std::vector<token>& sorted_tokens) {
+token::describe_ownership(const utils::chunked_vector<token>& sorted_tokens) {
     std::map<token, float> ownerships;
     auto i = sorted_tokens.begin();
 

--- a/dht/token.hh
+++ b/dht/token.hh
@@ -10,6 +10,7 @@
 
 #include "bytes_fwd.hh"
 #include "types/types.hh"
+#include "utils/chunked_vector.hh"
 
 #include <limits>
 #include <seastar/net/byteorder.hh>
@@ -194,7 +195,7 @@ public:
      * @param sortedtokens a sorted List of tokens
      * @return the mapping from 'token' to 'percentage of the ring owned by that token'.
      */
-    static std::map<token, float> describe_ownership(const std::vector<token>& sorted_tokens);
+    static std::map<token, float> describe_ownership(const utils::chunked_vector<token>& sorted_tokens);
 
     static data_type get_token_validator();
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -12,6 +12,7 @@
 #include "simple_strategy.hh"
 #include "exceptions/exceptions.hh"
 #include "utils/assert.hh"
+#include "utils/chunked_vector.hh"
 #include "utils/class_registrator.hh"
 #include <boost/algorithm/string.hpp>
 
@@ -31,7 +32,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
 }
 
 future<host_id_set> simple_strategy::calculate_natural_endpoints(const token& t, const token_metadata& tm) const {
-    const std::vector<token>& tokens = tm.sorted_tokens();
+    const utils::chunked_vector<token>& tokens = tm.sorted_tokens();
 
     if (tokens.empty()) {
         co_return host_id_set{};

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -544,8 +544,8 @@ std::optional<tablet_replica> tablet_map::maybe_get_selected_replica(tablet_id i
     });
 }
 
-future<std::vector<token>> tablet_map::get_sorted_tokens() const {
-    std::vector<token> tokens;
+future<utils::chunked_vector<token>> tablet_map::get_sorted_tokens() const {
+    utils::chunked_vector<token> tokens;
     tokens.reserve(tablet_count());
 
     for (auto id : tablet_ids()) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -511,7 +511,7 @@ public:
     std::optional<tablet_replica> maybe_get_selected_replica(tablet_id id, const topology& topo, const tablet_task_info& tablet_task_info) const;
 
     /// Returns a vector of sorted last tokens for tablets.
-    future<std::vector<token>> get_sorted_tokens() const;
+    future<utils::chunked_vector<token>> get_sorted_tokens() const;
 
     /// Returns the id of the first tablet.
     tablet_id first_tablet() const {

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -23,6 +23,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/sharded.hh>
+#include "utils/chunked_vector.hh"
 #include "utils/phased_barrier.hh"
 #include "service/topology_state_machine.hh"
 
@@ -158,7 +159,7 @@ public:
         return tmp;
     }
 private:
-    std::vector<token>::const_iterator _cur_it;
+    utils::chunked_vector<token>::const_iterator _cur_it;
     size_t _remaining = 0;
     const token_metadata_impl* _token_metadata = nullptr;
 
@@ -184,7 +185,7 @@ public:
     token_metadata(token_metadata&&) noexcept; // Can't use "= default;" - hits some static_assert in unique_ptr
     token_metadata& operator=(token_metadata&&) noexcept;
     ~token_metadata();
-    const std::vector<token>& sorted_tokens() const;
+    const utils::chunked_vector<token>& sorted_tokens() const;
     const tablet_metadata& tablets() const;
     tablet_metadata& tablets();
     void set_tablets(tablet_metadata);
@@ -365,11 +366,11 @@ private:
 
 struct topology_change_info {
     lw_shared_ptr<token_metadata> target_token_metadata;
-    std::vector<dht::token> all_tokens;
+    utils::chunked_vector<dht::token> all_tokens;
     token_metadata::read_new_t read_new;
 
     topology_change_info(lw_shared_ptr<token_metadata> target_token_metadata_,
-        std::vector<dht::token> all_tokens_,
+        utils::chunked_vector<dht::token> all_tokens_,
         token_metadata::read_new_t read_new_);
     future<> clear_gently();
 };

--- a/locator/util.cc
+++ b/locator/util.cc
@@ -8,6 +8,7 @@
 #include "locator/util.hh"
 #include "replica/database.hh"
 #include "gms/gossiper.hh"
+#include "utils/chunked_vector.hh"
 #include <seastar/coroutine/maybe_yield.hh>
 
 namespace locator {
@@ -28,7 +29,7 @@ construct_range_to_endpoint_map(
 
 // Caller is responsible to hold token_metadata valid until the returned future is resolved
 static future<dht::token_range_vector>
-get_all_ranges(const std::vector<token>& sorted_tokens) {
+get_all_ranges(const utils::chunked_vector<token>& sorted_tokens) {
     if (sorted_tokens.empty())
         co_return dht::token_range_vector();
     int size = sorted_tokens.size();
@@ -49,14 +50,14 @@ get_all_ranges(const std::vector<token>& sorted_tokens) {
 // Caller is responsible to hold token_metadata valid until the returned future is resolved
 future<std::unordered_map<dht::token_range, host_id_vector_replica_set>>
 get_range_to_address_map(locator::effective_replication_map_ptr erm,
-        const std::vector<token>& sorted_tokens) {
+        const utils::chunked_vector<token>& sorted_tokens) {
     co_return co_await construct_range_to_endpoint_map(erm, co_await get_all_ranges(sorted_tokens));
 }
 
 // Caller is responsible to hold token_metadata valid until the returned future is resolved
-static future<std::vector<token>>
+static future<utils::chunked_vector<token>>
 get_tokens_in_local_dc(const locator::token_metadata& tm) {
-    std::vector<token> filtered_tokens;
+    utils::chunked_vector<token> filtered_tokens;
     auto local_dc_filter = tm.get_topology().get_local_dc_filter();
     for (auto token : tm.sorted_tokens()) {
         auto endpoint = tm.get_endpoint(token);

--- a/locator/util.hh
+++ b/locator/util.hh
@@ -25,5 +25,5 @@ namespace gms {
 namespace locator {
     future<utils::chunked_vector<dht::token_range_endpoints>> describe_ring(const replica::database& db, const gms::gossiper& gossiper, const sstring& keyspace, bool include_only_local_dc = false);
     future<std::unordered_map<dht::token_range, host_id_vector_replica_set>> get_range_to_address_map(
-        locator::effective_replication_map_ptr erm, const std::vector<token>& sorted_tokens);
+        locator::effective_replication_map_ptr erm, const utils::chunked_vector<token>& sorted_tokens);
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -10,6 +10,7 @@
  */
 
 #include "storage_service.hh"
+#include "utils/chunked_vector.hh"
 #include "utils/disk_space_monitor.hh"
 #include "compaction/task_manager_module.hh"
 #include "gc_clock.hh"
@@ -3549,9 +3550,9 @@ future<std::map<gms::inet_address, float>> storage_service::effective_ownership(
         //
         // The call for get_range_for_endpoint is done once per endpoint
         const auto& tm = *erm->get_token_metadata_ptr();
-        const auto tokens = co_await std::invoke([&]() -> future<std::vector<token>> {
+        const auto tokens = co_await std::invoke([&]() -> future<utils::chunked_vector<token>> {
             if (!erm->get_replication_strategy().uses_tablets()) {
-                return make_ready_future<std::vector<token>>(tm.sorted_tokens());
+                return make_ready_future<utils::chunked_vector<token>>(tm.sorted_tokens());
             } else {
                 auto& cf = ss._db.local().find_column_family(keyspace_name, table_name);
                 const auto& tablets = tm.tablets().get_tablet_map(cf.schema()->id());


### PR DESCRIPTION
The `token_metadata_impl` stores the sorted tokens in an `std::vector`. With a large number of nodes, the size of this vector can grow quickly, and updating it might lead to oversized allocations.

This commit changes `_sorted_tokens` to a `chunked_vector` to avoid such issues. It also updates all related code to use `chunked_vector` instead of `std::vector`.

Fixes #24876

Output for `scylla perf-simple-query --smp=1 --duration=60` with number of tokens = `8448` :

Results with `std::vector` (i.e. without this PR) :
```
throughput:
	mean=   112183.50 standard-deviation=1770.85
	median= 112371.43 median-absolute-deviation=760.43
	maximum=114752.04 minimum=102289.51
instructions_per_op:
	mean=   49347.26 standard-deviation=63.61
	median= 49340.33 median-absolute-deviation=13.30
	maximum=49812.13 minimum=49297.54
cpu_cycles_per_op:
	mean=   20410.07 standard-deviation=146.28
	median= 20416.61 median-absolute-deviation=61.35
	maximum=21059.03 minimum=20121.46
```

Results with `utils::chunked_vector` (i.e. with this PR) :
```
throughput:
	mean=   112464.69 standard-deviation=1522.00
	median= 112734.25 median-absolute-deviation=870.83
	maximum=114471.77 minimum=103895.24
instructions_per_op:
	mean=   49418.04 standard-deviation=60.17
	median= 49410.39 median-absolute-deviation=15.99
	maximum=49853.48 minimum=49373.71
cpu_cycles_per_op:
	mean=   20353.32 standard-deviation=133.05
	median= 20352.83 median-absolute-deviation=68.93
	maximum=21019.85 minimum=20168.05
```

The results show that switching to `utils::chunked_vector` slightly increased the `instructions_per_op`(~70) but overall, the performance impact is minimal.

Improvement for large clusters. No need to backport.