### PR TITLE
storage_proxy: preallocate write response handler hash table

### DIFF
--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3154,6 +3154,12 @@ storage_proxy::storage_proxy(distributed<replica::database>& db, storage_proxy::
     slogger.trace("hinted DCs: {}", cfg.hinted_handoff_enabled.to_configuration_string());
     _hints_manager.register_metrics("hints_manager");
     _hints_for_views_manager.register_metrics("hints_for_views_manager");
+    if (!_db.local().get_config().developer_mode()) {
+        // preallocate 128K pointers and set max_load_factor to 8 to support around 1M outstanding requests
+        // without re-allocations
+        _response_handlers.reserve(128*1024);
+        _response_handlers.max_load_factor(8);
+    }
 }
 
 struct storage_proxy::remote& storage_proxy::remote() {


### PR DESCRIPTION
Currently it grows dynamically and triggers oversized allocation warning. Also it may be hard to find sufficient contiguous memory chunk after the system runs for a while. This patch pre-allocates enough memory for ~1M outstanding writes per shard.

Fixes #24660
Fixes #24217

No backports to 2025.2/2025.3 since commit 04fb2c026d7d3dfd9489480aae105d9de5f283ea was reverted there.