### PR TITLE
test.py: add pytest-timeout to the toolchain

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -39,6 +39,9 @@ debian_base_packages=(
     python3-pyparsing
     python3-colorama
     python3-tabulate
+    python3-pytest
+    python3-pytest-asyncio
+    python3-pytest-timeout
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev
@@ -90,6 +93,7 @@ fedora_packages=(
     python3-boto3
     python3-pytest
     python3-pytest-asyncio
+    python3-pytest-timeout
     python3-redis
     python3-unidiff
     python3-humanfriendly

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-42-20250727
+docker.io/scylladb/scylla-toolchain:fedora-42-20250729


### PR DESCRIPTION
Adding this plugin allows using timeout for a test or timeout for the whole session. This can be useful for Unit Test Custom task in the pipeline to avoid running tests is batches, that will mess with the test names later in Jenkins.

Closes #25210

[avi: regenerate frozen toolchain with optimized clang from

  https://devpkg.scylladb.com/clang/clang-20.1.8-Fedora-42-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-20.1.8-Fedora-42-x86_64.tar.gz
]

Not backporting, it's preparing to fix an annoying bug, but release branches work without it.