### PR TITLE
api: Simplify table_info::name extraction with std::views::transform

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -232,7 +232,7 @@ future<scrub_info> parse_scrub_options(const http_context& ctx, sharded<db::snap
     scrub_info info;
     auto [ keyspace, table_infos ] = parse_table_infos(ctx, *req, "cf");
     info.keyspace = std::move(keyspace);
-    info.column_families = table_infos | std::views::transform([] (auto ti) { return ti.name; }) | std::ranges::to<std::vector>();
+    info.column_families = table_infos | std::views::transform(&table_info::name) | std::ranges::to<std::vector>();
     auto scrub_mode_str = req->get_query_param("scrub_mode");
     auto scrub_mode = sstables::compaction_type_options::scrub::mode::abort;
 


### PR DESCRIPTION
Instead of using lambda, pass pointer to struct member. The result is the same, but the code is nicer.
