### PR TITLE
test: run mv tests depending on metrics on a standalone instance

### DIFF
--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -11,7 +11,7 @@ import time
 import logging
 from test.cluster.conftest import skip_mode
 from test.pylib.util import wait_for_view
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, new_test_table, new_materialized_view
 from cassandra.cqltypes import Int32Type
 
 logger = logging.getLogger(__name__)
@@ -74,3 +74,98 @@ async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) 
 
         logger.info(f"Deleting all rows from partition with key 0")
         await cql.run_async(f"DELETE FROM {ks}.tab WHERE key = 0", timeout=300)
+
+# Test deleting a large partition when there is a view with the same partition
+# key, and verify that view updates metrics is increased by exactly 1. Deleting
+# a partition in this case is expected to generate one view update for deleting
+# the corresponding view partition by a partition tombstone.
+# Reproduces #8199
+@pytest.mark.asyncio
+@pytest.mark.parametrize("permuted", [False, True])
+async def test_base_partition_deletion_with_metrics(manager: ManagerClient, permuted):
+    server = await manager.server_add()
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as test_keyspace:
+        async with new_test_table(manager, test_keyspace, 'p1 int, p2 int, c int, primary key ((p1,p2),c)') as table:
+            # Insert into one base partition. We will delete the entire partition
+            insert = cql.prepare(f'INSERT INTO {table} (p1,p2,c) VALUES (?,?,?)')
+            # The view partition key is a permutation of the base partition key.
+            async with new_materialized_view(manager, table, '*', '(p2,p1),c' if permuted else '(p1,p2),c', 'p1 is not null and p2 is not null and c is not null') as mv:
+                # the metric total_view_updates_pushed_local is incremented by 1 for each 100 row view
+                # updates, because it is collected in batches according to max_rows_for_view_updates.
+                # To verify the behavior, we want the metric to increase by at least 2 without the optimization,
+                # so 101 is the minimum value that works. With the optimization, we expect to have exactly 1 update
+                # for any N.
+                N = 101
+
+                # all operations are on this single partition
+                p1, p2 = 1, 10
+                where_clause_table = f"WHERE p1={p1} AND p2={p2}"
+                where_clause_mv = f"WHERE p2={p2} AND p1={p1}" if permuted else where_clause_table
+
+                for i in range(N):
+                    await cql.run_async(insert, [p1, p2, i])
+
+                # Before the deletion, all N rows should exist in the base and the view
+                allN = list(range(N))
+                assert allN == [x.c for x in await cql.run_async(f"SELECT c FROM {table} {where_clause_table}")]
+                assert allN == sorted([x.c for x in await cql.run_async(f"SELECT c FROM {mv} {where_clause_mv}")])
+
+                metrics_before = await manager.metrics.query(server.ip_addr)
+                updates_before = metrics_before.get('scylla_database_total_view_updates_pushed_local')
+
+                await cql.run_async(f"DELETE FROM {table} {where_clause_table}")
+
+                # After the deletion, all data should be gone from both base and view
+                assert [] == list(await cql.run_async(f"SELECT c FROM {table} {where_clause_table}"))
+                assert [] == list(await cql.run_async(f"SELECT c FROM {mv} {where_clause_mv}"))
+
+                metrics_after = await manager.metrics.query(server.ip_addr)
+                updates_after = metrics_after.get('scylla_database_total_view_updates_pushed_local')
+
+                print(f"scylla_database_total_view_updates_pushed_local: {updates_before} -> {updates_after}")
+                assert updates_after == updates_before + 1
+
+# Perform a deletion of a base partition in a batch with deletion of individual rows. Verify the
+# partition is deleted correctly and that a single update is generated for the view for deleting
+# the whole partition, and no view updates for each row.
+@pytest.mark.asyncio
+async def test_base_partition_deletion_in_batch_with_delete_row_with_metrics(manager: ManagerClient):
+    server = await manager.server_add()
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as test_keyspace:
+        async with new_test_table(manager, test_keyspace, 'p int, c int, v int, primary key ((p,c),v)') as table:
+            insert = cql.prepare(f'INSERT INTO {table} (p,c,v) VALUES (?,?,?)')
+            # The view partition key is the same as the base partition key.
+            async with new_materialized_view(manager, table, '*', '(p,c),v', 'p is not null and c is not null and v is not null') as mv:
+                N = 101 # See comment above
+                for i in range(N):
+                    await cql.run_async(insert, [1, 10, i])
+
+                # Before the deletion, all N rows should exist in the base and the view
+                allN = list(range(N))
+                assert allN == [x.v for x in await cql.run_async(f"SELECT v FROM {table} WHERE p=1 AND c=10")]
+                assert allN == sorted([x.v for x in await cql.run_async(f"SELECT v FROM {mv} WHERE p=1 AND c=10")])
+
+                metrics_before = await manager.metrics.query(server.ip_addr)
+                updates_before = metrics_before.get('scylla_database_total_view_updates_pushed_local')
+
+                # The batch deletes the entire partition and also, redundantly, deleting individual rows in the partition.
+                # We expect the view update to contain only a single update for deleting the partition.
+                cmd = 'BEGIN UNLOGGED BATCH '
+                for i in range(100,500):
+                    cmd += f'DELETE FROM {table} WHERE p=1 AND c=10 AND v={i}; '
+                cmd += f'DELETE FROM {table} WHERE p=1 AND c=10; '
+                cmd += 'APPLY BATCH;'
+                await cql.run_async(cmd)
+
+                # Verify the partition is deleted
+                assert [] == list(await cql.run_async(f"SELECT v FROM {table} WHERE p=1 AND c=10"))
+                assert [] == list(await cql.run_async(f"SELECT v FROM {mv} WHERE p=1 AND c=10"))
+
+                # Verify there is a single view update
+                metrics_after = await manager.metrics.query(server.ip_addr)
+                updates_after = metrics_after.get('scylla_database_total_view_updates_pushed_local')
+
+                print(f"scylla_database_total_view_updates_pushed_local: {updates_before} -> {updates_after}")
+                assert updates_after == updates_before + 1


### PR DESCRIPTION
The test_base_partition_deletion_with_metrics test case (and the batch variant) uses the metric of view updates done during its runtime to check if we didn't perform too many of them. The test runs in the cqlpy suite, which  runs all test cases sequentially on one Scylla instance. Because of this, if another test case starts a process which generates view updates and doesn't wait for it to finish before it exists, we may observe too many view updates in test_base_partition_deletion_with_metrics and fail the test.
In all test cases we make sure that all tables that were created during the test are dropped at the end. However, that doesn't stop the view building process immediately, so the issue can happen even if we drop the view. I confirmed it by adding a test just before test_base_partition_deletion_with_metrics which builds a big materialized view and drops it at the end - the metrics check still failed.

The issue could be caused by any of the existing test cases where we create a view and don't wait for it to be built. Note that even if we start adding rows after creating the view, some of them may still be included in the view building, as the view building process is started asynchronously. In such a scenario, the view building also doesn't cause any issues with the data in these tests - writes performed after view creation generate view updates synchronously when they're local (and we're running a single Scylla server), the corresponding view udpates generated during view building are redundant.

Because we have many test cases which could be causing this issue, instead of waiting for the view building to finish in every single one of them, we move the susceptible test cases to be run on separate Scylla instances, in the "cluster" suite. There, no other test cases will influence the results.

Fixes https://github.com/scylladb/scylladb/issues/20379
