### PR TITLE
Move feature-service config creation code out of feature-service itself

### DIFF
--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -36,9 +36,6 @@ static bool is_test_only_feature_enabled() {
             || is_test_only_feature_deprecated();
 }
 
-feature_config::feature_config() {
-}
-
 feature_service::feature_service(feature_config cfg) : _config(cfg) {
 #ifdef SCYLLA_ENABLE_ERROR_INJECTION
     initialize_suppressed_features_set();
@@ -53,7 +50,7 @@ feature_service::feature_service(feature_config cfg) : _config(cfg) {
 
 feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled) {
     feature_config fcfg;
-    fcfg._disabled_features = get_disabled_features_from_db_config(cfg, std::move(disabled));
+    fcfg.disabled_features = get_disabled_features_from_db_config(cfg, std::move(disabled));
     return fcfg;
 }
 
@@ -176,7 +173,7 @@ std::set<std::string_view> feature_service::supported_feature_set() const {
         features.insert(name);
     }
 
-    for (const sstring& s : _config._disabled_features) {
+    for (const sstring& s : _config.disabled_features) {
         features.erase(s);
     }
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -20,7 +20,6 @@
 #include "gms/feature.hh"
 
 namespace db {
-class config;
 class system_keyspace;
 }
 namespace service { class storage_service; }
@@ -35,15 +34,14 @@ struct feature_config {
     std::set<sstring> disabled_features;
 };
 
-feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
-std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
-
 class unsupported_feature_exception : public std::runtime_error {
 public:
     unsupported_feature_exception(std::string what)
             : runtime_error(std::move(what))
     {}
 };
+
+bool is_test_only_feature_enabled();
 
 using namespace std::literals;
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -32,12 +32,7 @@ class feature_service;
 class i_endpoint_state_change_subscriber;
 
 struct feature_config {
-private:
-    std::set<sstring> _disabled_features;
-    feature_config();
-
-    friend class feature_service;
-    friend feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled);
+    std::set<sstring> disabled_features;
 };
 
 feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -41,6 +41,7 @@ private:
 };
 
 feature_config feature_config_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
+std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
 
 class unsupported_feature_exception : public std::runtime_error {
 public:

--- a/init.cc
+++ b/init.cc
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <seastar/core/coroutine.hh>
 #include "sstables/sstable_compressor_factory.hh"
+#include "gms/feature_service.hh"
 
 logging::logger startlog("init");
 
@@ -67,6 +68,9 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
     return seeds;
 }
 
+std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, std::set<sstring> disabled) {
+    return gms::get_disabled_features_from_db_config(cfg, std::move(disabled));
+}
 
 std::vector<std::reference_wrapper<configurable>>& configurable::configurables() {
     static std::vector<std::reference_wrapper<configurable>> configurables;

--- a/init.cc
+++ b/init.cc
@@ -18,6 +18,8 @@
 
 logging::logger startlog("init");
 
+using namespace std::string_literals;
+
 std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
                                                      const gms::inet_address broadcast_address,
                                                      const bool fail_on_lookup_error) {
@@ -69,7 +71,54 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
 }
 
 std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, std::set<sstring> disabled) {
-    return gms::get_disabled_features_from_db_config(cfg, std::move(disabled));
+    switch (sstables::version_from_string(cfg.sstable_format())) {
+    case sstables::sstable_version_types::md:
+        startlog.warn("sstable_format must be 'me', '{}' is specified", cfg.sstable_format());
+        break;
+    case sstables::sstable_version_types::me:
+        break;
+    default:
+        SCYLLA_ASSERT(false && "Invalid sstable_format");
+    }
+
+    if (!cfg.enable_user_defined_functions()) {
+        disabled.insert("UDF");
+    } else {
+        if (!cfg.check_experimental(db::experimental_features_t::feature::UDF)) {
+            throw std::runtime_error(
+                    "You must use both enable_user_defined_functions and experimental_features:udf "
+                    "to enable user-defined functions");
+        }
+    }
+
+    if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
+        disabled.insert("ALTERNATOR_STREAMS"s);
+    }
+    if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
+        disabled.insert("KEYSPACE_STORAGE_OPTIONS"s);
+    }
+    if (!cfg.check_experimental(db::experimental_features_t::feature::VIEWS_WITH_TABLETS)) {
+        disabled.insert("VIEWS_WITH_TABLETS"s);
+    }
+    if (cfg.force_gossip_topology_changes()) {
+        if (cfg.enable_tablets_by_default()) {
+            throw std::runtime_error("Tablets cannot be enabled with gossip topology changes.  Use either --tablets-mode-for-new-keyspaces=enabled|enforced or --force-gossip-topology-changes, but not both.");
+        }
+        startlog.warn("The tablets feature is disabled due to forced gossip topology changes");
+        disabled.insert("TABLETS"s);
+    }
+    if (!cfg.table_digest_insensitive_to_expiry()) {
+        disabled.insert("TABLE_DIGEST_INSENSITIVE_TO_EXPIRY"s);
+    }
+    if (!cfg.commitlog_use_fragmented_entries()) {
+        disabled.insert("FRAGMENTED_COMMITLOG_ENTRIES"s);
+    }
+
+    if (!gms::is_test_only_feature_enabled()) {
+        disabled.insert("TEST_ONLY_FEATURE"s);
+    }
+
+    return disabled;
 }
 
 std::vector<std::reference_wrapper<configurable>>& configurable::configurables() {

--- a/init.hh
+++ b/init.hh
@@ -40,6 +40,7 @@ class bad_configuration_error : public std::exception {};
 [[nodiscard]] std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
                                                                    gms::inet_address broadcast_address,
                                                                    bool fail_on_lookup_error);
