### PR TITLE
cql3: yield in between prepares of a batch statement

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -1017,10 +1017,10 @@ future<::shared_ptr<untyped_result_set>>
 query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
-        const data_value_list& values,
+        std::vector<data_value_or_unset> values,
         cache_internal cache) {
     auto qs = query_state_for_internal_call();
-    co_return co_await execute_internal(query_string, cl, qs, values, cache);
+    co_return co_await execute_internal(query_string, cl, qs, std::move(values), cache);
 }
 
 future<::shared_ptr<untyped_result_set>>
@@ -1028,18 +1028,16 @@ query_processor::execute_internal(
         const sstring& query_string,
         db::consistency_level cl,
         service::query_state& query_state,
-        const data_value_list& values,
+        std::vector<data_value_or_unset> values,
         cache_internal cache) {
 
     if (log.is_enabled(logging::log_level::trace)) {
         log.trace("execute_internal: {}\"{}\" ({})", cache ? "(cached) " : "", query_string, fmt::join(values, ", "));
     }
     sstring owned_query_string(query_string);
-    // Own values before co_await; data_value_list may reference temporaries.
-    std::vector<data_value_or_unset> owned_values(values.begin(), values.end());
     if (cache) {
         auto p = co_await prepare_internal(owned_query_string);
-        co_return co_await execute_with_params(std::move(p), cl, query_state, owned_values);
+        co_return co_await execute_with_params(std::move(p), cl, query_state, values);
     } else {
         // For internal queries, we want the default dialect, not the user provided one
         auto np_stmt = parse_statement(owned_query_string, dialect{});
@@ -1048,7 +1046,7 @@ query_processor::execute_internal(
         auto&& [p, _] = co_await np_stmt->prepare(_db, _cql_stats, _cql_config);
         p->statement->raw_cql_statement = utils::chunked_string(owned_query_string);
         auto checked_weak_ptr = p->checked_weak_from_this();
-        co_return co_await execute_with_params(std::move(checked_weak_ptr), cl, query_state, owned_values).finally([p = std::move(p)] {});
+        co_return co_await execute_with_params(std::move(checked_weak_ptr), cl, query_state, values).finally([p = std::move(p)] {});
     }
 }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -629,24 +629,26 @@ future<::shared_ptr<result_message>>
 query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
-    auto p = get_statement(query_string, query_state.get_client_state(), d);
-    auto statement = p->statement;
-    if (statement->get_bound_terms() != options.get_values_count()) {
-        const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",
-                statement->get_bound_terms(),
-                options.get_values_count());
-        throw exceptions::invalid_request_exception(msg);
-    }
-    options.prepare(p->bound_names);
+    return get_statement(query_string, query_state.get_client_state(), d).then(
+            [this, &query_state, &options] (std::unique_ptr<statements::prepared_statement> p) {
+        auto statement = p->statement;
+        if (statement->get_bound_terms() != options.get_values_count()) {
+            const auto msg = format("Invalid amount of bind variables: expected {:d} received {:d}",
+                    statement->get_bound_terms(),
+                    options.get_values_count());
+            throw exceptions::invalid_request_exception(msg);
+        }
+        options.prepare(p->bound_names);
 
-    warn(unimplemented::cause::METRICS);
+        warn(unimplemented::cause::METRICS);
 #if 0
         if (!queryState.getClientState().isInternal)
             metrics.regularStatementsExecuted.inc();
 #endif
-    auto user = query_state.get_client_state().user();
-    tracing::trace(query_state.get_trace_state(), "Processing a statement for authenticated user: {}", user ? (user->name ? *user->name : "anonymous") : "no user authenticated");
-    return execute_maybe_with_guard(query_state, std::move(statement), options, &query_processor::do_execute_direct, std::move(p->warnings));
+        auto user = query_state.get_client_state().user();
+        tracing::trace(query_state.get_trace_state(), "Processing a statement for authenticated user: {}", user ? (user->name ? *user->name : "anonymous") : "no user authenticated");
+        return execute_maybe_with_guard(query_state, std::move(statement), options, &query_processor::do_execute_direct, std::move(p->warnings));
+    });
 }
 
 future<::shared_ptr<result_message>>
@@ -740,17 +742,19 @@ query_processor::prepare(utils::chunked_string query_string, const service::clie
     try {
         auto key = compute_id(query_string, client_state.get_raw_keyspace(), d);
         auto prep_entry = co_await _prepared_cache.get_pinned(key, [this, &query_string, &client_state, d] {
-                auto prepared = get_statement(query_string, client_state, d);
-                prepared->calculate_metadata_id();
-                auto bound_terms = prepared->statement->get_bound_terms();
-                if (bound_terms > std::numeric_limits<uint16_t>::max()) {
-                    throw exceptions::invalid_request_exception(
-                            format("Too many markers(?). {:d} markers exceed the allowed maximum of {:d}",
-                                bound_terms,
-                                std::numeric_limits<uint16_t>::max()));
-                }
-                throwing_assert(bound_terms == prepared->bound_names.size());
-                return make_ready_future<std::unique_ptr<statements::prepared_statement>>(std::move(prepared));
+                return get_statement(query_string, client_state, d).then(
+                        [] (std::unique_ptr<statements::prepared_statement> prepared) {
+                    prepared->calculate_metadata_id();
+                    auto bound_terms = prepared->statement->get_bound_terms();
+                    if (bound_terms > std::numeric_limits<uint16_t>::max()) {
+                        throw exceptions::invalid_request_exception(
+                                format("Too many markers(?). {:d} markers exceed the allowed maximum of {:d}",
+                                    bound_terms,
+                                    std::numeric_limits<uint16_t>::max()));
+                    }
+                    throwing_assert(bound_terms == prepared->bound_names.size());
+                    return prepared;
+                });
             });
 
         co_await utils::get_local_injector().inject(
@@ -782,30 +786,36 @@ prepared_cache_key_type query_processor::compute_id(
     return prepared_cache_key_type(md5_hasher::calculate(hash_target(query_string, keyspace).data()), d);
 }
 
-std::unique_ptr<prepared_statement>
+future<std::unique_ptr<prepared_statement>>
 query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d) {
-    // Measuring allocation cost requires that no yield points exist
-    // between bytes_before and bytes_after. It needs fixing if this
-    // function is ever futurized.
+    // Measure the synchronous parsing/setup cost. prepare() may yield
+    // for batch statements, so it reports its own prepare allocation cost
+    // separately (sampled without spanning a yield) instead of letting us
+    // bracket it here, which would fold in unrelated fibers' allocations.
     auto bytes_before = seastar::memory::stats().total_bytes_allocated();
     std::unique_ptr<raw::parsed_statement> statement = parse_statement(query, d);
 
-    // Set keyspace for statement that require login
+    // Set keyspace for statements that require login.
     auto cf_stmt = dynamic_cast<raw::cf_statement*>(statement.get());
     if (cf_stmt) {
         cf_stmt->prepare_keyspace(client_state);
     }
     ++_stats.prepare_invocations;
-    auto p = statement->prepare(_db, _cql_stats, _cql_config);
-    p->statement->raw_cql_statement = utils::chunked_string(query);
+
+    auto parse_cost = seastar::memory::stats().total_bytes_allocated() - bytes_before;
+
+    utils::chunked_string owned_query(query);
+
+    auto [p, prepare_cost] = co_await statement->prepare(_db, _cql_stats, _cql_config);
+    _parsing_cost_tracker.add_sample(parse_cost + prepare_cost);
+
+    p->statement->raw_cql_statement = std::move(owned_query);
     auto audit_info = p->statement->get_audit_info();
     if (audit_info) {
-        audit_info->set_query_string(query.linearize()); // Audit system may need linearized form
+        audit_info->set_query_string(p->statement->raw_cql_statement.linearize());
         p->statement->sanitize_audit_info();
     }
-    auto bytes_after = seastar::memory::stats().total_bytes_allocated();
-    _parsing_cost_tracker.add_sample(bytes_after - bytes_before);
-    return p;
+    co_return std::move(p);
 }
 
 std::unique_ptr<raw::parsed_statement>
@@ -909,14 +919,22 @@ query_options query_processor::make_internal_options(
             });
 }
 
