### PR TITLE
skip instead of xfail test_change_replication_factor_1_to_0

### DIFF
--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.xfail(reason="issue #20282"), pytest.mark.nightly]),
+        pytest.param(True, id="tablets", marks=[pytest.mark.skip(reason="issue #20282"), pytest.mark.nightly]),
     ],
 )
 @pytest.mark.asyncio


### PR DESCRIPTION
It's a waste of good machine time to xfail this rather than just skip. It takes >3m just to run the test and xfail.
We have a marker for it, we know why we skip it.

Fixes: https://github.com/scylladb/scylladb/issues/25310

Improvement to CI runtime, no real need to backport. We could, perhaps. Not material.