### PR TITLE
DRAFT!!!!!!11 schema_applier: unify handling of token_metadata during schema change

### DIFF
--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -280,7 +280,7 @@ static future<affected_keyspaces> merge_keyspaces(distributed<service::storage_p
     for (auto& name : created) {
         slogger.info("Creating keyspace {}", name);
         auto sk_after_v = sk_after.contains(name) ? sk_after.at(name) : nullptr;
-        auto ksm = co_await create_keyspace_metadata(proxy,
+        auto ksm = co_await create_keyspace_metadata(
                 schema_result_value_type{name, after.at(name)}, sk_after_v);
         affected.created.push_back(
                 co_await replica::database::prepare_create_keyspace_on_all_shards(
@@ -290,7 +290,7 @@ static future<affected_keyspaces> merge_keyspaces(distributed<service::storage_p
     for (auto& name : altered) {
         slogger.info("Altering keyspace {}", name);
         auto sk_after_v = sk_after.contains(name) ? sk_after.at(name) : nullptr;
-        auto tmp_ksm = co_await create_keyspace_metadata(proxy,
+        auto tmp_ksm = co_await create_keyspace_metadata(
                 schema_result_value_type{name, after.at(name)}, sk_after_v);
         affected.altered.push_back(
                 co_await replica::database::prepare_update_keyspace_on_all_shards(

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -665,12 +665,7 @@ future<> schema_applier::merge_tables_and_views()
     if (_tablet_hint) {
         slogger.info("Tablet metadata changed");
         auto new_token_metadata = co_await _ss.local().prepare_tablet_metadata(_tablet_hint);
-        co_await smp::invoke_on_others([this, &db, &new_token_metadata] () -> future<> {
-            auto& shared_metadata = db.local().get_shared_token_metadata();
-            _affected_tables_and_views.new_token_metadata.local() = shared_metadata.make_token_metadata_ptr(
-                    co_await new_token_metadata->clone_async());
-        });
-        _affected_tables_and_views.new_token_metadata.local() = std::move(new_token_metadata);
+        co_await _affected_tables_and_views.pending_token_metadata.assign(new_token_metadata);
     }
 }
 
@@ -719,11 +714,20 @@ future<schema_diff_per_shard> schema_diff_per_shard::copy_from(replica::database
     co_return result;
 }
 
- locator::mutable_token_metadata_ptr& new_token_metadata::local() {
-    return shards[this_shard_id()];
- }
+future<> pending_token_metadata::assign(locator::mutable_token_metadata_ptr new_token_metadata) {
+    auto& sharded_token_metadata = new_token_metadata->get_shared_token_metadata().container();
+    // clone a local copy of new_token_metadata on all other shards
+    co_await smp::invoke_on_others([this, &new_token_metadata, &sharded_token_metadata] () -> future<> {
+        local() = sharded_token_metadata.local().make_token_metadata_ptr(co_await new_token_metadata->clone_async());
+    });
+    local() = std::move(new_token_metadata);
+}
 
-future<> new_token_metadata::destroy() {
+locator::mutable_token_metadata_ptr& pending_token_metadata::local() {
+    return shards[this_shard_id()];
+}
+
+future<> pending_token_metadata::destroy() {
     return smp::invoke_on_all([this] () {
         shards[this_shard_id()] = nullptr;
     });
@@ -893,12 +897,12 @@ void schema_applier::commit_tables_and_views() {
 
     for (auto& schema : tables.created) {
         auto& ks = db.find_keyspace(schema->ks_name());
-        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.new_token_metadata.local());
+        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.pending_token_metadata.local());
     }
 
     for (auto& schema : views.created) {
         auto& ks = db.find_keyspace(schema->ks_name());
-        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.new_token_metadata.local());
+        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.pending_token_metadata.local());
     }
 
     diff.tables_and_views.local().columns_changed.reserve(tables.altered.size() + views.altered.size());
@@ -980,8 +984,8 @@ future<> schema_applier::finalize_tables_and_views() {
     // We must do it after tables are dropped so that table snapshot doesn't experience missing tablet map,
     // and so that compaction groups are not destroyed altogether.
     // TODO: maybe untangle this dependency
-    if (diff.new_token_metadata.local()) {
-        co_await _ss.local().commit_tablet_metadata(diff.new_token_metadata.local());
+    if (_tablet_hint) {
+        co_await _ss.local().commit_tablet_metadata(diff.pending_token_metadata.local());
     }
 
     co_await sharded_db.invoke_on_all([&diff] (replica::database& db) -> future<> {
@@ -1062,7 +1066,7 @@ future<> schema_applier::post_commit() {
 future<> schema_applier::destroy() {
     co_await _affected_user_types.stop();
     co_await _affected_tables_and_views.tables_and_views.stop();
-    co_await _affected_tables_and_views.new_token_metadata.destroy();
+    co_await _affected_tables_and_views.pending_token_metadata.destroy();
     co_await _functions_batch.stop();
 }
 

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -281,7 +281,7 @@ future<> schema_applier::merge_keyspaces()
                 schema_result_value_type{name, _after.keyspaces.at(name)}, sk_after_v);
         _affected_keyspaces.created.push_back(
                 co_await replica::database::prepare_create_keyspace_on_all_shards(
-                        sharded_db, _proxy, *ksm));
+                        sharded_db, _proxy, *ksm, _pending_token_metadata));
         _affected_keyspaces.names.created.insert(name);
     }
     for (auto& name : altered) {
@@ -291,7 +291,7 @@ future<> schema_applier::merge_keyspaces()
                 schema_result_value_type{name, _after.keyspaces.at(name)}, sk_after_v);
         _affected_keyspaces.altered.push_back(
                 co_await replica::database::prepare_update_keyspace_on_all_shards(
-                        sharded_db, *tmp_ksm));
+                        sharded_db, *tmp_ksm, _pending_token_metadata));
         _affected_keyspaces.names.altered.insert(name);
     }
     for (auto& key : _affected_keyspaces.names.dropped) {
@@ -664,7 +664,8 @@ future<> schema_applier::merge_tables_and_views()
 
     if (_tablet_hint) {
         slogger.info("Tablet metadata changed");
-        auto new_token_metadata = co_await _ss.local().prepare_tablet_metadata(_tablet_hint);
+        auto new_token_metadata = co_await _ss.local().prepare_tablet_metadata(
+                _tablet_hint, _pending_token_metadata.local());
         co_await _pending_token_metadata.assign(new_token_metadata);
     }
 }
@@ -851,6 +852,9 @@ future<> schema_applier::prepare(utils::chunked_vector<mutation>& muts) {
 
 future<> schema_applier::update() {
     _after = co_await get_schema_persisted_state();
+
+    co_await _pending_token_metadata.assign(
+            co_await _ss.local().get_mutable_token_metadata_ptr());
 
     co_await merge_keyspaces();
     co_await merge_types();

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -665,7 +665,7 @@ future<> schema_applier::merge_tables_and_views()
     if (_tablet_hint) {
         slogger.info("Tablet metadata changed");
         auto new_token_metadata = co_await _ss.local().prepare_tablet_metadata(_tablet_hint);
-        co_await _affected_tables_and_views.pending_token_metadata.assign(new_token_metadata);
+        co_await _pending_token_metadata.assign(new_token_metadata);
     }
 }
 
@@ -712,25 +712,6 @@ future<schema_diff_per_shard> schema_diff_per_shard::copy_from(replica::database
     }
 
     co_return result;
-}
-
-future<> pending_token_metadata::assign(locator::mutable_token_metadata_ptr new_token_metadata) {
-    auto& sharded_token_metadata = new_token_metadata->get_shared_token_metadata().container();
-    // clone a local copy of new_token_metadata on all other shards
-    co_await smp::invoke_on_others([this, &new_token_metadata, &sharded_token_metadata] () -> future<> {
-        local() = sharded_token_metadata.local().make_token_metadata_ptr(co_await new_token_metadata->clone_async());
-    });
-    local() = std::move(new_token_metadata);
-}
-
-locator::mutable_token_metadata_ptr& pending_token_metadata::local() {
-    return shards[this_shard_id()];
-}
-
-future<> pending_token_metadata::destroy() {
-    return smp::invoke_on_all([this] () {
-        shards[this_shard_id()] = nullptr;
-    });
 }
 
 static future<> notify_tables_and_views(service::migration_notifier& notifier, const affected_tables_and_views& diff) {
@@ -897,12 +878,12 @@ void schema_applier::commit_tables_and_views() {
 
     for (auto& schema : tables.created) {
         auto& ks = db.find_keyspace(schema->ks_name());
-        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.pending_token_metadata.local());
+        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, _pending_token_metadata.local());
     }
 
     for (auto& schema : views.created) {
         auto& ks = db.find_keyspace(schema->ks_name());
-        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, diff.pending_token_metadata.local());
+        db.add_column_family(ks, schema, ks.make_column_family_config(*schema, db), replica::database::is_new_cf::yes, _pending_token_metadata.local());
     }
 
     diff.tables_and_views.local().columns_changed.reserve(tables.altered.size() + views.altered.size());
@@ -985,7 +966,7 @@ future<> schema_applier::finalize_tables_and_views() {
     // and so that compaction groups are not destroyed altogether.
     // TODO: maybe untangle this dependency
     if (_tablet_hint) {
-        co_await _ss.local().commit_tablet_metadata(diff.pending_token_metadata.local());
+        co_await _ss.local().commit_tablet_metadata(_pending_token_metadata.local());
     }
 
     co_await sharded_db.invoke_on_all([&diff] (replica::database& db) -> future<> {
@@ -1066,7 +1047,7 @@ future<> schema_applier::post_commit() {
 future<> schema_applier::destroy() {
     co_await _affected_user_types.stop();
     co_await _affected_tables_and_views.tables_and_views.stop();
-    co_await _affected_tables_and_views.pending_token_metadata.destroy();
+    co_await _pending_token_metadata.destroy();
     co_await _functions_batch.stop();
 }
 

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -850,7 +850,7 @@ future<> schema_applier::load_mutable_token_metadata() {
     locator::mutable_token_metadata_ptr current_token_metadata = co_await _ss.local().get_mutable_token_metadata_ptr();
     if (_tablet_hint) {
         slogger.info("Tablet metadata changed");
-        new_token_metadata = co_await _ss.local().prepare_tablet_metadata(
+        new_token_metadata = co_await _ss.local().prepare_token_metadata_with_tablets_change(
                 _tablet_hint, current_token_metadata);
         co_return co_await _pending_token_metadata.assign(new_token_metadata);
     }

--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -661,13 +661,6 @@ future<> schema_applier::merge_tables_and_views()
         _affected_tables_and_views.table_shards.insert({uuid,
                 co_await replica::database::prepare_drop_table_on_all_shards(db, uuid)});
     });
-
-    if (_tablet_hint) {
-        slogger.info("Tablet metadata changed");
-        auto new_token_metadata = co_await _ss.local().prepare_tablet_metadata(
-                _tablet_hint, _pending_token_metadata.local());
-        co_await _pending_token_metadata.assign(new_token_metadata);
-    }
 }
 
 future<frozen_schema_diff> schema_diff_per_shard::freeze() const {
@@ -850,12 +843,23 @@ future<> schema_applier::prepare(utils::chunked_vector<mutation>& muts) {
     }
 }
 
+// Loads metadata into a single source of truth to ensure consistency.
+// It will be committed later if required by the current schema change.
+future<> schema_applier::load_mutable_token_metadata() {
+    locator::mutable_token_metadata_ptr new_token_metadata = nullptr;
+    locator::mutable_token_metadata_ptr current_token_metadata = co_await _ss.local().get_mutable_token_metadata_ptr();
+    if (_tablet_hint) {
+        slogger.info("Tablet metadata changed");
+        new_token_metadata = co_await _ss.local().prepare_tablet_metadata(
+                _tablet_hint, current_token_metadata);
+        co_return co_await _pending_token_metadata.assign(new_token_metadata);
+    }
+    co_await _pending_token_metadata.assign(current_token_metadata);
+}
+
 future<> schema_applier::update() {
     _after = co_await get_schema_persisted_state();
-
-    co_await _pending_token_metadata.assign(
-            co_await _ss.local().get_mutable_token_metadata_ptr());
-
+    co_await load_mutable_token_metadata();
     co_await merge_keyspaces();
     co_await merge_types();
     co_await _types_storage.init(_proxy.local().get_db(), _affected_keyspaces, _affected_user_types);

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -211,6 +211,12 @@ public:
     future<> destroy();
 
 private:
+    future<> merge_keyspaces();
+    future<> merge_types();
+    future<> merge_tables_and_views();
+    future<> merge_functions();
+    future<> merge_aggregates();
+
     void commit_tables_and_views();
     future<> finalize_tables_and_views();
     void commit_on_shard(replica::database& db);

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -149,8 +149,6 @@ struct affected_tables_and_views {
 
     std::unique_ptr<replica::tables_metadata_lock_on_all_shards> locks;
     std::unordered_map<table_id, replica::global_table_ptr> table_shards;
-
-    pending_token_metadata pending_token_metadata;
 };
 
 // We wrap it with pointer because change_batch needs to be constructed and destructed
@@ -170,6 +168,8 @@ class schema_applier {
 
     std::set<sstring> _keyspaces;
     std::unordered_map<keyspace_name, table_selector> _affected_tables;
+
+    locator::pending_token_metadata _pending_token_metadata;
     locator::tablet_metadata_change_hint _tablet_hint;
 
     schema_persisted_state _before;

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -130,9 +130,10 @@ struct schema_diff_per_shard {
 };
 
 
-class new_token_metadata {
+class pending_token_metadata {
     std::vector<locator::mutable_token_metadata_ptr> shards{smp::count};
 public:
+    future<> assign(locator::mutable_token_metadata_ptr new_token_metadata);
     locator::mutable_token_metadata_ptr& local();
     future<> destroy();
 };
@@ -149,7 +150,7 @@ struct affected_tables_and_views {
     std::unique_ptr<replica::tables_metadata_lock_on_all_shards> locks;
     std::unordered_map<table_id, replica::global_table_ptr> table_shards;
 
-    new_token_metadata new_token_metadata; // represents token metadata after updating tablets metadata, nullptr if there was no change
+    pending_token_metadata pending_token_metadata;
 };
 
 // We wrap it with pointer because change_batch needs to be constructed and destructed

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -169,6 +169,9 @@ class schema_applier {
     std::set<sstring> _keyspaces;
     std::unordered_map<keyspace_name, table_selector> _affected_tables;
 
+    // Copy of token metadata used for schema change, it has two purposes:
+    // - makes sure all updated schema entities use the same metadata
+    // - allows to change tablets metadata without immediately committing it.
     locator::pending_token_metadata _pending_token_metadata;
     locator::tablet_metadata_change_hint _tablet_hint;
 

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -187,6 +187,7 @@ class schema_applier {
     functions_change_batch_all_shards _functions_batch; // includes aggregates
 
     future<schema_persisted_state> get_schema_persisted_state();
+    future<> load_mutable_token_metadata();
 public:
     schema_applier(
             sharded<service::storage_proxy>& proxy,

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1280,7 +1280,6 @@ utils::chunked_vector<mutation> make_drop_keyspace_mutations(schema_features fea
  * @param partition Keyspace attributes in serialized form
  */
 future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
-        distributed<service::storage_proxy>& proxy,
         const schema_result_value_type& result,
         lw_shared_ptr<query::result_set> scylla_specific_rs)
 {

--- a/db/schema_tables.hh
+++ b/db/schema_tables.hh
@@ -238,7 +238,7 @@ utils::chunked_vector<mutation> make_create_keyspace_mutations(schema_features f
 
 utils::chunked_vector<mutation> make_drop_keyspace_mutations(schema_features features, lw_shared_ptr<keyspace_metadata> keyspace, api::timestamp_type timestamp);
 
-future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition, lw_shared_ptr<query::result_set> scylla_specific_rs);
+future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(const schema_result_value_type& partition, lw_shared_ptr<query::result_set> scylla_specific_rs);
 
 future<lw_shared_ptr<query::result_set>> extract_scylla_specific_keyspace_info(distributed<service::storage_proxy>& proxy, const schema_result_value_type& partition);
 

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -518,7 +518,7 @@ vnode_effective_replication_map::factory_key vnode_effective_replication_map::ma
     return factory_key(rs->get_type(), rs->get_config_options(), tmptr->get_ring_version());
 }
 
-future<vnode_effective_replication_map_ptr> effective_replication_map_factory::create_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr) {
+future<vnode_effective_replication_map_ptr> effective_replication_map_factory::create_effective_replication_map(replication_strategy_ptr rs, const token_metadata_ptr& tmptr) {
     // lookup key on local shard
     auto key = vnode_effective_replication_map::make_factory_key(rs, tmptr);
     auto erm = find_effective_replication_map(key);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -505,7 +505,7 @@ public:
     // vnode_effective_replication_map for the local shard.
     //
     // Therefore create should be called first on shard 0, then on all other shards.
-    future<vnode_erm_ptr> create_effective_replication_map(replication_strategy_ptr rs, token_metadata_ptr tmptr);
+    future<vnode_erm_ptr> create_effective_replication_map(replication_strategy_ptr rs, const token_metadata_ptr& tmptr);
 
     future<> stop() noexcept;
 

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -859,6 +859,10 @@ void token_metadata::set_shared_token_metadata(shared_token_metadata& stm) {
     _shared_token_metadata = &stm;
 }
 
+shared_token_metadata& token_metadata::get_shared_token_metadata() {
+    return *_shared_token_metadata;
+}
+
 const utils::chunked_vector<token>&
 token_metadata::sorted_tokens() const {
     return _impl->sorted_tokens();

--- a/locator/token_metadata.cc
+++ b/locator/token_metadata.cc
@@ -1325,4 +1325,28 @@ gms::inet_address host_id_or_endpoint::resolve_endpoint(const gms::gossiper& g) 
     return *endpoint_opt;
 }
 
+future<> pending_token_metadata::assign(locator::mutable_token_metadata_ptr new_token_metadata) {
+     auto& sharded_token_metadata = new_token_metadata->get_shared_token_metadata().container();
+    // clone a local copy of new_token_metadata on all other shards
+    co_await smp::invoke_on_others([this, &new_token_metadata, &sharded_token_metadata] () -> future<> {
+        local() = sharded_token_metadata.local().make_token_metadata_ptr(
+                co_await new_token_metadata->clone_async());
+    });
+    local() = std::move(new_token_metadata);
+}
+
+locator::mutable_token_metadata_ptr& pending_token_metadata::local() {
+    return _shards[this_shard_id()];
+}
+
+locator::token_metadata_ptr pending_token_metadata::local() const {
+    return _shards[this_shard_id()];
+}
+
+future<> pending_token_metadata::destroy() {
+    return smp::invoke_on_all([this] () {
+        _shards[this_shard_id()] = nullptr;
+    });
+}
+
 } // namespace locator

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -353,6 +353,8 @@ public:
     version_t get_version() const;
     void set_version(version_t version);
 
+    shared_token_metadata& get_shared_token_metadata();
+
     friend class token_metadata_impl;
     friend class shared_token_metadata;
 private:

--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -492,4 +492,14 @@ private:
     friend struct ::sort_by_proximity_topology;
 };
 
+class pending_token_metadata {
+    std::vector<locator::mutable_token_metadata_ptr> _shards{smp::count};
+public:
+    future<> assign(locator::mutable_token_metadata_ptr new_token_metadata);
+    locator::mutable_token_metadata_ptr& local();
+    locator::token_metadata_ptr local() const;
+    future<> destroy();
+    bool updated = false;
+};
+
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -746,7 +746,8 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, v);
         auto ksm = co_await create_keyspace_metadata(v, scylla_specific_rs);
-        auto ks = co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        auto token_metadata = get_shared_token_metadata().get();
+        auto ks = co_await create_keyspace(ksm, proxy.local().get_erm_factory(), token_metadata, system_keyspace::no);
         insert_keyspace(std::move(ks));
         co_return;
     }));
@@ -854,12 +855,11 @@ future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, 
     });
 }
 
-future<keyspace_change> database::prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const {
+future<keyspace_change> database::prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata, const locator::token_metadata_ptr& token_metadata) const {
     auto strategy = keyspace::create_replication_strategy(metadata);
     locator::vnode_effective_replication_map_ptr erm = nullptr;
     if (!strategy->is_per_table()) {
-        erm = co_await ks.create_effective_replication_map(strategy,
-            get_shared_token_metadata());
+        erm = co_await ks.create_effective_replication_map(strategy, token_metadata);
     }
     co_return keyspace_change{
         .metadata = metadata,
@@ -881,14 +881,14 @@ void database::update_keyspace(std::unique_ptr<keyspace_change> change) {
     ks.apply(*change);
 }
 
-future<database::keyspace_change_per_shard> database::prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm) {
+future<database::keyspace_change_per_shard> database::prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm, const locator::pending_token_metadata& pending_token_metadata) {
     keyspace_change_per_shard changes(smp::count);
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto& ks = db.find_keyspace(ksm.name());
         auto new_ksm = ::make_lw_shared<keyspace_metadata>(ksm.name(), ksm.strategy_name(), ksm.strategy_options(), ksm.initial_tablets(), ksm.durable_writes(),
                 ks.metadata()->cf_meta_data() | std::views::values | std::ranges::to<std::vector>(), ks.metadata()->user_types(), ksm.get_storage_options());
 
-        auto change = co_await db.prepare_update_keyspace(ks, new_ksm);
+        auto change = co_await db.prepare_update_keyspace(ks, new_ksm, pending_token_metadata.local());
         changes[this_shard_id()] = make_foreign(std::make_unique<keyspace_change>(std::move(change)));
         co_return;
     });
@@ -994,7 +994,8 @@ future<> database::create_local_system_table(
                 std::nullopt,
                 durable
                 );
-        auto ks = co_await create_keyspace(ksm, erm_factory, replica::database::system_keyspace::yes);
+        auto token_metadata = get_shared_token_metadata().get();
+        auto ks = co_await create_keyspace(ksm, erm_factory, token_metadata, replica::database::system_keyspace::yes);
         insert_keyspace(std::move(ks));
     }
     auto& ks = find_keyspace(ks_name);
@@ -1387,8 +1388,8 @@ keyspace::create_replication_strategy(lw_shared_ptr<keyspace_metadata> metadata)
     return abstract_replication_strategy::create_replication_strategy(metadata->strategy_name(), params);
 }
 
-future<locator::vnode_effective_replication_map_ptr> keyspace::create_effective_replication_map(locator::replication_strategy_ptr strategy, const locator::shared_token_metadata& stm) const {
-    co_return co_await _erm_factory.create_effective_replication_map(strategy, stm.get());
+future<locator::vnode_effective_replication_map_ptr> keyspace::create_effective_replication_map(locator::replication_strategy_ptr strategy, const locator::token_metadata_ptr& tm) const {
+    co_return co_await _erm_factory.create_effective_replication_map(strategy, tm);
 }
 
 void
@@ -1494,18 +1495,18 @@ std::vector<view_ptr> database::get_views() const {
             | std::views::transform([] (auto& cf) { return view_ptr(cf->schema()); }));
 }
 
-future<std::unique_ptr<keyspace>> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
+future<std::unique_ptr<keyspace>> database::create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, const locator::token_metadata_ptr& token_metadata, system_keyspace system) {
     auto kscfg = make_keyspace_config(*ksm, system);
     auto ks(std::make_unique<keyspace>(std::move(kscfg), erm_factory));
-    auto change = co_await prepare_update_keyspace(*ks, ksm);
+    auto change = co_await prepare_update_keyspace(*ks, ksm, token_metadata);
     ks->apply(std::move(change));
     co_return ks;
 }
 
 future<std::unique_ptr<keyspace>>
-database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system) {
+database::create_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, const locator::token_metadata_ptr& token_metadata, system_keyspace system) {
     co_await get_sstables_manager(system).init_keyspace_storage(ksm->get_storage_options(), ksm->name());
-    co_return co_await create_in_memory_keyspace(ksm, erm_factory, system);
+    co_return co_await create_in_memory_keyspace(ksm, erm_factory, token_metadata, system);
 }
 
 void database::insert_keyspace(std::unique_ptr<keyspace> ks) {
@@ -1516,11 +1517,11 @@ void database::insert_keyspace(std::unique_ptr<keyspace> ks) {
     _keyspaces.emplace(name, std::move(*ks));
 }
 
-future<database::created_keyspace_per_shard> database::prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata) {
+future<database::created_keyspace_per_shard> database::prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ks_metadata, const locator::pending_token_metadata& pending_token_metadata) {
     created_keyspace_per_shard created(smp::count);
     co_await modify_keyspace_on_all_shards(sharded_db, [&] (replica::database& db) -> future<> {
         auto ksm = keyspace_metadata::new_keyspace(ks_metadata);
-        auto ks = co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
+        auto ks = co_await db.create_keyspace(ksm, proxy.local().get_erm_factory(), pending_token_metadata.local(), system_keyspace::no);
         created[this_shard_id()] = make_foreign(std::move(ks));
     });
     co_return created;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -745,7 +745,7 @@ future<> database::parse_system_tables(distributed<service::storage_proxy>& prox
     using namespace db::schema_tables;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, v);
-        auto ksm = co_await create_keyspace_metadata(proxy, v, scylla_specific_rs);
+        auto ksm = co_await create_keyspace_metadata(v, scylla_specific_rs);
         auto ks = co_await create_keyspace(ksm, proxy.local().get_erm_factory(), system_keyspace::no);
         insert_keyspace(std::move(ks));
         co_return;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1397,7 +1397,7 @@ public:
             lw_shared_ptr<keyspace_metadata> metadata);
     future<locator::vnode_effective_replication_map_ptr> create_effective_replication_map(
             locator::replication_strategy_ptr strategy,
-            const locator::shared_token_metadata& stm) const;
+            const locator::token_metadata_ptr& tm) const;
     void update_effective_replication_map(locator::vnode_effective_replication_map_ptr erm);
 
     /**
@@ -1664,7 +1664,7 @@ private:
     future<> flush_system_column_families();
 
     using system_keyspace = bool_class<struct system_keyspace_tag>;
-    future<std::unique_ptr<keyspace>> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<std::unique_ptr<keyspace>> create_in_memory_keyspace(const lw_shared_ptr<keyspace_metadata>& ksm, locator::effective_replication_map_factory& erm_factory, const locator::token_metadata_ptr& token_metadata, system_keyspace system);
     void setup_metrics();
     void setup_scylla_memory_diagnostics_producer();
     reader_concurrency_semaphore& read_concurrency_sem();
@@ -1682,9 +1682,9 @@ private:
     template<typename Future>
     Future update_write_metrics(Future&& f);
     void update_write_metrics_for_timed_out_write();
-    future<std::unique_ptr<keyspace>> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, system_keyspace system);
+    future<std::unique_ptr<keyspace>> create_keyspace(const lw_shared_ptr<keyspace_metadata>&, locator::effective_replication_map_factory& erm_factory, const locator::token_metadata_ptr& token_metadata, system_keyspace system);
     void remove(table&) noexcept;
-    future<keyspace_change> prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const;
+    future<keyspace_change> prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata, const locator::token_metadata_ptr& token_metadata) const;
     static future<> modify_keyspace_on_all_shards(sharded<database>& sharded_db, std::function<future<>(replica::database&)> func);
 
     future<> foreach_reader_concurrency_semaphore(std::function<future<>(reader_concurrency_semaphore&)> func);
@@ -1784,14 +1784,14 @@ public:
      *
      * @return ready future when the operation is complete
      */
-    static future<created_keyspace_per_shard> prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm);
+    static future<created_keyspace_per_shard> prepare_create_keyspace_on_all_shards(sharded<database>& sharded_db, sharded<service::storage_proxy>& proxy, const keyspace_metadata& ksm, const locator::pending_token_metadata& pending_token_metadata);
     /* below, find_keyspace throws no_such_<type> on fail */
     keyspace& find_keyspace(std::string_view name);
     const keyspace& find_keyspace(std::string_view name) const;
     bool has_keyspace(std::string_view name) const;
     void validate_keyspace_update(keyspace_metadata& ksm);
     void validate_new_keyspace(keyspace_metadata& ksm);
