### PR TITLE
transport: replace throwing protocol_exception with returns

### DIFF
--- a/cql3/query_options.cc
+++ b/cql3/query_options.cc
@@ -160,12 +160,12 @@ void query_options::fill_value_views()
     }
 }
 
-db::consistency_level query_options::check_serial_consistency() const {
+utils::result_with_eptr<db::consistency_level> query_options::check_serial_consistency() const {
 
     if (_options.serial_consistency.has_value()) {
         return *_options.serial_consistency;
     }
-    throw exceptions::protocol_exception("Consistency level for LWT is missing for a request with conditions");
+    return bo::failure(std::make_exception_ptr(exceptions::protocol_exception("Consistency level for LWT is missing for a request with conditions")));
 }
 
 void query_options::cache_pk_function_call(computed_function_values::key_type id, computed_function_values::mapped_type value) const {

--- a/cql3/query_options.hh
+++ b/cql3/query_options.hh
@@ -18,6 +18,7 @@
 #include "service/query_state.hh"
 #include "service/pager/paging_state.hh"
 #include "cql3/values.hh"
+#include "utils/result.hh"
 #include "utils/small_vector.hh"
 #include "service/storage_proxy_fwd.hh"
 
@@ -204,7 +205,7 @@ public:
     }
 
     /**  Return serial consistency for conditional updates. Throws if the consistency is not set. */
-    db::consistency_level check_serial_consistency() const;
+    utils::result_with_eptr<db::consistency_level> check_serial_consistency() const;
 
     api::timestamp_type get_timestamp(service::query_state& state) const {
         auto tstamp = get_specific_options().timestamp;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -327,7 +327,10 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
         service::query_state& qs) const {
 
     auto cl_for_learn = options.get_consistency();
-    auto cl_for_paxos = options.check_serial_consistency();
+    utils::result_with_eptr<db::consistency_level> cl_for_paxos = options.check_serial_consistency();
+    if (!cl_for_paxos) [[unlikely]] {
+        return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(std::move(cl_for_paxos).error());
+    }
     seastar::shared_ptr<cas_request> request;
     schema_ptr schema;
 
@@ -376,7 +379,7 @@ future<shared_ptr<cql_transport::messages::result_message>> batch_statement::exe
 
     return qp.proxy().cas(schema, std::move(cas_shard), request, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
-            cl_for_paxos, cl_for_learn, batch_timeout, cas_timeout).then([this, request] (bool is_applied) {
+            std::move(cl_for_paxos).value(), cl_for_learn, batch_timeout, cas_timeout).then([this, request] (bool is_applied) {
         return request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
     });
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -377,7 +377,10 @@ future<::shared_ptr<cql_transport::messages::result_message>>
 modification_statement::execute_with_condition(query_processor& qp, service::query_state& qs, const query_options& options) const {
 
     auto cl_for_learn = options.get_consistency();
-    auto cl_for_paxos = options.check_serial_consistency();
+    utils::result_with_eptr<db::consistency_level> cl_for_paxos = options.check_serial_consistency();
+    if (!cl_for_paxos) [[unlikely]] {
+        return make_exception_future<shared_ptr<cql_transport::messages::result_message>>(std::move(cl_for_paxos).error());
+    }
     db::timeout_clock::time_point now = db::timeout_clock::now();
     const timeout_config& cfg = qs.get_client_state().get_timeout_config();
 
@@ -426,7 +429,7 @@ modification_statement::execute_with_condition(query_processor& qp, service::que
 
     return qp.proxy().cas(s, std::move(cas_shard), request, request->read_command(qp), request->key(),
             {read_timeout, qs.get_permit(), qs.get_client_state(), qs.get_trace_state()},
-            cl_for_paxos, cl_for_learn, statement_timeout, cas_timeout).then([this, request, tablet_replicas = std::move(tablet_info->tablet_replicas), token_range = tablet_info->token_range] (bool is_applied) {
+            std::move(cl_for_paxos).value(), cl_for_learn, statement_timeout, cas_timeout).then([this, request, tablet_replicas = std::move(tablet_info->tablet_replicas), token_range = tablet_info->token_range] (bool is_applied) {
         auto result = request->build_cas_result_set(_metadata, _columns_of_cas_result_set, is_applied);
         result->add_tablet_info(tablet_replicas, token_range);
         return result;

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -635,7 +635,7 @@ static void write(fragmented_temporary_buffer::ostream& out, T value) {
 
 template<std::integral T, typename Input>
 T read(Input& in) {
-    return net::ntoh(in.template read<T>());
+    return net::ntoh(in.template read<T>().value());
 }
 
 detail::sector_split_iterator::sector_split_iterator(const sector_split_iterator&) noexcept = default;
@@ -1793,7 +1793,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                 auto max_write = data_size - off;
                 auto to_write = std::min(avail, max_write);
                 auto rem = max_write - to_write;
-                partial_writer pw(writer, i, to_write, strm.read_view(to_write), rem, off, id);
+                partial_writer pw(writer, i, to_write, strm.read_view(to_write).value(), rem, off, id);
 
                 switch (s->allocate(pw, fake_permit, timeout)) {
                     case write_result::ok_need_batch_sync:

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -364,7 +364,7 @@ SEASTAR_TEST_CASE(test_commitlog_reader){
                 auto&& [buf, rp] = buf_rp;
                 auto linearization_buffer = bytes_ostream();
                 auto in = buf.get_istream();
-                auto str = to_string_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer));
+                auto str = to_string_view(in.read_bytes_view(buf.size_bytes(), linearization_buffer).value());
                 BOOST_CHECK_EQUAL(str, "hej bubba cow");
                 count++;
                 co_return;
@@ -671,8 +671,10 @@ SEASTAR_TEST_CASE(test_commitlog_replay_single_large_mutation){
                     auto in2 = rp_buf.get_istream();
                     for (size_t i = 0; i < size; ++i) {
                         auto c1 = in1.read<char>();
+                        BOOST_REQUIRE(c1);
                         auto c2 = in2.read<char>();
-                        BOOST_CHECK_EQUAL(c1, c2);
+                        BOOST_REQUIRE(c2);
+                        BOOST_CHECK_EQUAL(c1.value(), c2.value());
                     }
                     return make_ready_future<>();
                 });
@@ -740,8 +742,10 @@ SEASTAR_TEST_CASE(test_commitlog_replay_large_mutations){
                     auto in2 = rp_buf.get_istream();
                     for (size_t i = 0; i < size; ++i) {
                         auto c1 = in1.read<char>();
+                        BOOST_REQUIRE(c1);
                         auto c2 = in2.read<char>();
-                        BOOST_CHECK_EQUAL(c1, c2);
+                        BOOST_REQUIRE(c2);
+                        BOOST_CHECK_EQUAL(c1.value(), c2.value());
                     }
                     ++n;
                     return make_ready_future<>();

--- a/test/boost/fragmented_temporary_buffer_test.cc
+++ b/test/boost/fragmented_temporary_buffer_test.cc
@@ -15,11 +15,10 @@
 #include "test/lib/random_utils.hh"
 
 struct {
-    [[noreturn]]
-    static void throw_out_of_range(size_t a, size_t b) {
-        throw size_t(a + b);
+    static utils::result_with_eptr<void> out_of_range(size_t a, size_t b) {
+        return bo::failure(std::make_exception_ptr(size_t(a + b)));
     }
-} int_thrower;
+} int_creator;
 
 std::tuple<std::vector<fragmented_temporary_buffer>, uint64_t, uint16_t> get_buffers()
 {
@@ -208,10 +207,10 @@ SEASTAR_THREAD_TEST_CASE(test_empty_istream) {
 
     auto linearization_buffer = bytes_ostream();
     BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-    BOOST_CHECK_THROW(in.read<char>(), std::out_of_range);
-    BOOST_CHECK_THROW(in.read_view(1), std::out_of_range);
-    BOOST_CHECK_THROW(in.read_bytes_view(1, linearization_buffer), std::out_of_range);
-    BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer), bytes_view());
+    BOOST_CHECK_THROW(in.read<char>().value(), std::out_of_range);
+    BOOST_CHECK_THROW(in.read_view(1).value(), std::out_of_range);
+    BOOST_CHECK_THROW(in.read_bytes_view(1, linearization_buffer).value(), std::out_of_range);
+    BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer).value(), bytes_view());
     BOOST_CHECK(linearization_buffer.empty());
 }
 
@@ -223,18 +222,18 @@ SEASTAR_THREAD_TEST_CASE(test_read_pod) {
 
         auto in = ftb.get_istream();
         BOOST_CHECK_EQUAL(in.bytes_left(), sizeof(type1) + sizeof(type2));
-        BOOST_CHECK_EQUAL(in.read<type1>(), expected_value1);
+        BOOST_CHECK_EQUAL(in.read<type1>().value(), expected_value1);
         BOOST_CHECK_EQUAL(in.bytes_left(), sizeof(type2));
-        BOOST_CHECK_THROW(in.read<type1>(), std::out_of_range);
+        BOOST_CHECK_THROW(in.read<type1>().value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), sizeof(type2));
-        BOOST_CHECK_EQUAL(in.read<type2>(), expected_value2);
+        BOOST_CHECK_EQUAL(in.read<type2>().value(), expected_value2);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read<type2>(), std::out_of_range);
+        BOOST_CHECK_THROW(in.read<type2>().value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read<type1>(), std::out_of_range);
+        BOOST_CHECK_THROW(in.read<type1>().value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read<char>(), std::out_of_range);
-        BOOST_CHECK_EXCEPTION(in.read<char>(int_thrower), size_t, [] (size_t v) { return v == 1; });
+        BOOST_CHECK_THROW(in.read<char>().value(), std::out_of_range);
+        BOOST_CHECK_EXCEPTION(in.read<char>(int_creator).value(), size_t, [] (size_t v) { return v == 1; });
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
     };
 
@@ -253,21 +252,21 @@ SEASTAR_THREAD_TEST_CASE(test_read_to) {
         auto in = ftb.get_istream();
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value1.size() + expected_value2.size());
         actual_value = bytes(bytes::initialized_later(), expected_value1.size());
-        in.read_to(expected_value1.size(), actual_value.begin());
+        BOOST_CHECK(in.read_to(expected_value1.size(), actual_value.begin()).value());
         BOOST_CHECK_EQUAL(actual_value, expected_value1);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
-        BOOST_CHECK_THROW(in.read_to(expected_value1.size(), actual_value.begin()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_to(expected_value1.size(), actual_value.begin()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
         actual_value = bytes(bytes::initialized_later(), expected_value2.size());
-        in.read_to(expected_value2.size(), actual_value.begin());
+        BOOST_CHECK(in.read_to(expected_value2.size(), actual_value.begin()).value());
         BOOST_CHECK_EQUAL(actual_value, expected_value2);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_to(expected_value2.size(), actual_value.begin()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_to(expected_value2.size(), actual_value.begin()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_to(expected_value1.size(), actual_value.begin()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_to(expected_value1.size(), actual_value.begin()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_to(1, actual_value.begin()), std::out_of_range);
-        BOOST_CHECK_EXCEPTION(in.read_to(1, actual_value.begin(), int_thrower), size_t, [] (size_t v) { return v == 1; });
+        BOOST_CHECK_THROW(in.read_to(1, actual_value.begin()).value(), std::out_of_range);
+        BOOST_CHECK_EXCEPTION(in.read_to(1, actual_value.begin(), int_creator).value(), size_t, [] (size_t v) { return v == 1; });
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
     };
 
@@ -286,18 +285,18 @@ SEASTAR_THREAD_TEST_CASE(test_read_view) {
 
         auto in = ftb.get_istream();
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value1.size() + expected_value2.size());
-        BOOST_CHECK_EQUAL(linearized(in.read_view(expected_value1.size())), expected_value1);
+        BOOST_CHECK_EQUAL(linearized(in.read_view(expected_value1.size()).value()), expected_value1);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
-        BOOST_CHECK_THROW(in.read_view(expected_value1.size()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_view(expected_value1.size()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
-        BOOST_CHECK_EQUAL(linearized(in.read_view(expected_value2.size())), expected_value2);
+        BOOST_CHECK_EQUAL(linearized(in.read_view(expected_value2.size()).value()), expected_value2);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_view(expected_value2.size()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_view(expected_value2.size()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_view(expected_value1.size()), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_view(expected_value1.size()).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_view(1), std::out_of_range);
-        BOOST_CHECK_EXCEPTION(in.read_view(1, int_thrower), size_t, [] (size_t v) { return v == 1; });
+        BOOST_CHECK_THROW(in.read_view(1).value(), std::out_of_range);
+        BOOST_CHECK_EXCEPTION(in.read_view(1, int_creator).value(), size_t, [] (size_t v) { return v == 1; });
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
     };
 
@@ -316,22 +315,22 @@ SEASTAR_THREAD_TEST_CASE(test_read_bytes_view) {
         SCYLLA_ASSERT(expected_value2.size() < expected_value1.size());
 
         auto in = ftb.get_istream();
-        BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer), bytes_view());
+        BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer).value(), bytes_view());
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value1.size() + expected_value2.size());
-        BOOST_CHECK_EQUAL(in.read_bytes_view(expected_value1.size(), linearization_buffer), expected_value1);
+        BOOST_CHECK_EQUAL(in.read_bytes_view(expected_value1.size(), linearization_buffer).value(), expected_value1);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
-        BOOST_CHECK_THROW(in.read_bytes_view(expected_value1.size(), linearization_buffer), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_bytes_view(expected_value1.size(), linearization_buffer).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), expected_value2.size());
-        BOOST_CHECK_EQUAL(in.read_bytes_view(expected_value2.size(), linearization_buffer), expected_value2);
+        BOOST_CHECK_EQUAL(in.read_bytes_view(expected_value2.size(), linearization_buffer).value(), expected_value2);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_bytes_view(expected_value2.size(), linearization_buffer), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_bytes_view(expected_value2.size(), linearization_buffer).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_bytes_view(expected_value1.size(), linearization_buffer), std::out_of_range);
+        BOOST_CHECK_THROW(in.read_bytes_view(expected_value1.size(), linearization_buffer).value(), std::out_of_range);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read_bytes_view(1, linearization_buffer), std::out_of_range);
-        BOOST_CHECK_EXCEPTION(in.read_bytes_view(1, linearization_buffer, int_thrower), size_t, [] (size_t v) { return v == 1; });
+        BOOST_CHECK_THROW(in.read_bytes_view(1, linearization_buffer).value(), std::out_of_range);
+        BOOST_CHECK_EXCEPTION(in.read_bytes_view(1, linearization_buffer, int_creator).value(), size_t, [] (size_t v) { return v == 1; });
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer), bytes_view());
+        BOOST_CHECK_EQUAL(in.read_bytes_view(0, linearization_buffer).value(), bytes_view());
     };
 
 
@@ -444,7 +443,7 @@ SEASTAR_THREAD_TEST_CASE(test_skip) {
         BOOST_CHECK_EQUAL(in.bytes_left(), sizeof(type1) + sizeof(type2));
         in.skip(sizeof(type1));
         BOOST_CHECK_EQUAL(in.bytes_left(), sizeof(type2));
-        BOOST_CHECK_EQUAL(in.read<type2>(), expected_value2);
+        BOOST_CHECK_EQUAL(in.read<type2>().value(), expected_value2);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
         in.skip(sizeof(type2));
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
@@ -466,9 +465,9 @@ SEASTAR_THREAD_TEST_CASE(test_remove_suffix) {
         BOOST_CHECK_EQUAL(ftb.size_bytes(), sizeof(type1));
 
         auto in = ftb.get_istream();
-        BOOST_CHECK_EQUAL(in.read<type1>(), expected_value1);
+        BOOST_CHECK_EQUAL(in.read<type1>().value(), expected_value1);
         BOOST_CHECK_EQUAL(in.bytes_left(), 0);
-        BOOST_CHECK_THROW(in.read<char>(), std::out_of_range);
+        BOOST_CHECK_THROW(in.read<char>().value(), std::out_of_range);
 
         ftb.remove_suffix(sizeof(type1) - 1);
         BOOST_CHECK_EQUAL(ftb.size_bytes(), 1);

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -92,28 +92,28 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     res.serialize({sc::change_type::CREATED, sc::target_type::FUNCTION, "foo", "bar", "zed"}, version);
     res.serialize({sc::change_type::CREATED, sc::target_type::AGGREGATE, "foo", "bar", "zed"}, version);
 
-    auto msg = res.make_message(version, cql_transport::cql_compression::none).release();
+    auto msg = res.make_message(version, cql_transport::cql_compression::none).value().release();
     auto total_length = msg.len();
     auto fbufs = fragmented_temporary_buffer(msg.release(), total_length);
 
     bytes_ostream linearization_buffer;
     auto req = cql_transport::request_reader(fbufs.get_istream(), linearization_buffer);
-    BOOST_CHECK_EQUAL(unsigned(uint8_t(req.read_byte())), version | 0x80);
-    BOOST_CHECK_EQUAL(unsigned(req.read_byte()), 0); // flags
-    BOOST_CHECK_EQUAL(req.read_short(), stream_id);
-    BOOST_CHECK_EQUAL(unsigned(req.read_byte()), unsigned(opcode));
-    BOOST_CHECK_EQUAL(req.read_int() + 9, total_length);
+    BOOST_CHECK_EQUAL(unsigned(uint8_t(req.read_byte().value())), version | 0x80);
+    BOOST_CHECK_EQUAL(unsigned(req.read_byte().value()), 0); // flags
+    BOOST_CHECK_EQUAL(req.read_short().value(), stream_id);
+    BOOST_CHECK_EQUAL(unsigned(req.read_byte().value()), unsigned(opcode));
+    BOOST_CHECK_EQUAL(req.read_int().value() + 9, total_length);
 
-    auto v1 = req.read_value_view(version);
+    auto v1 = req.read_value_view(version).value();
     BOOST_CHECK(!v1.unset && v1.value.is_null());
-    auto v2 = req.read_value_view(version);
+    auto v2 = req.read_value_view(version).value();
     BOOST_CHECK(v2.unset);
-    BOOST_CHECK_EQUAL(to_bytes(req.read_value_view(version).value), value);
+    BOOST_CHECK_EQUAL(to_bytes(req.read_value_view(version).value().value), value);
 
     std::vector<std::string_view> names;
     std::vector<cql3::raw_value_view> values;
     cql3::unset_bind_variable_vector unset;
-    req.read_name_and_value_list(version, names, values, unset);
+    BOOST_CHECK(req.read_name_and_value_list(version, names, values, unset));
     BOOST_CHECK(std::none_of(unset.begin(), unset.end(), std::identity()));
     BOOST_CHECK(std::ranges::equal(names, names_and_values | std::views::transform([] (auto& name_and_value) {
         return std::string_view(name_and_value.first);
@@ -126,37 +126,37 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     })));
 
     auto received_string_list = std::vector<sstring>();
-    req.read_string_list(received_string_list);
+    BOOST_CHECK(req.read_string_list(received_string_list));
     BOOST_CHECK_EQUAL(received_string_list, string_list);
 
-    auto received_string_map = req.read_string_map();
+    auto received_string_map = req.read_string_map().value();
     BOOST_CHECK_EQUAL(received_string_map, string_unordered_map);
 
-    BOOST_CHECK_EQUAL(req.read_string(), "CREATED");
-    BOOST_CHECK_EQUAL(req.read_string(), "KEYSPACE");
-    BOOST_CHECK_EQUAL(req.read_string(), "foo");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "CREATED");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "KEYSPACE");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "foo");
 
-    BOOST_CHECK_EQUAL(req.read_string(), "CREATED");
-    BOOST_CHECK_EQUAL(req.read_string(), "TABLE");
-    BOOST_CHECK_EQUAL(req.read_string(), "foo");
-    BOOST_CHECK_EQUAL(req.read_string(), "bar");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "CREATED");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "TABLE");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "foo");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "bar");
 
