### PR TITLE
service/qos: Modularize service level controller to avoid invalid access to auth::service

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2285,6 +2285,16 @@ sharded<locator::shared_token_metadata> token_metadata;
                 api::unset_server_authorization_cache(ctx).get();
             });
 
+            sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
+                controller.register_auth_integration();
+            }).get();
+
+            auto unregister_sl_controller_integration = defer([] {
+                sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
+                    return controller.unregister_auth_integration();
+                }).get();
+            });
+
             // update the service level cache after the SL data accessor and auth service are initialized.
             if (sl_controller.local().is_v2()) {
                 sl_controller.local().update_cache(qos::update_both_cache_levels::yes).get();

--- a/main.cc
+++ b/main.cc
@@ -2262,6 +2262,13 @@ sharded<locator::shared_token_metadata> token_metadata;
             const qualified_name qualified_authenticator_name(auth::meta::AUTH_PACKAGE_NAME, cfg->authenticator());
             const qualified_name qualified_role_manager_name(auth::meta::AUTH_PACKAGE_NAME, cfg->role_manager());
 
+            // Reproducer of scylladb/scylladb#24792.
+            auto i24792_reproducer = defer([] {
+                if (utils::get_local_injector().enter("reload_service_level_cache_after_auth_service_is_stopped")) {
+                    sl_controller.local().update_cache(qos::update_both_cache_levels::yes).get();
+                }
+            });
+
             checkpoint(stop_signal, "starting auth service");
             auth::service_config auth_config;
             auth_config.authorizer_java_name = qualified_authorizer_name;

--- a/main.cc
+++ b/main.cc
@@ -2292,8 +2292,9 @@ sharded<locator::shared_token_metadata> token_metadata;
                 api::unset_server_authorization_cache(ctx).get();
             });
 
+            // Precondition: we can only call this after `auth::service` has been initialized and started on all shards.
             sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
-                controller.register_auth_integration();
+                controller.register_auth_integration(auth_service.local());
             }).get();
 
             auto unregister_sl_controller_integration = defer([] {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -282,7 +282,11 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
                 sl_logger.info("service level \"{}\" was updated. New values: (timeout: {}, workload_type: {}, shares: {})",
                         sl.first, sl.second.timeout, sl.second.workload, sl.second.shares);
             }
-            _auth_integration->clear_cache();
+
+            if (_auth_integration) {
+                _auth_integration->clear_cache();
+            }
+
             for (auto&& sl : service_levels_for_add) {
                 bool make_room = false;
                 std::map<sstring, service_level>::reverse_iterator it;
@@ -396,7 +400,10 @@ future<> service_level_controller::update_cache(update_both_cache_levels update_
     if (update_both_cache_levels) {
         co_await update_service_levels_cache(ctx);
     }
-    co_await _auth_integration->reload_cache();
+
+    if (_auth_integration) {
+        co_await _auth_integration->reload_cache();
+    }
 }
 
 void service_level_controller::stop_legacy_update_from_distributed_data() {

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -54,7 +54,7 @@ future<> service_level_controller::auth_integration::stop() {
 }
 
 void service_level_controller::auth_integration::clear_cache() {
-    _sl_controller._effective_service_levels_db.clear();
+    _cache.clear();
 }
 
 service_level_controller::service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config, scheduling_group default_scheduling_group, bool destroy_default_sg_on_drain)
@@ -387,7 +387,11 @@ future<> service_level_controller::auth_integration::reload_cache() {
     }
 
     co_await _sl_controller.container().invoke_on_all([effective_sl_map] (service_level_controller& sl_controller) -> future<> {
-        sl_controller._effective_service_levels_db = std::move(effective_sl_map);
+        // We probably cannot predict if `auth_integration` is still in place on another shard,
+        // so let's play it safe here.
+        if (sl_controller._auth_integration) {
+            sl_controller._auth_integration->_cache = std::move(effective_sl_map);
+        }
         co_await sl_controller.notify_effective_service_levels_cache_reloaded();
     });
 }
@@ -416,8 +420,8 @@ future<std::optional<service_level_options>> service_level_controller::auth_inte
     const auto _ = _stop_gate.hold();
 
     if (_sl_controller._sl_data_accessor->can_use_effective_service_level_cache()) {
-        auto effective_sl_it = _sl_controller._effective_service_levels_db.find(role_name);
-        co_return effective_sl_it != _sl_controller._effective_service_levels_db.end() 
+        auto effective_sl_it = _cache.find(role_name);
+        co_return effective_sl_it != _cache.end() 
             ? std::optional<service_level_options>(effective_sl_it->second)
             : std::nullopt;
     } else {
@@ -468,8 +472,8 @@ std::optional<service_level_options> service_level_controller::auth_integration:
         return std::nullopt;
     }
 
-    auto effective_sl_it = _sl_controller._effective_service_levels_db.find(role_name);
-    return effective_sl_it != _sl_controller._effective_service_levels_db.end() 
+    auto effective_sl_it = _cache.find(role_name);
+    return effective_sl_it != _cache.end() 
         ? std::optional<service_level_options>(effective_sl_it->second)
         : std::nullopt;
 }

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -43,6 +43,18 @@ constexpr const char* scheduling_group_name_pattern = "sl:{}";
 constexpr const char* deleted_scheduling_group_name_pattern = "sl_deleted:{}";
 constexpr const char* temp_scheduling_group_name_pattern = "sl_temp:{}";
 
