### PR TITLE
.gitignore: add rust target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ compile_commands.json
 clang_build
 .idea/
 nuke
+rust/target


### PR DESCRIPTION
When using automatic rust build tools in IDE,
the files generated in `rust/target/` directory
has been treated by git as unstaged changes.

After the change, the generated files will not
pollute the git changes interface.