### PR TITLE
[Backport 2025.2] repair: distribute tablet_repair_task_metas between shards

### DIFF
--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -12,6 +12,7 @@
 #include "repair/row_level.hh"
 
 #include "locator/network_topology_strategy.hh"
+#include "seastar/core/on_internal_error.hh"
 #include "streaming/stream_reason.hh"
 #include "gms/inet_address.hh"
 #include "gms/gossiper.hh"
@@ -2259,10 +2260,95 @@ static std::unordered_set<locator::host_id> get_token_owners_in_dcs(std::vector<
     return dc_endpoints;
 }
 
+future<> repair::remote_metas::for_each_local_meta(std::function<future<>(const tablet_repair_task_meta&)> func) const {
+    size_t this_shard = this_shard_id();
+    if (!_metas_on_shards[this_shard]) {
+        co_return;
+    }
+    for (size_t i = 0; i < _metas_on_shards[this_shard]->metas.size(); ++i) {
+        co_await func(_metas_on_shards[this_shard]->metas[i]);
+    }
+}
+
+future<repair::hosts_and_tables> repair::remote_metas::get_hosts_and_tables() const {
+    repair::hosts_and_tables ret;
+
+    co_await coroutine::parallel_for_each(smp::all_cpus(), [this, &ret](const auto& shard) -> future<> {
+        auto hosts_and_tables = co_await smp::submit_to(shard, [this]() mutable -> future<repair::hosts_and_tables> {
+            repair::hosts_and_tables shard_ret;
+
+            co_await for_each_local_meta([&shard_ret](const auto& meta) {
+                shard_ret.hosts.insert(meta.neighbors.all.begin(), meta.neighbors.all.end());
+                shard_ret.tables.insert(meta.tid);
+                return make_ready_future<>();
+            });
+
+            co_return shard_ret;
+        });
+
+        ret.hosts.insert(hosts_and_tables.hosts.begin(), hosts_and_tables.hosts.end());
+        ret.tables.insert(hosts_and_tables.tables.begin(), hosts_and_tables.tables.end());
+    });
+
+    co_return ret;
+}
+
+size_t repair::remote_metas::size() const {
+    return _metas_count;
+}
+
+void repair::remote_metas::clear() {
+    _metas_on_shards.clear();
+    _metas_count = 0;
+}
+
+future<> repair::remote_metas_builder::allocate_on_shard(size_t shard_id) {
+    _remote_metas._metas_on_shards[shard_id] = co_await smp::submit_to(shard_id, []() -> future<remote_metas::remote_data_ptr> {
+        auto ptr = make_lw_shared<remote_data>();
+        co_return remote_metas::remote_data_ptr(std::move(ptr));
+    });
+}
+
+future<> repair::remote_metas_builder::flush(size_t shard_id) {
+    auto it = _pending_metas.find(shard_id);
+    if (it == _pending_metas.end() || it->second.empty()) {
+        co_return;
+    }
+    auto local_pending_metas = std::move(it->second);
+    _pending_metas.erase(it);
+
+    auto& metas_ptr = _remote_metas._metas_on_shards[shard_id];
+    if (!metas_ptr) {
+        co_await allocate_on_shard(shard_id);
+    }
+    co_await smp::submit_to(shard_id, [metas = std::move(local_pending_metas), &metas_ptr]() {
+        metas_ptr->metas.reserve(metas_ptr->metas.size() + metas.size());
+        for (auto& m : metas) {
+            metas_ptr->metas.emplace_back(std::move(m));
+        }
+    });
+}
+
+future<> repair::remote_metas_builder::add_on_shard(size_t shard_id, tablet_repair_task_meta meta) {
+    ++_remote_metas._metas_count;
+    auto& local_pending_metas = _pending_metas[shard_id];
+    local_pending_metas.push_back(std::move(meta));
+    if (local_pending_metas.size() >= max_pending_metas_per_shard) {
+        co_await flush(shard_id);
+    }
+}
+
+future<repair::remote_metas> repair::remote_metas_builder::build() && {
+    for (size_t shard_id = 0; shard_id < smp::count; ++shard_id) {
+        co_await flush(shard_id);
+    }
+    co_return std::move(_remote_metas);
+}
+
 // Repair all tablets belong to this node for the given table
 future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_name, std::vector<sstring> table_names, bool primary_replica_only, dht::token_range_vector ranges_specified, std::vector<sstring> data_centers, std::unordered_set<locator::host_id> hosts, std::unordered_set<locator::host_id> ignore_nodes, std::optional<int> ranges_parallelism) {
     utils::chunked_vector<locator::effective_replication_map_ptr> erms;
-    std::vector<tablet_repair_task_meta> task_metas;
+    repair::remote_metas_builder task_metas_builder;
     for (auto& table_name : table_names) {
         lw_shared_ptr<replica::table> t;
         try {
@@ -2430,15 +2516,14 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
                 metas_added = true;
                 rlogger.debug("repair[{}] Repair tablet task table={}.{} master_shard_id={} range={} neighbors={} replicas={}",
                         rid.uuid(), keyspace_name, table_name, master_shard_id, r, repair_neighbors(nodes, shards).shard_map, m.replicas);
-                task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, r, repair_neighbors(nodes, shards), m.replicas});
-                co_await coroutine::maybe_yield();
+                co_await task_metas_builder.add_on_shard(master_shard_id, tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, r, repair_neighbors(nodes, shards), m.replicas});
             }
         }
         if (metas_added) {
             erms.push_back(std::move(erm));
         }
     }
