### PR TITLE
sstables/types.hh: Remove duplicate version.hh inclusion

### DIFF
--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -20,7 +20,6 @@
 #include "sstables/key.hh"
 #include "sstables/file_writer.hh"
 #include "db/commitlog/replay_position.hh"
-#include "version.hh"
 #include <vector>
 #include <unordered_map>
 #include <type_traits>


### PR DESCRIPTION
The latter header in included two times, one is enough
