### PR TITLE
[Backport 2025.3] transport: remove throwing protocol_exception on connection start

### DIFF
--- a/test/cqlpy/test_protocol_exceptions.py
+++ b/test/cqlpy/test_protocol_exceptions.py
@@ -25,6 +25,19 @@ def get_protocol_error_metrics(host) -> int:
 
     return result
 
+def get_cpp_exceptions_metrics(host) -> int:
+    result = 0
+    metrics = requests.get(f"http://{host}:9180/metrics").text
+    pattern = re.compile(r'^scylla_reactor_cpp_exceptions\{shard="\d+"\} (\d+)')
+
+    for metric_line in metrics.split('\n'):
+        match = pattern.match(metric_line)
+        if match:
+            count = int(match.group(1))
+            result += count
+
+    return result
+
 @contextmanager
 def cql_with_protocol(host_str, port, creds, protocol_version):
     try:
@@ -48,6 +61,10 @@ def try_connect(host, port, creds, protocol_version):
 # If there is a protocol version mismatch, the server should
 # raise a protocol error, which is counted in the metrics.
 def test_protocol_version_mismatch(scylla_only, request, host):
+    run_count = 100
+    cpp_exception_threshold = 10
+
+    cpp_exception_metrics_before = get_cpp_exceptions_metrics(host)
     protocol_exception_metrics_before = get_protocol_error_metrics(host)
 
     port = request.config.getoption("--port")
@@ -61,11 +78,15 @@ def test_protocol_version_mismatch(scylla_only, request, host):
     successful_session_count = try_connect(host, port, creds, protocol_version=4)
     assert successful_session_count == 1, "Expected to connect successfully with protocol version 4"
 
-    successful_session_count = try_connect(host, port, creds, protocol_version=42)
-    assert successful_session_count == 0, "Expected to fail connecting with protocol version 42"
+    for _ in range(run_count):
+        successful_session_count = try_connect(host, port, creds, protocol_version=42)
+        assert successful_session_count == 0, "Expected to fail connecting with protocol version 42"
 
     protocol_exception_metrics_after = get_protocol_error_metrics(host)
     assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+
+    cpp_exception_metrics_after = get_cpp_exceptions_metrics(host)
+    assert cpp_exception_metrics_after - cpp_exception_metrics_before <= cpp_exception_threshold, "Expected C++ protocol errors to not increase after the test"
 
 # Many protocol errors are caused by sending malformed messages.
 # It is not possible to reproduce them with the Python driver,
@@ -152,24 +173,54 @@ def no_ssl(request):
 # Test if the error is raised when sending a malformed BATCH message
 # containing an invalid BATCH kind.
 def test_invalid_kind_in_batch_message(scylla_only, no_ssl, host):
+    run_count = 100
+    cpp_exception_threshold = 10
+
+    cpp_exception_metrics_before = get_cpp_exceptions_metrics(host)
     protocol_exception_metrics_before = get_protocol_error_metrics(host)
-    _protocol_error_impl(host, trigger_bad_batch=True)
+
+    for _ in range(run_count):
+        _protocol_error_impl(host, trigger_bad_batch=True)
+
     protocol_exception_metrics_after = get_protocol_error_metrics(host)
-    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase"
+
+    cpp_exception_metrics_after = get_cpp_exceptions_metrics(host)
+    assert cpp_exception_metrics_after - cpp_exception_metrics_before <= cpp_exception_threshold, "Expected C++ protocol errors to not increase"
 
 # Test if the error is raised when sending an unexpected AUTH_RESPONSE
 # message during the authentication phase.
 def test_unexpected_message_during_auth(scylla_only, no_ssl, host):
+    run_count = 100
+    cpp_exception_threshold = 10
+
+    cpp_exception_metrics_before = get_cpp_exceptions_metrics(host)
     protocol_exception_metrics_before = get_protocol_error_metrics(host)
-    _protocol_error_impl(host, trigger_unexpected_auth=True)
+
+    for _ in range(run_count):
+        _protocol_error_impl(host, trigger_unexpected_auth=True)
+
     protocol_exception_metrics_after = get_protocol_error_metrics(host)
