### PR TITLE
service/vector_store_client: Add live configuration update support

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1394,7 +1394,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_allow_system_table_write(this, "alternator_allow_system_table_write", liveness::LiveUpdate, value_status::Used,
         false,
         "Allow writing to system tables using the .scylla.alternator.system prefix")
-    , vector_store_uri(this, "vector_store_uri", value_status::Used, "", "The URI of the vector store to use for vector search. If not set, vector search is disabled.")
+    , vector_store_uri(this, "vector_store_uri", liveness::LiveUpdate, value_status::Used, "", "The URI of the vector store to use for vector search. If not set, vector search is disabled.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , redis_port(this, "redis_port", value_status::Used, 0, "Port on which the REDIS transport listens for clients.")
     , redis_ssl_port(this, "redis_ssl_port", value_status::Used, 0, "Port on which the REDIS TLS native transport listens for clients.")

--- a/service/vector_store_client.hh
+++ b/service/vector_store_client.hh
@@ -101,9 +101,7 @@ public:
     auto stop() -> future<>;
 
     /// Check if the vector_store_client is disabled.
-    auto is_disabled() const {
-        return !bool{_impl};
-    }
+    auto is_disabled() const -> bool;
 
     /// Get the current host name.
     [[nodiscard]] auto host() const -> std::expected<host_name, disabled>;
@@ -130,4 +128,3 @@ struct vector_store_client_tester {
 };
 
 } // namespace service
-


### PR DESCRIPTION
service/vector_store_client: Add live configuration update support

Enable runtime updates of vector_store_uri configuration without
requiring server restart.
This allows to dynamically enable, disable, or switch the vector search service endpoint on the fly.

To improve the clarity the seastar::experimental::http::client is now wrapped in a private http_client class that also holds the host, address, and port information.

Tests have been added to verify that the client correctly handles transitions between enabled/disabled states and successfully switches traffic to a new endpoint after a configuration update.

Closes: VECTOR-102

No backport is needed as this is a new feature.