### PR TITLE
database_test: fix race in test_drop_quarantined_sstables

### DIFF
--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1666,7 +1666,7 @@ SEASTAR_TEST_CASE(enable_drained_compaction_manager) {
 SEASTAR_TEST_CASE(test_drop_quarantined_sstables) {
     return do_with_cql_env_thread([] (cql_test_env& e) {
         e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 100; i++) {
             e.execute_cql(format("insert into cf (p, c) values ('key{}', {})", i * i, i)).get();
             e.db().invoke_on_all([] (replica::database& db) {
                 auto& cf = db.find_column_family("ks", "cf");
@@ -1687,15 +1687,20 @@ SEASTAR_TEST_CASE(test_drop_quarantined_sstables) {
         auto quarantined_count = e.db().map_reduce0(
             [] (replica::database& _db) -> future<size_t> {
                 auto& cf = _db.find_column_family("ks", "cf");
-                std::atomic<size_t> quarantined_on_shard = 0;
+                size_t quarantined_on_shard = 0;
+                auto& cm = cf.get_compaction_manager();
                 co_await cf.parallel_foreach_compaction_group_view([&] (compaction::compaction_group_view& ts) -> future<> {
-                    auto sstables = co_await in_strategy_sstables(ts);
-                    if (sstables.empty()) {
-                        co_return;
-                    }
-                    auto idx = tests::random::get_int<size_t>(0, sstables.size() - 1);
-                    quarantined_on_shard++;
-                    co_await sstables[idx]->change_state(sstables::sstable_state::quarantine);
+                    return cm.run_with_compaction_disabled(ts, [&] () -> future<> {
+                        auto sstables = co_await in_strategy_sstables(ts);
+                        if (sstables.empty()) {
+                            co_return;
+                        }
+                        auto quarantine_n = 1 + tests::random::get_int<size_t>(sstables.size() / 5);
+                        quarantined_on_shard += quarantine_n;
+                        for (size_t i = 0; i < quarantine_n; i++) {
+                            co_await sstables[i]->change_state(sstables::sstable_state::quarantine);
+                        }
+                    });
                 });
                 co_return quarantined_on_shard;
             },


### PR DESCRIPTION
The test_drop_quarantined_sstables test could fail due to a race between
compaction and quarantining of SSTables. If compaction selects
an SSTable before it is moved to quarantine, and change_state is called during
compaction, the SSTable may already be removed, resulting in a
std::filesystem_error due to missing files.

This patch resolves the issue by wrapping the quarantine operation inside
run_with_compaction_disabled(). This ensures compaction is paused on the
compaction group view while SSTables are being quarantined, preventing the
race.

Additionally, updates the test to quarantine up to 1/5 SSTables instead
of one randomly and increases the number of sstables genereted to improve
test scenario.

Fixes scylladb/scylladb#25487

Backport is not required, test_drop_quarantined_sstables wasn't included in previous releases