-    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase"
+
+    cpp_exception_metrics_after = get_cpp_exceptions_metrics(host)
+    assert cpp_exception_metrics_after - cpp_exception_metrics_before <= cpp_exception_threshold, "Expected C++ protocol errors to not increase"
 
 # Test if the protocol exceptions do not decrease after running the test.
 # This is to ensure that the protocol exceptions are not cleared or reset
 # during the test execution.
 def test_no_protocol_exceptions(scylla_only, no_ssl, host):
+    run_count = 100
+    cpp_exception_threshold = 10
+
+    cpp_exception_metrics_before = get_cpp_exceptions_metrics(host)
     protocol_exception_metrics_before = get_protocol_error_metrics(host)
-    _protocol_error_impl(host)
+
+    for _ in range(run_count):
+        _protocol_error_impl(host)
+
     protocol_exception_metrics_after = get_protocol_error_metrics(host)
-    assert protocol_exception_metrics_after == protocol_exception_metrics_before, "Expected protocol errors to not increase after the test"
+    assert protocol_exception_metrics_after == protocol_exception_metrics_before, "Expected protocol errors to not increase"
+
+    cpp_exception_metrics_after = get_cpp_exceptions_metrics(host)
+    assert cpp_exception_metrics_after - cpp_exception_metrics_before <= cpp_exception_threshold, "Expected C++ protocol errors to not increase"

