### PR TITLE
[RFC] Support replication factor rack list for tablet-based keyspaces

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1646,7 +1646,8 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
             auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
             if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
                 locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
-                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
+                const auto& topo = sp.local_db().get_token_metadata().get_topology();
+                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
                 if (rs->uses_tablets()) {
                     co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
                     "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -16,6 +16,7 @@
 #include "cql3/statements/ks_prop_defs.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 namespace audit {
 
@@ -64,8 +65,8 @@ future<> audit_cf_storage_helper::migrate_audit_table(service::group0_guard grou
             data_dictionary::database db = _qp.db();
             cql3::statements::ks_prop_defs old_ks_prop_defs;
             auto old_ks_metadata = old_ks_prop_defs.as_ks_metadata_update(
-                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features());
-            std::map<sstring, sstring> strategy_opts;
+                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features(), db.get_config());
+            locator::replication_strategy_config_options strategy_opts;
             for (const auto &dc: _qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                 strategy_opts[dc] = "3";
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -158,7 +158,7 @@ public:
         });
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
+    void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
         if (schema.cdc_options().enabled()) {
             auto& db = _ctxt._proxy.get_db().local();
             auto logname = log_name(schema.cf_name());

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -22,6 +22,7 @@
 #include "cql3/query_processor.hh"
 #include "db/config.hh"
 #include "gms/feature_service.hh"
+#include "replica/database.hh"
 
 #include <boost/regex.hpp>
 #include <stdexcept>
@@ -109,7 +110,8 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
         // remove this check.
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(
             ksm->strategy_name(),
-            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()));
+            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()),
+            tmptr->get_topology());
         if (rs->uses_tablets()) {
             warnings.push_back(
                 "Tables in this keyspace will be replicated using Tablets "
@@ -193,7 +195,8 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     locator::replication_strategy_params params(opts, std::nullopt);
     auto replication_strategy = locator::abstract_replication_strategy::create_replication_strategy(
             locator::abstract_replication_strategy::to_qualified_class_name(
-                    *attrs.get_replication_strategy_class()), params)->get_type();
+                    *attrs.get_replication_strategy_class()), params,
+                    qp.db().real_database().get_token_metadata().get_topology())->get_type();
     auto rs_warn_list = qp.db().get_config().replication_strategy_warn_list();
     auto rs_fail_list = qp.db().get_config().replication_strategy_fail_list();
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -22,6 +22,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger logger("ks_prop_defs");
+
 static std::map<sstring, sstring> prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
@@ -29,7 +31,15 @@ static std::map<sstring, sstring> prepare_options(
         const std::map<sstring, sstring>& old_options = {}) {
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
-    if (locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) != "org.apache.cassandra.locator.NetworkTopologyStrategy") {
+    auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
+
+    logger.info("prepare_options: {}: is_nts={} {{{}}}", strategy_class, is_nts,
+            fmt::join(options | std::views::transform([] (auto& x) {
+                            return fmt::format("{}:{}", x.first, x.second);
+                    }),
+                    ","));
+
+    if (!is_nts) {
         return options;
     }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -75,6 +75,7 @@ static std::map<sstring, sstring> prepare_options(
             }
         }
 
+        // FIXME: expand rack names
         for (const auto& dc : tm.get_topology().get_datacenters()) {
             options.emplace(dc, *rf);
         }

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -82,6 +82,10 @@ static std::map<sstring, sstring> prepare_options(
         sstring val;
         size_t nr_racks = std::stol(rf);
         if (nr_racks > dc_racks.size()) {
+            if (tm.get_topology().get_config().force_rack_valid_keyspaces) {
+                throw exceptions::configuration_exception(fmt::format(
+                        "Replication factor {} exceeds the number of racks ({}) in dc {}", nr_racks, dc_racks.size(), dc));
+            }
             logger.warn("Cannot expand rf={}: dc_racks={}", rf, fmt::join(dc_racks | std::views::keys, ","));
             val = rf;
         } else {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -72,6 +72,9 @@ static std::map<sstring, sstring> prepare_options(
         if (it == all_dcs.end()) {
             return;
         }
+        if (options.count(dc)) {
+            return;
+        }
         const auto& dc_racks = it->second;
         auto ordered_racks = dc_racks | std::views::transform([] (const auto& x) { return x.first; }) | std::ranges::to<std::vector<sstring>>();
         std::ranges::sort(ordered_racks);

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -12,6 +12,7 @@
 
 #include "cql3/statements/property_definitions.hh"
 #include "data_dictionary/storage_options.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -58,13 +59,13 @@ public:
     explicit ks_prop_defs(std::map<sstring, sstring> options);
 
     void validate();
-    std::map<sstring, sstring> get_replication_options() const;
+    locator::replication_strategy_config_options get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
     std::optional<unsigned> get_initial_tablets(std::optional<unsigned> default_value, bool enforce_tablets = false) const;
     data_dictionary::storage_options get_storage_options() const;
     bool get_durable_writes() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&, const db::config&);
-    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&, const db::config&);
 };
 
 }

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -27,19 +27,26 @@ namespace statements {
 class property_definitions {
 public:
     using map_type = std::map<sstring, sstring>;
-    using value_type = std::variant<sstring, map_type>;
+    using list_type = std::vector<sstring>;
+    using extended_map_type = std::map<sstring, std::variant<sstring, list_type>>;
+    using value_type = std::variant<sstring, extended_map_type>;
+    using properties_map_type = std::unordered_map<sstring, value_type>;
 protected:
 #if 0
     protected static final Logger logger = LoggerFactory.getLogger(PropertyDefinitions.class);
 #endif
 
-    mutable std::unordered_map<sstring, value_type> _properties;
+    mutable properties_map_type _properties;
 
     property_definitions();
 public:
     void add_property(const sstring& name, sstring value);
 
-    void add_property(const sstring& name, const std::map<sstring, sstring>& value);
+    void add_property(const sstring& name, const map_type& value) {
+        add_property(name, to_extended_map(value));
+    }
+
+    void add_property(const sstring& name, const extended_map_type& value);
 
     void validate(const std::set<sstring>& keywords, const std::set<sstring>& exts = {}, const std::set<sstring>& obsolete = {}) const;
 
@@ -52,7 +59,11 @@ public:
 
     std::optional<value_type> get(const sstring& name) const;
 
-    std::optional<std::map<sstring, sstring>> get_map(const sstring& name) const;
+    std::optional<extended_map_type> get_extended_map(const sstring& name) const;
+    std::optional<map_type> get_map(const sstring& name) const;
+
+    static map_type to_simple_map(const extended_map_type&);
+    static extended_map_type to_extended_map(const map_type&);
 
     sstring get_string(sstring key, sstring default_value) const;
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -233,7 +233,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
     locator::replication_strategy_params params(strategy_options(), initial_tablets());
-    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params);
+    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params, topology);
     strategy->validate_options(fs, topology);
 }
 

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -53,7 +53,7 @@ struct storage_options {
 
     bool can_update_to(const storage_options& new_options);
 
-    static value_type from_map(std::string_view type, std::map<sstring, sstring> values);
+    static value_type from_map(std::string_view type, const std::map<sstring, sstring>& values);
 
     storage_options append_to_s3_prefix(const sstring& s) const;
 };

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -35,7 +35,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/util.hh"
-#include "types/user.hh"
+#include "cql3/statements/property_definitions.hh"
 
 static seastar::logger mlogger("legacy_schema_migrator");
 
