### PR TITLE
docs/alternator: mention missing ShardFilter support

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -282,6 +282,10 @@ experimental:
     instead of just a single MODIFY or INSERT.
     <https://github.com/scylladb/scylla/issues/6930>
     <https://github.com/scylladb/scylla/issues/6918>
+  * The optional ShardFilter parameter to DescribeStream, added to DynamoDB
+    in July 2025 to optimize shard discovery, is not yet implemented in
+    Alternator.
+    <https://github.com/scylladb/scylla/issues/25160>
 
 ## Unimplemented API features
 


### PR DESCRIPTION
Add in docs/alternator/compatibility.md a mention of the ShardFilter option which we don't support in Alternator Streams. This option was only introduced to DynamoDB a week ago, so it's not surprising we don't yet support it :-)

Refs #25160