### PR TITLE
Allow setting alternator_enforce_authorization to "warn"

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -206,7 +206,7 @@ executor::executor(gms::gossiper& gossiper,
       _mm(mm),
       _sdks(sdks),
       _cdc_metadata(cdc_metadata),
-      _enforce_authorization(_proxy.data_dictionary().get_config().alternator_enforce_authorization()),
+      _enforce_authorization(_proxy.data_dictionary().get_config().alternator_enforce_authorization),
       _ssg(ssg)
 {
     s_default_timeout_in_ms = std::move(default_timeout_in_ms);
@@ -838,11 +838,12 @@ future<executor::request_return_type> executor::describe_table(client_state& cli
 // SELECT, DROP, etc.) on the given table. When permission is denied an
 // appropriate user-readable api_error::access_denied is thrown.
 future<> verify_permission(
-    bool enforce_authorization,
+    db::tri_mode_restriction enforce_authorization,
     const service::client_state& client_state,
     const schema_ptr& schema,
-    auth::permission permission_to_check) {
-    if (!enforce_authorization) {
+    auth::permission permission_to_check,
+    alternator::stats& stats) {
+    if (enforce_authorization == db::tri_mode_restriction_t::mode::FALSE) {
         co_return;
     }
     // Unfortunately, the fix for issue #23218 did not modify the function
@@ -857,16 +858,25 @@ future<> verify_permission(
                 if (client_state.user() && client_state.user()->name) {
                     username = client_state.user()->name.value();
                 }
+                stats.authorization_failures++;
+                if (enforce_authorization == db::tri_mode_restriction_t::mode::WARN) {
+                    co_return;
+                }
                 throw api_error::access_denied(fmt::format(
                     "Write access denied on internal table {}.{} to role {} because it is not a superuser",
                     schema->ks_name(), schema->cf_name(), username));
         }
     }
     auto resource = auth::make_data_resource(schema->ks_name(), schema->cf_name());
-    if (!co_await client_state.check_has_permission(auth::command_desc(permission_to_check, resource))) {
+    if (!client_state.user() || !client_state.user()->name ||
+        !co_await client_state.check_has_permission(auth::command_desc(permission_to_check, resource))) {
         sstring username = "<anonymous>";
         if (client_state.user() && client_state.user()->name) {
             username = client_state.user()->name.value();
+        }
+        stats.authorization_failures++;
+        if (enforce_authorization == db::tri_mode_restriction_t::mode::WARN) {
+            co_return;
         }
         // Using exceptions for errors makes this function faster in the
         // success path (when the operation is allowed).
@@ -880,8 +890,8 @@ future<> verify_permission(
 // Similar to verify_permission() above, but just for CREATE operations.
 // Those do not operate on any specific table, so require permissions on
 // ALL KEYSPACES instead of any specific table.
-future<> verify_create_permission(bool enforce_authorization, const service::client_state& client_state) {
-    if (!enforce_authorization) {
+static future<> verify_create_permission(db::tri_mode_restriction_t::mode enforce_authorization, const service::client_state& client_state, alternator::stats& stats) {
+    if (enforce_authorization == db::tri_mode_restriction_t::mode::FALSE) {
         co_return;
     }
     auto resource = auth::resource(auth::resource_kind::data);
@@ -889,6 +899,10 @@ future<> verify_create_permission(bool enforce_authorization, const service::cli
         sstring username = "<anonymous>";
         if (client_state.user() && client_state.user()->name) {
             username = client_state.user()->name.value();
+        }
+        stats.authorization_failures++;
+        if (enforce_authorization == db::tri_mode_restriction_t::mode::WARN) {
+            co_return;
         }
         throw api_error::access_denied(format(
             "CREATE access on ALL KEYSPACES is denied to role {}", username));
@@ -907,7 +921,7 @@ future<executor::request_return_type> executor::delete_table(client_state& clien
 
     schema_ptr schema = get_table(_proxy, request);
     rjson::value table_description = co_await fill_table_description(schema, table_status::deleting, _proxy, client_state, trace_state, permit);
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::DROP);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::DROP, _stats);
     co_await _mm.container().invoke_on(0, [&, cs = client_state.move_to_other_shard()] (service::migration_manager& mm) -> future<> {
         size_t retries = mm.get_concurrent_ddl_retries();
         for (;;) {
@@ -1245,7 +1259,7 @@ future<executor::request_return_type> executor::tag_resource(client_state& clien
     if (tags->Size() < 1) {
         co_return api_error::validation("The number of tags must be at least 1") ;
     }
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER, _stats);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
         update_tags_map(*tags, tags_map, update_tags_action::add_tags);
     });
@@ -1266,7 +1280,7 @@ future<executor::request_return_type> executor::untag_resource(client_state& cli
 
     schema_ptr schema = get_table_from_arn(_proxy, rjson::to_string_view(*arn));
     get_stats_from_schema(_proxy, *schema)->api_operations.untag_resource++;
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER, _stats);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [tags](std::map<sstring, sstring>& tags_map) {
         update_tags_map(*tags, tags_map, update_tags_action::delete_tags);
     });
@@ -1452,7 +1466,7 @@ bytes extract_from_attrs_column_computation::compute_value(const schema&, const 
 }
 
 
-static future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, service::storage_proxy& sp, service::migration_manager& mm, gms::gossiper& gossiper, bool enforce_authorization) {
+static future<executor::request_return_type> create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, service::storage_proxy& sp, service::migration_manager& mm, gms::gossiper& gossiper, db::tri_mode_restriction enforce_authorization, stats& stats) {
     SCYLLA_ASSERT(this_shard_id() == 0);
 
     // We begin by parsing and validating the content of the CreateTable
@@ -1663,7 +1677,7 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
     set_table_creation_time(tags_map, db_clock::now());
     builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>(tags_map));
 
-    co_await verify_create_permission(enforce_authorization, client_state);
+    co_await verify_create_permission(enforce_authorization, client_state, stats);
 
     schema_ptr schema = builder.build();
     for (auto& view_builder : view_builders) {
@@ -1760,9 +1774,9 @@ future<executor::request_return_type> executor::create_table(client_state& clien
     _stats.api_operations.create_table++;
     elogger.trace("Creating table {}", request);
 
-    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = bool(_enforce_authorization)]
+    co_return co_await _mm.container().invoke_on(0, [&, tr = tracing::global_trace_state_ptr(trace_state), request = std::move(request), &sp = _proxy.container(), &g = _gossiper.container(), client_state_other_shard = client_state.move_to_other_shard(), enforce_authorization = db::tri_mode_restriction(_enforce_authorization)]
                                         (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
-        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local(), enforce_authorization);
+        co_return co_await create_table_on_shard0(client_state_other_shard.get(), tr, std::move(request), sp.local(), mm, g.local(), enforce_authorization, _stats);
     });
 }
 
@@ -1815,7 +1829,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
         verify_billing_mode(request);
     }
 
-    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = bool(_enforce_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request]
+    co_return co_await _mm.container().invoke_on(0, [&p = _proxy.container(), request = std::move(request), gt = tracing::global_trace_state_ptr(std::move(trace_state)), enforce_authorization = db::tri_mode_restriction(_enforce_authorization), client_state_other_shard = client_state.move_to_other_shard(), empty_request, &e = this->container()]
                                                 (service::migration_manager& mm) mutable -> future<executor::request_return_type> {
         schema_ptr schema;
         size_t retries = mm.get_concurrent_ddl_retries();
@@ -1986,7 +2000,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 co_return api_error::validation("UpdateTable requires one of GlobalSecondaryIndexUpdates, StreamSpecification or BillingMode to be specified");
             }
 
-            co_await verify_permission(enforce_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER);
+            co_await verify_permission(enforce_authorization, client_state_other_shard.get(), schema, auth::permission::ALTER, e.local()._stats);
             auto m = co_await service::prepare_column_family_update_announcement(p.local(), schema, std::vector<view_ptr>(), group0_guard.write_timestamp());
             for (view_ptr view : new_views) {
                 auto m2 = co_await service::prepare_new_view_announcement(p.local(), view, group0_guard.write_timestamp());
@@ -2710,7 +2724,7 @@ future<executor::request_return_type> executor::put_item(client_state& client_st
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY, _stats);
 
     auto cas_shard = op->shard_for_execute(needs_read_before_write);
 
@@ -2813,7 +2827,7 @@ future<executor::request_return_type> executor::delete_item(client_state& client
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY, _stats);
 
     auto cas_shard = op->shard_for_execute(needs_read_before_write);
 
@@ -3091,7 +3105,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
         }
     }
     for (const auto& b : mutation_builders) {
-        co_await verify_permission(_enforce_authorization, client_state, b.first, auth::permission::MODIFY);
+        co_await verify_permission(_enforce_authorization, client_state, b.first, auth::permission::MODIFY, _stats);
     }
     wcu_put_units = 0;
     wcu_delete_units = 0;
@@ -4245,7 +4259,7 @@ future<executor::request_return_type> executor::update_item(client_state& client
     tracing::add_table_name(trace_state, op->schema()->ks_name(), op->schema()->cf_name());
     const bool needs_read_before_write = op->needs_read_before_write();
 
-    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY);
+    co_await verify_permission(_enforce_authorization, client_state, op->schema(), auth::permission::MODIFY, _stats);
 
     auto cas_shard = op->shard_for_execute(needs_read_before_write);
 
@@ -4355,7 +4369,7 @@ future<executor::request_return_type> executor::get_item(client_state& client_st
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "GetItem");
     rcu_consumed_capacity_counter add_capacity(request, cl == db::consistency_level::LOCAL_QUORUM);
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT, _stats);
     service::storage_proxy::coordinator_query_result qr =
         co_await _proxy.query(
             schema, std::move(command), std::move(partition_ranges), cl,
@@ -4484,7 +4498,7 @@ future<executor::request_return_type> executor::batch_get_item(client_state& cli
     }
 
     for (const table_requests& tr : requests) {
-        co_await verify_permission(_enforce_authorization, client_state, tr.schema, auth::permission::SELECT);
+        co_await verify_permission(_enforce_authorization, client_state, tr.schema, auth::permission::SELECT, _stats);
     }
 
     _stats.api_operations.batch_get_item_batch_total += batch_size;
@@ -4949,10 +4963,10 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         filter filter,
         query::partition_slice::option_set custom_opts,
         service::client_state& client_state,
-        cql3::cql_stats& cql_stats,
+        alternator::stats& stats,
         tracing::trace_state_ptr trace_state,
         service_permit permit,
-        bool enforce_authorization) {
+        db::tri_mode_restriction enforce_authorization) {
     lw_shared_ptr<service::pager::paging_state> old_paging_state = nullptr;
 
     tracing::trace(trace_state, "Performing a database query");
@@ -4979,7 +4993,7 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         old_paging_state = make_lw_shared<service::pager::paging_state>(pk, pos, query::max_partitions, query_id::create_null_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0);
     }
 
-    co_await verify_permission(enforce_authorization, client_state, table_schema, auth::permission::SELECT);
+    co_await verify_permission(enforce_authorization, client_state, table_schema, auth::permission::SELECT, stats);
 
     auto regular_columns =
             table_schema->regular_columns() | std::views::transform(&column_definition::id)
@@ -5015,9 +5029,9 @@ static future<executor::request_return_type> do_query(service::storage_proxy& pr
         rjson::add(items_descr, "LastEvaluatedKey", encode_paging_state(*table_schema, *paging_state));
     }
     if (has_filter){
-        cql_stats.filtered_rows_read_total += p->stats().rows_read_total;
+        stats.cql_stats.filtered_rows_read_total += p->stats().rows_read_total;
         // update our "filtered_row_matched_total" for all the rows matched, despited the filter
-        cql_stats.filtered_rows_matched_total += size;
+        stats.cql_stats.filtered_rows_matched_total += size;
     }
     if (opt_items) {
         if (opt_items->size() >= max_items_for_rapidjson_array) {
@@ -5141,7 +5155,7 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
     verify_all_are_used(expression_attribute_values, used_attribute_values, "ExpressionAttributeValues", "Scan");
 
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
-            std::move(filter), query::partition_slice::option_set(), client_state, _stats.cql_stats, trace_state, std::move(permit), _enforce_authorization);
+            std::move(filter), query::partition_slice::option_set(), client_state, _stats, trace_state, std::move(permit), _enforce_authorization);
 }
 
 static dht::partition_range calculate_pk_bound(schema_ptr schema, const column_definition& pk_cdef, const rjson::value& comp_definition, const rjson::value& attrs) {
@@ -5621,7 +5635,7 @@ future<executor::request_return_type> executor::query(client_state& client_state
     query::partition_slice::option_set opts;
     opts.set_if<query::partition_slice::option::reversed>(!forward);
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
-            std::move(filter), opts, client_state, _stats.cql_stats, std::move(trace_state), std::move(permit), _enforce_authorization);
+            std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit), _enforce_authorization);
 }
 
 future<executor::request_return_type> executor::list_tables(client_state& client_state, service_permit permit, rjson::value request) {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -24,6 +24,7 @@
 #include "utils/updateable_value.hh"
 
 #include "tracing/trace_state.hh"
+#include "db/config.hh"
 
 namespace db {
     class system_distributed_keyspace;
@@ -139,7 +140,7 @@ class executor : public peering_sharded_service<executor> {
     service::migration_manager& _mm;
     db::system_distributed_keyspace& _sdks;
     cdc::metadata& _cdc_metadata;
-    utils::updateable_value<bool> _enforce_authorization;
+    utils::updateable_value<db::tri_mode_restriction> _enforce_authorization;
     // An smp_service_group to be used for limiting the concurrency when
     // forwarding Alternator request between shards - if necessary for LWT.
     smp_service_group _ssg;
@@ -263,7 +264,7 @@ bool is_big(const rjson::value& val, int big_size = 100'000);
 // Check CQL's Role-Based Access Control (RBAC) permission (MODIFY,
 // SELECT, DROP, etc.) on the given table. When permission is denied an
 // appropriate user-readable api_error::access_denied is thrown.
-future<> verify_permission(bool enforce_authorization, const service::client_state&, const schema_ptr&, auth::permission);
+future<> verify_permission(db::tri_mode_restriction enforce_authorization, const service::client_state&, const schema_ptr&, auth::permission, alternator::stats& stats);
 
 /**
  * Make return type for serializing the object "streamed",

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -7,6 +7,7 @@
  */
 
 #include "alternator/server.hh"
+#include "db/config.hh"
 #include "gms/application_state.hh"
 #include "utils/log.hh"
 #include <fmt/ranges.h>
@@ -267,22 +268,34 @@ protected:
 };
 
 future<std::string> server::verify_signature(const request& req, const chunked_content& content) {
-    if (!_enforce_authorization) {
+    if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::FALSE) {
         slogger.debug("Skipping authorization");
-        return make_ready_future<std::string>();
+        co_return std::string();
     }
     auto host_it = req._headers.find("Host");
     if (host_it == req._headers.end()) {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
+        }
         throw api_error::invalid_signature("Host header is mandatory for signature verification");
     }
     auto authorization_it = req._headers.find("Authorization");
     if (authorization_it == req._headers.end()) {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
+        }
         throw api_error::missing_authentication_token("Authorization header is mandatory for signature verification");
     }
     std::string host = host_it->second;
     std::string_view authorization_header = authorization_it->second;
     auto pos = authorization_header.find_first_of(' ');
     if (pos == std::string_view::npos || authorization_header.substr(0, pos) != "AWS4-HMAC-SHA256") {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
+        }
         throw api_error::invalid_signature(fmt::format("Authorization header must use AWS4-HMAC-SHA256 algorithm: {}", authorization_header));
     }
     authorization_header.remove_prefix(pos+1);
@@ -318,6 +331,10 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
 
     std::vector<std::string_view> credential_split = split(credential, '/');
     if (credential_split.size() != 5) {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
+        }
         throw api_error::validation(fmt::format("Incorrect credential information format: {}", credential));
     }
     std::string user(credential_split[0]);
@@ -342,29 +359,37 @@ future<std::string> server::verify_signature(const request& req, const chunked_c
     auto cache_getter = [&proxy = _proxy, &as = _auth_service] (std::string username) {
         return get_key_from_roles(proxy, as, std::move(username));
     };
-    return _key_cache.get_ptr(user, cache_getter).then([this, &req, &content,
-                                                    user = std::move(user),
-                                                    host = std::move(host),
-                                                    datestamp = std::move(datestamp),
-                                                    signed_headers_str = std::move(signed_headers_str),
-                                                    signed_headers_map = std::move(signed_headers_map),
-                                                    region = std::move(region),
-                                                    service = std::move(service),
-                                                    user_signature = std::move(user_signature)] (key_cache::value_ptr key_ptr) {
-        std::string signature;
-        try {
-            signature = utils::aws::get_signature(user, *key_ptr, std::string_view(host), "/", req._method,
-                datestamp, signed_headers_str, signed_headers_map, &content, region, service, "");
-        } catch (const std::exception& e) {
-            throw api_error::invalid_signature(e.what());
+    key_cache::value_ptr key_ptr(nullptr);
+    try {
+        key_ptr = co_await _key_cache.get_ptr(user, cache_getter);
+    } catch (const api_error& e) {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
         }
+        throw;
+    }
+    std::string signature;
+    try {
+        signature = utils::aws::get_signature(user, *key_ptr, std::string_view(host), "/", req._method,
+            datestamp, signed_headers_str, signed_headers_map, &content, region, service, "");
+    } catch (const std::exception& e) {
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
+        }
+        throw api_error::invalid_signature(e.what());
+    }
 
-        if (signature != std::string_view(user_signature)) {
-            _key_cache.remove(user);
-            throw api_error::unrecognized_client("The security token included in the request is invalid.");
+    if (signature != std::string_view(user_signature)) {
+        _key_cache.remove(user);
+        _executor._stats.authentication_failures++;
+        if (_enforce_authorization.get() == db::tri_mode_restriction_t::mode::WARN) {
+            co_return std::string();
         }
-        return user;
-    });
+        throw api_error::unrecognized_client("The security token included in the request is invalid.");
+    }
+    co_return user;
 }
 
 static tracing::trace_state_ptr create_tracing_session(tracing::tracing& tracing_instance) {
@@ -512,7 +537,6 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
         , _auth_service(auth_service)
         , _sl_controller(sl_controller)
         , _key_cache(1024, 1min, slogger)
-        , _enforce_authorization(false)
         , _enabled_servers{}
         , _pending_requests("alternator::server::pending_requests")
         , _timeout_config(_proxy.data_dictionary().get_config())
@@ -593,7 +617,7 @@ server::server(executor& exec, service::storage_proxy& proxy, gms::gossiper& gos
 }
 
 future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-        utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
+        utils::updateable_value<db::tri_mode_restriction> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
     _memory_limiter = memory_limiter;
     _enforce_authorization = std::move(enforce_authorization);
     _max_concurrent_requests = std::move(max_concurrent_requests);

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -20,6 +20,7 @@
 #include "utils/small_vector.hh"
 #include "utils/updateable_value.hh"
 #include <seastar/core/units.hh>
+#include "db/config.hh"
 
 struct client_data;
 
@@ -42,7 +43,7 @@ class server : public peering_sharded_service<server> {
     qos::service_level_controller& _sl_controller;
 
     key_cache _key_cache;
-    utils::updateable_value<bool> _enforce_authorization;
+    utils::updateable_value<db::tri_mode_restriction> _enforce_authorization;
     utils::small_vector<std::reference_wrapper<seastar::httpd::http_server>, 2> _enabled_servers;
     named_gate _pending_requests;
     // In some places we will need a CQL updateable_timeout_config object even
@@ -94,7 +95,7 @@ public:
     server(executor& executor, service::storage_proxy& proxy, gms::gossiper& gossiper, auth::service& service, qos::service_level_controller& sl_controller);
 
     future<> init(net::inet_address addr, std::optional<uint16_t> port, std::optional<uint16_t> https_port, std::optional<tls::credentials_builder> creds,
-            utils::updateable_value<bool> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            utils::updateable_value<db::tri_mode_restriction> enforce_authorization, semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
     future<> stop();
     // get_client_data() is called (on each shard separately) when the virtual
     // table "system.clients" is read. It is expected to generate a list of

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -155,6 +155,15 @@ static void register_metrics_with_optional_table(seastar::metrics::metric_groups
             seastar::metrics::make_histogram("batch_item_count_histogram", seastar::metrics::description("Histogram of the number of items in a batch request"), labels,
                     [&stats]{ return estimated_histogram_to_metrics(stats.api_operations.batch_write_item_histogram);})(op("BatchWriteItem")).aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
     });
+    // Only register the following metrics for the global metrics, not per-table
+    if (!has_table) {
+        metrics.add_group("alternator", {
+            seastar::metrics::make_counter("authentication_failures", stats.authentication_failures,
+                seastar::metrics::description("total number of authentication failures"), labels),
+            seastar::metrics::make_counter("authorization_failures", stats.authorization_failures,
+                seastar::metrics::description("total number of authorization failures"), labels),
+        });
+    }
 }
 
 void register_metrics(seastar::metrics::metric_groups& metrics, const stats& stats) {

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -79,6 +79,17 @@ public:
         utils::estimated_histogram batch_get_item_histogram{22}; // a histogram that covers the range 1 - 100
         utils::estimated_histogram batch_write_item_histogram{22}; // a histogram that covers the range 1 - 100
     } api_operations;
+    // Count of authentication and authorization failures. Counted when
+    // alternator_enforce_authorization is set to TRUE or WARN, so the latter
+    // setting allows the app to check if it has correct permissions set up
+    // before setting enforcement to TRUE.
+    // "authentication" failure means the request was not signed with a valid
+    // user and key combination. "authorization" failure means the request was
+    // authenticated to a valid user - but this user did not have permissions
+    // to perform the operation (considering RBAC settings and the user's
+    // superuser status).
+    uint64_t authentication_failures = 0;
+    uint64_t authorization_failures = 0;
     // Miscellaneous event counters
     uint64_t total_operations = 0;
     uint64_t unsupported_operations = 0;

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -827,7 +827,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     tracing::add_table_name(trace_state, schema->ks_name(), schema->cf_name());
 
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::SELECT, _stats);
 
     db::consistency_level cl = db::consistency_level::LOCAL_QUORUM;
     partition_key pk = iter.shard.id.to_partition_key(*schema);

--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -94,7 +94,7 @@ future<executor::request_return_type> executor::update_time_to_live(client_state
     }
     sstring attribute_name(v->GetString(), v->GetStringLength());
 
-    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER);
+    co_await verify_permission(_enforce_authorization, client_state, schema, auth::permission::ALTER, _stats);
     co_await db::modify_tags(_mm, schema->ks_name(), schema->cf_name(), [&](std::map<sstring, sstring>& tags_map) {
         if (enabled) {
             if (tags_map.contains(TTL_TAG_KEY)) {

--- a/db/config.cc
+++ b/db/config.cc
@@ -1373,7 +1373,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")
     , alternator_https_port(this, "alternator_https_port", value_status::Used, 0, "Alternator API HTTPS port.")
     , alternator_address(this, "alternator_address", value_status::Used, "0.0.0.0", "Alternator API listening address.")
-    , alternator_enforce_authorization(this, "alternator_enforce_authorization", value_status::Used, false, "Enforce checking the authorization header for every request in Alternator.")
+    , alternator_enforce_authorization(this, "alternator_enforce_authorization", liveness::LiveUpdate, value_status::Used, db::tri_mode_restriction_t::mode::FALSE, "Enforce checking the authorization header for every request in Alternator.")
     , alternator_write_isolation(this, "alternator_write_isolation", value_status::Used, "", "Default write isolation policy for Alternator.")
     , alternator_streams_time_window_s(this, "alternator_streams_time_window_s", value_status::Used, 10, "CDC query confidence window for alternator streams.")
     , alternator_timeout_in_ms(this, "alternator_timeout_in_ms", liveness::LiveUpdate, value_status::Used, 10000,

--- a/db/config.hh
+++ b/db/config.hh
@@ -482,7 +482,7 @@ public:
     named_value<uint16_t> alternator_port;
     named_value<uint16_t> alternator_https_port;
     named_value<sstring> alternator_address;
-    named_value<bool> alternator_enforce_authorization;
+    named_value<tri_mode_restriction> alternator_enforce_authorization;
     named_value<sstring> alternator_write_isolation;
     named_value<uint32_t> alternator_streams_time_window_s;
     named_value<uint32_t> alternator_timeout_in_ms;

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -109,6 +109,18 @@ to do what, configure the following in ScyllaDB's configuration:
     alternator_enforce_authorization: true
 ```
 
+Note: switching `alternator_enforce_authorization` from `false` to `true`
+before the client application has the proper secret keys and permission
+tables set up will cause the application's requests to immediately fail.
+Therefore, we recommend to begin by setting `alternator_enforce_authorization`
+to `warn`. This setting will continue to allow all requests without
+authentication or authorization failures - but will _count_ would-be
+authentication and authorization errors in the two metrics:
+    * `scylla_alternator_authentication_failures`
+    * `scylla_alternator_authorization_failures`
+When you see both metrics are not increasing, you can be sure the application
+is properly set up and `alternator_enforce_authorization` can be set to `true`.
+
 Alternator implements the same [signature protocol](https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)
 as DynamoDB and the rest of AWS. Clients use, as usual, an access key ID and
 a secret access key to prove their identity and the authenticity of their

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -32,7 +32,8 @@ import requests
 from botocore.exceptions import ClientError
 
 from test.alternator.test_manual_requests import get_signed_request
-from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read
+from test.alternator.test_cql_rbac import new_dynamodb, new_role
+from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read, scylla_config_temporary
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for
@@ -509,6 +510,102 @@ def test_ttl_stats(dynamodb, metrics, alternator_ttl_period_in_seconds):
                     break
                 time.sleep(0.1)
             assert not 'Item' in table.get_item(Key={'p': p0})
+
+# The following tests check the authentication and authorization failure
+# counters:
+#  * scylla_alternator_authentication_failures
+#  * scylla_alternator_authorization_failures
+# as well as their interaction with the alternator_enforce_authorization
+# configuration option:
+#
+# 1. When alternator_enforce_authorization is set to "false", these two metrics
+#    aren't incremented (and operations are allowed).
+# 2. When alternator_enforce_authorization is set to "warn", the two metrics
+#    are incremented but the operations are still allowed.
+# 3. When alternator_enforce_authorization is set to "true", the two metrics
+#    are incremented and the operations are not allowed.
+#
+# We have several tests here, for several kinds of authentication and
+# authorization errors. These are tests for issue #25308.
+
+# authentication failure 1: bogus username and secret key
+@pytest.mark.parametrize("enforce_auth", ['true', 'false', 'warn'])
+def test_authentication_failure_1(dynamodb, metrics, test_table_s, enforce_auth):
+    with scylla_config_temporary(dynamodb, 'alternator_enforce_authorization', enforce_auth):
+        with new_dynamodb(dynamodb, 'bogus_username', 'bogus_secret_key') as d:
+            # We don't expect get_item() to find any item, we just care if
+            # to see if it experiences an authentication failure, and if
+            # it increments the authentication failure metric.
+            saved_auth_failures = get_metric(metrics, 'scylla_alternator_authentication_failures')
+            tab = d.Table(test_table_s.name)
+            try:
+                tab.get_item(Key={'p': 'dog'})
+                operation_succeeded = True
+            except ClientError as e:
+                assert 'UnrecognizedClientException' in str(e)
+                operation_succeeded = False
+            if enforce_auth == 'true':
+                assert not operation_succeeded
+            else:
+                assert operation_succeeded
+            new_auth_failures = get_metric(metrics, 'scylla_alternator_authentication_failures')
+            if enforce_auth == 'false':
+                assert new_auth_failures == saved_auth_failures
+            else:
+                assert new_auth_failures == saved_auth_failures + 1
+
+# authentication failure 2: real username, wrong secret key
+# Unfortunately, tests that create a new role need to use CQL too.
+@pytest.mark.parametrize("enforce_auth", ['true', 'false', 'warn'])
+def test_authentication_failure_2(dynamodb, cql, metrics, test_table_s, enforce_auth):
+    with scylla_config_temporary(dynamodb, 'alternator_enforce_authorization', enforce_auth):
+        with new_role(cql) as (role, key):
+            with new_dynamodb(dynamodb, role, 'bogus_secret_key') as d:
+                saved_auth_failures = get_metric(metrics, 'scylla_alternator_authentication_failures')
+                tab = d.Table(test_table_s.name)
+                try:
+                    tab.get_item(Key={'p': 'dog'})
+                    operation_succeeded = True
+                except ClientError as e:
+                    assert 'UnrecognizedClientException' in str(e)
+                    operation_succeeded = False
+                if enforce_auth == 'true':
+                    assert not operation_succeeded
+                else:
+                    assert operation_succeeded
+                new_auth_failures = get_metric(metrics, 'scylla_alternator_authentication_failures')
+                if enforce_auth == 'false':
+                    assert new_auth_failures == saved_auth_failures
+                else:
+                    assert new_auth_failures == saved_auth_failures + 1
+
+# Authorization failure - a valid user but without permissions to do a
+# given operation.
+@pytest.mark.parametrize("enforce_auth", ['true', 'false', 'warn'])
+def test_authorization_failure(dynamodb, cql, metrics, test_table_s, enforce_auth):
+    with scylla_config_temporary(dynamodb, 'alternator_enforce_authorization', enforce_auth):
+        with new_role(cql) as (role, key):
+            with new_dynamodb(dynamodb, role, key) as d:
+                saved_auth_failures = get_metric(metrics, 'scylla_alternator_authorization_failures')
+                tab = d.Table(test_table_s.name)
+                try:
+                    # Note that the new role is not a superuser, so should
+                    # not have permissions to read from this table created
+                    # earlier by the superuser.
+                    tab.get_item(Key={'p': 'dog'})
+                    operation_succeeded = True
+                except ClientError as e:
+                    assert 'AccessDeniedException' in str(e)
+                    operation_succeeded = False
+                if enforce_auth == 'true':
+                    assert not operation_succeeded
+                else:
+                    assert operation_succeeded
+                new_auth_failures = get_metric(metrics, 'scylla_alternator_authorization_failures')
+                if enforce_auth == 'false':
+                    assert new_auth_failures == saved_auth_failures
+                else:
+                    assert new_auth_failures == saved_auth_failures + 1
 
 # TODO: there are additional metrics which we don't yet test here. At the
 # time of this writing they are:


### PR DESCRIPTION
An Alternator user was recently "bit" when switching `alternator_enforce_authorization` from "false" to "true": ְְְAfter the configuration change, all application requests suddenly failed because unbeknownst to the user, their application used incorrect secret keys. 

This series introduces a solution for users who want to **safely** switch `alternator_enforce_authorization`  from "false" to "true": Before switching from "false" to "true", the user can temporarily switch to "warn". In "warn" mode, authentication and authorization errors are counted in metrics (`scylla_alternator_authentication_failures` and `scylla_alternator_authorization_failures`) but the user's application continues to work. The user can then fix any errors in their application's setup, and only do the switch to "true" when the metrics show there are no more errors.

The first patch is the feature itself (the "warn" mode and the metrics), the second patch is a test for it, and the third patch is documentation recommending how to use the "warn" mode and the associated metrics to safely switch from "false" to "true".

Fixes #25308

This is a feature that users need, so it should probably be backported to live branches.