### PR TITLE
test/boost/vector_store_client_test.cc: Fix flaky tests

### DIFF
--- a/test/boost/vector_store_client_test.cc
+++ b/test/boost/vector_store_client_test.cc
@@ -64,7 +64,9 @@ auto generate_unavailable_localhost_port() -> port_number {
 auto listen_on_ephemeral_port(std::unique_ptr<http_server> server) -> future<std::tuple<std::unique_ptr<http_server>, socket_address>> {
     auto inaddr = net::inet_address(LOCALHOST);
     auto const addr = socket_address(inaddr, 0);
-    co_await server->listen(addr);
+    ::listen_options opts;
+    opts.set_fixed_cpu(this_shard_id());
+    co_await server->listen(addr, opts);
     auto const& listeners = http_server_tester::listeners(*server);
     BOOST_CHECK_EQUAL(listeners.size(), 1);
     co_return std::make_tuple(std::move(server), listeners[0].local_address().port());


### PR DESCRIPTION
The vector_store_client_test was observed to be flaky, sometimes hanging while waiting for a response from HTTP server.

Problem:
The default load balancing algorithm (in Seastar's posix_server_socket_impl::accept) could route an incoming connection to a different shard than the one executing the test. Because the HTTP server is a non-sharded service running only on the test's originating shard, any connection submitted to another shard would never be handled, causing the test client to hang waiting for response.

Solution:
The patch resolves the issue by explicitly setting fixed cpu load balancing algorithm. This ensures that incoming connections are always handled on the same shard where the HTTP server running.

This issue exists on master only. No backport needed.

References: VECTOR-150
References: #25234