### PR TITLE
test.py: native pytest repeats

### DIFF
--- a/test.py
+++ b/test.py
@@ -278,7 +278,7 @@ async def find_tests(options: argparse.Namespace) -> None:
                 await suite.add_test_list()
 
 
-def run_pytest(options: argparse.Namespace, run_id: int) -> tuple[int, list[SimpleNamespace]]:
+def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]:
     # When tests are executed in parallel on different hosts, we need to distinguish results from them.
     # So this host_id needed to not overwrite results from different hosts during Jenkins will copy to one directory.
     hostname = socket.gethostname()
@@ -286,7 +286,7 @@ def run_pytest(options: argparse.Namespace, run_id: int) -> tuple[int, list[Simp
     failed_tests = []
     temp_dir = pathlib.Path(options.tmpdir).absolute()
     report_dir =  temp_dir / 'report'
-    junit_output_file = report_dir / f'pytest_cpp_{run_id}_{host_id}.xml'
+    junit_output_file = report_dir / f'pytest_cpp_{host_id}.xml'
     files_to_run = []
     test_names = []
     for name in options.name:
@@ -308,6 +308,7 @@ def run_pytest(options: argparse.Namespace, run_id: int) -> tuple[int, list[Simp
         'pytest',
         "-s",  # don't capture print() output inside pytest
         '--color=yes',
+        f'--repeat={options.repeat}',
         modes,
     ]
     if options.list_tests:
@@ -319,7 +320,6 @@ def run_pytest(options: argparse.Namespace, run_id: int) -> tuple[int, list[Simp
             "-rf",
             f'-n{int(options.jobs)}',
             f'--tmpdir={temp_dir}',
-            f'--run_id={run_id}',
             f'--maxfail={options.max_failures}',
             f'--alluredir={report_dir / f"allure_{host_id}"}',
             '-v' if options.verbose else '-q',
@@ -433,16 +433,9 @@ async def run_all_tests(signaled: asyncio.Event, options: argparse.Namespace) ->
     failed = 0
     try:
         await start_3rd_party_services(tempdir_base=pathlib.Path(options.tmpdir), toxiproxy_byte_limit=options.byte_limit)
-        for i in range(1, options.repeat + 1):
-            result = run_pytest(options, run_id=i)
-            total_tests += result[0]
-            if total_tests == 0:
-                # no tests found, nothing to run, so breaking the loop
-                break
-            failed_tests.extend(result[1])
-            if len(failed_tests) >= max_failures != 0:
-                print("Too much failures, stopping")
-                break
+        result = run_pytest(options)
+        total_tests += result[0]
+        failed_tests.extend(result[1])
         console.print_start_blurb()
         TestSuite.artifacts.add_exit_artifact(None, TestSuite.hosts.cleanup)
         for test in TestSuite.all_tests():
@@ -521,7 +514,7 @@ async def main() -> int:
     if options.list_tests:
         print('\n'.join([f"{t.suite.mode:<8} {type(t.suite).__name__[:-9]:<11} {t.name}"
                          for t in TestSuite.all_tests()]))
-        run_pytest(options, run_id=1)
+        run_pytest(options)
         return 0
 
     if options.manual_execution and TestSuite.test_count() > 1:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,6 +6,8 @@
 from __future__ import annotations
 
 import asyncio
+import itertools
+import re
 import logging
 import sys
 from argparse import BooleanOptionalAction
@@ -16,8 +18,9 @@ from typing import TYPE_CHECKING
 import pytest
 
 from test import ALL_MODES, TEST_RUNNER, TOP_SRC_DIR
+from test.pylib.cpp.item import CppTestFunction
 from test.pylib.report_plugin import ReportPlugin
-from test.pylib.util import get_configured_modes
+from test.pylib.util import get_configured_modes, get_modes_to_run
 from test.pylib.suite.base import (
     TestSuite,
     get_testpy_test,
@@ -78,6 +81,8 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                           " '--logger-log-level raft=trace --default-log-level error'")
     parser.addoption('--x-log2-compaction-groups', action="store", default="0", type=int,
                      help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
+    parser.addoption('--repeat', action="store", default="1", type=int,
+                     help="number of times to repeat test execution")
 
     # Pass information about Scylla node from test.py to pytest.
     parser.addoption("--scylla-log-filename",
@@ -97,6 +102,29 @@ def build_mode(request: pytest.FixtureRequest) -> str:
         return mode[0]
     return "unknown"
 
+@pytest.fixture(scope="function")
+def get_params(request: pytest.FixtureRequest) -> Generator[None]:
+    # this dummy fixture only needed to modify the test name with run id and mode. We don't want to parametrize with
+    # some parameters, so we are returning existing params that function is accepting. This method only needed for
+    # pytest_generate_tests method
+    return request.param
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if TEST_RUNNER == "runpy":
+        return
+    repeat_count = metafunc.config.getoption("--repeat")
+    modes = get_modes_to_run(metafunc.config)
+
+    all_combinations = [*itertools.product(modes, range(repeat_count))]
+
+    metafunc.fixturenames.append('get_params')
+    metafunc.parametrize(
+        'get_params',
+        range(len(all_combinations)),
+        ids=[f"%{mode}.{run_id + 1}%" for mode, run_id in all_combinations],
+        indirect=True
+    )
 
 @pytest.fixture(autouse=True)
 def print_scylla_log_filename(request: pytest.FixtureRequest) -> Generator[None]:
@@ -144,29 +172,37 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     This is a standard pytest method.
     This is needed to modify the test names with dev mode and run id to differ them one from another
     """
-    run_id = config.getoption('run_id', None)
+    testpy_run_id = config.getoption('run_id', None)
+
+    def modify_test_name(s: str, testpy_run_id) -> str:
+        """
+        Modify the test name to extract run id from parameterized test name to the end of the name.
+        Convert names like:
+        cluster/test_multidc.py::test_multidc[%dev.1%]
+        cluster/test_multidc.py::test_putget_2dc_with_rf[%release.1%-nodes_list0-1]
+        to:
+        cluster/test_multidc.py::test_multidc.dev.1
+        cluster/test_multidc.py::test_putget_2dc_with_rf[nodes_list0-1].release.1
+        """
+        match = re.search(r'\[%([a-zA-Z_][\w]*)\.(\d+)%(-[^]]+)?]', s)
+        if not match:
+            return s
+
+        mode = match.group(1)
+        run_id = match.group(2)
+        suffix = match.group(3)
+        if suffix:
+            s = re.sub(r'\[%[a-zA-Z_][\w]*\.\d+%(-[^]]+)]', f'[{suffix[1:]}]', s)
+        else:
+            s = re.sub(r'\[%[a-zA-Z_][\w]*\.\d+%]', '', s)
+        return f"{s}.{mode}.{testpy_run_id}" if testpy_run_id else f"{s}.{mode}.{run_id}"
 
     for item in items:
-        # check if this is custom cpp tests that have additional attributes for name modification
-        if hasattr(item, 'mode'):
-            # modify name with mode that is always present in cpp tests
-            item.nodeid = f'{item.nodeid}.{item.mode}'
-            item.name = f'{item.name}.{item.mode}'
-            if item.run_id:
-                item.nodeid = f'{item.nodeid}.{item.run_id}'
-                item.name = f'{item.name}.{item.run_id}'
-        else:
-            # here go python tests that are executed through test.py
-            # since test.py is responsible for creating several tests with the required mode,
-            # a list with modes contains only one value,
-            # that's why in name modification the first element is used
-            modes = config.getoption('modes')
-            if modes:
-                item._nodeid = f'{item._nodeid}.{modes[0]}'
-                item.name = f'{item.name}.{modes[0]}'
-            if run_id:
-                item._nodeid = f'{item._nodeid}.{run_id}'
-                item.name = f'{item.name}.{run_id}'
+        if not isinstance(item, CppTestFunction):
+            # pytest_generate_tests is not triggered for C++ tests, so they have their own logic for test name
+            # modification that handled in CppTestFunction class.
+            item._nodeid = modify_test_name(item._nodeid, testpy_run_id)
+            item.name = modify_test_name(item.name, testpy_run_id)
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/test/cqlpy/run.py
+++ b/test/cqlpy/run.py
@@ -503,6 +503,7 @@ def run_pytest(pytest_dir, additional_parameters):
         # child:
         run_with_temporary_dir_pids = set() # no children to clean up on child
         run_pytest_pids = set()
+        os.environ.setdefault('SCYLLA_TEST_RUNNER', 'runpy')
         os.chdir(pytest_dir)
         os.setsid()
         os.execvp('pytest', ['pytest',

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -150,7 +150,7 @@ class BoostTestFacade(CppTestFacade):
             )
             failure = CppTestFailure(
                 file_name.name,
-                line_num=results[0].line_num if results is not None else -1,
+                line_num=results[0].line_num if results else -1,
                 contents=msg
             )
             return [failure], ''

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -102,6 +102,7 @@ class BoostTestFacade(CppTestFacade):
         file_name: Path,
         test_args:Sequence[str] = (),
         env: dict = None,
+        run_id: int = 1
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         def read_file(name: Path) -> str:
             try:
@@ -112,7 +113,7 @@ class BoostTestFacade(CppTestFacade):
         root_log_dir = self.temp_dir / mode
         log_xml = (root_log_dir /
                    f"{'.'.join(file_name.relative_to(TEST_DIR).parent.parts)}"
-                   f".{file_name.stem}.{test_name}.{self.run_id}.xml")
+                   f".{file_name.stem}.{test_name}.{run_id}.xml")
         args = [ str(executable),
                  '--report_level=no',
                  '--output_format=XML',
@@ -130,7 +131,7 @@ class BoostTestFacade(CppTestFacade):
         if self.random_seed:
             args.append(f'--random-seed={self.random_seed}')
         args.extend(test_args)
-        test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env)
+        test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env, run_id=run_id)
 
         log = read_file(log_xml)
 

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -110,7 +110,7 @@ class BoostTestFacade(CppTestFacade):
             except IOError:
                 return ''
         root_log_dir = self.temp_dir / mode
-        log_xml = root_log_dir / f"{test_name}.{self.run_id}.log"
+        log_xml = root_log_dir / f"{test_name}.{self.run_id}.xml"
         args = [ str(executable),
                  '--report_level=no',
                  '--output_format=XML',

--- a/test/pylib/cpp/boost/boost_facade.py
+++ b/test/pylib/cpp/boost/boost_facade.py
@@ -38,7 +38,7 @@ from xml.etree.ElementTree import ParseError
 
 import allure
 from pytest import Config
-from test import BUILD_DIR, COMBINED_TESTS
+from test import BUILD_DIR, COMBINED_TESTS, TEST_DIR
 from test.pylib.cpp.common_cpp_conftest import get_modes_to_run
 from test.pylib.cpp.facade import CppTestFacade, CppTestFailure
 
@@ -110,7 +110,9 @@ class BoostTestFacade(CppTestFacade):
             except IOError:
                 return ''
         root_log_dir = self.temp_dir / mode
-        log_xml = root_log_dir / f"{test_name}.{self.run_id}.xml"
+        log_xml = (root_log_dir /
+                   f"{'.'.join(file_name.relative_to(TEST_DIR).parent.parts)}"
+                   f".{file_name.stem}.{test_name}.{self.run_id}.xml")
         args = [ str(executable),
                  '--report_level=no',
                  '--output_format=XML',

--- a/test/pylib/cpp/common_cpp_conftest.py
+++ b/test/pylib/cpp/common_cpp_conftest.py
@@ -97,7 +97,7 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
         SCYLLA_TEST_ENV='yes',
     )
     pytest_config = parent.config
-    run_id = pytest_config.getoption('run_id')
+    repeat = pytest_config.getoption('repeat')
     modes = get_modes_to_run(parent.session.config)
     suite_config = read_suite_config(file_path.parent)
     no_parallel_cases = suite_config.get('no_parallel_cases', [])
@@ -120,9 +120,9 @@ def collect_items(file_path: PosixPath, parent: Collector, facade: CppTestFacade
     if len(custom_args) > 1:
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, parameters=custom_args,
                                    no_parallel_run=no_parallel_run, modes=modes, disabled_tests=disabled_tests,
-                                   run_id=run_id, facade=facade, env=test_env, coverage_config=coverage_config)
+                                   repeat=repeat, facade=facade, env=test_env, coverage_config=coverage_config)
     else:
         args.extend(custom_args)
         return CppFile.from_parent(parent=parent, path=file_path, arguments=args, no_parallel_run=no_parallel_run,
-                                   modes=modes, disabled_tests=disabled_tests, run_id=run_id, facade=facade,
+                                   modes=modes, disabled_tests=disabled_tests, repeat=repeat, facade=facade,
                                    env=test_env, coverage_config=coverage_config)

--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -62,7 +62,6 @@ class CppTestFailureList(Exception):
 class CppTestFacade(ABC):
     def __init__(self, config: Config, combined_tests: dict[str, list[str]] = None):
         self.temp_dir: Path = Path(config.getoption('tmpdir'))
-        self.run_id: int = config.getoption('run_id') or 1
         self.gather_metrics: bool = config.getoption('gather_metrics')
         self.save_log_on_success: bool = config.getoption('save_log_on_success')
         self.random_seed: int = config.getoption('random_seed')
@@ -72,17 +71,16 @@ class CppTestFacade(ABC):
         raise NotImplementedError
 
     def run_test(self, executable: Path, original_name: str, test_id: str, mode: str, file_name: Path,
-                 test_args: Sequence[str] = (), env: dict = None) -> tuple[Sequence[CppTestFailure] | None, str]:
+                 test_args: Sequence[str] = (), env: dict = None, run_id: int = 1) -> tuple[Sequence[CppTestFailure] | None, str]:
          raise NotImplementedError
 
     def run_process(self, test_name: str, mode: str, file_name: Path, args: list[str] = (),
-                    env: dict = None) -> \
-            tuple[bool, Path, int]:
+                    env: dict = None, run_id: int = 1) -> tuple[bool, Path, int]:
         root_log_dir = self.temp_dir / mode
         stdout_file_path = (root_log_dir /
                             f"{'.'.join(file_name.relative_to(TEST_DIR).parent.parts)}"
-                            f".{file_name.stem}.{test_name}_stdout.{self.run_id}.log")
-        test = make_test_object(test_name, file_name.parent.name, self.run_id, mode, log_dir=self.temp_dir)
+                            f".{file_name.stem}.{test_name}_stdout.{run_id}.log")
+        test = make_test_object(test_name, file_name.parent.name, run_id, mode, log_dir=self.temp_dir)
 
         resource_gather = get_resource_gather(self.gather_metrics, test=test)
         resource_gather.make_cgroup()

--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -33,7 +33,7 @@ from typing import Sequence
 
 from pytest import Config
 
-from test import TOP_SRC_DIR
+from test import TOP_SRC_DIR, TEST_DIR
 from test.pylib.cpp.util import make_test_object
 from test.pylib.resource_gather import get_resource_gather
 
@@ -79,7 +79,9 @@ class CppTestFacade(ABC):
                     env: dict = None) -> \
             tuple[bool, Path, int]:
         root_log_dir = self.temp_dir / mode
-        stdout_file_path = root_log_dir / f"{test_name}_stdout.{self.run_id}.log"
+        stdout_file_path = (root_log_dir /
+                            f"{'.'.join(file_name.relative_to(TEST_DIR).parent.parts)}"
+                            f".{file_name.stem}.{test_name}_stdout.{self.run_id}.log")
         test = make_test_object(test_name, file_name.parent.name, self.run_id, mode, log_dir=self.temp_dir)
 
         resource_gather = get_resource_gather(self.gather_metrics, test=test)

--- a/test/pylib/cpp/unit/unit_facade.py
+++ b/test/pylib/cpp/unit/unit_facade.py
@@ -32,9 +32,10 @@ class UnitTestFacade(CppTestFacade):
         file_name: Path,
         test_args: Sequence[str] = (),
         env: dict = None,
+        run_id: int = 1
     ) -> tuple[list[CppTestFailure], str] | tuple[None, str]:
         args = [str(executable), *test_args]
-        test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env)
+        test_passed, stdout_file_path, return_code = self.run_process(test_name, mode, file_name, args, env, run_id=run_id)
 
         if not test_passed:
             allure.attach(stdout_file_path.read_bytes(), name='output', attachment_type=allure.attachment_type.TEXT)

--- a/test/pylib/report_plugin.py
+++ b/test/pylib/report_plugin.py
@@ -12,17 +12,10 @@ from allure_pytest.utils import get_pytest_report_status
 
 class ReportPlugin:
     config = None
-    build_mode = None
-    run_id = None
 
-    # Pytest hook to modify test name to include mode and run_id
+    # Pytest hook to attach logs to the Allure report only when the test fails.
     def pytest_configure(self, config):
-        # getting build_mode in two steps is needed for the cases when no mode parameter is provided
-        self.build_mode = config.getoption("modes")
-        if self.build_mode:
-            self.build_mode = self.build_mode[0]
         self.config = config
-        self.run_id = config.getoption("run_id")
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(self):
@@ -38,14 +31,3 @@ class ReportPlugin:
                 allure.attach(report.capstdout, "stdout", allure.attachment_type.TEXT, None)
             if report.capstderr:
                 allure.attach(report.capstderr, "stderr", allure.attachment_type.TEXT, None)
-
-    @pytest.fixture(scope="function", autouse=True)
-    def allure_set_mode(self, request):
-        """
-        Add mode tag to be able to search by it.
-        Add parameters to make allure distinguish them and not put them to retries.
-        """
-        if self.build_mode is not None or self.run_id is not None:
-            allure.dynamic.tag(self.build_mode)
-            allure.dynamic.parameter('mode', self.build_mode)
-            allure.dynamic.parameter('run_id', self.run_id)


### PR DESCRIPTION
Previous way of execution repeat was to launch pytest for each repeat.
That was resource consuming, since each time pytest was doing discovery
of the tests. Now all repeats are done inside one pytest process.

Backport for 2025.3 is needed, since this functionality is framework only, and 2025.3 affected with this slow repeats as well.