### PR TITLE
test/boost: Add missing license headers

### DIFF
--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -2,7 +2,9 @@
  * Copyright (C) 2016 ScyllaDB
  */
 
-
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
 
 #include <boost/test/unit_test.hpp>
 #include <stdint.h>

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -2,7 +2,9 @@
  * Copyright (C) 2016 ScyllaDB
  */
 
-
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
 
 #include <boost/test/unit_test.hpp>
 

--- a/test/boost/kmip_wrapper.py
+++ b/test/boost/kmip_wrapper.py
@@ -1,3 +1,9 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
 import ssl
 import sys
 

--- a/test/boost/symmetric_key_test.cc
+++ b/test/boost/symmetric_key_test.cc
@@ -2,7 +2,9 @@
  * Copyright (C) 2016 ScyllaDB
  */
 
-
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
 
 #include <boost/test/unit_test.hpp>
 #include <boost/lexical_cast.hpp>


### PR DESCRIPTION
Add license headers to the EaR unit tests:

- test/boost/encrypted_file_test.cc
- test/boost/encryption_at_rest_test.cc
- test/boost/kmip_wrapper.py
- test/boost/symmetric_key_test.cc

These files were ported from scylla-enterprise to scylladb.git as part of migrating all enterprise-only features to the source-available release (patch: c596ae6eb1).

Fixes #25183.

Marking as draft because it conflicts with https://github.com/scylladb/scylladb/pull/24813/ on `kmip_wrapper.py`.