### PR TITLE
tasks: change _finished_children type

### DIFF
--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -158,7 +158,7 @@ public:
 
         class children {
             mutable foreign_task_map _children;
-            mutable std::vector<task_essentials> _finished_children;
+            mutable utils::chunked_vector<task_essentials> _finished_children;
             mutable rwlock _lock;
         public:
             bool all_finished() const noexcept;


### PR DESCRIPTION
Parent task keeps a vector of statuses (task_essentials) of its finished children. When the children number is large - for example because we have many tables and a child task is created for each table - we may hit oversize allocation while adding a new child essentials to the vector.

Keep task_essentails of children in chunked_vector.

Fixes: #25040.

Optimization, no backport.