### PR TITLE
transport: service_level_controller: create and use `driver` service level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 19 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 20 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/configure.py
+++ b/configure.py
@@ -1992,7 +1992,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=19',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=20',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -683,8 +683,11 @@ public:
     future<topology_requests_entries> get_node_ops_request_entries(db_clock::time_point end_time_limit);
 
 public:
+    future<std::optional<bool>> get_service_level_driver_created();
+    future<mutation> make_service_level_driver_created_mutation(bool is_created, api::timestamp_type timestamp);
+    future<std::optional<mutation>> get_service_level_driver_created_mutation();
+
     future<std::optional<int8_t>> get_service_levels_version();
-    
     future<mutation> make_service_levels_version_mutation(int8_t version, api::timestamp_type timestamp);
     future<std::optional<mutation>> get_service_levels_version_mutation();
 

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -23,9 +23,13 @@ By assigning each service level to the different roles within your organization,
 
 .. _`role` : /operating-scylla/security/rbac_usecase/
 
+Initially ScyllaDB has two service levels:
+ * ``'default'`` - Receives all load unassigned to any other service level.
+ * ``'driver'`` - Isolates metadata operations (for example, driver schema and topology fetches) and handles new connections before the user is authenticated and authorized. This reduces the impact of connection handling on regular query traffic. In most deployments, you do not need to tune the ``'driver'`` service level.
+
 Prerequisites
 =============
-To create a level of service and assign it to a role, you need:
+To create a new service level and assign it to a role, you need:
 
 * An :doc:`authenticated </operating-scylla/security/runtime-authentication>` and :doc:`authorized </operating-scylla/security/enable-authorization>` user 
 * At least one :ref:`role created <create-role-statement>`.
@@ -76,7 +80,7 @@ Where:
 Example
 .......
 
-There are 3 service levels (OLAP, OLTP, Default) where: (the percentage of resources = (Assigned Shares / Total Shares) x 100). Total Shares in this case is the total of all allocated shares + the Default SLA (1000). The percentage of resources would be:
+There are 4 service levels (OLAP, OLTP, driver, default) where: (the percentage of resources = (Assigned Shares / Total Shares) x 100). Total Shares in this case is the total of all allocated shares + the Default SLA (1000). The percentage of resources would be:
 
 .. list-table::
    :widths: 30 30 30 
