### PR TITLE
sstables/trie: add trie traversal routines

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -566,6 +566,7 @@ scylla_tests = set([
     'test/boost/top_k_test',
     'test/boost/transport_test',
     'test/boost/bti_node_sink_test',
+    'test/boost/trie_traversal_test',
     'test/boost/trie_writer_test',
     'test/boost/symmetric_key_test',
     'test/boost/types_test',

--- a/sstables/trie/trie_traversal.hh
+++ b/sstables/trie/trie_traversal.hh
@@ -1,0 +1,368 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "node_reader.hh"
+#include "utils/small_vector.hh"
+#include <seastar/core/future.hh>
+#include <seastar/core/coroutine.hh>
+#include "common.hh"
+#include "utils/assert.hh"
+
+namespace sstables::trie {
+
+// To be able to step over the trie (forwards and backwards),
+// the cursor has to keep a trail of all nodes between
+// root and the currently-visited node which
+// have a payload or more than one child.
+//
+// This type represents an entry in this trail.
+//
+// See also: node_reader::walk_down_along_key()
+struct trail_entry {
+    // Position/ID of the node in the file.
+    uint64_t pos;
+    // Position/ID of the node in the file.
+    uint16_t n_children;
+    // Index of the currently-visited child slot.
+    // (I.e. the next node in the trail is in the branch starting at this child slot).
+    // Special value -1 means that we are currently visiting *this* node,
+    // not any of its children.
+    int16_t child_idx;
+    // Payload bits for this node.
+    // (Non-zero if this node has a payload).
+    uint8_t payload_bits;
+    // For tests.
+    std::strong_ordering operator<=>(const trail_entry&) const = default;
+};
+
+// Note: for the partition index, the trail should never be longer than ~6 entries.
+// For the row index, it can get arbitrarily large.
+struct ancestor_trail : utils::small_vector<trail_entry, 8> {
+};
+
+// Converting keys from the regular Scylla format to the BTI byte-comparable format
+// can be expensive, so we allow the conversion to happen lazily.
+// To support that, the traversal routines take the key as an iterator/generator
+// of fragments (byte spans).
+//
+// Note: a std::generator<const_bytes>::iterator fulfils this concept.
+template <typename T>
+concept comparable_bytes_iterator = requires (T it) {
+    // Users of comparable_bytes_iterator want to modify the contents of `*it`
+    // (for their convenience, not due to necessity), so operator* returns a reference.
+    { *it } -> std::same_as<const_bytes&&>;
+    // Allowed to destroy `*it`;
+    { ++it };
+    // Since this concept is designed for lazy evaluation,
+    // the "end" of the sequence is usually more naturally encoded
+    // as something in the iterator itself, rather than some external "end" object.
+    //
+    // So we don't bother with iterator pairs and we instead
+    // require the iterator itself to know if it's done.
+    { it == std::default_sentinel } -> std::same_as<bool>;
+    { it != std::default_sentinel } -> std::same_as<bool>;
+};
+
+// State of the "traverse" routine.
+// Serves as both an input and an output argument.
+struct traversal_state {
+    // The next node we should look at.
+    // Should be initialized to the position of the root node
+    // when the search starts.
+    // Special value `-1` means that the search is over.
+    int64_t next_pos = -1;
+    // The number of traversed trie edges (== number of traversed characters of the key).
+    int edges_traversed = 0;
+    // The trail of all "important" (cf. node_reader::walk_down_along_key)
+    // ancestors of the currently-visited node/edge.
+    //
+    // (Note: after "traverse" return, the final ("found") node
+    // is included here regardless of whether it's "important".
+    ancestor_trail trail;
+};
+
+// The synchronous part of `traverse`.
+// Walks down the trie,
+// over the nodes inside the page currently loaded in `page`,
+// along edges selected by `key_it`,
+// appending all visited "important" (cf `node_reader::walk_down_along_key`)
+// updating `state` accordingly,
+// until `key_it` is exhausted, or leaf is reached, or there's no child matching the next byte of `key_it`.
+inline void traverse_single_page(
+    node_reader auto& page,
+    comparable_bytes_iterator auto&& key_it,
+    traversal_state& state
+) {
+    // Body of the loop wants to know the next character of `key_it`,
+    // and accesses it as `(*key_it)[0]`.
+    // We need to skip empty fragments somewhere for that to work.
+    // We do it before each loop iteration.
+    while (key_it != std::default_sentinel && (*key_it).empty()) {
+        ++key_it;
+    }
+    while (page.cached(state.next_pos) && key_it != std::default_sentinel) {
+        // Empty fragments should have been already skipped.
+        expensive_assert(!(*key_it).empty());
+
+        node_traverse_result traverse_one = page.walk_down_along_key(state.next_pos, *key_it);
+        state.edges_traversed += traverse_one.traversed_key_bytes;
+        // Note: the protocol between `walk_down_along_key` and `traverse_single_page`
+        // is that `walk_down_along_key` can silently skip some "unimportant"
+        // edges without giving `traverse_single_page` a chance to remember them,
+        // and those skipped edges are counted into `traversed_key_bytes`,
+        // but the last visited edge (i.e. the edge which best matches `(*key_it)[traversed_key_bytes]`)
+        // is returned to the caller and is not counted into `traversed_key_bytes`.
+        // (even if it's just as "skippable" as the skipped edges).
+        //
+        // So with a valid `node_reader`, `traversed_key_bytes` must have been smaller
+        // than key_it->.size()
+        *key_it = (*key_it).subspan(traverse_one.traversed_key_bytes);
+        expensive_assert(!(*key_it).empty());
+
+        // walk_down_along_key finds the first child edge greater or equal
+        // to `(*key_it)[0]`.
+        // If it's greater, then the traversal stops here. If it's equal, we will continue walking down.
+        //
+        // Note: this doesn't mean that we can continue walking down *in the current page*,
+        // just that we can continue in general. It might require loading a new page.
+        bool can_continue = traverse_one.found_byte == int((*key_it)[0]);
+
+        if (can_continue) {
+            // The chosen edge wasn't "traversed" by `walk_down_along_key`,
+            // (just because that's the protocol we chose).
+            // We "traverse" this edge ourselves, here.
+            state.next_pos = traverse_one.body_pos - traverse_one.child_offset;
+            state.edges_traversed += 1;
+            *key_it = (*key_it).subspan(1);
+        } else {
+            // Special value -1 means that the traversal is finished.
+            state.next_pos = -1;
+        }
+        // We add the node to the trail if if's an "important" node (has payload or children)
+        // or if it's the last node reachable along the passed key.
+        bool add_to_trail = traverse_one.payload_bits || traverse_one.n_children > 1 || !can_continue;
+        expensive_log("traversing pos={} add_to_trail={} found_byte={} can_continue={} body_pos={} child_offset={}",
+                state.next_pos, add_to_trail, traverse_one.found_byte, can_continue, traverse_one.body_pos, traverse_one.child_offset);
+        if (add_to_trail) {
+            state.trail.push_back(trail_entry{
+                .pos = traverse_one.body_pos,
+                .n_children = traverse_one.n_children,
+                .child_idx = traverse_one.found_idx,
+                .payload_bits = traverse_one.payload_bits});
+        }
+
+        // Body of the loop wants to know the next character of `key_it`,
+        // and accesses it as `(*key_it)[0]`.
+        // We need to skip empty fragments somewhere for that to work.
+        // We do it before each loop iteration.
+        while (key_it != std::default_sentinel && (*key_it).empty()) {
+            ++key_it;
+        }
+    }
+}
+
+// Walks down the trie, from the given root,
+// along the edges matching `key_it`,
+// until the key is exhausted or there's no child matching
+// the next key byte.
+//
+// The returned trail contains the last visited node
+// and all its "important" ancestors.
+//
+// The alst visited node has `.child_idx` set to -1 if it matches the key exactly,
+// or to "lower_bound(child_edges, first_mismatching_key_byte)" otherwise.
+inline seastar::future<traversal_state> traverse(
+    node_reader auto& input,
+    comparable_bytes_iterator auto&& key_it,
+    int64_t root_pos
+) {
+    traversal_state state = {.next_pos = root_pos};
+    while (state.next_pos >= 0 && key_it != std::default_sentinel) {
+        co_await input.load(state.next_pos);
+        traverse_single_page(input, key_it, state);
+    }
+    if (state.next_pos >= 0) {
+        co_await input.load(state.next_pos);
+        load_final_node_result final_node = input.read_node(state.next_pos);
+        state.trail.push_back(trail_entry{
+                .pos = state.next_pos,
+                .n_children = final_node.n_children,
+                .child_idx = -1,
+                .payload_bits = final_node.payload_bits});
+    }
+    co_await input.load(state.trail.back().pos);
+    co_return std::move(state);
+}
+
+// The synchronous part of descend_leftmost.
+inline void descend_leftmost_single_page(
+    node_reader auto& page,
+    ancestor_trail& trail,
+    int64_t& next_pos
+) {
+    while (page.cached(next_pos)) {
+        node_traverse_sidemost_result traverse_one = page.walk_down_leftmost_path(next_pos);
+        if (traverse_one.payload_bits || traverse_one.n_children > 1) {
+            if (!(trail.back().payload_bits || trail.back().n_children > 1)) {
+                trail.pop_back();
+            }
+            trail.push_back(trail_entry{
+                .pos = traverse_one.body_pos,
+                .n_children = traverse_one.n_children,
+                .child_idx = 0,
+                .payload_bits = traverse_one.payload_bits});
+        }
+
+        if (traverse_one.payload_bits) {
+            next_pos = -1;
+            trail.back().child_idx = -1;
+        } else {
+            SCYLLA_ASSERT(traverse_one.n_children >= 1);
+            next_pos = traverse_one.body_pos - traverse_one.child_offset;
+        }
+    }
+}
+
+// Walks down the trie to the leaf, from a node with the given
+// trail and position, always taking the leftmost path.
+inline seastar::future<> descend_leftmost(
+    node_reader auto& input,
+    ancestor_trail& trail,
+    int64_t next_pos
+) {
+    while (next_pos >= 0) {
+        co_await input.load(next_pos);
+        // Note: next_pos passed by reference.
+        descend_leftmost_single_page(input, trail, next_pos);
+    }
+}
+
+// Ascends to the first node which has a child edge to the right
+// of the current path, and visits that edge.
+inline bool ascend_to_right_edge(ancestor_trail& trail) {
+    if (trail.back().child_idx != -1) {
+        trail.back().child_idx -= 1;
+    }
+    for (int i = trail.size() - 1; i >= 0; --i) {
+        if (trail[i].child_idx + 1 < trail[i].n_children) {
+            trail[i].child_idx += 1;
+            trail.resize(i + 1);
+            return true;
+        }
+    }
+    trail[0].child_idx = trail[0].n_children;
+    trail.resize(1);
+    return false;
+}
+
+// Steps the cursor represented by `trail` forwards until
+// the first payloaded node.
+// If there's no such node, visits EOF.
+// (I.e. visits the root of the trail and sets its child idx past the end).
+inline seastar::future<> step(
+    node_reader auto& input,
+    ancestor_trail& trail
+) {
+    if (ascend_to_right_edge(trail)) {
+        co_await input.load(trail.back().pos);
+        get_child_result child = input.get_child(trail.back().pos, trail.back().child_idx, true);
+
+        trail.back().child_idx = child.idx;
+        int64_t next_pos = trail.back().pos - child.offset;
+        co_await descend_leftmost(input, trail, next_pos);
+    }
+    co_await input.load(trail.back().pos);
+}
+
+// The synchronous part of descend_rightmost.
+inline void descend_rightmost_single_page(
+    node_reader auto& page,
+    ancestor_trail& trail,
+    int64_t& next_pos
+) {
+    while (page.cached(next_pos)) {
+        node_traverse_sidemost_result traverse_one = page.walk_down_rightmost_path(next_pos);
+        if (traverse_one.payload_bits || traverse_one.n_children > 1) {
+            if (!(trail.back().payload_bits || trail.back().n_children > 1)) {
+                trail.pop_back();
+            }
+            trail.push_back(trail_entry{
+                .pos = traverse_one.body_pos,
+                .n_children = traverse_one.n_children,
+                .child_idx = traverse_one.n_children - 1,
+                .payload_bits = traverse_one.payload_bits});
+        }
+
+        if (traverse_one.n_children >= 1) {
+            next_pos = traverse_one.body_pos - traverse_one.child_offset;
+        } else {
+            next_pos = -1;
+            trail.back().child_idx = -1;
+        }
+    }
+}
+
+// Like descend_leftmost, but always takes the rightmost path.
+inline seastar::future<> descend_rightmost(
+    node_reader auto& input,
+    ancestor_trail& trail,
+    int64_t next_pos
+) {
+    while (next_pos >= 0) {
+        co_await input.load(next_pos);
+        // Note: next_pos passed by reference.
+        descend_rightmost_single_page(input, trail, next_pos);
+    }
+}
+
+// If the currently visited edge-or-node has a proper ancestor node
+// with a child edge to the left of the trail, visits that edge.
+// Otherwise, if the currently visited edge-or-node has a proper ancestor node
+// with a payload, visits that node.
+// Otherwise, if the trail root has a payload, visits the root.
+// Otherwise, visits the first child edge of the root.
+inline bool ascend_to_left_edge(ancestor_trail& trail) {
+    for (int i = trail.size() - 1; i >= 0; --i) {
+        if (trail[i].child_idx > 0 || (trail[i].child_idx == 0 && trail[i].payload_bits)) {
+            trail[i].child_idx -= 1;
+            trail.resize(i + 1);
+            return true;
+        }
+    }
+    trail[0].child_idx = trail[0].payload_bits ? -1 : 0;
+    trail.resize(1);
+    return false;
+}
+
+// Steps the cursor represented by `trail` backwards until
+// the first payloaded node.
+// If there's no such node, visits the first payloaded node in the trie.
+// Otherwise visits EOF. (I.e. visits the root of the trail and sets its child idx past the end).
+inline seastar::future<> step_back(
+    node_reader auto& input,
+    ancestor_trail& trail
+) {
+    bool didnt_go_past_start = ascend_to_left_edge(trail);
+    if (trail.back().child_idx >= 0 && trail.back().child_idx < trail.back().n_children) {
+        co_await input.load(trail.back().pos);
+        get_child_result child = input.get_child(trail.back().pos, trail.back().child_idx, false);
+
+        trail.back().child_idx = child.idx;
+        int64_t next_pos = trail.back().pos - child.offset;
+        if (didnt_go_past_start) {
+            co_await descend_rightmost(input, trail, next_pos);
+        } else {
+            co_await descend_leftmost(input, trail, next_pos);
+        }
+    }
+    co_await input.load(trail.back().pos);
+}
+
+} // namespace sstables::trie

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -268,6 +268,8 @@ add_scylla_test(transport_test
   KIND SEASTAR)
 add_scylla_test(bti_node_sink_test
   KIND BOOST)
+add_scylla_test(trie_traversal_test
+  KIND SEASTAR)
 add_scylla_test(trie_writer_test
   KIND BOOST)
 add_scylla_test(types_test

--- a/test/boost/trie_traversal_test.cc
+++ b/test/boost/trie_traversal_test.cc
@@ -1,0 +1,459 @@
+/*
+ * Copyright (C) 2024-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include "test/lib/log.hh"
+#include <fmt/ranges.h>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/testing/test_case.hh>
+#include "sstables/trie/trie_traversal.hh"
+#include <generator>
+#include <numeric>
+
+namespace trie = sstables::trie;
+
+using trie::const_bytes;
+
+// generate_all_strings("abc", 2) = {"", "a", "aa", "ab", "ac", "b", "ba", "bb", "bc", "c", "ca", "cb", "cc"}
+std::vector<std::string> generate_all_strings(std::string_view chars_raw, size_t max_len) {
+    std::string chars(chars_raw);
+    std::ranges::sort(chars);
+    std::ranges::unique(chars);
+
+    std::vector<std::string> all_strings;
+    all_strings.push_back("");
+    size_t prev_old_n = 0;
+    for (size_t i = 0; i < max_len; ++i) {
+        size_t old_n = all_strings.size();
+        for (size_t k = prev_old_n; k < old_n; ++k) {
+            for (auto c : chars) {
+                all_strings.push_back(all_strings[k]);
+                all_strings.back().push_back(c);
+            }
+        }
+        prev_old_n = old_n;
+    }
+    std::ranges::sort(all_strings);
+    return all_strings;
+}
+
+// generate_all_subsets(4, 2) = {{0, 1}, {0, 2}, {0, 3}, {1, 2}, {1, 3}, {2, 3}}
+std::vector<std::vector<size_t>> generate_all_subsets(size_t n, size_t k) {
+    if (k == 0) {
+        return {std::vector<size_t>()};
+    }
+    using sample = std::vector<size_t>;
+    std::vector<size_t> wksp(k);
+    auto first = wksp.begin();
+    auto last = wksp.end();
+    // Fill wksp with first possible sample.
+    std::ranges::iota(wksp, 0);
+    std::vector<sample> samples;
+    while (true) {
+        samples.push_back(wksp);
+        // Advance wksp to next possible sample.
+        auto mt = last;
+        --mt;
+        while (mt > first && *mt == n - (last - mt)) {
+            --mt;
+        }
+        if (mt == first && *mt == n - (last - mt)) {
+            break;
+        }
+        ++(*mt);
+        while (++mt != last) {
+            *mt = *(mt - 1) + 1;
+        }
+    }
+    return samples;
+}
+
+inline const_bytes string_as_bytes(std::string_view sv) {
+    return std::as_bytes(std::span(sv.data(), sv.size()));
+}
+
+inline std::string_view bytes_as_string(const_bytes sv) {
+    return {reinterpret_cast<const char*>(sv.data()), sv.size()};
+}
+
+template <>
+struct fmt::formatter<trie::trail_entry> : fmt::formatter<string_view> {
+    auto format(const trie::trail_entry& r, fmt::format_context& ctx) const
+            -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "trail_entry(id={} child_idx={} payload_bits={})", r.pos, r.child_idx, r.payload_bits);
+    }
+};
+
+// Builds a trie from the given set of strings (in the most obviously correct way it can),
+// and computes the full set of legal cursor states for such a trie and their corresponding semantics.
+// (Each state corresponds to some place in the order established by the strings).
+struct reference_trie {
+    struct node {
+        std::vector<std::pair<std::byte, uint64_t>> children;
+        uint8_t payload_bits = 0;
+        int lookup_child(std::byte x) {
+            return std::ranges::lower_bound(children, x, {}, [] (const auto& c) { return c.first; }) - children.begin();
+        }
+    };
+
+    std::vector<node> _nodes;
+
+    uint64_t add_node() {
+        _nodes.emplace_back();
+        return _nodes.size() - 1;
+    }
+
+    node* at(uint64_t pos) {
+        return &_nodes.at(pos);
+    }
+
+    reference_trie(std::span<const_bytes> strings) {
+        add_node();
+        for (const auto& s : strings) {
+            uint64_t it = 0;
+            for (size_t i = 0; i < s.size(); ++i) {
+                auto b = std::byte(s[i]);
+                auto child_idx = at(it)->lookup_child(b);
+                if (child_idx < int(at(it)->children.size())) {
+                    it = it + at(it)->children.at(child_idx).second;
+                } else {
+                    auto new_node = add_node(); 
+                    at(it)->children.emplace_back(b, new_node - it);
+                    it = new_node;
+                }
+            }
+            at(it)->payload_bits = 1;
+        }
+        std::ranges::reverse(_nodes);
+    }
+
+    struct cursor_state {
+        decltype(trie::traversal_state::trail) trail;
+        std::strong_ordering operator<=>(const cursor_state&) const = default;
+    };
+
+    // The "semantics" of the cursor state.
+    // The output semantics of a given cursor operation should be the right function
+    // of the input semantics, and nothing else.
+    struct meaning {
+        // The cursor corresponds to some position in the key universe.
+        // Either to one of the present keys, or to some position "in between".
+        // (For a given pair of neighboring keys, all possible positions in between
+        // those keys are semantically equal and have the same rank).
+        //
+        // That is, rank 0 means "before all present keys",
+        // rank 1 means "at key idx 0",
+        // rank 2 means "between key idx 0 and key idx 1",
+        // rank 3 means "at key idx 1",
+        // etc.
+        int rank;
+        // The depth doesn't matter in an input,
+        // but we track it to check that the `edges_traversed` result of `traverse`
+        // is consistent with it.
+        int depth;
+    };
+
+    std::map<cursor_state, meaning> enumerate_all_legal_states() {
+        struct recursion_state {
+            int rank = 0;
+            int depth = 0;
+            cursor_state cursor;
+            std::map<cursor_state, meaning> result;
+        };
+
+        recursion_state state;
+
+        // Fun fact: at first I tried to capture `state` by reference, but that crashes the compiler (clang 18.1.8)
+        // with `error: cannot compile this l-value expression yet`.
+        // Passing it via a parameter works. It seems that recursive closures have some rough edges.
+        auto visit = [&] (this auto& visit, recursion_state& state, uint64_t pos) -> void {
+            node* x = at(pos);
+            if (x->payload_bits) {
+                state.rank += 1;
+            }
+            state.cursor.trail.push_back(trie::trail_entry{
+                .pos = pos, 
+                .n_children = x->children.size(),
+                .child_idx = -1,
+                .payload_bits = x->payload_bits,
+            });
+            state.result.emplace(state.cursor, meaning{.rank = state.rank, .depth = state.depth});
+            testlog.trace("enumerate_all_legal_states: {}: {}, {}", fmt::join(state.cursor.trail, ", "), state.rank, state.depth);
+            state.cursor.trail.pop_back();
+            if (x->payload_bits) {
+                state.rank += 1;
+            }
+            bool relevant = x->children.size() > 1 || x->payload_bits;
+            for (int child_idx = 0; child_idx < int(x->children.size()); ++child_idx) {
+                state.cursor.trail.push_back(trie::trail_entry{
+                    .pos = pos, 
+                    .n_children = x->children.size(),
+                    .child_idx = child_idx,
+                    .payload_bits = x->payload_bits,
+                });
+                state.result.emplace(state.cursor, meaning{.rank = state.rank, .depth = state.depth});
+                testlog.trace("enumerate_all_legal_states: {}: {}, {}", fmt::join(state.cursor.trail, ", "), state.rank, state.depth);
+                if (!relevant) {
+                    state.cursor.trail.pop_back();
+                }
+                state.depth += 1;
+                visit(state, pos - x->children[child_idx].second);
+                state.depth -= 1;
+                if (relevant) {
+                    state.cursor.trail.pop_back();
+                }
+            }
+            state.cursor.trail.push_back(trie::trail_entry{
+                .pos = pos,
+                .n_children = x->children.size(),
+                .child_idx = x->children.size(),
+                .payload_bits = x->payload_bits,
+            });
+            state.result.emplace(state.cursor, meaning{.rank = state.rank, .depth = state.depth});
+            testlog.trace("enumerate_all_legal_states: {}: {}, {}", fmt::join(state.cursor.trail, ", "), state.rank, state.depth);
+            state.cursor.trail.pop_back();
+        };
+
+        visit(state, _nodes.size() - 1);
+        return state.result;
+    }
+};
+
+struct custom_node_reader {
+    std::optional<uint64_t> cached_pos;
+    reference_trie& rt;
+    // A node_reader is allowed to skip an arbitrary number
+    // of "unimportant" nodes.
+    bool multibyte_traverse = true;
+
+    void allow_multibyte_traverse(bool allow) {
+        multibyte_traverse = allow;
+    }
+
+    bool cached(int64_t pos) {
+        return cached_pos && cached_pos.value() == uint64_t(pos);
+    }
+
+    const_bytes get_payload(int64_t pos) {
+        return const_bytes();
+    }
+
+    seastar::future<> load(int64_t pos) {
+        cached_pos = pos;
+        return seastar::make_ready_future<>();
+    }
+
+    trie::load_final_node_result read_node(int64_t pos) {
+        SCYLLA_ASSERT(pos == cached_pos);
+        auto* x = rt.at(pos);
+        return trie::load_final_node_result{
+            .n_children = x->children.size(),
+            .payload_bits = x->payload_bits,
+        };
+    }
+    trie::node_traverse_result walk_down_along_key(int64_t pos, const_bytes key) {
+        SCYLLA_ASSERT(pos == cached_pos);
+        int i;
+        for (i = 0; i + 1 < int(key.size()); ++i) {
+            if (multibyte_traverse
+                && rt.at(pos)->payload_bits == 0
+                && rt.at(pos)->children.size() == 1
+                && rt.at(pos)->children.begin()->first == key[i]
+            ) {
+                pos = pos - rt.at(pos)->children.front().second;
+            } else {
+                break;
+            }
+        }
+        auto child = rt.at(pos)->lookup_child(key[i]);
+        auto found = child != int(rt.at(pos)->children.size());
+        return trie::node_traverse_result{
+            .payload_bits = rt.at(pos)->payload_bits,
+            .n_children = rt.at(pos)->children.size(),
+            .found_idx = found ? child : rt.at(pos)->children.size(),
+            .found_byte = found ? int(rt.at(pos)->children.at(child).first) : -1,
+            .traversed_key_bytes = i,
+            .body_pos = pos,
+            .child_offset = found ? rt.at(pos)->children.at(child).second : -1,
+        };
+    }
+    trie::node_traverse_sidemost_result walk_down_leftmost_path(int64_t pos) {
+        SCYLLA_ASSERT(pos == cached_pos);
+        auto* x = rt.at(pos);
+        auto has_children = x->children.size() > 0;
+        return trie::node_traverse_sidemost_result{
+            .payload_bits = x->payload_bits,
+            .n_children = x->children.size(),
+            .body_pos = pos,
+            .child_offset = has_children ? x->children.begin()->second : -1,
+        };
+    }
+    trie::node_traverse_sidemost_result walk_down_rightmost_path(int64_t pos) {
+        SCYLLA_ASSERT(pos == cached_pos);
+        auto* x = rt.at(pos);
+        auto has_children = x->children.size() > 0;
+        return trie::node_traverse_sidemost_result{
+            .payload_bits = x->payload_bits,
+            .n_children = x->children.size(),
+            .body_pos = pos,
+            .child_offset = has_children ? x->children.rbegin()->second : -1,
+        };
+    }
+    trie::get_child_result get_child(int64_t pos, int child_idx, bool forward) {
+        SCYLLA_ASSERT(pos == cached_pos);
+        auto* x = rt.at(pos);
+        SCYLLA_ASSERT(size_t(child_idx) < x->children.size());
+        return trie::get_child_result{
+            .idx = child_idx,
+            .offset = x->children[child_idx].second,
+        };
+    }
+};
+static_assert(trie::node_reader<custom_node_reader>);
+
+static auto single_fragment_generator(std::span<const std::byte> only_frag) -> std::generator<std::span<const std::byte>> {
+    co_yield only_frag;
+}
+static auto onebyte_fragment_generator(std::span<const std::byte> only_frag) -> std::generator<std::span<const std::byte>> {
+    for (size_t i = 0; i < only_frag.size(); ++i) {
+        co_yield only_frag.subspan(i, 1);
+    }
+}
+static auto onebyte_or_empty_fragment_generator(std::span<const std::byte> only_frag) -> std::generator<std::span<const std::byte>> {
+    for (size_t i = 0; i < only_frag.size(); ++i) {
+        co_yield const_bytes();
+        co_yield only_frag.subspan(i, 1);
+    }
+}
+using fragment_generator_fn = decltype(&single_fragment_generator);
+const static fragment_generator_fn fragment_generators[] = {
+    single_fragment_generator,
+    onebyte_fragment_generator,
+    onebyte_or_empty_fragment_generator,
+};
+
+// Tests the traverse() function.
+// 
+// Testing strategy:
+// build a trie containing the given set of keys,
+// then test for all possible queries that the cursor created by `traverse`
+// is in a legal state, and that the state corresponds to the right position in the set of keys.
+// (And also test that "edges_traversed" is set correctly).
+void test_traverse(std::span<const_bytes> key_domain, std::span<const_bytes> keys) {
+    SCYLLA_ASSERT(!keys.empty());
+    testlog.debug("test_traverse: testing key set: {}", keys);
+
+    auto ref_trie = reference_trie(keys);
+    auto legal_states = ref_trie.enumerate_all_legal_states();
+    custom_node_reader input{.rt = ref_trie};
+
+    auto traverse_from_root = [&] (const_bytes key, fragment_generator_fn frag_gen) -> trie::traversal_state {
+        return trie::traverse(input, frag_gen(key).begin(), ref_trie._nodes.size() - 1).get();
+    };
+
+    for (bool multibyte_traverse : {true, false})
+    for (const auto& frag_gen : fragment_generators)
+    for (const auto& x : key_domain) {
+        input.allow_multibyte_traverse(multibyte_traverse);
+        testlog.trace("Traversing \"{}\"", bytes_as_string(x));
+        auto traversal_state = traverse_from_root(x, frag_gen);
+        auto actual_cursor = reference_trie::cursor_state{
+            .trail = traversal_state.trail
+        };
+        testlog.trace("Got: {}", fmt::join(actual_cursor.trail, ", "));
+        auto lower_bound = std::ranges::lower_bound(keys, x, std::ranges::lexicographical_compare) - keys.begin();
+        auto expected_rank = 2 * lower_bound + 1 - (lower_bound >= int(keys.size()) || !std::ranges::equal(x, keys[lower_bound]));
+        auto actual_meaning = legal_states.at(actual_cursor);
+        BOOST_REQUIRE_EQUAL(actual_meaning.rank, expected_rank);
+        BOOST_REQUIRE_EQUAL(actual_meaning.depth, traversal_state.edges_traversed);
+    }
+}
+
+// Tests the step() and step_back() functions.
+// 
+// Testing strategy:
+// build a trie containing the given set of keys,
+// then for every possible legal state of a cursor on that trie,
+// check that the results of step()/step_back() are also legal states,
+// which correspond to a rank incremented/decremented w.r.t. the starting state.
+void test_step(std::span<const_bytes> keys) {
+    testlog.debug("test_step: testing key set: {}", keys);
+
+    auto ref_trie = reference_trie(keys);
+    auto legal_states = ref_trie.enumerate_all_legal_states();
+    custom_node_reader input{.rt = ref_trie};
+
+    for (const auto& x : legal_states) {
+        testlog.trace("Testing state {}", fmt::join(x.first.trail, ", "));
+        {
+            auto trail = x.first.trail;
+            trie::step(input, trail).get();
+            // step() moves to the next key.
+            // So if the starting state corresponds to a key (rank % 2 == 1), 
+            // rank should grow by 2,
+            // and if the starting state corresponds to an intermediate position (rank % 2 == 0),
+            // rank should grow by 1.
+            // (Unless the next key doesn't exist. Then the end state should correspond to the max rank).
+            auto expected_rank = std::min<int>(x.second.rank + 1 + x.second.rank % 2, keys.size() * 2);
+            testlog.trace("Got after step: {}", fmt::join(trail, ", "));
+            auto actual_meaning = legal_states.at(reference_trie::cursor_state{.trail = trail});
+            BOOST_REQUIRE_EQUAL(actual_meaning.rank, expected_rank);
+        }
+        {
+            auto trail = x.first.trail;
+            trie::step_back(input, trail).get();
+            // step_back() moves to the previous key.
+            // So if the starting state corresponds to a key (rank % 2 == 1), 
+            // rank should shrink by 2,
+            // and if the starting state corresponds to an intermediate position (rank % 2 == 0),
+            // rank should shrink by 1.
+            // (Unless the previous key doesn't exist. Then the end state should correspond to the first key.
+            auto min_rank_for_step_back = keys.size() ? 1 : 0;
+            auto expected_rank = std::max<int>(x.second.rank - 1 - x.second.rank % 2, min_rank_for_step_back);
+            auto actual_meaning = legal_states.at(reference_trie::cursor_state{.trail = trail});
+            BOOST_REQUIRE_EQUAL(actual_meaning.rank, expected_rank);
+        }
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
+    // The length of the test grows at least exponentially with those parameters.
+    // Anything bigger than these is overly long for CI.
+    // But it might be a good idea to make them slightly bigger to check
+    // changes in trie code.
+    size_t max_input_length = 3;
+    size_t max_set_size = 3;
+    const char chars[] = "bdf";
+    auto all_strings = generate_all_strings(chars, max_input_length);
+    auto all_strings_views = std::vector<const_bytes>();
+    for (const auto& x : all_strings) {
+        all_strings_views.push_back(string_as_bytes(x));
+    }
+    size_t case_counter = 0;
+    testlog.info("test_exhaustive: start");
+    for (size_t set_size = 0; set_size <= max_set_size; ++set_size) {
+        auto subsets = generate_all_subsets(all_strings.size(), set_size);
+        testlog.info("{} subsets to test", subsets.size());
+        std::vector<const_bytes> test_set;
+        for (const auto& x : subsets) {
+            test_set.clear();
+            for (const auto& i : x) {
+                test_set.push_back(all_strings_views[i]);
+            }
+            if (case_counter % 1000 == 0) {
+                testlog.info("test_exhaustive: in progress: cases={}", case_counter);
+            }
+            if (test_set.empty()) {
+                continue; // Empty tries are illegal.
+            }
+            test_traverse(all_strings_views, test_set);
+            test_step(test_set);
+            case_counter += 1;
+        }
+    }
+    testlog.info("test_exhaustive: cases={}", case_counter);
+}


### PR DESCRIPTION
This is yet another part in the BTI index project.

Overarching issue: https://github.com/scylladb/scylladb/issues/19191
Previous part: https://github.com/scylladb/scylladb/pull/25317
Next part: implementing sstable index writers and readers on top of the abstract trie writers/readers.

The new code added in this PR isn't used outside of tests yet, but it's posted as a separate PR for reviewability. 

`trie::node_reader`, added in a previous series, contains encoding-aware logic for traversing a single node
(or a batch of nodes) during a trie search.

This commits adds encoding-agnostic functions which drive the the `trie::node_reader` in a loop to traverse the whole branch.

Together, the added functions (`traverse`, `step`, `step_back`) and the data structure they modify (`ancestor_trail`) constitute a trie cursor. We might later wrap them into some `trie_cursor` class, but regardless of whether we are going to do that, keeping them (also) as free functions makes them easier to test.

No backports needed, new functionality.