### PR TITLE
tools: toolchain: dbuild: increase depth of nested podman configuration coverage

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -176,11 +176,25 @@ volume_path = "$HOME/.local/share/containers/storage/libpod"
 # netns = private, the default, doesn't work in nested containers,
 # and we don't mind using the host network anyway.
 netns = "host"
+
 EOF
+
+    storage_conf="$(mktemp)"
+    tmpfiles+=("$storage_conf")
+    cat > "$storage_conf" <<EOF
+
+[storage]
+driver = "overlay"
+runroot = "/run/containers/storage"
+graphroot = "$HOME/.local/share/containers/storage"
+
+EOF
+
     if grep -q 'cgroup2.*/sys/fs/cgroup ' /proc/mounts; then
         docker_common_args+=(
             -v "$HOME/.local/share/containers:$HOME/.local/share/containers"
             -v "$containers_conf:/etc/containers/containers.conf.d/nested.conf"
+            -v "$storage_conf:/etc/containers/storage.conf"
             --pids-limit -1
             --annotation run.oci.keep_original_groups=1
         )


### PR DESCRIPTION

The initial support for nested containers (2d2a2ef277) worked on my machine (tm) and even laptop, but does not work on fresh installs. This is likely due to changes in where persistent configuration is stored on the host between various podman versions; even though my podman is fully updated, it uses configuration created long ago.

Make nested containers work on fresh installs by also configuring /etc/containers/storage.conf. The important piece is to set graphroot to the same location as the host.

Verified both on my machine and on a fresh install.

Since no release uses nested containers yet, no need for backport.