### PR TITLE
key: clustering_bounds_comparator: avoid thread_local initialization guard overhead

### DIFF
--- a/keys/clustering_bounds_comparator.hh
+++ b/keys/clustering_bounds_comparator.hh
@@ -32,7 +32,7 @@ bound_kind reverse_kind(bound_kind k);
 int32_t weight(bound_kind k);
 
 class bound_view {
-    const static thread_local clustering_key _empty_prefix;
+    const static thread_local clustering_key_prefix _empty_prefix;
     std::reference_wrapper<const clustering_key_prefix> _prefix;
     bound_kind _kind;
 public:

--- a/keys/clustering_bounds_comparator.hh
+++ b/keys/clustering_bounds_comparator.hh
@@ -32,7 +32,7 @@ bound_kind reverse_kind(bound_kind k);
 int32_t weight(bound_kind k);
 
 class bound_view {
-    const static thread_local clustering_key_prefix _empty_prefix;
+    const static thread_local constinit clustering_key_prefix _empty_prefix;
     std::reference_wrapper<const clustering_key_prefix> _prefix;
     bound_kind _kind;
 public:

--- a/keys/keys.cc
+++ b/keys/keys.cc
@@ -106,7 +106,7 @@ int32_t weight(bound_kind k) {
     abort();
 }
 
-const thread_local clustering_key_prefix bound_view::_empty_prefix = clustering_key_prefix::make_empty();
+const thread_local constinit clustering_key_prefix bound_view::_empty_prefix = clustering_key_prefix::make_empty();
 
 std::ostream&
 operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {

--- a/keys/keys.cc
+++ b/keys/keys.cc
@@ -106,7 +106,7 @@ int32_t weight(bound_kind k) {
     abort();
 }
 
-const thread_local clustering_key_prefix bound_view::_empty_prefix = clustering_key::make_empty();
+const thread_local clustering_key_prefix bound_view::_empty_prefix = clustering_key_prefix::make_empty();
 
 std::ostream&
 operator<<(std::ostream& os, const exploded_clustering_prefix& ecp) {

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -150,7 +150,7 @@ class compound_wrapper {
 protected:
     managed_bytes _bytes;
 protected:
-    compound_wrapper(managed_bytes&& b) : _bytes(std::move(b)) {}
+    constexpr compound_wrapper(managed_bytes&& b) : _bytes(std::move(b)) {}
 
     static inline const auto& get_compound_type(const schema& s) {
         return TopLevel::get_compound_type(s);
@@ -174,8 +174,8 @@ public:
         return with_schema_wrapper(s, *static_cast<const TopLevel*>(this));
     }
 
-    static TopLevel make_empty() {
-        return from_exploded(std::vector<bytes>());
+    static constexpr TopLevel make_empty() {
+        return TopLevel::from_bytes(managed_bytes());
     }
 
     static TopLevel make_empty(const schema&) {
@@ -574,7 +574,7 @@ template <typename TopLevel, typename TopLevelView, typename FullTopLevel>
 class prefix_compound_wrapper : public compound_wrapper<TopLevel, TopLevelView> {
     using base = compound_wrapper<TopLevel, TopLevelView>;
 protected:
-    prefix_compound_wrapper(managed_bytes&& b) : base(std::move(b)) {}
+    constexpr prefix_compound_wrapper(managed_bytes&& b) : base(std::move(b)) {}
 public:
     using prefix_view_type = prefix_view_on_prefix_compound<TopLevel>;
 
@@ -844,7 +844,7 @@ public:
 };
 
 class clustering_key_prefix : public prefix_compound_wrapper<clustering_key_prefix, clustering_key_prefix_view, clustering_key> {
-    explicit clustering_key_prefix(managed_bytes&& b)
+    explicit constexpr clustering_key_prefix(managed_bytes&& b)
             : prefix_compound_wrapper<clustering_key_prefix, clustering_key_prefix_view, clustering_key>(std::move(b))
     { }
 public:
@@ -875,7 +875,7 @@ public:
     using compound = lw_shared_ptr<compound_type<allow_prefixes::yes>>;
 
     static clustering_key_prefix from_bytes(const managed_bytes& b) { return clustering_key_prefix(managed_bytes(b)); }
-    static clustering_key_prefix from_bytes(managed_bytes&& b) { return clustering_key_prefix(std::move(b)); }
+    static constexpr clustering_key_prefix from_bytes(managed_bytes&& b) { return clustering_key_prefix(std::move(b)); }
     static clustering_key_prefix from_bytes(managed_bytes_view b) { return clustering_key_prefix(managed_bytes(b)); }
     static clustering_key_prefix from_bytes(bytes_view b) {
         return clustering_key_prefix(managed_bytes(b));

--- a/test/boost/managed_bytes_test.cc
+++ b/test/boost/managed_bytes_test.cc
@@ -405,3 +405,10 @@ BOOST_AUTO_TEST_CASE(test_to_hex) {
     });
 }
 
+static constexpr bool constexpr_managed_bytes() {
+    managed_bytes mb1;
+    auto mb2 = std::move(mb1);
+    return std::is_constant_evaluated();
+}
+
+static_assert(constexpr_managed_bytes());


### PR DESCRIPTION
I noticed clustering_bounds_comparator was running an unnecessary
thread_local initialization guard. This series switches the variable
to constinit initialization, removing the guard.

Performance measurements (perf-simple-query) show an unimpressive
20 instruction per op reduction. However, each instruction counts!

Before:

```
throughput:
	mean=   203642.54 standard-deviation=1102.99
	median= 204328.69 median-absolute-deviation=955.56
	maximum=204624.13 minimum=202222.19
instructions_per_op:
	mean=   42097.59 standard-deviation=40.07
	median= 42111.83 median-absolute-deviation=30.65
	maximum=42139.88 minimum=42044.91
cpu_cycles_per_op:
	mean=   22664.81 standard-deviation=131.28
	median= 22581.10 median-absolute-deviation=111.57
	maximum=22832.30 minimum=22553.24
```

After:

```
throughput:
	mean=   204397.73 standard-deviation=2277.71
	median= 204942.95 median-absolute-deviation=2191.54
	maximum=207588.30 minimum=202162.80
instructions_per_op:
	mean=   42087.21 standard-deviation=27.30
	median= 42092.75 median-absolute-deviation=20.33
	maximum=42108.33 minimum=42041.51
cpu_cycles_per_op:
	mean=   22589.79 standard-deviation=219.24
	median= 22544.82 median-absolute-deviation=191.98
	maximum=22835.11 minimum=22303.52
```



(Very) minor performance improvement, no backport suggestd.