### PR TITLE
test/cqlpy/test_cdc.py: Add validation test for re-attached log tables

### DIFF
--- a/test/cqlpy/test_cdc.py
+++ b/test/cqlpy/test_cdc.py
@@ -239,3 +239,106 @@ def test_rename_column_of_fake_cdc_log_table(cql, test_keyspace, scylla_only):
         cql.execute(f"ALTER TABLE {test_keyspace}.{fake_cdc_log_table_name} RENAME p TO q")
     finally:
         cql.execute(f"DROP TABLE IF EXISTS {test_keyspace}.{fake_cdc_log_table_name}")
+
+# When the user disables CDC on a table, the CDC log table is not removed. Instead, it's detached from the base table,
+# and it functions as a normal table (with some differences). If that log table lives up to the point when the user
+# re-enabled CDC on the base table, instead of creating a new log table, the old one is re-attached to the base.
+#
+# Verify that changes in the base table after disabling CDC are reflected on the log table after re-enabling CDC.
+# Verify that we can perform basic operations on the log table without running into problems.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_reattach_cdc_log_table_after_altering_base(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, "p int, v int, u int, a int, PRIMARY KEY (p, v)", "WITH cdc = {'enabled': true}") as table:
+        cdc_log_table = f"{table}_scylla_cdc_log"
+
+        # Prefill the table with some data. It shouldn't matter, but let's do it anyway.
+        cql.execute(f"INSERT INTO {table} (p, v, u, a) VALUES (1, 2, 3, 4)")
+        # Detach the log table.
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': false}}")
+
+        # Change the base table.
+        cql.execute(f"ALTER TABLE {table} DROP a")
+        cql.execute(f"ALTER TABLE {table} ADD b double")
+        cql.execute(f"ALTER TABLE {table} RENAME v TO v2")
+
+        # Make sure that the detached log table still exists and is not affected by any changes in the base table.
+        cql.execute(f"INSERT INTO {table} (p, v2, u, b) VALUES (5, 6, 7, 9.2)")
+        result = cql.execute(f"SELECT * FROM {cdc_log_table} WHERE p = 5 ALLOW FILTERING").all()
+        assert len(result) == 0
+
+        # Reattach the log table.
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': true}}")
+
+        # Confirm the definition of the log table has been updated.
+        expected_definition = f'CREATE TABLE {cdc_log_table} (\n' \
+                               '    "cdc$stream_id" blob,\n' \
+                               '    "cdc$time" timeuuid,\n' \
+                               '    "cdc$batch_seq_no" int,\n' \
+                               '    b double,\n' \
+                               '    "cdc$deleted_b" boolean,\n' \
+                               '    "cdc$deleted_u" boolean,\n' \
+                               '    "cdc$end_of_batch" boolean,\n' \
+                               '    "cdc$operation" tinyint,\n' \
+                               '    "cdc$ttl" bigint,\n' \
+                               '    p int,\n' \
+                               '    u int,\n' \
+                               '    v2 int,\n' \
+                               '    v int,\n' \
+                               '    "cdc$deleted_a" boolean,\n' \
+                               '    a int,\n' \
+                               '    PRIMARY KEY ("cdc$stream_id", "cdc$time", "cdc$batch_seq_no")\n' \
+                               ')'
+        describe_result = cql.execute(f"DESC TABLE {cdc_log_table} WITH INTERNALS").one()
+        assert hasattr(describe_result, "create_statement")
+
+        assert expected_definition in describe_result.create_statement
+        assert f"ALTER TABLE {cdc_log_table} DROP v" in describe_result.create_statement
+        assert f'ALTER TABLE {cdc_log_table} DROP "cdc$deleted_a"' in describe_result.create_statement
+        assert f"ALTER TABLE {cdc_log_table} DROP a" in describe_result.create_statement
+
+        # Changes on the base table should be reflected on the log table again.
+        cql.execute(f"INSERT INTO {table} (p, v2, u, b) VALUES (10, 11, 12, 13.3)")
+        result = cql.execute(f"SELECT * FROM {cdc_log_table} WHERE p = 10 ALLOW FILTERING").all()
+        assert len(result) > 0
+
+# When the user disables CDC on a table, the CDC log table is not removed. Instead, it's detached from the base table,
+# and it functions as a normal table (with some differences). If that log table lives up to the point when the user
+# re-enabled CDC on the base table, instead of creating a new log table, the old one is re-attached to the base.
+#
+# Verify that changes in the base table after disabling CDC are reflected on the log table after re-enabling CDC,
+# and that the log table ends up with the same definition as if it had never been detached.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_reattach_cdc_log_table_after_altering_base_schema(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, "p int, v int, u int, a int, PRIMARY KEY (p, v)", "WITH cdc = {'enabled': true}") as t1, \
+          new_test_table(cql, test_keyspace, "p int, v int, u int, a int, PRIMARY KEY (p, v)", "WITH cdc = {'enabled': true}") as t2:
+        # We'll be performing the same operations on the tables: one with disabled CDC, the other with enabled CDC.
+        cql.execute(f"ALTER TABLE {t2} WITH cdc = {{'enabled': false}}")
+
+        for table in [t1, t2]:
+            cql.execute(f"ALTER TABLE {table} DROP a")
+            cql.execute(f"ALTER TABLE {table} ADD b double")
+            cql.execute(f"ALTER TABLE {table} RENAME v TO v2")
+
+        cql.execute(f"ALTER TABLE {t2} WITH cdc = {{'enabled': true}}")
+
+        cdc_log_t1 = f"{t1}_scylla_cdc_log"
+        cdc_log_t2 = f"{t2}_scylla_cdc_log"
+
+        # Note that we cannot use `WITH INTERNALS` here because it'll also include the UUIDs
+        # of the tables, which will obviously be different.
+        desc_t1 = cql.execute(f"DESC TABLE {cdc_log_t1}").one()
+        assert hasattr(desc_t1, "create_statement")
+        create_stmt_t1 = desc_t1.create_statement
+
+        desc_t2 = cql.execute(f"DESC TABLE {cdc_log_t2}").one()
+        assert hasattr(desc_t2, "create_statement")
+        create_stmt_t2 = desc_t2.create_statement
+
+        # We need to change the name of one of the tables.
+        create_stmt_t2 = create_stmt_t2.replace(t2, t1)
+
+        assert create_stmt_t1 == create_stmt_t2


### PR DESCRIPTION
When the user disables CDC on a table, the CDC log table is not removed. Instead, it's detached from the base table, and it functions as a normal table (with some differences). If that log table lives up to the point when the user re-enabled CDC on the base table, instead of creating a new log table, the old one is re-attached to the base.

For more context on that, see commit:
scylladb/scylladb@adda43edc75b901b2329bca8f3eb74596698d05f.

In this commit, we add validation tests that check whether the changes on the base table after disabling CDC are reflected on the log table after re-enabling CDC. The definition of the log table should be the same as if CDC had never been disabled.

Backport: not needed. We're just adding additional tests.