### PR TITLE
List Alternator clients in system.clients virtual table

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -167,4 +167,8 @@ future<> controller::request_stop_server() {
     });
 }
 
+future<utils::chunked_vector<client_data>> controller::get_client_data() {
+    return _server.local().get_client_data();
+}
+
 }

--- a/alternator/controller.hh
+++ b/alternator/controller.hh
@@ -90,6 +90,10 @@ public:
     virtual future<> start_server() override;
     virtual future<> stop_server() override;
     virtual future<> request_stop_server() override;
+    // This virtual function is called (on each shard separately) when the
+    // virtual table "system.clients" is read. It is expected to generate a
+    // list of clients connected to this server (on this shard).
+    virtual future<utils::chunked_vector<client_data>> get_client_data() override;
 };
 
 }

--- a/alternator/scoped_item_list.hh
+++ b/alternator/scoped_item_list.hh
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+/**
+ * scoped_item_list<T> holds a list of items of type T, which are
+ * automatically removed from the list when they go out of scope.
+ * This is useful, for example, to hold a list of ongoing requests in a server
+ * (on one particular shard), so that they can be listed by an API that wants
+ * to list such requests (e.g., the "system.clients" virtual table).
+ *
+ * When creating an item in the list with the emplace() method, a handle is
+ * returned which can be used to continue accessing the item. When this handle
+ * goes out of scope, the item is automatically removed from the list.
+ * 
+ * Importantly, scoped_item_list<T> also provides for_each_gently() - a
+ * stall-safe way to iterate over the list. for_each_gently() run a function
+ * on each item in the list, but can preempt between items when our time quota
+ * is finished, to avoid stalls.
+ * 
+ * NOTE:
+ * scoped_item_list<T> currently assumes that when it is destroyed, it is
+ * already empty, i.e., all handles returned by it had already been destroyed.
+ * If this is not the case, on_fatal_internal_error() is called.
+ * This assumption holds when used in the Alternator server, where the server
+ * and the scoped_item_list<T> it contains, are only destroyed after
+ * waiting for the _pending_requests gate to close, and it cannot close
+ * before all calls to handle_api_request() are done. And since
+ * handle_api_request() is the only place that holds scoped_item_list<T>
+ * handles, when all these calls finished no handles can be held.
+ * 
+ * This class is inspired by the generic_server::connection class,
+ * which uses similar code to hold ongoing requests in a list, but
+ * is too tightly integrated into generic_server, which Alternator
+ * cannot use because it uses Seastar's HTTP server for managing the
+ * connections.
+ */
+
+#pragma once
+
+
+#include <list>
+
+#include <boost/intrusive/list.hpp>
+
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include "seastarx.hh"
+#include "utils/on_internal_error.hh"
+
+template <typename T>
+class scoped_item_list {
+    class handle : public boost::intrusive::list_base_hook<> {
+        friend scoped_item_list;
+        T value;
+        scoped_item_list* owner;
+        template <typename... Args>
+        handle(scoped_item_list* o, Args&&... args)
+            : value(std::forward<Args>(args)...), owner(o) {}
+    public:
+        ~handle() {
+            if (owner) {
+                // If we're in the middle of for_each_gently() on this list,
+                // and it was planning to continue on this item after its
+                // interruption, we have to help it by updating its iterator
+                // to skip this item that we now plan to delete.
+                typename scoped_item_list::list_type::iterator iter = owner->_list.iterator_to(*this);
+                for (auto&& gi : owner->_gentle_iterators) {
+                    if (gi.iter == iter) {
+                        gi.iter++;
+                    }
+                }
+                owner->_list.erase(iter);
+            }
+        }
+        T& get() { return value; }
+        T* operator->() { return &value; }
+        T& operator*() { return value; }
+
+        handle(handle&& other) noexcept :
+            boost::intrusive::list_base_hook<>(std::move(other)), 
+            value(std::move(other.value)), owner(other.owner) {
+                other.owner = nullptr;
+        }
+        handle& operator=(handle&& other) = delete;
+        handle(const handle&) = delete;
+        handle& operator=(const handle&) = delete;
+    };
+
+    using list_type = boost::intrusive::list<handle, boost::intrusive::constant_time_size<false>>;
+    list_type _list;
+
+public:
+    template <typename... Args>
+    handle emplace(Args&&... args) {
+        handle ret(this, std::forward<Args>(args)...);
+        _list.push_back(ret);
+        return ret;
+    }
+    scoped_item_list() = default;
+    ~scoped_item_list() {
+        // We usually expect that when the scoped_item_list<T> is destroyed,
+        // the list is already empty. For example, in the Alternator server,
+        // the list is destroyed when the server object is destroyed, and the
+        // server is only destroyed after all requests are done - so all
+        // handles those requests held to list items have been destroyed, so
+        // the list is empty.
+        // But if for some reason the list is not empty, it's not a disaster
+        // either - we just remove the "owner" pointer from all the handles.
+        // Each handle will continue to hold its item as before, but it is
+        // detached from any list.
+        for (auto& h : _list) {
+            h.owner = nullptr;
+        }
+        // We don't expect that the scoped_item_list<T> be destroyed while any
+        // for_each_gently() are still running. In general trying to do that
+        // doesn't make sense - since for_each_gently() is a method of the
+        // object being destroyed. We could have allowed this by making the
+        // _gentle_iterators list an intrusive list as well, but it's not
+        // worth the effort, since we don't expect this to ever happen.
+        if (!_gentle_iterators.empty()) {
+            utils::on_fatal_internal_error("scoped_item_list destroyed while "
+                "for_each_gently() is still running");
+        }
+    }
+    scoped_item_list(const scoped_item_list&) = delete;
+    scoped_item_list& operator=(const scoped_item_list&) = delete;
+
+    bool empty() const { return _list.empty(); }
+
+    struct gentle_iterator {
+        list_type::iterator iter, end;
+        gentle_iterator(scoped_item_list<T>& s) : iter(s._list.begin()), end(s._list.end()) {}
+        gentle_iterator(const gentle_iterator&) = delete;
+        gentle_iterator(gentle_iterator&&) = delete;
+    };
+    std::list<gentle_iterator> _gentle_iterators;
+
+    // for_each_gently() is a stall-safe way to iterate over the list, i.e.,
+    // run a given function fn on each item in the list, possibly preempting
+    // between items when our time quota is finished, to avoid stalls.
+    // Note that the function fn cannot be preempted (it does not return a
+    // future) - it would not be safe if it did, and the item it was working
+    // on was destroyed.
+    future<> for_each_gently(noncopyable_function<void(T&)> fn) {
+        _gentle_iterators.emplace_front(*this);
+        typename std::list<gentle_iterator>::iterator gi = _gentle_iterators.begin();
+        return seastar::do_until([ gi ] { return gi->iter == gi->end; },
+            [ gi, fn = std::move(fn) ] {
+                fn((gi->iter++)->get());
+                return make_ready_future<>();
+            }
+        ).finally([ this, gi ] { _gentle_iterators.erase(gi); });
+    }
+};

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "alternator/executor.hh"
+#include "alternator/scoped_item_list.hh"
 #include <seastar/core/future.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/http/httpd.hh>
