### PR TITLE
test: test_maintenance_socket: use cluster_con for driver sessions

### DIFF
--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -8,6 +8,7 @@ from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import Cluster, NoHostAvailable
 from cassandra import Unauthorized
 from cassandra.connection import UnixSocketEndPoint
+from test.cluster.conftest import cluster_con
 from test.pylib.manager_client import ManagerClient
 
 import pytest
@@ -37,7 +38,8 @@ async def test_maintenance_socket(manager: ManagerClient):
     else:
         pytest.fail("Client should not be able to connect if auth provider is not specified")
 
-    cluster = Cluster([server.ip_addr], auth_provider=PlainTextAuthProvider(username="cassandra", password="cassandra"))
+    cluster = cluster_con([server.ip_addr], 9042, False,
+                          PlainTextAuthProvider(username="cassandra", password="cassandra"))
     session = cluster.connect()
 
     session.execute("CREATE ROLE john WITH PASSWORD = 'password' AND LOGIN = true;")
@@ -47,7 +49,8 @@ async def test_maintenance_socket(manager: ManagerClient):
     session.execute("CREATE TABLE ks2.t1 (pk int PRIMARY KEY, val int);")
     session.execute("GRANT SELECT ON ks1.t1 TO john;")
 
-    cluster = Cluster([server.ip_addr], auth_provider=PlainTextAuthProvider(username="john", password="password"))
+    cluster = cluster_con([server.ip_addr], 9042, False,
+                          PlainTextAuthProvider(username="john", password="password"))
     session = cluster.connect()
     try:
         session.execute("SELECT * FROM ks2.t1")
@@ -56,7 +59,7 @@ async def test_maintenance_socket(manager: ManagerClient):
     else:
         pytest.fail("User 'john' has no permissions to access ks2.t1")
 
-    maintenance_cluster = Cluster([UnixSocketEndPoint(socket)])
+    maintenance_cluster = cluster_con([UnixSocketEndPoint(socket)], 9042, False)
     maintenance_session = maintenance_cluster.connect()
 
     # check that the maintenance session has superuser permissions


### PR DESCRIPTION
The test creates all driver sessions by itself. As a consequence, all
sessions use the default request timeout of 10s. This can be too low for
the debug mode, as observed in scylladb/scylla-enterprise#5601.

In this commit, we change the test to use `cluster_con`, so that the
sessions have the request timeout set to 200s from now on.

Fixes scylladb/scylla-enterprise#5601

This commit changes only the test and is a CI stability improvement,
so it should be backported all the way to 2024.2. 2024.1 doesn't have
this test.