### PR TITLE
test.py: change boost test stdout to use filehandler instead of pipe

### DIFF
--- a/test/pylib/cpp/facade.py
+++ b/test/pylib/cpp/facade.py
@@ -86,10 +86,8 @@ class CppTestFacade(ABC):
         resource_gather.make_cgroup()
         os.chdir(TOP_SRC_DIR)
         timeout = TIMEOUT_DEBUG if mode == 'debug' else TIMEOUT
-        p, out = resource_gather.run_process(args, timeout, env)
+        p = resource_gather.run_process(args, timeout, stdout_file_path, env)
 
-        with open(stdout_file_path, 'w') as fd:
-            fd.write(out)
         metrics = resource_gather.get_test_metrics()
         test_passed = p.returncode == 0
         resource_gather.write_metrics_to_db(metrics, success=test_passed)


### PR DESCRIPTION
With current implementation, if pytest will be killed, it will not be able to write the stdout from the boost test. With a new way, it should be updated while test executing, instead of writing it in the end of the test.


Framework change only, that worth backporting to 2025.3