### PR TITLE
scripts/coverage.py: correct the coverage report path

### DIFF
--- a/scripts/coverage.py
+++ b/scripts/coverage.py
@@ -151,6 +151,7 @@ def generate_coverage_report(path="build/coverage/test", name="tests", input_fil
         subprocess.check_call(["llvm-cov", "export", "-format=lcov", f"-instr-profile={profdata_path}"] + [f"-object={exe}" for exe in test_executables], stdout=f)
 
     html_report_path = os.path.join(path, f"{name}")
+    os.makedirs(html_report_path, exist_ok=True)
     html_report_url = os.path.abspath(os.path.join(html_report_path, "index.html"))
 
     maybe_print(f"Generating html report in {html_report_path}")


### PR DESCRIPTION
the `path/name` directory is not exist and needs to be created first.

if not, `./test.py --mode=coverage` will report:
```bash
genhtml: ERROR: cannot change to directory build/coverage/tests!
Traceback (most recent call last):
  File "/scylladb/./test.py", line 1624, in workaround_python26789
    code = await main()
           ^^^^^^^^^^^^
  File "/scylladb/./test.py", line 1608, in main
    coverage.generate_coverage_report("build/coverage", "tests")
  File "/scylladb/scripts/coverage.py", line 161, in generate_coverage_report
    subprocess.check_call(genhtml_cmd + ["-o", html_report_path, info_path])
  File "/usr/lib64/python3.11/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['genhtml', '-q', '-o', 'build/coverage/tests', 'build/coverage/tests.info']' returned non-zero exit status 20.
```