+service_level_controller::auth_integration::auth_integration(service_level_controller& sl_controller)
+    : _sl_controller(sl_controller)
+{}
+
+future<> service_level_controller::auth_integration::stop() {
+    co_return;
+}
+
+void service_level_controller::auth_integration::clear_cache() {
+    _sl_controller._effective_service_levels_db.clear();
+}
+
 service_level_controller::service_level_controller(sharded<auth::service>& auth_service, locator::shared_token_metadata& tm, abort_source& as, service_level_options default_service_level_config, scheduling_group default_scheduling_group, bool destroy_default_sg_on_drain)
         : _sl_data_accessor(nullptr)
         , _auth_service(auth_service)
@@ -269,7 +281,7 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
                 sl_logger.info("service level \"{}\" was updated. New values: (timeout: {}, workload_type: {}, shares: {})",
                         sl.first, sl.second.timeout, sl.second.workload, sl.second.shares);
             }
-            _effective_service_levels_db.clear();
+            _auth_integration->clear_cache();
             for (auto&& sl : service_levels_for_add) {
                 bool make_room = false;
                 std::map<sstring, service_level>::reverse_iterator it;
@@ -301,27 +313,27 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
     });
 }
 
-future<> service_level_controller::update_effective_service_levels_cache() {
+future<> service_level_controller::auth_integration::reload_cache() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
     
-    if (!_auth_service.local_is_initialized()) {
+    if (!_sl_controller._auth_service.local_is_initialized()) {
         // Auth service might be not initialized yet.
         co_return;
     }
-    if (!_sl_data_accessor || !_sl_data_accessor->can_use_effective_service_level_cache()) {
+    if (!_sl_controller._sl_data_accessor || !_sl_controller._sl_data_accessor->can_use_effective_service_level_cache()) {
         // Don't populate the effective service level cache until auth is migrated to raft.
         // Otherwise, executing the code that follows would read roles data
         // from system_auth tables; that would be bad because reading from
-        // those tables is prone to timeouts, and `update_effective_service_levels_cache`
+        // those tables is prone to timeouts, and `reload_cache`
         // is called from the group0 context - a timeout like that would render
         // group0 non-functional on the node until restart.
         //
         // See scylladb/scylladb#24963 for more details.
         co_return;
     }
-    auto units = co_await get_units(_global_controller_db->notifications_serializer, 1);
+    auto units = co_await get_units(_sl_controller._global_controller_db->notifications_serializer, 1);
 
-    auto& role_manager = _auth_service.local().underlying_role_manager();
+    auto& role_manager = _sl_controller._auth_service.local().underlying_role_manager();
     const auto all_roles = co_await role_manager.query_all();
     const auto hierarchy = co_await role_manager.query_all_directly_granted();
     // includes only roles with attached service level
@@ -339,11 +351,11 @@ future<> service_level_controller::update_effective_service_levels_cache() {
         std::optional<service_level_options> sl_options;
 
         if (auto sl_name_it = attributes.find(role); sl_name_it != attributes.end()) {
-            if (auto sl_it = _service_levels_db.find(sl_name_it->second); sl_it != _service_levels_db.end()) { 
+            if (auto sl_it = _sl_controller._service_levels_db.find(sl_name_it->second); sl_it != _sl_controller._service_levels_db.end()) { 
                 sl_options = sl_it->second.slo;
                 sl_options->init_effective_names(sl_name_it->second);
                 sl_options->shares_name = sl_name_it->second;
-            } else if (_effectively_dropped_sls.contains(sl_name_it->second)) {
+            } else if (_sl_controller._effectively_dropped_sls.contains(sl_name_it->second)) {
                 // service level might be effective dropped, then it's not present in `_service_levels_db`
                 sl_logger.warn("Service level {} is effectively dropped and its values are ignored.", sl_name_it->second);
             } else {
@@ -371,7 +383,7 @@ future<> service_level_controller::update_effective_service_levels_cache() {
         co_await coroutine::maybe_yield();
     }
 
-    co_await container().invoke_on_all([effective_sl_map] (service_level_controller& sl_controller) -> future<> {
+    co_await _sl_controller.container().invoke_on_all([effective_sl_map] (service_level_controller& sl_controller) -> future<> {
         sl_controller._effective_service_levels_db = std::move(effective_sl_map);
         co_await sl_controller.notify_effective_service_levels_cache_reloaded();
     });
@@ -382,7 +394,7 @@ future<> service_level_controller::update_cache(update_both_cache_levels update_
     if (update_both_cache_levels) {
         co_await update_service_levels_cache(ctx);
     }
-    co_await update_effective_service_levels_cache();
+    co_await _auth_integration->reload_cache();
 }
 
 void service_level_controller::stop_legacy_update_from_distributed_data() {
@@ -394,14 +406,14 @@ void service_level_controller::stop_legacy_update_from_distributed_data() {
     _global_controller_db->dist_data_update_aborter.request_abort();
 }
 
-future<std::optional<service_level_options>> service_level_controller::find_effective_service_level(const sstring& role_name) {
-    if (_sl_data_accessor->can_use_effective_service_level_cache()) {
-        auto effective_sl_it = _effective_service_levels_db.find(role_name);
-        co_return effective_sl_it != _effective_service_levels_db.end() 
+future<std::optional<service_level_options>> service_level_controller::auth_integration::find_effective_service_level(const sstring& role_name) {
+    if (_sl_controller._sl_data_accessor->can_use_effective_service_level_cache()) {
+        auto effective_sl_it = _sl_controller._effective_service_levels_db.find(role_name);
+        co_return effective_sl_it != _sl_controller._effective_service_levels_db.end() 
             ? std::optional<service_level_options>(effective_sl_it->second)
             : std::nullopt;
     } else {
-        auto& role_manager = _auth_service.local().underlying_role_manager();
+        auto& role_manager = _sl_controller._auth_service.local().underlying_role_manager();
         auto roles = co_await role_manager.query_granted(role_name, auth::recursive_role_query::yes);
 
         // converts a list of roles into the chosen service level.
@@ -412,8 +424,8 @@ future<std::optional<service_level_options>> service_level_controller::find_effe
                     if (!sl_name) {
                         return std::nullopt;
                     }
-                    auto sl_it = _service_levels_db.find(*sl_name);
-                    if ( sl_it == _service_levels_db.end()) {
+                    auto sl_it = _sl_controller._service_levels_db.find(*sl_name);
+                    if ( sl_it == _sl_controller._service_levels_db.end()) {
                         return std::nullopt;
                     }
 
@@ -438,15 +450,25 @@ future<std::optional<service_level_options>> service_level_controller::find_effe
     }
 }
 
-std::optional<service_level_options> service_level_controller::find_cached_effective_service_level(const sstring& role_name) {
-    if (!_sl_data_accessor->is_v2()) {
+future<std::optional<service_level_options>> service_level_controller::find_effective_service_level(const sstring& role_name) {
+    SCYLLA_ASSERT(_auth_integration != nullptr);
+    return _auth_integration->find_effective_service_level(role_name);
+}
+
+std::optional<service_level_options> service_level_controller::auth_integration::find_cached_effective_service_level(const sstring& role_name) {
+    if (!_sl_controller._sl_data_accessor->is_v2()) {
         return std::nullopt;
     }
 
-    auto effective_sl_it = _effective_service_levels_db.find(role_name);
-    return effective_sl_it != _effective_service_levels_db.end() 
+    auto effective_sl_it = _sl_controller._effective_service_levels_db.find(role_name);
+    return effective_sl_it != _sl_controller._effective_service_levels_db.end() 
         ? std::optional<service_level_options>(effective_sl_it->second)
         : std::nullopt;
+}
+
+std::optional<service_level_options> service_level_controller::find_cached_effective_service_level(const sstring& role_name) {
+    SCYLLA_ASSERT(_auth_integration != nullptr);
+    return _auth_integration->find_cached_effective_service_level(role_name);
 }
 
 future<>  service_level_controller::notify_service_level_added(sstring name, service_level sl_data) {
@@ -545,15 +567,20 @@ scheduling_group service_level_controller::get_scheduling_group(sstring service_
     }
 }
 
-future<scheduling_group> service_level_controller::get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr) {
+future<scheduling_group> service_level_controller::auth_integration::get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr) {
     if (usr && usr->name) {
         auto sl_opt = co_await find_effective_service_level(*usr->name);
         auto& sl_name = (sl_opt && sl_opt->shares_name) ? *sl_opt->shares_name : default_service_level_name;
-        co_return get_scheduling_group(sl_name);
+        co_return _sl_controller.get_scheduling_group(sl_name);
     }
     else {
-        co_return get_default_scheduling_group();
+        co_return _sl_controller.get_default_scheduling_group();
     }
+}
+
+future<scheduling_group> service_level_controller::get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr) {
+    SCYLLA_ASSERT(_auth_integration != nullptr);
+    return _auth_integration->get_user_scheduling_group(usr);
 }
 
 std::optional<sstring> service_level_controller::get_active_service_level() {
@@ -995,8 +1022,8 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
     co_return result;
 }
 
-future<std::vector<cql3::description>> service_level_controller::describe_attached_service_levels() {
-    const auto attached_service_levels = co_await _auth_service.local().underlying_role_manager().query_attribute_for_all("service_level");
+future<std::vector<cql3::description>> service_level_controller::auth_integration::describe_attached_service_levels() {
+    const auto attached_service_levels = co_await _sl_controller._auth_service.local().underlying_role_manager().query_attribute_for_all("service_level");
 
     std::vector<cql3::description> result{};
     result.reserve(attached_service_levels.size());
@@ -1026,13 +1053,28 @@ future<std::vector<cql3::description>> service_level_controller::describe_attach
 }
 
 future<std::vector<cql3::description>> service_level_controller::describe_service_levels() {
+    SCYLLA_ASSERT(_auth_integration != nullptr);
+
     std::vector<cql3::description> created_service_levels_descs = co_await describe_created_service_levels();
-    std::vector<cql3::description> attached_service_levels_descs = co_await describe_attached_service_levels();
+    std::vector<cql3::description> attached_service_levels_descs = co_await _auth_integration->describe_attached_service_levels();
 
     created_service_levels_descs.insert(created_service_levels_descs.end(),
             std::make_move_iterator(attached_service_levels_descs.begin()), std::make_move_iterator(attached_service_levels_descs.end()));
 
     co_return created_service_levels_descs;
+}
+
+void service_level_controller::register_auth_integration() {
+    SCYLLA_ASSERT(_auth_integration == nullptr);
+    _auth_integration = std::make_unique<auth_integration>(*this);
+}
+
+future<> service_level_controller::unregister_auth_integration() {
+    SCYLLA_ASSERT(_auth_integration != nullptr);
+    // First, prevent new tasks coming to `auth_integration`.
+    auto tmp = std::exchange(_auth_integration, nullptr);
+    // Now we can stop it.
+    co_await tmp->stop();
 }
 
 future<shared_ptr<service_level_controller::service_level_distributed_data_accessor>> 

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -45,10 +45,11 @@ constexpr const char* temp_scheduling_group_name_pattern = "sl_temp:{}";
 
 service_level_controller::auth_integration::auth_integration(service_level_controller& sl_controller)
     : _sl_controller(sl_controller)
+    , _stop_gate("service_level_controller_auth_integration_stop_gate")
 {}
 
 future<> service_level_controller::auth_integration::stop() {
-    co_return;
+    co_await _stop_gate.close();
 }
 
 void service_level_controller::auth_integration::clear_cache() {
@@ -315,6 +316,7 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
 
 future<> service_level_controller::auth_integration::reload_cache() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
+    const auto _ = _stop_gate.hold();
     
     if (!_sl_controller._auth_service.local_is_initialized()) {
         // Auth service might be not initialized yet.
@@ -407,6 +409,8 @@ void service_level_controller::stop_legacy_update_from_distributed_data() {
 }
 
 future<std::optional<service_level_options>> service_level_controller::auth_integration::find_effective_service_level(const sstring& role_name) {
+    const auto _ = _stop_gate.hold();
+
     if (_sl_controller._sl_data_accessor->can_use_effective_service_level_cache()) {
         auto effective_sl_it = _sl_controller._effective_service_levels_db.find(role_name);
         co_return effective_sl_it != _sl_controller._effective_service_levels_db.end() 
@@ -568,6 +572,8 @@ scheduling_group service_level_controller::get_scheduling_group(sstring service_
 }
 
 future<scheduling_group> service_level_controller::auth_integration::get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr) {
+    const auto _ = _stop_gate.hold();
+
     if (usr && usr->name) {
         auto sl_opt = co_await find_effective_service_level(*usr->name);
         auto& sl_name = (sl_opt && sl_opt->shares_name) ? *sl_opt->shares_name : default_service_level_name;
@@ -1023,6 +1029,8 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
 }
 
 future<std::vector<cql3::description>> service_level_controller::auth_integration::describe_attached_service_levels() {
+    const auto _ = _stop_gate.hold();
+
     const auto attached_service_levels = co_await _sl_controller._auth_service.local().underlying_role_manager().query_attribute_for_all("service_level");
 
     std::vector<cql3::description> result{};

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -43,8 +43,9 @@ constexpr const char* scheduling_group_name_pattern = "sl:{}";
 constexpr const char* deleted_scheduling_group_name_pattern = "sl_deleted:{}";
 constexpr const char* temp_scheduling_group_name_pattern = "sl_temp:{}";
 
-service_level_controller::auth_integration::auth_integration(service_level_controller& sl_controller)
+service_level_controller::auth_integration::auth_integration(service_level_controller& sl_controller, auth::service& auth_service)
     : _sl_controller(sl_controller)
+    , _auth_service(auth_service)
     , _stop_gate("service_level_controller_auth_integration_stop_gate")
 {}
 
@@ -321,11 +322,7 @@ future<> service_level_controller::update_service_levels_cache(qos::query_contex
 future<> service_level_controller::auth_integration::reload_cache() {
     SCYLLA_ASSERT(this_shard_id() == global_controller);
     const auto _ = _stop_gate.hold();
-    
-    if (!_sl_controller._auth_service.local_is_initialized()) {
-        // Auth service might be not initialized yet.
-        co_return;
-    }
+
     if (!_sl_controller._sl_data_accessor || !_sl_controller._sl_data_accessor->can_use_effective_service_level_cache()) {
         // Don't populate the effective service level cache until auth is migrated to raft.
         // Otherwise, executing the code that follows would read roles data
@@ -339,7 +336,7 @@ future<> service_level_controller::auth_integration::reload_cache() {
     }
     auto units = co_await get_units(_sl_controller._global_controller_db->notifications_serializer, 1);
 
-    auto& role_manager = _sl_controller._auth_service.local().underlying_role_manager();
+    auto& role_manager = _auth_service.underlying_role_manager();
     const auto all_roles = co_await role_manager.query_all();
     const auto hierarchy = co_await role_manager.query_all_directly_granted();
     // includes only roles with attached service level
@@ -424,7 +421,7 @@ future<std::optional<service_level_options>> service_level_controller::auth_inte
             ? std::optional<service_level_options>(effective_sl_it->second)
             : std::nullopt;
     } else {
-        auto& role_manager = _sl_controller._auth_service.local().underlying_role_manager();
+        auto& role_manager = _auth_service.underlying_role_manager();
         auto roles = co_await role_manager.query_granted(role_name, auth::recursive_role_query::yes);
 
         // converts a list of roles into the chosen service level.
@@ -1038,7 +1035,7 @@ future<std::vector<cql3::description>> service_level_controller::describe_create
 future<std::vector<cql3::description>> service_level_controller::auth_integration::describe_attached_service_levels() {
     const auto _ = _stop_gate.hold();
 
-    const auto attached_service_levels = co_await _sl_controller._auth_service.local().underlying_role_manager().query_attribute_for_all("service_level");
+    const auto attached_service_levels = co_await _auth_service.underlying_role_manager().query_attribute_for_all("service_level");
 
     std::vector<cql3::description> result{};
     result.reserve(attached_service_levels.size());
@@ -1079,9 +1076,9 @@ future<std::vector<cql3::description>> service_level_controller::describe_servic
     co_return created_service_levels_descs;
 }
 
-void service_level_controller::register_auth_integration() {
+void service_level_controller::register_auth_integration(auth::service& auth_service) {
     SCYLLA_ASSERT(_auth_integration == nullptr);
-    _auth_integration = std::make_unique<auth_integration>(*this);
+    _auth_integration = std::make_unique<auth_integration>(*this, auth_service);
 }
 
 future<> service_level_controller::unregister_auth_integration() {

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -129,6 +129,7 @@ public:
     private:
         // FIXME: Will be extended in an upcoming commit.
         service_level_controller& _sl_controller;
+        auth::service& _auth_service;
 
         /// This gate is supposed to synchronize `stop` with other tasks that
         /// this interface performs. Because of that, EVERY coroutine function
@@ -138,7 +139,7 @@ public:
         seastar::named_gate _stop_gate;
 
     public:
-        auth_integration(service_level_controller&);
+        auth_integration(service_level_controller&, auth::service&);
 
         future<> stop();
 
@@ -233,7 +234,7 @@ public:
      */
     future<> start();
 
-    void register_auth_integration();
+    void register_auth_integration(auth::service&);
 
     future<> unregister_auth_integration();
 

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -127,10 +127,11 @@ public:
         friend class service_level_controller;
 
     private:
-        // FIXME: Will be extended in an upcoming commit.
         service_level_controller& _sl_controller;
         auth::service& _auth_service;
 
+        /// Mappings `role name` -> `service level options`.
+        std::map<sstring, service_level_options> _cache;
         /// This gate is supposed to synchronize `stop` with other tasks that
         /// this interface performs. Because of that, EVERY coroutine function
         /// of this class should hold it throughout its execution.
@@ -208,8 +209,6 @@ private:
 
     // Invariant: Non-null strictly within the lifetime of `auth::service`.
     std::unique_ptr<auth_integration> _auth_integration = nullptr;
-    // role name -> effective service_level_options 
-    std::map<sstring, service_level_options> _effective_service_levels_db;
 
     // Keeps names of effectively dropped service levels. Those service levels exits in the table but are not present in _service_levels_db cache
     std::set<sstring> _effectively_dropped_sls;

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -122,6 +122,50 @@ public:
     };
     using service_level_distributed_data_accessor_ptr = ::shared_ptr<service_level_distributed_data_accessor>;
 
+    class auth_integration {
+    private:
+        friend class service_level_controller;
+
+    private:
+        // FIXME: Will be extended in an upcoming commit.
+        service_level_controller& _sl_controller;
+
+    public:
+        auth_integration(service_level_controller&);
+
+        future<> stop();
+
+        /// Find the effective service level for a given role.
+        /// If there is no applicable service level for it, `std::nullopt` is returned instead.
+        future<std::optional<service_level_options>> find_effective_service_level(const sstring& role_name);
+        /// Synchronous version of `find_effective_service_level` that only checks the cache.
+        std::optional<service_level_options> find_cached_effective_service_level(const sstring& role_name);
+
+        future<scheduling_group> get_user_scheduling_group(const std::optional<auth::authenticated_user>& usr);
+
+        template <typename Func, typename Ret = std::invoke_result_t<Func>>
+            requires std::invocable<Func>
+        futurize_t<Ret> with_user_service_level(const std::optional<auth::authenticated_user>& user, Func&& func) {
+            if (user && user->name) {
+                const std::optional<service_level_options> maybe_sl_opts = co_await find_effective_service_level(*user->name);
+                const sstring& sl_name = maybe_sl_opts && maybe_sl_opts->shares_name
+                        ? *maybe_sl_opts->shares_name
+                        : service_level_controller::default_service_level_name;
+
+                co_return co_await _sl_controller.with_service_level(sl_name, std::forward<Func>(func));
+            } else {
+                co_return co_await _sl_controller.with_service_level(service_level_controller::default_service_level_name, std::forward<Func>(func));
+            }
+        }
+
+        future<std::vector<cql3::description>> describe_attached_service_levels();
+
+        /// Must be executed on shard 0.
+        future<> reload_cache();
+
+        void clear_cache();
+    };
+
 private:
     struct global_controller_data {
         service_levels_info  static_configurations{};
@@ -150,8 +194,12 @@ private:
 
     // service level name -> service_level object
     std::map<sstring, service_level> _service_levels_db;
+
+    // Invariant: Non-null strictly within the lifetime of `auth::service`.
+    std::unique_ptr<auth_integration> _auth_integration = nullptr;
     // role name -> effective service_level_options 
     std::map<sstring, service_level_options> _effective_service_levels_db;
+
     // Keeps names of effectively dropped service levels. Those service levels exits in the table but are not present in _service_levels_db cache
     std::set<sstring> _effectively_dropped_sls;
     std::pair<const sstring*, service_level*> _sl_lookup[max_scheduling_groups()];
@@ -174,6 +222,10 @@ public:
      * @return a future that resolves when the initialization is over.
      */
     future<> start();
+
+    void register_auth_integration();
+
+    future<> unregister_auth_integration();
 
     void set_distributed_data_accessor(service_level_distributed_data_accessor_ptr sl_data_accessor);
 
@@ -222,14 +274,8 @@ public:
     template <typename Func, typename Ret = std::invoke_result_t<Func>>
     requires std::invocable<Func>
     futurize_t<Ret> with_user_service_level(const std::optional<auth::authenticated_user>& usr, Func&& func) {
-        if (usr && usr->name) {
-            return find_effective_service_level(*usr->name).then([this, func = std::move(func)] (std::optional<service_level_options> opts) mutable {
-                auto& service_level_name = (opts && opts->shares_name) ? *opts->shares_name : default_service_level_name;
-                return with_service_level(service_level_name, std::move(func));
-            });
-        } else {
-            return with_service_level(default_service_level_name, std::move(func));
-        }
+        SCYLLA_ASSERT(_auth_integration != nullptr);
+        return _auth_integration->with_user_service_level(usr, std::forward<Func>(func));
     }
 
     /**
@@ -300,15 +346,6 @@ public:
      * @return a future that is resolved when the update is done
      */
     future<> update_service_levels_cache(qos::query_context ctx = qos::query_context::unspecified);
-
-    /**
-     * Updates effective service levels cache.
-     * The method uses service levels cache (_service_levels_db)
-     * and data from auth tables.
-     * Must be executed on shard 0.
-     * @return a future that is resolved when the update is done
-     */
-    future<> update_effective_service_levels_cache();
 
     /**
      * Service levels cache consists of two levels: service levels cache and effective service levels cache

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -487,3 +487,11 @@ async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     # Check if group0 is healthy
     s2 = await manager.server_add(config=auth_config, property_file={"dc": "dc1", "rack": "rack3"})
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
+
+# Reproduces scylladb/scylladb#24792.
+@pytest.mark.asyncio
+@skip_mode("release", "error injection is disabled in release mode")
+async def test_reload_service_levels_after_auth_service_is_stopped(manager: ManagerClient):
+    config = {**auth_config, "error_injections_at_startup": ["reload_service_level_cache_after_auth_service_is_stopped"]}
+    s1 = await manager.server_add(config=config)
+    await manager.server_stop_gracefully(s1.server_id)

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1109,8 +1109,9 @@ private:
                 _auth_service.stop().get();
             });
 
-            _sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
-                controller.register_auth_integration();
+            // Precondition: we can only call this after `auth::service` has been initialized and started on all shards.
+            _sl_controller.invoke_on_all([&auth_service = _auth_service] (qos::service_level_controller& controller) {
+                controller.register_auth_integration(auth_service.local());
             }).get();
 
             auto unregister_sl_controller_integration = defer([this] {

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -143,6 +143,7 @@ private:
     sharded<db::view::view_update_generator> _view_update_generator;
     sharded<service::migration_notifier> _mnotifier;
     sharded<qos::service_level_controller> _sl_controller;
+    sharded<qos::service_level_controller::auth_integration> _sl_controller_auth_integration;
     sharded<service::topology_state_machine> _topology_state_machine;
     sharded<utils::walltime_compressor_tracker> _compressor_tracker;
     sharded<service::migration_manager> _mm;
@@ -1106,6 +1107,16 @@ private:
                 // double execution of the shutdown method, which causes waiting for 
                 // an invalid future if we're unlucky.
                 _auth_service.stop().get();
+            });
+
+            _sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
+                controller.register_auth_integration();
+            }).get();
+
+            auto unregister_sl_controller_integration = defer([this] {
+                _sl_controller.invoke_on_all([] (qos::service_level_controller& controller) {
+                    return controller.unregister_auth_integration();
+                }).get();
             });
 
             db::batchlog_manager_config bmcfg;


### PR DESCRIPTION
Move management over effective service levels from `service_level_controller`
to a new dedicated type -- `auth_integration`.

### Problem

Before these changes, it was possible for the service level controller to try
to access `auth::service` after it was deinitialized. For instance, it could
happen when reloading the cache. That HAS happened as described in the following
issue: scylladb/scylladb#24792.

Although the problem might have been mitigated or even resolved in
scylladb/scylladb@10214e13bdf44f82c2d6a53cdcf4d0ae288c838a, it's not clear
how the service will be used in the future. It's best to prevent similar bugs
than trying to fix them later on.

The logic responsible for preventing to access an uninitialized `auth::service`
was also either non-existent, complex, or non-sufficient.

### Solution

To prevent accessing `auth::service` by the service level controller, we extract
the relevant portion of the code to a separate entity -- `auth_integration`.
It's an internal helper type whose sole purpose is to manage effective service
levels.

Thanks to that, we were able to nest the lifetime of `auth_integration` within
the lifetime of `auth::service`. It's now impossible to attempt to dereference
it while it's uninitialized.

If a bug related to an invalid access is spotted again, though, it might also
be easier to debug it now.

### Impact

There should be no visible change to the users of the interface of the service
level controller. We strived to make the patch minimal, and the only affected
part of the logic should be related to how `auth::service` is accessed.

The relevant portion of the initialization and deinitialization flow:

(a) Before the changes:

1. Initialize `service_level_controller`. Pass a reference to an uninitialized
   `auth::service` to it.
2. Initialize other services.
3. Initialize and start `auth::service`.
4. (work)
5. Stop and deinitialize `auth::service`.
6. Deinitialize other services.
7. Deinitialize `service_level_controller`.

(b) After the changes:

1. Initialize `service_level_controller`. Pass a reference to an uninitialized
   `auth::service` to it. (*)
2. Initialize other services.
3. Initialize and start `auth::service`.
4. Initialize `auth_integration`. Register it in `service_level_controller`.
5. (work)
6. Unregister `auth_integration` in `service_level_controller` and deinitialize
   it.
7. Stop and deinitialize `auth::service`.
8. Deinitialize other services.
9. Deinitialize `service_level_controller`.

(*):
    The reference to `auth::service` in `service_level_controller` is still
    necessary. We need to access the service when dropping a distributed
    service level.

    Although it would be best to cut that link between the service level
    controller and `auth::service` too, effectively separating the entities,
    it would require more work, so we leave it as-is for now.

    It shouldn't prove problematic as far as accessing an uninitialized service
    goes. Trying to drop a service level at the point when we're de-initializing
    auth should be impossible.

    For more context, see the function `drop_distributed_service_level` in
    `service_level_controller`.

### Testing

A trivial test has been included in the PR. Although its value is questionable
as we only try to reload the service level cache at a specific moment, it's
probably the best we can deliver to provide a reproducer of the issue this patch
is resolving.

Fixes scylladb/scylladb#24792

Backport: The impact of the bug was minimal as it only affected the shutdown.
However, since CI is failing because of it, let's backport the change to all
supported versions.