--- a/test/cqlpy/test_protocol_exceptions.py
+++ b/test/cqlpy/test_protocol_exceptions.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+from cassandra.cluster import NoHostAvailable
+from contextlib import contextmanager
+import pytest
+import re
+import requests
+import socket
+import struct
+from test.cqlpy.util import cql_session
+
+def get_protocol_error_metrics(host) -> int:
+    result = 0
+    metrics = requests.get(f"http://{host}:9180/metrics").text
+    pattern = re.compile(r'^scylla_transport_cql_errors_total\{shard="\d+",type="protocol_error"\} (\d+)')
+
+    for metric_line in metrics.split('\n'):
+        match = pattern.match(metric_line)
+        if match:
+            count = int(match.group(1))
+            result += count
+
+    return result
+
+@contextmanager
+def cql_with_protocol(host_str, port, creds, protocol_version):
+    try:
+        with cql_session(
+                host=host_str,
+                port=port,
+                is_ssl=creds["ssl"],
+                username=creds["username"],
+                password=creds["password"],
+                protocol_version=protocol_version,
+        ) as session:
+            yield session
+            session.shutdown()
+    except NoHostAvailable:
+        yield None
+
+def try_connect(host, port, creds, protocol_version):
+    with cql_with_protocol(host, port, creds, protocol_version) as session:
+        return 1 if session else 0
+
+# If there is a protocol version mismatch, the server should
+# raise a protocol error, which is counted in the metrics.
+def test_protocol_version_mismatch(scylla_only, request, host):
+    protocol_exception_metrics_before = get_protocol_error_metrics(host)
+
+    port = request.config.getoption("--port")
+    # Use the default superuser credentials, which work for both Scylla and Cassandra
+    creds = {
+        "ssl": request.config.getoption("--ssl"),
+        "username": request.config.getoption("--auth_username") or "cassandra",
+        "password": request.config.getoption("--auth_password") or "cassandra",
+    }
+
+    successful_session_count = try_connect(host, port, creds, protocol_version=4)
+    assert successful_session_count == 1, "Expected to connect successfully with protocol version 4"
+
+    successful_session_count = try_connect(host, port, creds, protocol_version=42)
+    assert successful_session_count == 0, "Expected to fail connecting with protocol version 42"
+
+    protocol_exception_metrics_after = get_protocol_error_metrics(host)
+    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+
+# Many protocol errors are caused by sending malformed messages.
+# It is not possible to reproduce them with the Python driver,
+# so we use a low-level socket connection to send the messages.
+# To avoid code duplication of this low-level code, we use a common
+# implementation function with parameters. To trigger a specific
+# protocol error, the appropriate trigger should be set to True.
+def _protocol_error_impl(host, *, trigger_bad_batch=False, trigger_unexpected_auth=False):
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, 9042))
+    try:
+        # STARTUP
+        startup = bytearray()
+        startup += struct.pack("!B", 0x04)         # version 4
+        startup += struct.pack("!B", 0x00)         # flags
+        startup += struct.pack("!H", 0x01)         # stream = 1
+        startup += struct.pack("!B", 0x01)         # opcode = STARTUP
+        body = b'\x00\x01\x00\x0bCQL_VERSION\x00\x053.0.0'
+        startup += struct.pack("!I", len(body))
+        startup += body
+        s.send(startup)
+
+        # READY or AUTHENTICATE?
+        frame = s.recv(4096)
+        op = frame[4]
+        assert op in (0x02, 0x03), f"expected READY(2) or AUTHENTICATE(3), got {hex(op)}"
+
+        if op == 0x02:
+            # READY path
+            if trigger_unexpected_auth:
+                pytest.skip("server not configured with authentication, skipping unexpected auth test")
+        elif op == 0x03:
+            # AUTHENTICATE path
+            if trigger_unexpected_auth:
+                # send OPTIONS to trigger auth‐state exception
+                bad = bytearray()
+                bad += struct.pack("!B", 0x04)        # version 4
+                bad += struct.pack("!B", 0x00)        # flags
+                bad += struct.pack("!H", 0x02)        # stream = 2
+                bad += struct.pack("!B", 0x05)        # opcode = OPTIONS
+                bad += struct.pack("!I", 0)           # body length = 0
+                s.send(bad)
+                s.recv(4096)
+                return
+
+            # send correct AUTH_RESPONSE
+            auth = bytearray()
+            auth += struct.pack("!B", 0x04)
+            auth += struct.pack("!B", 0x00)
+            auth += struct.pack("!H", 0x02)       # stream = 2
+            auth += struct.pack("!B", 0x0F)       # AUTH_RESPONSE
+            payload = b'\x00cassandra\x00cassandra'
+            auth += struct.pack("!I", len(payload))
+            auth += payload
+            s.send(auth)
+            # wait for AUTH_SUCCESS (0x10)
+            resp = s.recv(4096)
+            assert resp[4] == 0x10, f"expected AUTH_SUCCESS, got {hex(resp[4])}"
+
+        if trigger_bad_batch:
+            bad = bytearray()
+            bad += struct.pack("!B", 0x04)        # version 4
+            bad += struct.pack("!B", 0x00)        # flags
+            bad += struct.pack("!H", 0x03)        # stream = 3
+            bad += struct.pack("!B", 0x0D)        # BATCH
+            bbody = bytearray()
+            bbody += struct.pack("!B", 0x00)      # batch type = LOGGED
+            bbody += struct.pack("!H", 0x01)      # 1 statement
+            bbody += struct.pack("!B", 0xFF)      # INVALID kind = 255
+            bad += struct.pack("!I", len(bbody))
+            bad += bbody
+            s.send(bad)
+            s.recv(4096)
+
+    finally:
+        s.close()
+
+@pytest.fixture
+def no_ssl(request):
+    if request.config.getoption("--ssl"):
+        pytest.skip("skipping non-SSL test on SSL-enabled run")
+    yield
+
+# Test if the error is raised when sending a malformed BATCH message
+# containing an invalid BATCH kind.
+def test_invalid_kind_in_batch_message(scylla_only, no_ssl, host):
+    protocol_exception_metrics_before = get_protocol_error_metrics(host)
+    _protocol_error_impl(host, trigger_bad_batch=True)
+    protocol_exception_metrics_after = get_protocol_error_metrics(host)
+    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+
+# Test if the error is raised when sending an unexpected AUTH_RESPONSE
+# message during the authentication phase.
+def test_unexpected_message_during_auth(scylla_only, no_ssl, host):
+    protocol_exception_metrics_before = get_protocol_error_metrics(host)
+    _protocol_error_impl(host, trigger_unexpected_auth=True)
+    protocol_exception_metrics_after = get_protocol_error_metrics(host)
+    assert protocol_exception_metrics_after > protocol_exception_metrics_before, "Expected protocol errors to increase after the test"
+
+# Test if the protocol exceptions do not decrease after running the test.
+# This is to ensure that the protocol exceptions are not cleared or reset
+# during the test execution.
+def test_no_protocol_exceptions(scylla_only, no_ssl, host):
+    protocol_exception_metrics_before = get_protocol_error_metrics(host)
+    _protocol_error_impl(host)
+    protocol_exception_metrics_after = get_protocol_error_metrics(host)
+    assert protocol_exception_metrics_after == protocol_exception_metrics_before, "Expected protocol errors to not increase after the test"

