### PR TITLE
cdc, vector_search: enable CDC when the index is created

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -177,6 +177,13 @@ public:
     }
 
     void on_before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
+        bool has_vector_index = secondary_index::vector_index::has_vector_index(new_schema);
+        if (has_vector_index) {
+            // If we have a vector index, we need to ensure that the CDC log is created
+            // satisfying the minimal requirements of Vector Search.
+            secondary_index::vector_index::check_cdc_options(new_schema);
+        }
+
         bool is_cdc = cdc_enabled(new_schema);
         bool was_cdc = cdc_enabled(old_schema);
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -21,6 +21,7 @@
 #include "cdc/metadata.hh"
 #include "cdc/cdc_partitioner.hh"
 #include "bytes.hh"
+#include "index/vector_index.hh"
 #include "replica/database.hh"
 #include "db/schema_tables.hh"
 #include "schema/schema.hh"
@@ -176,8 +177,8 @@ public:
     }
 
     void on_before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
-        bool is_cdc = new_schema.cdc_options().enabled();
-        bool was_cdc = old_schema.cdc_options().enabled();
+        bool is_cdc = cdc_enabled(new_schema);
+        bool was_cdc = cdc_enabled(old_schema);
 
         // if we are turning off cdc we can skip this, since even if columns change etc,
         // any writer should see cdc -> off together with any actual schema changes to
@@ -419,6 +420,10 @@ static const sstring cdc_meta_column_prefix = "cdc$";
 static const sstring cdc_deleted_column_prefix = cdc_meta_column_prefix + "deleted_";
 static const sstring cdc_deleted_elements_column_prefix = cdc_meta_column_prefix + "deleted_elements_";
 
+bool cdc_enabled(const schema& s) {
+    return s.cdc_options().enabled() || secondary_index::vector_index::has_vector_index(s);
+}
+
 bool is_log_name(const std::string_view& table_name) {
     return table_name.ends_with(cdc_log_suffix);
 }
