### PR TITLE
cql3/result_set: set GLOBAL_TABLES_SPEC in `metadata` if appropriate

### DIFF
--- a/cql3/result_set.cc
+++ b/cql3/result_set.cc
@@ -18,14 +18,22 @@ namespace cql3 {
 metadata::metadata(std::vector<lw_shared_ptr<column_specification>> names_)
         : _flags(flag_enum_set())
         , _column_info(make_lw_shared<column_info>(std::move(names_)))
-{ }
+{
+    if (!_column_info->_names.empty() && column_specification::all_in_same_table(_column_info->_names)) {
+        _flags.set<flag::GLOBAL_TABLES_SPEC>();
+    }
+}
 
 metadata::metadata(flag_enum_set flags, std::vector<lw_shared_ptr<column_specification>> names_, uint32_t column_count,
         lw_shared_ptr<const service::pager::paging_state> paging_state)
     : _flags(flags)
     , _column_info(make_lw_shared<column_info>(std::move(names_), column_count))
     , _paging_state(std::move(paging_state))
-{ }
+{
+    if (!_column_info->_names.empty() && column_specification::all_in_same_table(_column_info->_names)) {
+        _flags.set<flag::GLOBAL_TABLES_SPEC>();
+    }
+}
 
 // The maximum number of values that the ResultSet can hold. This can be bigger than columnCount due to CASSANDRA-4911
 uint32_t metadata::value_count() const {


### PR DESCRIPTION
Unless the client uses the SKIP_METADATA flag,
Scylla attaches some metadata to query results returned to the CQL client.
In particular, it attaches the spec (keyspace name, table name, name, type) of the returned columns.

By default, the keyspace name and table name is present in each column spec. However, since they are almost always the same for every column (I can't think of any case when they aren't the same; it would make sense if Cassandra supported joins, but it doesn't) that's a waste.

So, as an optimization, the CQL protocol has the GLOBAL_TABLES_SPEC flag. The flag can be set if all columns belong to the same table, and if is set, then the keyspace and table name are only written in the first column spec, and skipped in other column specs.

Scylla sets this flag, if appropriate, in responses to a PREPARE requests. But it never sets the flag in responses to queries.

But it could. And this patch causes it to do that.

Fixes #17788

No backporting needed.