### PR TITLE
test/cqlpy: two small fixes for "--release" feature

### DIFF
--- a/test/cqlpy/fetch_scylla.py
+++ b/test/cqlpy/fetch_scylla.py
@@ -101,9 +101,10 @@ def download_scylla(release, dir):
     def comparison_key(x):
         x = x[1:].replace('.', '-').split('-')[0]
         if x.startswith('rc'):
-            return '00~'+x
+            # 0~rc1 came before 0, so let's add /, which is before 0
+            return '/0~'+x
         elif x.startswith('0~rc'):
-            return '0'+x
+            return '/'+x
         else:
             return '%02d' % (int(x))
     candidates = sorted(candidates, key=comparison_key, reverse=True)

--- a/test/cqlpy/run
+++ b/test/cqlpy/run
@@ -1,22 +1,12 @@
 #!/usr/bin/env python3
 
 import sys
+import os
 
 import run   # run.py in this directory
 
-print('Scylla is: ' + run.find_scylla() + '.')
-
-ssl = '--ssl' in sys.argv
-if ssl:
-    cmd = run.run_scylla_ssl_cql_cmd
-    check_cql = run.check_ssl_cql
-else:
-    cmd = run.run_scylla_cmd
-    check_cql = run.check_cql
-
-# If the first option (TODO: improve the command line processing this up)
-# is "--release", download that release (see fetch_scylla.py for supported
-# release numbers), and use that.
+# If the first option is "--release", download that release (see
+# fetch_scylla.py for supported release numbers), and use that.
 # The downloaded Scylla will be cached in the directory build/<release>,
 # where <release> is the specific release downloaded (e.g., if the user
 # asks "--release 2022.1" and the downloaded release is 2022.1.9, it
@@ -27,6 +17,15 @@ if len(sys.argv) > 1 and sys.argv[1] == '--release':
     cmd = lambda pid, dir: run.run_precompiled_scylla_cmd(exe, pid, dir)
     check_cql = run.check_cql
     sys.argv = sys.argv[0:1] + sys.argv[3:]
+    os.environ['SCYLLA'] = exe # so find_scylla() prints the right one
+elif '--ssl' in sys.argv:
+    cmd = run.run_scylla_ssl_cql_cmd
+    check_cql = run.check_ssl_cql
+else:
+    cmd = run.run_scylla_cmd
+    check_cql = run.check_cql
+
+print('Scylla is: ' + run.find_scylla() + '.')
 
 # If the "--vnodes" option is given, drop the "tablets" experimental
 # feature (turned on in run.py) so that all tests will be run with the


### PR DESCRIPTION
This small series fixes two small bugs in the "--release" feature of test/cqlpy/run and test/alternator/run, which allows a developer to run signle-node functional tests against any past release of Scylla. The two patches fix:

1. Allow "run --release" to be used when Scylla has not even been built from source.
2. Fix a mistake in choosing the most recent release when only a ".0" and RC releases are available. This is currently the case for the 2025.2 branch, which is why I discovered the bug now.

Fixes #25223

This patch only affects developer's experience if using the test/cqlpy/run script manually (these scripts are not used by CI), so should not be backported.