@@ -541,7 +541,7 @@ public:
         for (auto& ks : _keyspaces) {
             auto ksm = ::make_lw_shared<keyspace_metadata>(ks.name
                             , ks.replication_params["class"] // TODO, make ksm like c3?
-                            , ks.replication_params
+                            , cql3::statements::property_definitions::to_extended_map(ks.replication_params)
                             , std::nullopt
                             , ks.durable_writes);
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1907,7 +1907,7 @@ static void make_update_indices_mutations(
             continue;
         }
         auto ksm = db.find_keyspace(new_table->ks_name()).metadata();
-        db.get_notifier().before_create_column_family(*ksm, *view, mutations, timestamp);
+        db.get_notifier().before_create_column_family(db, *ksm, *view, mutations, timestamp);
     }
 
     mutations.emplace_back(std::move(indices_mutation));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -24,6 +24,7 @@
 #include "system_keyspace_view_types.hh"
 #include "schema/schema_builder.hh"
 #include "timestamp.hh"
+#include "types/vector.hh"
 #include "utils/assert.hh"
 #include "utils/hashers.hh"
 #include "utils/log.hh"

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -104,7 +104,7 @@ For example:
 .. code-block:: cql
 
    CREATE KEYSPACE Excalibur
-   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : 1, 'DC2' : 3}
+   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : ['RAC1', 'RAC2', 'RAC3'], 'DC2' : 3}
    AND durable_writes = true;
 
 The supported ``options`` are:
@@ -154,22 +154,24 @@ factor independently for each data-center. The rest of the sub-options are
 key-value pairs where a key is a data-center name and its value is the
 associated replication factor. Options:
 
-===================================== ====== =============================================
-sub-option                             type  description
-===================================== ====== =============================================
-``'<datacenter>'``                     int   The number of replicas to store per range in
-                                             the provided datacenter.
-``'replication_factor'``               int   The number of replicas to use as a default
-                                             per datacenter if not specifically provided.
-                                             Note that this always defers to existing
-                                             definitions or explicit datacenter settings.
-                                             For example, to have three replicas per
-                                             datacenter, supply this with a value of 3.
+===================================== ========= =============================================
+sub-option                             type      description
+===================================== ========= =============================================
+``'<datacenter>'``                     int      The number of replicas to store per range in
+                                                the provided datacenter.
+``'replication_factor'``               int|list The number of replicas to use as a default
+                                                per datacenter if not specifically provided,
+                                                or a list of rack names to place replicas.
 
-                                             The replication factor configured for a DC
-                                             should be equal to or lower than the number
-                                             of nodes in that DC. Configuring a higher RF 
-                                             may prevent creating tables in that keyspace. 
+                                                Note that this always defers to existing
+                                                definitions or explicit datacenter settings.
+                                                For example, to have three replicas per
+                                                datacenter, supply this with a value of 3.
+
+                                                The replication factor configured for a DC
+                                                should be equal to or lower than the number
+                                                of nodes in that DC. Configuring a higher RF 
+                                                may prevent creating tables in that keyspace. 
 ===================================== ====== =============================================
 
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
@@ -186,6 +188,9 @@ An example of auto-expanding datacenters with two datacenters: ``DC1`` and ``DC2
     DESCRIBE KEYSPACE excalibur
         CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '3'} AND durable_writes = true;
 
+    DESCRIBE KEYSPACE excalibur
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1', 'RAC2', 'RAC3' ]} AND durable_writes = true;
+
 
 An example of auto-expanding and overriding a datacenter::
 
@@ -193,7 +198,7 @@ An example of auto-expanding and overriding a datacenter::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 2}
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '2'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1-1', 'RAC1-2', 'RAC1-3' ], 'DC2': [ 'RAC2-1', 'RAC2-2' ]} AND durable_writes = true;
 
 An example that excludes a datacenter while using ``replication_factor``::
 
@@ -201,7 +206,7 @@ An example that excludes a datacenter while using ``replication_factor``::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 0} ;
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1', 'RAC2', 'RAC3' ]} AND durable_writes = true;
 
 .. _tablets:
 

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -67,17 +67,19 @@ abstract_replication_strategy::abstract_replication_strategy(
     }
 }
 
-abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params) {
+abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology* topo) {
     try {
-        return create_object<abstract_replication_strategy, replication_strategy_params>(strategy_name, std::move(params));
+        return create_object<abstract_replication_strategy, replication_strategy_params, const locator::topology*>(strategy_name, std::move(params), std::move(topo));
     } catch (const no_such_class& e) {
         throw exceptions::configuration_exception(e.what());
     }
 }
 
+// class registry signature must match the actual replication strategies' signature
 using strategy_class_registry = class_registry<
     locator::abstract_replication_strategy,
-    replication_strategy_params>;
+    replication_strategy_params,
+    const topology*>;
 
 sstring abstract_replication_strategy::to_qualified_class_name(std::string_view strategy_class_name) {
     return strategy_class_registry::to_qualified_class_name(strategy_class_name);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -153,18 +153,22 @@ const tablet_aware_replication_strategy* abstract_replication_strategy::maybe_as
     return dynamic_cast<const tablet_aware_replication_strategy*>(this);
 }
 