-    BOOST_CHECK_EQUAL(req.read_string(), "CREATED");
-    BOOST_CHECK_EQUAL(req.read_string(), "TYPE");
-    BOOST_CHECK_EQUAL(req.read_string(), "foo");
-    BOOST_CHECK_EQUAL(req.read_string(), "bar");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "CREATED");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "TYPE");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "foo");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "bar");
 
-    BOOST_CHECK_EQUAL(req.read_string(), "CREATED");
-    BOOST_CHECK_EQUAL(req.read_string(), "FUNCTION");
-    BOOST_CHECK_EQUAL(req.read_string(), "foo");
-    BOOST_CHECK_EQUAL(req.read_string(), "bar");
-    BOOST_CHECK_EQUAL(req.read_short(), 1);
-    BOOST_CHECK_EQUAL(req.read_string(), "zed");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "CREATED");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "FUNCTION");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "foo");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "bar");
+    BOOST_CHECK_EQUAL(req.read_short().value(), 1);
+    BOOST_CHECK_EQUAL(req.read_string().value(), "zed");
 
-    BOOST_CHECK_EQUAL(req.read_string(), "CREATED");
-    BOOST_CHECK_EQUAL(req.read_string(), "AGGREGATE");
-    BOOST_CHECK_EQUAL(req.read_string(), "foo");
-    BOOST_CHECK_EQUAL(req.read_string(), "bar");
-    BOOST_CHECK_EQUAL(req.read_short(), 1);
-    BOOST_CHECK_EQUAL(req.read_string(), "zed");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "CREATED");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "AGGREGATE");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "foo");
+    BOOST_CHECK_EQUAL(req.read_string().value(), "bar");
+    BOOST_CHECK_EQUAL(req.read_short().value(), 1);
+    BOOST_CHECK_EQUAL(req.read_string().value(), "zed");
 }

