### PR TITLE
raft_group0: split shutdown into abort-and-drain and destroy

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2134,7 +2134,8 @@ sharded<locator::shared_token_metadata> token_metadata;
             group0_service.start().get();
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
                 sl_controller.local().abort_group0_operations();
-                group0_service.abort().get();
+                group0_service.abort_and_drain().get();
+                group0_service.destroy();
             });
 
             utils::get_local_injector().inject("stop_after_starting_group0_service",

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -251,7 +251,8 @@ raft_server_for_group raft_group0::create_server_for_group0(raft::group_id gid, 
     auto* cl = qp.proxy().get_db().local().schema_commitlog();
     auto config = raft::server::configuration {
         .on_background_error = [gid, this](std::exception_ptr e) {
-            _raft_gr.abort_server(gid, fmt::format("background error, {}", e));
+            // The future will be waited indirectly in raft_group0::abort_and_drain.
+            (void)_raft_gr.abort_server(gid, fmt::format("background error, {}", e));
             _status_for_monitoring = status_for_monitoring::aborted;
         }
     };
@@ -413,22 +414,51 @@ future<group0_info> persistent_discovery::run(
     }
 }
 
-future<> raft_group0::abort() {
-    group0_log.debug("Raft group0 service is aborting...");
+future<> raft_group0::abort_and_drain() {
+    if (!_aborted) {
+        // Async lambdas are destroyed at the first co_await,
+        // so accessing lambda-local state (like 'this') afterward would result
+        // in use-after-free. To avoid that, we delegate to a helper function,
+        // do_abort_and_drain().
 
-    co_await smp::invoke_on_all([this]() {
-        return uninit_rpc_verbs(_ms.local());
-    });
+        _aborted = futurize_invoke([this]() { return do_abort_and_drain(); });
+    }
+    return _aborted->get_future();
+}
 
-    _leadership_monitor_as.request_abort();
+future<> raft_group0::do_abort_and_drain() {
+    group0_log.debug("Aborting raft group0 service...");
 
-    co_await _shutdown_gate.close();
+    // abort_server() may already be running in the background if triggered by the 
+    // on_background_error callback. We wait for that to complete. This code 
+    // shouldn't normally throw, but we wrap it in try/catch just in case, to ensure 
+    // we still wait for the background abort.
 
-    co_await std::move(_leadership_monitor);
+    try {
+        co_await smp::invoke_on_all([this]() {
+            return uninit_rpc_verbs(_ms.local());
+        });
 
-    co_await stop_group0();
+        _leadership_monitor_as.request_abort();
 
-    group0_log.debug("Raft group0 service is aborted");
+        co_await _shutdown_gate.close();
+
+        co_await std::move(_leadership_monitor);
+    } catch (...) {
+        rslog.warn("Failed to abort raft group0: {}", std::current_exception());
+    }
+
+    if (auto* group0_id = std::get_if<raft::group_id>(&_group0)) {
+        co_await _raft_gr.abort_server(*group0_id, "raft group0 is aborted");
+    }
+
+    group0_log.debug("Raft group0 service aborted");
+}
+
+void raft_group0::destroy() {
+    if (auto* group0_id = std::get_if<raft::group_id>(&_group0)) {
+        _raft_gr.destroy_server(*group0_id);
+    }
 }
 
 future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm, bool topology_change_enabled) {
@@ -859,12 +889,6 @@ future<> raft_group0::finish_setup_after_join(service::storage_service& ss, cql3
             upgrade_to_group0(ss, qp, mm, topology_change_enabled).get();
         });
     });
