### PR TITLE
init.hh: Remove unused forward declarations

### DIFF
--- a/init.hh
+++ b/init.hh
@@ -21,15 +21,10 @@
 
 namespace db {
 class extensions;
-class seed_provider_type;
 class config;
-namespace view {
-class view_update_generator;
-}
 }
 
 namespace gms {
-class feature_service;
 class inet_address;
 }
 


### PR DESCRIPTION
The init.hh contains some bits that only main.cc needs. Some of its forward declarations are neede by neither the headers itself, nor the main.cc that includes it.
