### PR TITLE
commitlog: replace std::enable_if with a constraint

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -17,6 +17,7 @@
 #include <unordered_set>
 #include <exception>
 #include <filesystem>
+#include <concepts>
 
 #include <fmt/ranges.h>
 
@@ -632,8 +633,8 @@ static void write(fragmented_temporary_buffer::ostream& out, T value) {
     out.write(reinterpret_cast<const char*>(&v), sizeof(v));
 }
 
-template<typename T, typename Input>
-std::enable_if_t<std::is_fundamental<T>::value, T> read(Input& in) {
+template<std::integral T, typename Input>
+T read(Input& in) {
     return net::ntoh(in.template read<T>());
 }
 


### PR DESCRIPTION
std::enable_if is obsolete and was replaced with concepts and constraint.

Replace the std::is_fundamental_v enable_if constraint with std::integral. The latter is more accurate - std::ntoh() is not defined for floats, for example. In any case, we only read integrals in commitlog.

Minor cleanup; not backporting.