### PR TITLE
scylla-sstable: print_query_results_json: continue loop if row is disengaged

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -2856,6 +2856,7 @@ void print_query_results_json(const cql3::result& result) {
             writer.Key(column_metadata[i]->name->text());
             if (!row[i]) {
                 writer.Null();
+                continue;
             }
             const auto value = to_json_string(*column_metadata[i]->type, *row[i]);
             const auto type = to_json_type(*column_metadata[i]->type, *row[i]);


### PR DESCRIPTION
Otherwise it is accessed right when exiting the if block.

Fixes #25325

* Requires backport as far 2025.2 (introduced in https://github.com/scylladb/scylladb/commit/5d09182ce5dbac346926b61f6c90d0f2feace89c)