### PR TITLE
[Backport 2025.1] repair: distribute tablet_repair_task_metas between shards

### DIFF
--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -268,7 +268,6 @@ struct tablet_repair_task_meta {
     dht::token_range range;
     repair_neighbors neighbors;
     locator::tablet_replica_set replicas;
-    locator::effective_replication_map_ptr erm;
 };
 
 namespace std {

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -114,17 +114,19 @@ private:
     size_t _metas_size = 0;
     gc_clock::time_point _flush_time;
     service::frozen_topology_guard _topo_guard;
+    utils::chunked_vector<locator::effective_replication_map_ptr> _erms;
     bool _skip_flush;
 public:
     bool sched_by_scheduler = false;
 public:
-    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, bool skip_flush = false)
+    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr> erms, bool skip_flush = false)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", tasks::task_id::create_null_id(), reason)
         , _keyspace(std::move(keyspace))
         , _tables(std::move(tables))
         , _metas(std::move(metas))
         , _ranges_parallelism(ranges_parallelism)
         , _topo_guard(topo_guard)
+        , _erms(std::move(erms))
         , _skip_flush(skip_flush)
     {
     }

--- a/repair/task_manager_module.hh
+++ b/repair/task_manager_module.hh
@@ -13,8 +13,11 @@
 #include "service/topology_guard.hh"
 #include "streaming/stream_reason.hh"
 #include "tasks/task_manager.hh"
+#include <cstddef>
 
 namespace repair {
+
+class remote_metas;
 
 class repair_task_impl : public tasks::task_manager::task::impl {
 protected:
@@ -104,11 +107,52 @@ protected:
     virtual future<std::optional<double>> expected_total_workload() const override;
 };
 
+struct hosts_and_tables {
+    std::unordered_set<locator::host_id> hosts;
+    std::unordered_set<table_id> tables;
+};
+
+struct remote_data {
+    utils::chunked_vector<tablet_repair_task_meta> metas;
+};
+
+class remote_metas {
+public:
+    using remote_data_ptr = foreign_ptr<lw_shared_ptr<remote_data>>;
+private:
+    std::vector<remote_data_ptr> _metas_on_shards;
+    size_t _metas_count = 0;
+
+    remote_metas() : _metas_on_shards(smp::count) {}
+public:
+    future<> for_each_local_meta(std::function<future<>(const tablet_repair_task_meta&)> func) const;
+    size_t size() const;
+    void clear();
+    future<hosts_and_tables> get_hosts_and_tables() const;
+
+    friend class remote_metas_builder;
+};
+
+class remote_metas_builder {
+private:
+    remote_metas _remote_metas;
+    std::unordered_map<size_t, std::vector<tablet_repair_task_meta>> _pending_metas;
+    constexpr static size_t max_pending_metas_per_shard = 32;
+public:
+    remote_metas_builder() : _remote_metas() {}
+
+    future<> add_on_shard(size_t shard_id, tablet_repair_task_meta meta);
+    future<remote_metas> build() &&;
+private:
+    future<> flush(size_t shard_id);
+    future<> allocate_on_shard(size_t shard_id);
+};
+
 class tablet_repair_task_impl : public repair_task_impl {
 private:
     sstring _keyspace;
     std::vector<sstring> _tables;
-    std::vector<tablet_repair_task_meta> _metas;
+    remote_metas _metas;
     optimized_optional<abort_source::subscription> _abort_subscription;
     std::optional<int> _ranges_parallelism;
     size_t _metas_size = 0;
@@ -119,7 +163,7 @@ private:
 public:
     bool sched_by_scheduler = false;
 public:
-    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, std::vector<tablet_repair_task_meta> metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr> erms, bool skip_flush = false)
+    tablet_repair_task_impl(tasks::task_manager::module_ptr module, repair_uniq_id id, sstring keyspace, std::vector<sstring> tables, streaming::stream_reason reason, remote_metas metas, std::optional<int> ranges_parallelism, service::frozen_topology_guard topo_guard, utils::chunked_vector<locator::effective_replication_map_ptr> erms, bool skip_flush = false)
         : repair_task_impl(module, id.uuid(), id.id, "keyspace", keyspace, "", "", tasks::task_id::create_null_id(), reason)
         , _keyspace(std::move(keyspace))
         , _tables(std::move(tables))


### PR DESCRIPTION
Currently, in repair_service::repair_tablets a shard that initiates
the repair keeps repair_tablet_metas of all tablets that have a replica
on this node (on any shard). This may lead to oversized allocations.

Modify tablet_repair_task_impl to repair only the tablets which replicas
are kept on this shard. Modify repair_service::repair_tablets to gather
repair_tablet_metas only on local shard. repair_tablets is invoked on
all shards.

Add a new legacy_tablet_repair_task_impl that covers tablet repair started with
async_repair. A user can use sequence number of this task to manage the repair
using storage_service API.

In a test that reproduced this, we have seen 11136 tablets and 5636096 bytes
allocation failure. If we had a node with 250 shards, 100 tablets each, we could
reach 12MB kept on one shard for the whole repair time.

Fixes: https://github.com/scylladb/scylladb/issues/23632

Needs backport to all live branches as they are all vulnerable to such crashes.