### PR TITLE
topology_coordinator: migrate auth first, then service levels

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -900,7 +900,9 @@ future<> storage_service::merge_topology_snapshot(raft_snapshot snp) {
 
 future<> storage_service::update_service_levels_cache(qos::update_both_cache_levels update_only_effective_cache, qos::query_context ctx) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    co_await _sl_controller.local().update_cache(update_only_effective_cache, ctx);
+    if (_sl_controller.local().is_v2()) {
+        co_await _sl_controller.local().update_cache(update_only_effective_cache, ctx);
+    }
 }
 
 future<> storage_service::compression_dictionary_updated_callback_all() {


### PR DESCRIPTION
Right now, service levels are migrated in one group0 command and auth is migrated in the next one. This has a bad effect on the group0 state reload logic - modifying service levels in group0 causes the effective service levels cache to be recalculated, and to do so we need to fetch information about all roles. If the reload happens after SL upgrade and before auth upgrade, the query for roles will be directed to the legacy auth tables in system_distributed - and the query, being a potentially remote query, has a timeout. If the query times out, it will throw an exception which will break the group0 apply fiber and the node will need to be restarted to bring it back to work.

To solve this issue, reverse the order of migrations - migrate auth first and only then service levels. This will avoid the aforementioned unpleasant situation where group0 reload issues remote queries that can time out.

Fixes: scylladb/scylladb#24963

Should be backported to all versions which support upgrade to topology over raft - the issue described here may put the cluster into a state which is difficult to get out of (group0 apply fiber can break on multiple nodes, which necessitates their restart).