### PR TITLE
Fix lifetime problems between group0 and sstable dictionary trainings

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4843,6 +4843,7 @@ future<std::vector<std::byte>> storage_service::train_dict(utils::chunked_vector
 
 future<> storage_service::publish_new_sstable_dict(table_id t_id, std::span<const std::byte> dict, service::raft_group0_client& group0_client) {
     co_await container().invoke_on(0, coroutine::lambda([t_id, dict, &group0_client] (storage_service& local_ss) -> future<> {
+        auto group0_holder = local_ss._group0->hold_group0_gate();
         while (true) {
             try {
                 auto name = fmt::format("sstables/{}", t_id);

--- a/sstable_dict_autotrainer.cc
+++ b/sstable_dict_autotrainer.cc
@@ -143,7 +143,11 @@ future<> sstable_dict_autotrainer::run() {
                 co_await tick();
             }
         } catch (const abort_requested_exception&) {
-            alogger.debug("sstable_dict_autotrainer::run(): exiting");
+            alogger.debug("sstable_dict_autotrainer::run(): exiting via abort_requested_exception");
+        } catch (const gate_closed_exception&) {
+            alogger.debug("sstable_dict_autotrainer::run(): exiting via gate_closed_exception");
+        } catch (const raft::stopped_error&) {
+            alogger.debug("sstable_dict_autotrainer::run(): exiting via raft::stopped_error");
         } catch (...) {
             alogger.debug("sstable_dict_autotrainer::run(): tick() failed with: {}", std::current_exception());
         }


### PR DESCRIPTION
Apparently the group0 server object dies (and is freed) during drain/shutdown, and I didn't take that into account in my https://github.com/scylladb/scylladb/pull/23025, which still attempts to use it afterwards.

The patch fixes two problems.
The problem with `is_raft_leader` has been observed in tests.
The problems with `publish_new_sstable_dict` has not been observed, but AFAIU (based on code inspection) it exists. I didn't attempt to prove its existence with a test.    

Should be backported to 2025.3.