### PR TITLE
test: audit: ignore cassandra user audit logs in AUTH tests

### DIFF
--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -958,6 +958,16 @@ class TestCQLAudit(AuditTester):
         with self.assert_entries_were_added(session, expected_audit_entries, filter_out_cassandra_auth=True):
             self.prepare(user="test", password="test", create_keyspace=False)
 
+    def test_cassandra_login(self):
+        """
+        Test user login to default (cassandra) user
+        """
+        session = self.prepare(user="cassandra", password="cassandra", create_keyspace=False)
+        expected_audit_entries = [AuditEntry(category="AUTH", statement="LOGIN", user="cassandra", table="", ks="", cl="", error=False)]
+
+        with self.assert_entries_were_added(session, expected_audit_entries, filter_out_cassandra_auth=False):
+            self.prepare(user="cassandra", password="cassandra", create_keyspace=False)
+
     def test_categories(self):
         """
         Test filtering audit categories

--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -338,7 +338,7 @@ class TestCQLAudit(AuditTester):
 
     def get_audit_entries_count(self, session):
         res_list = self.get_audit_log_list(session)
-        res_list = self.filter_out_noise(res_list, filter_out_auth=True, filter_out_use=True)
+        res_list = self.filter_out_noise(res_list, filter_out_all_auth=True, filter_out_use=True)
         logger.debug("Printing audit table content:")
         for row in res_list:
             logger.debug("  %s", row)
@@ -451,8 +451,8 @@ class TestCQLAudit(AuditTester):
 
     # Filter out queries that can appear in random moments of the tests,
     # such as LOGINs and USE statements.
-    def filter_out_noise(self, rows, filter_out_auth, filter_out_use):
-        if filter_out_auth:
+    def filter_out_noise(self, rows, filter_out_all_auth=False, filter_out_use=False):
+        if filter_out_all_auth:
             rows = [row for row in rows if row.category != "AUTH"]
         if filter_out_use:
             rows = [row for row in rows if "USE " not in row.operation]
@@ -481,10 +481,13 @@ class TestCQLAudit(AuditTester):
             if merge_duplicate_rows:
                 new_rows = self.deduplicate_audit_entries(new_rows)
 
+            auth_not_expected = (len([entry for entry in expected_entries if entry.category == "AUTH"]) == 0)
+            use_not_expected = (len([entry for entry in expected_entries if "USE " in entry.statement]) == 0)
+
             new_rows = self.filter_out_noise(
                 new_rows,
-                filter_out_auth=len([entry for entry in expected_entries if entry.category == "AUTH"]) == 0,
-                filter_out_use=len([entry for entry in expected_entries if "USE " in entry.statement]) == 0
+                filter_out_all_auth=auth_not_expected,
+                filter_out_use=use_not_expected
             )
 
             assert len(new_rows) <= len(expected_entries)

--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -474,6 +474,7 @@ class TestCQLAudit(AuditTester):
             set_of_rows_after = set(rows_after)
             assert len(set_of_rows_after) == len(rows_after), f"audit table contains duplicate rows: {rows_after}"
 
+            nonlocal new_rows
             new_rows = rows_after[len(rows_before) :]
             assert set(new_rows) == set_of_rows_after - set_of_rows_before, f"new rows are not the last rows in the audit table: {rows_after}"
 
@@ -490,7 +491,8 @@ class TestCQLAudit(AuditTester):
             return len(new_rows) == len(expected_entries)
 
         wait_for(is_number_of_new_rows_correct, timeout=60)
-        sorted_new_rows = sorted(new_rows, key=lambda row: (row.node, row.category, row.consistency, row.error, row.keyspace_name, row_operation, row_source, row_table_name, row.username))
+        sorted_new_rows = sorted(new_rows, key=lambda row: (row.node, row.category, row.consistency, row.error, row.keyspace_name, row.operation, row.source, row.table_name, row.username))
+        assert len(sorted_new_rows) == len(expected_entries)
         for row, entry in zip(sorted_new_rows, sorted(expected_entries)):
             self.assert_audit_row_eq(row, entry.category, entry.statement, entry.table, entry.ks, entry.user, entry.cl, entry.error)
 

--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -451,15 +451,17 @@ class TestCQLAudit(AuditTester):
 
     # Filter out queries that can appear in random moments of the tests,
     # such as LOGINs and USE statements.
-    def filter_out_noise(self, rows, filter_out_all_auth=False, filter_out_use=False):
+    def filter_out_noise(self, rows, filter_out_all_auth=False, filter_out_cassandra_auth=False, filter_out_use=False):
         if filter_out_all_auth:
             rows = [row for row in rows if row.category != "AUTH"]
+        if filter_out_cassandra_auth:
+            rows = [row for row in rows if not (row.category == "AUTH" and row.username == "cassandra")]
         if filter_out_use:
             rows = [row for row in rows if "USE " not in row.operation]
         return rows
 
     @contextmanager
-    def assert_entries_were_added(self, session: Session, expected_entries: list[AuditEntry], merge_duplicate_rows: bool = True):
+    def assert_entries_were_added(self, session: Session, expected_entries: list[AuditEntry], merge_duplicate_rows: bool = True, filter_out_cassandra_auth: bool = False):
         # Get audit entries before executing the query, to later compare with
         # audit entries after executing the query.
         rows_before = self.get_audit_log_list(session)
@@ -487,6 +489,7 @@ class TestCQLAudit(AuditTester):
             new_rows = self.filter_out_noise(
                 new_rows,
                 filter_out_all_auth=auth_not_expected,
+                filter_out_cassandra_auth=filter_out_cassandra_auth,
                 filter_out_use=use_not_expected
             )
 
@@ -832,7 +835,7 @@ class TestCQLAudit(AuditTester):
         session = self.prepare(user="cassandra", password="cassandra")
 
         expected_entry = AuditEntry(category="AUTH", statement="LOGIN", table="", ks="", user="wrong_user", cl="", error=True)
-        with self.assert_entries_were_added(session, [expected_entry]):
+        with self.assert_entries_were_added(session, [expected_entry], filter_out_cassandra_auth=True):
             try:
                 bad_session = self.exclusive_cql_connection(self.cluster.nodelist()[0], user="wrong_user", password="wrong_password")
                 pytest.fail()
@@ -952,7 +955,7 @@ class TestCQLAudit(AuditTester):
 
         expected_audit_entries = [AuditEntry(category="AUTH", statement="LOGIN", user="test", table="", ks="", cl="", error=False)]
 
-        with self.assert_entries_were_added(session, expected_audit_entries):
+        with self.assert_entries_were_added(session, expected_audit_entries, filter_out_cassandra_auth=True):
             self.prepare(user="test", password="test", create_keyspace=False)
 
     def test_categories(self):


### PR DESCRIPTION
Audit tests are vulnerable to noise from LOGIN queries (because AUTH
audit logs can appear at any time). Most tests already use the
`filter_out_noise` mechanism to remove this noise, but tests
focused on AUTH verification did not, leading to sporadic failures.

This change adds a filter to ignore AUTH logs generated by the default
"cassandra" user, so tests only verify logs from the user created
specifically for each test.

Additionally, this PR:
 - Adds missing `nonlocal new_rows` statement that prevented some checks from being called
 - Adds a testcase for audit logs of `cassandra` user

Fixes: https://github.com/scylladb/scylladb/issues/25069