+[[nodiscard]] std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, std::set<sstring> disabled = {});
 
 class service_set {
 public:

--- a/main.cc
+++ b/main.cc
@@ -875,7 +875,8 @@ sharded<locator::shared_token_metadata> token_metadata;
                 startlog.warn("Ignoring unused features found in config: {}", unused_features);
             }
 
-            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg);
+            gms::feature_config fcfg;
+            fcfg.disabled_features = get_disabled_features_from_db_config(*cfg);
 
             checkpoint(stop_signal, "starting feature service");
             debug::the_feature_service = &feature_service;

--- a/test/boost/schema_registry_test.cc
+++ b/test/boost/schema_registry_test.cc
@@ -14,6 +14,7 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/lowres_clock.hh>
+#include "init.hh"
 #include "data_dictionary/user_types_metadata.hh"
 #include "schema/schema_registry.hh"
 #include "schema/schema_builder.hh"
@@ -47,7 +48,7 @@ struct dummy_init {
     seastar::lowres_clock::duration grace_period;
     dummy_init()
             : config(std::make_unique<db::config>())
-            , fs(gms::feature_config_from_db_config(*config))
+            , fs({get_disabled_features_from_db_config(*config)})
             , grace_period(std::chrono::seconds(config->schema_registry_grace_period())) {
         local_schema_registry().init(db::schema_ctxt(*config, std::make_shared<data_dictionary::dummy_user_types_storage>(), fs));
     }

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -551,7 +551,8 @@ private:
 
             auto stop_configurables = defer_verbose_shutdown("configurables", [&] { notify_set.notify_all(configurable::system_state::stopped).get(); });
 
-            gms::feature_config fcfg = gms::feature_config_from_db_config(*cfg, cfg_in.disabled_features);
+            gms::feature_config fcfg;
+            fcfg.disabled_features = get_disabled_features_from_db_config(*cfg, cfg_in.disabled_features);
             _feature_service.start(fcfg).get();
             auto stop_feature_service = defer_verbose_shutdown("feature service", [this] { _feature_service.stop().get(); });
 

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -11,6 +11,7 @@
 #include "test/lib/sstable_test_env.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/test_utils.hh"
+#include "init.hh"
 #include "db/config.hh"
 #include "db/large_data_handler.hh"
 #include "db/corrupt_data_handler.hh"
@@ -226,7 +227,7 @@ test_env::impl::impl(test_env_config cfg, sstable_compressor_factory& scfarg, ss
     , dir(tdir == nullptr ? local_dir.value() : *tdir)
     , db_config(make_db_config(dir.path().native(), cfg.storage))
     , dir_sem(1)
-    , feature_service(gms::feature_config_from_db_config(*db_config))
+    , feature_service({get_disabled_features_from_db_config(*db_config)})
     , nop_cd_handler(db::corrupt_data_handler::register_metrics::no)
     , scf(scfarg)
     , mgr(

--- a/test/manual/gossip.cc
+++ b/test/manual/gossip.cc
@@ -12,6 +12,7 @@
 #include <seastar/core/app-template.hh>
 #include <seastar/util/closeable.hh>
 
+#include "init.hh"
 #include "db/config.hh"
 #include "db/system_distributed_keyspace.hh"
 #include "gms/feature_service.hh"
@@ -85,7 +86,8 @@ int main(int ac, char ** av) {
             compressor_tracker.start([] { return utils::walltime_compressor_tracker::config{}; }).get();
             auto stop_compressor_tracker = deferred_stop(compressor_tracker);
 
-            auto cfg = gms::feature_config_from_db_config(db::config(), {});
+            gms::feature_config cfg;
+            cfg.disabled_features = get_disabled_features_from_db_config(db::config());
             feature_service.start(cfg).get();
 
             gossip_address_map.start().get();

--- a/test/manual/message.cc
+++ b/test/manual/message.cc
@@ -204,7 +204,7 @@ int main(int ac, char ** av) {
             compressor_tracker.start([] { return utils::walltime_compressor_tracker::config{}; }).get();
             auto stop_compressor_tracker = deferred_stop(compressor_tracker);
             seastar::sharded<gms::feature_service> feature_service;
-            auto cfg = gms::feature_config_from_db_config(db::config(), {});
+            gms::feature_config cfg;
             feature_service.start(cfg).get();
             seastar::sharded<gms::gossip_address_map> gossip_address_map;
             gossip_address_map.start().get();

--- a/tools/read_mutation.hh
+++ b/tools/read_mutation.hh
@@ -13,6 +13,7 @@
 #include <string_view>
 #include <optional>
 
+#include "init.hh"
 #include "db/cache_tracker.hh"
 #include "db/config.hh"
 #include "db/large_data_handler.hh"
@@ -39,7 +40,7 @@ struct sstable_manager_service {
 
     explicit sstable_manager_service(const db::config& dbcfg, sstable_compressor_factory& scf)
         : corrupt_data_handler(db::corrupt_data_handler::register_metrics::no)
-        , feature_service(gms::feature_config_from_db_config(dbcfg))
+        , feature_service({get_disabled_features_from_db_config(dbcfg)})
         , dir_sem(1)
         , sst_man("schema_loader", large_data_handler, corrupt_data_handler, dbcfg, feature_service, tracker, memory::stats().total_memory(), dir_sem, []{ return locator::host_id{}; }, scf, abort) {
     }

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -235,7 +235,7 @@ sstring read_file(std::filesystem::path path) {
 std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view schema_str) {
     cql3::cql_stats cql_stats;
 
-    gms::feature_service feature_service(gms::feature_config_from_db_config(cfg));
+    gms::feature_service feature_service({get_disabled_features_from_db_config(cfg)});
     feature_service.enable(feature_service.supported_feature_set()).get();
     feature_service.views_with_tablets.enable();
 
@@ -468,7 +468,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     }
 
     auto user_type_storage = std::make_shared<single_keyspace_user_types_storage>(std::move(utm));
-    gms::feature_service features(gms::feature_config_from_db_config(dbcfg));
+    gms::feature_service features({get_disabled_features_from_db_config(dbcfg)});
     db::schema_ctxt ctxt(dbcfg, user_type_storage, features);
 
     if (empty(tables)) {
@@ -498,7 +498,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
 
     db::nop_large_data_handler large_data_handler;
     db::nop_corrupt_data_handler corrupt_data_handler(db::corrupt_data_handler::register_metrics::no);
-    gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
+    gms::feature_service feature_service({get_disabled_features_from_db_config(dbcfg)});
     cache_tracker tracker;
     sstables::directory_semaphore dir_sem(1);
     abort_source abort;

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3560,7 +3560,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
             return 1;
         }
 
-        gms::feature_service feature_service(gms::feature_config_from_db_config(dbcfg));
+        gms::feature_service feature_service({get_disabled_features_from_db_config(dbcfg)});
         auto scf = make_sstable_compressor_factory_for_tests_in_thread();
         cache_tracker tracker;
         sstables::directory_semaphore dir_sem(1);


### PR DESCRIPTION
Nowadays the way to configure an internal service is

1. service declares its config struct
2. caller (main/test/tool) fills the respective config with values it wants
3. the service is started with the config passed by value

The feature service code behaves likewise, but provides a helper method to create its config out of db::config. This PR moves this helper out of gms code, so that it doesn't mess with system-wide db::config and only needs its own small struct feature_config.

For the reference: similar changes with other services: #23705 , #20174 , #19166 