### PR TITLE
tools: toolchain: dbuild: forward container registry credentials

### DIFF
--- a/tools/toolchain/dbuild
+++ b/tools/toolchain/dbuild
@@ -206,6 +206,14 @@ EOF
     # to /etc/containers/containers.conf
 fi
 
+# Forward authentication, to avoid docker hub unauthenticated rate limits.
+for auth_json in "${XDG_RUNTIME_DIR}/containers/auth.json" "${HOME}/.config/containers/auth.json"; do
+    if [[ -f "$auth_json" ]]; then
+        docker_common_args+=(-v "${auth_json}:${HOME}/.config/containers/auth.json")
+        break
+    fi
+done
+
 if [ "$PWD" != "$toplevel" ]; then
      docker_common_args+=(-v "$toplevel:$toplevel")
 fi


### PR DESCRIPTION
Docker hub rate-limits unauthenticated image pulls, so forward the host's credentials to the container. This prevents rate limit errors when running nested containers.

Try the locations for the credentials in order and bind-mount the
first that exists to a location that gets picked up.

Verified with `podman login --get-login docker.io` in the container.

Since no release branches use nested containers, no backport is needed.