@@ -432,7 +437,7 @@ bool is_log_for_some_table(const replica::database& db, const sstring& ks_name, 
     if (!base_schema) {
         return false;
     }
-    return base_schema->cdc_options().enabled();
+    return cdc_enabled(*base_schema);
 }
 
 schema_ptr get_base_table(const replica::database& db, const schema& s) {
@@ -1793,7 +1798,7 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
     // we do all this because in the case of batches, we can have mixed schemas.
     auto e = mutations.end();
     auto i = std::find_if(mutations.begin(), e, [](const mutation& m) {
-        return m.schema()->cdc_options().enabled();
+        return cdc_enabled(*m.schema());
     });
 
     if (i == e) {
@@ -1809,7 +1814,7 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
             auto& m = mutations[idx];
             auto s = m.schema();
 
-            if (!s->cdc_options().enabled()) {
+            if (!cdc_enabled(*s)) {
                 return make_ready_future<>();
             }
 
@@ -1874,7 +1879,7 @@ cdc::cdc_service::impl::augment_mutation_call(lowres_clock::time_point timeout, 
 
 bool cdc::cdc_service::needs_cdc_augmentation(const utils::chunked_vector<mutation>& mutations) const {
     return std::any_of(mutations.begin(), mutations.end(), [](const mutation& m) {
-        return m.schema()->cdc_options().enabled();
+        return cdc_enabled(*m.schema());
     });
 }
 

--- a/cdc/log.hh
+++ b/cdc/log.hh
@@ -106,6 +106,8 @@ bool is_log_for_some_table(const replica::database& db, const sstring& ks_name, 
 schema_ptr get_base_table(const replica::database&, const schema&);
 schema_ptr get_base_table(const replica::database&, std::string_view, std::string_view);
 
+bool cdc_enabled(const schema& s);
+
 seastar::sstring base_name(std::string_view log_name);
 seastar::sstring log_name(std::string_view table_name);
 seastar::sstring log_data_column_name(std::string_view column_name);

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -12,6 +12,8 @@
 #include "exceptions/exceptions.hh"
 #include "schema/schema.hh"
 #include "index/vector_index.hh"
+#include "index/secondary_index.hh"
+#include "index/secondary_index_manager.hh"
 #include "concrete_types.hh"
 #include "utils/managed_string.hh"
 #include <seastar/core/sstring.hh>
@@ -93,6 +95,18 @@ void vector_index::validate(const schema &schema, cql3::statements::index_prop_d
         }
         it->second(option.second);
     }
+}
+
+bool vector_index::has_vector_index(const schema& s) {
+    auto i = s.indices();
+    return std::any_of(i.begin(), i.end(), [](const auto& index) {
+        auto it = index.options().find(db::index::secondary_index::custom_index_option_name);
+        if (it != index.options().end()) {
+            auto custom_class = secondary_index_manager::get_custom_class_factory(it->second);
+            return (custom_class && dynamic_cast<vector_index*>((*custom_class)().get()));
+        }
+        return false;
+    });
 }
 
 std::unique_ptr<secondary_index::custom_index> vector_index_factory() {

--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -7,6 +7,8 @@
  */
 
 
+#include "cdc/cdc_options.hh"
+#include "cdc/log.hh"
 #include "cql3/statements/index_target.hh"
 #include "cql3/util.hh"
 #include "exceptions/exceptions.hh"
@@ -73,11 +75,10 @@ std::optional<cql3::description> vector_index::describe(const index_metadata& im
     };
 }
 
-void vector_index::validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) {
+void vector_index::check_target(const schema& schema, const std::vector<::shared_ptr<cql3::statements::index_target>>& targets) {
     if (targets.size() != 1) {
         throw exceptions::invalid_request_exception("Vector index can only be created on a single column");
     }
-
     auto target = targets[0];
     auto c_def = schema.get_column_definition(to_bytes(target->column_name()));
     if (!c_def) {
@@ -87,7 +88,52 @@ void vector_index::validate(const schema &schema, cql3::statements::index_prop_d
     if (!type->is_vector() || static_cast<const vector_type_impl*>(type.get())->get_elements_type()->get_kind() != abstract_type::kind::float_kind) {
         throw exceptions::invalid_request_exception(format("Vector indexes are only supported on columns of vectors of floats", target->column_name()));
     }
+}
 
+void vector_index::check_cdc_not_explicitly_disabled(const schema& schema) {
+    auto cdc_options = schema.cdc_options();
+    if (cdc_options.is_enabled_set() && !cdc_options.enabled()) {
+        // If CDC is explicitly disabled by the user, we cannot create the vector index.
+        throw exceptions::invalid_request_exception(format(
+            "Cannot create the vector index when CDC is explicitly disabled.\n"
+                "Please enable CDC with the required parameters first.\n"
+                "CDC's TTL must be at least {} seconds (24 hours), "
+                "and the CDC's delta mode must be set to 'full' or postimage must be enabled "
+                "to enable Vector Search.\n"
+                "Check documentation on how to setup CDC's parameters - "
+                "https://docs.scylladb.com/manual/branch-2025.2/features/cdc/cdc-intro.html#cdc-parameters",
+                VS_TTL_SECONDS));
+    }
+}
+
+void vector_index::check_cdc_options(const schema& schema) {
+    auto cdc_options = schema.cdc_options();
+    if (cdc_options.enabled()) {
+        auto ttl = cdc_options.ttl();
+        auto delta_mode = cdc_options.get_delta_mode();
+        auto postimage = cdc_options.postimage();
+        if ((ttl && ttl < VS_TTL_SECONDS) ||
+            (delta_mode != cdc::delta_mode::full && !postimage)) {
+            throw exceptions::invalid_request_exception(
+                secondary_index::vector_index::has_vector_index(schema) ?
+                format("Vector Search is enabled on this table.\n"
+                "The CDC log must meet the minimal requirements of Vector Search.\n"
+                "This means that the CDC's TTL must be at least {} seconds (24 hours), "
+                "and the CDC's delta mode must be set to 'full' or postimage must be enabled.\n",
+                VS_TTL_SECONDS) :
+                format("To enable Vector Search on this table, "
+                "the CDC log must meet the minimal requirements of Vector Search.\n"
+                "CDC's TTL must be at least {} seconds (24 hours), "
+                "and the CDC's delta mode must be set to 'full' or postimage must be enabled "
+                "to enable Vector Search.\n"
+                "Check documentation on how to setup CDC's parameters - "
+                "https://docs.scylladb.com/manual/branch-2025.2/features/cdc/cdc-intro.html#cdc-parameters",
+                VS_TTL_SECONDS));
+        }
+    }
+}
+
+void vector_index::check_index_options(cql3::statements::index_prop_defs& properties) {
     for (auto option: properties.get_raw_options()) {
         auto it = supported_options.find(option.first);
         if (it == supported_options.end()) {
@@ -95,6 +141,13 @@ void vector_index::validate(const schema &schema, cql3::statements::index_prop_d
         }
         it->second(option.second);
     }
+}
+
+void vector_index::validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) {
+    check_target(schema, targets);
+    check_cdc_not_explicitly_disabled(schema);
+    check_cdc_options(schema);
+    check_index_options(properties);
 }
 
 bool vector_index::has_vector_index(const schema& s) {

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -26,8 +26,8 @@ public:
     std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
     bool view_should_exist() const override;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
+    static bool has_vector_index(const schema& s);
 };
 
 std::unique_ptr<secondary_index::custom_index> vector_index_factory();
-
 }

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -19,14 +19,22 @@
 namespace secondary_index {
 
 class vector_index: public custom_index {
-
 public:
+    // The minimal TTL for the CDC used by Vector Search.
+    // Required to ensure that the data is not deleted until the vector index is fully built.
+    static constexpr int VS_TTL_SECONDS = 86400; // 24 hours
+
     vector_index() = default;
     ~vector_index() override = default;
     std::optional<cql3::description> describe(const index_metadata& im, const schema& base_schema) const override;
     bool view_should_exist() const override;
     void validate(const schema &schema, cql3::statements::index_prop_defs &properties, const std::vector<::shared_ptr<cql3::statements::index_target>> &targets, const gms::feature_service& fs) override;
     static bool has_vector_index(const schema& s);
+    static void check_cdc_options(const schema& schema);
+private:
+    void check_cdc_not_explicitly_disabled(const schema& schema);
+    void check_target(const schema& schema, const std::vector<::shared_ptr<cql3::statements::index_target>>& targets);
+    void check_index_options(cql3::statements::index_prop_defs& properties);
 };
 
 std::unique_ptr<secondary_index::custom_index> vector_index_factory();

--- a/test/cql/vs_cdc_enable_disable_test.cql
+++ b/test/cql/vs_cdc_enable_disable_test.cql
@@ -1,0 +1,41 @@
+-- Important: using the same partition key for each row so the results of select from log table
+-- do not depend on how stream IDs are assigned to partition keys.
+
+-- Error messages contain a keyspace name. Make the output stable.
+-- CDC and tablets are not working together yet, turn them off.
+CREATE KEYSPACE ks
+    WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
+    tablets = {'enabled': false};
+
+-- create table with vector column
+create table ks.t (pk int, ck int, v vector<float, 3>, primary key(pk, ck));
+
+-- create index on vector column using 'vector_index' custom class
+-- this enables CDC automatically
+create index on ks.t (v) using 'vector_index';
+
+-- this write goes to the log
+insert into ks.t (pk, ck, v) values (0, 1, [100.0, 101.0, 102.0]);
+
+-- drop index disable CDC. should retain the log
+drop index ks.t_v_idx;
+
+-- add more data to base - should not generate log
+insert into ks.t (pk, ck, v) values (0, 2, [200.0, 201.0, 202.0]);
+
+-- should still work, and give one row (0, 1, [100.0, 101.0, 102.0])
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
+
+-- add more data
+insert into ks.t (pk, ck, v) values (0, 3, [300.0, 301.0, 302.0]);
+
+-- recreate the index
+create index on ks.t (v) using 'vector_index';
+
+-- more data - this should also go to log.
+insert into ks.t (pk, ck, v) values (0, 4, [400.0, 401.0, 402.0]);
+
+-- gives two rows (0, 1, [100.0, 101.0, 102.0])+(0, 4, [400.0, 401.0, 402.0])
+select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
+
+DROP KEYSPACE ks;

--- a/test/cql/vs_cdc_enable_disable_test.result
+++ b/test/cql/vs_cdc_enable_disable_test.result
@@ -1,0 +1,62 @@
+> -- Important: using the same partition key for each row so the results of select from log table
+> -- do not depend on how stream IDs are assigned to partition keys.
+> 
+> -- Error messages contain a keyspace name. Make the output stable.
+> -- CDC and tablets are not working together yet, turn them off.
+> CREATE KEYSPACE ks
+>     WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND
+>     tablets = {'enabled': false};
+OK
+> 
+> -- create table with vector column
+> create table ks.t (pk int, ck int, v vector<float, 3>, primary key(pk, ck));
+OK
+> 
+> -- create index on vector column using 'vector_index' custom class
+> -- this enables CDC automatically
+> create index on ks.t (v) using 'vector_index';
+OK
+> 
+> -- this write goes to the log
+> insert into ks.t (pk, ck, v) values (0, 1, [100.0, 101.0, 102.0]);
+OK
+> 
+> -- drop index disable CDC. should retain the log
+> drop index ks.t_v_idx;
+OK
+> 
+> -- add more data to base - should not generate log
+> insert into ks.t (pk, ck, v) values (0, 2, [200.0, 201.0, 202.0]);
+OK
+> 
+> -- should still work, and give one row (0, 1, [100.0, 101.0, 102.0])
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
++--------------------+-----------------+-----------+------+------+-----------------------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v                     |
+|--------------------+-----------------+-----------+------+------+-----------------------|
+|                  0 |               2 | null      |    0 |    1 | [100.0, 101.0, 102.0] |
++--------------------+-----------------+-----------+------+------+-----------------------+
+> 
+> -- add more data
+> insert into ks.t (pk, ck, v) values (0, 3, [300.0, 301.0, 302.0]);
+OK
+> 
+> -- recreate the index
+> create index on ks.t (v) using 'vector_index';
+OK
+> 
+> -- more data - this should also go to log.
+> insert into ks.t (pk, ck, v) values (0, 4, [400.0, 401.0, 402.0]);
+OK
+> 
+> -- gives two rows (0, 1, [100.0, 101.0, 102.0])+(0, 4, [400.0, 401.0, 402.0])
+> select "cdc$batch_seq_no", "cdc$operation", "cdc$ttl", pk, ck, v from ks.t_scylla_cdc_log;
++--------------------+-----------------+-----------+------+------+-----------------------+
+|   cdc$batch_seq_no |   cdc$operation | cdc$ttl   |   pk |   ck | v                     |
+|--------------------+-----------------+-----------+------+------+-----------------------|
+|                  0 |               2 | null      |    0 |    1 | [100.0, 101.0, 102.0] |
+|                  0 |               2 | null      |    0 |    4 | [400.0, 401.0, 402.0] |
++--------------------+-----------------+-----------+------+------+-----------------------+
+> 
+> DROP KEYSPACE ks;
+OK

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -53,6 +53,9 @@ def test_cannot_query_empty_vector_column(cql, test_keyspace):
 #         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
 #     }
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_cannot_query_wrong_number_of_dimensions(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -69,6 +72,9 @@ def test_cannot_query_wrong_number_of_dimensions(cql, test_keyspace):
             "SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5] LIMIT 5"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_multi_vector_orderings_not_allowed(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))") as table:
 
@@ -83,6 +89,9 @@ def test_multi_vector_orderings_not_allowed(cql, test_keyspace):
             "SELECT * FROM %s ORDER BY val1 ANN OF [2.5, 3.5, 4.5], val2 ANN OF [2.1, 3.2, 4.0] LIMIT 2"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_descending_vector_ordering_is_not_allowed(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, val vector<float, 3>, PRIMARY KEY(pk))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -91,6 +100,9 @@ def test_descending_vector_ordering_is_not_allowed(cql, test_keyspace):
         assert_invalid_message(cql, table, "Descending ANN ordering is not supported",
                                "SELECT val FROM %s where val=[1.2, 1.2, 1.2] ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_vector_ordering_is_not_allowed_with_clustering_ordering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -118,6 +130,9 @@ def test_invalid_column_name_with_ann(cql, test_keyspace):
             "SELECT k FROM %s ORDER BY bad_col ANN OF [1.0] LIMIT 1"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_cannot_perform_non_ann_query_on_vector_index(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -150,6 +165,9 @@ def test_cannot_order_with_ann_on_non_vector_column(cql, test_keyspace):
 #         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
 #     }
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_must_have_limit_specified_and_within_max_allowed(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>)") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -187,6 +205,9 @@ def test_must_have_limit_specified_and_within_max_allowed(cql, test_keyspace):
 #         assertEquals(1, result.size());
 #     }
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_cannot_have_aggregation_on_ann_query(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>, c int)") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -202,6 +223,9 @@ def test_cannot_have_aggregation_on_ann_query(cql, test_keyspace):
             "SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_multiple_vector_columns_in_query_fail_correctly(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"
@@ -230,6 +254,9 @@ def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_q
             "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
     ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
         SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE
@@ -276,6 +303,9 @@ def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_ke
             "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_cannot_have_per_partition_limit_with_ann_ordering(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))") as table:
         custom_index = "vector_index" if is_scylla(cql) else "StorageAttachedIndex"

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -25,10 +25,11 @@ DescRowType = Any
 
 DEFAULT_SUPERUSER = "cassandra"
 # The prefix of the create statement returned by `DESC SCHEMA` and corresponding to a CDC log table.
-CDC_LOG_TABLE_DESC_PREFIX =                                                                 \
-                "/* Do NOT execute this statement! It's only for informational purposes.\n" \
-                "   A CDC log table is created automatically when the base is created.\n"   \
-                "\n"
+CDC_LOG_TABLE_DESC_PREFIX =                                                                \
+    "/* Do NOT execute this statement! It's only for informational purposes.\n"            \
+    "   A CDC log table is created automatically when creating the base with CDC\n"        \
+    "   enabled option or creating the vector index on the base table's vector column.\n"  \
+    "\n"
 CDC_LOG_TABLE_DESC_SUFFIX = "\n*/"
 
 def filter_non_default_user(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:

--- a/test/cqlpy/test_invalid_ann_queries.py
+++ b/test/cqlpy/test_invalid_ann_queries.py
@@ -25,6 +25,9 @@ def test_ann_query_without_index(cql, test_keyspace):
             cql.execute(f"SELECT * FROM {table} ORDER BY v ANN OF [0.1, 0.2, 0.3] LIMIT 5")
 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_ann_query_with_ck_filtering(cql, test_keyspace):
     ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
         SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE
@@ -41,6 +44,9 @@ def test_ann_query_with_ck_filtering(cql, test_keyspace):
 
 # Although Cassandra allows for such queries, these queries fail with assertion error.
 # In Scylla, such queries are not allowed, as it is unclear if the filtering should happen pre or post ANN search.
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_ann_query_not_allow_any_filtering(scylla_only, cql, test_keyspace):
     schema = 'p int primary key, c int, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -10,14 +10,18 @@ import pytest
 from .util import new_test_table, is_scylla
 from cassandra.protocol import InvalidRequest, ConfigurationException
 
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
 
 
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_without_custom_keyword(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -28,6 +32,9 @@ def test_create_vector_search_index_without_custom_keyword(cql, test_keyspace):
         
         cql.execute(f"CREATE INDEX ON {table}(v) USING '{custom_class}'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_custom_index_with_invalid_class(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -35,24 +42,36 @@ def test_create_custom_index_with_invalid_class(cql, test_keyspace):
         with pytest.raises((InvalidRequest, ConfigurationException), match=r"Non-supported custom class|Unable to find"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING '{invalid_custom_class}'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_custom_index_without_custom_class(cql, test_keyspace):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises((InvalidRequest, ConfigurationException), match=r"CUSTOM index requires specifying|Unable to find"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v)")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_on_nonvector_column(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v int'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Vector indexes are only supported on columns of vectors of floats"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_options(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Unsupported option"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'bad_option': 'bad_value'}}")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_numeric_value(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -65,18 +84,27 @@ def test_create_vector_search_index_with_bad_numeric_value(cql, test_keyspace, s
         with pytest.raises(InvalidRequest, match="out of valid range"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'construction_beam_width': '5000' }}") 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_with_bad_similarity_value(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Unsupported similarity function"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index' WITH OPTIONS = {{'similarity_function': 'bad_similarity_function'}}") 
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_create_vector_search_index_on_nonfloat_vector_column(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<int, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         with pytest.raises(InvalidRequest, match="Vector indexes are only supported on columns of vectors of floats"):
             cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
 
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_no_view_for_vector_search_index(cql, test_keyspace, scylla_only):
     schema = 'p int primary key, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
@@ -88,7 +116,9 @@ def test_no_view_for_vector_search_index(cql, test_keyspace, scylla_only):
         result = cql.execute(f"SELECT * FROM system_schema.views WHERE keyspace_name = '{test_keyspace}' AND view_name = 'def_index'")
         assert len(result.current_rows) == 1, "Regular index should create a view in system_schema.views"
         
-
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
 def test_describe_custom_index(cql, test_keyspace):
     schema = 'p int primary key, v1 vector<float, 3>, v2 vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -7,7 +7,7 @@
 ###############################################################################
 
 import pytest
-from .util import new_test_table, is_scylla
+from .util import new_test_table, is_scylla, unique_name
 from cassandra.protocol import InvalidRequest, ConfigurationException
 
 @pytest.mark.parametrize("test_keyspace",
@@ -145,3 +145,155 @@ def test_describe_custom_index(cql, test_keyspace):
 
         assert f"CREATE CUSTOM INDEX custom ON {table}{maybe_space}(v1) USING '{custom_class}'" in a_desc
         assert f"CREATE CUSTOM INDEX custom1 ON {table}{maybe_space}(v2) USING '{custom_class}'" in b_desc
+
+
+###############################################################################
+# Tests for CDC with vector indexes
+#
+# The following tests verify that the constraints between Vector Search
+# and CDC settings are properly enforced.
+#
+# If a vector index is created, CDC may only be enabled with options meeting
+# the Vector Search requirements:
+#   - CDC's TTL must be at least 24 hours (86400 seconds) OR set to 0 (infinite).
+#   - CDC's delta mode must be set to 'full' or CDC's postimage must be enabled.
+#
+# We test that:
+#   * Enabling CDC with default or valid options succeeds.
+#   * Enabling CDC with invalid TTL (< 24h) or invalid delta and postimage
+#     disabled is rejected.
+#   * Preimage options can be freely toggled.
+#   * Disabling CDC is not allowed when a vector index already exists.
+#
+# We also verify that creating a vector index is forbidden
+# if CDC is enabled but uses invalid options or CDC is explicitly disabled
+# (set to false by the user), and allowed only when CDC is either undeclared
+# or configured to satisfy the minimal Vector Search requirements.
+###############################################################################
+
+
+VS_TTL_SECONDS = 86400  # 24 hours
+
+
+def alter_cdc(cql, table, options):
+    try:
+        cql.execute(f"ALTER TABLE {table} WITH cdc = {options}")
+    except InvalidRequest as e:
+        with pytest.raises(InvalidRequest, match="CDC log must meet the minimal requirements of Vector Search"):
+            raise e
+        return False
+    return True
+
+
+def create_index(cql, test_keyspace, table, column):
+    idx_name = f"{column}_idx_{unique_name()}"
+    query = f"CREATE INDEX {idx_name} ON {table} ({column}) USING 'vector_index'"
+    try:
+        cql.execute(query)
+    except InvalidRequest as e:
+        with pytest.raises(InvalidRequest, match="CDC log must meet the minimal requirements of Vector Search"):
+            raise e
+        return False
+    cql.execute(f"DROP INDEX {test_keyspace}.{idx_name}")
+    return True
+
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_try_create_cdc_with_vector_search_enabled(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # The vector index requires CDC to be enabled with specific options:
+        # - TTL must be at least 24 hours (86400 seconds)
+        # - delta mode must be set to 'full' or postimage must be enabled.
+
+        # Enable Vector Search by creating a vector index.
+        cql.execute(f"CREATE INDEX v_idx ON {table} (v) USING 'vector_index'")
+
+        # Allow creating CDC log table with default options.
+        assert alter_cdc(cql, table, {'enabled': True})
+
+        # Disallow changing CDC's TTL to less than 24 hours.
+        assert not alter_cdc(cql, table, {'enabled': True, 'ttl': 1})
+        assert alter_cdc(cql, table, {'enabled': True, 'ttl': 86400})
+
+        # Allow changing CDC's TTL to 0 (infinite).
+        assert alter_cdc(cql, table, {'enabled': True, 'ttl': 0})
+
+        # Disallow changing CDC's delta to 'keys' if postimage is disabled.
+        assert not alter_cdc(cql, table, {'enabled': True, 'delta': 'keys'})
+        assert alter_cdc(cql, table, {'enabled': True, 'delta': 'full'})
+
+        # Allow creating CDC with postimage enabled instead of delta set to 'full'.
+        assert alter_cdc(cql, table, {'enabled': True, 'postimage': True, 'delta': 'keys'})
+
+        # Allow changing CDC's preimage and enabling postimage freely.
+        assert alter_cdc(cql, table, {'enabled': True, 'preimage': True})
+        assert alter_cdc(cql, table, {'enabled': True, 'preimage': False})
+        assert alter_cdc(cql, table, {'enabled': True, 'postimage': True})
+        assert alter_cdc(cql, table, {'enabled': True, 'preimage': True, 'postimage': True})
+
+        # Disallow changing CDC's postimage to false when delta is 'keys'.
+        assert not alter_cdc(cql, table, {'enabled': True, 'delta': 'keys', 'postimage': False})
+
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_try_disable_cdc_with_vector_search_enabled(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # Enable Vector Search by creating a vector index.
+        cql.execute(f"CREATE INDEX v_idx ON {table} (v) USING 'vector_index'")
+
+        # Disallow disabling CDC when Vector Search is enabled.
+        with pytest.raises(InvalidRequest, match="Cannot disable CDC when Vector Search is enabled on the table"):
+            cql.execute(f"ALTER TABLE {table} WITH cdc = {{'enabled': False}}")
+
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_try_enable_vector_search_with_cdc_enabled(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # The vector index requires CDC to be enabled with specific options:
+        # - TTL must be at least 24 hours (86400 seconds)
+        # - delta mode must be set to 'full' or postimage must be enabled.
+
+        # Disallow creating the vector index when CDC's TTL is less than 24h.
+        assert alter_cdc(cql, table, {'enabled': True, 'ttl': 1})
+        assert not create_index(cql, test_keyspace, table, "v")
+
+        # Allow creating the vector index when CDC's TTL is 0 (infinite).
+        assert alter_cdc(cql, table, {'enabled': True, 'ttl': 0})
+        assert create_index(cql, test_keyspace, table, "v")
+
+        # Disallow creating the vector index when CDC's delta is set to 'keys'.
+        assert alter_cdc(cql, table, {'enabled': True, 'delta': 'keys'})
+        assert not create_index(cql, test_keyspace, table, "v")
+
+        # Allow creating the vector index when CDC's postimage is enabled instead of delta set to 'full'.
+        assert alter_cdc(cql, table, {'enabled': True, 'delta': 'keys', 'postimage': True})
+        assert create_index(cql, test_keyspace, table, "v")
+
+        # Allow creating the vector index when CDC's options fulfill the minimal requirements of Vector Search.
+        assert alter_cdc(cql, table, {'enabled': True, 'ttl': 172800, 'delta': 'full', 'preimage': True, 'postimage': True})
+        assert create_index(cql, test_keyspace, table, "v")
+
+
+@pytest.mark.parametrize("test_keyspace",
+                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
+                         indirect=True)
+def test_try_enable_vector_search_with_cdc_disabled(scylla_only, cql, test_keyspace):
+    schema = "pk int primary key, v vector<float, 3>"
+    with new_test_table(cql, test_keyspace, schema) as table:
+        # Disallow creating the vector index when CDC is explicitly disabled.
+        assert alter_cdc(cql, table, {'enabled': False, 'ttl': 172800, 'postimage' : True})
+        with pytest.raises(InvalidRequest, match="Cannot create the vector index when CDC is explicitly disabled."):
+            cql.execute(f"CREATE INDEX v_idx ON {table} (v) USING 'vector_index'")
+
+        # Allow creating the vector index when CDC is enabled again.
+        assert alter_cdc(cql, table, {'enabled': True})
+        assert create_index(cql, test_keyspace, table, "v")


### PR DESCRIPTION
When a vector index is created in Scylla, it is initially built using a full scan of the database. After that, it stays up to date by tracking changes through CDC, which should be automatically enabled when the vector index is created.

When a user attempts to enable Vector Search (VS), the system checks whether Change Data Capture (CDC) is enabled and properly configured:

1. CDC is not enabled

    - CDC is automatically enabled with the minimum required TTL (Time-to-Live) for VS (24 hours) and the delta mode set to 'full' or post-image is enabled.

    - If the user later tries to reduce the CDC TTL below 24 hours or set delta mode to 'keys' with post-image disabled, the action fails.

    - Error message: Clearly states that CDC TTL must be at least 24 hours and delta mode must be set to 'full' or post-image must be enabled for VS to function.

2. CDC is already enabled

    - If CDC TTL is ≥ 24 hours and delta mode is set to 'full' or post-image is enabled: VS is enabled successfully.

    - If CDC TTL is < 24 hours or delta mode is set to 'keys' with post-image disabled: The VS enabling process fails.

    - Error message: Informs the user that CDC TTL must be at least 24 hours, delta mode must be set to 'full' or post-image must be enabled, and provides a link to documentation on how to update the TTL, delta mode, and post-image.

When a user attempts to disable CDC when VS is enabled, the action will fail and the user will be informed by error message that clearly states that VS needs to be disabled (vector indexes have to be dropped) first.

Full setup requirements and steps will be detailed in the documentation of Vector Search.

Co-authored-by: @smoczy123 

Fixes: VECTOR-27
Fixes: VECTOR-25