### PR TITLE
db/hints: Improve logging

### DIFF
--- a/db/hints/internal/hint_sender.cc
+++ b/db/hints/internal/hint_sender.cc
@@ -175,14 +175,14 @@ future<> hint_sender::stop(drain should_drain) noexcept {
             //
             // The next call for send_hints_maybe() will send the last hints to the current end point and when it is
             // done there is going to be no more pending hints and the corresponding hints directory may be removed.
-            manager_logger.trace("Draining for {}: start", end_point_key());
+            manager_logger.info("Draining for {}: start", end_point_key());
             set_draining();
             send_hints_maybe();
             _ep_manager.flush_current_hints().handle_exception([] (auto e) {
                 manager_logger.error("Failed to flush pending hints: {}. Ignoring...", e);
             }).get();
             send_hints_maybe();
-            manager_logger.trace("Draining for {}: end", end_point_key());
+            manager_logger.info("Draining for {}: end", end_point_key());
         }
         // TODO: Change this log to match the class name, but first make sure no test
         //       relies on the old one.

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -635,7 +635,7 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept 
         co_return;
     }
 
-    manager_logger.trace("Draining starts for {}", host_id);
+    manager_logger.info("Draining starts for {}", host_id);
 
     const auto holder = seastar::gate::holder{_draining_eps_gate};
     // As long as we hold on to this lock, no migration of hinted handoff to host IDs
@@ -661,7 +661,7 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept 
 
             return ep_man.with_file_update_mutex([&ep_man] -> future<> {
                 return remove_file(ep_man.hints_dir().native()).then([&ep_man] {
-                    manager_logger.debug("Removed hint directory for {}", ep_man.end_point_key());
+                    manager_logger.info("Removed hint directory for {}", ep_man.end_point_key());
                 });
             });
         });
@@ -722,7 +722,7 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept 
         manager_logger.error("Exception when draining {}: {}", host_id, eptr);
     }
 
-    manager_logger.trace("drain_for: finished draining {}", host_id);
+    manager_logger.info("drain_for: finished draining {}", host_id);
 }
 
 void manager::update_backlog(size_t backlog, size_t max_backlog) {

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -539,6 +539,7 @@ future<> manager::change_host_filter(host_filter filter) {
                 "change_host_filter: cannot change the configuration because hints all hints were drained"});
     }
 
+    manager_logger.info("Initiating changing the host filter");
     manager_logger.debug("change_host_filter: changing from {} to {}", _host_filter, filter);
 
     // Change the host_filter now and save the old one so that we can
@@ -611,11 +612,19 @@ future<> manager::change_host_filter(host_filter filter) {
             });
         });
     } catch (...) {
+        const sstring exception_message = eptr
+                ? seastar::format("{} + {}", eptr, std::current_exception())
+                : seastar::format("{}", std::current_exception);
+
+        manager_logger.warn("Changing the host filter has failed: {}", exception_message);
+
         if (eptr) {
             std::throw_with_nested(eptr);
         }
         throw;
     }
+
+    manager_logger.info("The host filter has been changed successfully");
 }
 
 bool manager::check_dc_for(endpoint_id ep) const noexcept {


### PR DESCRIPTION
We improve logging in critical functions in hinted handoff
to capture more information about the behavior of the module.
That should help us in debugging sessions.

The logs should only be printed during more important events
and so they should not clog the log files.

Backport: not necessary.