### PR TITLE
metrics, vector search: add metrics to the vector store client

### DIFF
--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -14,20 +14,6 @@
 namespace alternator {
 
 const char* ALTERNATOR_METRICS = "alternator";
-static seastar::metrics::histogram estimated_histogram_to_metrics(const utils::estimated_histogram& histogram) {
-    seastar::metrics::histogram res;
-    res.buckets.resize(histogram.bucket_offsets.size());
-    uint64_t cumulative_count = 0;
-    res.sample_count = histogram._count;
-    res.sample_sum = histogram._sample_sum;
-    for (size_t i = 0; i < res.buckets.size(); i++) {
-        auto& v = res.buckets[i];
-        v.upper_bound = histogram.bucket_offsets[i];
-        cumulative_count += histogram.buckets[i];
-        v.count = cumulative_count;
-    }
-    return res;
-}
 
 static seastar::metrics::label column_family_label("cf");
 static seastar::metrics::label keyspace_label("ks");

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -408,6 +408,7 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
         std::optional<expression> limit;
         std::optional<expression> per_partition_limit;
         raw::select_statement::parameters::orderings_type orderings;
+        raw::select_statement::parameters::ann_orderings_type ann_orderings;
         bool allow_filtering = false;
         raw::select_statement::parameters::statement_subtype statement_subtype = raw::select_statement::parameters::statement_subtype::REGULAR;
         bool bypass_cache = false;
@@ -425,14 +426,14 @@ selectStatement returns [std::unique_ptr<raw::select_statement> expr]
              )
       ( K_WHERE w=whereClause { wclause = std::move(w); } )?
       ( K_GROUP K_BY gbcolumns=listOfIdentifiers)?
-      ( K_ORDER K_BY orderByClause[orderings] ( ',' orderByClause[orderings] )* )?
+      ( K_ORDER K_BY orderByClause[orderings, ann_orderings] ( ',' orderByClause[orderings, ann_orderings] )* )?
       ( K_PER K_PARTITION K_LIMIT rows=intValue { per_partition_limit = std::move(rows); } )?
       ( K_LIMIT rows=intValue { limit = std::move(rows); } )?
       ( K_ALLOW K_FILTERING  { allow_filtering = true; } )?
       ( K_BYPASS K_CACHE { bypass_cache = true; })?
       ( usingTimeoutServiceLevelClause[attrs] )?
       {
-          auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
+          auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), std::move(ann_orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
           $expr = std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
             std::move(sclause), std::move(wclause), std::move(limit), std::move(per_partition_limit),
             std::move(gbcolumns), std::move(attrs));
@@ -484,11 +485,24 @@ whereClause returns [uexpression clause]
         { clause = conjunction{std::move(terms)}; }
     ;
 
-orderByClause[raw::select_statement::parameters::orderings_type& orderings]
+orderByClause[raw::select_statement::parameters::orderings_type& orderings, raw::select_statement::parameters::ann_orderings_type& ann_orderings]
     @init{
         raw::select_statement::ordering ordering = raw::select_statement::ordering::ascending;
+        std::optional<expression> ann_ordering;
     }
-    : c=cident (K_ASC | K_DESC { ordering = raw::select_statement::ordering::descending; })? { orderings.emplace_back(c, ordering); }
+    : c=cident (K_ANN K_OF t=term {ann_ordering=std::move(t);})? (K_ASC | K_DESC { ordering = raw::select_statement::ordering::descending; })?
+    {
+        if (!ann_ordering)
+        {
+            orderings.emplace_back(c, ordering);
+        } else {
+            if (ordering != raw::select_statement::ordering::ascending) {
+                throw exceptions::invalid_request_exception(
+                    "Descending ANN ordering is not supported");
+            }
+            ann_orderings.emplace_back(c, ann_ordering.value());
+        }
+    }
     ;
 
 jsonValue returns [uexpression value]
@@ -660,6 +674,7 @@ pruneMaterializedViewStatement returns [std::unique_ptr<raw::select_statement> e
         std::optional<expression> limit;
         std::optional<expression> per_partition_limit;
         raw::select_statement::parameters::orderings_type orderings;
+        raw::select_statement::parameters::ann_orderings_type ann_orderings;
         bool allow_filtering = false;
         raw::select_statement::parameters::statement_subtype statement_subtype = raw::select_statement::parameters::statement_subtype::PRUNE_MATERIALIZED_VIEW;
         bool bypass_cache = false;
@@ -668,7 +683,7 @@ pruneMaterializedViewStatement returns [std::unique_ptr<raw::select_statement> e
     }
 	: K_PRUNE K_MATERIALIZED K_VIEW cf=columnFamilyName (K_WHERE w=whereClause { wclause = std::move(w); } )? ( usingClause[attrs] )?
 	  {
-	        auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
+	        auto params = make_lw_shared<raw::select_statement::parameters>(std::move(orderings), std::move(ann_orderings), is_distinct, allow_filtering, statement_subtype, bypass_cache);
 	        return std::make_unique<raw::select_statement>(std::move(cf), std::move(params),
             std::vector<shared_ptr<raw_selector>>(), std::move(wclause), std::move(limit), std::move(per_partition_limit),
             std::vector<::shared_ptr<cql3::column_identifier::raw>>(), std::move(attrs));
@@ -2243,6 +2258,7 @@ K_ORDER:       O R D E R;
 K_BY:          B Y;
 K_ASC:         A S C;
 K_DESC:        D E S C;
+K_ANN:         A N N;
 K_ALLOW:       A L L O W;
 K_FILTERING:   F I L T E R I N G;
 K_IF:          I F;

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -26,6 +26,7 @@
 #include "cql3/statements/request_validations.hh"
 #include "cql3/functions/token_fct.hh"
 #include "dht/i_partitioner.hh"
+#include "db/schema_tables.hh"
 #include "types/tuple.hh"
 
 namespace {
@@ -1274,14 +1275,16 @@ statement_restrictions::statement_restrictions(data_dictionary::database db,
         }
 
         const auto& im = index_opt->metadata();
-        sstring index_table_name = im.name() + "_index";
-        schema_ptr view_schema = db.find_schema(schema->ks_name(), index_table_name);
-        _view_schema = view_schema;
+        if (db::schema_tables::should_create_view(im)) {
+            sstring index_table_name = im.name() + "_index";
+            schema_ptr view_schema = db.find_schema(schema->ks_name(), index_table_name);
+            _view_schema = view_schema;
 
-        if (im.local()) {
-            prepare_indexed_local(*view_schema);
-        } else {
-            prepare_indexed_global(*view_schema);
+            if (im.local()) {
+                prepare_indexed_local(*view_schema);
+            } else {
+                prepare_indexed_global(*view_schema);
+            }
         }
     }
 }

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -195,7 +195,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
         return def;
     }) | std::ranges::to<std::unordered_set<const column_definition*>>();
 