-    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, tasks::task_id::create_null_id(), table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, service::default_session_id, std::move(erms));
+    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, tasks::task_id::create_null_id(), table_names, streaming::stream_reason::repair, co_await std::move(task_metas_builder).build(), ranges_parallelism, service::default_session_id, std::move(erms));
 }
 
 // It is called by the repair_tablet rpc verb to repair the given tablet
@@ -2497,11 +2582,11 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
         co_return flush_time;
     }
 
-    std::vector<tablet_repair_task_meta> task_metas;
+    repair::remote_metas_builder task_metas_builder;
     auto ranges_parallelism = std::nullopt;
     auto start = std::chrono::steady_clock::now();
-    task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, table_id, *master_shard_id, range, repair_neighbors(nodes, shards), replicas});
-    auto task_impl_ptr = seastar::make_shared<repair::tablet_repair_task_impl>(_repair_module, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr>{}, rebuild_replicas.has_value());
+    co_await task_metas_builder.add_on_shard(*master_shard_id, tablet_repair_task_meta{keyspace_name, table_name, table_id, *master_shard_id, range, repair_neighbors(nodes, shards), replicas});
+    auto task_impl_ptr = seastar::make_shared<repair::tablet_repair_task_impl>(_repair_module, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, co_await std::move(task_metas_builder).build(), ranges_parallelism, topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr>{}, rebuild_replicas.has_value());
     task_impl_ptr->sched_by_scheduler = true;
     auto task = co_await _repair_module->make_task(task_impl_ptr, global_tablet_repair_task_info);
     task->start();
