### PR TITLE
db/schema_applier: mark schema synced after commit on all shards

### DIFF
--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -1038,6 +1038,7 @@ future<> schema_applier::commit() {
     // with a new e_r_m instance.
     SCYLLA_ASSERT(this_shard_id() == 0);
     commit_on_shard(sharded_db.local());
+    co_await utils::get_local_injector().inject("schema_applier_delay_between_commit_on_shards", std::chrono::seconds(1));
     co_await sharded_db.invoke_on_others([this] (replica::database& db) {
         commit_on_shard(db);
     });

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -142,6 +142,7 @@ struct affected_tables_and_views_per_shard {
     schema_diff_per_shard tables;
     schema_diff_per_shard views;
     std::vector<bool> columns_changed;
+    shared_promise<> committed_on_all_shards;
 };
 
 struct affected_tables_and_views {

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -200,6 +200,12 @@ mutation reverse(mutation mut) {
     return *std::move(mut).consume(reverse_rebuilder, consume_in_reverse::yes).result;
 }
 
+mutation reverse_with_load(mutation mut) {
+    auto reverse_schema = mut.schema()->get_reversed();
+    mutation_rebuilder_v2 reverse_rebuilder(reverse_schema);
+    return *std::move(mut).consume(reverse_rebuilder, consume_in_reverse::yes).result;
+}
+
 namespace {
 class mutation_by_size_splitter {
     struct partition_state {

--- a/mutation/mutation.hh
+++ b/mutation/mutation.hh
@@ -458,7 +458,9 @@ std::ranges::subrange<utils::chunked_vector<mutation>::const_iterator> slice(
 
 // Reverses the mutation as if it was created with a schema with reverse
 // clustering order. The resulting mutation will contain a reverse schema too.
+// `reverse_with_load` additionally ensures the schema is loaded in the schema registry.
 mutation reverse(mutation mut);
+mutation reverse_with_load(mutation mut);
 
 template <> struct fmt::formatter<mutation> : fmt::formatter<string_view> {
     auto format(const mutation&, fmt::format_context& ctx) const -> decltype(ctx.out());

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1831,7 +1831,8 @@ public:
     void init_schema_commitlog();
 
     using is_new_cf = bool_class<struct is_new_cf_tag>;
-    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr);
+    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr,
+        seastar::noncopyable_function<future<>()> syncer = [] { return make_ready_future(); });
     future<> make_column_family_directory(schema_ptr schema);
     future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new);
 
@@ -2013,7 +2014,7 @@ public:
     static future<> snapshot_keyspace_on_all_shards(sharded<database>& sharded_db, std::string_view ks_name, sstring tag, bool skip_flush);
 
 public:
-    bool update_column_family(schema_ptr s);
+    bool update_column_family(schema_ptr s, seastar::noncopyable_function<future<>()> syncer = [] { return make_ready_future(); });
 private:
     keyspace::config make_keyspace_config(const keyspace_metadata& ksm, system_keyspace is_system);
     struct table_truncate_state;

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -264,7 +264,7 @@ frozen_schema schema_registry_entry::frozen() const {
     return *_frozen_schema;
 }
 
-future<> schema_registry_entry::maybe_sync(std::function<future<>()> syncer) {
+future<> schema_registry_entry::maybe_sync(seastar::noncopyable_function<future<>()> syncer) {
     switch (_sync_state) {
         case schema_registry_entry::sync_state::SYNCED:
             return make_ready_future<>();

--- a/schema/schema_registry.cc
+++ b/schema/schema_registry.cc
@@ -301,6 +301,13 @@ future<> schema_registry_entry::maybe_sync(seastar::noncopyable_function<future<
     abort();
 }
 
+future<> schema_registry_entry::maybe_wait_for_sync() {
+    if (_sync_state == sync_state::SYNCING) {
+        return _synced_promise.get_shared_future();
+    }
+    return make_ready_future<>();
+}
+
 bool schema_registry_entry::is_synced() const {
     return _sync_state == sync_state::SYNCED;
 }

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -92,6 +92,8 @@ public:
     bool is_synced() const;
     // Initiates asynchronous schema sync or returns ready future when is already synced.
     future<> maybe_sync(seastar::noncopyable_function<future<>()> sync);
+    // Wait for sync if the state is SYNCING.
+    future<> maybe_wait_for_sync();
     // Marks this schema version as synced. Syncing cannot be in progress.
     void mark_synced();
     // Can be called from other shards

--- a/schema/schema_registry.hh
+++ b/schema/schema_registry.hh
@@ -91,7 +91,7 @@ public:
     // Can be called from other shards
     bool is_synced() const;
     // Initiates asynchronous schema sync or returns ready future when is already synced.
-    future<> maybe_sync(std::function<future<>()> sync);
+    future<> maybe_sync(seastar::noncopyable_function<future<>()> sync);
     // Marks this schema version as synced. Syncing cannot be in progress.
     void mark_synced();
     // Can be called from other shards

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1241,6 +1241,12 @@ future<schema_ptr> migration_manager::get_schema_for_write(table_schema_version 
     }
 
     auto s = local_schema_registry().get_or_null(v);
+
+    // if syncing is in progress, wait for it first.
+    if (s) {
+        co_await s->registry_entry()->maybe_wait_for_sync();
+    }
+
     // `_enable_schema_pulls` may change concurrently with this function (but only from `true` to `false`).
     bool use_raft = !_enable_schema_pulls;
     if ((!s || !s->is_synced()) && use_raft) {

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -156,6 +156,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
         co_await e.db().invoke_on_all([gs = global_schema_ptr(gen.schema())](replica::database& db) -> future<> {
             co_await db.add_column_family_and_make_directory(gs.get(), replica::database::is_new_cf::yes);
         });
+        gen.set_schema(local_schema_registry().get(gen.schema()->version()));
         auto& cf = e.local_db().find_column_family(gen.schema());
         const auto& local_sharder = cf.schema()->get_sharder();
 

--- a/test/cluster/mv/test_create_mv.py
+++ b/test/cluster/mv/test_create_mv.py
@@ -1,0 +1,52 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import asyncio
+import pytest
+import logging
+
+from test.pylib.manager_client import ManagerClient
+from test.cluster.util import new_test_keyspace
+
+
+logger = logging.getLogger(__name__)
+
+# Reproduces issue #23831
+# Create a MV while inserts are ongoing to the base table, with propagation delay between shards.
+# In the time that the the MV is committed on one shard but not yet on the other, the shard may try
+# to generate view updates and apply them on the other shard, which doesn't have the MV table ready yet.
+# We want to verify it's handled gracefully without errors.
+@pytest.mark.asyncio
+async def test_mv_create_during_inserts(manager: ManagerClient):
+    cmdline = ['--smp', '2']
+    servers = await manager.servers_add(1, cmdline=cmdline)
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int)")
+
+        stop_writer = asyncio.Event()
+
+        async def do_writes_async():
+            i = 0
+            while not stop_writer.is_set():
+                await cql.run_async(f"INSERT INTO {ks}.test(pk, v) VALUES({i}, {i+1})")
+                await asyncio.sleep(0.1)
+                i += 1
+
+        writer_task = asyncio.create_task(do_writes_async())
+
+        log = await manager.server_open_log(servers[0].server_id)
+
+        await manager.api.enable_injection(servers[0].ip_addr, "schema_applier_delay_between_commit_on_shards", one_shot=False)
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE v IS NOT NULL PRIMARY KEY (v, pk)")
+
+        # Stop the writer and wait for it to complete
+        stop_writer.set()
+        await writer_task
+
+        matches = await log.grep("Error applying view update")
+        assert len(matches) == 0, f"Found errors applying view updates: {matches[0]}"

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2419,6 +2419,10 @@ schema_ptr random_mutation_generator::schema() const {
     return _impl->_schema;
 }
 
+void random_mutation_generator::set_schema(schema_ptr s) {
+    _impl->_schema = s;
+}
+
 range_tombstone random_mutation_generator::make_random_range_tombstone() {
     return _impl->make_random_range_tombstone();
 }

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -69,6 +69,7 @@ public:
     // Generates n mutations sharing the same schema nad sorted by their decorated keys.
     utils::chunked_vector<mutation> operator()(size_t n);
     schema_ptr schema() const;
+    void set_schema(schema_ptr s);
     clustering_key make_random_key();
     range_tombstone make_random_range_tombstone();
     std::vector<dht::decorated_key> make_partition_keys(size_t n);


### PR DESCRIPTION
When adding a new schema to a new table or altered table, add it
initially in SYNCING state, and mark it as synced only after the change
is committed on all shards.

This solves an issue where a schema is added to a table on one shard,
then this shard starts generating mutations using the new schema, and
sends the mutations to another shard. At this point the change may not
be committed on the other shard - the table may not exist (on table/view
create), or the table exists but uses the older schema (on table/view
alter), so the operation can fail with a table not found error, or
succeed with a silent corruption because the mutation is downgraded to
old schema.

By marking the schema synced only after it's committed on all shards, we
ensure a schema is not used to apply mutations before it's ready on all
shards, and the syncer functions allows us to wait for it to become
synced, when we can continue to use it safely.

Fixes https://github.com/scylladb/scylladb/issues/23831
Fixes https://github.com/scylladb/scylladb/issues/14146
Fixes: SCYLLADB-1255

backport not needed - small CI stability issue