-    static future<keyspace_change_per_shard> prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm);
+    static future<keyspace_change_per_shard> prepare_update_keyspace_on_all_shards(sharded<database>& sharded_db, const keyspace_metadata& ksm, const locator::pending_token_metadata& pending_token_metadata);
     std::vector<sstring> get_non_system_keyspaces() const;
     std::vector<sstring> get_user_keyspaces() const;
     std::vector<sstring> get_all_keyspaces() const;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -108,8 +108,15 @@ future<> migration_manager::drain()
 void migration_manager::init_messaging_service()
 {
     auto reload_schema_in_bg = [this] {
-        (void) with_gate(_background_tasks, [this] {
-            return reload_schema().handle_exception([] (std::exception_ptr ep) {
+        (void) with_gate(_background_tasks, [this] -> future<> {
+            // Reloading schema triggers schema merge which depends on storage service.
+            while (!_ss.local_is_initialized()) {
+                if (_as.abort_requested()) {
+                    co_return;
+                }
+                co_await seastar::sleep_abortable(10ms, _as);
+            }
+            co_await reload_schema().handle_exception([] (std::exception_ptr ep) {
                 // Due to features being unordered, reload might fail because
                 // some tables still have the wrong version and looking up e.g.
                 // the base-table of a view will fail.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5613,9 +5613,12 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
     return update_topology_change_info(reason, acquire_merge_lock::no);
 }
 
-future<locator::mutable_token_metadata_ptr> storage_service::prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint) {
+future<locator::mutable_token_metadata_ptr> storage_service::prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata) {
     SCYLLA_ASSERT(this_shard_id() == 0);
-    auto tmptr = co_await get_mutable_token_metadata_ptr();
+    auto tmptr = pending_token_metadata;
+    if (!tmptr) {
+        tmptr = co_await get_mutable_token_metadata_ptr();
+    }
     if (hint) {
         co_await replica::update_tablet_metadata(_db.local(), _qp, tmptr->tablets(), hint);
     } else {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5613,7 +5613,7 @@ future<> storage_service::keyspace_changed(const sstring& ks_name) {
     return update_topology_change_info(reason, acquire_merge_lock::no);
 }
 
-future<locator::mutable_token_metadata_ptr> storage_service::prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata) {
+future<locator::mutable_token_metadata_ptr> storage_service::prepare_token_metadata_with_tablets_change(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata) {
     SCYLLA_ASSERT(this_shard_id() == 0);
     auto tmptr = pending_token_metadata;
     if (!tmptr) {
@@ -5635,7 +5635,7 @@ future<> storage_service::commit_tablet_metadata(locator::mutable_token_metadata
 
 future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_change_hint& hint) {
     co_await commit_tablet_metadata(
-            co_await prepare_tablet_metadata(hint));
+            co_await prepare_token_metadata_with_tablets_change(hint));
 }
 
 future<> storage_service::process_tablet_split_candidate(table_id table) noexcept {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -77,6 +77,9 @@ class batchlog_manager;
 namespace view {
 class view_builder;
 }
+namespace schema_tables {
+class schema_applier;
+}
 }
 
 namespace netw {
@@ -255,7 +258,7 @@ public:
     future<> uninit_messaging_service();
 
     // If a hint is provided, only the changed parts of the tablet metadata will be (re)loaded.
-    future<locator::mutable_token_metadata_ptr> prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint);
+    future<locator::mutable_token_metadata_ptr> prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata = nullptr);
     future<> commit_tablet_metadata(locator::mutable_token_metadata_ptr tmptr);
     future<> update_tablet_metadata(const locator::tablet_metadata_change_hint& hint);
 
@@ -306,6 +309,7 @@ private:
 
     friend struct ::node_ops_ctl;
     friend void check_raft_rpc_scheduling_group(storage_service&, std::string_view);
+    friend class db::schema_tables::schema_applier;
 public:
 
     const gms::gossiper& gossiper() const noexcept {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -258,7 +258,7 @@ public:
     future<> uninit_messaging_service();
 
     // If a hint is provided, only the changed parts of the tablet metadata will be (re)loaded.
-    future<locator::mutable_token_metadata_ptr> prepare_tablet_metadata(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata = nullptr);
+    future<locator::mutable_token_metadata_ptr> prepare_token_metadata_with_tablets_change(const locator::tablet_metadata_change_hint& hint, mutable_token_metadata_ptr pending_token_metadata = nullptr);
     future<> commit_tablet_metadata(locator::mutable_token_metadata_ptr tmptr);
     future<> update_tablet_metadata(const locator::tablet_metadata_change_hint& hint);
 


### PR DESCRIPTION
TODO:
- cover letter
- split commit_tablet_metadata into prepare + commit phases
- more testing runs

Fixes #https://github.com/scylladb/scylladb/issues/24414