@@ -2524,14 +2609,14 @@ tasks::is_user_task repair::tablet_repair_task_impl::is_user_task() const noexce
 
 future<> repair::tablet_repair_task_impl::release_resources() noexcept {
     _metas_size = _metas.size();
-    _metas = {};
+    _metas.clear();
     _tables = {};
     _erms = {};
     return make_ready_future();
 }
 
 size_t repair::tablet_repair_task_impl::get_metas_size() const noexcept {
-    return _metas.size() > 0 ? _metas.size() : _metas_size;
+    return _metas_size == 0 ? _metas.size() : _metas_size;
 }
 
 future<> repair::tablet_repair_task_impl::run() {
@@ -2549,11 +2634,9 @@ future<> repair::tablet_repair_task_impl::run() {
         // Start the off strategy updater
         std::unordered_set<locator::host_id> participants;
         std::unordered_set<table_id> table_ids;
-        for (auto& meta : _metas) {
-            thread::maybe_yield();
-            participants.insert(meta.neighbors.all.begin(), meta.neighbors.all.end());
-            table_ids.insert(meta.tid);
-        }
+        auto hosts_and_tables = _metas.get_hosts_and_tables().get();
+        participants = std::move(hosts_and_tables.hosts);
+        table_ids = std::move(hosts_and_tables.tables);
         abort_source as;
         auto off_strategy_updater = seastar::async([&rs, uuid = id.uuid().uuid(), &table_ids, &participants, &as] {
             auto tables = std::list<table_id>(table_ids.begin(), table_ids.end());
@@ -2594,19 +2677,17 @@ future<> repair::tablet_repair_task_impl::run() {
 
         auto parent_shard = this_shard_id();
         std::vector<gc_clock::time_point> flush_times(smp::count);
-        rs.container().invoke_on_all([&idx, &flush_times, id, metas = _metas, parent_data, reason = _reason, tables = _tables, sched_by_scheduler = sched_by_scheduler, ranges_parallelism = _ranges_parallelism, parent_shard, topo_guard = _topo_guard, skip_flush = _skip_flush] (repair_service& rs) -> future<> {
+        rs.container().invoke_on_all([&idx, &flush_times, id, &metas = _metas, &parent_data, reason = _reason, &tables = _tables, sched_by_scheduler = sched_by_scheduler, ranges_parallelism = _ranges_parallelism, parent_shard, topo_guard = _topo_guard, skip_flush = _skip_flush] (repair_service& rs) -> future<> {
             std::exception_ptr error;
-            for (auto& m : metas) {
-                if (m.master_shard_id != this_shard_id()) {
-                    continue;
-                }
+            co_await metas.for_each_local_meta(coroutine::lambda([&rs, metas_size = metas.size(), &idx, id, &flush_times, parent_data, reason, &tables, sched_by_scheduler = sched_by_scheduler, ranges_parallelism, parent_shard, topo_guard, skip_flush, &error] (const tablet_repair_task_meta& m) -> future<> {
+                co_await coroutine::maybe_yield();
                 auto nr = idx.fetch_add(1);
                 rlogger.info("repair[{}] Repair {} out of {} tablets: table={}.{} range={} replicas={}",
-                    id.uuid(), nr, metas.size(), m.keyspace_name, m.table_name, m.range, m.replicas);
+                    id.uuid(), nr, metas_size, m.keyspace_name, m.table_name, m.range, m.replicas);
                 lw_shared_ptr<replica::table> t = rs._db.local().get_tables_metadata().get_table_if_exists(m.tid);
                 if (!t) {
                     rlogger.debug("repair[{}] Table {}.{} does not exist anymore", id.uuid(), m.keyspace_name, m.table_name);
-                    continue;
+                    co_return;
                 }
                 if (co_await rs.get_repair_module().is_aborted(id.uuid(), parent_shard)) {
                     throw abort_requested_exception();
@@ -2654,7 +2735,7 @@ future<> repair::tablet_repair_task_impl::run() {
                 auto current = flush_times[this_shard_id()];
                 auto time = task_impl_ptr->get_flush_time();
                 flush_times[this_shard_id()] = current == gc_clock::time_point() ? time : std::min(current, time);
-            }
+            }));
             if (error) {
                 co_await coroutine::return_exception_ptr(std::move(error));
             }

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2261,6 +2261,7 @@ static std::unordered_set<locator::host_id> get_token_owners_in_dcs(std::vector<
 
 // Repair all tablets belong to this node for the given table
 future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_name, std::vector<sstring> table_names, bool primary_replica_only, dht::token_range_vector ranges_specified, std::vector<sstring> data_centers, std::unordered_set<locator::host_id> hosts, std::unordered_set<locator::host_id> ignore_nodes, std::optional<int> ranges_parallelism) {
+    utils::chunked_vector<locator::effective_replication_map_ptr> erms;
     std::vector<tablet_repair_task_meta> task_metas;
     for (auto& table_name : table_names) {
         lw_shared_ptr<replica::table> t;
@@ -2366,6 +2367,7 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
         }
 
         size_t nr = 0;
+        bool metas_added = false;
         for (auto& m : metas) {
             nr++;
             rlogger.debug("repair[{}] Collect {} out of {} tablets: table={}.{} tablet_id={} range={} replicas={} primary_replica_only={}",
@@ -2425,14 +2427,18 @@ future<> repair_service::repair_tablets(repair_uniq_id rid, sstring keyspace_nam
                 }
             }
             for (auto& r : intersection_ranges) {
+                metas_added = true;
                 rlogger.debug("repair[{}] Repair tablet task table={}.{} master_shard_id={} range={} neighbors={} replicas={}",
                         rid.uuid(), keyspace_name, table_name, master_shard_id, r, repair_neighbors(nodes, shards).shard_map, m.replicas);
-                task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, r, repair_neighbors(nodes, shards), m.replicas, erm});
+                task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, tid, master_shard_id, r, repair_neighbors(nodes, shards), m.replicas});
                 co_await coroutine::maybe_yield();
             }
         }
+        if (metas_added) {
+            erms.push_back(std::move(erm));
+        }
     }
-    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, tasks::task_id::create_null_id(), table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, service::default_session_id);
+    auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>({}, rid, keyspace_name, tasks::task_id::create_null_id(), table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, service::default_session_id, std::move(erms));
 }
 
 // It is called by the repair_tablet rpc verb to repair the given tablet
@@ -2495,7 +2501,7 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     auto ranges_parallelism = std::nullopt;
     auto start = std::chrono::steady_clock::now();
     task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, table_id, *master_shard_id, range, repair_neighbors(nodes, shards), replicas});
-    auto task_impl_ptr = seastar::make_shared<repair::tablet_repair_task_impl>(_repair_module, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, topo_guard, rebuild_replicas.has_value());
+    auto task_impl_ptr = seastar::make_shared<repair::tablet_repair_task_impl>(_repair_module, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr>{}, rebuild_replicas.has_value());
     task_impl_ptr->sched_by_scheduler = true;
     auto task = co_await _repair_module->make_task(task_impl_ptr, global_tablet_repair_task_info);
     task->start();
@@ -2520,6 +2526,7 @@ future<> repair::tablet_repair_task_impl::release_resources() noexcept {
     _metas_size = _metas.size();
     _metas = {};
     _tables = {};
+    _erms = {};
     return make_ready_future();
 }
 

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -268,7 +268,6 @@ struct tablet_repair_task_meta {
     dht::token_range range;
     repair_neighbors neighbors;
     locator::tablet_replica_set replicas;
-    locator::effective_replication_map_ptr erm;
 };
 
 namespace std {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -114,17 +114,19 @@ private:
     size_t _metas_size = 0;
     gc_clock::time_point _flush_time;
     service::frozen_topology_guard _topo_guard;
+    utils::chunked_vector<locator::effective_replication_map_ptr> _erms;
     bool _skip_flush;
 public:
     bool sched_by_scheduler = false;
 public:
-    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, tasks::task_id parent_id, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, bool skip_flush = false)
+    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, tasks::task_id parent_id, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr> erms, bool skip_flush = false)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", parent_id, reason)
         , _keyspace(std::move(keyspace))
         , _tables(std::move(tables))
         , _metas(std::move(metas))
         , _ranges_parallelism(ranges_parallelism)
         , _topo_guard(topo_guard)
+        , _erms(std::move(erms))
         , _skip_flush(skip_flush)
     {
     }


### PR DESCRIPTION
Currently, in repair_service::repair_tablets a shard that initiates
the repair keeps repair_tablet_metas of all tablets that have a replica
on this node (on any shard). This may lead to oversized allocations.

Modify tablet_repair_task_impl to repair only the tablets which replicas
are kept on this shard. Modify repair_service::repair_tablets to gather
repair_tablet_metas only on local shard. repair_tablets is invoked on
all shards.

Add a new legacy_tablet_repair_task_impl that covers tablet repair started with
async_repair. A user can use sequence number of this task to manage the repair
using storage_service API.

In a test that reproduced this, we have seen 11136 tablets and 5636096 bytes
allocation failure. If we had a node with 250 shards, 100 tablets each, we could
reach 12MB kept on one shard for the whole repair time.

Fixes: https://github.com/scylladb/scylladb/issues/23632

Needs backport to all live branches as they are all vulnerable to such crashes.