--- a/transport/request.hh
+++ b/transport/request.hh
@@ -11,6 +11,7 @@
 #include "server.hh"
 #include "utils/utf8.hh"
 #include "utils/fragmented_temporary_buffer.hh"
+#include "utils/result.hh"
 
 namespace cql_transport {
 
@@ -28,20 +29,21 @@ class request_reader {
     fragmented_temporary_buffer::istream _in;
     bytes_ostream* _linearization_buffer;
 private:
-    struct exception_thrower {
-        [[noreturn]] [[gnu::cold]]
-        static void throw_out_of_range(size_t attempted_read, size_t actual_left) {
-            throw exceptions::protocol_exception(format("truncated frame: expected {:d} bytes, length is {:d}", attempted_read, actual_left));
-        };
+    struct exception_creator {
+        [[gnu::cold]]
+        static utils::result_with_eptr<void> out_of_range(size_t attempted_read, size_t actual_left) {
+            return bo::failure(std::make_exception_ptr(exceptions::protocol_exception(format("truncated frame: expected {:d} bytes, length is {:d}", attempted_read, actual_left))));
+        }
     };
-    static void validate_utf8(std::string_view s) {
+    static utils::result_with_eptr<void> validate_utf8(std::string_view s) {
         auto error_pos = utils::utf8::validate_with_error_position(to_bytes_view(s));
         if (error_pos) {
-            throw exceptions::protocol_exception(format("Cannot decode string as UTF8, invalid character at byte offset {}", *error_pos));
+            return bo::failure(exceptions::protocol_exception(format("Cannot decode string as UTF8, invalid character at byte offset {}", *error_pos)));
         }
+        return bo::success();
     }
 
-    static db::consistency_level wire_to_consistency(int16_t v) {
+    static utils::result_with_eptr<db::consistency_level> wire_to_consistency(int16_t v) {
         switch (v) {
         case 0x0000: return db::consistency_level::ANY;
         case 0x0001: return db::consistency_level::ONE;
@@ -54,7 +56,7 @@ private:
         case 0x0008: return db::consistency_level::SERIAL;
         case 0x0009: return db::consistency_level::LOCAL_SERIAL;
         case 0x000A: return db::consistency_level::LOCAL_ONE;
-        default:     throw exceptions::protocol_exception(format("Unknown code {:d} for a consistency level", v));
+        default:     return bo::failure(exceptions::protocol_exception(format("Unknown code {:d} for a consistency level", v)));
         }
     }
 public:
@@ -71,130 +73,237 @@ public:
         return _in.bytes_left();
     }
 
-    bytes_view read_raw_bytes_view(size_t n) {
-        return _in.read_bytes_view(n, *_linearization_buffer, exception_thrower());
-    }
-
-    int8_t read_byte() {
-        return _in.read<int8_t>(exception_thrower());
-    }
-
-    int32_t read_int() {
-        return be_to_cpu(_in.read<int32_t>(exception_thrower()));
-    }
-
-    int64_t read_long() {
-        return be_to_cpu(_in.read<int64_t>(exception_thrower()));
-    }
-
-    uint16_t read_short() {
-        return be_to_cpu(_in.read<uint16_t>(exception_thrower()));
-    }
-
-    sstring read_string() {
-        auto n = read_short();
-        sstring s = uninitialized_string(n);
-        _in.read_to(n, s.begin(), exception_thrower());
-        validate_utf8(s);
-        return s;
-    }
-
-    std::string_view read_string_view() {
-        auto n = read_short();
-        auto bv = _in.read_bytes_view(n, *_linearization_buffer, exception_thrower());
-        auto s = std::string_view(reinterpret_cast<const char*>(bv.data()), bv.size());
-        validate_utf8(s);
-        return s;
-    }
-
-    std::string_view read_long_string_view() {
-        auto n = read_int();
-        auto bv = _in.read_bytes_view(n, *_linearization_buffer, exception_thrower());
-        auto s = std::string_view(reinterpret_cast<const char*>(bv.data()), bv.size());
-        validate_utf8(s);
-        return s;
-    }
-
-    bytes_opt read_bytes() {
-        auto len = read_int();
-        if (len < 0) {
-            return {};
+    utils::result_with_eptr<bytes_view> read_raw_bytes_view(size_t n) {
+        utils::result_with_eptr<bytes_view> bv = _in.read_bytes_view(n, *_linearization_buffer, exception_creator());
+        if (!bv) [[unlikely]] {
+            return bo::failure(std::move(bv).error());
         }
-        bytes b(bytes::initialized_later(), len);
-        _in.read_to(len, b.begin(), exception_thrower());
+        return std::move(bv).value();
+    }
+
+    utils::result_with_eptr<int8_t> read_byte() {
+        utils::result_with_eptr<int8_t> v = _in.read<int8_t>(exception_creator());
+        if (!v) [[unlikely]] {
+            return bo::failure(std::move(v).error());
+        }
+        return be_to_cpu(std::move(v).value());
+    }
+
+    utils::result_with_eptr<int32_t> read_int() {
+        utils::result_with_eptr<int32_t> v = _in.read<int32_t>(exception_creator());
+        if (!v) [[unlikely]] {
+            return bo::failure(std::move(v).error());
+        }
+        return be_to_cpu(std::move(v).value());
+    }
+
+    utils::result_with_eptr<int64_t> read_long() {
+        utils::result_with_eptr<int64_t> v = _in.read<int64_t>(exception_creator());
+        if (!v) [[unlikely]] {
+            return bo::failure(std::move(v).error());
+        }
+        return be_to_cpu(std::move(v).value());
+    }
+
+    utils::result_with_eptr<uint16_t> read_short() {
+        utils::result_with_eptr<uint16_t> v = _in.read<uint16_t>(exception_creator());
+        if (!v) [[unlikely]] {
+            return bo::failure(std::move(v).error());
+        }
+        return be_to_cpu(v.value());
+    }
+
+    utils::result_with_eptr<sstring> read_string() {
+        utils::result_with_eptr<uint16_t> n = read_short();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).error());
+        }
+        sstring s = uninitialized_string(n.value());
+        auto output = _in.read_to(n.value(), s.begin(), exception_creator());
+        if (!output) [[unlikely]] {
+            return bo::failure(std::move(output).error());
+        }
+        utils::result_with_eptr<void> check = validate_utf8(s);
+        if (!check) [[unlikely]] {
+            return bo::failure(std::move(check).error());
+        }
+        return s;
+    }
+
+    utils::result_with_eptr<std::string_view> read_string_view() {
+        utils::result_with_eptr<uint16_t> n = read_short();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).error());
+        }
+        utils::result_with_eptr<bytes_view> bv = _in.read_bytes_view(n.value(), *_linearization_buffer, exception_creator());
+        if (!bv) [[unlikely]] {
+            return bo::failure(std::move(bv).error());
+        }
+        auto s = std::string_view(reinterpret_cast<const char*>(bv.value().data()), bv.value().size());
+        utils::result_with_eptr<void> check = validate_utf8(s);
+        if (!check) [[unlikely]] {
+            return bo::failure(std::move(check).error());
+        }
+        return s;
+    }
+
+    utils::result_with_eptr<std::string_view> read_long_string_view() {
+        utils::result_with_eptr<int32_t> n = read_int();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).error());
+        }
+        utils::result_with_eptr<bytes_view> bv = _in.read_bytes_view(n.value(), *_linearization_buffer, exception_creator());
+        if (!bv) [[unlikely]] {
+            return bo::failure(std::move(bv).error());
+        }
+        auto s = std::string_view(reinterpret_cast<const char*>(bv.value().data()), bv.value().size());
+        utils::result_with_eptr<void> check = validate_utf8(s);
+        if (!check) [[unlikely]] {
+            return bo::failure(std::move(check).error());
+        }
+        return s;
+    }
+
+    utils::result_with_eptr<bytes> read_bytes() {
+        utils::result_with_eptr<int32_t> len = read_int();
+        if (!len) [[unlikely]] {
+            return bo::failure(std::move(len).error());
+        }
+        if (len.value() < 0) {
+            return {bytes(bytes::initialized_later(), 0)};
+        }
+        bytes b(bytes::initialized_later(), len.value());
+        auto output = _in.read_to(len.value(), b.begin(), exception_creator());
+        if (!output) [[unlikely]] {
+            return bo::failure(std::move(output).error());
+        }
         return {std::move(b)};
     }
 
