### PR TITLE
storage_service, group0_state_machine: move SL cache update from `topology_state_load()` to `load_snapshot()`

### DIFF
--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -305,8 +305,7 @@ future<> service_level_controller::update_effective_service_levels_cache() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
     
     if (!_auth_service.local_is_initialized()) {
-        // Because cache update is triggered in `topology_state_load()`, auth service
-        // might be not initialized yet.
+        // Auth service might be not initialized yet.
         co_return;
     }
     auto units = co_await get_units(_global_controller_db->notifications_serializer, 1);

--- a/service/raft/group0_state_machine.cc
+++ b/service/raft/group0_state_machine.cc
@@ -333,6 +333,7 @@ future<> group0_state_machine::load_snapshot(raft::snapshot_id id) {
     if (_feature_service.compression_dicts) {
         co_await _ss.compression_dictionary_updated_callback_all();
     }
+    co_await _ss.update_service_levels_cache(qos::update_both_cache_levels::yes, qos::query_context::group0);
     _ss._topology_state_machine.event.broadcast();
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -706,7 +706,6 @@ future<> storage_service::topology_state_load(state_change_hint hint) {
     co_await _sl_controller.invoke_on_all([this] (qos::service_level_controller& sl_controller) {
         sl_controller.upgrade_to_v2(_qp, _group0->client());
     });
-    co_await update_service_levels_cache(qos::update_both_cache_levels::yes, qos::query_context::group0);
 
     // the view_builder is migrated to v2 in view_builder::migrate_to_v2.
     // it writes a v2 version mutation as topology_change, then we get here
@@ -900,7 +899,10 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
 
 future<> storage_service::update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache, qos::query_context ctx) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    co_await _sl_controller.local().update_cache(update_only_effective_cache, ctx);
+    if (_sl_controller.local().is_v2()) {
+        // Skip cache update unless the topology upgrade is done
+        co_await _sl_controller.local().update_cache(update_only_effective_cache, ctx);
+    }
 }
 
 future<> storage_service::compression_dictionary_updated_callback_all() {


### PR DESCRIPTION
Currently the service levels cache is unnecessarily updated in every call of `topology_state_load()`.
But it is enough to reload it only when a snapshot is loaded. 
(The cache is also already updated when there is a change to one of `service_levels_v2`, `role_members`, `role_attributes` tables.)

Fixes scylladb/scylladb#25114
Fixes scylladb/scylladb#23065

All versions with service levels on raft has this issue, so this patch can be backported to fix it.