-long abstract_replication_strategy::parse_replication_factor(sstring rf)
-{
+void replication_factor_data::parse(const sstring& rf) {
     if (rf.empty() || std::any_of(rf.begin(), rf.end(), [] (char c) {return !isdigit(c);})) {
         throw exceptions::configuration_exception(
                 format("Replication factor must be numeric and non-negative, found '{}'", rf));
     }
     try {
-        return std::stol(rf);
+        _count = std::stol(rf);
     } catch (...) {
         throw exceptions::configuration_exception(
             sstring("Replication factor must be numeric; found ") + rf);
     }
+}
+
+replication_factor_data abstract_replication_strategy::parse_replication_factor(sstring rf)
+{
+    return replication_factor_data(rf);
 }
 
 static
@@ -693,4 +697,8 @@ auto fmt::formatter<locator::vnode_effective_replication_map::factory_key>::form
         sep = ',';
     }
     return out;
+}
+
+auto fmt::formatter<locator::replication_factor_data>::format(const locator::replication_factor_data& rf, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", rf.count());
 }

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -127,7 +127,10 @@ public:
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
 
     virtual ~abstract_replication_strategy() {}
-    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology* = nullptr);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
+        return create_replication_strategy(strategy_name, std::move(params), &topo);
+    }
     static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -71,10 +71,8 @@ class replication_factor_data {
     std::variant<size_t, std::vector<sstring>> _data;
 
 public:
-    using allow_racks = bool_class<struct allow_racks_tag>;
-
-    explicit replication_factor_data(const sstring& rf, allow_racks ar = allow_racks::no) {
-        parse(rf, ar);
+    explicit replication_factor_data(const sstring& rf, const std::unordered_set<sstring>* allowed_racks = nullptr) {
+        parse(rf, allowed_racks);
     }
 
     size_t count() const noexcept {
@@ -85,7 +83,7 @@ public:
     }
 
 private:
-    void parse(const sstring& rf, allow_racks ar);
+    void parse(const sstring& rf, const std::unordered_set<sstring>* allowed_racks);
 };
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
@@ -140,7 +138,8 @@ public:
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
         return create_replication_strategy(strategy_name, std::move(params), &topo);
     }
-    static replication_factor_data parse_replication_factor(sstring rf, replication_factor_data::allow_racks ar = replication_factor_data::allow_racks::no);
+    static replication_factor_data parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(sstring rf, const std::unordered_set<sstring>& racks);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -67,8 +67,10 @@ class per_table_replication_strategy;
 class tablet_aware_replication_strategy;
 class effective_replication_map;
 
+using rack_list = std::vector<sstring>;
+
 class replication_factor_data {
-    std::variant<size_t, std::vector<sstring>> _data;
+    std::variant<size_t, rack_list> _data;
 
 public:
     explicit replication_factor_data(const sstring& rf, const std::unordered_set<sstring>* allowed_racks = nullptr) {
@@ -80,6 +82,14 @@ public:
         [] (const size_t& count) { return count; },
         [] (const std::vector<sstring>& racks) { return racks.size(); },
         }, _data);
+    }
+
+    bool is_rack_based() const noexcept {
+        return std::holds_alternative<rack_list>(_data);
+    }
+
+    const rack_list& get_rack_list() const {
+        return std::get<rack_list>(_data);
     }
 
 private:

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -63,6 +63,21 @@ class per_table_replication_strategy;
 class tablet_aware_replication_strategy;
 class effective_replication_map;
 
+class replication_factor_data {
+    size_t _count = 0;
+
+public:
+    explicit replication_factor_data(const sstring& rf) {
+        parse(rf);
+    }
+
+    size_t count() const noexcept {
+        return _count;
+    }
+
+private:
+    void parse(const sstring& rf);
+};
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
     friend class vnode_effective_replication_map;
@@ -113,7 +128,7 @@ public:
 
     virtual ~abstract_replication_strategy() {}
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
-    static long parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
@@ -476,6 +491,11 @@ struct appending_hash<locator::vnode_effective_replication_map::factory_key> {
             h.update(val.c_str(), val.size());
         }
     }
+};
+
+template <>
+struct fmt::formatter<locator::replication_factor_data> : fmt::formatter<string_view> {
+    auto format(const locator::replication_factor_data&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 namespace std {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -73,7 +73,7 @@ class replication_factor_data {
     std::variant<size_t, rack_list> _data;
 
 public:
-    explicit replication_factor_data(const sstring& rf, const std::unordered_set<sstring>* allowed_racks = nullptr) {
+    explicit replication_factor_data(const sstring& rf, const std::unordered_set<sstring>& allowed_racks) {
         parse(rf, allowed_racks);
     }
 
@@ -93,7 +93,7 @@ public:
     }
 
 private:
-    void parse(const sstring& rf, const std::unordered_set<sstring>* allowed_racks);
+    void parse(const sstring& rf, const std::unordered_set<sstring>& allowed_racks);
 };
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
@@ -144,11 +144,10 @@ public:
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
 
     virtual ~abstract_replication_strategy() {}
-    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology* = nullptr);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology*);
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
         return create_replication_strategy(strategy_name, std::move(params), &topo);
     }
-    static replication_factor_data parse_replication_factor(sstring rf);
     static replication_factor_data parse_replication_factor(sstring rf, const std::unordered_set<sstring>& racks);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -16,7 +16,7 @@
 
 namespace locator {
 
-everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params) :
+everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::everywhere_topology) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -49,7 +49,8 @@ sstring everywhere_replication_strategy::sanity_check_read_replicas(const effect
 }
 
 
-using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.EverywhereStrategy");
 static registry registrator_short_name("EverywhereStrategy");
 }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -16,7 +16,7 @@
 namespace locator {
 class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
-    everywhere_replication_strategy(replication_strategy_params params);
+    everywhere_replication_strategy(replication_strategy_params params, const locator::topology*);
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -14,7 +14,7 @@
 
 namespace locator {
 
-local_strategy::local_strategy(replication_strategy_params params) :
+local_strategy::local_strategy(replication_strategy_params params, const topology*) :
         abstract_replication_strategy(params, replication_strategy_type::local) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -40,7 +40,8 @@ sstring local_strategy::sanity_check_read_replicas(const effective_replication_m
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");
 

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -22,7 +22,7 @@ using token = dht::token;
 
 class local_strategy : public abstract_replication_strategy {
 public:
-    local_strategy(replication_strategy_params params);
+    local_strategy(replication_strategy_params params, const topology*);
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -74,7 +74,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
             }
         }
 
-        auto rf = parse_replication_factor(val);
+        auto rf = parse_replication_factor(val, replication_factor_data::allow_racks::yes);
         rep_factor += rf.count();
         _dc_rep_factor.emplace(key, rf);
         _datacenteres.push_back(key);
@@ -295,7 +295,7 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs,
             throw exceptions::configuration_exception(format("Unrecognized strategy option {{{}}} "
                 "passed to NetworkTopologyStrategy", this->to_qualified_class_name(c.first)));
         }
-        parse_replication_factor(c.second);
+        parse_replication_factor(c.second, replication_factor_data::allow_racks::yes);
     }
 }
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -45,11 +45,6 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
 
