### PR TITLE
rest_api: add endpoint which drops all quarantined sstables

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3177,6 +3177,38 @@
                ]
             }
          ]
+      },
+      {
+         "path":"/storage_service/drop_quarantined_sstables",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Drops all quarantined sstables in all keyspaces or specified keyspace and tables",
+               "type":"void",
+               "nickname":"drop_quarantined_sstables",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"keyspace",
+                     "description":"The keyspace name to drop quarantined sstables from.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  },
+                  {
+                     "name":"tables",
+                     "description":"Comma-separated table names to drop quarantined sstables from.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                  }
+               ]
+            }
+         ]
       }
    ],
    "models":{

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1822,6 +1822,36 @@ rest_get_schema_versions(sharded<service::storage_service>& ss, std::unique_ptr<
         });
 }
 
+static
+future<json::json_return_type>
+rest_drop_quarantined_sstables(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    auto keyspace = req->get_query_param("keyspace");
+    try {
+        if (!keyspace.empty()) {
+            keyspace = validate_keyspace(ctx, keyspace);
+            auto it = req->query_parameters.find("tables");
+            auto table_infos = parse_table_infos(keyspace, ctx, it != req->query_parameters.end() ? it->second : "");
+
+            co_await ctx.db.invoke_on_all([&table_infos](replica::database& db) -> future<> {
+                return parallel_for_each(table_infos, [&db](const auto& table) -> future<> {
+                    const auto& [table_name, table_id] = table;
+                    return db.find_column_family(table_id).drop_quarantined_sstables();
+                });
+            });
+        } else {
+            co_await ctx.db.invoke_on_all([](replica::database& db) -> future<> {
+                return db.get_tables_metadata().parallel_for_each_table([](table_id, lw_shared_ptr<replica::table> t) -> future<> {
+                    return t->drop_quarantined_sstables();
+                });
+            });
+        }
+    } catch (...) {
+        apilog.error("drop_quarantined_sstables: failed with exception: {}", std::current_exception());
+        throw;
+    }
+
+    co_return json_void();
+}
 
 // Disambiguate between a function that returns a future and a function that returns a plain value, also
 // add std::ref() as a courtesy. Also handles ks_cf_func signatures.
@@ -1925,6 +1955,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::tablet_balancing_enable.set(r, rest_bind(rest_tablet_balancing_enable, ss));
     ss::quiesce_topology.set(r, rest_bind(rest_quiesce_topology, ss));
     sp::get_schema_versions.set(r, rest_bind(rest_get_schema_versions, ss));