-    bytes read_short_bytes() {
-        auto n = read_short();
-        bytes b(bytes::initialized_later(), n);
-        _in.read_to(n, b.begin(), exception_thrower());
+    utils::result_with_eptr<bytes> read_short_bytes() {
+        utils::result_with_eptr<uint16_t> n = read_short();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).error());
+        }
+        bytes b(bytes::initialized_later(), n.value());
+        auto output = _in.read_to(n.value(), b.begin(), exception_creator());
+        if (!output) [[unlikely]] {
+            return bo::failure(std::move(output).error());
+        }
         return b;
     }
 
-    value_view_and_unset read_value_view(uint8_t version) {
-        auto len = read_int();
-        if (len < 0) {
+    utils::result_with_eptr<value_view_and_unset> read_value_view(uint8_t version) {
+        utils::result_with_eptr<int32_t> len = read_int();
+        if (!len) [[unlikely]] {
+            return bo::failure(std::move(len).error());
+        }
+        if (len.value() < 0) {
             if (version < 4) {
-                return cql3::raw_value_view::make_null();
+                return bo::success(cql3::raw_value_view::make_null());
             }
-            if (len == -1) {
-                return cql3::raw_value_view::make_null();
-            } else if (len == -2) {
-                return value_view_and_unset(unset_tag());
+            if (len.value() == -1) {
+                return bo::success(cql3::raw_value_view::make_null());
+            } else if (len.value() == -2) {
+                return bo::success(value_view_and_unset(unset_tag()));
             } else {
-                throw exceptions::protocol_exception(format("invalid value length: {:d}", len));
+                return std::make_exception_ptr(exceptions::protocol_exception(format("invalid value length: {:d}", len.value())));
             }
         }
-        return cql3::raw_value_view::make_value(_in.read_view(len, exception_thrower()));
+        utils::result_with_eptr<fragmented_temporary_buffer::view> view = _in.read_view(len.value(), exception_creator());
+        if (!view) [[unlikely]] {
+                return bo::failure(std::move(view).error());
+        }
+        return bo::success(cql3::raw_value_view::make_value(std::move(view).value()));
     }
 
-    void read_name_and_value_list(uint8_t version, std::vector<std::string_view>& names, std::vector<cql3::raw_value_view>& values,
+    utils::result_with_eptr<void> read_name_and_value_list(uint8_t version, std::vector<std::string_view>& names, std::vector<cql3::raw_value_view>& values,
             cql3::unset_bind_variable_vector& unset) {
-        uint16_t size = read_short();
-        names.reserve(size);
-        unset.reserve(size);
-        values.reserve(size);
-        for (uint16_t i = 0; i < size; i++) {
-            names.emplace_back(read_string_view());
-            auto&& [value, is_unset] = read_value_view(version);
+        utils::result_with_eptr<uint16_t> size = read_short();
+        if (!size) [[unlikely]] {
+            return bo::failure(std::move(size).error());
+        }
+        names.reserve(size.value());
+        unset.reserve(size.value());
+        values.reserve(size.value());
+        for (uint16_t i = 0; i < size.value(); i++) {
+            auto name = read_string_view();
+            if (!name) [[unlikely]] {
+                return bo::failure(std::move(name).error());
+            }
+            names.emplace_back(std::move(name).value());
+            utils::result_with_eptr<value_view_and_unset> vv = read_value_view(version);
+            if (!vv) [[unlikely]] {
+                return bo::failure(std::move(vv).error());
+            }
+            auto&& [value, is_unset] = std::move(vv).value();
             values.emplace_back(std::move(value));
             unset.emplace_back(is_unset);
         }
+        return bo::success();
     }
 
-    void read_string_list(std::vector<sstring>& strings) {
-        uint16_t size = read_short();
-        strings.reserve(size);
-        for (uint16_t i = 0; i < size; i++) {
-            strings.emplace_back(read_string());
+    utils::result_with_eptr<void> read_string_list(std::vector<sstring>& strings) {
+        utils::result_with_eptr<uint16_t> size = read_short();
+        if (!size) [[unlikely]] {
+            return bo::failure(std::move(size).error());
         }
+        strings.reserve(size.value());
+        for (uint16_t i = 0; i < size.value(); i++) {
+            utils::result_with_eptr<sstring> str = read_string();
+            if (!str) [[unlikely]] {
+                return bo::failure(std::move(str).error());
+            }
+            strings.emplace_back(std::move(str).value());
+        }
+        return bo::success();
     }
 
-    void read_value_view_list(uint8_t version, std::vector<cql3::raw_value_view>& values, cql3::unset_bind_variable_vector& unset) {
-        uint16_t size = read_short();
-        values.reserve(size);
-        unset.reserve(size);
-        for (uint16_t i = 0; i < size; i++) {
-            auto&& [value, is_unset] = read_value_view(version);
+    utils::result_with_eptr<void> read_value_view_list(uint8_t version, std::vector<cql3::raw_value_view>& values, cql3::unset_bind_variable_vector& unset) {
+        utils::result_with_eptr<uint16_t> size = read_short();
+        if (!size) [[unlikely]] {
+            return bo::failure(std::move(size).error());
+        }
+        values.reserve(size.value());
+        unset.reserve(size.value());
+        for (uint16_t i = 0; i < size.value(); i++) {
+            utils::result_with_eptr<value_view_and_unset> vv = read_value_view(version);
+            if (!vv) [[unlikely]] {
+                return bo::failure(std::move(vv).error());
+            }
+            auto&& [value, is_unset] = std::move(vv).value();
             values.emplace_back(std::move(value));
             unset.emplace_back(is_unset);
         }
+        return bo::success();
     }
 
-    db::consistency_level read_consistency() {
-        return wire_to_consistency(read_short());
+    utils::result_with_eptr<db::consistency_level> read_consistency() {
+        utils::result_with_eptr<uint16_t> v = read_short();
+        if (!v) [[unlikely]] {
+            return bo::failure(std::move(v).error());
+        }
+        return wire_to_consistency(v.value());
     }
 
-    std::unordered_map<sstring, sstring> read_string_map() {
+    utils::result_with_eptr<std::unordered_map<sstring, sstring>> read_string_map() {
         std::unordered_map<sstring, sstring> string_map;
-        auto n = read_short();
-        for (auto i = 0; i < n; i++) {
-            auto key = read_string();
-            auto val = read_string();
+        utils::result_with_eptr<uint16_t> n = read_short();
+        if (!n) [[unlikely]] {
+            return bo::failure(std::move(n).error());
+        }
+        for (auto i = 0; i < n.value(); i++) {
+            utils::result_with_eptr<sstring> key = read_string();
+            if (!key) [[unlikely]] {
+                return bo::failure(std::move(key).error());
+            }
+            utils::result_with_eptr<sstring> val = read_string();
+            if (!val) [[unlikely]] {
+                return bo::failure(std::move(val).error());
+            }
             string_map.emplace(std::piecewise_construct,
-                std::forward_as_tuple(std::move(key)),
-                std::forward_as_tuple(std::move(val)));
+                std::forward_as_tuple(std::move(key).value()),
+                std::forward_as_tuple(std::move(val).value()));
         }
         return string_map;
     }
@@ -220,18 +329,31 @@ private:
         options_flag::NAMES_FOR_VALUES
     >;
 public:
-    std::unique_ptr<cql3::query_options> read_options(uint8_t version, const cql3::cql_config& cql_config) {
-        auto consistency = read_consistency();
-        auto flags = enum_set<options_flag_enum>::from_mask(read_byte());
+    utils::result_with_eptr<std::unique_ptr<cql3::query_options>> read_options(uint8_t version, const cql3::cql_config& cql_config) {
+        utils::result_with_eptr<db::consistency_level> consistency = read_consistency();
+        if (!consistency) [[unlikely]] {
+            return bo::failure(std::move(consistency).error());
+        }
+        utils::result_with_eptr<int8_t> b = read_byte();
+        if (!b) [[unlikely]] {
+            return bo::failure(std::move(b).error());
+        }
+        auto flags = enum_set<options_flag_enum>::from_mask(b.value());
         std::vector<cql3::raw_value_view> values;
         cql3::unset_bind_variable_vector unset;
         std::vector<std::string_view> names;
 
         if (flags.contains<options_flag::VALUES>()) {
             if (flags.contains<options_flag::NAMES_FOR_VALUES>()) {
-                read_name_and_value_list(version, names, values, unset);
+                utils::result_with_eptr<void> nvl = read_name_and_value_list(version, names, values, unset);
+                if (!nvl) [[unlikely]] {
+                    return bo::failure(std::move(nvl).error());
+                }
             } else {
-                read_value_view_list(version, values, unset);
+                utils::result_with_eptr<void> vvl = read_value_view_list(version, values, unset);
+                if (!vvl) [[unlikely]] {
+                    return bo::failure(std::move(vvl).error());
+                }
             }
         }
 
@@ -242,22 +364,41 @@ public:
         std::unique_ptr<cql3::query_options> options;
         if (flags) {
             lw_shared_ptr<service::pager::paging_state> paging_state;
-            int32_t page_size = flags.contains<options_flag::PAGE_SIZE>() ? read_int() : -1;
+            int32_t page_size = -1;
+            if (flags.contains<options_flag::PAGE_SIZE>()) {
+                utils::result_with_eptr<int32_t> v = read_int();
+                if (!v) [[unlikely]] {
+                    return bo::failure(std::move(v).error());
+                }
+                page_size = v.value();
+            }
             if (flags.contains<options_flag::PAGING_STATE>()) {
-                paging_state = service::pager::paging_state::deserialize(read_bytes());
+                utils::result_with_eptr<bytes> bv = read_bytes();
+                if (!bv) [[unlikely]] {
+                    return bo::failure(std::move(bv).error());
+                }
+                paging_state = service::pager::paging_state::deserialize(bv.value());
             }
 
             db::consistency_level serial_consistency = db::consistency_level::SERIAL;
             if (flags.contains<options_flag::SERIAL_CONSISTENCY>()) {
-                serial_consistency = read_consistency();
+                auto sc = read_consistency();
+                if (!sc) [[unlikely]] {
+                    return bo::failure(std::move(sc).error());
+                }
+                serial_consistency = sc.value();
             }
 
             api::timestamp_type ts = api::missing_timestamp;
             if (flags.contains<options_flag::TIMESTAMP>()) {
-                ts = read_long();
+                utils::result_with_eptr<int64_t> v = read_long();
+                if (!v) [[unlikely]] {
+                    return bo::failure(std::move(v).error());
+                }
+                ts = v.value();
                 if (ts < api::min_timestamp || ts > api::max_timestamp) {
-                    throw exceptions::protocol_exception(format("Out of bound timestamp, must be in [{:d}, {:d}] (got {:d})",
-                        api::min_timestamp, api::max_timestamp, ts));
+                    return bo::failure(std::make_exception_ptr(exceptions::protocol_exception(format("Out of bound timestamp, must be in [{:d}, {:d}] (got {:d})",
+                        api::min_timestamp, api::max_timestamp, ts))));
                 }
             }
 
@@ -265,11 +406,11 @@ public:
             if (!names.empty()) {
                 onames = std::move(names);
             }
-            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::move(onames),
+            options = std::make_unique<cql3::query_options>(cql_config, consistency.value(), std::move(onames),
                 cql3::raw_value_view_vector_with_unset(std::move(values), std::move(unset)), skip_metadata,
                 cql3::query_options::specific_options{page_size, std::move(paging_state), serial_consistency, ts});
         } else {
-            options = std::make_unique<cql3::query_options>(cql_config, consistency, std::nullopt,
+            options = std::make_unique<cql3::query_options>(cql_config, consistency.value(), std::nullopt,
                 cql3::raw_value_view_vector_with_unset(std::move(values), std::move(unset)), skip_metadata,
                 cql3::query_options::specific_options::DEFAULT);
         }

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -81,7 +81,7 @@ public:
 
     // Make a non-owning scattered_message of the response. Remains valid as long
     // as the response object is alive.
-    scattered_message<char> make_message(uint8_t version, cql_compression compression);
+    utils::result_with_eptr<scattered_message<char>> make_message(uint8_t version, cql_compression compression);
 
     cql_binary_opcode opcode() const {
         return _opcode;
@@ -107,9 +107,9 @@ private:
         return frame_buf;
     }
 
-    sstring make_frame(uint8_t version, size_t length) {
+    utils::result_with_eptr<sstring> make_frame(uint8_t version, size_t length) {
         if (version > 0x04) {
-            throw exceptions::protocol_exception(format("Invalid or unsupported protocol version: {:d}", version));
+            return bo::failure(std::make_exception_ptr(exceptions::protocol_exception(format("Invalid or unsupported protocol version: {:d}", version))));
         }
 
         return make_frame_one<cql_binary_frame_v3>(version, length);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -65,6 +65,7 @@
 #include "transport/cql_protocol_extension.hh"
 #include "utils/bit_cast.hh"
 #include "utils/labels.hh"
+#include "utils/result.hh"
 #include "utils/reusable_buffer.hh"
 
 template<typename T = void>
@@ -922,7 +923,11 @@ future<fragmented_temporary_buffer> cql_server::connection::read_and_decompress_
 
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_startup(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
-    auto options = in.read_string_map();
+    utils::result_with_eptr<std::unordered_map<sstring, sstring>> o = in.read_string_map();
+    if (!o) {
+        co_return coroutine::exception(std::move(o).error());
+    }
+    std::unordered_map<sstring, sstring> options = std::move(o).value();
     auto compression_opt = options.find("COMPRESSION");
     if (compression_opt != options.end()) {
          auto compression = compression_opt->second;
@@ -992,8 +997,11 @@ void cql_server::connection::update_scheduling_group() {
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_auth_response(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
     auto sasl_challenge = client_state.get_auth_service()->underlying_authenticator().new_sasl_challenge();
-    auto buf = in.read_raw_bytes_view(in.bytes_left());
-    auto challenge = sasl_challenge->evaluate_response(buf);
+    utils::result_with_eptr<bytes_view> buf = in.read_raw_bytes_view(in.bytes_left());
+    if (!buf) {
+        return make_exception_future<std::unique_ptr<cql_server::response>>(std::move(buf).error());
+    }
+    auto challenge = sasl_challenge->evaluate_response(buf.value());
     if (sasl_challenge->is_complete()) {
         return sasl_challenge->get_authenticated_user().then_wrapped([this, sasl_challenge, stream, &client_state, challenge = std::move(challenge), trace_state](future<auth::authenticated_user> f) mutable {
             bool failed = f.failed();
@@ -1099,10 +1107,17 @@ process_query_internal(service::client_state& client_state, distributed<cql3::qu
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
         cql3::dialect dialect) {
-    auto query = in.read_long_string_view();
+    utils::result_with_eptr<std::string_view> query = in.read_long_string_view();
+    if (!query) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(query).error());
+    }
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
-    q_state->options = in.read_options(version, qp.local().get_cql_config());
+    auto o = in.read_options(version, qp.local().get_cql_config());
+    if (!o) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(o).error());
+    }
+    q_state->options = std::move(o).value();
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {
         options.set_cached_pk_function_calls(std::move(cached_pk_fn_calls));
@@ -1111,14 +1126,14 @@ process_query_internal(service::client_state& client_state, distributed<cql3::qu
 
     if (init_trace) {
         tracing::set_page_size(trace_state, options.get_page_size());
-        tracing::add_query(trace_state, query);
+        tracing::add_query(trace_state, query.value());
         tracing::set_common_query_parameters(trace_state, options.get_consistency(),
             options.get_serial_consistency(), options.get_specific_options().timestamp);
 
         tracing::begin(trace_state, "Execute CQL3 query", client_state.get_client_address());
     }
 
-    return qp.local().execute_direct_without_checking_exception_message(query, query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
+    return qp.local().execute_direct_without_checking_exception_message(query.value(), query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
         if (msg->move_to_shard()) {
             return cql_server::process_fn_return_type(make_foreign(dynamic_pointer_cast<messages::result_message::bounce_to_shard>(msg)));
         } else if (msg->is_exception()) {
@@ -1139,7 +1154,11 @@ cql_server::connection::process_query(uint16_t stream, request_reader in, servic
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_prepare(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
 
-    auto query = sstring(in.read_long_string_view());
+    utils::result_with_eptr<std::string_view> query_sv = in.read_long_string_view();
+    if (!query_sv) {
+        return make_exception_future<std::unique_ptr<cql_server::response>>(std::move(query_sv).error());
+    }
+    auto query = sstring(query_sv.value());
     auto dialect = get_dialect();
 
     tracing::add_query(trace_state, query);
@@ -1166,7 +1185,11 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls,
         cql3::dialect dialect) {
-    cql3::prepared_cache_key_type cache_key(in.read_short_bytes(), dialect);
+    utils::result_with_eptr<bytes> cache_key_bytes = in.read_short_bytes();
+    if (!cache_key_bytes) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).error());
+    }
+    cql3::prepared_cache_key_type cache_key(cache_key_bytes.value(), dialect);
     auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
     bool needs_authorization = false;
 
@@ -1182,13 +1205,22 @@ process_execute_internal(service::client_state& client_state, distributed<cql3::
         throw exceptions::prepared_query_not_found_exception(id);
     }
 
-    cql_metadata_id_wrapper metadata_id = is_metadata_id_supported(client_state)
-        ? cql_metadata_id_wrapper(cql3::cql_metadata_id_type(in.read_short_bytes()), prepared->get_metadata_id())
-        : cql_metadata_id_wrapper();
+    cql_metadata_id_wrapper metadata_id = cql_metadata_id_wrapper();
+    if (is_metadata_id_supported(client_state)) {
+        utils::result_with_eptr<bytes> metadata_id_bytes = in.read_short_bytes();
+        if (!metadata_id_bytes) {
+            return make_exception_future<cql_server::process_fn_return_type>(std::move(metadata_id_bytes).error());
+        }
+        metadata_id = cql_metadata_id_wrapper(cql3::cql_metadata_id_type(std::move(metadata_id_bytes).value()), prepared->get_metadata_id());
+    }
 
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
-    q_state->options = in.read_options(version, qp.local().get_cql_config());
+    auto o = in.read_options(version, qp.local().get_cql_config());
+    if (!o) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(o).error());
+    }
+    q_state->options = std::move(o).value();
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {
         options.set_cached_pk_function_calls(std::move(cached_pk_fn_calls));
@@ -1245,39 +1277,55 @@ static future<cql_server::process_fn_return_type>
 process_batch_internal(service::client_state& client_state, distributed<cql3::query_processor>& qp, request_reader in,
         uint16_t stream, cql_protocol_version_type version,
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect) {
-    const auto type = in.read_byte();
-    const unsigned n = in.read_short();
+    const utils::result_with_eptr<int8_t> type = in.read_byte();
+    if (!type) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(type).error());
+    }
+    const utils::result_with_eptr<uint16_t> n = in.read_short();
+    if (!n) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(n).error());
+    }
 
     std::vector<cql3::statements::batch_statement::single_statement> modifications;
     std::vector<cql3::raw_value_view_vector_with_unset> values;
     std::unordered_map<cql3::prepared_cache_key_type, cql3::authorized_prepared_statements_cache::value_type> pending_authorization_entries;
 
-    modifications.reserve(n);
-    values.reserve(n);
+    modifications.reserve(n.value());
+    values.reserve(n.value());
 
     if (init_trace) {
         tracing::begin(trace_state, "Execute batch of CQL3 queries", client_state.get_client_address());
     }
 
-    for ([[gnu::unused]] auto i : std::views::iota(0u, n)) {
-        const auto kind = in.read_byte();
+    for ([[gnu::unused]] auto i : std::views::iota(0u, n.value())) {
+        const utils::result_with_eptr<int8_t> kind = in.read_byte();
+        if (!kind) {
+            return make_exception_future<cql_server::process_fn_return_type>(std::move(kind).error());
+        }
 
         std::unique_ptr<cql3::statements::prepared_statement> stmt_ptr;
         cql3::statements::prepared_statement::checked_weak_ptr ps;
-        bool needs_authorization(kind == 0);
+        bool needs_authorization(kind.value() == 0);
 
-        switch (kind) {
+        switch (kind.value()) {
         case 0: {
-            auto query = in.read_long_string_view();
-            stmt_ptr = qp.local().get_statement(query, client_state, dialect);
+            utils::result_with_eptr<std::string_view> query = in.read_long_string_view();
+            if (!query) {
+                return make_exception_future<cql_server::process_fn_return_type>(std::move(query).error());
+            }
+            stmt_ptr = qp.local().get_statement(query.value(), client_state, dialect);
             ps = stmt_ptr->checked_weak_from_this();
             if (init_trace) {
-                tracing::add_query(trace_state, query);
+                tracing::add_query(trace_state, query.value());
             }
             break;
         }
         case 1: {
-            cql3::prepared_cache_key_type cache_key(in.read_short_bytes(), dialect);
+            utils::result_with_eptr<bytes> cache_key_bytes = in.read_short_bytes();
+            if (!cache_key_bytes) {
+                return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).error());
+            }
+            cql3::prepared_cache_key_type cache_key(cache_key_bytes.value(), dialect);
             auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
 
             // First, try to lookup in the cache of already authorized statements. If the corresponding entry is not found there
@@ -1299,7 +1347,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
         default:
             return make_exception_future<cql_server::process_fn_return_type>(exceptions::protocol_exception(
                     "Invalid query kind in BATCH messages. Must be 0 or 1 but got "
-                            + std::to_string(int(kind))));
+                            + std::to_string(int(kind.value()))));
         }
 
         if (dynamic_cast<cql3::statements::modification_statement*>(ps->statement.get()) == nullptr) {
@@ -1315,7 +1363,10 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
 
         std::vector<cql3::raw_value_view> tmp;
         cql3::unset_bind_variable_vector unset;
-        in.read_value_view_list(version, tmp, unset);
+        auto rvl = in.read_value_view_list(version, tmp, unset);
+        if (!rvl) {
+            return make_exception_future<cql_server::process_fn_return_type>(std::move(rvl).error());
+        }
 
         auto stmt = ps->statement;
         if (stmt->get_bound_terms() != tmp.size()) {
@@ -1329,8 +1380,11 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
     auto q_state = std::make_unique<cql_query_state>(client_state, trace_state, std::move(permit));
     auto& query_state = q_state->query_state;
     // #563. CQL v2 encodes query_options in v1 format for batch requests.
-    q_state->options = std::make_unique<cql3::query_options>(cql3::query_options::make_batch_options(std::move(*in.read_options(version,
-                                                                     qp.local().get_cql_config())), std::move(values)));
+    auto o = in.read_options(version, qp.local().get_cql_config());
+    if (!o) {
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(o).error());
+    }
+    q_state->options = std::make_unique<cql3::query_options>(cql3::query_options::make_batch_options(std::move(*o.value()), std::move(values)));
     auto& options = *q_state->options;
     if (!cached_pk_fn_calls.empty()) {
         options.set_cached_pk_function_calls(std::move(cached_pk_fn_calls));
@@ -1344,7 +1398,7 @@ process_batch_internal(service::client_state& client_state, distributed<cql3::qu
         tracing::trace(trace_state, "Creating a batch statement");
     }
 
-    auto batch = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
+    auto batch = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries))
             .then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
         if (msg->move_to_shard()) {
@@ -1378,7 +1432,10 @@ cql_server::connection::process_register(uint16_t stream, request_reader in, ser
     using ret_type = std::unique_ptr<cql_server::response>;
 
     std::vector<sstring> event_types;
-    in.read_string_list(event_types);
+    auto sl = in.read_string_list(event_types);
+    if (!sl) {
+        return make_exception_future<ret_type>(std::move(sl).error());
+    }
     for (auto&& event_type : event_types) {
         utils::result_with_exception<event::event_type, exceptions::protocol_exception> et = parse_event_type(event_type);
         if (!et) {
@@ -1694,21 +1751,34 @@ cql_server::connection::make_schema_change_event(const event::schema_change& eve
 void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, service_permit permit, cql_compression compression)
 {
     _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response), permit = std::move(permit)] () mutable {
-        auto message = response->make_message(_version, compression);
-        message.on_delete([response = std::move(response)] { });
-        return _write_buf.write(std::move(message)).then([this] {
+        utils::result_with_eptr<scattered_message<char>> message = response->make_message(_version, compression);
+        if (!message) [[unlikely]] {
+            if (auto* exp = try_catch<exceptions::cassandra_exception>(message.error())) {
+                clogger.error("{}: write_response: failed to make message, code {}, message [{}]", _client_state.get_remote_address(), exp->code(), exp->what());
+            } else if (auto* exp = try_catch<std::exception>(message.error())) {
+                clogger.error("{}: write_response: failed to make message, message [{}]", _client_state.get_remote_address(), exp->what());
+            } else {
+                clogger.error("{}: write_response: failed to make message", _client_state.get_remote_address());
+            }
+            return make_ready_future<>();
+        }
+        message.value().on_delete([response = std::move(response)] { });
+        return _write_buf.write(std::move(message).value()).then([this] {
             return _write_buf.flush();
         });
     });
 }
 
-scattered_message<char> cql_server::response::make_message(uint8_t version, cql_compression compression) {
+utils::result_with_eptr<scattered_message<char>> cql_server::response::make_message(uint8_t version, cql_compression compression) {
     if (compression != cql_compression::none) {
         compress(compression);
     }
     scattered_message<char> msg;
-    auto frame = make_frame(version, _body.size());
-    msg.append(std::move(frame));
+    utils::result_with_eptr<sstring> frame = make_frame(version, _body.size());
+    if (!frame) [[unlikely]] {
+        return bo::failure(std::move(frame).error());
+    }
+    msg.append(std::move(frame).value());
     for (auto&& fragment : _body.fragments()) {
         msg.append_static(reinterpret_cast<const char*>(fragment.data()), fragment.size());
     }

--- a/utils/fragmented_temporary_buffer.hh
+++ b/utils/fragmented_temporary_buffer.hh
@@ -19,6 +19,7 @@
 #include "bytes_ostream.hh"
 #include "contiguous_shared_buffer.hh"
 #include "fragment_range.hh"
+#include "result.hh"
 
 /// Fragmented buffer consisting of multiple Buffer objects.
 template <ContiguousSharedBuffer Buffer>
@@ -306,8 +307,8 @@ inline basic_fragmented_buffer<Buffer>::operator view() const noexcept
 namespace fragmented_temporary_buffer_concepts {
 
 template<typename T>
-concept ExceptionThrower = requires(T obj, size_t n) {
-    obj.throw_out_of_range(n, n);
+concept ExceptionCreator = requires(T obj, size_t n) {
+    { obj.out_of_range(n, n) } -> utils::EptrResult;
 };
 
 }
@@ -334,20 +335,25 @@ private:
         }
     }
 
-    template<typename ExceptionThrower>
-    requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
-    void check_out_of_range(ExceptionThrower& exceptions, size_t n) {
+    template<typename ExceptionCreator>
+    requires fragmented_temporary_buffer_concepts::ExceptionCreator<ExceptionCreator>
+    utils::result_with_eptr<void>
+    check_out_of_range(ExceptionCreator& exceptions, size_t n) {
         if (bytes_left() < n) [[unlikely]] {
-            exceptions.throw_out_of_range(n, bytes_left());
+            return exceptions.out_of_range(n, bytes_left());
             // Let's allow skipping this check if the user trusts its input
             // data.
         }
+        return bo::success();
     }
 
-    template<typename T, typename ExceptionThrower>
+    template<typename T, typename ExceptionCreator>
     [[gnu::noinline]] [[gnu::cold]]
-    T read_slow(ExceptionThrower&& exceptions) {
-        check_out_of_range(exceptions, sizeof(T));
+    utils::result_with_eptr<T> read_slow(ExceptionCreator&& exceptions) {
+        auto check = check_out_of_range(exceptions, sizeof(T));
+        if (!check) [[unlikely]] {
+            return bo::failure(std::move(check).error());
+        }
 
         T obj;
         size_t left = sizeof(T);
@@ -378,13 +384,12 @@ private:
         }
     }
 public:
-    struct default_exception_thrower {
-        [[noreturn]] [[gnu::cold]]
-        static void throw_out_of_range(size_t attempted_read, size_t actual_left) {
-            throw std::out_of_range(format("attempted to read {:d} bytes from a {:d} byte buffer", attempted_read, actual_left));
+    struct default_exception_creator {
+        [[gnu::cold]]
+        static utils::result_with_eptr<void> out_of_range(size_t attempted_read, size_t actual_left) {
+            return bo::failure(std::out_of_range(format("attempted to read {:d} bytes from a {:d} byte buffer", attempted_read, actual_left)));
         }
     };
-    static_assert(fragmented_temporary_buffer_concepts::ExceptionThrower<default_exception_thrower>);
 
     istream(const vector_type& fragments, size_t total_size) noexcept
         : _current(fragments.begin())
@@ -404,11 +409,15 @@ public:
         _current_position += n;
     }
 
-    template<typename T, typename ExceptionThrower = default_exception_thrower>
-    requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
-    T read(ExceptionThrower&& exceptions = default_exception_thrower()) {
+    template<typename T, typename ExceptionCreator = default_exception_creator>
+    requires fragmented_temporary_buffer_concepts::ExceptionCreator<ExceptionCreator>
+    utils::result_with_eptr<T> read(ExceptionCreator&& exceptions = default_exception_creator()) {
         if (contig_remain() < sizeof(T)) [[unlikely]] {
-            return read_slow<T>(std::forward<ExceptionThrower>(exceptions));
+            utils::result_with_eptr<T> check = read_slow<T>(std::forward<ExceptionCreator>(exceptions));
+            if (!check) [[unlikely]] {
+                return bo::failure(std::move(check).error());
+            }
+            return bo::success(std::move(check).value());
         }
         T obj;
         std::copy_n(_current_position, sizeof(T), reinterpret_cast<char*>(&obj));
@@ -416,15 +425,18 @@ public:
         return obj;
     }
 
-    template<typename Output, typename ExceptionThrower = default_exception_thrower>
-    requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
-    Output read_to(size_t n, Output out, ExceptionThrower&& exceptions = default_exception_thrower()) {
+    template<typename Output, typename ExceptionCreator = default_exception_creator>
+    requires fragmented_temporary_buffer_concepts::ExceptionCreator<ExceptionCreator>
+    utils::result_with_eptr<Output> read_to(size_t n, Output out, ExceptionCreator&& exceptions = default_exception_creator()) {
         if (contig_remain() >= n) [[likely]] {
             out = std::copy_n(_current_position, n, out);
             _current_position += n;
             return out;
         }
-        check_out_of_range(exceptions, n);
+        auto range = check_out_of_range(exceptions, n);
+        if (!range) [[unlikely]] {
+            return bo::failure(std::move(range).error());
+        }
         out = std::copy(_current_position, _current_end, out);
         n -= _current_end - _current_position;
         next_fragment();
@@ -438,15 +450,18 @@ public:
         return out;
     }
 
-    template<typename ExceptionThrower = default_exception_thrower>
-    requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
-    view read_view(size_t n, ExceptionThrower&& exceptions = default_exception_thrower()) {
+    template<typename ExceptionCreator = default_exception_creator>
+    requires fragmented_temporary_buffer_concepts::ExceptionCreator<ExceptionCreator>
+    utils::result_with_eptr<view> read_view(size_t n, ExceptionCreator&& exceptions = default_exception_creator()) {
         if (contig_remain() >= n) [[likely]] {
             auto v = view(_current, _current_position - _current->get(), n);
             _current_position += n;
             return v;
         }
-        check_out_of_range(exceptions, n);
+        auto range = check_out_of_range(exceptions, n);
+        if (!range) [[unlikely]] {
+            return bo::failure(std::move(range).error());
+        }
         auto v = view(_current, _current_position - _current->get(), n);
         n -= _current_end - _current_position;
         next_fragment();
@@ -458,17 +473,23 @@ public:
         return v;
     }
 
-    template<typename ExceptionThrower = default_exception_thrower>
-    requires fragmented_temporary_buffer_concepts::ExceptionThrower<ExceptionThrower>
-    bytes_view read_bytes_view(size_t n, bytes_ostream& linearization_buffer, ExceptionThrower&& exceptions = default_exception_thrower()) {
+    template<typename ExceptionCreator = default_exception_creator>
+    requires fragmented_temporary_buffer_concepts::ExceptionCreator<ExceptionCreator>
+    utils::result_with_eptr<bytes_view> read_bytes_view(size_t n, bytes_ostream& linearization_buffer, ExceptionCreator&& exceptions = default_exception_creator()) {
         if (contig_remain() >= n) [[likely]] {
             auto v = bytes_view(reinterpret_cast<const bytes::value_type*>(_current_position), n);
             _current_position += n;
             return v;
         }
-        check_out_of_range(exceptions, n);
+        auto range = check_out_of_range(exceptions, n);
+        if (!range) [[unlikely]] {
+            return bo::failure(std::move(range).error());
+        }
         auto ptr = linearization_buffer.write_place_holder(n);
-        read_to(n, ptr, std::forward<ExceptionThrower>(exceptions));
+        auto output = read_to(n, ptr, std::forward<ExceptionCreator>(exceptions));
+        if (!output) [[unlikely]] {
+            return bo::failure(std::move(output).error());
+        }
         return bytes_view(reinterpret_cast<const bytes::value_type*>(ptr), n);
     }
 };

--- a/utils/result.hh
+++ b/utils/result.hh
@@ -59,4 +59,24 @@ concept ResultRebindableTo =
 template<typename T, ExceptionContainerResult R>
 using rebind_result = bo::result<T, typename R::error_type, exception_container_throw_policy>;
 
+struct result_with_eptr_throw_policy : bo::policy::base {
+    template<class Impl> static constexpr void wide_value_check(Impl&& self) {
+        if (!base::_has_value(self)) {
+            std::rethrow_exception(base::_error(self));
+        }
+    }
+
+    template<class Impl> static constexpr void wide_error_check(Impl&& self) {
+        if (!base::_has_error(self)) {
+            throw bo::bad_result_access("no error");
+        }
+    }
+};
+
+template<typename T>
+using result_with_eptr = bo::result<T, std::exception_ptr, result_with_eptr_throw_policy>;
+
+template<typename R>
+concept EptrResult = bo::is_basic_result<R>::value && std::same_as<typename R::error_type, std::exception_ptr>;
+
 }


### PR DESCRIPTION
Replace throwing `protocol_exception` with returning it as a result or an exceptional future in the transport server module. The goal is to improve performance.

Most of the `protocol_exception` throws were made from `fragmented_temporary_buffer` module, by passing `exception_thrower()` to its `read*` methods. `fragmented_temporary_buffer` is changed so that it now accepts an exception creator, not exception thrower. `fragmented_temporary_buffer_concepts::ExceptionCreator` concept replaced `fragmented_temporary_buffer_concepts::ExceptionThrower` and all methods that have been throwing now return failed result of type `utils::result_with_eptr`. This change is then propagated to the callers.

The scope of this patch is `protocol_exception`, so commitlog just calls `.value()` method on the result. If the result failed, that will throw the exception from the result, as defined by `utils::result_with_eptr_throw_policy`. This means that the behavior of commitlog module stays the same.

transport server module handles results gracefully. All the caller functions that return non-future value `T` now return `utils::result_with_eptr<T>`. When the caller is a function that returns a future, and it receives failed result, `make_exception_future(std::move(failed_result).value())` is returned. The rest of the callstack up to the transport server `handle_error` function is already working without throwing, and that's how zero throws is achieved.

cql3 module changes do the same as transport server module.

Fixes: #24567

This PR is a continuation of #24738 [transport: remove throwing protocol_exception on connection start](https://github.com/scylladb/scylladb/pull/24738). This one fixes the issue which the previous PR just referenced. It should be backported to the same versions: 2025.3, 2025.2, 2025.1.