### PR TITLE
tasks: do not use binary progress for task manager tasks

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -1472,10 +1472,6 @@ future<std::optional<double>> repair::user_requested_repair_task_impl::expected_
     co_return _ranges.size() * _cfs.size() * smp::count;
 }
 
-std::optional<double> repair::user_requested_repair_task_impl::expected_children_number() const {
-    return smp::count;
-}
-
 future<int> repair_start(seastar::sharded<repair_service>& repair, sharded<gms::gossip_address_map>& am,
         sstring keyspace, std::unordered_map<sstring, sstring> options) {
     return repair.invoke_on(0, [keyspace = std::move(keyspace), options = std::move(options), &am] (repair_service& local_repair) {
@@ -1627,10 +1623,6 @@ future<> repair::data_sync_repair_task_impl::run() {
 
 future<std::optional<double>> repair::data_sync_repair_task_impl::expected_total_workload() const {
     co_return _cfs_size ? std::make_optional<double>(_ranges.size() * _cfs_size * smp::count) : std::nullopt;
-}
-
-std::optional<double> repair::data_sync_repair_task_impl::expected_children_number() const {
-    return smp::count;
 }
 
 future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr, std::unordered_set<dht::token> bootstrap_tokens) {
@@ -2707,10 +2699,6 @@ future<> repair::tablet_repair_task_impl::run() {
 future<std::optional<double>> repair::tablet_repair_task_impl::expected_total_workload() const {
     auto sz = get_metas_size();
     co_return sz ? std::make_optional<double>(sz) : std::nullopt;
-}
-
-std::optional<double> repair::tablet_repair_task_impl::expected_children_number() const {
-    return get_metas_size();
 }
 
 node_ops_cmd_category categorize_node_ops_cmd(node_ops_cmd cmd) noexcept {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -74,7 +74,6 @@ protected:
     future<> run() override;
 
     virtual future<std::optional<double>> expected_total_workload() const override;
-    virtual std::optional<double> expected_children_number() const override;
 };
 
 class data_sync_repair_task_impl : public repair_task_impl {
@@ -103,7 +102,6 @@ protected:
     future<> run() override;
 
     virtual future<std::optional<double>> expected_total_workload() const override;
-    virtual std::optional<double> expected_children_number() const override;
 };
 
 class tablet_repair_task_impl : public repair_task_impl {
@@ -145,7 +143,6 @@ protected:
     future<> run() override;
 
     virtual future<std::optional<double>> expected_total_workload() const override;
-    virtual std::optional<double> expected_children_number() const override;
 };
 
 class shard_repair_task_impl : public repair_task_impl {

--- a/tasks/task_manager.hh
+++ b/tasks/task_manager.hh
@@ -226,7 +226,6 @@ public:
             future<> finish_failed(std::exception_ptr ex, std::string error) noexcept;
             future<> finish_failed(std::exception_ptr ex) noexcept;
             virtual future<std::optional<double>> expected_total_workload() const;
-            virtual std::optional<double> expected_children_number() const;
             task_manager::task::progress get_binary_progress() const;
 
             friend task;


### PR DESCRIPTION
Currently, progress of a parent task depends on expected_total_workload, expected_children_number, and children progresses. Basically, if total workload is known or all children have already been created, progresses of children are summed up. Otherwise binary progress is returned.

As a result, two tasks of the same type may return progress in different units. If they are children of the same task and this parent gathers the progress - it becomes meaningless.

Drop expected_children_number as we can't assume that children are able to show their progresses.

Modify get_progress method - progress is calculated based on children progresses. If expected_total_workload isn't specified, the total progress of a task may grow. If expected_total_workload isn't specified and no children are created, empty progress (0/0) is returned.

Fixes: https://github.com/scylladb/scylladb/issues/24650.

Fix of task progress; needs backport to all versions