### PR TITLE
[Backport 2025.2] test: introduce upgrade tests to test.py, add a SSTable dict compression upgrade test

### DIFF
--- a/test.py
+++ b/test.py
@@ -200,6 +200,8 @@ def parse_cmd_line() -> argparse.Namespace:
                         help='Let me manually run the test executable at the moment this script would run it')
     parser.add_argument('--byte-limit', action="store", default=randint(0, 2000), type=int,
                         help="Specific byte limit for failure injection (random by default)")
+    parser.add_argument('--skip-internet-dependent-tests', action="store_true",
+                        help="Skip tests which depend on artifacts from the internet.")
     scylla_additional_options = parser.add_argument_group('Additional options for Scylla tests')
     scylla_additional_options.add_argument('--x-log2-compaction-groups', action="store", default="0", type=int,
                              help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -65,6 +65,8 @@ def pytest_addoption(parser):
                         help='username for authentication')
     parser.addoption('--auth_password', action='store', default=None,
                         help='password for authentication')
+    parser.addoption('--skip-internet-dependent-tests', action='store_true',
+                     help='Skip tests which depend on artifacts from the internet')
     parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
                      help='Provide the URL to artifacts directory to generate the link to failed tests directory '
                           'with logs')

--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -1,0 +1,209 @@
+# Copyright 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+
+import asyncio
+import random
+import logging
+import pytest
+import itertools
+import os
+import pathlib
+import contextlib
+import time
+from test.pylib.manager_client import ManagerClient, ServerInfo
+from test.pylib.rest_client import read_barrier, HTTPError
+from test.pylib.scylla_cluster import ScyllaVersionDescription, get_scylla_2025_1_description
+from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from cassandra.cluster import ConsistencyLevel
+from cassandra.policies import FallthroughRetryPolicy, ConstantReconnectionPolicy
+from cassandra.protocol import ServerError
+from cassandra.query import SimpleStatement
+from collections.abc import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+@pytest.fixture(scope="function")
+def internet_dependency_enabled(request) -> None:
+    if request.config.getoption('skip_internet_dependent_tests'):
+        pytest.skip(reason="skip_internet_dependent_tests is set")
+
+@pytest.fixture(scope="function")
+async def scylla_2025_1(request, build_mode, internet_dependency_enabled) -> AsyncIterator[ScyllaVersionDescription]:
+    yield await get_scylla_2025_1_description(build_mode)
+
+async def change_version(manager: ManagerClient, s: ServerInfo, exe: str):
+    await manager.server_stop_gracefully(s.server_id)
+    await manager.server_switch_executable(s.server_id, exe)
+    await manager.server_start(s.server_id)
+
+async def test_upgrade_and_rollback(manager: ManagerClient, scylla_2025_1: ScyllaVersionDescription):
+    new_exe = os.getenv("SCYLLA")
+    assert new_exe
+
+    logger.info("Bootstrapping cluster")
+    servers = (await manager.servers_add(2, cmdline=[
+        '--logger-log-level=storage_service=debug',
+        '--logger-log-level=api=trace',
+        '--logger-log-level=database=debug',
+        '--abort-on-seastar-bad-alloc',
+        '--dump-memory-diagnostics-on-alloc-failure-kind=all',
+    ], version=scylla_2025_1))
+
+    logger.info("Creating tables")
+    cql = manager.get_cql()
+
+    algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4WithDicts', 'ZstdWithDicts']
+    initial_algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4', 'Zstd']
+
+    await cql.run_async("""
+        CREATE KEYSPACE test
+        WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}
+    """)
+    await asyncio.gather(*[
+        cql.run_async(f'''
+            CREATE TABLE test."{algo}" (pk int PRIMARY KEY, c blob)
+            WITH COMPRESSION = {{'sstable_compression': '{initial_algo}Compressor'}};
+        ''')
+        for algo, initial_algo in zip(algorithms, initial_algorithms)
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Disabling autocompaction for the tables")
+    for algo in algorithms:
+        await asyncio.gather(*[manager.api.disable_autocompaction(s.ip_addr, "test", algo) for s in servers])
+
+    logger.info("Populating tables")
+    blob = random.randbytes(16*1024);
+    n_blobs = 100
+    for algo in algorithms:
+        insert = cql.prepare(f'''INSERT INTO test."{algo}" (pk, c) VALUES (?, ?);''')
+        insert.consistency_level = ConsistencyLevel.ALL;
+        for pks in itertools.batched(range(n_blobs), n=100):
+            await asyncio.gather(*[
+                cql.run_async(insert, [k, blob])
+                for k in pks
+            ])
+    total_uncompressed_size = len(blob) * n_blobs * 2
+
+    logger.info("Flushing tables")
+    await asyncio.gather(*[manager.api.keyspace_flush(s.ip_addr, "test") for s in servers])
+
+    async def validate_select():
+        logger.info("Validating readability of tables")
+        for algo in algorithms:
+            select = cql.prepare(f'''SELECT c FROM test."{algo}" WHERE pk = ? BYPASS CACHE;''')
+            select.consistency_level = ConsistencyLevel.ALL
+            results = await cql.run_async(select, [42])
+            assert results[0][0] == blob
+
+    async def get_data_size_for_server(server: ServerInfo, cf: str) -> int:
+        sstable_info = await manager.api.get_sstable_info(server.ip_addr, "test", cf)
+        sizes = [x['data_size'] for s in sstable_info for x in s['sstables']]
+        return sum(sizes)
+
+    async def get_total_data_size(cf: str) -> int:
+        return sum(await asyncio.gather(*[get_data_size_for_server(s, cf) for s in servers]))
+
+    logger.info("Checking size of initial SSTables")
+    for algo in algorithms:
+        assert (await get_total_data_size(algo)) > 0.9 * total_uncompressed_size
+
+    logger.info("Sanity check: old version returns 404 on retrain_dict")
+    try:
+        await manager.api.retrain_dict(servers[0].ip_addr, "test", algorithms[0])
+    except HTTPError as e:
+        assert e.code == 404
+    else:
+        raise Exception(f'Expected HTTPError, got no exception')
+
+    logger.info("Upgrading server 0")
+    await change_version(manager, servers[0], new_exe)
+
+    logger.info("Checking that new version returns 500 on retrain_dict before full upgrade")
+    try:
+        await manager.api.retrain_dict(servers[0].ip_addr, "test", algorithms[0])
+    except HTTPError as e:
+        assert e.code == 500
+    else:
+        raise Exception(f'Expected HTTPError, got no exception')
+
+    await validate_select()
+
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    for new_algo in ['LZ4WithDicts', 'ZstdWithDicts']:
+        @contextlib.asynccontextmanager
+        async def with_expect_server_error(msg):
+            try:
+                yield
+            except ServerError as e:
+                if e.message != msg:
+                    raise
+            else:
+                raise Exception('Expected a ServerError, got no exceptions')
+
+        expected_error = f"sstable_compression {new_algo}Compressor can't be used before all nodes are upgraded to a versions which supports it"
+
+        logger.info("Checking that new version before full upgrade rejects CREATE TABLE with new compressors")
+        async with with_expect_server_error(expected_error):
+            await cql.run_async(SimpleStatement(f'''
+                CREATE TABLE test.bad (pk int PRIMARY KEY, c blob)
+                WITH COMPRESSION = {{'sstable_compression': '{new_algo}Compressor'}};
+            ''', retry_policy=FallthroughRetryPolicy()), host=hosts[0])
+
+        logger.info("Checking that new version before full upgrade rejects ALTER TABLE with new compressors")
+        async with with_expect_server_error(expected_error):
+            await cql.run_async(SimpleStatement(f'''
+                ALTER TABLE test."Zstd"
+                WITH COMPRESSION = {{'sstable_compression': '{new_algo}Compressor'}};
+            ''', retry_policy=FallthroughRetryPolicy()), host=hosts[0])
+
+
+    logger.info("Rewriting SSTables after server 0 upgrade")
+    await manager.api.keyspace_upgrade_sstables(servers[0].ip_addr, "test")
+
+    await validate_select()
+
+    logger.info("Downgrading server 0")
+    await change_version(manager, servers[0], scylla_2025_1.path)
+
+    await validate_select()
+
+    logger.info("Upgrading both servers")
+    await asyncio.gather(
+        change_version(manager, servers[0], new_exe),
+        change_version(manager, servers[1], new_exe)
+    )
+
+    logger.info("Waiting for SSTABLE_COMPRESSION_DICTS cluster feature")
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await asyncio.gather(*(wait_for_feature("SSTABLE_COMPRESSION_DICTS", cql, h, time.time() + 60) for h in hosts))
+
+    logger.info("Enabling dict-aware algorithms")
+    await asyncio.gather(*[
+        cql.run_async(f'''
+            ALTER TABLE test."{algo}" WITH COMPRESSION = {{'sstable_compression': '{algo}Compressor'}};
+        ''')
+        for algo in algorithms
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Retraining dict")
+    await asyncio.gather(*[
+        manager.api.retrain_dict(servers[0].ip_addr, "test", algo)
+        for algo in algorithms
+    ])
+    await asyncio.gather(*[read_barrier(manager.api, s.ip_addr) for s in servers])
+
+    logger.info("Rewriting SSTables")
+    await asyncio.gather(*[manager.api.keyspace_upgrade_sstables(s.ip_addr, "test") for s in servers])
+
+    await validate_select()
+
+    logger.info("Checking SSTable sizes")
+    assert (await get_total_data_size("ZstdWithDicts")) < 0.1 * total_uncompressed_size
+    assert (await get_total_data_size("LZ4WithDicts")) < 0.1 * total_uncompressed_size
+    assert (await get_total_data_size("Zstd")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("LZ4")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("Snappy")) > 0.9 * total_uncompressed_size
+    assert (await get_total_data_size("Deflate")) > 0.9 * total_uncompressed_size

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -284,6 +284,12 @@ class ManagerClient():
         logger.debug("ManagerClient unpausing %s", server_id)
         await self.client.put_json(f"/cluster/server/{server_id}/unpause")
 
+    async def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
+        """Switch the executable path of a stopped server"""
+        logger.debug("ManagerClient starting %s", server_id)
+        data = {"path": path}
+        await self.client.put_json(f"/cluster/server/{server_id}/switch_executable", data)
+
     async def server_wipe_sstables(self, server_id: ServerNum, keyspace: str, table: str) -> None:
         """Delete all files for the given table from the data directory"""
         logger.debug("ManagerClient wiping sstables on %s, keyspace=%s, table=%s", server_id, keyspace, table)

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -19,7 +19,7 @@ from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMetricsClient
 from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, Host
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
-from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer
+from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
 from cassandra.cluster import Session as CassandraSession, \
     ExecutionProfile, EXEC_PROFILE_DEFAULT  # type: ignore # pylint: disable=no-name-in-module
 from cassandra.policies import WhiteListRoundRobinPolicy
@@ -297,6 +297,7 @@ class ManagerClient():
                                 replace_cfg: Optional[ReplaceConfig],
                                 cmdline: Optional[List[str]],
                                 config: Optional[dict[str, Any]],
+                                version: Optional[ScyllaVersionDescription],
                                 property_file: Union[List[dict[str, Any]], dict[str, Any], None],
                                 start: bool,
                                 seeds: Optional[List[IPAddress]],
@@ -310,6 +311,8 @@ class ManagerClient():
             data['cmdline'] = cmdline
         if config:
             data['config'] = config
+        if version:
+            data['version'] = version._asdict()
         if property_file:
             data['property_file'] = property_file
         if seeds:
@@ -326,6 +329,7 @@ class ManagerClient():
                          replace_cfg: Optional[ReplaceConfig] = None,
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
+                         version: Optional[ScyllaVersionDescription] = None,
                          property_file: Optional[dict[str, Any]] = None,
                          start: bool = True,
                          expected_error: Optional[str] = None,
@@ -340,6 +344,7 @@ class ManagerClient():
                 replace_cfg,
                 cmdline,
                 config,
+                version,
                 property_file,
                 start,
                 seeds,
@@ -380,6 +385,7 @@ class ManagerClient():
     async def servers_add(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,
                           config: Optional[dict[str, Any]] = None,
+                          version: Optional[ScyllaVersionDescription] = None,
                           property_file: Union[List[dict[str, Any]], dict[str, Any], None] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
@@ -398,7 +404,7 @@ class ManagerClient():
             property_file = [{"dc":auto_rack_dc, "rack":f"rack{i+1}"} for i in range(servers_num)]
 
         try:
-            data = self._create_server_add_data(None, cmdline, config, property_file, start, seeds, expected_error, server_encryption, None)
+            data = self._create_server_add_data(None, cmdline, config, version, property_file, start, seeds, expected_error, server_encryption, None)
             data['servers_num'] = servers_num
             server_infos = await self.client.put_json("/cluster/addservers", data, response_type="json",
                                                       timeout=ScyllaServer.TOPOLOGY_TIMEOUT * servers_num)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1287,6 +1287,15 @@ class ScyllaCluster:
         server = self.running[server_id]
         server.unpause()
 
+    def server_switch_executable(self, server_id: ServerNum, path: str) -> None:
+        """Switch the executable path of a stopped server"""
+        self.logger.info("Cluster %s upgrading server %s to executable %s", self.name, server_id, path)
+        server = self.servers[server_id]
+        assert not server.is_running, f"Server {server_id} is running: stop it first and then change its executable"
+        self.is_dirty = True
+        server.exe = pathlib.Path(path).resolve()
+        server.check_scylla_executable()
+
     def server_get_process_status(self, server_id: ServerNum) -> str:
         assert server_id in self.running
 
@@ -1549,6 +1558,7 @@ class ScyllaClusterManager:
         add_get('/cluster/server/{server_id}/get_config', self._server_get_config)
         add_put('/cluster/server/{server_id}/update_config', self._server_update_config)
         add_put('/cluster/server/{server_id}/update_cmdline', self._server_update_cmdline)
+        add_put('/cluster/server/{server_id}/switch_executable', self._server_switch_executable)
         add_put('/cluster/server/{server_id}/change_ip', self._server_change_ip)
         add_put('/cluster/server/{server_id}/change_rpc_address', self._server_change_rpc_address)
         add_get('/cluster/server/{server_id}/get_log_filename', self._server_get_log_filename)
@@ -1853,6 +1863,14 @@ class ScyllaClusterManager:
         data = await request.json()
         self.cluster.update_cmdline(ServerNum(int(request.match_info["server_id"])),
                                     data['cmdline_options'])
+
+    async def _server_switch_executable(self, request: aiohttp.web.Request) -> None:
+        """Switch the executable of the server to the one specified by 'path'
+           Marks the cluster as dirty."""
+        assert self.cluster
+        path = (await request.json())["path"]
+        server_id = ServerNum(int(request.match_info["server_id"]))
+        self.cluster.server_switch_executable(server_id, path)
 
     async def _server_change_ip(self, request: aiohttp.web.Request) -> dict[str, object]:
         """Pass change_ip command for the given server to the cluster"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -927,6 +927,7 @@ class ScyllaCluster:
         property_file: dict[str, Any] | None
         config_from_test: dict[str, Any]
         cmdline_from_test: List[str]
+        version: Optional[ScyllaVersionDescription]
         server_encryption: str
 
     def __init__(self, logger: Union[logging.Logger, logging.LoggerAdapter],
@@ -1025,6 +1026,7 @@ class ScyllaCluster:
     async def add_server(self, replace_cfg: Optional[ReplaceConfig] = None,
                          cmdline: Optional[List[str]] = None,
                          config: Optional[dict[str, Any]] = None,
+                         version: Optional[ScyllaVersionDescription] = None,
                          property_file: Optional[dict[str, Any]] = None,
                          start: bool = True,
                          seeds: Optional[List[IPAddress]] = None,
@@ -1081,7 +1083,8 @@ class ScyllaCluster:
             property_file = property_file,
             config_from_test = extra_config,
             server_encryption = server_encryption,
-            cmdline_from_test = cmdline or []
+            cmdline_from_test = cmdline or [],
+            version = version,
         )
 
         server = None
@@ -1120,6 +1123,7 @@ class ScyllaCluster:
     async def add_servers(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,
                           config: Optional[dict[str, Any]] = None,
+                          version: Optional[ScyllaVersionDescription] = None,
                           property_file: Union[list[dict[str, Any]], dict[str, Any], None] = None,
                           start: bool = True,
                           seeds: Optional[List[IPAddress]] = None,
@@ -1137,7 +1141,7 @@ class ScyllaCluster:
                 assert type(property_file) is list and len(property_file) == servers_num
                 return property_file[i]
 
-        return await gather_safely(*(self.add_server(None, cmdline, config, get_property_file(i), start, seeds, server_encryption, expected_error)
+        return await gather_safely(*(self.add_server(None, cmdline, config, version, get_property_file(i), start, seeds, server_encryption, expected_error)
                                       for i in range(servers_num)))
 
     def endpoint(self) -> str:
@@ -1691,10 +1695,12 @@ class ScyllaClusterManager:
 
         data = await request.json()
         replace_cfg = ReplaceConfig(**data["replace_cfg"]) if "replace_cfg" in data else None
+        version = ScyllaVersionDescription(**data["version"]) if "version" in data else None
         s_info = await self.cluster.add_server(
             replace_cfg=replace_cfg,
             cmdline=data.get("cmdline"),
             config=data.get("config"),
+            version=version,
             property_file=data.get("property_file"),
             start=data.get("start", True),
             seeds=data.get("seeds"),
@@ -1708,7 +1714,8 @@ class ScyllaClusterManager:
         """Add new servers concurrently"""
         assert self.cluster
         data = await request.json()
-        s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'),
+        version = ScyllaVersionDescription(**data["version"]) if "version" in data else None
+        s_infos = await self.cluster.add_servers(data.get('servers_num'), data.get('cmdline'), data.get('config'), version,
                                                  data.get('property_file'), data.get('start', True),
                                                  data.get('seeds', None), data.get('server_encryption'), data.get('expected_error', None))
         return [s_info.as_dict() for s_info in s_infos]

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 from scripts import coverage
 from test import path_to
 from test.pylib.pool import Pool
-from test.pylib.scylla_cluster import ScyllaCluster, ScyllaServer, merge_cmdline_options
+from test.pylib.scylla_cluster import ScyllaCluster, ScyllaServer, merge_cmdline_options, get_current_version_description
 from test.pylib.suite.base import Test, TestSuite, read_log, run_test
 from test.pylib.util import LogPrefixAdapter
 
@@ -85,7 +85,7 @@ class PythonTestSuite(TestSuite):
 
             server = ScyllaServer(
                 mode=self.mode,
-                exe=self.scylla_exe,
+                version=get_current_version_description(self.scylla_exe),
                 vardir=self.log_dir,
                 logger=create_cfg.logger,
                 cluster_name=create_cfg.cluster_name,

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -85,7 +85,7 @@ class PythonTestSuite(TestSuite):
 
             server = ScyllaServer(
                 mode=self.mode,
-                version=get_current_version_description(self.scylla_exe),
+                version=(create_cfg.version or get_current_version_description(self.scylla_exe)),
                 vardir=self.log_dir,
                 logger=create_cfg.logger,
                 cluster_name=create_cfg.cluster_name,

--- a/test/pylib/suite/topology.py
+++ b/test/pylib/suite/topology.py
@@ -48,6 +48,8 @@ class TopologyTest(PythonTest):
         async with get_cluster_manager(self.uname, self.suite.clusters, str(self.suite.log_dir)) as manager:
             self.args.insert(0, "--tmpdir={}".format(options.tmpdir))
             self.args.insert(0, "--manager-api={}".format(manager.sock_path))
+            if options.skip_internet_dependent_tests:
+                self.args.insert(0, "--skip-internet-dependent-tests")
             if options.artifacts_dir_url:
                 self.args.insert(0, "--artifacts_dir_url={}".format(options.artifacts_dir_url))
 

--- a/test/pylib/suite/topology.py
+++ b/test/pylib/suite/topology.py
@@ -54,7 +54,7 @@ class TopologyTest(PythonTest):
             try:
                 # Note: start manager here so cluster (and its logs) is available in case of failure
                 await manager.start()
-                self.success = await run_test(self, options)
+                self.success = await run_test(self, options, env=self.suite.scylla_env)
             except Exception as e:
                 self.server_log = manager.cluster.read_server_log()
                 self.server_log_filename = manager.cluster.server_log_filename()

--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -142,6 +142,9 @@ if [[ -z "$CARGO_HOME" ]]; then
     mkdir -p "$CARGO_HOME"
 fi
 
+export XDG_CACHE_HOME="${XDG_CACHE_HOME:-$HOME/.cache}"
+mkdir -p "$XDG_CACHE_HOME/scylladb"
+
 is_podman="$($tool --help | grep -o podman)"
 
 docker_common_args=()
@@ -211,6 +214,8 @@ docker_common_args+=(
        -v /etc/localtime:/etc/localtime:ro \
        --env CARGO_HOME \
        -v "${CARGO_HOME}:${CARGO_HOME}" \
+       --env XDG_CACHE_HOME \
+       -v "${XDG_CACHE_HOME}/scylladb:${XDG_CACHE_HOME}/scylladb" \
        -w "$PWD" \
        -e HOME="$HOME" \
        "${docker_args[@]}" \


### PR DESCRIPTION
This PR adds an upgrade test for SSTable compression with shared dictionaries, and adds some bits to pylib and test.py to support that.

In the series, we:

1. Mount $XDG_CACHE_DIR into dbuild.
2. Add a pylib function which downloads and installs a released ScyllaDB package into a subdirectory of $XDG_CACHE_DIR/scylladb/test.py, and returns the path to bin/scylla.
3. Add new methods and params to the cluster manager, which let the test start nodes with historical Scylla executables, and switch executables during the test.
4. Add a test which uses the above to run an upgrade test between the released package and the current build.
5. Add --run-internet-dependent-tests to test.py which lets the user of test.py skip this test (and potentially other internet-dependent tests in the future).

(The patch modifying wait_for_cql_and_get_hosts is a part of the new test — the new test needs it to test how particular nodes in a mixed-version cluster react to some CQL queries.)

This is a follow-up to https://github.com/scylladb/scylladb/pull/23025, split into a separate PR because the potential addition of upgrade tests to test.py deserved a separate thread.

Needs backport to 2025.2, because that's where the tested feature is introduced.

Fixes https://github.com/scylladb/scylladb/issues/24110

- (cherry picked from commit https://github.com/scylladb/scylladb/commit/63218bb094c39476f783e9ddbc3b03818ba0b74b)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/cc7432888e13bfb349fec9315fc2122c10b8f196)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/34098fbd1f54b27f3d7937479830f5ecfabfcc9d)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/2ef0db0a6b054108890f5d47d64327fe9ec852ed)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/1ff7e09edc40f7f83f0caef562d05c24762fa729)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/5da19ff6a6b380e7d4f6e20e1c7b880e8cbe81c6)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/d3cb873532947209d5885cfcebefddb0e7b5132b)
- (cherry picked from commit https://github.com/scylladb/scylladb/commit/dd878505ca9ab35f4ae3a0bfe9dc16b1efd8af9b)

Parent PR: https://github.com/scylladb/scylladb/pull/23538