@@ -19,6 +20,8 @@
 #include "utils/small_vector.hh"
 #include "utils/updateable_value.hh"
 #include <seastar/core/units.hh>
+
+struct client_data;
 
 namespace alternator {
 
@@ -74,12 +77,30 @@ class server : public peering_sharded_service<server> {
     };
     json_parser _json_parser;
 
+    // The server maintains a list of ongoing requests, that are being handled
+    // by handle_api_request(). It uses this list in get_client_data(), which
+    // is called when reading the "system.clients" virtual table.
+    struct ongoing_request {
+        socket_address _client_address;
+        sstring _user_agent;
+        sstring _username;
+        scheduling_group _scheduling_group;
+        bool _is_https;
+        client_data make_client_data() const;
+    };
+    scoped_item_list<ongoing_request> _ongoing_requests;
+
 public:
     server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
             utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
+    // get_client_data() is called (on each shard separately) when the virtual
+    // table "system.clients" is read. It is expected to generate a list of
+    // clients connected to this server (on this shard). This function is
+    // called by alternator::controller::get_client_data().
+    future<utils::chunked_vector<client_data>> get_client_data();
 private:
     void set_routes(seastar::httpd::routes& r);
     // If verification succeeds, returns the authenticated user's username

--- a/utils/on_internal_error.cc
+++ b/utils/on_internal_error.cc
@@ -19,4 +19,8 @@ namespace utils {
     seastar::on_internal_error(on_internal_error_logger, reason);
 }
 
+[[noreturn]] void on_fatal_internal_error(std::string_view reason) noexcept{
+    seastar::on_fatal_internal_error(on_internal_error_logger, reason);
+}
+
 }

--- a/utils/on_internal_error.hh
+++ b/utils/on_internal_error.hh
@@ -31,4 +31,11 @@ namespace utils {
 /// current backtrace.
 [[noreturn]] void on_internal_error(std::string_view reason);
 
+/// Report an internal error and abort unconditionally
+///
+/// The error will be logged, containing \p reason and the current backtrace,
+/// and the program will be aborted, regardless of the abort_on_internal_error
+/// setting.
+[[noreturn]] void on_fatal_internal_error(std::string_view reason) noexcept;
+
 }


### PR DESCRIPTION
Before this series, the "system.clients" virtual table lists active connections (and their various properties, like client address, logged in username and client version) only for CQL requests. This series adds also Alternator clients to system.clients. One of the interesting use cases of this new feature is understanding exactly which SDK a user is using -without inspecting their application code.  Different SDKs pass different "User-Agent" headers in requests, and that User-Agent will be visible in the system.clients entries for Alternator requests as the "driver_name" field.

Unlike CQL where logged in username, driver name, etc. applies to a complete connection, in the Alternator API, different requests can theoretically be signed by different users and carry different headers but still arrive over the same HTTP connection. So instead of listing the currently open Alternator *connections*, we will list the currently active *requests*.

The first two patches introduce utilities that will be useful in the implementation. The third patch is the implementation itself (which is quite simple with the utility introduced in the second patch), and the fourth patch a regression test for the new feature.

Fixes #24993

This patch adds a new feature, so doesn't require a backport. Nevertheless, if we want it to get to existing customers more quickly to allow us to better understand their use case by reading the system.clients table, we may want to consider backporting this patch to existing branches. There is some risk involved in this patch, because it adds code that gets run on every Alternator request, so a bug on it can cause problems for every Alternator request.