+    ss::drop_quarantined_sstables.set(r, rest_bind(rest_drop_quarantined_sstables, ctx, ss));
 }
 
 void unset_storage_service(http_context& ctx, routes& r) {
@@ -2007,6 +2038,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::tablet_balancing_enable.unset(r);
     ss::quiesce_topology.unset(r);
     sp::get_schema_versions.unset(r);
+    ss::drop_quarantined_sstables.unset(r);
 }
 
 void set_load_meter(http_context& ctx, routes& r, service::load_meter& lm) {

--- a/dist/common/nodetool-completion
+++ b/dist/common/nodetool-completion
@@ -165,6 +165,7 @@ have nodetool && have cqlsh &&
             upgradesstables
             verify
             viewbuildstatus
+            dropquarantinedsstables
 	    '
 
         local optwks='
@@ -188,6 +189,7 @@ have nodetool && have cqlsh &&
             toppartitions
             verify
             viewbuildstatus
+            dropquarantinedsstables
             '
 
         local optwcfs='

--- a/docs/operating-scylla/nodetool-commands/dropquarantinedsstables.rst
+++ b/docs/operating-scylla/nodetool-commands/dropquarantinedsstables.rst
@@ -1,0 +1,44 @@
+Nodetool dropquarantinedsstables
+==================================
+**dropquarantinedsstables** - Drop quarantined SSTables from the specified keyspace and table(s), or from all
+keyspaces if no keyspace is specified.
+
+OPTIONS
+.......
+
+====================================================================  ==================================================================================================================
+Parameter                                                             Description
+====================================================================  ==================================================================================================================
+``[<keyspace>]``                                                      Optional. The keyspace to drop quarantined SSTables from. If not specified, all keyspaces will be affected.
+--------------------------------------------------------------------  ------------------------------------------------------------------------------------------------------------------
+``[<table...>]``                                                      Optional. One or more tables to drop quarantined SSTables from. If not specified, all tables in the keyspace will be affected.
+====================================================================  ==================================================================================================================
+
+Examples
+........
+
+Drop quarantined SSTables from all keyspaces and tables
+
+.. code-block:: shell
+
+   > nodetool dropquarantinedsstables
+
+Drop quarantined SSTables from all tables in a keyspace (mykeyspace)
+
+.. code-block:: shell
+
+   > nodetool dropquarantinedsstables mykeyspace
+
+Drop quarantined SSTables from a specific table (mytable) in a keyspace (mykeyspace)
+
+.. code-block:: shell
+
+   > nodetool dropquarantinedsstables mykeyspace mytable
+
+Drop quarantined SSTables from multiple specific tables (mytable1, mytable2) in a keyspace (mykeyspace)
+
+.. code-block:: shell
+
+   > nodetool dropquarantinedsstables mykeyspace mytable1 mytable2
+
+.. include:: nodetool-index.rst

--- a/docs/operating-scylla/nodetool.rst
+++ b/docs/operating-scylla/nodetool.rst
@@ -25,6 +25,7 @@ Nodetool
    nodetool-commands/disablebinary
    nodetool-commands/disablegossip
    nodetool-commands/drain
+   nodetool-commands/dropquarantinedsstables
    nodetool-commands/enableautocompaction
    nodetool-commands/enablebackup
    nodetool-commands/enablebinary
@@ -98,6 +99,7 @@ Operations that are not listed below are currently not available.
 * :doc:`disablebinary </operating-scylla/nodetool-commands/disablebinary/>` - Disable native transport (binary protocol).
 * :doc:`disablegossip </operating-scylla/nodetool-commands/disablegossip/>` - Disable gossip (effectively marking the node down).
 * :doc:`drain </operating-scylla/nodetool-commands/drain/>` - Drain the node (stop accepting writes and flush all column families).
+* :doc:`dropquarantinedsstables </operating-scylla/nodetool-commands/dropquarantinedsstables>` :code:`<keyspace>` :code:`<table>` Drop quarantined SSTables from the specified keyspace and table(s), or from all keyspaces if no keyspace is specified.
 * :doc:`enableautocompaction </operating-scylla/nodetool-commands/enableautocompaction/>` - Enable automatic compaction of a keyspace or table.
 * :doc:`enablebackup </operating-scylla/nodetool-commands/enablebackup/>` - Enable incremental backup.
 * :doc:`enablebinary </operating-scylla/nodetool-commands/enablebinary/>` - Re-enable native transport (binary protocol).

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1066,6 +1066,7 @@ public:
     lw_shared_ptr<const sstable_list> get_sstables() const;
     lw_shared_ptr<const sstable_list> get_sstables_including_compacted_undeleted() const;
     std::vector<sstables::shared_sstable> select_sstables(const dht::partition_range& range) const;
+    future<> drop_quarantined_sstables();
     size_t sstables_count() const;
     std::vector<uint64_t> sstable_count_per_level() const;
     int64_t get_unleveled_sstables() const;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2292,6 +2292,89 @@ std::vector<sstables::shared_sstable> table::select_sstables(const dht::partitio
     return _sstables->select(range);
 }
 
+future<> table::drop_quarantined_sstables() {
+    class quarantine_removal_updater : public row_cache::external_updater_impl {
+        table& _t;
+        std::vector<sstables::shared_sstable>& _removed;
+        struct compaction_group_update {
+            lw_shared_ptr<sstables::sstable_set> new_main_sstables;
+            lw_shared_ptr<sstables::sstable_set> new_maintenance_sstables;
+            std::vector<sstables::shared_sstable> removed_main_sstables;
+        };
+        std::unordered_map<compaction_group*, compaction_group_update> _cg_updates;
+
+    public:
+        explicit quarantine_removal_updater(table& t, std::vector<sstables::shared_sstable>& removed)
+            : _t(t), _removed(removed) {}
+
+        virtual future<> prepare() override {
+            _t.for_each_compaction_group([&] (compaction_group& cg) {
+                auto new_main = make_lw_shared<sstables::sstable_set>(cg.make_main_sstable_set());
+                auto new_maintenance = cg.make_maintenance_sstable_set();
+                std::vector<sstables::shared_sstable> removed_main;
+
+                cg.main_sstables()->for_each_sstable([&] (const sstables::shared_sstable& sst) {
+                    if (sst->is_quarantined()) {
+                        _removed.emplace_back(sst);
+                        removed_main.emplace_back(sst);
+
+                    } else {
+                        new_main->insert(sst);
+                    }
+                });
+
+
+                cg.maintenance_sstables()->for_each_sstable([&] (const sstables::shared_sstable& sst) {
+                    if (sst->is_quarantined()) {
+                        _removed.emplace_back(sst);
+                    } else {
+                        new_maintenance->insert(sst);
+                    }
+                });
+
+                _cg_updates[&cg] = compaction_group_update{
+                    .new_main_sstables = std::move(new_main),
+                    .new_maintenance_sstables = std::move(new_maintenance),
+                    .removed_main_sstables = std::move(removed_main)
+                };
+            });
+            co_return;
+        }
+
+        virtual void execute() override {
+            for (auto& [cg, update] : _cg_updates) {
+                cg->set_main_sstables(std::move(update.new_main_sstables));
+                cg->set_maintenance_sstables(std::move(update.new_maintenance_sstables));
+            }
+            _t.refresh_compound_sstable_set();
+            for (auto& [cg, d] : _cg_updates) {
+                cg->get_backlog_tracker().replace_sstables(d.removed_main_sstables, {});
+            }
+        }
+
+        static std::unique_ptr<row_cache::external_updater_impl> make(table& t, std::vector<sstables::shared_sstable>& removed) {
+            return std::make_unique<quarantine_removal_updater>(t, removed);
+        }
+    };
+
+
+    _stats.pending_sstable_deletions++;
+    auto undo_stats = defer([this] {
+        _stats.pending_sstable_deletions--;
+    });
+
+    auto permit = co_await get_sstable_list_permit();
+
+    std::vector<sstables::shared_sstable> removed;
+    auto updater = row_cache::external_updater(quarantine_removal_updater::make(*this, removed));
+    co_await _cache.invalidate(std::move(updater));
+
+    _cache.refresh_snapshot();
+    rebuild_statistics();
+
+    co_await delete_sstables_atomically(permit, std::move(removed));
+}
+
 bool storage_group::no_compacted_sstable_undeleted() const {
     return std::ranges::all_of(compaction_groups(), [] (const_compaction_group_ptr& cg) {
         return cg->compacted_undeleted_sstables().empty();

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1663,4 +1663,65 @@ SEASTAR_TEST_CASE(enable_drained_compaction_manager) {
     });
 }
 
+SEASTAR_TEST_CASE(test_drop_quarantined_sstables) {
+    return do_with_cql_env_thread([] (cql_test_env& e) -> future<> {
+        e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
+        for (int i = 0; i < 10; i++) {
+            e.execute_cql(format("insert into cf (p, c) values ('key{}', {})", i * i, i)).get();
+             e.db().invoke_on_all([] (replica::database& db) {
+                auto& cf = db.find_column_family("ks", "cf");
+                return cf.flush();
+            }).get();
+        }
+
+        auto initial_sstable_count = co_await e.db().map_reduce0(
+            [] (replica::database& db) -> future<size_t> {
+                auto& cf = db.find_column_family("ks", "cf");
+                co_return cf.sstables_count();
+            },
+            0,
+            std::plus<size_t>{}
+        );
+        BOOST_REQUIRE_GT(initial_sstable_count, 0);
+
+        auto quarantined_count = co_await e.db().map_reduce0(
+            [] (replica::database& _db) -> future<size_t> {
+                auto& cf = _db.find_column_family("ks", "cf");
+                std::atomic<size_t> quarantined_on_shard = 0;
+                co_await cf.parallel_foreach_table_state([&] (compaction::table_state& ts) -> future<> {
+                    auto sstables = in_strategy_sstables(ts);
+                    if (sstables.empty()) {
+                        co_return;
+                    }
+                    auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
+                    quarantined_on_shard++;
+                    co_await sstables[idx]->change_state(sstables::sstable_state::quarantine);
+                });
+                co_return quarantined_on_shard;
+            },
+            size_t(0),
+            std::plus<size_t>{}
+        );
+        BOOST_REQUIRE_GT(quarantined_count, 0);
+
+        co_await e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            return cf.drop_quarantined_sstables();
+        });
+
+        auto remaining_quarantined = co_await e.db().map_reduce0(
+            [] (replica::database& db) -> future<size_t> {
+                auto& cf = db.find_column_family("ks", "cf");
+                auto& sstables = *cf.get_sstables();
+                co_return std::count_if(sstables.begin(), sstables.end(), [] (shared_sstable sst) {
+                    return sst->is_quarantined();
+                });
+            },
+            size_t(0),
+            std::plus<size_t>{}
+        );
+        BOOST_REQUIRE_EQUAL(remaining_quarantined, 0);
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/nodetool/test_dropquarantinedsstables.py
+++ b/test/nodetool/test_dropquarantinedsstables.py
@@ -1,0 +1,63 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+from test.nodetool.rest_api_mock import expected_request
+from test.nodetool.utils import check_nodetool_fails_with
+
+
+def test_dropquarantinedsstables_all_keyspaces(nodetool):
+    nodetool("dropquarantinedsstables", expected_requests=[
+        expected_request("POST", "/storage_service/drop_quarantined_sstables")
+    ])
+
+
+def test_dropquarantinedsstables_one_keyspace(nodetool):
+    nodetool("dropquarantinedsstables", "--keyspace", "ks1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1"})
+    ])
+
+
+def test_dropquarantinedsstables_one_table(nodetool):
+    nodetool("dropquarantinedsstables", "--keyspace", "ks1", "--table", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1", "tables": "tbl1"})
+    ])
+
+
+def test_dropquarantinedsstables_multiple_tables(nodetool):
+    nodetool("dropquarantinedsstables", "--keyspace", "ks1", "--table", "tbl1", "--table", "tbl2", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1", "tables": "tbl1,tbl2"})
+    ])
+
+
+def test_dropquarantinedsstables_non_existent_keyspace(nodetool):
+    check_nodetool_fails_with(
+        nodetool,
+        ("dropquarantinedsstables", "--keyspace", "non_existent_ks"),
+        {"expected_requests": [expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"])]},
+        ["nodetool: Keyspace [non_existent_ks] does not exist.",
+         "error processing arguments: keyspace non_existent_ks does not exist"])
+
+
+def test_dropquarantinedsstables_keyspace_positional(nodetool):
+    nodetool("dropquarantinedsstables", "ks1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1"})
+    ])
+
+
+def test_dropquarantinedsstables_keyspace_and_table_positional(nodetool):
+    nodetool("dropquarantinedsstables", "ks1", "tbl1", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1", "tables": "tbl1"})
+    ])
+
+
+def test_dropquarantinedsstables_keyspace_and_multiple_tables_positional(nodetool):
+    nodetool("dropquarantinedsstables", "ks1", "tbl1", "tbl2", "tbl3", expected_requests=[
+        expected_request("GET", "/storage_service/keyspaces", response=["ks1", "ks2"]),
+        expected_request("POST", "/storage_service/drop_quarantined_sstables", params={"keyspace": "ks1", "tables": "tbl1,tbl2,tbl3"})
+    ])


### PR DESCRIPTION
Added a new POST endpoint `/storage_service/drop_quarantined_sstables` to the REST API.
This endpoint allows dropping all quarantined SSTables either globally or
for a specific keyspace and tables.
Optional query parameters `keyspace` and `tables` (comma-separated table names) can be
provided to limit the scope of the operation.

Fixes scylladb/scylladb#19061

Backport is not required, it is new functionality 