### PR TITLE
test/cqlpy: in README.md, remind users of run-cassandra to set NODETOOL

### DIFF
--- a/test/cqlpy/README.md
+++ b/test/cqlpy/README.md
@@ -264,6 +264,7 @@ as bin/nodetool and other things), which you will ask run-cassandra to use:
 
 ```
 export CASSANDRA=/tmp/apache-cassandra-4.1.4/bin/cassandra
+export NODETOOL=/tmp/apache-cassandra-4.1.4/bin/nodetool
 test/cqlpy/run-cassandra testfile.py::testfunc
 ```
 
@@ -295,5 +296,6 @@ with run-cassandra:
 
 ```
 export CASSANDRA=/tmp/cassandra/bin/cassandra
+export NODETOOL=/tmp/cassandra/bin/nodetool
 test/cqlpy/run-cassandra testfile.py::testfunc
 ```


### PR DESCRIPTION
test/cqlpy/README.md explains how to run the cqlpy tests against Cassandra, and mentions that if you don't have "nodetool" in your path you need to set the NODETOOL variable. However, when giving a simple example how to use the run-cassandra script, we forgot to remind the user to set NODETOOL in addition to CASSANDRA, causing confusion for users who didn't know why tests were failing.

So this patch fixes the section in test/cqlpy/README.md with the run-cassandra example to also set the NODETOOL environment variable, not just CASSANDRA.

This is just a documentation improvement for developers, no need to backport.