--- a/test/cqlpy/util.py
+++ b/test/cqlpy/util.py
@@ -201,7 +201,7 @@ def index_table_name(index_name : str):
 
 # Helper function for establishing a connection with given username and password
 @contextmanager
-def cql_session(host, port, is_ssl, username, password, request_timeout=120):
+def cql_session(host, port, is_ssl, username, password, request_timeout=120, protocol_version=4):
     profile = ExecutionProfile(
         load_balancing_policy=RoundRobinPolicy(),
         consistency_level=ConsistencyLevel.LOCAL_QUORUM,
@@ -221,10 +221,7 @@ def cql_session(host, port, is_ssl, username, password, request_timeout=120):
     cluster = Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
         contact_points=[host],
         port=int(port),
-        # TODO: make the protocol version an option, to allow testing with
-        # different versions. If we drop this setting completely, it will
-        # mean pick the latest version supported by the client and the server.
-        protocol_version=4,
+        protocol_version=protocol_version,
         auth_provider=PlainTextAuthProvider(username=username, password=password),
         ssl_context=ssl_context,
         # The default timeout for new connections is 5 seconds, and for

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -867,7 +867,7 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
                     throw std::runtime_error("CQL frame uncompressed length is negative: " + std::to_string(uncomp_len));
                 }
                 auto in = input_buffer.get_linearized_view(v);