-    logger.info("options={{{}}} topology={}", fmt::join(opts | std::views::transform([] (auto& x) {
-                        return fmt::format("{}:{}", x.first, x.second);
-                    }),
-                    ","), bool(topo));
-
     process_tablet_options(*this, opts, params);
 
     size_t rep_factor = 0;
@@ -57,6 +52,10 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
     if (topo) {
         dcs_opt = &topo->get_datacenter_racks();
     }
+
+    logger.info("options={{{}}} dcs={}", fmt::join(opts | std::views::transform([] (auto& x) {
+        return fmt::format("{}:{}", x.first, x.second);
+    }), ","), dcs_opt ? fmt::format("{}", fmt::join(*dcs_opt | std::views::keys, ",")) : "<null>");
 
     for (auto& config_pair : opts) {
         auto& key = config_pair.first;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -16,6 +16,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/core/on_internal_error.hh>
 
 #include "locator/network_topology_strategy.hh"
 #include "locator/load_sketch.hh"
@@ -48,14 +49,13 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
     process_tablet_options(*this, opts, params);
 
     size_t rep_factor = 0;
-    const std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<host_id>>>* dcs_opt = nullptr;
-    if (topo) {
-        dcs_opt = &topo->get_datacenter_racks();
-    }
+    assert(topo);
+    const std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<host_id>>>& dcs
+        = topo->get_datacenter_racks();
 
     logger.info("options={{{}}} dcs={}", fmt::join(opts | std::views::transform([] (auto& x) {
         return fmt::format("{}:{}", x.first, x.second);
-    }), ","), dcs_opt ? fmt::format("{}", fmt::join(*dcs_opt | std::views::keys, ",")) : "<null>");
+    }), ","), fmt::format("{}", fmt::join(dcs | std::views::keys, ",")));
 
     for (auto& config_pair : opts) {
         auto& key = config_pair.first;
@@ -78,24 +78,20 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
             }
         }
 
-        std::optional<replication_factor_data> rf;
-        if (dcs_opt && !dcs_opt->empty()) {
-            auto dc = dcs_opt->find(key);
-            if (dc == dcs_opt->end()) {
-                throw exceptions::configuration_exception(format("Unrecognized datacenter name '{}'", key));
-            }
-            std::unordered_set<sstring> racks;
-            // FIXME: use ranges::to transformation
-            for (auto& i : std::views::keys(dc->second)) {
-                racks.insert(i);
-            }
-
-            rf = parse_replication_factor(val, racks);
-        } else {
-            rf = parse_replication_factor(val);
+        auto dc = dcs.find(key);
+        std::unordered_set<sstring> racks;
+        if (dc != dcs.end()) {
+            racks = dc->second | std::views::keys | std::ranges::to<std::unordered_set<sstring>>();
+        } else if (!dcs.empty()) {
+            throw exceptions::configuration_exception(format("Unrecognized datacenter name '{}'", key));
         }
-        rep_factor += rf->count();
-        _dc_rep_factor.emplace(key, std::move(*rf));
+
+        replication_factor_data rf = parse_replication_factor(val, racks);
+        if (rf.count() && !rf.is_rack_based()) {
+            on_fatal_internal_error(rslogger, format("Invalid replication factor option: {}: must be a comma-separated list of rack names, or 0", val));
+        }
+        rep_factor += rf.count();
+        _dc_rep_factor.emplace(key, std::move(rf));
         _datacenteres.push_back(key);
     }
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -87,7 +87,7 @@ network_topology_strategy::network_topology_strategy(replication_strategy_params
         }
 
         replication_factor_data rf = parse_replication_factor(val, racks);