-}
-
-future<> raft_group0::stop_group0() {
-    if (auto* group0_id = std::get_if<raft::group_id>(&_group0)) {
-        co_await _raft_gr.stop_server(*group0_id, "raft group0 is stopped");
-    }
 }
 
 bool raft_group0::is_member(raft::server_id id, bool include_voters_only) {

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -414,10 +414,6 @@ future<group0_info> persistent_discovery::run(
 }
 
 future<> raft_group0::abort() {
-    if (_aborted) {
-        co_return;
-    }
-    _aborted = true;
     group0_log.debug("Raft group0 service is aborting...");
 
     co_await smp::invoke_on_all([this]() {

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -133,7 +133,6 @@ class raft_group0 {
     future<> _leadership_monitor = make_ready_future<>();
     abort_source _leadership_monitor_as;
     utils::updateable_value_source<bool> _leadership_observable;
-    bool _aborted = false;
 
 public:
     // Passed to `setup_group0` when replacing a node.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4701,17 +4701,9 @@ future<> storage_service::drain() {
 }
 
 future<> storage_service::do_drain() {
-    // Need to stop transport before group0, otherwise RPCs may fail with raft_group_not_found.
     co_await stop_transport();
 
-    // group0 persistence relies on local storage, so we need to stop group0 first.
-    // This must be kept in sync with defer_verbose_shutdown for group0 in main.cc to
-    // handle the case when initialization fails before reaching drain_on_shutdown for ss.
-    _sl_controller.local().abort_group0_operations();
     co_await wait_for_group0_stop();
-    if (_group0) {
-        co_await _group0->abort();
-    }
 
     co_await tracing::tracing::tracing_instance().invoke_on_all(&tracing::tracing::shutdown);
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4701,9 +4701,17 @@ future<> storage_service::drain() {
 }
 
 future<> storage_service::do_drain() {
+    // Need to stop transport before group0, otherwise RPCs may fail with raft_group_not_found.
     co_await stop_transport();
 
+    // group0 persistence relies on local storage, so we need to stop group0 first.
+    // This must be kept in sync with defer_verbose_shutdown for group0 in main.cc to
+    // handle the case when initialization fails before reaching drain_on_shutdown for ss.
+    _sl_controller.local().abort_group0_operations();
     co_await wait_for_group0_stop();
+    if (_group0) {
+        co_await _group0->abort_and_drain();
+    }
 
     co_await tracing::tracing::tracing_instance().invoke_on_all(&tracing::tracing::shutdown);
 

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -59,8 +59,8 @@ async def test_group0_apply_while_node_is_being_shutdown(manager: ManagerClient)
     logger.info("Triggering s0 shutdown")
     stop_s0_task = asyncio.create_task(manager.server_stop_gracefully(s0.server_id))
 
-    logger.info("Waiting for group0 to start aborting on s0")
-    await log.wait_for('Raft group0 service is aborting...')
+    logger.info("Waiting for 'Aborting raft group0 service...' on s0")
+    await log.wait_for('Aborting raft group0 service...')
 
     logger.info("Releasing topology_state_load_before_update_cdc on s0")
     await manager.api.message_injection(s0.ip_addr, 'topology_state_load_before_update_cdc')

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -991,13 +991,6 @@ private:
             auto shutdown_db = defer_verbose_shutdown("database tables", [this] {
                 _db.invoke_on_all(&replica::database::shutdown).get();
             });
-            // XXX: drain_on_shutdown raft before stopping the database and
-            // query processor. Group registry stop raft groups
-            // when stopped, and until then the groups may use
-            // the database and the query processor.
-            auto drain_raft = defer_verbose_shutdown("raft group registry servers", [this] {
-                _group0_registry.invoke_on_all(&service::raft_group_registry::drain_on_shutdown).get();
-            });
 
             _view_update_generator.invoke_on_all(&db::view::view_update_generator::start).get();
 
@@ -1039,7 +1032,8 @@ private:
 
             group0_service.start().get();
             auto stop_group0_service = defer_verbose_shutdown("group 0 service", [&group0_service] {
-                group0_service.abort().get();
+                group0_service.abort_and_drain().get();
+                group0_service.destroy();
             });
 
             _ss.local().set_group0(group0_service);


### PR DESCRIPTION
Previously, `raft_group0::abort()` was called in `storage_service::do_drain` (introduced in #24418) to stop the group0 Raft server before destroying local storage. This was necessary because `raft::server` depends on storage (via `raft_sys_table_storage` and `group0_state_machine`).

However, this caused issues: services like `sstable_dict_autotrainer` and `auth::service`, which use `group0_client` but are not stopped by `storage_service`, could trigger use-after-free if `raft_group0` was destroyed too early. This can happen both during normal shutdown and when 'nodetool drain' is used.

This PR reworks the shutdown logic:
* Introduces `abort_and_drain()`, which aborts the server and waits for background tasks to finish, but keeps the server object alive. Clients will see `raft::stopped_error` if they try to access group0 after this method is called.
* Final destruction now happens in `abort_and_destroy()`, called later from `main.cc`, ensuring safe cleanup.

The `raft_server_for_group::aborted` is changed to a `shared_future`, as it is now awaited in both abort methods.

Node startup can fail before reaching `storage_service`, in which case `drain_on_shutdown()` and `abort_and_drain()` are never called. To ensure proper cleanup, `raft_group0` deinitialization logic must be included in both `abort_and_drain()` and `abort_and_destroy()`.

Refs #25115

Fixes #24625

Backport: the changes are complicated and not safe to backport, we'll backport a revert of the original patch (#24418) in a separate PR.