@@ -90,12 +94,15 @@ There are 3 service levels (OLAP, OLTP, Default) where: (the percentage of resou
      - 4%
    * - OLTP
      - 1000
-     - 48%
-   * - Default
+     - 44%
+   * - driver
+     - 200
+     - 8%
+   * - default
      - 1000
-     - 48%
+     - 44%
    * - Total 
-     - 2100
+     - 2300
      - 100%
 
 **Procedure**
@@ -115,10 +122,12 @@ There are 3 service levels (OLAP, OLTP, Default) where: (the percentage of resou
 
    service_level | shares
    --------------+-------
+          driver |    200
+   --------------+-------
             olap |    100
    --------------+-------
             oltp |   1000
-   (2 rows)
+   (3 rows)
 
 Change Resource Allocation for a Service Level 
 -----------------------------------------------
@@ -235,9 +244,10 @@ Run the following:
 
    service_level  | shares
    ---------------+--------
+           driver |     200
              olap |     100
              oltp |    1000
-   (2 rows)
+   (3 rows)
 
 
 Delete a Service Level
@@ -425,7 +435,7 @@ In order for workload prioritization to take effect, application users need to b
 
 Limits
 ======
-ScyllaDB is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
+ScyllaDB is limited to 9 service levels, including the default and driver levels; this means you can create up to 7 service levels.
 
 
 Additional References

--- a/generic_server.cc
+++ b/generic_server.cc
@@ -15,6 +15,7 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/coroutine/switch_to.hh>
 #include <utility>
 
 namespace generic_server {
@@ -366,6 +367,7 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
 }
 
 future<> server::do_accepts(int which, bool keepalive, socket_address server_addr, bool is_tls) {
+    co_await coroutine::switch_to(get_scheduling_group_for_new_connection());
     while (!_gate.is_closed()) {
         seastar::gate::holder holder(_gate);
         bool shed = false;
@@ -385,6 +387,7 @@ future<> server::do_accepts(int which, bool keepalive, socket_address server_add
                 }
             }
             accept_result cs_sa = co_await _listeners[which].accept();
+            co_await coroutine::switch_to(get_scheduling_group_for_new_connection());
             if (_gate.is_closed()) {
                 break;
             }

--- a/generic_server.hh
+++ b/generic_server.hh
@@ -23,6 +23,7 @@
 #include <seastar/net/api.hh>
 #include <seastar/net/tls.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/scheduling.hh>
 
 namespace generic_server {
 
@@ -152,6 +153,7 @@ public:
 
 protected:
     virtual seastar::shared_ptr<connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) = 0;
+    virtual scheduling_group get_scheduling_group_for_new_connection() const = 0;
 
     future<> for_each_gently(noncopyable_function<void(connection&)>);
 };

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -170,6 +170,7 @@ public:
     gms::feature lwt_with_tablets { *this, "LWT_WITH_TABLETS"sv };
     gms::feature repair_msg_split { *this, "REPAIR_MSG_SPLIT"sv };
     gms::feature view_building_coordinator { *this, "VIEW_BUILDING_COORDINATOR"sv };
+    gms::feature driver_service_level { *this, "DRIVER_SERVICE_LEVEL"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/service/client_state.hh
+++ b/service/client_state.hh
@@ -105,6 +105,7 @@ private:
     std::optional<sstring> _driver_name, _driver_version;
 
     auth_state _auth_state = auth_state::UNINITIALIZED;
+    bool _control_connection = false;
 
     // isInternal is used to mark ClientState as used by some internal component
     // that should have an ability to modify system keyspace.
@@ -140,6 +141,14 @@ public:
 
     void set_auth_state(auth_state new_state) noexcept {
         _auth_state = new_state;
+    }
+
+    bool is_control_connection() const noexcept {
+        return _control_connection;
+    }
+
+    bool set_control_connection() noexcept {
+        return _control_connection = true;
     }
 
     std::optional<sstring> get_driver_name() const {

--- a/service/qos/raft_service_level_distributed_data_accessor.cc
+++ b/service/qos/raft_service_level_distributed_data_accessor.cc
@@ -56,31 +56,34 @@ static void validate_state(const service::raft_group0_client& group0_client) {
     }
 }
 
-future<> raft_service_level_distributed_data_accessor::set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const {
-    validate_state(_group0_client);
-    
+future<utils::chunked_vector<mutation>> raft_service_level_distributed_data_accessor::set_service_level_mutations(cql3::query_processor& qp, sstring service_level_name, qos::service_level_options slo, api::timestamp_type timestamp) {
     static sstring insert_query = format("INSERT INTO {}.{} (service_level, timeout, workload_type) VALUES (?, ?, ?);", db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2);
     static sstring update_shares_query = format("UPDATE {}.{} SET shares = ? WHERE service_level = ?", db::system_keyspace::NAME, db::system_keyspace::SERVICE_LEVELS_V2);
     data_value workload = slo.workload == qos::service_level_options::workload_type::unspecified
             ? data_value::make_null(utf8_type)
             : data_value(qos::service_level_options::to_string(slo.workload));
 
-    auto muts = co_await _qp.get_mutations_internal(insert_query, qos_query_state(), mc.write_timestamp(), {service_level_name, timeout_to_data_value(slo.timeout), workload});
+    auto muts = co_await qp.get_mutations_internal(insert_query, qos_query_state(), timestamp, {service_level_name, timeout_to_data_value(slo.timeout), workload});
     auto muts_shares = co_await std::visit(overloaded_functor {
         [&] (const service_level_options::unset_marker& um) -> future<utils::chunked_vector<mutation>> {
             co_return utils::chunked_vector<mutation>();
         },
         [&] (const service_level_options::delete_marker& dm) -> future<utils::chunked_vector<mutation>> {
-            co_return co_await _qp.get_mutations_internal(update_shares_query, qos_query_state(), mc.write_timestamp(), {data_value::make_null(int32_type), data_value(service_level_name)});
+            co_return co_await qp.get_mutations_internal(update_shares_query, qos_query_state(), timestamp, {data_value::make_null(int32_type), data_value(service_level_name)});
         },
         [&] (const int32_t& s) -> future<utils::chunked_vector<mutation>> {
-            co_return co_await _qp.get_mutations_internal(update_shares_query, qos_query_state(), mc.write_timestamp(), {data_value(s), data_value(service_level_name)});
+            co_return co_await qp.get_mutations_internal(update_shares_query, qos_query_state(), timestamp, {data_value(s), data_value(service_level_name)});
         }
     }, slo.shares);
 
     muts.insert(muts.end(), muts_shares.begin(), muts_shares.end());
+    co_return muts;
+}
 
-    mc.add_mutations(std::move(muts), format("service levels internal statement: {}", insert_query));
+future<> raft_service_level_distributed_data_accessor::set_service_level(sstring service_level_name, qos::service_level_options slo, service::group0_batch& mc) const {
+    validate_state(_group0_client);
+    auto muts = co_await raft_service_level_distributed_data_accessor::set_service_level_mutations(_qp, service_level_name, slo, mc.write_timestamp());
+    mc.add_mutations(std::move(muts), format("set_service_level with service_level={}, timeout={}, workload_type={}", service_level_name, timeout_to_data_value(slo.timeout).to_parsable_string(), data_value(qos::service_level_options::to_string(slo.workload))));
 }
 
 future<> raft_service_level_distributed_data_accessor::drop_service_level(sstring service_level_name, service::group0_batch& mc) const {

--- a/service/qos/raft_service_level_distributed_data_accessor.hh
+++ b/service/qos/raft_service_level_distributed_data_accessor.hh
@@ -41,6 +41,7 @@ public:
     virtual bool is_v2() const override;
     virtual bool can_use_effective_service_level_cache() const override;
     virtual ::shared_ptr<service_level_distributed_data_accessor> upgrade_to_v2(cql3::query_processor& qp, service::raft_group0_client& group0_client) const override;
+    static future<utils::chunked_vector<mutation>> set_service_level_mutations(cql3::query_processor& qp, sstring service_level_name, qos::service_level_options slo, api::timestamp_type timestamp);
 };
 
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -958,7 +958,27 @@ future<> service_level_controller::unregister_subscriber(qos_configuration_chang
     return _subscribers.remove(subscriber);
 }
 
-static sstring describe_service_level(std::string_view sl_name, const service_level_options& sl_opts) {
+enum class describe_cmd: uint8_t {
+    CREATE,
+    CREATE_IF_NOT_EXISTS,
+    ALTER,
+    DROP_IF_EXISTS,
+};
+
+std::string_view describe_cmd_to_sstring(describe_cmd cmd_enum) {
+    switch (cmd_enum) {
+        case describe_cmd::CREATE:
+            return "CREATE SERVICE LEVEL";
+        case describe_cmd::CREATE_IF_NOT_EXISTS:
+            return "CREATE SERVICE LEVEL IF NOT EXISTS";
+        case describe_cmd::ALTER:
+            return "ALTER SERVICE LEVEL";
+        case describe_cmd::DROP_IF_EXISTS:
+            return "DROP SERVICE LEVEL IF EXISTS";
+    };
+}
+
+static sstring describe_service_level(std::string_view sl_name, const service_level_options& sl_opts, describe_cmd cmd=describe_cmd::CREATE) {
     using slo = service_level_options;
 
     utils::small_vector<sstring, 3> opts{};
@@ -992,12 +1012,44 @@ static sstring describe_service_level(std::string_view sl_name, const service_le
     }
 
     if (opts.size() == 0) {
-        return seastar::format("CREATE SERVICE LEVEL {};", sl_name_formatted);
+        return seastar::format("{} {};", describe_cmd_to_sstring(cmd), sl_name_formatted);
     }
 
-    return seastar::format("CREATE SERVICE LEVEL {} WITH {};", sl_name_formatted, fmt::join(opts, " AND "));
+    return seastar::format("{} {} WITH {};", describe_cmd_to_sstring(cmd), sl_name_formatted, fmt::join(opts, " AND "));
 }
 
+utils::small_vector<cql3::description, 2> describe_driver_service_level(const std::optional<service_level_options>& driver_service_level_slo) {
+    utils::small_vector<cql3::description, 2> result;
+    const auto service_level_type = "service_level";
+    if (driver_service_level_slo.has_value()) {
+        // We need to use CREATE IF EXISTS because `driver` service level can be already created automatically
+        // We also need to ALTER because if driver exists, it can have different shares number
+        const sstring create_statement = describe_service_level(service_level_controller::driver_service_level_name, driver_service_level_slo.value(), describe_cmd::CREATE_IF_NOT_EXISTS);
+        const sstring alter_statement = describe_service_level(service_level_controller::driver_service_level_name, driver_service_level_slo.value(), describe_cmd::ALTER);
+
+        result.push_back(cql3::description {
+            .keyspace = std::nullopt,
+            .type = service_level_type,
+            .name = service_level_controller::driver_service_level_name,
+            .create_statement = managed_string(create_statement)
+        });
+        result.push_back(cql3::description {
+            .keyspace = std::nullopt,
+            .type = service_level_type,
+            .name = service_level_controller::driver_service_level_name,
+            .create_statement = managed_string(alter_statement)
+        });
+    } else {
+        const sstring drop_statement = describe_service_level(service_level_controller::driver_service_level_name, service_level_options{}, describe_cmd::DROP_IF_EXISTS);
+        result.push_back(cql3::description {
+            .keyspace = std::nullopt,
+            .type = service_level_type,
+            .name = service_level_controller::driver_service_level_name,
+            .create_statement = managed_string(drop_statement)
+        });
+    }
+    return result;
+}
 
 future<std::vector<cql3::description>> service_level_controller::describe_created_service_levels() const {
 
@@ -1013,8 +1065,14 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
     //
     // If Raft is not used yet, updating the cache will happen every 10 seconds. We deem it
     // good enough if someone does attempt to make a backup in that state.
+
+    std::optional<service_level_options> driver_service_level_slo;
     for (const auto& [sl_name, sl] : _service_levels_db) {
         if (sl.is_static) {
+            continue;
+        }
+        if (sl_name == driver_service_level_name) {
+            driver_service_level_slo = sl.slo;
             continue;
         }
 
@@ -1032,8 +1090,13 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
     }
 
     std::ranges::sort(result, std::less<>{}, std::mem_fn(&cql3::description::name));
+    auto driver_sl_description = describe_driver_service_level(driver_service_level_slo);
 
-    co_return result;
+    std::vector<cql3::description> combined;
+    combined.reserve(result.size() + driver_sl_description.size());
+    std::move(driver_sl_description.begin(), driver_sl_description.end(), std::back_inserter(combined));
+    std::move(result.begin(), result.end(), std::back_inserter(combined));
+    co_return combined;
 }
 
 future<std::vector<cql3::description>> service_level_controller::auth_integration::describe_attached_service_levels() {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -104,6 +104,7 @@ using update_both_cache_levels = bool_class<class update_both_cache_levels_tag>;
 class service_level_controller : public peering_sharded_service<service_level_controller>, public service::endpoint_lifecycle_subscriber {
 public:
     static inline const int32_t default_shares = 1000;
+    static constexpr auto driver_service_level_name = "driver";
 
     class service_level_distributed_data_accessor {
     public:

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -15,12 +15,14 @@
 #include <seastar/core/sharded.hh>
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/with_scheduling_group.hh>
+#include <seastar/core/lowres_clock.hh>
 
 #include "seastarx.hh"
 #include "auth/service.hh"
 #include "cql3/description.hh"
 #include <map>
 #include "qos_common.hh"
+#include "mutation/mutation.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "qos_configuration_change_subscriber.hh"
 #include "service/raft/raft_group0_client.hh"
@@ -222,6 +224,7 @@ private:
     unsigned _logged_intervals;
     atomic_vector<qos_configuration_change_subscriber*> _subscribers;
     optimized_optional<abort_source::subscription> _early_abort_subscription;
+    seastar::lowres_clock::time_point _last_unsuccessful_driver_sl_creation_attemp = seastar::lowres_clock::time_point::min();
     void do_abort() noexcept;
 public:
     service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config,
@@ -344,6 +347,18 @@ public:
      * @return a future that is resolved when the update loop stops.
      */
     void maybe_start_legacy_update_from_distributed_data(std::function<steady_clock_type::duration()> interval_f, service::storage_service& storage_service, service::raft_group0_client& group0_client);
+
+    /**
+     * Get mutations required to:
+     * 1. create `sl:driver`
+     * 2. store information that `sl:driver` was created in `system.scylla_local`
+     */
+    static future<utils::chunked_vector<mutation>> get_create_driver_service_level_mutations(db::system_keyspace& sys_ks, api::timestamp_type timestamp);
+    /**
+     * Create `sl:driver` using _sl_data_accessor if possible. If `sl:driver` exists or it's created, store
+       the information it was created in `system.scylla_local`.
+     */
+    future<std::optional<service::group0_guard>> migrate_to_driver_service_level(service::group0_guard guard, db::system_keyspace& sys_ks);
 
     /**
      * Request abort of update loop.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1365,6 +1365,11 @@ future<> storage_service::raft_initialize_discovery_leader(const join_node_reque
 
     insert_join_request_mutations.emplace_back(co_await _sys_ks.local().make_auth_version_mutation(write_timestamp, db::system_keyspace::auth_version_t::v2));
 
+    auto sl_driver_mutations = co_await qos::service_level_controller::get_create_driver_service_level_mutations(_sys_ks.local(), write_timestamp);
+    for (auto& m : sl_driver_mutations) {
+        insert_join_request_mutations.emplace_back(m);
+    }
+
     if (!utils::get_local_injector().is_enabled("skip_vb_v2_version_mut")) {
         insert_join_request_mutations.emplace_back(
                 co_await _sys_ks.local().make_view_builder_version_mutation(write_timestamp, db::system_keyspace::view_builder_version_t::v2));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1192,6 +1192,7 @@ future<> storage_service::raft_state_monitor_fiber(raft::server& raft, gate::hol
                     get_ring_delay(),
                     _lifecycle_notifier,
                     _feature_service,
+                    _sl_controller.local(),
                     _topology_cmd_rpc_tracker);
         }
     } catch (...) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -7530,6 +7530,11 @@ void storage_service::init_messaging_service() {
                 std::move(muts.begin(), muts.end(), std::back_inserter(mutations));
             }
 
+            auto sl_driver_created_mut = co_await ss._sys_ks.local().get_service_level_driver_created_mutation();
+            if (sl_driver_created_mut) {
+                mutations.push_back(canonical_mutation(*sl_driver_created_mut));
+            }
+
             auto sl_version_mut = co_await ss._sys_ks.local().get_service_levels_version_mutation();
             if (sl_version_mut) {
                 mutations.push_back(canonical_mutation(*sl_version_mut));

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -127,6 +127,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     abort_source& _as;
     gms::feature_service& _feature_service;
     endpoint_lifecycle_notifier& _lifecycle_notifier;
+    qos::service_level_controller& _sl_controller;
 
     raft::server& _raft;
     const raft::term_t _term;
@@ -3154,13 +3155,16 @@ public:
             raft_topology_cmd_handler_type raft_topology_cmd_handler,
             tablet_allocator& tablet_allocator,
             std::chrono::milliseconds ring_delay,
-            gms::feature_service& feature_service, endpoint_lifecycle_notifier& lifecycle_notifier,
+            gms::feature_service& feature_service,
+            endpoint_lifecycle_notifier& lifecycle_notifier,
+            qos::service_level_controller& sl_controller,
             topology_coordinator_cmd_rpc_tracker& topology_cmd_rpc_tracker)
         : _sys_dist_ks(sys_dist_ks), _gossiper(gossiper), _messaging(messaging)
         , _shared_tm(shared_tm), _sys_ks(sys_ks), _db(db)
         , _tablet_load_stats_refresh_interval_in_seconds(db.get_config().tablet_load_stats_refresh_interval_in_seconds)
         , _group0(group0), _topo_sm(topo_sm), _vb_sm(vb_sm), _as(as)
         , _feature_service(feature_service), _lifecycle_notifier(lifecycle_notifier)
+        , _sl_controller(sl_controller)
         , _raft(raft_server), _term(raft_server.get_current_term())
         , _raft_topology_cmd_handler(std::move(raft_topology_cmd_handler))
         , _tablet_allocator(tablet_allocator)
@@ -3790,6 +3794,7 @@ future<> run_topology_coordinator(
         std::chrono::milliseconds ring_delay,
         endpoint_lifecycle_notifier& lifecycle_notifier,
         gms::feature_service& feature_service,
+        qos::service_level_controller& sl_controller,
         topology_coordinator_cmd_rpc_tracker& topology_cmd_rpc_tracker) {
 
     topology_coordinator coordinator{
@@ -3799,6 +3804,7 @@ future<> run_topology_coordinator(
             tablet_allocator,
             ring_delay,
             feature_service, lifecycle_notifier,
+            sl_controller,
             topology_cmd_rpc_tracker};
 
     std::exception_ptr ex;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -3187,6 +3187,10 @@ public:
 };
 
 future<std::optional<group0_guard>> topology_coordinator::maybe_migrate_system_tables(group0_guard guard) {
+    // Some of the upgrades are guarded by _feature_service. If the feature gets enabled,
+    // it's in `topology_coordinator::enable_features` ,so  topology_coordinator will re-run its loop
+    // and `maybe_migrate_system_tables` will be called.
+
     // Check if we can upgrade the view_build_status table to v2, being managed by group0.
     // First we upgrade to an intermediate version v1_5 where we write to both tables, then
     // we upgrade to v2.
@@ -3211,6 +3215,13 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_migrate_system_t
         auto tmptr = get_token_metadata_ptr();
         co_await db::view::view_builder::migrate_to_v2(tmptr, _sys_ks, _sys_ks.query_processor(), _group0.client(), _as, std::move(guard));
         co_return std::nullopt;
+    }
+
+    if (_sl_controller.is_v2() && _feature_service.driver_service_level) {
+        const auto sl_driver_created = co_await _sys_ks.get_service_level_driver_created();
+        if (!sl_driver_created.value_or(false)) {
+            co_return co_await _sl_controller.migrate_to_driver_service_level(std::move(guard), _sys_ks);
+        }
     }
 
     co_return std::move(guard);

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -19,6 +19,7 @@
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/topology_state_machine.hh"
 #include "db/view/view_building_state.hh"
+#include "service/qos/service_level_controller.hh"
 
 namespace db {
 class system_keyspace;
@@ -90,6 +91,7 @@ future<> run_topology_coordinator(
         std::chrono::milliseconds ring_delay,
         endpoint_lifecycle_notifier& lifecycle_notifier,
         gms::feature_service& feature_service,
+        qos::service_level_controller& sl_controller,
         topology_coordinator_cmd_rpc_tracker& topology_cmd_rpc_tracker);
 
 }

--- a/test/boost/auth_test.cc
+++ b/test/boost/auth_test.cc
@@ -225,9 +225,10 @@ SEASTAR_TEST_CASE(test_alter_with_timeouts) {
 
         auto sl_is_v2 = e.local_client_state().get_service_level_controller().is_v2();
 	    auto msg = cquery_nofail(e, format("SELECT timeout FROM {}", sl_is_v2 ? "system.service_levels_v2" : "system_distributed.service_levels"));
-        assert_that(msg).is_rows().with_rows({{
-            duration_type->from_string("5ms")
-        }});
+        assert_that(msg).is_rows().with_rows({
+            {duration_type->from_string("5ms")},
+            {{}}, // `sl:driver`
+        });
 
         cquery_nofail(e, "ALTER SERVICE LEVEL sl WITH timeout = 35s");
 
@@ -312,9 +313,10 @@ SEASTAR_TEST_CASE(test_alter_with_workload_type) {
 
         auto sl_is_v2 = e.local_client_state().get_service_level_controller().is_v2();
 	    auto msg = cquery_nofail(e, format("SELECT workload_type FROM {}", sl_is_v2 ? "system.service_levels_v2" : "system_distributed.service_levels"));
-        assert_that(msg).is_rows().with_rows({{
-            {}
-        }});
+        assert_that(msg).is_rows().with_rows({
+            {{}},
+            {"batch"}, // `sl:driver`
+        });
 
         e.refresh_client_state().get();
         // Default workload type is `unspecified`

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5202,14 +5202,16 @@ SEASTAR_TEST_CASE(test_user_based_sla_queries) {
         e.execute_cql("ALTER SERVICE_LEVEL sl_1 WITH SHARES = 111;").get();
         msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
-            {utf8_type->decompose("sl_1"), {}, {}, int32_type->decompose(111), utf8_type->decompose("35.69%")},
-            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("64.31%")},
+            {utf8_type->decompose("driver"), {}, {utf8_type->decompose("batch")}, int32_type->decompose(200), utf8_type->decompose("39.14%")},
+            {utf8_type->decompose("sl_1"), {}, {}, int32_type->decompose(111), utf8_type->decompose("21.72%")},
+            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("39.14%")},
         });
         //drop service levels
         e.execute_cql("DROP SERVICE_LEVEL sl_1;").get();
         msg = e.execute_cql("LIST ALL SERVICE_LEVELS;").get();
         assert_that(msg).is_rows().with_rows({
-            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("100.00%")},
+            {utf8_type->decompose("driver"), {}, {utf8_type->decompose("batch")}, int32_type->decompose(200), utf8_type->decompose("50.00%")},
+            {utf8_type->decompose("sl_2"), {}, {}, int32_type->decompose(200), utf8_type->decompose("50.00%")},
         });
 
         // validate exceptions (illegal requests)

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1302,7 +1302,7 @@ SEASTAR_THREAD_TEST_CASE(per_service_level_reader_concurrency_semaphore_test) {
         sharded<qos::service_level_controller>& sl_controller = e.service_level_controller_service();
         std::array<sstring, num_service_levels> sl_names;
         qos::service_level_options slo;
-        size_t expected_total_weight = 0;
+        size_t expected_total_weight = 200; // 200 from `sl:driver`
         auto index_to_weight = [] (size_t i) -> size_t {
             return (i + 1)*100;
         };
@@ -1328,6 +1328,8 @@ SEASTAR_THREAD_TEST_CASE(per_service_level_reader_concurrency_semaphore_test) {
             BOOST_REQUIRE_EQUAL(expected_total_weight, dbt.get_total_user_reader_concurrency_semaphore_weight());
             sl_names[i] = sl_name;
             size_t total_distributed_memory = 0;
+            // Include `sl:driver` in computations
+            total_distributed_memory += get_reader_concurrency_semaphore_for_sl("driver").available_resources().memory;
             for (unsigned j = 0 ; j <= i ; j++) {
                 reader_concurrency_semaphore& sem = get_reader_concurrency_semaphore_for_sl(sl_names[j]);
                 // Make sure that all semaphores that has been created until now - have the right amount of available memory

--- a/test/boost/generic_server_test.cc
+++ b/test/boost/generic_server_test.cc
@@ -29,6 +29,7 @@ protected:
     [[noreturn]] shared_ptr<connection> make_connection(socket_address, connected_socket&&, socket_address, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override {
         SCYLLA_ASSERT(false);
     }
+    scheduling_group get_scheduling_group_for_new_connection() const override { return current_scheduling_group(); }
 };
 
 SEASTAR_TEST_CASE(stop_without_listening) {

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -13,6 +13,7 @@ from test.pylib.manager_client import ManagerClient
 from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
         delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, wait_for_token_ring_and_group0_consistency
 from test.cluster.conftest import skip_mode
+from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
 from cassandra.protocol import InvalidRequest
@@ -433,9 +434,8 @@ async def test_service_levels_over_limit(manager: ManagerClient):
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
 
-    SL_LIMIT = 7
     sls = []
-    for i in range(SL_LIMIT + 1):
+    for i in range(MAX_USER_SERVICE_LEVELS + 1):
         sl = f"sl_{i}_{unique_name()}"
         sls.append(sl)
         await cql.run_async(f"CREATE SERVICE LEVEL {sl}")

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -11,12 +11,14 @@ from test.pylib.rest_client import get_host_api_address, read_barrier
 from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import trigger_snapshot, wait_until_topology_upgrade_finishes, enter_recovery_state, reconnect_driver, \
-        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, wait_for_token_ring_and_group0_consistency, wait_until_driver_service_level_created, get_topology_coordinator, find_server_by_host_id
+        delete_raft_topology_state, delete_raft_data_and_upgrade_state, wait_until_upgrade_finishes, \
+        wait_for_token_ring_and_group0_consistency, wait_until_driver_service_level_created, get_topology_coordinator, \
+        find_server_by_host_id
 from test.cluster.conftest import skip_mode
 from test.cqlpy.test_service_levels import MAX_USER_SERVICE_LEVELS
 from cassandra import ConsistencyLevel
 from cassandra.query import SimpleStatement
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, QueryMessage
 from cassandra.auth import PlainTextAuthProvider
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
@@ -575,3 +577,75 @@ async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
         service_levels = await cql.run_async("LIST ALL SERVICE LEVELS", host=host)
         service_level_names = [sl.service_level for sl in service_levels]
         assert "driver" not in service_level_names
+
+def get_processed_tasks_for_group(metrics, group):
+    res = metrics.get("scylla_scheduler_tasks_processed", {'group': group})
+    if res is None:
+        return 0
+    return res
+
+@pytest.mark.asyncio
+async def _verify_tasks_processed_metrics(manager, server, used_group, unused_group, func):
+    number_of_requests = 1000
+
+    def get_processed_tasks_for_group(metrics, group):
+        res = metrics.get("scylla_scheduler_tasks_processed", {'group': group})
+        if res is None:
+            return 0
+        return res
+
+    metrics = await manager.metrics.query(server.ip_addr)
+    initial_tasks_processed_by_used_group = get_processed_tasks_for_group(metrics, used_group)
+    initial_tasks_processed_by_unused_group = get_processed_tasks_for_group(metrics, unused_group)
+
+    await asyncio.gather(*[asyncio.to_thread(func) for i in range(number_of_requests)])
+
+    metrics = await manager.metrics.query(server.ip_addr)
+    assert get_processed_tasks_for_group(metrics, used_group) - initial_tasks_processed_by_used_group > number_of_requests
+    assert get_processed_tasks_for_group(metrics, unused_group) - initial_tasks_processed_by_unused_group < number_of_requests
+
+@pytest.mark.asyncio
+async def test_driver_service_level_not_used_for_user_queries(manager: ManagerClient) -> None:
+    server = await manager.server_add(config=auth_config)
+
+    cql = manager.get_cql()
+    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    func = lambda: cql.execute(f"SELECT * from system.peers")
+    await _verify_tasks_processed_metrics(manager, server, 'sl:default', 'sl:driver', func)
+
+    await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
+    await cql.run_async(f"ATTACH SERVICE LEVEL test TO cassandra", host=h)
+
+    func = lambda: cql.execute(f"SELECT * from system.peers")
+    await _verify_tasks_processed_metrics(manager, server, 'sl:test', 'sl:driver', func)
+
+@pytest.mark.asyncio
+async def test_driver_service_level_used_for_driver_queries(manager: ManagerClient) -> None:
+    server = await manager.server_add(config=auth_config)
+
+    cql = manager.get_cql()
+    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+    await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
+    await cql.run_async(f"ATTACH SERVICE LEVEL test TO cassandra", host=h)
+
+    async def get_control_connection_query_function(manager):
+        await manager.driver_connect() # restart control connection
+        cql = manager.get_cql()
+        control_connection = cql.cluster.control_connection._connection
+        query = QueryMessage("select * from system.peers", 1)
+        return cql, lambda: control_connection.wait_for_response(query)
+
+    cql, func = await get_control_connection_query_function(manager)
+    await _verify_tasks_processed_metrics(manager, server, 'sl:driver', 'sl:test', func)
+
+    await cql.run_async(f"DROP SERVICE LEVEL driver", host=h)
+    cql, func = await get_control_connection_query_function(manager)
+    await _verify_tasks_processed_metrics(manager, server, 'sl:test', 'sl:driver', func)
+
+    await cql.run_async(f"CREATE SERVICE LEVEL driver", host=h)
+    cql, func = await get_control_connection_query_function(manager)
+    await _verify_tasks_processed_metrics(manager, server, 'sl:driver', 'sl:test', func)

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -204,6 +204,11 @@ async def wait_until_topology_upgrade_finishes(manager: ManagerClient, ip_addr: 
         return status == "done" or None
     await wait_for(check, deadline=deadline, period=1.0)
 
+async def wait_until_driver_service_level_created(cql: Session, deadline: float):
+    async def check():
+        service_levels = await cql.run_async("LIST ALL SERVICE_LEVELS")
+        return ("driver" in [sl.service_level for sl in service_levels]) or None
+    await wait_for(check, deadline=deadline, period=1.0)
 
 async def delete_raft_topology_state(cql: Session, host: Host):
     await cql.run_async("truncate table system.topology", host=host)

--- a/test/cqlpy/test_describe.py
+++ b/test/cqlpy/test_describe.py
@@ -46,8 +46,12 @@ def filter_grant_roles(desc_result_iter: Iterable[DescRowType]) -> Iterable[Desc
 def filter_grant_permissions(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
     return filter(lambda result: result.type == "grant_permission", desc_result_iter)
 
-def filter_service_levels(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
-    return filter(lambda result: result.type == "service_level", desc_result_iter)
+def filter_service_levels(desc_result_iter: Iterable[DescRowType], filter_driver: bool = True) -> Iterable[DescRowType]:
+    # Filter out driver service level, which is created by the system automatically
+    f = lambda result: result.type == "service_level"
+    if filter_driver:
+        f = (lambda result: result.type == "service_level" and result.name != "driver")
+    return filter(f, desc_result_iter)
 
 def filter_attached_service_levels(desc_result_iter: Iterable[DescRowType]) -> Iterable[DescRowType]:
     return filter(lambda result: result.type == "service_level_attachment", desc_result_iter)
@@ -1624,6 +1628,7 @@ class AuthSLContext:
     def __enter__(self):
         if self.ks:
             self.cql.execute(f"CREATE KEYSPACE {self.ks} WITH REPLICATION = {{ 'class': 'SimpleStrategy', 'replication_factor': 1 }}")
+        self.driver_sl = self.cql.execute("LIST SERVICE LEVEL driver").one()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -1641,6 +1646,9 @@ class AuthSLContext:
             service_levels = [record.service_level for record in service_levels_iter]
             for sl in service_levels:
                 self.cql.execute(f"DROP SERVICE LEVEL {make_identifier(sl, quotation_mark='"')}")
+            # Restore driver service level if it was removed by the test
+            self.cql.execute(f"CREATE SERVICE LEVEL {self.driver_sl.service_level} WITH WORKLOAD_TYPE = '{self.driver_sl.workload_type}' AND SHARES = {self.driver_sl.shares}")
+
 
 class ServiceLevel:
     default_shares_value = 1000

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -18,6 +18,11 @@ from cassandra.util import Duration
 import pytest
 import time
 
+# MAX_USER_SERVICE_LEVELS represents the maximal number of service levels that users can create.
+# The value is documentented in `docs/features/workload-prioritization.rst`.
+# It's used for regression testing of user service level limit in this and other files.
+MAX_USER_SERVICE_LEVELS = 7
+
 @contextmanager
 def new_service_level(cql, timeout=None, workload_type=None, shares=None, role=None):
     params = ""
@@ -161,7 +166,7 @@ def test_scheduling_groups_limit(scylla_only, cql):
                 created_count = created_count + 1
 
     assert created_count > 0
-    assert created_count == 7 # regression check
+    assert created_count == MAX_USER_SERVICE_LEVELS # regression check
 
 def test_default_shares_in_listings(scylla_only, cql):
     with scylla_inject_error(cql, "create_service_levels_without_default_shares", one_shot=False), \

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -147,7 +147,7 @@ def test_list_effective_service_level_without_attached(scylla_only, cql):
         with pytest.raises(InvalidRequest, match=f"Role {role} doesn't have assigned any service level"):
             cql.execute(f"LIST EFFECTIVE SERVICE LEVEL OF {role}")
 
-# Scylla Enterprise limits the number of service levels to a small number (8 including 1 default service level).
+# ScyllaDB limits the number of service levels to a small number (9 including 1 default and 1 driver service level).
 # This test verifies that attempting to create more service levels than that results in an InvalidRequest error
 # and doesn't silently succeed. 
 # The test also has a regression check if a user can create exactly 7 service levels.

--- a/test/perf/perf_generic_server.cc
+++ b/test/perf/perf_generic_server.cc
@@ -70,6 +70,7 @@ public:
         return make_shared<test_connection>(*this, std::move(fd), sem, std::move(initial_sem_units), _conf);
     }
 
+    scheduling_group get_scheduling_group_for_new_connection() const override { return current_scheduling_group(); }
 
     test_server(const test_config& conf)
     : generic_server::server("test_server", plog,

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -532,6 +532,8 @@ class ScyllaRESTAPIClient:
         params = {"cf": table, "key": key}
         return await self.client.get_json(f'/storage_service/natural_endpoints/{keyspace}', host=node_ip, params=params)
 
+    async def reload_raft_topology_state(self, node_ip: str):
+        await self.client.post("/storage_service/raft_topology/reload", node_ip)
 
 class ScyllaMetricsLine:
     def __init__(self, name: str, labels: dict, value: float):

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -12,6 +12,7 @@
 #include "cql3/statements/modification_statement.hh"
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/semaphore.hh>
+#include "seastar/coroutine/switch_to.hh"
 #include "types/collection.hh"
 #include "types/list.hh"
 #include "types/set.hh"
@@ -993,11 +994,19 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
 }
 
 void cql_server::connection::update_scheduling_group() {
+    if (_client_state.is_control_connection()) {
+        switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
+            auto shg = _server._sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
+            _current_scheduling_group = shg;
+            co_return co_await _server._sl_controller.with_service_level(qos::service_level_controller::driver_service_level_name, std::move(process_loop));
+        });
+    } else {
         switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
             auto shg = co_await _server._sl_controller.get_user_scheduling_group(_client_state.user());
             _current_scheduling_group = shg;
             co_return co_await _server._sl_controller.with_user_service_level(_client_state.user(), std::move(process_loop));
         });
+    }
 }
 
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_auth_response(uint16_t stream, request_reader in, service::client_state& client_state,
@@ -1436,6 +1445,13 @@ future<std::unique_ptr<cql_server::response>>
 cql_server::connection::process_register(uint16_t stream, request_reader in, service::client_state& client_state,
         tracing::trace_state_ptr trace_state) {
     using ret_type = std::unique_ptr<cql_server::response>;
+
+    if (!_client_state.is_control_connection()) {
+        if (_server._sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
+            _client_state.set_control_connection();
+            update_scheduling_group();
+        }
+    }
 
     std::vector<sstring> event_types;
     auto sl = in.read_string_list(event_types);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -993,11 +993,11 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
 }
 
 void cql_server::connection::update_scheduling_group() {
-    switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
-        auto shg = co_await _server._sl_controller.get_user_scheduling_group(_client_state.user());
-        _current_scheduling_group = shg;
-        co_return co_await _server._sl_controller.with_user_service_level(_client_state.user(), std::move(process_loop));
-    });
+        switch_tenant([this] (noncopyable_function<future<> ()> process_loop) -> future<> {
+            auto shg = co_await _server._sl_controller.get_user_scheduling_group(_client_state.user());
+            _current_scheduling_group = shg;
+            co_return co_await _server._sl_controller.with_user_service_level(_client_state.user(), std::move(process_loop));
+        });
 }
 
 future<std::unique_ptr<cql_server::response>> cql_server::connection::process_auth_response(uint16_t stream, request_reader in, service::client_state& client_state,

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -983,6 +983,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
             res = make_autheticate(stream, a.qualified_java_name(), trace_state);
         }
     } else {
+        update_scheduling_group();
         _ready = true;
         on_connection_ready();
         res = make_ready(stream, trace_state);

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -638,7 +638,7 @@ cql_server::connection::connection(cql_server& server, socket_address server_add
     , _server(server)
     , _server_addr(server_addr)
     , _client_state(service::client_state::external_tag{}, server._auth_service, &server._sl_controller, server.timeout_config(), addr)
-    , _current_scheduling_group(default_scheduling_group())
+    , _current_scheduling_group(server.get_scheduling_group_for_new_connection())
 {
     _shedding_timer.set_callback([this] {
         clogger.debug("Shedding all incoming requests due to overload");

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -367,6 +367,12 @@ private:
 
 private:
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;
+    scheduling_group get_scheduling_group_for_new_connection() const override {
+        if (_sl_controller.has_service_level(qos::service_level_controller::driver_service_level_name)) {
+            return _sl_controller.get_scheduling_group(qos::service_level_controller::driver_service_level_name);
+        }
+        return default_scheduling_group();
+    }
 
     ::timeout_config timeout_config() const { return _config.timeout_config.current_values(); }
 };


### PR DESCRIPTION
This patch series:
 - Increases the number of allowed scheduling groups to allow creation of `sl:driver`
 - Implements `create_driver_service_level` that creates `sl:driver` with shares=200 if it wasn't already created
 - Implements creation of `sl:driver` for new systems and tests in `raft_initialize_discovery_leader`
 - Modifies `topology_coordinator` to use  create `sl:driver` after upgrades.
 - Implements using `sl:driver` for new connections in `transport/server`
 - Adds to `transport/server` recognition of driver's control connections and forcing them to keep using `sl:driver`.
 - Adds tests to verify the new functionality
 - Modifies existing tests to let them pass after `sl:driver` is added
 - Modifies the documentation to contain new `sl:driver`


The changes were evaluated by a test with the following scenario ([test_connections-sl-driver.py](https://github.com/user-attachments/files/22021273/test_connections-sl-driver.py)):
 - Start ScyllaDB with one node
 - Create 1000 keyspaces, 1 table in each keyspace
 - Start `cassandra-stress` (`-rate threads=50  -mode native cql3`)
 - Run connection storm with 1000 session (100 python processes, 10 sessions each)

The maximum latency during connection storm dropped **from 224.94ms to 41.43ms** (those numbers are average from 20 test executions, were max latency was in [140ms, 361ms] before change and [31.4ms, 61.5ms] after).

The snippet of cassandra-stress output from the moment of connection storm:
Before:
```
type       total ops,    op/s,    pk/s,   row/s,    mean,     med,     .95,     .99,    .999,     max,   time,   stderr, errors,  gc: #,  max ms,  sum ms,  sdv ms,      mb
...
total,        789206,   85887,   85887,   85887,     0.6,     0.3,     2.0,     2.0,     2.5,     5.0,    9.0,  0.09679,      0,      0,       0,       0,       0,       0
total,        909322,  120116,  120116,  120116,     0.4,     0.2,     1.9,     2.0,     2.1,     3.1,   10.0,  0.09053,      0,      0,       0,       0,       0,       0
total,        964392,   55070,   55070,   55070,     0.9,     0.4,     2.0,     4.5,     7.7,    18.9,   11.0,  0.09203,      0,      0,       0,       0,       0,       0
total,        975705,   11313,   11313,   11313,     4.4,     3.5,     6.5,    24.5,    82.7,    83.0,   12.0,  0.11713,      0,      0,       0,       0,       0,       0
total,        987548,   11843,   11843,   11843,     4.2,     3.5,     6.5,    33.7,    48.6,    51.5,   13.0,  0.13366,      0,      0,       0,       0,       0,       0
total,        995422,    7874,    7874,    7874,     6.3,     4.0,     7.7,    85.6,   112.9,   113.5,   14.0,  0.14753,      0,      0,       0,       0,       0,       0
total,       1007228,   11806,   11806,   11806,     4.3,     3.5,     6.5,    29.1,    43.8,    87.1,   15.0,  0.15598,      0,      0,       0,       0,       0,       0
total,       1012840,    5612,    5612,    5612,     8.2,     5.0,    11.5,   121.8,   166.6,   170.1,   16.0,  0.16535,      0,      0,       0,       0,       0,       0
total,       1016186,    3346,    3346,    3346,    13.4,     7.4,    20.1,   204.9,   207.6,   210.4,   17.0,  0.17405,      0,      0,       0,       0,       0,       0
total,       1025462,    9276,    9276,    9276,     6.3,     3.9,     9.6,    74.6,   206.8,   210.0,   18.0,  0.17800,      0,      0,       0,       0,       0,       0
total,       1035979,   10517,   10517,   10517,     4.8,     3.5,     6.7,    38.5,    82.6,    83.0,   19.0,  0.18120,      0,      0,       0,       0,       0,       0
total,       1047488,   11509,   11509,   11509,     4.3,     3.5,     6.0,    32.6,    72.3,    74.0,   20.0,  0.18334,      0,      0,       0,       0,       0,       0
total,       1077456,   29968,   29968,   29968,     1.7,     1.6,     2.9,     3.6,     7.0,     8.2,   21.0,  0.17943,      0,      0,       0,       0,       0,       0
total,       1105490,   28034,   28034,   28034,     1.8,     1.8,     3.5,     4.6,     5.3,    13.8,   22.0,  0.17609,      0,      0,       0,       0,       0,       0
total,       1132221,   26731,   26731,   26731,     1.9,     1.8,     3.8,     5.2,     8.4,    11.1,   23.0,  0.17314,      0,      0,       0,       0,       0,       0
total,       1162149,   29928,   29928,   29928,     1.7,     1.7,     3.0,     4.5,     8.0,     9.1,   24.0,  0.16950,      0,      0,       0,       0,       0,       0
...
```

After:
```
type       total ops,    op/s,    pk/s,   row/s,    mean,     med,     .95,     .99,    .999,     max,   time,   stderr, errors,  gc: #,  max ms,  sum ms,  sdv ms,      mb
...
total,        822863,   94379,   94379,   94379,     0.5,     0.3,     2.0,     2.0,     2.1,     3.7,    9.0,  0.06669,      0,      0,       0,       0,       0,       0
total,        937337,  114474,  114474,  114474,     0.4,     0.2,     2.0,     2.0,     2.1,     3.4,   10.0,  0.06301,      0,      0,       0,       0,       0,       0
total,        986630,   49293,   49293,   49293,     1.0,     1.0,     2.0,     2.1,    17.9,    19.0,   11.0,  0.07318,      0,      0,       0,       0,       0,       0
total,       1026734,   40104,   40104,   40104,     1.2,     1.0,     2.0,     2.2,     6.3,     7.1,   12.0,  0.08410,      0,      0,       0,       0,       0,       0
total,       1066124,   39390,   39390,   39390,     1.3,     1.0,     2.0,     2.2,     2.6,     3.4,   13.0,  0.09108,      0,      0,       0,       0,       0,       0
total,       1103082,   36958,   36958,   36958,     1.3,     1.1,     2.1,     2.5,     3.1,     4.2,   14.0,  0.09643,      0,      0,       0,       0,       0,       0
total,       1141987,   38905,   38905,   38905,     1.3,     1.0,     2.0,     2.4,    11.4,    12.7,   15.0,  0.09894,      0,      0,       0,       0,       0,       0
total,       1180023,   38036,   38036,   38036,     1.3,     1.0,     2.0,     3.7,     5.6,     7.1,   16.0,  0.10070,      0,      0,       0,       0,       0,       0
total,       1216481,   36458,   36458,   36458,     1.4,     1.0,     2.1,     3.6,     4.7,     5.0,   17.0,  0.10210,      0,      0,       0,       0,       0,       0
total,       1256819,   40338,   40338,   40338,     1.2,     1.0,     2.0,     2.2,     3.5,     5.4,   18.0,  0.10173,      0,      0,       0,       0,       0,       0
total,       1295122,   38303,   38303,   38303,     1.3,     1.0,     2.0,     2.4,    21.0,    21.1,   19.0,  0.10136,      0,      0,       0,       0,       0,       0
total,       1334743,   39621,   39621,   39621,     1.3,     1.0,     2.0,     2.3,     3.3,     4.0,   20.0,  0.10055,      0,      0,       0,       0,       0,       0
total,       1375579,   40836,   40836,   40836,     1.2,     1.0,     2.0,     2.1,     3.4,     5.7,   21.0,  0.09927,      0,      0,       0,       0,       0,       0
total,       1415576,   39997,   39997,   39997,     1.2,     1.0,     2.0,     2.3,     3.2,     4.1,   22.0,  0.09807,      0,      0,       0,       0,       0,       0
total,       1449268,   33692,   33692,   33692,     1.5,     1.4,     2.5,     3.2,     4.2,     5.6,   23.0,  0.09800,      0,      0,       0,       0,       0,       0
total,       1471873,   22605,   22605,   22605,     2.2,     2.0,     4.8,     5.9,     7.0,     7.9,   24.0,  0.10015,      0,      0,       0,       0,       0,       0
...
```

Fixes: https://github.com/scylladb/scylladb/issues/24411

This is a new feature, so no backport needed.