-        if (rf.count() && !rf.is_rack_based()) {
+        if (topo->get_config().force_rack_valid_keyspaces && rf.count() && !rf.is_rack_based()) {
             on_fatal_internal_error(rslogger, format("Invalid replication factor option: {}: must be a comma-separated list of rack names, or 0", val));
         }
         rep_factor += rf.count();

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -386,9 +386,9 @@ future<tablet_replica_set> network_topology_strategy::reallocate_tablets(schema_
 
     // FIXME: Handle RF++ for old keyspaces by using the old method.
 
-    // #22688 - take all dcs in topology into account when determining migration.
+    // take only dcs wiht replicas into account when determining migration.
     // Any change should still have been pre-checked to never exceed rf factor one.
-    for (const auto& dc : tm->get_topology().get_datacenters()) {
+    for (const auto& dc : _dc_rep_factor | std::views::keys) {
         auto new_racks = get_dc_racks(dc);
         auto diff = diff_racks(old_racks_per_dc[dc], new_racks);
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -38,10 +38,18 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-network_topology_strategy::network_topology_strategy(replication_strategy_params params) :
+static logging::logger logger("network_topology_strategy");
+
+network_topology_strategy::network_topology_strategy(replication_strategy_params params, const topology* topo) :
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
+
+    logger.info("options={{{}}} topology={}", fmt::join(opts | std::views::transform([] (auto& x) {
+                        return fmt::format("{}:{}", x.first, x.second);
+                    }),
+                    ","), bool(topo));
+
     process_tablet_options(*this, opts, params);
 
     size_t rep_factor = 0;
@@ -551,7 +559,8 @@ sstring network_topology_strategy::sanity_check_read_replicas(const effective_re
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.NetworkTopologyStrategy");
 static registry registrator_short_name("NetworkTopologyStrategy");
 }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -12,6 +12,7 @@
 
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablet_replication_strategy.hh"
+#include "seastar/core/on_internal_error.hh"
 
 #include <optional>
 #include <unordered_set>
@@ -44,7 +45,7 @@ public:
         auto dc_rack = _dc_rep_factor.find(dc);
         if (dc_rack == _dc_rep_factor.end()) {
             static rack_list empty_rack_list; // for now
-            rslogger.warn("get_dc_racks: no racks found for dc={}", dc);
+            rslogger.debug("get_dc_racks: no racks found for dc={}", dc);
             return empty_rack_list;
         }
         const replication_factor_data& rf = dc_rack->second;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -83,6 +83,7 @@ public:
 
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, token_metadata_ptr, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
+    future<tablet_replica_set> reallocate_tablets_racklist(schema_ptr, token_metadata_ptr, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
     future<tablet_replica_set> add_tablets_in_dc(schema_ptr, token_metadata_ptr, load_sketch&, tablet_id,
             std::map<sstring, std::unordered_set<locator::host_id>>& replicas_per_rack,
             const tablet_replica_set& cur_replicas,

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -31,7 +31,7 @@ public:
 
     size_t get_replication_factor(const sstring& dc) const override {
         auto dc_factor = _dc_rep_factor.find(dc);
-        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second;
+        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second.count();
     }
 
     const std::vector<sstring>& get_datacenters() const {
@@ -58,6 +58,9 @@ protected:
 
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;
 
+public:
+    using dc_rep_factor_map = std::unordered_map<sstring, replication_factor_data>;
+
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, token_metadata_ptr, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
     future<tablet_replica_set> add_tablets_in_dc(schema_ptr, token_metadata_ptr, load_sketch&, tablet_id,
@@ -69,7 +72,7 @@ private:
             sstring dc, size_t dc_node_count, size_t dc_rf) const;
 
     // map: data centers -> replication factor
-    std::unordered_map<sstring, size_t> _dc_rep_factor;
+    dc_rep_factor_map _dc_rep_factor;
 
     std::vector<sstring> _datacenteres;
     size_t _rep_factor;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -13,6 +13,7 @@
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/tablet_replication_strategy.hh"
 #include "seastar/core/on_internal_error.hh"
+#include "seastar/util/backtrace.hh"
 
 #include <optional>
 #include <unordered_set>

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -23,7 +23,7 @@ class load_sketch;
 class network_topology_strategy : public abstract_replication_strategy
                                 , public tablet_aware_replication_strategy {
 public:
-    network_topology_strategy(replication_strategy_params params);
+    network_topology_strategy(replication_strategy_params params, const topology* topo);
 
     virtual size_t get_replication_factor(const token_metadata&) const override {
         return _rep_factor;

--- a/locator/rack_inferring_snitch.hh
+++ b/locator/rack_inferring_snitch.hh
@@ -35,12 +35,12 @@ struct rack_inferring_snitch : public snitch_base {
 
     virtual sstring get_rack() const override {
         auto& endpoint = _cfg.broadcast_address;
-        return std::to_string(uint8_t(endpoint.bytes()[2]));
+        return fmt::format("rack{}", uint8_t(endpoint.bytes()[2]));
     }
 
     virtual sstring get_datacenter() const override {
         auto& endpoint = _cfg.broadcast_address;
-        return std::to_string(uint8_t(endpoint.bytes()[1]));
+        return fmt::format("dc{}", uint8_t(endpoint.bytes()[1]));
     }
 
     virtual sstring get_name() const override {

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -24,7 +24,7 @@ simple_strategy::simple_strategy(replication_strategy_params params, const locat
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            _replication_factor = parse_replication_factor(val).count();
+            _replication_factor = parse_replication_factor(val, {}).count();
             break;
         }
     }
@@ -69,7 +69,7 @@ void simple_strategy::validate_options(const gms::feature_service&, const locato
     if (it == _config_options.end()) {
         throw exceptions::configuration_exception("SimpleStrategy requires a replication_factor strategy option.");
     }
-    parse_replication_factor(it->second);
+    parse_replication_factor(it->second, {});
     if (_uses_tablets) {
         throw exceptions::configuration_exception("SimpleStrategy doesn't support tablet replication");
     }

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -17,7 +17,7 @@
 
 namespace locator {
 
-simple_strategy::simple_strategy(replication_strategy_params params) :
+simple_strategy::simple_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::simple) {
     for (auto& config_pair : _config_options) {
         auto& key = config_pair.first;
@@ -85,7 +85,8 @@ sstring simple_strategy::sanity_check_read_replicas(const effective_replication_
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.SimpleStrategy");
 static registry registrator_short_name("SimpleStrategy");
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -24,7 +24,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            _replication_factor = parse_replication_factor(val);
+            _replication_factor = parse_replication_factor(val).count();
             break;
         }
     }

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -16,7 +16,7 @@ namespace locator {
 
 class simple_strategy : public abstract_replication_strategy {
 public:
-    simple_strategy(replication_strategy_params params);
+    simple_strategy(replication_strategy_params params, const topology*);
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -52,6 +52,10 @@ public:
     /// current replica list, as replication factor changes involve table rebuilding transitions
     /// which are not instantaneous.
     virtual size_t get_replication_factor(const sstring& dc) const = 0;
+
+    virtual bool is_rack_based() const = 0;
+
+    virtual const rack_list& get_dc_racks(const sstring& dc) const = 0;
 };
 
 } // namespace locator

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -189,6 +189,9 @@ public:
         host_id this_host_id;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;
+
+        // If true then this topology only contains keyspaces which are rf-rack-valid.
+        // This also means that all keyspaces are using rack-list based replication factor.
         bool force_rack_valid_keyspaces = true;
 
         bool operator==(const config&) const = default;

--- a/locator/topology.hh
+++ b/locator/topology.hh
@@ -189,6 +189,7 @@ public:
         host_id this_host_id;
         endpoint_dc_rack local_dc_rack;
         bool disable_proximity_sorting = false;
+        bool force_rack_valid_keyspaces = true;
 
         bool operator==(const config&) const = default;
     };

--- a/main.cc
+++ b/main.cc
@@ -1031,6 +1031,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             tm_cfg.topo_cfg.this_endpoint = broadcast_addr;
             tm_cfg.topo_cfg.this_cql_address = broadcast_rpc_addr;
             tm_cfg.topo_cfg.local_dc_rack = snitch.local()->get_location();
+            tm_cfg.topo_cfg.force_rack_valid_keyspaces = cfg->rf_rack_valid_keyspaces();
             if (snitch.local()->get_name() == "org.apache.cassandra.locator.SimpleSnitch") {
                 //
                 // Simple snitch wants sort_by_proximity() not to reorder nodes anyhow

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -990,7 +990,7 @@ future<> database::create_local_system_table(
         bool durable = _cfg.data_file_directories().size() > 0;
         auto ksm = make_lw_shared<keyspace_metadata>(ks_name,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 durable
                 );

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1394,6 +1394,7 @@ public:
     lw_shared_ptr<keyspace_metadata> metadata() const;
 
     static locator::replication_strategy_ptr create_replication_strategy(
+            const locator::topology& topology,
             lw_shared_ptr<keyspace_metadata> metadata);
     future<locator::vnode_effective_replication_map_ptr> create_effective_replication_map(
             locator::replication_strategy_ptr strategy,

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -17,6 +17,7 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "cql3/column_specification.hh"
+#include "cql3/statements/index_prop_defs.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/core/sstring.hh>
@@ -174,8 +175,6 @@ public:
     }
     bool operator==(const speculative_retry& other) const = default;
 };
-
-typedef std::unordered_map<sstring, sstring> index_options_map;
 
 enum class index_metadata_kind {
     keys,

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -33,6 +33,9 @@ class function_name;
 namespace locator {
 class tablet_metadata_change_hint;
 }
+namespace replica {
+    class database;
+}
 
 #include "timestamp.hh"
 
@@ -80,8 +83,8 @@ public:
     // of the column family's keyspace. The reason for this is that we sometimes create a keyspace
     // and its column families together. Therefore, listeners can't load the keyspace from the
     // database. Instead, they should use the `ksm` parameter if needed.
-    virtual void on_before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
-    virtual void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp);
+    virtual void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp);
     virtual void on_before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type) {}
@@ -145,8 +148,8 @@ public:
     future<> drop_function(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
     future<> drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
 
-    void before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
-    void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1254,7 +1254,7 @@ public:
             },
             [] (const join_node_request_result::rejected& rej) {
                 throw std::runtime_error(
-                        format("the topology coordinator rejected request to join the cluster: {}", rej.reason));
+                        format("the topology coordinator rejected request to join the cluster: {}, at {}", rej.reason, current_backtrace()));
             },
         }, result.result);
 
@@ -7317,7 +7317,7 @@ future<join_node_response_result> storage_service::join_node_response_handler(jo
             },
             [&] (const join_node_response_params::rejected& rej) -> future<join_node_response_result> {
                 auto eptr = std::make_exception_ptr(std::runtime_error(
-                        format("the topology coordinator rejected request to join the cluster: {}", rej.reason)));
+                        format("the topology coordinator rejected request to join the cluster: {}, at {}", rej.reason, current_backtrace())));
                 _join_node_response_done.set_exception(std::move(eptr));
 
                 co_return join_node_response_result{};

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3261,11 +3261,11 @@ public:
         }
     }
 
-    void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, cfms, muts, ts);
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, {s.shared_from_this()}, muts, ts);
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3218,10 +3218,9 @@ public:
     // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
     void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) {
         locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
-        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
+        auto tm = _db.get_shared_token_metadata().get();
+        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params, tm->get_topology());
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
-            auto tm = _db.get_shared_token_metadata().get();
-
             std::unordered_map<table_id, schema_ptr> new_cfms_map;
             for (auto s : cfms) {
                 new_cfms_map[s->id()] = s;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -959,7 +959,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
-                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
                     } catch (const std::exception& e) {
                         error = e.what();

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -114,7 +114,7 @@ public:
     topology_mutation_builder& set_tablet_balancing_enabled(bool);
     topology_mutation_builder& set_new_cdc_generation_data_uuid(const utils::UUID& value);
     topology_mutation_builder& set_committed_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
-    topology_mutation_builder& set_new_keyspace_rf_change_data(const sstring &ks_name, const std::map<sstring, sstring> &rf_per_dc);
+    topology_mutation_builder& set_new_keyspace_rf_change_data(const sstring &ks_name, const std::map<sstring, std::variant<sstring, std::vector<sstring>>>& rf_per_dc);
     topology_mutation_builder& set_unpublished_cdc_generations(const std::vector<cdc::generation_id_v2>& values);
     topology_mutation_builder& set_global_topology_request(global_topology_request);
     topology_mutation_builder& set_global_topology_request_id(const utils::UUID&);
@@ -155,7 +155,7 @@ public:
     topology_request_tracking_mutation_builder& set(const char* cell, global_topology_request value);
     topology_request_tracking_mutation_builder& done(std::optional<sstring> error = std::nullopt);
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
-    topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
+    topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, std::variant<sstring, std::vector<sstring>>>& rf_per_dc);
 
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "cql3/statements/property_definitions.hh"
 #include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -158,7 +159,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     data_dictionary::database db = qp.db();
 
-    std::map<sstring, sstring> opts;
+    locator::replication_strategy_config_options opts;
     opts["replication_factor"] = replication_factor;
     auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt);
 
