### PR TITLE
fix(test.py) incorrect markers argument in boost tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -340,7 +340,7 @@ def run_pytest(options: argparse.Namespace) -> tuple[int, list[SimpleNamespace]]
     else:
         args.append('--save-log-on-success')
     if options.markers:
-        args.append(f"-m={options.markers}")
+        args.append(f'-m="{options.markers}"')
     args.extend(files_to_run)
 
     args = shlex.split(' '.join(args))


### PR DESCRIPTION
pytest parkers argument can be space separated like "not unstable" to pass such argument propperly in CLI(bash) command we should use double quates

tested locally on command:
./tools/toolchain/dbuild  ./test.py --markers="not unstable" test/boost/auth_passwords_test.cc

before change: no tests ran in 1.12s
after: 8 passed in 2.45s

