### PR TITLE
test.py: add pytest-timeout to the toolchain

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -39,6 +39,9 @@ debian_base_packages=(
     python3-pyparsing
     python3-colorama
     python3-tabulate
+    python3-pytest
+    python3-pytest-asyncio
+    python3-pytest-timeout
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev
@@ -86,6 +89,7 @@ fedora_packages=(
     python3-boto3
     python3-pytest
     python3-pytest-asyncio
+    python3-pytest-timeout
     python3-redis
     python3-unidiff
     python3-humanfriendly


### PR DESCRIPTION
Adding this plugin allows using timeout for a test or timeout for the whole session. This can be useful for Unit Test Custom task in the pipeline to avoid running tests is batches, that will mess with the test names later in Jenkins.

This is adding one plugin for pytest, that can be useful for 2025.3.