### PR TITLE
cql3: Fix crash on ANN OF query when TRACING ON is enabled

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1174,7 +1174,9 @@ indexed_table_select_statement::do_execute(query_processor& qp,
                              service::query_state& state,
                              const query_options& options) const
 {
-    tracing::add_table_name(state.get_trace_state(), _view_schema->ks_name(), _view_schema->cf_name());
+    if (_view_schema) {
+        tracing::add_table_name(state.get_trace_state(), _view_schema->ks_name(), _view_schema->cf_name());
+    }
     tracing::add_table_name(state.get_trace_state(), keyspace(), column_family());
 
     auto cl = options.get_consistency();


### PR DESCRIPTION
cql3: Fix crash on ANN OF query when TRACING ON is enabled

Executing a vector search (SELECT with ANN OF ordering) query with `TRACING ON` enabled
caused a node to crash due to a null pointer dereference.

This occurred because a vector index does not have an associated view
table, making its `_view_schema` member null. The implementation
attempted to enable tracing on this null view schema, leading to the
crash.

The fix adds a null check for `_view_schema` before attempting to
enable tracing on the view (index) table.

A regression test is included to prevent this from happening again.

Fixes: VECTOR-179

No backport is needed, as the bug is not present in any released version.