### PR TITLE
topology coordinator: drop no longer needed token metadata barrier

### DIFF
--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2079,32 +2079,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         rtlogger.info("entered `{}` transition state", *tstate);
         switch (*tstate) {
             case topology::transition_state::join_group0: {
-                    auto node = get_node_to_work_on(std::move(guard));
-                    if (node.rs->state == node_state::replacing) {
-                        // Make sure all nodes are no longer trying to write to a node being replaced. This is important
-                        // if the new node have the same IP, so that old write will not go to the new node by mistake after this point.
-                        // It is important to do so before the call to finish_accepting_node() below since after this call the new node becomes
-                        // a full member of the cluster and it starts loading an initial snapshot. Since snapshot loading is not atomic any queries
-                        // that are done in parallel may see a partial state.
-                        try {
-                            node = retake_node(co_await global_token_metadata_barrier(std::move(node.guard), get_excluded_nodes(node)), node.id);
-                        } catch (term_changed_error&) {
-                            throw;
-                        } catch (group0_concurrent_modification&) {
-                            throw;
-                        } catch (raft::request_aborted&) {
-                            throw;
-                        } catch (...) {
-                            rtlogger.error("transition_state::join_group0, "
-                                            "global_token_metadata_barrier failed, error {}",
-                                            std::current_exception());
-                            _rollback = fmt::format("global_token_metadata_barrier failed in join_group0 state {}", std::current_exception());
-                            break;
-                        }
-                    }
-
-                bool accepted;
-                std::tie(node, accepted) = co_await finish_accepting_node(std::move(node));
+                auto [node, accepted] = co_await finish_accepting_node(get_node_to_work_on(std::move(guard)));
 
                 // If responding to the joining node failed, move the node to the left state and
                 // stop the topology transition.


### PR DESCRIPTION
Currently we do token metadata barrier before accepting a replacing node. It was needed for the "replace with the same IP" case to make sure old request will not contact new node by mistake. But now since we address nodes by id this is no longer possible since old requests will use old id and will be rejected.