-    auto parameters = make_lw_shared<raw::select_statement::parameters>(raw::select_statement::parameters::orderings_type(), false, true);
+    auto parameters = make_lw_shared<raw::select_statement::parameters>(raw::select_statement::parameters::orderings_type(), raw::select_statement::parameters::ann_orderings_type(), false, true);
     raw::select_statement raw_select(_base_name, std::move(parameters), _select_clause, _where_clause, std::nullopt, std::nullopt, {}, std::make_unique<cql3::attributes::raw>());
     raw_select.prepare_keyspace(keyspace());
     raw_select.set_bound_variables({});

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -46,9 +46,11 @@ public:
     class parameters final {
     public:
         using orderings_type = std::vector<std::pair<shared_ptr<column_identifier::raw>, ordering>>;
+        using ann_orderings_type = std::vector<std::pair<shared_ptr<column_identifier::raw>, expr::expression>>;
         enum class statement_subtype { REGULAR, JSON, PRUNE_MATERIALIZED_VIEW, MUTATION_FRAGMENTS };
     private:
         const orderings_type _orderings;
+        const ann_orderings_type _ann_orderings;
         const bool _is_distinct;
         const bool _allow_filtering;
         const statement_subtype _statement_subtype;
@@ -56,9 +58,11 @@ public:
     public:
         parameters();
         parameters(orderings_type orderings,
+            ann_orderings_type ann_orderings,
             bool is_distinct,
             bool allow_filtering);
         parameters(orderings_type orderings,
+            ann_orderings_type ann_orderings,
             bool is_distinct,
             bool allow_filtering,
             statement_subtype statement_subtype,
@@ -70,11 +74,13 @@ public:
         bool bypass_cache() const;
         bool is_prune_materialized_view() const;
         orderings_type const& orderings() const;
+        ann_orderings_type const& ann_orderings() const;
     };
     template<typename T>
     using compare_fn = std::function<bool(const T&, const T&)>;
 
     using result_row_type = std::vector<managed_bytes_opt>;
+    using prepared_ann_ordering_type = std::pair<const column_definition*, expr::expression>;
     using ordering_comparator_type = compare_fn<result_row_type>;
 protected:
     virtual audit::statement_category category() const override;

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -132,6 +132,10 @@ private:
 
     void verify_ordering_is_valid(const prepared_orderings_type&, const schema&, const restrictions::statement_restrictions& restrictions) const;
 
+    void verify_ann_ordering_is_valid(const parameters& params, const std::optional<expr::expression>& limit, const std::optional<expr::expression>& per_partition_limit, const selection::selection& selection) const;
+
+    prepared_ann_ordering_type prepare_ann_ordering(const schema& schema, const parameters& params, prepare_context& ctx, data_dictionary::database db) const;
+
     // Checks whether this ordering reverses all results.
     // We only allow leaving select results unchanged or reversing them.
     bool is_ordering_reversed(const prepared_orderings_type&) const;

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -18,6 +18,9 @@
 #include "cql3/statements/prune_materialized_view_statement.hh"
 #include "cql3/statements/strongly_consistent_select_statement.hh"
 
+#include "exceptions/exceptions.hh"
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/exception.hh>
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "service/qos/qos_common.hh"
 #include "transport/messages/result_message.hh"
@@ -25,6 +28,8 @@
 #include "cql3/selection/selection.hh"
 #include "cql3/util.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
+#include "index/secondary_index.hh"
+#include "types/vector.hh"
 #include "validation.hh"
 #include "exceptions/unrecognized_entity_exception.hh"
 #include <optional>
@@ -111,20 +116,24 @@ select_statement::parameters::parameters()
 { }
 
 select_statement::parameters::parameters(orderings_type orderings,
+                                         ann_orderings_type ann_orderings,
                                          bool is_distinct,
                                          bool allow_filtering)
     : _orderings{std::move(orderings)}
+    , _ann_orderings{std::move(ann_orderings)}
     , _is_distinct{is_distinct}
     , _allow_filtering{allow_filtering}
     , _statement_subtype{statement_subtype::REGULAR}
 { }
 
 select_statement::parameters::parameters(orderings_type orderings,
+                                         ann_orderings_type ann_orderings,
                                          bool is_distinct,
                                          bool allow_filtering,
                                          statement_subtype statement_subtype,
                                          bool bypass_cache)
     : _orderings{std::move(orderings)}
+    , _ann_orderings{std::move(ann_orderings)}
     , _is_distinct{is_distinct}
     , _allow_filtering{allow_filtering}
     , _statement_subtype{statement_subtype}
@@ -157,6 +166,10 @@ bool select_statement::parameters::is_prune_materialized_view() const {
 
 select_statement::parameters::orderings_type const& select_statement::parameters::orderings() const {
     return _orderings;
+}
+
+select_statement::parameters::ann_orderings_type const& select_statement::parameters::ann_orderings() const {
+    return _ann_orderings;
 }
 
 timeout_config_selector
@@ -986,6 +999,7 @@ indexed_table_select_statement::prepare(data_dictionary::database db,
                                         ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                         bool is_reversed,
                                         ordering_comparator_type ordering_comparator,
+                                        std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                         std::optional<expr::expression> limit,
                                          std::optional<expr::expression> per_partition_limit,
                                          cql_stats &stats,
@@ -994,6 +1008,27 @@ indexed_table_select_statement::prepare(data_dictionary::database db,
     auto cf = db.find_column_family(schema);
     auto& sim = cf.get_index_manager();
     auto [index_opt, used_index_restrictions] = restrictions->find_idx(sim);
+
+    if (prepared_ann_ordering.has_value()) {
+        auto indexes = sim.list_indexes();
+        auto it = std::find_if(indexes.begin(), indexes.end(), [&prepared_ann_ordering](const auto& ind) {
+            return (ind.metadata().options().contains(db::index::secondary_index::custom_index_option_name)
+                && ind.metadata().options().at(db::index::secondary_index::custom_index_option_name) == ann_custom_index_option)
+                && (ind.target_column() == prepared_ann_ordering->first->name_as_text());
+        });
+
+        if (it == indexes.end()) {
+            throw exceptions::invalid_request_exception("ANN ordering by vector requires the column to be indexed");
+        } else {
+            index_opt = *it;
+        }
+    } else if (index_opt) {
+        auto it = index_opt->metadata().options().find(db::index::secondary_index::custom_index_option_name);
+        if (it != index_opt->metadata().options().end() && it->second == ann_custom_index_option) {
+            throw exceptions::invalid_request_exception("Vector indexes only support ANN queries");
+        }
+    }
+
     if (!index_opt) {
         throw std::runtime_error("No index found.");
     }
@@ -1009,6 +1044,7 @@ indexed_table_select_statement::prepare(data_dictionary::database db,
             std::move(group_by_cell_indices),
             is_reversed,
             std::move(ordering_comparator),
+            std::move(prepared_ann_ordering),
             std::move(limit),
             std::move(per_partition_limit),
             stats,
@@ -1026,6 +1062,7 @@ indexed_table_select_statement::indexed_table_select_statement(schema_ptr schema
                                                            ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                                            bool is_reversed,
                                                            ordering_comparator_type ordering_comparator,
+                                                           std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                                            std::optional<expr::expression> limit,
                                                            std::optional<expr::expression> per_partition_limit,
                                                            cql_stats &stats,
@@ -1037,6 +1074,7 @@ indexed_table_select_statement::indexed_table_select_statement(schema_ptr schema
     , _index{index}
     , _used_index_restrictions(std::move(used_index_restrictions))
     , _view_schema(view_schema)
+    , _prepared_ann_ordering(std::move(prepared_ann_ordering))
 {
     if (_index.metadata().local()) {
         _get_partition_ranges_for_posting_list = [this] (const query_options& options) { return get_partition_ranges_for_local_index_posting_list(options); };
@@ -1145,7 +1183,20 @@ indexed_table_select_statement::do_execute(query_processor& qp,
             ? source_selector::INTERNAL : source_selector::USER;
     ++_stats.query_cnt(src_sel, _ks_sel, cond_selector::NO_CONDITIONS, statement_type::SELECT);
 
-    SCYLLA_ASSERT(_restrictions->uses_secondary_indexing());
+    SCYLLA_ASSERT(_restrictions->uses_secondary_indexing() || _prepared_ann_ordering.has_value());
+
+    if (_prepared_ann_ordering.has_value()) {
+        auto limit = get_limit(options, _limit);
+        if (limit > max_ann_query_limit) {
+            co_await coroutine::return_exception(exceptions::invalid_request_exception(fmt::format("Use of ANN OF in an ORDER BY clause requires a LIMIT that is not greater than {}. LIMIT was {}", max_ann_query_limit, limit)));
+        }
+
+        auto [ann_column, ann_vector_expr] = _prepared_ann_ordering.value();
+        auto ann_vector = ann_column->type->deserialize(expr::evaluate(ann_vector_expr, options).to_bytes());
+        // TODO: not implemented
+        logger.debug("Executing ANN search for vector {}", ann_vector.to_parsable_string());
+        throw exceptions::invalid_request_exception("ANN index not implemented");
+    }
 
     _stats.unpaged_select_queries(_ks_sel) += options.get_page_size() <= 0;
 
@@ -2052,6 +2103,13 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     select_statement::ordering_comparator_type ordering_comparator;
     bool is_reversed_ = false;
 
+    std::optional<prepared_ann_ordering_type> prepared_ann_ordering;
+
+    if (!_parameters->ann_orderings().empty()) {
+        verify_ann_ordering_is_valid(*_parameters, _limit, _per_partition_limit, *selection);
+        prepared_ann_ordering = prepare_ann_ordering( *schema, *_parameters, ctx, db);
+    }
+
     if (!_parameters->orderings().empty()) {
         SCYLLA_ASSERT(!for_view);
         verify_ordering_is_allowed(*_parameters, *restrictions);
@@ -2145,7 +2203,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
                 prepare_limit(db, ctx, _per_partition_limit),
                 stats,
                 std::move(prepared_attrs));
-    } else if (restrictions->uses_secondary_indexing()) {
+    } else if (restrictions->uses_secondary_indexing() || prepared_ann_ordering) {
         stmt = indexed_table_select_statement::prepare(
                 db,
                 schema,
@@ -2156,6 +2214,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
                 std::move(group_by_cell_indices),
                 is_reversed_,
                 std::move(ordering_comparator),
+                std::move(prepared_ann_ordering),
                 prepare_limit(db, ctx, _limit),
                 prepare_limit(db, ctx, _per_partition_limit),
                 stats,
@@ -2369,6 +2428,57 @@ void select_statement::verify_ordering_is_valid(const prepared_orderings_type& o
             }
         }
     }
+}
+
+void select_statement::verify_ann_ordering_is_valid(const parameters& params, const std::optional<expr::expression>& limit,
+                                                    const std::optional<expr::expression>& per_partition_limit,
+                                                    const selection::selection& selection) const {
+
+    if (!params.orderings().empty()) {
+        throw exceptions::invalid_request_exception(
+            "ANN ordering does not support any other ordering");
+    }
+
+    if (params.ann_orderings().size() != 1) {
+        throw exceptions::invalid_request_exception(
+                "Cannot specify more than one ANN ordering");
+    }
+
+    if (params.allow_filtering()) {
+        throw exceptions::invalid_request_exception("ANN ordering by vector requires all restricted column(s) to be indexed");
+    }
+
+    if (!limit.has_value()) {
+        throw exceptions::invalid_request_exception("ANN query must specify a LIMIT");
+    }
+
+    if (per_partition_limit.has_value()) {
+        throw exceptions::invalid_request_exception("ANN queries do not support per-partition limits");
+    }
+
+    if (selection.is_aggregate()) {
+        throw exceptions::invalid_request_exception("ANN queries can not be run with aggregation");
+    }
+}
+
+select_statement::prepared_ann_ordering_type select_statement::prepare_ann_ordering(const schema& schema, const parameters& params, prepare_context& ctx, data_dictionary::database db) const {
+    auto [column_id, ann_vector] = _parameters->ann_orderings().front();
+
+    ::shared_ptr<column_identifier> column = column_id->prepare_column_identifier(schema);
+    const column_definition* def = schema.get_column_definition(column->name());
+    if (!def) {
+        throw exceptions::invalid_request_exception(
+                fmt::format("Undefined column name {}", column->name()));
+    }
+
+    if (!def->type->is_vector() || static_cast<const vector_type_impl*>(def->type.get())->get_elements_type()->get_kind() != abstract_type::kind::float_kind) {
+        throw exceptions::invalid_request_exception("ANN ordering is only supported on float vector indexes");
+    }
+
+    auto e =  expr::prepare_expression(ann_vector, db, keyspace(),nullptr, def->column_specification);
+    expr::fill_prepare_context(e, ctx);
+
+    return std::make_pair(std::move(def), std::move(e));
 }
 
 select_statement::ordering_comparator_type select_statement::get_ordering_comparator(const prepared_orderings_type& orderings,

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1192,10 +1192,31 @@ indexed_table_select_statement::do_execute(query_processor& qp,
         }
 
         auto [ann_column, ann_vector_expr] = _prepared_ann_ordering.value();
-        auto ann_vector = ann_column->type->deserialize(expr::evaluate(ann_vector_expr, options).to_bytes());
-        // TODO: not implemented
-        logger.debug("Executing ANN search for vector {}", ann_vector.to_parsable_string());
-        throw exceptions::invalid_request_exception("ANN index not implemented");
+
+        // FIXME: Find a more efficient way to convert from data_value to std::vector<float>
+        std::vector<float> ann_vector;
+        std::ranges::transform(value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(expr::evaluate(ann_vector_expr, options).to_bytes())),
+            std::back_inserter(ann_vector),
+            [](const auto& v) { return value_cast<float>(v); });
+
+        auto as = abort_source();
+        auto pkeys = co_await qp.vector_store_client().ann(_schema->ks_name(), _index.metadata().name(), _schema , std::move(ann_vector), limit, as);
+
+        if (!pkeys.has_value()) {
+            co_await coroutine::return_exception(exceptions::invalid_request_exception(fmt::format("ANN query cannot be executed with vector_store disabled")));
+        }
+
+        // If there are no clustering columns, we have to convert the partition keys to partition ranges.
+        if (_schema->clustering_key_size() == 0) {
+            std::vector<dht::partition_range> partition_ranges;
+            std::ranges::transform(pkeys.value(), std::back_inserter(partition_ranges), [](const auto& pkey) {
+                    return dht::partition_range::make_singular(pkey.partition);
+                });
+
+            co_return co_await this->execute_base_query(qp, std::move(partition_ranges), state, options, now, nullptr);
+        }
+
+        co_return co_await this->execute_base_query(qp, std::move(*pkeys), state, options, now, nullptr);
     }
 
     _stats.unpaged_select_queries(_ks_sel) += options.get_page_size() <= 0;

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -15,6 +15,7 @@
 #include "cql3/cql_statement.hh"
 #include "cql3/stats.hh"
 #include <seastar/core/shared_ptr.hh>
+#include <string_view>
 #include "transport/messages/result_message.hh"
 #include "index/secondary_index_manager.hh"
 #include "exceptions/coordinator_result.hh"
@@ -61,6 +62,7 @@ public:
     using coordinator_result = exceptions::coordinator_result<T>;
     using parameters = raw::select_statement::parameters;
     using ordering_comparator_type = raw::select_statement::ordering_comparator_type;
+    using prepared_ann_ordering_type = raw::select_statement::prepared_ann_ordering_type;
     static constexpr int DEFAULT_COUNT_PAGE_SIZE = 10000;
     bool _may_use_token_aware_routing;
 protected:
@@ -186,10 +188,13 @@ class indexed_table_select_statement : public select_statement {
     secondary_index::index _index;
     expr::expression _used_index_restrictions;
     schema_ptr _view_schema;
+    std::optional<prepared_ann_ordering_type>  _prepared_ann_ordering;
     noncopyable_function<dht::partition_range_vector(const query_options&)> _get_partition_ranges_for_posting_list;
     noncopyable_function<query::partition_slice(const query_options&)> _get_partition_slice_for_posting_list;
 public:
     static constexpr size_t max_base_table_query_concurrency = 4096;
+    static constexpr size_t max_ann_query_limit = 1000;
+    static constexpr std::string_view ann_custom_index_option = "vector_index";
 
     static ::shared_ptr<cql3::statements::select_statement> prepare(data_dictionary::database db,
                                                                     schema_ptr schema,
@@ -200,6 +205,7 @@ public:
                                                                     ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                                                     bool is_reversed,
                                                                     ordering_comparator_type ordering_comparator,
+                                                                    std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                                                     std::optional<expr::expression> limit,
                                                                     std::optional<expr::expression> per_partition_limit,
                                                                     cql_stats &stats,
@@ -213,6 +219,7 @@ public:
                                    ::shared_ptr<std::vector<size_t>> group_by_cell_indices,
                                    bool is_reversed,
                                    ordering_comparator_type ordering_comparator,
+                                   std::optional<prepared_ann_ordering_type> prepared_ann_ordering,
                                    std::optional<expr::expression> limit,
                                    std::optional<expr::expression> per_partition_limit,
                                    cql_stats &stats,

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1840,7 +1840,7 @@ void add_table_or_view_to_schema_mutation(schema_ptr s, api::timestamp_type time
 static schema_mutations make_view_mutations(view_ptr view, api::timestamp_type timestamp, bool with_columns);
 static void make_drop_table_or_view_mutations(schema_ptr schema_table, schema_ptr table_or_view, api::timestamp_type timestamp, utils::chunked_vector<mutation>& mutations);
 
-static bool should_create_view(const index_metadata & index) {
+bool should_create_view(const index_metadata & index) {
     auto custom_class = secondary_index::secondary_index_manager::get_custom_class(index);
     if (!custom_class) {
         return true;

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -306,6 +306,8 @@ utils::chunked_vector<mutation> make_drop_view_mutations(lw_shared_ptr<keyspace_
 
 void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view_ptr& v, schema_ptr base_schema);
 
+bool should_create_view(const index_metadata& im);
+
 sstring serialize_kind(column_kind kind);
 column_kind deserialize_kind(sstring kind);
 data_type parse_type(sstring str);

--- a/service/vector_store_client.cc
+++ b/service/vector_store_client.cc
@@ -14,12 +14,14 @@
 #include "utils/sequential_producer.hh"
 #include "dht/i_partitioner.hh"
 #include "keys.hh"
+#include "utils/histogram_metrics_helper.hh"
 #include "utils/rjson.hh"
 #include "schema/schema.hh"
 #include <charconv>
 #include <exception>
 #include <fmt/ranges.h>
 #include <regex>
+#include <seastar/core/metrics.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/exception.hh>
 #include <seastar/http/client.hh>
@@ -63,6 +65,9 @@ constexpr auto HTTP_REQUEST_RETRIES = 3;
 
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 logging::logger vslogger("vector_store_client");
+
+static seastar::metrics::label status("status");
+static seastar::metrics::label dns_code("dns_code");
 
 auto parse_port(std::string const& port_txt) -> std::optional<port_number> {
     auto port = port_number{};
@@ -206,11 +211,35 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
     return std::move(keys);
 }
 
+bool buffers_equal_string(const std::vector<temporary_buffer<char>>& buffers, const sstring& str) {
+    size_t total_size = 0;
+    for (const auto& buf : buffers) {
+        total_size += buf.size();
+    }
+    if (total_size != str.size()) {
+        return false;
+    }
+
+    size_t str_pos = 0;
+    for (const auto& buf : buffers) {
+        if (memcmp(buf.get(), str.data() + str_pos, buf.size()) != 0) {
+            return false;
+        }
+        str_pos += buf.size();
+    }
+    return true;
+}
+
 } // namespace
 
 namespace service {
 
 struct vector_store_client::impl {
+    struct stats {
+        uint64_t dns_refresh_successes = 0; ///< The number of times the DNS service was refreshed to get the vector-store service address.
+        uint64_t dns_refresh_failures = 0; ///< The number of times the DNS service refresh failed to get the vector-store service address.
+    };
+
     lw_shared_ptr<http_client> current_client;
     std::vector<lw_shared_ptr<http_client>> old_clients;
     host_name host;
@@ -224,21 +253,26 @@ struct vector_store_client::impl {
     milliseconds dns_refresh_interval = DNS_REFRESH_INTERVAL;
     milliseconds wait_for_client_timeout = WAIT_FOR_CLIENT_TIMEOUT;
     unsigned http_request_retries = HTTP_REQUEST_RETRIES;
-    std::function<future<std::optional<inet_address>>(sstring const&)> dns_resolver;
+    std::function<future<std::optional<inet_address>>(sstring const&, stats&)> dns_resolver;
     sequential_producer<lw_shared_ptr<http_client>> client_producer;
+
+    stats _stats; ///< The statistics for the vector-store service.
+    seastar::metrics::metric_groups _metrics;
 
     impl(host_name host_, port_number port_)
         : host(std::move(host_))
         , port(port_)
-        , dns_resolver([](auto const& host) -> future<std::optional<inet_address>> {
+        , dns_resolver([](auto const& host, stats& _stats) -> future<std::optional<inet_address>> {
             auto addr = co_await coroutine::as_future(net::dns::resolve_name(host));
             if (addr.failed()) {
+                _stats.dns_refresh_failures++;
                 auto err = addr.get_exception();
                 if (try_catch<std::system_error>(err) != nullptr) {
                     co_return std::nullopt;
                 }
                 co_await coroutine::return_exception_ptr(std::move(err));
             }
+            _stats.dns_refresh_successes++;
             co_return co_await std::move(addr);
         })
         , client_producer([&]() -> future<lw_shared_ptr<http_client>> {
@@ -246,6 +280,10 @@ struct vector_store_client::impl {
             co_await wait_for_signal(refresh_client_cv, lowres_clock::now() + wait_for_client_timeout);
             co_return current_client;
         }) {
+            _metrics.add_group("vector_store", {
+                seastar::metrics::make_counter("dns_refreshes", _stats.dns_refresh_successes, seastar::metrics::description("Number of times the DNS service was refreshed to get the vector-store service address."))(dns_code("SUCCESS")),
+                seastar::metrics::make_counter("dns_refreshes", _stats.dns_refresh_failures, seastar::metrics::description("Number of times the DNS service refresh failed to get the vector-store service address."))(dns_code("FAILURE")),
+            });
     }
 
     /// Refresh the http client with a new address resolved from the DNS name.
@@ -253,7 +291,7 @@ struct vector_store_client::impl {
     /// If the address is the same as the current one, do nothing.
     /// Old clients are saved for later cleanup in a specific task.
     auto refresh_addr() -> future<> {
-        auto new_addr = co_await dns_resolver(host);
+        auto new_addr = co_await dns_resolver(host, _stats);
         if (!new_addr) {
             current_client = nullptr;
             co_return;
@@ -435,6 +473,14 @@ struct vector_store_client::impl {
 };
 
 vector_store_client::vector_store_client(config const& cfg) {
+    _metrics.add_group("vector_store", {
+        seastar::metrics::make_counter("ann_requests", _stats.ann_initializing, seastar::metrics::description("Number of ANN requests made to the Vector Store service."))(status("INITIALIZING")),
+        seastar::metrics::make_counter("ann_requests", _stats.ann_connecting_to_db, seastar::metrics::description("Number of ANN requests made to the Vector Store service."))(status("CONNECTING_TO_DB")),
+        seastar::metrics::make_counter("ann_requests", _stats.ann_bootstraping, seastar::metrics::description("Number of ANN requests made to the Vector Store service."))(status("BOOTSTRAPPING")),
+        seastar::metrics::make_counter("ann_requests", _stats.ann_serving, seastar::metrics::description("Number of ANN requests made to the Vector Store service."))(status("SERVING")),
+        seastar::metrics::make_histogram("ann_limit_histogram", [this] { return estimated_histogram_to_metrics(_stats.ann_limit_histogram); }, seastar::metrics::description("Histogram of the limits used in ANN requests.")),
+        seastar::metrics::make_histogram("ann_latencies", [this] { return to_metrics_histogram(_stats.ann_latencies); }, seastar::metrics::description("Histogram of the latencies of ANN requests.")),
+    });
     auto config_uri = cfg.vector_store_uri();
     if (config_uri.empty()) {
         vslogger.info("Vector Store service URI is not configured.");
@@ -492,11 +538,36 @@ auto vector_store_client::port() const -> std::expected<port_number, disabled> {
 
 auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, embedding embedding, limit limit, abort_source& as)
         -> future<std::expected<primary_keys, ann_error>> {
+    _stats.ann_limit_histogram.add(limit);
+    auto start_time = lowres_system_clock::now();
     if (is_disabled()) {
         vslogger.error("Disabled Vector Store while calling ann");
         co_return std::unexpected{disabled{}};
     }
 
+    auto status_path = "/api/v1/status";
+    auto status_resp = co_await _impl->make_request(operation_type::GET, status_path, std::nullopt, as);
+    if (!status_resp) {
+        co_return std::unexpected{disabled{}};
+    }
+    if (status_resp->status != http::reply::status_type::ok) {
+        vslogger.error("Vector Store returned error: HTTP status {}: {}", status_resp->status, status_resp->content);
+        co_return std::unexpected{service_error{status_resp->status}};
+    }
+    
+    if (buffers_equal_string(status_resp->content, "\"INITIALIZING\"")) {
+        _stats.ann_initializing++;
+    } else if (buffers_equal_string(status_resp->content, "\"CONNECTING_TO_DB\"")) {
+        _stats.ann_connecting_to_db++;
+    } else if (buffers_equal_string(status_resp->content, "\"BOOTSTRAPPING\"")) {
+        _stats.ann_bootstraping++;
+    } else if (buffers_equal_string(status_resp->content, "\"SERVING\"")) {
+        _stats.ann_serving++;
+    } else {
+        vslogger.error("Vector Store returned unknown status: {}", status_resp->content);
+        co_return std::unexpected{service_reply_format_error{}};
+    }
+    
     auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
     auto content = write_ann_json(std::move(embedding), limit);
 
@@ -515,7 +586,10 @@ auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_pt
     }
 
     try {
-        co_return read_ann_json(rjson::parse(std::move(resp->content)), schema);
+        auto response = read_ann_json(rjson::parse(std::move(resp->content)), schema);
+        auto latency = lowres_system_clock::now() - start_time;
+        _stats.ann_latencies.add(latency);
+        co_return response;
     } catch (const rjson::error& e) {
         vslogger.error("Vector Store returned invalid JSON: {}", e.what());
         co_return std::unexpected{service_reply_format_error{}};
@@ -547,7 +621,9 @@ void vector_store_client_tester::set_dns_resolver(vector_store_client& vsc, std:
     if (vsc.is_disabled()) {
         on_internal_error(vslogger, "Cannot set dns_resolver on a disabled vector store client");
     }
-    vsc._impl->dns_resolver = std::move(resolver);
+    vsc._impl->dns_resolver = [resolver](auto const& host, vector_store_client::impl::stats& _stats) -> future<std::optional<inet_address>> {
+        return resolver(host);
+    };
 }
 
 void vector_store_client_tester::trigger_dns_resolver(vector_store_client& vsc) {

--- a/service/vector_store_client.hh
+++ b/service/vector_store_client.hh
@@ -9,6 +9,9 @@
 #pragma once
 
 #include "seastarx.hh"
+#include "utils/estimated_histogram.hh"
+#include <cstdint>
+#include <seastar/core/metrics_registration.hh>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/http/reply.hh>
@@ -94,8 +97,21 @@ public:
     auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, embedding embedding, limit limit, abort_source& as)
             -> future<std::expected<primary_keys, ann_error>>;
 
+    
+    struct stats {
+        uint64_t ann_initializing = 0; ///< The number of ANN requests made while vector store was initializing.
+        uint64_t ann_connecting_to_db = 0;   ///< The number of ANN requests made while vector store was connecting to the DB.
+        uint64_t ann_bootstraping = 0;  ///< The number of ANN requests made while vector store was bootstraping.
+        uint64_t ann_serving = 0; ///< The The number of ANN requests made while vector store was serving.
+        utils::estimated_histogram ann_limit_histogram{35}; ///< Histogram of the limits used in ANN requests.
+        utils::time_estimated_histogram ann_latencies; ///< Histogram of the latencies of ANN requests.
+    };
+
+    stats _stats; ///< The statistics for the vector-store service.
+
 private:
     friend struct vector_store_client_tester;
+    seastar::metrics::metric_groups _metrics; ///< The metrics for the vector-store service.
 };
 
 /// A tester for the vector_store_client, used for testing purposes.

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -1,0 +1,393 @@
+# This file was translated from the original Java test from the Apache
+# Cassandra source repository, as of commit bb66561142788270ab450c02de836b3952ed37b4
+#
+# The original Apache Cassandra license:
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from .porting import *
+
+# public class VectorInvalidQueryTest extends SAITester
+# {
+#     @BeforeClass
+#     public static void setupClass()
+#     {
+#         requireNetwork();
+#     }
+
+#     @Test
+#     public void cannotCreateEmptyVectorColumn()
+#     {
+#         assertThatThrownBy(() -> execute(String.format("CREATE TABLE %s.%s (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))",
+#                                                        KEYSPACE, createTableName())))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("vectors may only have positive dimensions; given 0");
+#     }
+
+#     @Test
+#     public void cannotQueryEmptyVectorColumn()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+#         assertThatThrownBy(() -> execute("SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("vectors may only have positive dimensions; given 0");
+#     }
+
+#     @Test
+#     public void cannotIndex1DWithCosine()
+#     {
+#         createTable("CREATE TABLE %s (pk int, v vector<float, 1>, PRIMARY KEY(pk))");
+#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'cosine'}"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasRootCauseMessage(StorageAttachedIndex.VECTOR_1_DIMENSION_COSINE_ERROR);
+#     }
+
+#     @Test
+#     public void cannotInsertWrongNumberOfDimensions()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0])"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
+#     }
+
+#     @Test
+#     public void cannotQueryWrongNumberOfDimensions()
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])");
+#         execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5] LIMIT 5"))
+#         .isInstanceOf(InvalidRequestException.class)
+#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
+#     }
+
+#     @Test
+#     public void testMultiVectorOrderingsNotAllowed() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("Cannot specify more than one ANN ordering",
+#                              "SELECT * FROM %s ORDER BY val1 ann of [2.5, 3.5, 4.5], val2 ann of [2.1, 3.2, 4.0] LIMIT 2");
+#     }
+
+#     @Test
+#     public void testDescendingVectorOrderingIsNotAllowed() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("Descending ANN ordering is not supported",
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2");
+#     }
+
+#     @Test
+#     public void testVectorOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage("ANN ordering does not support any other ordering",
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2");
+#     }
+
+#     @Test
+#     public void testVectorOrderingIsNotAllowedWithoutIndex() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void testInvalidColumnNameWithAnn() throws Throwable
+#     {
+#         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
+#         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + '.' + table),
+#                              "SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1");
+#     }
+
+#     @Test
+#     public void cannotPerformNonANNQueryOnVectorIndex() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage(StatementRestrictions.VECTOR_INDEXES_ANN_ONLY_MESSAGE,
+#                              "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]");
+#     }
+
+#     @Test
+#     public void cannotOrderWithAnnOnNonVectorColumn() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int, v int, primary key(k))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
+#                              "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1");
+#     }
+
+#     @Test
+#     public void disallowZeroVectorsWithCosineSimilarity()
+#     {
+#         createTable(KEYSPACE, "CREATE TABLE %s (pk int primary key, value vector<float, 2>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(value) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'cosine'}");
+
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, [0.0, 0.0])")).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(0.0f, 0.0f))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1.0f, Float.NaN))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(1.0f, Float.POSITIVE_INFINITY))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("INSERT INTO %s (pk, value) VALUES (0, ?)", vector(Float.NEGATIVE_INFINITY, 1.0f))).isInstanceOf(InvalidRequestException.class);
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
+#     }
+
+#     @Test
+#     public void mustHaveLimitSpecifiedAndWithinMaxAllowed()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_LIMIT_ERROR);
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(String.format(StorageAttachedIndex.ANN_LIMIT_ERROR, IndexWriterConfig.MAX_TOP_K, 1001));
+#     }
+
+#     @Test
+#     public void mustHaveLimitWithinPageSize()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 3>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (k, v) VALUES (1, [1.0, 2.0, 3.0])");
+#         execute("INSERT INTO %s (k, v) VALUES (2, [2.0, 3.0, 4.0])");
+#         execute("INSERT INTO %s (k, v) VALUES (3, [3.0, 4.0, 5.0])");
+
+#         ClientWarn.instance.captureWarnings();
+#         ResultSet result = execute("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [2.0, 3.0, 4.0] LIMIT 10", 9);
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_PAGE_SIZE_WARNING, 9, 10, 10), ClientWarn.instance.getWarnings().get(0));
+#         assertEquals(1, result.size());
+
+#         ClientWarn.instance.captureWarnings();
+#         result = execute("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [2.0, 3.0, 4.0] LIMIT 10", 11);
+#         assertNull(ClientWarn.instance.getWarnings());
+#         assertEquals(1, result.size());
+#     }
+
+#     @Test
+#     public void cannotHaveAggregationOnANNQuery()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+
+#         assertThatThrownBy(() -> executeNet("SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"))
+#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_AGGREGATION_ERROR);
+#     }
+
+#     @Test
+#     public void multipleVectorColumnsInQueryFailCorrectlyTest() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void annOrderingIsNotAllowedWithoutIndexWhereIndexedColumnExistsInQueryTest() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
+#         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
+#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
+#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void cannotPostFilterOnNonIndexedColumnWithAnnOrdering() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)");
+#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+
+#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+#                              "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+#     }
+
+#     @Test
+#     public void cannotHavePerPartitionLimitWithAnnOrdering()
+#     {
+#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_PARTITION_LIMIT_ERROR);
+#     }
+
+#     @Test
+#     public void cannotCreateIndexOnNonFloatVector()
+#     {
+#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<int, 1>)");
+
+#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'"))
+#             .isInstanceOf(InvalidRequestException.class).hasRootCauseMessage(StorageAttachedIndex.VECTOR_NON_FLOAT_ERROR);
+#     }
+
+#     @Test
+#     public void canOrderWithWhereOnPrimaryColumns() throws Throwable
+#     {
+#         createTable("CREATE TABLE %s (a int, b int, c int, d int, v vector<float, 2>, PRIMARY KEY ((a,b),c,d))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
+
+#         execute("INSERT INTO %s (a, b, c, d, v) VALUES (1, 2, 1, 2, [6.0,1.0])");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE v > [5.0,1.0] ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage("v cannot be restricted by more than one relation in an ANN ordering");
+
+#         ResultSet result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE);
+
+#         createIndex("CREATE CUSTOM INDEX c_idx ON %s(c) USING 'StorageAttachedIndex'");
+
+#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1"))
+#             .isInstanceOf(InvalidQueryException.class).hasMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE);
+
+#         dropIndex("DROP INDEX %s.c_idx");
+#         createIndex("CREATE CUSTOM INDEX ON %s(d) USING 'StorageAttachedIndex'");
+
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c = 1 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND d = 2 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#         result = execute("SELECT * FROM %s WHERE a = 1 AND b = 2 AND c > 0 ORDER BY v ANN OF [2.0,1.0] LIMIT 1", ConsistencyLevel.ONE);
+#         assertEquals(1, result.size());
+#     }
+
+#     @Test
+#     public void canOnlyExecuteWithCorrectConsistencyLevel()
+#     {
+#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
+#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
+#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
+
+#         ClientWarn.instance.captureWarnings();
+#         ResultSet result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.ONE);
+#         assertEquals(3, result.size());
+#         assertNull(ClientWarn.instance.getWarnings());
+
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_ONE);
+#         assertEquals(3, result.size());
+#         assertNull(ClientWarn.instance.getWarnings());
+
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.QUORUM);
+#         assertEquals(3, result.size());
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_WARNING, ConsistencyLevel.QUORUM, ConsistencyLevel.ONE),
+#                      ClientWarn.instance.getWarnings().get(0));
+
+#         ClientWarn.instance.captureWarnings();
+#         result = execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_QUORUM);
+#         assertEquals(3, result.size());
+#         assertEquals(1, ClientWarn.instance.getWarnings().size());
+#         assertEquals(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_WARNING, ConsistencyLevel.LOCAL_QUORUM, ConsistencyLevel.LOCAL_ONE),
+#                      ClientWarn.instance.getWarnings().get(0));
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.SERIAL))
+#             .isInstanceOf(InvalidRequestException.class)
+#             .hasMessage(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_ERROR, ConsistencyLevel.SERIAL));
+
+#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY v ANN OF [2] LIMIT 3", ConsistencyLevel.LOCAL_SERIAL))
+#             .isInstanceOf(InvalidRequestException.class)
+#             .hasMessage(String.format(SelectStatement.TOPK_CONSISTENCY_LEVEL_ERROR, ConsistencyLevel.LOCAL_SERIAL));
+#     }
+
+#     protected ResultSet execute(String query, ConsistencyLevel consistencyLevel)
+#     {
+#         return execute(query, consistencyLevel, -1);
+#     }
+
+#     protected ResultSet execute(String query, int pageSize)
+#     {
+#         return execute(query, ConsistencyLevel.ONE, pageSize);
+#     }
+
+#     protected ResultSet execute(String query, ConsistencyLevel consistencyLevel, int pageSize)
+#     {
+#         ClientState state = ClientState.forInternalCalls();
+#         QueryState queryState = new QueryState(state);
+
+#         CQLStatement statement = QueryProcessor.parseStatement(formatQuery(query), queryState.getClientState());
+#         statement.validate(state);
+
+#         QueryOptions options = QueryOptions.withConsistencyLevel(QueryOptions.forInternalCalls(Collections.emptyList()), consistencyLevel);
+#         options = QueryOptions.withPageSize(options, pageSize);
+
+#         return ((ResultMessage.Rows)statement.execute(queryState, options, Dispatcher.RequestTime.forImmediateExecution())).result;
+#     }
+# }

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -6,32 +6,30 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .porting import *
+from ..util import is_scylla
 
-# public class VectorInvalidQueryTest extends SAITester
-# {
-#     @BeforeClass
-#     public static void setupClass()
-#     {
-#         requireNetwork();
-#     }
+ANN_REQUIRES_INDEX_MESSAGE = "ANN ordering by vector requires the column to be indexed"
+ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = "ANN ordering by vector requires all restricted column(s) to be indexed"
+VECTOR_INDEXES_ANN_ONLY_MESSAGE = "Vector indexes only support ANN queries"
+ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE = "ANN ordering is only supported on float vector indexes"
+TOPK_AGGREGATION_ERROR = "can not be run with aggregation"
 
-#     @Test
-#     public void cannotCreateEmptyVectorColumn()
-#     {
-#         assertThatThrownBy(() -> execute(String.format("CREATE TABLE %s.%s (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))",
-#                                                        KEYSPACE, createTableName())))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("vectors may only have positive dimensions; given 0");
-#     }
+def test_cannot_create_empty_vector_column(cql, test_keyspace):
+        assert_invalid_message(
+            cql,
+            "",
+            "dimension",
+            f"CREATE TABLE {test_keyspace}.test_table (pk int, str_val text, val vector<float, 0>, PRIMARY KEY(pk))"
+        )
 
-#     @Test
-#     public void cannotQueryEmptyVectorColumn()
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-#         assertThatThrownBy(() -> execute("SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("vectors may only have positive dimensions; given 0");
-#     }
+@pytest.mark.xfail(reason="similarity_cosine not implemented yet")
+def test_cannot_query_empty_vector_column(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        assert_invalid_message(
+            cql, table,
+            "dimension",
+            "SELECT similarity_cosine((vector<float, 0>) [], []) FROM %s"
+        )
 
 #     @Test
 #     public void cannotIndex1DWithCosine()
@@ -52,93 +50,99 @@ from .porting import *
 #         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
 #     }
 
-#     @Test
-#     public void cannotQueryWrongNumberOfDimensions()
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+def test_cannot_query_wrong_number_of_dimensions(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val) USING 'vector_index'")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val) USING 'sai'")
 
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])");
-#         execute("INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])");
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (0, 'A', [1.0, 2.0, 3.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (1, 'B', [2.0, 3.0, 4.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (2, 'C', [3.0, 4.0, 5.0])")
+        execute(cql, table, "INSERT INTO %s (pk, str_val, val) VALUES (3, 'D', [4.0, 5.0, 6.0])")
 
-#         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY val ann of [2.5, 3.5] LIMIT 5"))
-#         .isInstanceOf(InvalidRequestException.class)
-#         .hasMessage("Invalid vector literal for val of type vector<float, 3>; expected 3 elements, but given 2");
-#     }
+        assert_invalid_message(
+            cql, table,
+            "Invalid vector literal",
+            "SELECT * FROM %s ORDER BY val ANN OF [2.5, 3.5] LIMIT 5"
+        )
 
-#     @Test
-#     public void testMultiVectorOrderingsNotAllowed() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(str_val) USING 'StorageAttachedIndex'");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val1) USING 'StorageAttachedIndex'");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val2) USING 'StorageAttachedIndex'");
+def test_multi_vector_orderings_not_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val1 vector<float, 3>, val2 vector<float, 3>, PRIMARY KEY(pk))") as table:
 
-#         assertInvalidMessage("Cannot specify more than one ANN ordering",
-#                              "SELECT * FROM %s ORDER BY val1 ann of [2.5, 3.5, 4.5], val2 ann of [2.1, 3.2, 4.0] LIMIT 2");
-#     }
+        # Scylla doesnt support custom indexes on text columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX ON %s(str_val)")
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val1) USING 'vector_index'")
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val2) USING 'vector_index'")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val1) USING 'sai'")
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(val2) USING 'sai'")
 
-#     @Test
-#     public void testDescendingVectorOrderingIsNotAllowed() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, val vector<float, 3>, PRIMARY KEY(pk))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        assert_invalid_message(
+            cql, table, "Cannot specify more than one ANN ordering",
+            "SELECT * FROM %s ORDER BY val1 ANN OF [2.5, 3.5, 4.5], val2 ANN OF [2.1, 3.2, 4.0] LIMIT 2"
+        )
 
-#         assertInvalidMessage("Descending ANN ordering is not supported",
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2");
-#     }
+def test_descending_vector_ordering_is_not_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE INDEX c_index ON %s(val) USING 'vector_index'")
+        else:
+            execute(cql, table, "CREATE INDEX c_index ON %s(val) USING 'sai'")
 
-#     @Test
-#     public void testVectorOrderingIsNotAllowedWithClusteringOrdering() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
+        assert_invalid_message(cql, table, "Descending ANN ordering is not supported",
+                               "SELECT val FROM %s where val=[1.2, 1.2, 1.2] ORDER BY val ann of [2.5, 3.5, 4.5] DESC LIMIT 2")
 
-#         assertInvalidMessage("ANN ordering does not support any other ordering",
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2");
-#     }
+def test_vector_ordering_is_not_allowed_with_clustering_ordering(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (val) using 'vector_index'")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (val) using 'sai'")
 
-#     @Test
-#     public void testVectorOrderingIsNotAllowedWithoutIndex() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))");
+        assert_invalid_message(cql, table, "ANN ordering does not support any other ordering",
+                               "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5], ck ASC LIMIT 2")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5");
+def test_vector_ordering_is_not_allowed_without_index(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, str_val text, val vector<float, 3>, PRIMARY KEY(pk))") as table:
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY val ann of [2.5, 3.5, 4.5] LIMIT 5 ALLOW FILTERING");
-#     }
+def test_invalid_column_name_with_ann(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
+        assert_invalid_message(
+            cql, table,
+            f"Undefined column name",
+            "SELECT k FROM %s ORDER BY bad_col ANN OF [1.0] LIMIT 1"
+        )
 
-#     @Test
-#     public void testInvalidColumnNameWithAnn() throws Throwable
-#     {
-#         String table = createTable(KEYSPACE, "CREATE TABLE %s (k int, c int, v int, primary key (k, c))");
-#         assertInvalidMessage(String.format("Undefined column name bad_col in table %s", KEYSPACE + '.' + table),
-#                              "SELECT k from %s ORDER BY bad_col ANN OF [1.0] LIMIT 1");
-#     }
+def test_cannot_perform_non_ann_query_on_vector_index(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (val) using 'vector_index'")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (val) using 'sai'")
+        assert_invalid_message(
+            cql, table, VECTOR_INDEXES_ANN_ONLY_MESSAGE,
+            "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]"
+        )
 
-#     @Test
-#     public void cannotPerformNonANNQueryOnVectorIndex() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk int, ck int, val vector<float, 3>, PRIMARY KEY(pk, ck))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(val) USING 'StorageAttachedIndex'");
-
-#         assertInvalidMessage(StatementRestrictions.VECTOR_INDEXES_ANN_ONLY_MESSAGE,
-#                              "SELECT * FROM %s WHERE val = [1.0, 2.0, 3.0]");
-#     }
-
-#     @Test
-#     public void cannotOrderWithAnnOnNonVectorColumn() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int, v int, primary key(k))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
-#                              "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1");
-#     }
+def test_cannot_order_with_ann_on_non_vector_column(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, v int, PRIMARY KEY(k))") as table:
+        # Scylla doesn't support custom indexes on int columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX c_index ON %s (v)")
+        assert_invalid_message(
+            cql, table, ANN_ONLY_SUPPORTED_ON_VECTOR_MESSAGE,
+            "SELECT * FROM %s ORDER BY v ANN OF 1 LIMIT 1"
+        )
 
 #     @Test
 #     public void disallowZeroVectorsWithCosineSimilarity()
@@ -154,18 +158,22 @@ from .porting import *
 #         assertThatThrownBy(() -> execute("SELECT * FROM %s ORDER BY value ann of [0.0, 0.0] LIMIT 2")).isInstanceOf(InvalidRequestException.class);
 #     }
 
-#     @Test
-#     public void mustHaveLimitSpecifiedAndWithinMaxAllowed()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_must_have_limit_specified_and_within_max_allowed(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>)") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (v) USING 'vector_index' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'}")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX c_index ON %s (v) using 'sai' WITH OPTIONS = {'similarity_function': 'euclidean'}")
 
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_LIMIT_ERROR);
+        assert_invalid_message(
+            cql, table, "LIMIT" if is_scylla(cql) else "limit",
+            "SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0]"
+        )
 
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(String.format(StorageAttachedIndex.ANN_LIMIT_ERROR, IndexWriterConfig.MAX_TOP_K, 1001));
-#     }
+        assert_invalid_message(
+            cql, table, "LIMIT",
+            f"SELECT * FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 1001"
+        )
 
 #     @Test
 #     public void mustHaveLimitWithinPageSize()
@@ -189,103 +197,126 @@ from .porting import *
 #         assertEquals(1, result.size());
 #     }
 
-#     @Test
-#     public void cannotHaveAggregationOnANNQuery()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_cannot_have_aggregation_on_ann_query(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>, c int)") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'vector_index' WITH OPTIONS = {'similarity_function' : 'EUCLIDEAN'}")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'sai' WITH OPTIONS = {'similarity_function' : 'euclidean'}")
 
-#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (2, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (3, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)")
 
-#         assertThatThrownBy(() -> executeNet("SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"))
-#         .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_AGGREGATION_ERROR);
-#     }
+        assert_invalid_message(
+            cql, table, TOPK_AGGREGATION_ERROR,
+            "SELECT sum(c) FROM %s WHERE k = 1 ORDER BY v ANN OF [0] LIMIT 4"
+        )
 
-#     @Test
-#     public void multipleVectorColumnsInQueryFailCorrectlyTest() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v1) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_multiple_vector_columns_in_query_fail_correctly(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v1 vector<float, 1>, v2 vector<float, 1>)") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v1) USING 'vector_index' WITH OPTIONS = {'similarity_function' : 'EUCLIDEAN'}")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v1) USING 'sai' WITH OPTIONS = {'similarity_function' : 'euclidean'}")
 
-#         execute("INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])");
+        execute(cql, table, "INSERT INTO %s (k, v1, v2) VALUES (1, [1], [2])")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] ALLOW FILTERING");
-#     }
+        # Added a LIMIT here to account for differences in the sequence of validation checks between Scylla and Cassandra.
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s WHERE v1 = [1] ORDER BY v2 ANN OF [2] LIMIT 3 ALLOW FILTERING"
+        )
 
-#     @Test
-#     public void annOrderingIsNotAllowedWithoutIndexWhereIndexedColumnExistsInQueryTest() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<float, 1>, c int)");
-#         createIndex("CREATE CUSTOM INDEX ON %s(c) USING 'StorageAttachedIndex'");
+def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_query(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<float, 1>, c int)") as table:
+        # Scylla doesn't support custom indexes on int columns so we use a regular index.
+        execute(cql, table, "CREATE INDEX c_index ON %s (c)")
 
-#         execute("INSERT INTO %s (k, v, c) VALUES (1, [4], 1)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (2, [3], 10)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (3, [2], 100)");
-#         execute("INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (2, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (3, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (k, v, c) VALUES (4, [1], 1000)")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEX_MESSAGE,
-#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-#     }
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else ANN_REQUIRES_INDEX_MESSAGE,
+            "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
 
-#     @Test
-#     public void cannotPostFilterOnNonIndexedColumnWithAnnOrdering() throws Throwable
-#     {
-#         createTable("CREATE TABLE %s (pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
+def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
+    with create_table(
+        cql,
+        test_keyspace,
+        "(pk1 int, pk2 int, ck1 int, ck2 int, v vector<float, 1>, c int, primary key ((pk1, pk2), ck1, ck2))"
+    ) as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'vector_index' WITH OPTIONS = {'similarity_function': 'EUCLIDEAN'}")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'sai' WITH OPTIONS = {'similarity_function': 'euclidean'}")
 
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)");
-#         execute("INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)");
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (1, 1, 1, 1, [4], 1)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (2, 2, 1, 1, [3], 10)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (3, 3, 1, 1, [2], 100)")
+        execute(cql, table, "INSERT INTO %s (pk1, pk2, ck1, ck2, v, c) VALUES (4, 4, 1, 1, [1], 1000)")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
+        assert_invalid_message(
+            cql, table, ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
+            "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE ck1 >= 0 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+def test_cannot_have_per_partition_limit_with_ann_ordering(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))") as table:
+        if is_scylla(cql):
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'vector_index' WITH OPTIONS = {'similarity_function' : 'EUCLIDEAN'}")
+        else:
+            execute(cql, table, "CREATE CUSTOM INDEX ON %s(v) USING 'sai' WITH OPTIONS = {'similarity_function' : 'euclidean'}")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 1, [1])")
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 2, [2])")
+        execute(cql, table, "INSERT INTO %s (k, c, v) VALUES (1, 3, [3])")
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk1 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
+        assert_invalid_message(
+            cql, table, "do not support per-partition limits",
+            "SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"
+        )
 
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE pk1 = 1 AND pk2 = 1 AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-
-#         assertInvalidMessage(StatementRestrictions.ANN_REQUIRES_INDEXED_FILTERING_MESSAGE,
-#                              "SELECT * FROM %s WHERE token(pk1, pk2) = token(1, 1) AND ck2 = 1 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING");
-#     }
-
-#     @Test
-#     public void cannotHavePerPartitionLimitWithAnnOrdering()
-#     {
-#         createTable("CREATE TABLE %s (k int, c int, v vector<float, 1>, PRIMARY KEY(k, c))");
-#         createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex' WITH OPTIONS = {'similarity_function' : 'euclidean'}");
-
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 1, [1])");
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 2, [2])");
-#         execute("INSERT INTO %s (k, c, v) VALUES (1, 3, [3])");
-
-#         assertThatThrownBy(() -> executeNet("SELECT * FROM %s ORDER BY v ANN OF [2] PER PARTITION LIMIT 1 LIMIT 3"))
-#             .isInstanceOf(InvalidQueryException.class).hasMessage(SelectStatement.TOPK_PARTITION_LIMIT_ERROR);
-#     }
-
-#     @Test
-#     public void cannotCreateIndexOnNonFloatVector()
-#     {
-#         createTable("CREATE TABLE %s (k int PRIMARY KEY, v vector<int, 1>)");
-
-#         assertThatThrownBy(() -> createIndex("CREATE CUSTOM INDEX ON %s(v) USING 'StorageAttachedIndex'"))
-#             .isInstanceOf(InvalidRequestException.class).hasRootCauseMessage(StorageAttachedIndex.VECTOR_NON_FLOAT_ERROR);
-#     }
+def test_cannot_create_index_on_non_float_vector(cql, test_keyspace):
+    with create_table(cql, test_keyspace, "(k int PRIMARY KEY, v vector<int, 1>)") as table:
+        if is_scylla(cql):
+            assert_invalid_message(
+                cql, table, "float",
+                "CREATE CUSTOM INDEX ON %s(v) USING 'vector_index'"
+            )
+        else:
+            assert_invalid_message(
+                cql, table, "float",
+                "CREATE CUSTOM INDEX ON %s(v) USING 'sai'"
+            )
 
 #     @Test
 #     public void canOrderWithWhereOnPrimaryColumns() throws Throwable

--- a/utils/histogram_metrics_helper.cc
+++ b/utils/histogram_metrics_helper.cc
@@ -18,3 +18,18 @@ seastar::metrics::histogram to_metrics_summary(const utils::summary_calculator& 
     }
     return res;
 }
+
+seastar::metrics::histogram estimated_histogram_to_metrics(const utils::estimated_histogram& histogram) {
+    seastar::metrics::histogram res;
+    res.buckets.resize(histogram.bucket_offsets.size());
+    uint64_t cumulative_count = 0;
+    res.sample_count = histogram._count;
+    res.sample_sum = histogram._sample_sum;
+    for (size_t i = 0; i < res.buckets.size(); i++) {
+        auto& v = res.buckets[i];
+        v.upper_bound = histogram.bucket_offsets[i];
+        cumulative_count += histogram.buckets[i];
+        v.count = cumulative_count;
+    }
+    return res;
+}

--- a/utils/histogram_metrics_helper.hh
+++ b/utils/histogram_metrics_helper.hh
@@ -38,6 +38,8 @@ seastar::metrics::histogram to_metrics_histogram(const utils::approx_exponential
     return res;
 }
 
+seastar::metrics::histogram estimated_histogram_to_metrics(const utils::estimated_histogram& histogram);
+
 /*!
  * \brief get a metrics summary from timed_rate_moving_average_with_summary
  *


### PR DESCRIPTION
This PR adds metrics to the vector store client, as described in https://scylladb.atlassian.net/wiki/spaces/RND/pages/86245395/Vector+Store+Core+APIs#Metrics:

- number of requests (aggregated by status)
- latency histogram
- histogram of the limit parameter in the vector search queries
- number of the dns refreshes (aggregated by outcome)

This PR is conditional on https://github.com/scylladb/scylladb/pull/24444, only the last commit is actually a part of this PR.