-                return output_buffer.make_fragmented_temporary_buffer(uncomp_len, [&in] (bytes_mutable_view out) {
+                return utils::result_into_future(output_buffer.make_fragmented_temporary_buffer(uncomp_len, [&in] (bytes_mutable_view out) -> utils::result_with_exception<size_t, std::runtime_error> {
                     auto ret = LZ4_decompress_safe(reinterpret_cast<const char*>(in.data()), reinterpret_cast<char*>(out.data()), in.size(), out.size());
                     if (ret < 0) {
                         throw std::runtime_error("CQL frame LZ4 uncompression failure");
@@ -875,8 +875,8 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
                     if (static_cast<size_t>(ret) != out.size()) {  // ret is known to be positive here
                         throw std::runtime_error("Malformed CQL frame - provided uncompressed size different than real uncompressed size");
                     }
-                    return static_cast<size_t>(ret);
-                });
+                    return bo::success(static_cast<size_t>(ret));
+                }));
             });
         } else if (_compression == cql_compression::snappy) {
             return _buffer_reader.read_exactly(_read_buf, length).then([] (fragmented_temporary_buffer buf) {
@@ -887,7 +887,7 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
                 if (snappy_uncompressed_length(reinterpret_cast<const char*>(in.data()), in.size(), &uncomp_len) != SNAPPY_OK) {
                     throw std::runtime_error("CQL frame Snappy uncompressed size is unknown");
                 }
-                return output_buffer.make_fragmented_temporary_buffer(uncomp_len, [&in] (bytes_mutable_view out) {
+                return utils::result_into_future(output_buffer.make_fragmented_temporary_buffer(uncomp_len, [&in] (bytes_mutable_view out) -> utils::result_with_exception<size_t, std::runtime_error> {
                     size_t output_len = out.size();
                     if (snappy_uncompress(reinterpret_cast<const char*>(in.data()), in.size(), reinterpret_cast<char*>(out.data()), &output_len) != SNAPPY_OK) {
                         throw std::runtime_error("CQL frame Snappy uncompression failure");
@@ -895,8 +895,8 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
                     if (output_len != out.size()) {
                         throw std::runtime_error("Malformed CQL frame - provided uncompressed size different than real uncompressed size");
                     }
-                    return output_len;
-                });
+                    return bo::success(output_len);
+                }));
             });
         } else {
             throw exceptions::protocol_exception(format("Unknown compression algorithm"));
@@ -1710,7 +1710,7 @@ void cql_server::response::compress_lz4()
 
     auto in = input_buffer.get_linearized_view(_body);
     size_t output_len = LZ4_COMPRESSBOUND(in.size()) + 4;
-    _body = output_buffer.make_bytes_ostream(output_len, [&in] (bytes_mutable_view out) {
+    auto bytes_ostream = output_buffer.make_bytes_ostream(output_len, [&in] (bytes_mutable_view out) -> utils::result_with_exception<size_t, std::runtime_error> {
         out.data()[0] = (in.size() >> 24) & 0xFF;
         out.data()[1] = (in.size() >> 16) & 0xFF;
         out.data()[2] = (in.size() >> 8) & 0xFF;
@@ -1719,8 +1719,12 @@ void cql_server::response::compress_lz4()
         if (ret == 0) {
             throw std::runtime_error("CQL frame LZ4 compression failure");
         }
-        return static_cast<size_t>(ret) + 4;
+        return bo::success(static_cast<size_t>(ret) + 4);
     });
+    if (!bytes_ostream) {
+        throw std::move(bytes_ostream).as_failure();
+    }
+    _body = std::move(bytes_ostream).value();
 }
 
 void cql_server::response::compress_snappy()
@@ -1730,15 +1734,19 @@ void cql_server::response::compress_snappy()
 
     auto in = input_buffer.get_linearized_view(_body);
     size_t output_len = snappy_max_compressed_length(in.size());
-    _body = output_buffer.make_bytes_ostream(output_len, [&in] (bytes_mutable_view out) {
+    auto bytes_ostream = output_buffer.make_bytes_ostream(output_len, [&in] (bytes_mutable_view out) -> utils::result_with_exception<size_t, std::runtime_error> {
         // FIXME: snappy internally performs allocations greater than 128 kiB.
         const memory::scoped_large_allocation_warning_threshold slawt{256*1024};
         size_t actual_len = out.size();
         if (snappy_compress(reinterpret_cast<const char*>(in.data()), in.size(), reinterpret_cast<char*>(out.data()), &actual_len) != SNAPPY_OK) {
             throw std::runtime_error("CQL frame Snappy compression failure");
         }
-        return actual_len;
+        return bo::success(actual_len);
     });
+    if (!bytes_ostream) {
+        throw std::move(bytes_ostream).as_failure();
+    }
+    _body = std::move(bytes_ostream).value();
 }
 
 void cql_server::response::serialize(const event::schema_change& event, uint8_t version)

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -25,6 +25,7 @@
 #include <seastar/net/tls.hh>
 #include <seastar/core/metrics_registration.hh>
 #include "utils/fragmented_temporary_buffer.hh"
+#include "utils/result.hh"
 #include "service_permit.hh"
 #include <seastar/core/sharded.hh>
 #include <seastar/core/execution_stage.hh>
@@ -36,6 +37,7 @@
 #include "transport/messages/result_message.hh"
 #include "utils/chunked_vector.hh"
 #include "exceptions/coordinator_result.hh"
+#include "exceptions/exceptions.hh"
 #include "db/operation_type.hh"
 #include "service/maintenance_mode.hh"
 
@@ -292,7 +294,7 @@ private:
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit);
         unsigned frame_size() const;
         unsigned pick_request_cpu();
-        cql_binary_frame_v3 parse_frame(temporary_buffer<char> buf) const;
+        utils::result_with_exception<cql_binary_frame_v3, exceptions::protocol_exception, class cql_frame_error> parse_frame(temporary_buffer<char> buf) const;
         future<fragmented_temporary_buffer> read_and_decompress_frame(size_t length, uint8_t flags);
         future<std::optional<cql_binary_frame_v3>> read_frame();
         future<std::unique_ptr<cql_server::response>> process_startup(uint16_t stream, request_reader in, service::client_state& client_state, tracing::trace_state_ptr trace_state);


### PR DESCRIPTION
`protocol_exception` is thrown in several places. This has become a performance issue, especially when starting/restarting a server. To alleviate this issue, throwing the exception has to be replaced with returning it as a result or an exceptional future.

This PR replaces throws in the `transport/server` module. This is achieved by using result_with_exception, and in some places, where suitable, just by creating and returning an exceptional future.

There are four commits in this PR. The first commit introduces tests in `test/cqlpy`. The second commit refactors transport server `handle_error` to not rethrow exceptions. The third commit refactors reusable buffer writer callbacks. The fourth commit replaces throwing `protocol_exception` to returning it.

Based on the comments on an issue linked in https://github.com/scylladb/scylladb/issues/24567, the main culprit from the side of protocol exceptions is the invalid protocol version one, so I tested that exception for performance.

In order to see if there is a measurable difference, a modified version of `test_protocol_version_mismatch` Python is used, with 100'000 runs across 10 processes (not threads, to avoid Python GIL). One test run consisted of 1 warm-up run and 5 measured runs. First test run has been executed on the current code, with throwing protocol exceptions. Second test urn has been executed on the new code, with returning protocol exceptions. The performance report is in https://github.com/scylladb/scylladb/pull/24738#issuecomment-3051611069. It shows ~10% gains in real, user, and sys time for this test.

Testing

Build: `release`

Test file: `test/cqlpy/test_protocol_exceptions.py`
Test name: `test_protocol_version_mismatch` (modified for mass connection requests)

Test arguments:
```
max_attempts=100'000
num_parallel=10
# total runs = 1'000'000
```

Throwing `protocol_exception` results:
```
real=1:26.97  user=10:00.27  sys=2:34.55  cpu=867%
real=1:26.95  user=9:57.10  sys=2:32.50  cpu=862%
real=1:26.93  user=9:56.54  sys=2:35.59  cpu=865%
real=1:26.96  user=9:54.95  sys=2:32.33  cpu=859%
real=1:26.96  user=9:53.39  sys=2:33.58  cpu=859%

real=1:26.95 user=9:56.85 sys=2:34.11 cpu=862%   # average
```

Returning `protocol_exception` as `result_with_exception` or an exceptional future:
```
real=1:18.46  user=9:12.21  sys=2:19.08  cpu=881%
real=1:18.44  user=9:04.03  sys=2:17.91  cpu=869%
real=1:18.47  user=9:12.94  sys=2:19.68  cpu=882%
real=1:18.49  user=9:13.60  sys=2:19.88  cpu=883%
real=1:18.48  user=9:11.76  sys=2:17.32  cpu=878%

real=1:18.47 user=9:10.91 sys=2:18.77 cpu=879%   # average
```

This PR replaced `transport/server` throws of `protocol_exception` with returns. There are a few other places where protocol exceptions are thrown, and there are many places where `invalid_request_exception` is thrown. That is out of scope of this single PR, so the PR just refs, and does not resolve issue #24567.

Refs: #24567
Fixes: #25271 

This PR improves performance in cases when protocol exceptions happen, for example during connection storms. It will require backporting.

* (cherry picked from commit https://github.com/scylladb/scylladb/commit/7aaeed012e0f07a7bbb55c36a3e10c9d265e8421)

* (cherry picked from commit https://github.com/scylladb/scylladb/commit/30d424e0d3468a8566adcd669f5f02bd5c011bd0)

* (cherry picked from commit https://github.com/scylladb/scylladb/commit/9f4344a4353193b0c9944d0fc251f701d215d370)

* (cherry picked from commit https://github.com/scylladb/scylladb/commit/5390f92afcbac99d59f19297e3db48fbda033d13)

* (cherry picked from commit https://github.com/scylladb/scylladb/commit/4a6f71df6873e116cedccd3c4afc63f397f72ec0)

Parent PR: #24738 