@@ -167,7 +168,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
         auto ts = group0_guard.write_timestamp();
 
         if (!db.has_keyspace(keyspace_name)) {
-            std::map<sstring, sstring> opts;
+            locator::replication_strategy_config_options opts;
             if (replication_strategy_name == "org.apache.cassandra.locator.NetworkTopologyStrategy") {
                 for (const auto &dc: qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                     opts[dc] = replication_factor;

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -3872,6 +3872,12 @@ SEASTAR_TEST_CASE(test_rf_expand) {
     constexpr static auto simple = "org.apache.cassandra.locator.SimpleStrategy";
     constexpr static auto network_topology = "org.apache.cassandra.locator.NetworkTopologyStrategy";
 
+    cql_test_config cfg;
+
+    // FIXME: Auto-expand with rack-valid keyspaces requires constructing a proper topology where
+    // it can be done, but we don't have infrastructure to do that yet. The default datacenter1 has one rack.
+    cfg.db_config->rf_rack_valid_keyspaces.set(false);
+
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto get_replication = [&] (const sstring& ks) {
             auto msg = e.execute_cql(
@@ -3932,7 +3938,7 @@ SEASTAR_TEST_CASE(test_rf_expand) {
             {"class", network_topology},
             {"datacenter1", "2"}
         });
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_int_sum_overflow) {
@@ -4367,6 +4373,12 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
 }
 
 SEASTAR_TEST_CASE(test_describe_view_schema) {
+    cql_test_config cfg = describe_test_config();
+
+    // FIXME: Auto-expand with rack-valid keyspaces requires constructing a proper topology where
+    // it can be done, but we don't have infrastructure to do that yet. The default datacenter1 has one rack.
+    cfg.db_config->rf_rack_valid_keyspaces.set(false);
+
     return do_with_cql_env_thread([] (cql_test_env& e) {
         std::string base_table = "CREATE TABLE \"KS\".\"cF\" (\n"
                 "    pk blob,\n"
@@ -4434,7 +4446,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
 
             BOOST_CHECK_EQUAL(normalize_white_space(base_schema_desc.create_statement.value().linearize()), normalize_white_space(base_table));
         }
-    }, describe_test_config());
+    }, std::move(cfg));
 }
 
 shared_ptr<cql_transport::messages::result_message> cql_func_require_nofail(

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -317,7 +317,7 @@ void simple_test() {
     locator::replication_strategy_params params323(options323, std::nullopt);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params323);
+        "NetworkTopologyStrategy", params323, stm.get()->get_topology());
 
     full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
@@ -331,7 +331,7 @@ void simple_test() {
     locator::replication_strategy_params params320(options320, std::nullopt);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params320);
+        "NetworkTopologyStrategy", params320, stm.get()->get_topology());
 
     full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
