### PR TITLE
raft: replication test: change rpc_propose_conf_change test to SEASTAR_THREAD_TEST_CASE

### DIFF
--- a/test/raft/replication_test.cc
+++ b/test/raft/replication_test.cc
@@ -305,7 +305,9 @@ RAFT_TEST_CASE(rpc_load_conf_from_log, (test_case{
 // Shrunk later to 2 nodes and then expanded back to 3 nodes.
 // Test that both configuration changes update RPC configuration correspondingly
 // on all nodes.
-RAFT_TEST_CASE(rpc_propose_conf_change, (test_case{
+// TODO: change to RAFT_TEST_CASE once it's stable for handling packet drops
+SEASTAR_THREAD_TEST_CASE(rpc_propose_conf_change) {
+    replication_test<lowres_clock>((test_case{
          .nodes = 3, .total_values = 0,
          .updates = {
             // Remove node C from the cluster configuration.
@@ -320,7 +322,9 @@ RAFT_TEST_CASE(rpc_propose_conf_change, (test_case{
             // also the newly integrated node gets the actual RPC configuration, too.
             check_rpc_config{{node_id{0},node_id{1},node_id{2}},
                              rpc_address_set{node_id{0},node_id{1},node_id{2}}},
-         }}));
+         }})
+    , false, tick_delta);
+}
 
 // 3 node cluster {A, B, C}.
 // Test that leader elections don't change RPC configuration.


### PR DESCRIPTION

RAFT_TEST_CASE macro creates 2 test cases, one with random 20% packet loss named name_drops. The framework makes hard coded assumptions about leader which doesn't hold well in case of packet losses.

This short term fix disables the packet drop variant of the specified test. It should be safe to re-enable it once the whole framework is re-worked to remove these hard coded assumptions.

This PR fixes a bug. Hence we need to backport it.

Fixes: scylladb/scylladb#23816