### PR TITLE
test/alternator: enable more relevant logs in CI.

### DIFF
--- a/test/alternator/suite.yaml
+++ b/test/alternator/suite.yaml
@@ -5,6 +5,16 @@ run_first:
     - test_scan
     - test_tracing
     - test_ttl
+extra_scylla_cmdline_options:
+  - '--logger-log-level=alternator-auth=trace'
+  - '--logger-log-level=alternator-conditions=trace'
+  - '--logger-log-level=alternator-executor=trace'
+  - '--logger-log-level=alternator-serialization=trace'
+  - '--logger-log-level=alternator-server=trace'
+  - '--logger-log-level=alternator-executor=trace'
+  - '--logger-log-level=alternator_controller=trace'
+  - '--logger-log-level=alternator_ttl=trace'
+  - '--logger-log-level=paxos=trace'
 extra_scylla_config_options:
   {
     experimental_features: [


### PR DESCRIPTION
This patch sets, for alternator test suite, all 'alternator-*' loggers and 'paxos' logger to trace level. This should significantly ease debugging of failed tests, while it has no effect on test time and increases log size only by 7%. This affects running alternator tests only with `test.py`, not with `test/alternator/run`.

Closes #24645

Suggested backporting - it may help if tests fail in backport branches.