@@ -418,7 +418,7 @@ void heavy_origin_test() {
 
     locator::replication_strategy_params params(config_options, std::nullopt);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params);
+        "NetworkTopologyStrategy", params, stm.get()->get_topology());
 
     full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
@@ -513,7 +513,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
         locator::replication_strategy_params params(options, tablet_count);
         auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(tab_awr_ptr);
         auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), tablet_count).get();
@@ -605,7 +605,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
     testlog.debug("tablet_count={} options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, stm.get()->get_topology());
     auto nts_ptr = dynamic_cast<const network_topology_strategy*>(ars_ptr.get());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
@@ -618,7 +618,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
         testlog.debug("Increasing rf_per_dc={}", rf_per_dc);
         locator::replication_strategy_params inc_params(inc_options, tablet_count);
         auto inc_ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto inc_nts_ptr = dynamic_cast<const network_topology_strategy*>(inc_ars_ptr.get());
         auto inc_tab_awr_ptr = inc_ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(inc_tab_awr_ptr);
@@ -632,7 +632,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
         testlog.debug("Increasing rf_per_dc={}", rf_per_dc);
         locator::replication_strategy_params dec_params(dec_options, tablet_count);
         auto dec_ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto dec_nts_ptr = dynamic_cast<const network_topology_strategy*>(dec_ars_ptr.get());
         auto dec_tab_awr_ptr = dec_ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(dec_tab_awr_ptr);
@@ -825,7 +825,8 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
                                                                         return std::make_pair(p.first, to_sstring(p.second));
                                                                     })
                                                 | std::ranges::to<std::map<sstring, sstring>>(),
-                                    std::nullopt));
+                                    std::nullopt),
+                                    &topo);
 
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {
@@ -1299,7 +1300,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, tmptr->get_topology());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
     auto base_tmap = tab_awr_ptr->allocate_tablets_for_new_table(base_schema, tmptr, 1).get();
@@ -1453,7 +1454,7 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, tmptr->get_topology());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
     auto base_tmap = tab_awr_ptr->allocate_tablets_for_new_table(base_schema, tmptr, 1).get();

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -954,13 +954,13 @@ SEASTAR_TEST_CASE(test_rack_aware_rf) {
 
         unsigned shard_count = 2;
         topo.add_node(service::node_state::normal, shard_count);
-        auto s = "CREATE KEYSPACE ks11 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1'} AND tablets = {'enabled':true}";
+        auto s = "CREATE KEYSPACE ks11 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1a'} AND tablets = {'enabled':true}";
         testlog.info("{}", s);
         e.execute_cql(s).get();
 
         topo.start_new_rack();
         topo.add_node(service::node_state::normal, shard_count);
-        s = "CREATE KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1,rack2'} AND tablets = {'enabled':true}";
+        s = "CREATE KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1a,rack1b'} AND tablets = {'enabled':true}";
         testlog.info("{}", s);
         e.execute_cql(s).get();
 
@@ -968,7 +968,7 @@ SEASTAR_TEST_CASE(test_rack_aware_rf) {
         topo.add_node(service::node_state::normal, shard_count);
         topo.start_new_rack();
         topo.add_node(service::node_state::normal, shard_count);
-        s = "CREATE KEYSPACE ks22 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1,rack2', 'dc2':'rack1,rack2'} AND tablets = {'enabled':true}";
+        s = "CREATE KEYSPACE ks22 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1':'rack1a,rack1b', 'dc2':'rack2a,rack2b'} AND tablets = {'enabled':true}";
         testlog.info("{}", s);
         e.execute_cql(s).get();
     });

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3803,7 +3803,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     locator::replication_strategy_params params(test_config.options, tablet_count);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params);
+        "NetworkTopologyStrategy", params, stm.get()->get_topology());
 
     auto tablet_aware_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tablet_aware_ptr);
@@ -3865,7 +3865,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     try {
         tablet_map old_tablets = stm.get()->tablets().get_tablet_map(s->id());
         locator::replication_strategy_params params{test_config.new_dc_rep_factor, old_tablets.tablet_count()};
-        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto tmap = new_strategy->maybe_as_tablet_aware()->reallocate_tablets(s, stm.get(), old_tablets).get();
 
         auto const& ts = tmap.tablets();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3786,6 +3786,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     tm_cfg.topo_cfg.this_endpoint = test_config.ring_points[0].host;
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
     tm_cfg.topo_cfg.this_host_id = test_config.ring_points[0].id;
+    tm_cfg.topo_cfg.force_rack_valid_keyspaces = false; // FIXME: Convert the test to use rack lists.
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
     auto stop_stm = deferred_stop(stm);
 

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -43,7 +43,8 @@ namespace {
     mutable_vnode_erm_ptr create_erm(mutable_token_metadata_ptr tmptr, replication_strategy_config_options opts = {}) {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
-        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt));
+        auto& topo = tmptr->get_topology();
+        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt), &topo);
         return calculate_effective_replication_map(std::move(strategy), tmptr).get();
     }
 }

--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -64,14 +64,12 @@ class ScyllaCluster:
                 self.manager.servers_add(servers_num=nodes, config=self._config_options, start=False, auto_rack_dc="dc1")
             case list():
                 for dc, n_nodes in enumerate(nodes, start=1):