-statements::prepared_statement::checked_weak_ptr query_processor::prepare_internal(const sstring& query_string) {
+future<statements::prepared_statement::checked_weak_ptr>
+query_processor::prepare_internal(const sstring& query_string) {
     auto& p = _internal_statements[query_string];
     if (p == nullptr) {
-        auto np = parse_statement(query_string, internal_dialect())->prepare(_db, _cql_stats, _cql_config);
+        // The parsing-cost estimate isn't tracked for internal statements, so
+        // the prepare allocation cost is discarded.
+        auto&& [np, _] = co_await parse_statement(query_string, internal_dialect())->prepare(_db, _cql_stats, _cql_config);
         np->statement->raw_cql_statement = utils::chunked_string(query_string);
-        p = std::move(np); // inserts it into map
+        // Re-lookup because co_await may allow a rehash that invalidates p.
+        auto& slot = _internal_statements[query_string];
+        if (slot == nullptr) {
+            slot = std::move(np);
+        }
+        co_return slot->checked_weak_from_this();
     }
-    return p->checked_weak_from_this();
+    co_return p->checked_weak_from_this();
 }
 
 struct internal_query_state {
@@ -927,18 +945,18 @@ struct internal_query_state {
     bool more_results = true;
 };
 
-internal_query_state query_processor::create_paged_state(
+future<internal_query_state> query_processor::create_paged_state(
         const sstring& query_string,
         db::consistency_level cl,
-        const data_value_list& values,
+        std::vector<data_value_or_unset> values,
         int32_t page_size,
         std::optional<service::query_state> qs) {
-    auto p = prepare_internal(query_string);
+    auto p = co_await prepare_internal(query_string);
     auto opts = make_internal_options(p, values, cl, page_size);
     if (!qs) {
         qs.emplace(query_state_for_internal_call());
     }
-    return internal_query_state{query_string, std::make_unique<cql3::query_options>(std::move(opts)), std::move(p), std::move(qs), true};
+    co_return internal_query_state{query_string, std::make_unique<cql3::query_options>(std::move(opts)), std::move(p), std::move(qs), true};
 }
 
 bool query_processor::has_more_results(cql3::internal_query_state& state) const {
@@ -966,9 +984,8 @@ query_processor::execute_paged_internal(internal_query_state& state) {
 
     class visitor : public result_message::visitor_base {
         internal_query_state& _state;
-        query_processor& _qp;
     public:
-        visitor(internal_query_state& state, query_processor& qp) : _state(state), _qp(qp) {
+        visitor(internal_query_state& state) : _state(state) {
         }
         virtual ~visitor() = default;
         void visit(const result_message::rows& rmrs) override {
@@ -982,14 +999,13 @@ query_processor::execute_paged_internal(internal_query_state& state) {
                     const service::pager::paging_state& st = *rs.get_metadata().paging_state();
                     lw_shared_ptr<service::pager::paging_state> shrd = make_lw_shared<service::pager::paging_state>(st);
                     _state.opts = std::make_unique<query_options>(std::move(_state.opts), shrd);
-                    _state.p = _qp.prepare_internal(_state.query_string);
                 }
             } else {
                 _state.more_results = false;
             }
         }
     };
-    visitor v(state, *this);
+    visitor v(state);
     if (msg != nullptr) {
         msg->accept(v);
     }
@@ -1018,15 +1034,21 @@ query_processor::execute_internal(
     if (log.is_enabled(logging::log_level::trace)) {
         log.trace("execute_internal: {}\"{}\" ({})", cache ? "(cached) " : "", query_string, fmt::join(values, ", "));
     }
+    sstring owned_query_string(query_string);
+    // Own values before co_await; data_value_list may reference temporaries.
+    std::vector<data_value_or_unset> owned_values(values.begin(), values.end());
     if (cache) {
-        auto p = prepare_internal(query_string);
-        return execute_with_params(std::move(p), cl, query_state, values);
+        auto p = co_await prepare_internal(owned_query_string);
+        co_return co_await execute_with_params(std::move(p), cl, query_state, owned_values);
     } else {
         // For internal queries, we want the default dialect, not the user provided one
-        auto p = parse_statement(query_string, dialect{})->prepare(_db, _cql_stats, _cql_config);
-        p->statement->raw_cql_statement = utils::chunked_string(query_string);
+        auto np_stmt = parse_statement(owned_query_string, dialect{});
+        // The parsing-cost estimate isn't tracked for internal statements, so
+        // the prepare allocation cost is discarded.
+        auto&& [p, _] = co_await np_stmt->prepare(_db, _cql_stats, _cql_config);
+        p->statement->raw_cql_statement = utils::chunked_string(owned_query_string);
         auto checked_weak_ptr = p->checked_weak_from_this();
-        return execute_with_params(std::move(checked_weak_ptr), cl, query_state, values).finally([p = std::move(p)] {});
+        co_return co_await execute_with_params(std::move(checked_weak_ptr), cl, query_state, owned_values).finally([p = std::move(p)] {});
     }
 }
 
@@ -1036,7 +1058,7 @@ future<utils::chunked_vector<mutation>> query_processor::get_mutations_internal(
         api::timestamp_type timestamp,
         std::vector<data_value_or_unset> values) {
     log.debug("get_mutations_internal: \"{}\" ({})", query_string, fmt::join(values, ", "));
-    auto stmt = prepare_internal(query_string);
+    auto stmt = co_await prepare_internal(query_string);
     auto mod_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(stmt->statement);
     if (!mod_stmt) {
         on_internal_error(log, "Only modification statement is supported in get_mutations_internal");
@@ -1057,7 +1079,7 @@ query_processor::execute_with_params(
         statements::prepared_statement::checked_weak_ptr p,
         db::consistency_level cl,
         service::query_state& query_state,
-        const data_value_list& values) {
+        const std::vector<data_value_or_unset>& values) {
     auto opts = make_internal_options(p, values, cl);
     auto statement = p->statement;
 
@@ -1276,7 +1298,7 @@ future<> query_processor::query_internal(
         int32_t page_size,
         noncopyable_function<future<stop_iteration>(const cql3::untyped_result_set_row&)> f,
         std::optional<service::query_state> qs) {
-    auto query_state = create_paged_state(query_string, cl, values, page_size, std::move(qs));
+    auto query_state = co_await create_paged_state(query_string, cl, std::vector<data_value_or_unset>(values.begin(), values.end()), page_size, std::move(qs));
     co_return co_await for_each_cql_result(query_state, std::move(f));
 }
 

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -626,10 +626,10 @@ query_processor::execute_maybe_with_guard(service::query_state& query_state, ::s
 }
 
 future<::shared_ptr<result_message>>
-query_processor::execute_direct_without_checking_exception_message(utils::chunked_string_view query_string, service::query_state& query_state, dialect d, query_options& options) {
+query_processor::execute_direct_without_checking_exception_message(utils::chunked_string query_string, service::query_state& query_state, dialect d, query_options& options) {
     log.trace("execute_direct: \"{}\"", query_string);
     tracing::trace(query_state.get_trace_state(), "Parsing a statement");
-    return get_statement(query_string, query_state.get_client_state(), d).then(
+    return get_statement(std::move(query_string), query_state.get_client_state(), d).then(
             [this, &query_state, &options] (std::unique_ptr<statements::prepared_statement> p) {
         auto statement = p->statement;
         if (statement->get_bound_terms() != options.get_values_count()) {
@@ -742,7 +742,7 @@ query_processor::prepare(utils::chunked_string query_string, const service::clie
     try {
         auto key = compute_id(query_string, client_state.get_raw_keyspace(), d);
         auto prep_entry = co_await _prepared_cache.get_pinned(key, [this, &query_string, &client_state, d] {
-                return get_statement(query_string, client_state, d).then(
+                return get_statement(utils::chunked_string(query_string), client_state, d).then(
                         [] (std::unique_ptr<statements::prepared_statement> prepared) {
                     prepared->calculate_metadata_id();
                     auto bound_terms = prepared->statement->get_bound_terms();
@@ -787,7 +787,7 @@ prepared_cache_key_type query_processor::compute_id(
 }
 
 future<std::unique_ptr<prepared_statement>>
-query_processor::get_statement(utils::chunked_string_view query, const service::client_state& client_state, dialect d) {
+query_processor::get_statement(utils::chunked_string query, const service::client_state& client_state, dialect d) {
     // Measure the synchronous parsing/setup cost. prepare() may yield
     // for batch statements, so it reports its own prepare allocation cost
     // separately (sampled without spanning a yield) instead of letting us
@@ -804,12 +804,10 @@ query_processor::get_statement(utils::chunked_string_view query, const service::
 
     auto parse_cost = seastar::memory::stats().total_bytes_allocated() - bytes_before;
 
-    utils::chunked_string owned_query(query);
-
     auto [p, prepare_cost] = co_await statement->prepare(_db, _cql_stats, _cql_config);
     _parsing_cost_tracker.add_sample(parse_cost + prepare_cost);
 
-    p->statement->raw_cql_statement = std::move(owned_query);
+    p->statement->raw_cql_statement = std::move(query);
     auto audit_info = p->statement->get_audit_info();
     if (audit_info) {
         audit_info->set_query_string(p->statement->raw_cql_statement.linearize());

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -338,7 +338,7 @@ public:
             std::optional<service::group0_guard> guard,
             cql3::cql_warnings_vec warnings);
 
-    statements::prepared_statement::checked_weak_ptr prepare_internal(const sstring& query);
+    future<statements::prepared_statement::checked_weak_ptr> prepare_internal(const sstring& query);
 
     /*!
      * \brief iterate over all cql results using paging
@@ -454,7 +454,7 @@ public:
             statements::prepared_statement::checked_weak_ptr p,
             db::consistency_level,
             service::query_state& query_state,
-            const data_value_list& values = { });
+            const std::vector<data_value_or_unset>& values);
 
     future<::shared_ptr<cql_transport::messages::result_message>> do_execute_with_params(
             service::query_state& query_state,
@@ -513,7 +513,7 @@ public:
     // For the local node, waits directly without an RPC.
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
 
-    std::unique_ptr<statements::prepared_statement> get_statement(
+    future<std::unique_ptr<statements::prepared_statement>> get_statement(
             utils::chunked_string_view query,
             const service::client_state& client_state,
             dialect d);
@@ -569,10 +569,10 @@ private:
      *
      * When using paging internally a state object is needed.
      */
-    internal_query_state create_paged_state(
+    future<internal_query_state> create_paged_state(
             const sstring& query_string,
             db::consistency_level,
-            const data_value_list& values,
+            std::vector<data_value_or_unset> values,
             int32_t page_size,
             std::optional<service::query_state> qs = std::nullopt);
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -309,12 +309,12 @@ public:
     inline
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_direct(
-            utils::chunked_string_view query_string,
+            utils::chunked_string query_string,
             service::query_state& query_state,
             dialect d,
             query_options& options) {
         return execute_direct_without_checking_exception_message(
-                query_string,
+                std::move(query_string),
                 query_state,
                 d,
                 options)
@@ -325,7 +325,7 @@ public:
     // The result_message::exception must be explicitly handled.
     future<::shared_ptr<cql_transport::messages::result_message>>
     execute_direct_without_checking_exception_message(
-            utils::chunked_string_view query_string,
+            utils::chunked_string query_string,
             service::query_state& query_state,
             dialect d,
             query_options& options);
@@ -514,7 +514,7 @@ public:
     future<> wait_for_table_raft_groups_on_all_hosts(table_id table, lowres_clock::time_point timeout);
 
     future<std::unique_ptr<statements::prepared_statement>> get_statement(
-            utils::chunked_string_view query,
+            utils::chunked_string query,
             const service::client_state& client_state,
             dialect d);
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -409,13 +409,13 @@ public:
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
-            const data_value_list&,
+            std::vector<data_value_or_unset>,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
             db::consistency_level,
             service::query_state& query_state,
-            const data_value_list& values,
+            std::vector<data_value_or_unset> values,
             cache_internal cache);
     future<::shared_ptr<untyped_result_set>> execute_internal(
             const sstring& query_string,
@@ -431,8 +431,8 @@ public:
         return execute_internal(query_string, cl, query_state, {}, cache);
     }
     future<::shared_ptr<untyped_result_set>>
-    execute_internal(const sstring& query_string, const data_value_list& values, cache_internal cache) {
-        return execute_internal(query_string, db::consistency_level::ONE, values, cache);
+    execute_internal(const sstring& query_string, std::vector<data_value_or_unset> values, cache_internal cache) {
+        return execute_internal(query_string, db::consistency_level::ONE, std::move(values), cache);
     }
     future<::shared_ptr<untyped_result_set>>
     execute_internal(const sstring& query_string, cache_internal cache) {

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -277,7 +277,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::alter_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+cql3::statements::alter_keyspace_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_keyspace_statement>(*this));
 }
 

--- a/cql3/statements/alter_keyspace_statement.hh
+++ b/cql3/statements/alter_keyspace_statement.hh
@@ -37,7 +37,7 @@ public:
     future<> check_access(query_processor& qp, const service::client_state& state) const override;
     void validate(query_processor& qp, const service::client_state& state) const override;
     virtual future<std::tuple<::shared_ptr<event_t>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
     bool changes_tablets(query_processor& qp) const;
 };

--- a/cql3/statements/alter_role_statement.hh
+++ b/cql3/statements/alter_role_statement.hh
@@ -33,7 +33,7 @@ public:
                 , _options(std::move(options)) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/alter_service_level_statement.cc
+++ b/cql3/statements/alter_service_level_statement.cc
@@ -24,7 +24,7 @@ alter_service_level_statement::alter_service_level_statement(sstring service_lev
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::alter_service_level_statement::prepare(
+cql3::statements::alter_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<alter_service_level_statement>(*this));
 }

--- a/cql3/statements/alter_service_level_statement.hh
+++ b/cql3/statements/alter_service_level_statement.hh
@@ -23,7 +23,7 @@ class alter_service_level_statement final : public service_level_statement {
 
 public:
     alter_service_level_statement(sstring service_level, shared_ptr<sl_prop_defs> attrs);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/alter_table_statement.cc
+++ b/cql3/statements/alter_table_statement.cc
@@ -561,7 +561,7 @@ alter_table_statement::prepare_schema_mutations(query_processor& qp, const query
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::alter_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+cql3::statements::alter_table_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Cannot happen; alter_table_statement is never instantiated as a raw statement
     // (instead we instantiate alter_table_statement::raw_statement)
     utils::on_internal_error("alter_table_statement cannot be prepared. Use alter_table_statement::raw_statement instead");
@@ -590,7 +590,7 @@ alter_table_statement::raw_statement::raw_statement(cf_name name,
     {}
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+alter_table_statement::raw_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     auto t = db.try_find_table(keyspace(), column_family());
     std::optional<schema_ptr> s = t ? std::make_optional(t->schema()) : std::nullopt;
     std::optional<sstring> warning = check_restricted_table_properties(s, keyspace(), column_family(), *_properties, cfg.twcs_restrictions);

--- a/cql3/statements/alter_table_statement.hh
+++ b/cql3/statements/alter_table_statement.hh
@@ -64,7 +64,7 @@ public:
 
     virtual uint32_t get_bound_terms() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     virtual future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
@@ -92,7 +92,7 @@ public:
                   std::unique_ptr<attributes::raw> attrs,
                   shared_ptr<column_identifier::raw> ttl_change);
     
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual audit::statement_category category() const override { return audit::statement_category::DDL; }
 };

--- a/cql3/statements/alter_type_statement.cc
+++ b/cql3/statements/alter_type_statement.cc
@@ -209,12 +209,12 @@ user_type alter_type_statement::renames::make_updated_type(data_dictionary::data
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_type_statement::add_or_alter::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+alter_type_statement::add_or_alter::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_type_statement::add_or_alter>(*this));
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_type_statement::renames::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+alter_type_statement::renames::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_type_statement::renames>(*this));
 }
 

--- a/cql3/statements/alter_type_statement.hh
+++ b/cql3/statements/alter_type_statement.hh
@@ -54,7 +54,7 @@ public:
                  const shared_ptr<column_identifier> field_name,
                  const shared_ptr<cql3_type::raw> field_type);
     virtual user_type make_updated_type(data_dictionary::database db, user_type to_update) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     user_type do_add(data_dictionary::database db, user_type to_update) const;
     user_type do_alter(data_dictionary::database db, user_type to_update) const;
@@ -71,7 +71,7 @@ public:
     void add_rename(shared_ptr<column_identifier> previous_name, shared_ptr<column_identifier> new_name);
 
     virtual user_type make_updated_type(data_dictionary::database db, user_type to_update) const override;
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/alter_view_statement.cc
+++ b/cql3/statements/alter_view_statement.cc
@@ -98,7 +98,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-alter_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+alter_view_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<alter_view_statement>(*this));
 }
 

--- a/cql3/statements/alter_view_statement.hh
+++ b/cql3/statements/alter_view_statement.hh
@@ -35,7 +35,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/attach_service_level_statement.cc
+++ b/cql3/statements/attach_service_level_statement.cc
@@ -29,7 +29,7 @@ bool attach_service_level_statement::needs_guard(query_processor& qp, service::q
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::attach_service_level_statement::prepare(
+cql3::statements::attach_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<attach_service_level_statement>(*this));
 }

--- a/cql3/statements/attach_service_level_statement.hh
+++ b/cql3/statements/attach_service_level_statement.hh
@@ -22,7 +22,7 @@ class attach_service_level_statement final : public service_level_statement {
 public:
     attach_service_level_statement(sstring service_level, sstring role_name);
     virtual bool needs_guard(query_processor& qp, service::query_state&) const override;
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -452,8 +452,13 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     std::vector<cql3::statements::batch_statement::single_statement> statements;
     statements.reserve(_parsed_statements.size());
 
-    auto bytes_before = seastar::memory::stats().total_bytes_allocated();
+    // Each prepared sub-statement owns its schema through modification_statement::s.
+    // A schema change while we yield can invalidate caches, but it cannot make an
+    // already prepared sub-statement refer to freed schema state; cache invalidation
+    // after this returns is handled by the prepared-cache caller.
+    uint64_t prepare_bytes = 0;
     for (auto&& parsed : _parsed_statements) {
+        auto bytes_before = seastar::memory::stats().total_bytes_allocated();
         auto statement = parsed->make_prepared_modification_statement(db, meta, stats);
         if (!first_ks) {
             first_ks = statement->keyspace();
@@ -466,8 +471,11 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
         if (audit_info) {
             audit_info->set_query_string(parsed->get_raw_cql());
         }
+        prepare_bytes += seastar::memory::stats().total_bytes_allocated() - bytes_before;
+        co_await coroutine::maybe_yield();
     }
 
+    auto bytes_before = seastar::memory::stats().total_bytes_allocated();
     auto&& prep_attrs = _attrs->prepare(db, "[batch]", "[batch]");
     prep_attrs->fill_prepare_context(meta);
 
@@ -480,7 +488,7 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     auto p = std::make_unique<prepared_statement>(audit_info(), make_shared<cql3::statements::batch_statement>(std::move(batch_statement_)),
                                                   meta.get_variable_specifications(),
                                                   std::move(partition_key_bind_indices));
-    uint64_t prepare_bytes = seastar::memory::stats().total_bytes_allocated() - bytes_before;
+    prepare_bytes += seastar::memory::stats().total_bytes_allocated() - bytes_before;
 
     co_return std::pair(std::move(p), prepare_bytes);
 }

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -14,11 +14,13 @@
 #include "db/consistency_level_validations.hh"
 #include "data_dictionary/data_dictionary.hh"
 #include <seastar/core/execution_stage.hh>
+#include <seastar/core/memory.hh>
 #include "cas_request.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
 #include "tracing/trace_state.hh"
 #include "utils/unique_view.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 template<typename T = void>
 using coordinator_result = exceptions::coordinator_result<T>;
@@ -440,26 +442,26 @@ void batch_statement::build_cas_result_set_metadata() {
 
 namespace raw {
 
-std::unique_ptr<prepared_statement>
-batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
-    auto&& meta = get_prepare_context();
+future<std::pair<std::unique_ptr<prepared_statement>, uint64_t>>
+batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config&) {
+    auto& meta = get_prepare_context();
 
     std::optional<sstring> first_ks;
     std::optional<sstring> first_cf;
     bool have_multiple_cfs = false;
-
     std::vector<cql3::statements::batch_statement::single_statement> statements;
     statements.reserve(_parsed_statements.size());
 
+    auto bytes_before = seastar::memory::stats().total_bytes_allocated();
     for (auto&& parsed : _parsed_statements) {
+        auto statement = parsed->make_prepared_modification_statement(db, meta, stats);
         if (!first_ks) {
-            first_ks = parsed->keyspace();
-            first_cf = parsed->column_family();
+            first_ks = statement->keyspace();
+            first_cf = statement->column_family();
         } else {
-            have_multiple_cfs |= first_ks.value() != parsed->keyspace();
-            have_multiple_cfs |= first_cf.value() != parsed->column_family();
+            have_multiple_cfs |= first_ks.value() != statement->keyspace() || first_cf.value() != statement->column_family();
         }
-        statements.emplace_back(parsed->prepare(db, meta, stats));
+        statements.emplace_back(std::move(statement));
         auto audit_info = statements.back().statement->get_audit_info();
         if (audit_info) {
             audit_info->set_query_string(parsed->get_raw_cql());
@@ -472,12 +474,15 @@ batch_statement::prepare(data_dictionary::database db, cql_stats& stats, const c
     cql3::statements::batch_statement batch_statement_(meta.bound_variables_size(), _type, std::move(statements), std::move(prep_attrs), stats);
 
     std::vector<uint16_t> partition_key_bind_indices;
-    if (!have_multiple_cfs && batch_statement_.get_statements().size() > 0) {
+    if (!have_multiple_cfs && !batch_statement_.get_statements().empty()) {
         partition_key_bind_indices = meta.get_partition_key_bind_indexes(*batch_statement_.get_statements()[0].statement->s);
     }
-    return std::make_unique<prepared_statement>(audit_info(), make_shared<cql3::statements::batch_statement>(std::move(batch_statement_)),
-                                                     meta.get_variable_specifications(),
-                                                     std::move(partition_key_bind_indices));
+    auto p = std::make_unique<prepared_statement>(audit_info(), make_shared<cql3::statements::batch_statement>(std::move(batch_statement_)),
+                                                  meta.get_variable_specifications(),
+                                                  std::move(partition_key_bind_indices));
+    uint64_t prepare_bytes = seastar::memory::stats().total_bytes_allocated() - bytes_before;
+
+    co_return std::pair(std::move(p), prepare_bytes);
 }
 
 audit::statement_category batch_statement::category() const {
@@ -486,9 +491,6 @@ audit::statement_category batch_statement::category() const {
 
 }
 
-
 }
 
 }
-
-

--- a/cql3/statements/create_aggregate_statement.cc
+++ b/cql3/statements/create_aggregate_statement.cc
@@ -78,7 +78,7 @@ seastar::future<shared_ptr<db::functions::function>> create_aggregate_statement:
     co_return ::make_shared<functions::user_aggregate>(_name, initcond, std::move(state_func), std::move(reduce_func), std::move(final_func));
 }
 
-std::unique_ptr<prepared_statement> create_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> create_aggregate_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_aggregate_statement>(*this));
 }
 

--- a/cql3/statements/create_aggregate_statement.hh
+++ b/cql3/statements/create_aggregate_statement.hh
@@ -24,7 +24,7 @@ namespace functions {
 namespace statements {
 
 class create_aggregate_statement final : public create_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
 

--- a/cql3/statements/create_function_statement.cc
+++ b/cql3/statements/create_function_statement.cc
@@ -54,7 +54,7 @@ create_function_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), sstring(), sstring());
 }
 
-std::unique_ptr<prepared_statement> create_function_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> create_function_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_function_statement>(*this));
 }
 

--- a/cql3/statements/create_function_statement.hh
+++ b/cql3/statements/create_function_statement.hh
@@ -23,7 +23,7 @@ namespace functions {
 namespace statements {
 
 class create_function_statement final : public create_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
     virtual seastar::future<shared_ptr<db::functions::function>> create(query_processor& qp, db::functions::function* old) const override;

--- a/cql3/statements/create_index_statement.cc
+++ b/cql3/statements/create_index_statement.cc
@@ -811,7 +811,7 @@ create_index_statement::prepare_schema_mutations(query_processor& qp, const quer
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_index_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+create_index_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _cql_stats = &stats;
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_index_statement>(*this));
 }

--- a/cql3/statements/create_index_statement.hh
+++ b/cql3/statements/create_index_statement.hh
@@ -54,7 +54,7 @@ public:
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     struct base_schema_with_new_index {
         schema_ptr schema;

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -159,7 +159,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::create_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+cql3::statements::create_keyspace_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _attrs->set_default_replication_strategy_class_option();
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_keyspace_statement>(*this));
 }

--- a/cql3/statements/create_keyspace_statement.hh
+++ b/cql3/statements/create_keyspace_statement.hh
@@ -72,7 +72,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> grant_permissions_to_creator(const service::client_state&, service::group0_batch&) const override;
 

--- a/cql3/statements/create_role_statement.hh
+++ b/cql3/statements/create_role_statement.hh
@@ -37,7 +37,7 @@ public:
                 , _if_not_exists(if_not_exists) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/create_service_level_statement.cc
+++ b/cql3/statements/create_service_level_statement.cc
@@ -27,7 +27,7 @@ create_service_level_statement::create_service_level_statement(sstring service_l
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::create_service_level_statement::prepare(
+cql3::statements::create_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<create_service_level_statement>(*this));
 }

--- a/cql3/statements/create_service_level_statement.hh
+++ b/cql3/statements/create_service_level_statement.hh
@@ -24,7 +24,7 @@ class create_service_level_statement final : public service_level_statement {
 
 public:
     create_service_level_statement(sstring service_level, shared_ptr<sl_prop_defs> attrs, bool if_not_exists);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/create_table_statement.cc
+++ b/cql3/statements/create_table_statement.cc
@@ -151,7 +151,7 @@ void create_table_statement::add_column_metadata_from_aliases(schema_builder& bu
 }
 
 std::unique_ptr<prepared_statement>
-create_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+create_table_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Cannot happen; create_table_statement is never instantiated as a raw statement
     // (instead we instantiate create_table_statement::raw_statement)
     throwing_assert(0 && "create_table_statement::prepare");
@@ -175,7 +175,7 @@ create_table_statement::raw_statement::raw_statement(cf_name name, bool if_not_e
     , _if_not_exists{if_not_exists}
 { }
 
-std::unique_ptr<prepared_statement> create_table_statement::raw_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> create_table_statement::raw_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     // Column family name
     const sstring& cf_name = _cf_name->get_column_family();
     boost::regex name_regex("\\w+");

--- a/cql3/statements/create_table_statement.hh
+++ b/cql3/statements/create_table_statement.hh
@@ -74,7 +74,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     future<::shared_ptr<messages::result_message>> execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 
@@ -114,7 +114,7 @@ private:
 public:
     raw_statement(cf_name name, bool if_not_exists);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     cf_properties& properties() {
         return _properties;

--- a/cql3/statements/create_type_statement.cc
+++ b/cql3/statements/create_type_statement.cc
@@ -145,7 +145,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_type_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+create_type_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<create_type_statement>(*this));
 }
 

--- a/cql3/statements/create_type_statement.hh
+++ b/cql3/statements/create_type_statement.hh
@@ -43,7 +43,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     static void check_for_duplicate_names(user_type type);
 

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -208,7 +208,7 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     raw_select.set_bound_variables({});
 
     cql_stats ignored;
-    auto prepared = raw_select.prepare(db, ignored, default_cql_config, true);
+    auto prepared = raw_select.prepare_for_view(db, ignored, default_cql_config, true);
     auto restrictions = static_pointer_cast<statements::select_statement>(prepared->statement)->get_restrictions();
 
     auto base_primary_key_cols =
@@ -422,7 +422,7 @@ create_view_statement::prepare_schema_mutations(query_processor& qp, const query
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-create_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+create_view_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     if (!_prepare_ctx.get_variable_specifications().empty()) {
         throw exceptions::invalid_request_exception(format("Cannot use query parameters in CREATE MATERIALIZED VIEW statements"));
     }

--- a/cql3/statements/create_view_statement.hh
+++ b/cql3/statements/create_view_statement.hh
@@ -59,7 +59,7 @@ public:
     virtual future<> check_access(query_processor& qp, const service::client_state& state) const override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     // FIXME: continue here. See create_table_statement.hh and CreateViewStatement.java
 private:

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -881,7 +881,7 @@ describe_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), "system", "");
 }
 
-std::unique_ptr<prepared_statement> describe_statement::prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> describe_statement::make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     bool internals = bool(_with_internals);
     auto desc_stmt = std::visit(overloaded_functor{
         [] (const describe_cluster&) -> ::shared_ptr<statements::describe_statement> {

--- a/cql3/statements/detach_service_level_statement.cc
+++ b/cql3/statements/detach_service_level_statement.cc
@@ -27,7 +27,7 @@ bool detach_service_level_statement::needs_guard(query_processor& qp, service::q
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::detach_service_level_statement::prepare(
+cql3::statements::detach_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<detach_service_level_statement>(*this));
 }

--- a/cql3/statements/detach_service_level_statement.hh
+++ b/cql3/statements/detach_service_level_statement.hh
@@ -19,7 +19,7 @@ class detach_service_level_statement final : public service_level_statement {
     sstring _role_name;
 public:
     detach_service_level_statement(sstring role_name);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/drop_aggregate_statement.cc
+++ b/cql3/statements/drop_aggregate_statement.cc
@@ -19,7 +19,7 @@ namespace cql3 {
 
 namespace statements {
 
-std::unique_ptr<prepared_statement> drop_aggregate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> drop_aggregate_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_aggregate_statement>(*this));
 }
 

--- a/cql3/statements/drop_aggregate_statement.hh
+++ b/cql3/statements/drop_aggregate_statement.hh
@@ -14,7 +14,7 @@ namespace cql3 {
 class query_processor;
 namespace statements {
 class drop_aggregate_statement final : public drop_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
 protected:

--- a/cql3/statements/drop_function_statement.cc
+++ b/cql3/statements/drop_function_statement.cc
@@ -30,7 +30,7 @@ drop_function_statement::audit_info() const {
     return audit::audit::create_audit_info(category(), sstring(), sstring());
 }
 
-std::unique_ptr<prepared_statement> drop_function_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> drop_function_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_function_statement>(*this));
 }
 

--- a/cql3/statements/drop_function_statement.hh
+++ b/cql3/statements/drop_function_statement.hh
@@ -15,7 +15,7 @@ namespace cql3 {
 class query_processor;
 namespace statements {
 class drop_function_statement final : public drop_function_statement_base {
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 protected:
     virtual audit::statement_category category() const override;

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -91,7 +91,7 @@ drop_index_statement::prepare_schema_mutations(query_processor& qp, const query_
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_index_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+drop_index_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     _cql_stats = &stats;
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_index_statement>(*this));
 }

--- a/cql3/statements/drop_index_statement.hh
+++ b/cql3/statements/drop_index_statement.hh
@@ -46,7 +46,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     schema_ptr lookup_indexed_table(query_processor& qp) const;
     schema_ptr make_drop_idex_schema(query_processor& qp) const;

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -73,7 +73,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_keyspace_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+drop_keyspace_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_keyspace_statement>(*this));
 }
 

--- a/cql3/statements/drop_keyspace_statement.hh
+++ b/cql3/statements/drop_keyspace_statement.hh
@@ -32,7 +32,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/drop_role_statement.hh
+++ b/cql3/statements/drop_role_statement.hh
@@ -31,7 +31,7 @@ public:
     drop_role_statement(const cql3::role_name& name, bool if_exists) : _role(name.to_string()), _if_exists(if_exists) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual void validate(query_processor&, const service::client_state&) const override;
 

--- a/cql3/statements/drop_service_level_statement.cc
+++ b/cql3/statements/drop_service_level_statement.cc
@@ -20,7 +20,7 @@ drop_service_level_statement::drop_service_level_statement(sstring service_level
     _service_level(service_level), _if_exists(if_exists) {}
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::drop_service_level_statement::prepare(
+cql3::statements::drop_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<drop_service_level_statement>(*this));
 }

--- a/cql3/statements/drop_service_level_statement.hh
+++ b/cql3/statements/drop_service_level_statement.hh
@@ -21,7 +21,7 @@ class drop_service_level_statement final : public service_level_statement {
     bool _if_exists;
 public:
     drop_service_level_statement(sstring service_level, bool if_exists);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor&, service::query_state&, const query_options&, std::optional<service::group0_guard> guard) const override;

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -67,7 +67,7 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_w
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_table_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+drop_table_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_table_statement>(*this));
 }
 

--- a/cql3/statements/drop_table_statement.hh
+++ b/cql3/statements/drop_table_statement.hh
@@ -28,7 +28,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/drop_type_statement.cc
+++ b/cql3/statements/drop_type_statement.cc
@@ -151,7 +151,7 @@ drop_type_statement::prepare_schema_mutations(query_processor& qp, const query_o
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_type_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+drop_type_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_type_statement>(*this));
 }
 

--- a/cql3/statements/drop_type_statement.hh
+++ b/cql3/statements/drop_type_statement.hh
@@ -32,7 +32,7 @@ public:
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 private:
     bool validate_while_executing(query_processor&) const;
 };

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -65,7 +65,7 @@ drop_view_statement::prepare_schema_mutations(query_processor& qp, const query_o
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-drop_view_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+drop_view_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), make_shared<drop_view_statement>(*this));
 }
 

--- a/cql3/statements/drop_view_statement.hh
+++ b/cql3/statements/drop_view_statement.hh
@@ -34,7 +34,7 @@ public:
 
     future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chunked_vector<mutation>, cql3::cql_warnings_vec>> prepare_schema_mutations(query_processor& qp, const query_options& options, api::timestamp_type) const override;
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 };
 
 }

--- a/cql3/statements/grant_role_statement.hh
+++ b/cql3/statements/grant_role_statement.hh
@@ -32,7 +32,7 @@ public:
         : _role(name.to_string()), _grantee(grantee.to_string()) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/grant_statement.cc
+++ b/cql3/statements/grant_statement.cc
@@ -14,7 +14,7 @@
 #include "service/query_state.hh"
 #include "service/raft/raft_group0_client.hh"
 
-std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::grant_statement::prepare(
+std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::grant_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<grant_statement>(*this));
 }

--- a/cql3/statements/grant_statement.hh
+++ b/cql3/statements/grant_statement.hh
@@ -22,7 +22,7 @@ class grant_statement : public permission_altering_statement {
 public:
     using permission_altering_statement::permission_altering_statement;
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&

--- a/cql3/statements/list_effective_service_level_statement.cc
+++ b/cql3/statements/list_effective_service_level_statement.cc
@@ -26,7 +26,7 @@ list_effective_service_level_statement::list_effective_service_level_statement(s
 : _role_name(std::move(role_name)) {}
 
 std::unique_ptr<prepared_statement> 
-list_effective_service_level_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+list_effective_service_level_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_effective_service_level_statement>(*this));
 }
 

--- a/cql3/statements/list_effective_service_level_statement.hh
+++ b/cql3/statements/list_effective_service_level_statement.hh
@@ -19,7 +19,7 @@ class list_effective_service_level_statement final : public service_level_statem
 public:
     list_effective_service_level_statement(sstring role_name);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_permissions_statement.cc
+++ b/cql3/statements/list_permissions_statement.cc
@@ -37,7 +37,7 @@ cql3::statements::list_permissions_statement::list_permissions_statement(
             , _recursive(recursive) {
 }
 
-std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_permissions_statement::prepare(
+std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_permissions_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_permissions_statement>(*this));
 }

--- a/cql3/statements/list_permissions_statement.hh
+++ b/cql3/statements/list_permissions_statement.hh
@@ -32,7 +32,7 @@ private:
 public:
     list_permissions_statement(auth::permission_set, std::optional<auth::resource>, std::optional<sstring>, bool);
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_roles_statement.hh
+++ b/cql3/statements/list_roles_statement.hh
@@ -33,7 +33,7 @@ public:
     list_roles_statement(const std::optional<role_name>& grantee, bool recursive)
         : _grantee(grantee ? sstring(grantee->to_string()) : std::optional<sstring>()), _recursive(recursive) {}
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/list_service_level_attachments_statement.cc
+++ b/cql3/statements/list_service_level_attachments_statement.cc
@@ -34,7 +34,7 @@ list_service_level_attachments_statement::list_service_level_attachments_stateme
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::list_service_level_attachments_statement::prepare(
+cql3::statements::list_service_level_attachments_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_service_level_attachments_statement>(*this));
 }

--- a/cql3/statements/list_service_level_attachments_statement.hh
+++ b/cql3/statements/list_service_level_attachments_statement.hh
@@ -21,7 +21,7 @@ class list_service_level_attachments_statement final : public service_level_stat
 public:
     list_service_level_attachments_statement(sstring role_name);
     list_service_level_attachments_statement();
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/list_service_level_statement.cc
+++ b/cql3/statements/list_service_level_statement.cc
@@ -37,7 +37,7 @@ list_service_level_statement::list_service_level_statement(sstring service_level
 }
 
 std::unique_ptr<cql3::statements::prepared_statement>
-cql3::statements::list_service_level_statement::prepare(
+cql3::statements::list_service_level_statement::make_prepared_statement(
         data_dictionary::database db, cql_stats &stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_service_level_statement>(*this));
 }

--- a/cql3/statements/list_service_level_statement.hh
+++ b/cql3/statements/list_service_level_statement.hh
@@ -20,7 +20,7 @@ class list_service_level_statement final : public service_level_statement {
     bool _describe_all;
 public:
     list_service_level_statement(sstring service_level, bool describe_all);
-    std::unique_ptr<cql3::statements::prepared_statement> prepare(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
+    std::unique_ptr<cql3::statements::prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats &stats, const cql_config& cfg) override;
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
     virtual future<::shared_ptr<cql_transport::messages::result_message>>

--- a/cql3/statements/list_users_statement.cc
+++ b/cql3/statements/list_users_statement.cc
@@ -23,7 +23,7 @@ shared_ptr<const cql3::metadata> cql3::statements::list_users_statement::get_res
                 cql3::make_column_spec(db::system_keyspace::NAME, "users", "super", boolean_type)});
 }
 
-std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_users_statement::prepare(
+std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::list_users_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_users_statement>(*this));
 }

--- a/cql3/statements/list_users_statement.hh
+++ b/cql3/statements/list_users_statement.hh
@@ -21,7 +21,7 @@ namespace statements {
 class list_users_statement : public authentication_statement {
 public:
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual seastar::shared_ptr<const metadata> get_result_metadata() const override;
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -580,12 +580,12 @@ modification_statement::prepare_for_broadcast_tables() const {
 namespace raw {
 
 std::unique_ptr<prepared_statement>
-modification_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+modification_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto meta = get_prepare_context();
 
     auto statement = std::invoke([&] -> shared_ptr<cql_statement> {
-        auto result = prepare(db, meta, stats);
+        auto result = make_prepared_modification_statement(db, meta, stats);
 
         if (strong_consistency::is_strongly_consistent(db, schema->ks_name())) {
             return ::make_shared<strong_consistency::modification_statement>(std::move(result));
@@ -603,7 +603,7 @@ modification_statement::prepare(data_dictionary::database db, cql_stats& stats, 
 }
 
 ::shared_ptr<cql3::statements::modification_statement>
-modification_statement::prepare(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const {
+modification_statement::make_prepared_modification_statement(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
 
     auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());

--- a/cql3/statements/raw/batch_statement.hh
+++ b/cql3/statements/raw/batch_statement.hh
@@ -46,7 +46,10 @@ public:
         }
     }
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    // Yields between preparation of the contained sub-statements to avoid
+    // reactor stalls on large batches (#24578).
+    virtual future<std::pair<std::unique_ptr<prepared_statement>, uint64_t>> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+
 protected:
     virtual audit::statement_category category() const override;
     virtual audit::audit_info_ptr audit_info() const override {

--- a/cql3/statements/raw/describe_statement.hh
+++ b/cql3/statements/raw/describe_statement.hh
@@ -81,7 +81,7 @@ public:
     explicit describe_statement(describe_config config);
     void with_internals_details(bool with_hashed_passwords);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     static std::unique_ptr<describe_statement> cluster();
     static std::unique_ptr<describe_statement> schema(bool full);

--- a/cql3/statements/raw/modification_statement.hh
+++ b/cql3/statements/raw/modification_statement.hh
@@ -39,8 +39,8 @@ protected:
     modification_statement(cf_name name, std::unique_ptr<attributes::raw> attrs, std::optional<expr::expression> conditions = {}, bool if_not_exists = false, bool if_exists = false);
 
 public:
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
-    ::shared_ptr<cql3::statements::modification_statement> prepare(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    ::shared_ptr<cql3::statements::modification_statement> make_prepared_modification_statement(data_dictionary::database db, prepare_context& ctx, cql_stats& stats) const;
     void add_raw(sstring&& raw) { _raw_cql = std::move(raw); }
     const sstring& get_raw_cql() const { return _raw_cql; }
 protected:

--- a/cql3/statements/raw/parsed_statement.cc
+++ b/cql3/statements/raw/parsed_statement.cc
@@ -10,11 +10,14 @@
 
 #include "parsed_statement.hh"
 
+#include <seastar/core/memory.hh>
+
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/column_specification.hh"
 
 #include "cql3/cql_statement.hh"
 #include "cql3/result_set.hh"
+#include "utils/on_internal_error.hh"
 
 namespace cql3 {
 
@@ -36,6 +39,19 @@ const prepare_context& parsed_statement::get_prepare_context() const {
 // Used by the parser and preparable statement
 void parsed_statement::set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names) {
     _prepare_ctx.set_bound_variables(bound_names);
+}
+
+future<std::pair<std::unique_ptr<prepared_statement>, uint64_t>>
+parsed_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+    auto bytes_before = seastar::memory::stats().total_bytes_allocated();
+    auto p = make_prepared_statement(db, stats, cfg);
+    auto prepare_allocation_bytes = seastar::memory::stats().total_bytes_allocated() - bytes_before;
+    return make_ready_future<std::pair<std::unique_ptr<prepared_statement>, uint64_t>>(std::move(p), prepare_allocation_bytes);
+}
+
+std::unique_ptr<prepared_statement>
+parsed_statement::make_prepared_statement(data_dictionary::database, cql_stats&, const cql_config&) {
+    utils::on_internal_error("parsed_statement::make_prepared_statement() called for a statement that only supports async prepare()");
 }
 
 }

--- a/cql3/statements/raw/parsed_statement.hh
+++ b/cql3/statements/raw/parsed_statement.hh
@@ -43,9 +43,16 @@ public:
 
     void set_bound_variables(const std::vector<::shared_ptr<column_identifier>>& bound_names);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) = 0;
+    // Returns {prepared statement, gross bytes allocated by the synchronous
+    // prepare work}. The allocation cost is measured without spanning any
+    // yield, so callers can account for the preparation cost.
+    virtual future<std::pair<std::unique_ptr<prepared_statement>, uint64_t>> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg);
 
 protected:
+    // Synchronous implementation point for non-batch statements. External
+    // callers use prepare(); batch_statement overrides prepare() directly.
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg);
+
     virtual audit::statement_category category() const = 0;
     virtual audit::audit_info_ptr audit_info() const = 0;
 };

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -108,10 +108,10 @@ public:
             std::vector<::shared_ptr<cql3::column_identifier::raw>> group_by_columns,
             std::unique_ptr<cql3::attributes::raw> attrs);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override {
-        return prepare(db, stats, cfg, false);
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override {
+        return prepare_for_view(db, stats, cfg, false);
     }
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view);
+    std::unique_ptr<prepared_statement> prepare_for_view(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view);
 private:
     std::vector<selection::prepared_selector> maybe_jsonize_select_clause(std::vector<selection::prepared_selector> select, data_dictionary::database db, schema_ptr schema);
     ::shared_ptr<const restrictions::statement_restrictions> prepare_restrictions(

--- a/cql3/statements/raw/truncate_statement.hh
+++ b/cql3/statements/raw/truncate_statement.hh
@@ -31,7 +31,7 @@ public:
      */
     truncate_statement(cf_name name, std::unique_ptr<attributes::raw> attrs);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual audit::statement_category category() const override;
 };

--- a/cql3/statements/raw/use_statement.hh
+++ b/cql3/statements/raw/use_statement.hh
@@ -29,7 +29,7 @@ private:
 public:
     use_statement(sstring keyspace);
 
-    virtual std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    virtual std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 protected:
     virtual audit::statement_category category() const override;
     virtual audit::audit_info_ptr audit_info() const override {

--- a/cql3/statements/revoke_role_statement.hh
+++ b/cql3/statements/revoke_role_statement.hh
@@ -32,7 +32,7 @@ public:
             : _role(name.to_string()), _revokee(revokee.to_string()) {
     }
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     virtual future<> check_access(query_processor& qp, const service::client_state&) const override;
 

--- a/cql3/statements/revoke_statement.cc
+++ b/cql3/statements/revoke_statement.cc
@@ -13,7 +13,7 @@
 #include "cql3/statements/prepared_statement.hh"
 #include "service/query_state.hh"
 
-std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::revoke_statement::prepare(
+std::unique_ptr<cql3::statements::prepared_statement> cql3::statements::revoke_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<revoke_statement>(*this));
 }

--- a/cql3/statements/revoke_statement.hh
+++ b/cql3/statements/revoke_statement.hh
@@ -22,7 +22,7 @@ class revoke_statement : public permission_altering_statement {
 public:
     using permission_altering_statement::permission_altering_statement;
 
-    std::unique_ptr<prepared_statement> prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
+    std::unique_ptr<prepared_statement> make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) override;
 
     future<::shared_ptr<cql_transport::messages::result_message>> execute(query_processor&
                     , service::query_state&

--- a/cql3/statements/role-management-statements.cc
+++ b/cql3/statements/role-management-statements.cc
@@ -67,7 +67,7 @@ static auth::authentication_options extract_authentication_options(const cql3::r
 // `create_role_statement`
 //
 
-std::unique_ptr<prepared_statement> create_role_statement::prepare(
+std::unique_ptr<prepared_statement> create_role_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<create_role_statement>(*this));
 }
@@ -202,7 +202,7 @@ void create_role_statement::sanitize_audit_info() {
 // `alter_role_statement`
 //
 
-std::unique_ptr<prepared_statement> alter_role_statement::prepare(
+std::unique_ptr<prepared_statement> alter_role_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<alter_role_statement>(*this));
 }
@@ -288,7 +288,7 @@ void alter_role_statement::sanitize_audit_info() {
 // `drop_role_statement`
 //
 
-std::unique_ptr<prepared_statement> drop_role_statement::prepare(
+std::unique_ptr<prepared_statement> drop_role_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<drop_role_statement>(*this));
 }
@@ -343,7 +343,7 @@ drop_role_statement::execute(query_processor&, service::query_state& state, cons
 // `list_roles_statement`
 //
 
-std::unique_ptr<prepared_statement> list_roles_statement::prepare(
+std::unique_ptr<prepared_statement> list_roles_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<list_roles_statement>(*this));
 }
@@ -473,7 +473,7 @@ list_roles_statement::execute(query_processor& qp, service::query_state& state, 
 // `grant_role_statement`
 //
 
-std::unique_ptr<prepared_statement> grant_role_statement::prepare(
+std::unique_ptr<prepared_statement> grant_role_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<grant_role_statement>(*this));
 }
@@ -503,7 +503,7 @@ grant_role_statement::execute(query_processor&, service::query_state& state, con
 // `revoke_role_statement`
 //
 
-std::unique_ptr<prepared_statement> revoke_role_statement::prepare(
+std::unique_ptr<prepared_statement> revoke_role_statement::make_prepared_statement(
                 data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<revoke_role_statement>(*this));
 }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2038,7 +2038,7 @@ group_by_references_clustering_keys(const selection::selection& sel, const std::
     });
 }
 
-std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view) {
+std::unique_ptr<prepared_statement> select_statement::prepare_for_view(data_dictionary::database db, cql_stats& stats, const cql_config& cfg, bool for_view) {
     schema_ptr underlying_schema = validation::validate_column_family(db, keyspace(), column_family());
     schema_ptr schema = _parameters->is_mutation_fragments() ? mutation_fragments_select_statement::generate_output_schema(underlying_schema) : underlying_schema;
     prepare_context& ctx = get_prepare_context();

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -35,7 +35,7 @@ truncate_statement::truncate_statement(cf_name name, std::unique_ptr<attributes:
     throwing_assert(!_attrs->time_to_live.has_value());
 }
 
-std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
+std::unique_ptr<prepared_statement> truncate_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg) {
     schema_ptr schema = validation::validate_column_family(db, keyspace(), column_family());
     auto prepared_attributes = _attrs->prepare(db, keyspace(), column_family());
     auto ctx = get_prepare_context();

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -36,7 +36,7 @@ use_statement::use_statement(sstring keyspace)
 {
 }
 
-std::unique_ptr<prepared_statement> use_statement::prepare(data_dictionary::database db, cql_stats& stats, const cql_config& cfg)
+std::unique_ptr<prepared_statement> use_statement::make_prepared_statement(data_dictionary::database db, cql_stats& stats, const cql_config& cfg)
 {
     return std::make_unique<prepared_statement>(audit_info(), ::make_shared<cql3::statements::use_statement>(_keyspace));
 }

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -131,7 +131,7 @@ cql3::statements::select_statement& view_info::select_statement(data_dictionary:
         raw->prepare_keyspace(_schema.ks_name());
         raw->set_bound_variables({});
         cql3::cql_stats ignored;
-        auto prepared = raw->prepare(db, ignored, cql3::default_cql_config, true);
+        auto prepared = raw->prepare_for_view(db, ignored, cql3::default_cql_config, true);
         _select_statement = static_pointer_cast<cql3::statements::select_statement>(prepared->statement);
     }
     return *_select_statement;

--- a/service/raft/raft_sys_table_storage.cc
+++ b/service/raft/raft_sys_table_storage.cc
@@ -39,11 +39,6 @@ raft_sys_table_storage::raft_sys_table_storage(cql3::query_processor& qp, raft::
     // max_mutation_size = 1/2 of commitlog segment size, thus _max_mutation_size is set 1/3 of commitlog segment size to leave space for metadata.
     , _max_mutation_size(_qp.db().get_config().schema_commitlog_segment_size_in_mb() * 1024 * 1024 / 3)
 {
-    static const auto store_cql = format("INSERT INTO system.{} (group_id, term, \"index\", data) VALUES (?, ?, ?, ?)",
-        db::system_keyspace::RAFT);
-    auto prepared_stmt_ptr = _qp.prepare_internal(store_cql);
-    shared_ptr<cql3::cql_statement> cql_stmt = prepared_stmt_ptr->statement;
-    _store_entry_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(cql_stmt);
 }
 
 future<> raft_sys_table_storage::store_term_and_vote(raft::term_t term, raft::server_id vote) {
@@ -187,6 +182,14 @@ future<> raft_sys_table_storage::store_snapshot_descriptor(const raft::snapshot_
 }
 
 future<size_t> raft_sys_table_storage::do_store_log_entries_one_batch(const std::vector<raft::log_entry_ptr>& entries, size_t start_idx) {
+    if (!_store_entry_stmt) {
+        static const auto store_cql = format("INSERT INTO system.{} (group_id, term, \"index\", data) VALUES (?, ?, ?, ?)",
+            db::system_keyspace::RAFT);
+        auto prepared_stmt_ptr = co_await _qp.prepare_internal(store_cql);
+        shared_ptr<cql3::cql_statement> cql_stmt = prepared_stmt_ptr->statement;
+        _store_entry_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(cql_stmt);
+    }
+
     std::vector<cql3::statements::batch_statement::single_statement> batch_stmts;
     // statement values that can be allocated at once (one contiguous allocation)
     std::vector<std::vector<cql3::raw_value>> stmt_values;

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -29,9 +29,9 @@ static schema_ptr parse_new_cf_statement(cql3::query_processor& qp, const sstrin
 
     cql3::statements::raw::cf_statement* parsed_cf_stmt = static_cast<cql3::statements::raw::cf_statement*>(parsed.get());
     (void)parsed_cf_stmt->keyspace(); // This will SCYLLA_ASSERT if cql statement did not contain keyspace
+    auto [prepared, _] = parsed_cf_stmt->prepare(db, qp.get_cql_stats(), qp.get_cql_config()).get();
     ::shared_ptr<cql3::statements::create_table_statement> statement =
-                    static_pointer_cast<cql3::statements::create_table_statement>(
-                                    parsed_cf_stmt->prepare(db, qp.get_cql_stats(), qp.get_cql_config())->statement);
+                    static_pointer_cast<cql3::statements::create_table_statement>(prepared->statement);
     auto schema = statement->get_cf_meta_data(db);
 
     // Generate the CF UUID based on its KF names. This is needed to ensure that

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -311,7 +311,7 @@ public:
 
     virtual future<utils::chunked_vector<mutation>> get_modification_mutations(const sstring& text) override {
         auto qs = make_query_state();
-        auto cql_stmt = local_qp().get_statement(text, qs->get_client_state(), test_dialect())->statement;
+        auto cql_stmt = (co_await local_qp().get_statement(text, qs->get_client_state(), test_dialect()))->statement;
         auto modif_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(std::move(cql_stmt));
         if (!modif_stmt) {
             throw std::runtime_error(format("get_stmt_mutations: not a modification statement: {}", text));
@@ -321,7 +321,7 @@ public:
         cql3::statements::modification_statement::json_cache_opt json_cache = modif_stmt->maybe_prepare_json_cache(qo);
         std::vector<dht::partition_range> keys = modif_stmt->build_partition_keys(qo, json_cache);
 
-        return modif_stmt->get_mutations(local_qp(), qo, timeout, false, qo.get_timestamp(*qs), *qs, json_cache, keys)
+        co_return co_await modif_stmt->get_mutations(local_qp(), qo, timeout, false, qo.get_timestamp(*qs), *qs, json_cache, keys)
             .finally([qs, modif_stmt = std::move(modif_stmt)] {});
     }
 
@@ -1290,14 +1290,15 @@ public:
                 __FUNCTION__, batch_type == batch_statement::type::LOGGED ? "LOGGED" : "UNLOGGED", fmt::join(queries, "\n  "));
 
         std::vector<batch_statement::single_statement> modifications;
-        std::ranges::transform(queries, back_inserter(modifications), [this](const auto& query) {
-            auto stmt = local_qp().get_statement(query, _core_local.local().client_state, test_dialect());
-            if (!dynamic_cast<modification_statement*>(stmt->statement.get())) {
+        for (const auto& query : queries) {
+            auto stmt = co_await local_qp().get_statement(query, _core_local.local().client_state, test_dialect());
+            auto mod = dynamic_cast<modification_statement*>(stmt->statement.get());
+            if (!mod) {
                 throw exceptions::invalid_request_exception(
                     "Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed.");
             }
-            return batch_statement::single_statement(static_pointer_cast<modification_statement>(stmt->statement));
-        });
+            modifications.emplace_back(static_pointer_cast<modification_statement>(stmt->statement));
+        }
         auto batch = ::make_shared<batch_statement>(
             batch_type,
             std::move(modifications),
@@ -1305,9 +1306,8 @@ public:
             local_qp().get_cql_stats());
         auto qs = make_query_state();
         auto& lqo = *qo;
-        return local_qp().execute_batch_without_checking_exception_message(batch, *qs, lqo, {}).then([qs, batch, qo = std::move(qo)] (auto msg) {
-            return cql_transport::messages::propagate_exception_as_future(std::move(msg));
-        });
+        auto msg = co_await local_qp().execute_batch_without_checking_exception_message(batch, *qs, lqo, {});
+        co_return co_await cql_transport::messages::propagate_exception_as_future(std::move(msg));
     }
 
     virtual sharded<qos::service_level_controller>& service_level_controller_service() override {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -311,7 +311,7 @@ public:
 
     virtual future<utils::chunked_vector<mutation>> get_modification_mutations(const sstring& text) override {
         auto qs = make_query_state();
-        auto cql_stmt = (co_await local_qp().get_statement(text, qs->get_client_state(), test_dialect()))->statement;
+        auto cql_stmt = (co_await local_qp().get_statement(utils::chunked_string(text), qs->get_client_state(), test_dialect()))->statement;
         auto modif_stmt = dynamic_pointer_cast<cql3::statements::modification_statement>(std::move(cql_stmt));
         if (!modif_stmt) {
             throw std::runtime_error(format("get_stmt_mutations: not a modification statement: {}", text));
@@ -1291,7 +1291,7 @@ public:
 
         std::vector<batch_statement::single_statement> modifications;
         for (const auto& query : queries) {
-            auto stmt = co_await local_qp().get_statement(query, _core_local.local().client_state, test_dialect());
+            auto stmt = co_await local_qp().get_statement(utils::chunked_string(query), _core_local.local().client_state, test_dialect());
             auto mod = dynamic_cast<modification_statement*>(stmt->statement.get());
             if (!mod) {
                 throw exceptions::invalid_request_exception(

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -280,7 +280,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
         auto raw_statement = cql3::query_processor::parse_statement(
                 fmt::format("CREATE KEYSPACE {} WITH replication = {{'class': 'SimpleStrategy', 'replication_factor': '1'}}", name),
                 cql3::dialect{});
-        auto prepared_statement = raw_statement->prepare(db, cql_stats, cql3::default_cql_config);
+        auto [prepared_statement, _] = raw_statement->prepare(db, cql_stats, cql3::default_cql_config).get();
         auto* statement = prepared_statement->statement.get();
         auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement);
         SCYLLA_ASSERT(p);
@@ -304,7 +304,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
             throw std::runtime_error("tools::do_load_schemas(): CQL statement does not have keyspace specified");
         }
         auto ks = find_or_create_keyspace(cf_statement->keyspace());
-        auto prepared_statement = cf_statement->prepare(db, cql_stats, cql3::default_cql_config);
+        auto [prepared_statement, _] = cf_statement->prepare(db, cql_stats, cql3::default_cql_config).get();
         auto* statement = prepared_statement->statement.get();
 
         if (auto p = dynamic_cast<cql3::statements::create_keyspace_statement*>(statement)) {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1753,7 +1753,7 @@ validate_and_prepare_query(std::string_view query, std::string_view table_name, 
     cql3::cql_stats cql_stats;
 
     try {
-        auto prepared_statement = raw_statement->prepare(db, cql_stats, cql3::default_cql_config);
+        auto [prepared_statement, _] = raw_statement->prepare(db, cql_stats, cql3::default_cql_config).get();
         return std::move(prepared_statement->statement);
     } catch (...) {
         throw std::invalid_argument(seastar::format("failed to prepare query: {}", std::current_exception()));

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -1608,7 +1608,7 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
         tracing::begin(trace_state, "Execute CQL3 query", client_state.get_client_address());
     }
 
-    return qp.local().execute_direct_without_checking_exception_message(query.assume_value(), query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
+    return qp.local().execute_direct_without_checking_exception_message(std::move(query).assume_value(), query_state, dialect, options).then([q_state = std::move(q_state), stream, skip_metadata, version] (auto msg) {
         if (msg->as_bounce()) {
             return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
         } else if (msg->is_exception()) {
@@ -1779,16 +1779,11 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             if (!query) {
                 co_await coroutine::return_exception_ptr(std::move(query).assume_error());
             }
-            // query owns its storage and is a local that lives across the
-            // co_await below, so we can hand get_statement() a view into it
-            // (get_statement() makes its own copy before it suspends) and still
-            // use it for tracing afterwards.
-            const utils::chunked_string& query_text = query.assume_value();
-            stmt_ptr = co_await qp.local().get_statement(query_text, client_state, dialect);
-            ps = stmt_ptr->checked_weak_from_this();
             if (init_trace && trace_state) {
-                tracing::add_query(trace_state, query_text);
+                tracing::add_query(trace_state, query.assume_value());
             }
+            stmt_ptr = co_await qp.local().get_statement(std::move(query).assume_value(), client_state, dialect);
+            ps = stmt_ptr->checked_weak_from_this();
             break;
         }
         case 1: {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -32,6 +32,7 @@
 #include <seastar/core/seastar.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
 #include <seastar/coroutine/try_future.hh>
 #include <seastar/net/byteorder.hh>
 #include <seastar/core/metrics.hh>
@@ -1744,11 +1745,11 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         service_permit permit, tracing::trace_state_ptr trace_state, bool init_trace, cql3::computed_function_values cached_pk_fn_calls, cql3::dialect dialect, cql_sg_stats& sg_stats, api::timestamp_type request_start_timestamp) {
     const utils::result_with_exception_ptr<int8_t> type = in.read_byte();
     if (!type) {
-        return make_exception_future<cql_server::process_fn_return_type>(std::move(type).assume_error());
+        co_await coroutine::return_exception_ptr(std::move(type).assume_error());
     }
     const utils::result_with_exception_ptr<uint16_t> n = in.read_short();
     if (!n) {
-        return make_exception_future<cql_server::process_fn_return_type>(std::move(n).assume_error());
+        co_await coroutine::return_exception_ptr(std::move(n).assume_error());
     }
 
     std::vector<cql3::statements::batch_statement::single_statement> modifications;
@@ -1765,7 +1766,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     for ([[gnu::unused]] auto i : std::views::iota(0u, n.assume_value())) {
         const utils::result_with_exception_ptr<int8_t> kind = in.read_byte();
         if (!kind) {
-            return make_exception_future<cql_server::process_fn_return_type>(std::move(kind).assume_error());
+            co_await coroutine::return_exception_ptr(std::move(kind).assume_error());
         }
 
         std::unique_ptr<cql3::statements::prepared_statement> stmt_ptr;
@@ -1776,19 +1777,24 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         case 0: {
             utils::result_with_exception_ptr<utils::chunked_string> query = in.read_long_chunked_string();
             if (!query) {
-                return make_exception_future<cql_server::process_fn_return_type>(std::move(query).assume_error());
+                co_await coroutine::return_exception_ptr(std::move(query).assume_error());
             }
-            stmt_ptr = qp.local().get_statement(query.assume_value(), client_state, dialect);
+            // query owns its storage and is a local that lives across the
+            // co_await below, so we can hand get_statement() a view into it
+            // (get_statement() makes its own copy before it suspends) and still
+            // use it for tracing afterwards.
+            const utils::chunked_string& query_text = query.assume_value();
+            stmt_ptr = co_await qp.local().get_statement(query_text, client_state, dialect);
             ps = stmt_ptr->checked_weak_from_this();
             if (init_trace && trace_state) {
-                tracing::add_query(trace_state, query.assume_value());
+                tracing::add_query(trace_state, query_text);
             }
             break;
         }
         case 1: {
             utils::result_with_exception_ptr<bytes> cache_key_bytes = in.read_short_bytes();
             if (!cache_key_bytes) {
-                return make_exception_future<cql_server::process_fn_return_type>(std::move(cache_key_bytes).assume_error());
+                co_await coroutine::return_exception_ptr(std::move(cache_key_bytes).assume_error());
             }
             cql3::prepared_cache_key_type cache_key(cache_key_bytes.assume_value(), dialect);
             auto& id = cql3::prepared_cache_key_type::cql_id(cache_key);
@@ -1799,7 +1805,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             if (!ps) {
                 ps = qp.local().get_prepared(cache_key);
                 if (!ps) {
-                    return make_exception_future<cql_server::process_fn_return_type>(exceptions::prepared_query_not_found_exception(id));
+                    co_await coroutine::return_exception(exceptions::prepared_query_not_found_exception(id));
                 }
                 // authorize a particular prepared statement only once
                 needs_authorization = pending_authorization_entries.emplace(std::move(cache_key), ps->checked_weak_from_this()).second;
@@ -1810,13 +1816,13 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
             break;
         }
         default:
-            return make_exception_future<cql_server::process_fn_return_type>(exceptions::protocol_exception(
+            co_await coroutine::return_exception(exceptions::protocol_exception(
                     "Invalid query kind in BATCH messages. Must be 0 or 1 but got "
                             + std::to_string(int(kind.assume_value()))));
         }
 
         if (dynamic_cast<cql3::statements::modification_statement*>(ps->statement.get()) == nullptr) {
-            return make_exception_future<cql_server::process_fn_return_type>(exceptions::invalid_request_exception("Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed."));
+            co_await coroutine::return_exception(exceptions::invalid_request_exception("Invalid statement in batch: only UPDATE, INSERT and DELETE statements are allowed."));
         }
         ::shared_ptr<cql3::statements::modification_statement> modif_statement_ptr = static_pointer_cast<cql3::statements::modification_statement>(ps->statement);
         if (init_trace && trace_state) {
@@ -1830,13 +1836,12 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         cql3::unset_bind_variable_vector unset;
         auto rvl = in.read_value_view_list(version, tmp, unset);
         if (!rvl) {
-            return make_exception_future<cql_server::process_fn_return_type>(std::move(rvl).assume_error());
+            co_await coroutine::return_exception_ptr(std::move(rvl).assume_error());
         }
 
         auto stmt = ps->statement;
         if (stmt->get_bound_terms() != tmp.size()) {
-            return make_exception_future<cql_server::process_fn_return_type>(
-                    exceptions::invalid_request_exception(format("There were {:d} markers(?) in CQL but {:d} bound variables",
+            co_await coroutine::return_exception(exceptions::invalid_request_exception(format("There were {:d} markers(?) in CQL but {:d} bound variables",
                             stmt->get_bound_terms(), tmp.size())));
         }
         values.emplace_back(cql3::raw_value_view_vector_with_unset(std::move(tmp), std::move(unset)));
@@ -1847,7 +1852,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
     // #563. CQL v2 encodes query_options in v1 format for batch requests.
     auto o = in.read_options(version, qp.local().get_cql_config());
     if (!o) {
-        return make_exception_future<cql_server::process_fn_return_type>(std::move(o).assume_error());
+        co_await coroutine::return_exception_ptr(std::move(o).assume_error());
     }
     q_state->options = std::make_unique<cql3::query_options>(cql3::query_options::make_batch_options(std::move(*o.assume_value()), std::move(values)));
     auto& options = *q_state->options;
@@ -1866,18 +1871,15 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
 
     auto batch = ::make_shared<cql3::statements::batch_statement>(cql3::statements::batch_statement::type(type.assume_value()), std::move(modifications), cql3::attributes::none(), qp.local().get_cql_stats());
     batch->set_audit_info(batch->audit_info());
-    return qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries))
-            .then([stream, batch, q_state = std::move(q_state), trace_state = query_state.get_trace_state(), version] (auto msg) {
-        if (msg->as_bounce()) {
-            return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
-        } else if (msg->is_exception()) {
-            return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
-        } else {
-            tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
-
-            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, trace_state, version, cql_metadata_id_wrapper{})));
-        }
-    });
+    auto msg = co_await qp.local().execute_batch_without_checking_exception_message(batch, query_state, options, std::move(pending_authorization_entries));
+    if (msg->as_bounce()) {
+        co_return cql_server::process_fn_return_type(make_foreign(static_pointer_cast<messages::result_message::bounce>(msg)));
+    } else if (msg->is_exception()) {
+        co_return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
+    } else {
+        tracing::trace(query_state.get_trace_state(), "Done processing - preparing a result");
+        co_return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, query_state.get_trace_state(), version, cql_metadata_id_wrapper{})));
+    }
 }
 
 // Copy the bytes from an istream into a bytes_ostream.


### PR DESCRIPTION
Batch preparation used to synchronously prepare every sub-statement in one reactor turn. This PR makes parsed statement preparation future-returning and lets `batch_statement::prepare()` yield between sub-statement prepares.

Fixes https://github.com/scylladb/scylladb/issues/24578

No need to backport, not a big severity, doesn't show up in the field, only hit once.