### PR TITLE
Preserve PyKMIP logs from failed KMIP tests

### DIFF
--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -320,6 +320,14 @@ static future<> kmip_test_helper(const std::function<future<>(const kmip_test_in
     tmpdir tmp;
     bool host_set = false;
 
+    // Preserve tmpdir on exception.
+    // The directory contains PyKMIP server logs that may help diagnose test failures.
+    // Allow the user to disable this with an env var (e.g., for local debugging).
+    auto preserve_tmpdir = get_var_or_default("SCYLLA_TEST_PRESERVE_TMP_ON_EXCEPTION", "true");
+    if (preserve_tmpdir == "1" || strcasecmp(preserve_tmpdir.data(), "true") == 0) {
+        tmp.preserve_on_exception(true);
+    }
+
     static const char* def_resourcedir = "./test/resource/certs";
     const char* resourcedir = std::getenv("KMIP_RESOURCE_DIR");
     if (resourcedir == nullptr) {

--- a/test/lib/tmpdir.cc
+++ b/test/lib/tmpdir.cc
@@ -24,6 +24,9 @@ void tmpdir::remove() noexcept {
 
 tmpdir::sweeper::~sweeper() {
     memory::scoped_critical_alloc_section dfg;
+    if (_tmpd._preserve_on_exception && std::uncaught_exceptions() > 0) {
+        return;
+    }
     if (!_tmpd._path.empty()) {
         for (const auto& ent : fs::directory_iterator(_tmpd._path)) {
             fs::remove_all(ent.path());
@@ -62,5 +65,8 @@ void tmpdir::operator=(tmpdir&& other) noexcept {
 }
 
 tmpdir::~tmpdir() {
+    if (_preserve_on_exception && std::uncaught_exceptions() > 0) {
+        return;
+    }
     remove();
 }

--- a/test/lib/tmpdir.hh
+++ b/test/lib/tmpdir.hh
@@ -17,6 +17,7 @@ namespace fs = std::filesystem;
 // automatically when tmpdir object goes out of scope.
 class tmpdir {
     fs::path _path;
+    bool _preserve_on_exception = false;
 
 private:
     void remove() noexcept;
@@ -40,4 +41,5 @@ public:
 
     const fs::path& path() const noexcept { return _path; }
     sweeper make_sweeper() const noexcept { return sweeper(*this); }
+    void preserve_on_exception(bool p) { _preserve_on_exception = p; }
 };


### PR DESCRIPTION
This PR extends the `tmpdir` class with an option to preserve the directory if the destructor is called during stack unwinding. It also uses this feature in KMIP tests, where the tmpdir contains PyKMIP server logs, which may be useful when diagnosing test failures.

Fixes #25339.

Not so important to be backported.