### PR TITLE
storage_proxy.cc: get_cas_shard: fallback to the primary replica shard

### DIFF
--- a/dht/auto_refreshing_sharder.hh
+++ b/dht/auto_refreshing_sharder.hh
@@ -41,7 +41,7 @@ public:
 
     virtual ~auto_refreshing_sharder();
 
-    virtual unsigned shard_for_reads(const token& t) const override;
+    virtual std::optional<unsigned> try_get_shard_for_reads(const token& t) const override;
 
     virtual dht::shard_replica_set shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel) const override;
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -43,8 +43,8 @@ static_sharder::shard_of(const token& t) const {
     return dht::shard_of(_shard_count, _sharding_ignore_msb_bits, t);
 }
 
-unsigned
-static_sharder::shard_for_reads(const token& t) const {
+std::optional<unsigned>
+static_sharder::try_get_shard_for_reads(const token& t) const {
     return shard_of(t);
 }
 
@@ -513,8 +513,8 @@ auto_refreshing_sharder::refresh() {
     });
 }
 
-unsigned auto_refreshing_sharder::shard_for_reads(const token& t) const {
-    return _sharder->shard_for_reads(t);
+std::optional<unsigned> auto_refreshing_sharder::try_get_shard_for_reads(const token& t) const {
+    return _sharder->try_get_shard_for_reads(t);
 }
 
 dht::shard_replica_set


### PR DESCRIPTION
Currently, `get_cas_shard` uses `sharder.shard_for_reads` to decide which shard to use for LWT execution—both on replicas and the coordinator.

If the coordinator is not a replica, `shard_for_reads` returns a default shard (shard 0). There are at least two problems with this:
* shard 0 can become overloaded, because all LWT coordinators-but-not-replacas are served on it.
* mismatch with replicas: the default shard doesn't match what `shard_for_reads` returns on replicas. This hinders the "same shard for client and server" RPC level optimization.

In this PR we change `get_cas_shard` to use a primary replica shard if the current node is not a replica. This guarantees that all LWT coordinators for the same tablet will be served on the same shard. This is important for LWT coordinator locks (`paxos::paxos_state::get_cas_lock`). Also, if all tablet replicas on different nodes live on the same shard, RPC optimization will make sure that no additional `smp::submit_to` will be needed on server side.

backport: not needed, since this fix applies only to LWT over tablets, and this feature is not released yet