### PR TITLE
service: pass current session_id to repair rpc

### DIFF
--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -76,8 +76,8 @@ verb [[cancellable]] tablet_stream_data (raft::server_id dst_id, locator::global
 verb [[cancellable]] tablet_cleanup (raft::server_id dst_id, locator::global_tablet_id);
 verb [[cancellable]] table_load_stats_v1 (raft::server_id dst_id) -> locator::load_stats_v1;
 verb [[cancellable]] table_load_stats (raft::server_id dst_id) -> locator::load_stats;
-verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id) -> service::tablet_operation_repair_result;
-verb [[cancellable]] tablet_repair_colocated(raft::server_id dst_id, locator::global_tablet_id, std::vector<locator::global_tablet_id>) -> service::tablet_operation_repair_result;
+verb [[cancellable]] tablet_repair(raft::server_id dst_id, locator::global_tablet_id, service::session_id session [[version 2025.4]]) -> service::tablet_operation_repair_result;
+verb [[cancellable]] tablet_repair_colocated(raft::server_id dst_id, locator::global_tablet_id, std::vector<locator::global_tablet_id>, service::session_id session [[version 2025.4]]) -> service::tablet_operation_repair_result;
 verb [[]] estimate_sstable_volume(table_id table) -> uint64_t;
 verb [[]] sample_sstables(table_id table, uint64_t chunk_size, uint64_t n_chunks) -> utils::chunked_vector<temporary_buffer<char>>;
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -209,8 +209,8 @@ private:
     future<service::tablet_operation_result> do_tablet_operation(locator::global_tablet_id tablet,
                                  sstring op_name,
                                  std::function<future<service::tablet_operation_result>(locator::tablet_metadata_guard&)> op);
-    future<service::tablet_operation_repair_result> repair_tablet(locator::global_tablet_id);
-    future<service::tablet_operation_repair_result> repair_colocated_tablets(locator::global_tablet_id, std::vector<locator::global_tablet_id>);
+    future<service::tablet_operation_repair_result> repair_tablet(locator::global_tablet_id, service::session_id);
+    future<service::tablet_operation_repair_result> repair_colocated_tablets(locator::global_tablet_id, std::vector<locator::global_tablet_id>, service::session_id);
     future<> stream_tablet(locator::global_tablet_id);
     // Clones storage of leaving tablet into pending one. Done in the context of intra-node migration,
     // when both of which sit on the same node. So all the movement is local.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1434,10 +1434,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         auto dst = locator::maybe_get_primary_replica(gid.tablet, {tsi.read_from.begin(), tsi.read_from.end()}, [] (const auto& tr) { return true; }).value().host;
                         rtlogger.info("Initiating repair phase of tablet rebuild host={} tablet={}", dst, gid);
-                        return do_with(gids, [this, dst] (const auto& gids) {
-                            return do_for_each(gids, [this, dst] (locator::global_tablet_id gid) {
+                        return do_with(gids, [this, dst, session_id = trinfo.session_id] (const auto& gids) {
+                            return do_for_each(gids, [this, dst, session_id] (locator::global_tablet_id gid) {
                                 return ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
-                                        dst, _as, raft::server_id(dst.uuid()), gid).discard_result();
+                                        dst, _as, raft::server_id(dst.uuid()), gid, session_id).discard_result();
                             });
                         });
                     })) {
@@ -1652,9 +1652,9 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         rtlogger.info("Initiating tablet repair host={} tablet={}", dst, gid);
                         auto res = gids.size() > 1 ?
                                 co_await ser::storage_service_rpc_verbs::send_tablet_repair_colocated(&_messaging,
-                                    dst, _as, raft::server_id(dst.uuid()), gid, gids)
+                                    dst, _as, raft::server_id(dst.uuid()), gid, gids, trinfo->session_id)
                                 : co_await ser::storage_service_rpc_verbs::send_tablet_repair(&_messaging,
-                                    dst, _as, raft::server_id(dst.uuid()), gid);
+                                    dst, _as, raft::server_id(dst.uuid()), gid, trinfo->session_id);
                         auto duration = std::chrono::duration<float>(db_clock::now() - sched_time);
                         auto& tablet_state = _tablets[tablet];
                         tablet_state.repair_time = db_clock::from_time_t(gc_clock::to_time_t(res.repair_time));

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1201,3 +1201,19 @@ async def test_tablet_rebuild(manager: ManagerClient):
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_tablet_rebuild_failure(manager: ManagerClient):
     await check_tablet_rebuild_with_repair(manager, True)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_repair_with_invalid_session_id(manager: ManagerClient):
+    injection = "handle_tablet_migration_repair_random_session"
+    token = -1
+    servers, cql, hosts, ks, table_id = await create_table_insert_data_for_repair(manager)
+
+    logs = [await manager.server_open_log(s.server_id) for s in servers]
+    marks = [await log.mark() for log in logs]
+
+    [await manager.api.enable_injection(s.ip_addr, injection, one_shot=True) for s in servers]
+    await manager.api.tablet_repair(servers[0].ip_addr, ks, "test", token)
+
+    matches = [await log.grep("std::runtime_error \(Session not found", from_mark=mark) for log, mark in zip(logs, marks)]
+    assert sum(len(x) for x in matches) > 0


### PR DESCRIPTION
Currently, in repair_tablet we retrieve session_id from tablet
map (and throw if it isn't specified). In case of topology
coordinator failover, we may end up in a situation where a node
runs outdated repair, treating session of a different operation
as the repair's session:

- topology coordinator starts repair transition (A);
- topology coordinator sends tablet repair rpc to node1;
- topology coordinator is separated from the cluster;
- new topology coordinator is elected;
- new topology coordinator sees waiting repair request (A_2)
  and executes it;
- new repair of the same tablet is requested (B);
- new topology coordinator starts repair transition (B);
- new topology coordinator sends tablet repair rpc to node2;
- node2 starts repair (B) as repair master;
- node1 starts repair (A), checks the current session (B), proceeds
  with repair (B) as repair master.

Send current session_id in repair_tablet rpc. If this session_id
and session id got from tablet map don't match, an exception
is thrown.

Fixes: https://github.com/scylladb/scylladb/issues/23318.

No backport; changes in rpc signatures