+                    dc_name = f"dc{dc}"
                     self.manager.servers_add(
                         servers_num=n_nodes,
                         config=self._config_options,
-                        property_file={
-                            "dc": f"dc{dc}",
-                            "rack": "RAC1",
-                        },
                         start=False,
+                        auto_rack_dc=dc_name
                     )
             case dict():
                 # Supported spec: {"dc1": {"rack1": 3, "rack2": 2}, "dc2": {"rack1": 2}}

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -92,7 +92,7 @@ async def test_alternator_ttl_scheduling_group(manager: ManagerClient):
        in the wrong scheduling group. We can assume this because we don't
        run multiple tests in parallel on the same cluster.
     """
-    servers = await manager.servers_add(3, config=alternator_config)
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
     alternator = get_alternator(servers[0].ip_addr)
     table = alternator.create_table(TableName=unique_table_name(),
         BillingMode='PAY_PER_REQUEST',

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -312,7 +312,7 @@ async def test_upgrade(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logger.info("Creating keyspace and table")
-    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks_name:
+    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks_name:
         table = f"{ks_name}.t"
         await verify_table_versions_synced(cql, hosts)
         await cql.run_async(f"create table {table} (pk int primary key)")

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -127,7 +127,7 @@ async def test_schema_versioning_with_recovery(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(3)]
+    servers = await manager.servers_add(3, config=cfg, auto_rack_dc='dc1')
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -297,7 +297,7 @@ async def test_upgrade(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(2)]
+    servers = await manager.servers_add(2, config=cfg, auto_rack_dc='dc1')
     cql = manager.get_cql()
 
     logging.info("Waiting until driver connects to every server")

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -225,11 +225,12 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
+        pattern = re.compile("Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy|Unrecognized datacenter name 'INVALID_DC'")
         # try modifying the keyspace
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
         execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -568,6 +568,7 @@ private:
             tm_cfg.topo_cfg.this_endpoint = my_address;
             tm_cfg.topo_cfg.this_cql_address = my_address;
             tm_cfg.topo_cfg.local_dc_rack = { _snitch.local()->get_datacenter(), _snitch.local()->get_rack() };
+            tm_cfg.topo_cfg.force_rack_valid_keyspaces = cfg->rf_rack_valid_keyspaces();
             _token_metadata.start([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg).get();
             auto stop_token_metadata = defer_verbose_shutdown("token metadata", [this] { _token_metadata.stop().get(); });
 

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -71,6 +71,7 @@ public:
 private:
     cql_test_env& _env;
     int _nr_nodes = 0;
+    int _dc_id;
     int _rack_id;
     sstring _dc;
     sstring _rack;
@@ -150,8 +151,7 @@ public:
     // Starts building a new rack in the current DC.
     // Returns location of the new rack.
     endpoint_dc_rack start_new_rack() {
-        _rack_id++;
-        _rack = fmt::format("rack{}", _rack_id);
+        _rack = fmt::format("rack{}{:c}", _dc_id, 'a' + _rack_id++);
         return rack();
     }
 
@@ -159,7 +159,8 @@ public:
     // DC is named uniquely in the scope of the process, not just this object.
     endpoint_dc_rack start_new_dc() {
         static std::atomic<int> next_id = 1;
-        _dc = fmt::format("dc{}", next_id.fetch_add(1));
+        _dc_id = next_id.fetch_add(1);
+        _dc = fmt::format("dc{}", _dc_id);
         _rack_id = 0;
         return start_new_rack();
     }

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -77,6 +77,7 @@ private:
     sstring _rack;
     shared_load_stats _load_stats;
     std::vector<locator::host_id> _hosts;
+    std::unordered_map<sstring, std::vector<sstring>> _dc_racks;
 private:
     inet_address make_node_address(int n) {
         assert(n > 0);
@@ -165,6 +166,10 @@ public:
         return start_new_rack();
     }
 
+    std::unordered_map<sstring, std::vector<sstring>> get_dc_racks() const {
+        return _dc_racks;
+    }
+
     locator::load_stats_ptr get_load_stats() const {
         return _load_stats.get();
     }
@@ -228,6 +233,7 @@ public:
             }
         }
         _hosts.push_back(id);
+        _dc_racks[dc_rack.dc].push_back(dc_rack.rack);
         return id;
     }
 

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
 
+#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "data_dictionary/keyspace_metadata.hh"
 #include "db/cql_type_parser.hh"
@@ -71,7 +72,7 @@ tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
 
     auto ks = make_lw_shared<data_dictionary::keyspace_metadata>(keyspace_name,
                                                                  "org.apache.cassandra.locator.LocalStrategy",
-                                                                 std::map<sstring, sstring>{},
+                                                                 locator::replication_strategy_config_options{},
                                                                  std::nullopt, false);
     db::cql_type_parser::raw_builder ut_builder(*ks);
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -161,7 +161,7 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}};
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}, nullptr};
         return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -259,7 +259,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
     real_db.keyspaces.emplace_back(make_lw_shared<keyspace_metadata>(
                 db::schema_tables::NAME,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 false));
     real_db.tables.emplace_back(dd_impl, real_db.keyspaces.back(), db::schema_tables::dropped_columns(), false);
@@ -445,7 +445,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     if (types_mut) {
         query::result_set result(*types_mut);
 
-        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", std::map<sstring, sstring>{}, std::nullopt, false);
+        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", locator::replication_strategy_config_options{}, std::nullopt, false);
         db::cql_type_parser::raw_builder ut_builder(*ks);
 
         auto get_list = [] (const query::result_set_row& row, const char* name) {


### PR DESCRIPTION
[DISCLAIMER this branch is work in progress, this PR is opened for running CI and preliminary review]

This change extends the CQL replication options syntax so the replication factor can be stated as a list of rack names.
For example: `{ 'mydatacenter': [ 'myrack1', 'myrack2', 'myrack4' ] }`

When providing a numeric replication factor like the `{'replication_factor': '3'}` "wildcard" or `{'dc1': '3'}` for a specific datacenter, if the keyspace is rf-rack-valid, the replication factor options are expended and RF racks are selected at random for the affected datacenters racks (if there are enough racks, otherwise an error is returned).

Specifying the rack list also allows to add replicas on the specified racks (increasing the replication factor), or decommissioning certain racks from their replicas (by omitting them from the current datacenter rack-list), or replacing a single rack from a datacenter rack-list to migrate all replicas from the dropped rack onto the new rack.

It is intended that ALTER KEYSPACE with a given rack-list could be used for migrating replicas in rf-rack invalid keyspaces, where RF < nr_racks in a datacenter and the replicas may be allocated across all available racks.  In this case, the existing replicas will be migrated into the specified rack-list which specifies a subset of the available racks, and when done, the keyspace will become rf-rack-valid.

* New feature, no backport required.