### PR TITLE
doc: add support for RHEL 10

### DIFF
--- a/docs/_static/data/os-support.json
+++ b/docs/_static/data/os-support.json
@@ -2,7 +2,7 @@
     "Linux Distributions": {
       "Ubuntu": ["22.04", "24.04"],
       "Debian": ["11"],
-      "Rocky / CentOS / RHEL": ["8", "9"],
+      "Rocky / CentOS / RHEL": ["8", "9", "10"],
       "Amazon Linux": ["2023"]
     },
     "ScyllaDB Versions": [
@@ -11,7 +11,7 @@
         "supported_OS": {
           "Ubuntu": ["22.04", "24.04"],
           "Debian": ["11"],
-          "Rocky / CentOS / RHEL": ["8", "9"],
+          "Rocky / CentOS / RHEL": ["8", "9", "10"],
           "Amazon Linux": ["2023"]
         }
       },


### PR DESCRIPTION
This PR adds RHEL 10 to the list of supported platforms.

Fixes https://github.com/scylladb/scylladb/issues/25436

This PR must be backported to branch-2025.3, as the support is added in that version.