### PR TITLE
qos: don't populate effective service level cache until auth is migrated to raft

### DIFF
--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -9,6 +9,7 @@
 #include "auth/standard_role_manager.hh"
 
 #include <optional>
+#include <stdexcept>
 #include <unordered_set>
 #include <vector>
 
@@ -28,6 +29,7 @@
 #include "cql3/util.hh"
 #include "db/consistency_level_type.hh"
 #include "exceptions/exceptions.hh"
+#include "utils/error_injection.hh"
 #include "utils/log.hh"
 #include <seastar/core/loop.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -673,6 +675,12 @@ future<role_set> standard_role_manager::query_all() {
 
     // To avoid many copies of a view.
     static const auto role_col_name_string = sstring(meta::roles_table::role_col_name);
+
+    if (utils::get_local_injector().enter("standard_role_manager_fail_legacy_query")) {
+        if (legacy_mode(_qp)) {
+            throw std::runtime_error("standard_role_manager::query_all: failed due to error injection");
+        }
+    }
 
     const auto results = co_await _qp.execute_internal(
             query,

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -100,6 +100,10 @@ bool raft_service_level_distributed_data_accessor::is_v2() const {
     return true;
 }
 
+bool raft_service_level_distributed_data_accessor::can_use_effective_service_level_cache() const {
+    return !auth::legacy_mode(_qp);
+}
+
 ::shared_ptr<service_level_controller::service_level_distributed_data_accessor> raft_service_level_distributed_data_accessor::upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const {
     return nullptr;
 }

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -39,6 +39,7 @@ public:
     virtual future<> commit_mutations(service::group0_batch&& mc, abort_source& as) const override;
 
     virtual bool is_v2() const override;
+    virtual bool can_use_effective_service_level_cache() const override;
     virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override;
 };
 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -309,6 +309,17 @@ future<> service_level_controller::update_effective_service_levels_cache() {
         // might be not initialized yet.
         co_return;
     }
+    if (!_sl_data_accessor || !_sl_data_accessor->can_use_effective_service_level_cache()) {
+        // Don't populate the effective service level cache until auth is migrated to raft.
+        // Otherwise, executing the code that follows would read roles data
+        // from system_auth tables; that would be bad because reading from
+        // those tables is prone to timeouts, and `update_effective_service_levels_cache`
+        // is called from the group0 context - a timeout like that would render
+        // group0 non-functional on the node until restart.
+        //
+        // See scylladb/scylladb#24963 for more details.
+        co_return;
+    }
     auto units = co_await get_units(_global_controller_db->notifications_serializer, 1);
 
     auto& role_manager = _auth_service.local().underlying_role_manager();
@@ -385,7 +396,7 @@ void service_level_controller::stop_legacy_update_from_distributed_data() {
 }
 
 future<std::optional<service_level_options>> service_level_controller::find_effective_service_level(const sstring& role_name) {
-    if (_sl_data_accessor->is_v2()) {
+    if (_sl_data_accessor->can_use_effective_service_level_cache()) {
         auto effective_sl_it = _effective_service_levels_db.find(role_name);
         co_return effective_sl_it != _effective_service_levels_db.end() 
             ? std::optional<service_level_options>(effective_sl_it->second)

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -114,6 +114,9 @@ public:
         virtual future<> commit_mutations(service::group0_batch&& mc, abort_source& as) const = 0;
 
         virtual bool is_v2() const = 0;
+        // Returns whether effective service level cache can be populated and used.
+        // This is equivalent to checking whether auth + raft have been migrated to raft.
+        virtual bool can_use_effective_service_level_cache() const = 0;
         // Returns v2(raft) data accessor. If data accessor is already a raft one, returns nullptr.
         virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const = 0;
     };

--- a/service/qos/standard_service_level_distributed_data_accessor.cc
+++ b/service/qos/standard_service_level_distributed_data_accessor.cc
@@ -37,6 +37,10 @@ bool standard_service_level_distributed_data_accessor::is_v2() const {
     return false;
 }
 
+bool standard_service_level_distributed_data_accessor::can_use_effective_service_level_cache() const {
+    return false;
+}
+
 ::shared_ptr<service_level_controller::service_level_distributed_data_accessor> standard_service_level_distributed_data_accessor::upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const {
     return ::static_pointer_cast<service_level_controller::service_level_distributed_data_accessor>(
                 ::make_shared<raft_service_level_distributed_data_accessor>(qp, group0_client));

--- a/service/qos/standard_service_level_distributed_data_accessor.hh
+++ b/service/qos/standard_service_level_distributed_data_accessor.hh
@@ -31,6 +31,7 @@ public:
     virtual future<> commit_mutations(service::group0_batch&& mc, abort_source& as) const override { return make_ready_future(); }
 
     virtual bool is_v2() const override;
+    virtual bool can_use_effective_service_level_cache() const override;
     virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override;
 };
 }

--- a/test/boost/service_level_controller_test.cc
+++ b/test/boost/service_level_controller_test.cc
@@ -166,6 +166,9 @@ SEASTAR_THREAD_TEST_CASE(too_many_service_levels) {
         virtual bool is_v2() const override {
             return true;
         }
+        virtual bool can_use_effective_service_level_cache() const override {
+            return true;
+        }
         virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override {
             return make_shared<data_accessor>();
         }

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -60,7 +60,7 @@ async def test_service_levels_snapshot(manager: ManagerClient):
     assert set([sl.service_level for sl in result]) == set([sl.service_level for sl in new_result])
 
 @pytest.mark.asyncio
-async def test_service_levels_upgrade(request, manager: ManagerClient):
+async def test_service_levels_upgrade(request, manager: ManagerClient, build_mode: str):
     # First, force the first node to start in legacy mode
     cfg = {**auth_config, 'force_gossip_topology_changes': True, 'tablets_mode_for_new_keyspaces': 'disabled'}
 
@@ -87,6 +87,11 @@ async def test_service_levels_upgrade(request, manager: ManagerClient):
 
     result = await cql.run_async("SELECT service_level FROM system_distributed.service_levels")
     assert set([sl.service_level for sl in result]) == set(sls)
+
+    if build_mode in ("debug", "dev"):
+        # See scylladb/scylladb/#24963 for more details
+        logging.info("Enabling an error injection in legacy role manager, to check that we don't query auth in system_auth")
+        await asyncio.gather(*(manager.api.enable_injection(s.ip_addr, "standard_role_manager_fail_legacy_query", one_shot=False) for s in servers))
 
     logging.info("Triggering upgrade to raft topology")
     await manager.api.upgrade_to_raft_topology(hosts[0].address)


### PR DESCRIPTION
Right now, service levels are migrated in one group0 command and auth is migrated in the next one. This has a bad effect on the group0 state reload logic - modifying service levels in group0 causes the effective service levels cache to be recalculated, and to do so we need to fetch information about all roles. If the reload happens after SL upgrade and before auth upgrade, the query for roles will be directed to the legacy auth tables in system_auth - and the query, being a potentially remote query, has a timeout. If the query times out, it will throw an exception which will break the group0 apply fiber and the node will need to be restarted to bring it back to work.

In order to solve this issue, make sure that the service level module does not start populating and using the service level cache until both service levels and auth are migrated to raft. This is achieved by adding the check both to the cache population logic and the effective service level getter - they now look at service level's accessor new method, `can_use_effective_service_level_cache` which takes a look at the auth version.

Fixes: scylladb/scylladb#24963

Should be backported to all versions which support upgrade to topology over raft - the issue described here may put the cluster into a state which is difficult to get out of (group0 apply fiber can break on multiple nodes, which necessitates their restart).