### PR TITLE
Revert "dist/docker/debian/build_docker.sh: add scylla-server-dbg"

### DIFF
--- a/dist/docker/debian/build_docker.sh
+++ b/dist/docker/debian/build_docker.sh
@@ -83,7 +83,6 @@ fi
 packages=(
     "build/dist/$config/debian/${product}_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-server_$version-$release-1_$arch.deb"
-    "build/dist/$config/debian/$product-server-dbg_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-kernel-conf_$version-$release-1_$arch.deb"
     "build/dist/$config/debian/$product-node-exporter_$version-$release-1_$arch.deb"


### PR DESCRIPTION
This reverts commit d7a02eceeae923fdd2c832160217b753be675aac.

This makes our containers MUCH larger than they need to be: 800.46 MB (2025.1.5) vs. 273.36 M (2025.1.3).

Fixes: https://github.com/scylladb/scylladb/issues/25479

