### PR TITLE
test/cluster/conftest: cluster_con: provide default values for port and use_ssl

### DIFF
--- a/test/cluster/auth_cluster/test_maintenance_socket.py
+++ b/test/cluster/auth_cluster/test_maintenance_socket.py
@@ -38,8 +38,8 @@ async def test_maintenance_socket(manager: ManagerClient):
     else:
         pytest.fail("Client should not be able to connect if auth provider is not specified")
 
-    cluster = cluster_con([server.ip_addr], 9042, False,
-                          PlainTextAuthProvider(username="cassandra", password="cassandra"))
+    cluster = cluster_con([server.ip_addr],
+                          auth_provider=PlainTextAuthProvider(username="cassandra", password="cassandra"))
     session = cluster.connect()
 
     session.execute("CREATE ROLE john WITH PASSWORD = 'password' AND LOGIN = true;")
@@ -49,8 +49,7 @@ async def test_maintenance_socket(manager: ManagerClient):
     session.execute("CREATE TABLE ks2.t1 (pk int PRIMARY KEY, val int);")
     session.execute("GRANT SELECT ON ks1.t1 TO john;")
 
-    cluster = cluster_con([server.ip_addr], 9042, False,
-                          PlainTextAuthProvider(username="john", password="password"))
+    cluster = cluster_con([server.ip_addr], auth_provider=PlainTextAuthProvider(username="john", password="password"))
     session = cluster.connect()
     try:
         session.execute("SELECT * FROM ks2.t1")
@@ -59,7 +58,7 @@ async def test_maintenance_socket(manager: ManagerClient):
     else:
         pytest.fail("User 'john' has no permissions to access ks2.t1")
 
-    maintenance_cluster = cluster_con([UnixSocketEndPoint(socket)], 9042, False)
+    maintenance_cluster = cluster_con([UnixSocketEndPoint(socket)])
     maintenance_session = maintenance_cluster.connect()
 
     # check that the maintenance session has superuser permissions

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -100,7 +100,8 @@ class CustomConnection(Cluster.connection_class):
 
 
 # cluster_con helper: set up client object for communicating with the CQL API.
-def cluster_con(hosts: list[IPAddress | EndPoint], port: int, use_ssl: bool, auth_provider=None, load_balancing_policy=RoundRobinPolicy()):
+def cluster_con(hosts: list[IPAddress | EndPoint], port: int = 9042, use_ssl: bool = False, auth_provider=None,
+                load_balancing_policy=RoundRobinPolicy()):
     """Create a CQL Cluster connection object according to configuration.
        It does not .connect() yet."""
     assert len(hosts) > 0, "python driver connection needs at least one host to connect to"

--- a/test/cluster/test_initial_token.py
+++ b/test/cluster/test_initial_token.py
@@ -20,10 +20,8 @@ async def test_initial_token(manager: ManagerClient) -> None:
     cfg2 = {'initial_token': f"{tokens[2]}, {tokens[3]}"}
     s1 = await manager.server_add(config=cfg1)
     s2 = await manager.server_add(config=cfg2)
-    cql1 = cluster_con([s1.ip_addr], 9042, False,
-                        load_balancing_policy=WhiteListRoundRobinPolicy([s1.ip_addr])).connect()
-    cql2 = cluster_con([s2.ip_addr], 9042, False,
-                        load_balancing_policy=WhiteListRoundRobinPolicy([s2.ip_addr])).connect()
+    cql1 = cluster_con([s1.ip_addr], load_balancing_policy=WhiteListRoundRobinPolicy([s1.ip_addr])).connect()
+    cql2 = cluster_con([s2.ip_addr], load_balancing_policy=WhiteListRoundRobinPolicy([s2.ip_addr])).connect()
     res1 = cql1.execute("SELECT tokens From system.local").one()
     res2 = cql2.execute("SELECT tokens From system.local").one()
     assert all([i in res1.tokens for i in tokens[:2]]) and all([i in res2.tokens for i in tokens[-2:]])

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -30,7 +30,7 @@ async def test_maintenance_mode(manager: ManagerClient):
     server_a, server_b = await manager.server_add(), await manager.server_add()
     socket_endpoint = UnixSocketEndPoint(await manager.server_get_maintenance_socket_path(server_a.server_id))
 
-    cluster = cluster_con([server_b.ip_addr], 9042, False)
+    cluster = cluster_con([server_b.ip_addr])
     cql = cluster.connect()
 
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'SimpleStrategy', 'replication_factor': 1}") as ks:
@@ -69,7 +69,7 @@ async def test_maintenance_mode(manager: ManagerClient):
         # Check that the regular CQL port is not available
         assert socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect_ex((server_a.ip_addr, 9042)) != 0
 
-        maintenance_cluster = cluster_con([socket_endpoint], 9042, False,
+        maintenance_cluster = cluster_con([socket_endpoint],
                                         load_balancing_policy=WhiteListRoundRobinPolicy([socket_endpoint]))
         maintenance_cql = maintenance_cluster.connect()
 

--- a/test/cluster/test_metadata_id.py
+++ b/test/cluster/test_metadata_id.py
@@ -18,7 +18,7 @@ async def create_server_and_cqls(manager, cqls_num):
     server = await manager.server_add()
 
     def create_cluster_connection():
-        return cluster_con([server.ip_addr], 9042, False,
+        return cluster_con([server.ip_addr],
             load_balancing_policy=WhiteListRoundRobinPolicy([server.ip_addr])).connect()
 
     return tuple(create_cluster_connection() for _ in range(cqls_num))

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -128,9 +128,9 @@ async def test_query_dc_with_rf_0_does_not_crash_db(request: pytest.FixtureReque
             property_file={"dc": f"dc{i}", "rack": "myrack"},
         ))
 
-    dc1_connection = cluster_con([servers[0].ip_addr], 9042, False,
+    dc1_connection = cluster_con([servers[0].ip_addr],
                                  load_balancing_policy=WhiteListRoundRobinPolicy([servers[0].ip_addr])).connect()
-    dc2_connection = cluster_con([servers[1].ip_addr], 9042, False,
+    dc2_connection = cluster_con([servers[1].ip_addr],
                                  load_balancing_policy=WhiteListRoundRobinPolicy([servers[1].ip_addr])).connect()
 
     random_tables = RandomTables(request.node.name, manager, ks, 1, dc_replication)

--- a/test/cluster/test_no_removed_node_event_on_ip_change.py
+++ b/test/cluster/test_no_removed_node_event_on_ip_change.py
@@ -41,7 +41,7 @@ async def test_no_removed_node_event_on_ip_change(manager: ManagerClient, caplog
     # is goes to the first node, so that we get the TOPOLOGY_CHANGE notifications
     # about the second.
     test_cluster: Cluster
-    with cluster_con([servers[0].ip_addr, s1_old_ip, s1_new_ip], manager.port, manager.use_ssl,
+    with cluster_con([servers[0].ip_addr, s1_old_ip, s1_new_ip],
                      load_balancing_policy=WhiteListRoundRobinPolicy([servers[0].ip_addr])) as test_cluster:
         logger.info("connecting driver")
         test_cql: Session

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -122,7 +122,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
     # replica, 1 pending replica, CL=LOCAL_QUORUM requires 2 normal replicas). So, we can start sending writes to dc2
     # only after increasing RF to 3, which we do - see finish_writes_dc2.
     dc1_cql = cluster_con(
-            [srv.ip_addr for srv in live_servers], 9042, False,
+            [srv.ip_addr for srv in live_servers],
             load_balancing_policy=WhiteListRoundRobinPolicy([srv.ip_addr for srv in live_servers])).connect()
     finish_writes_dc1 = await start_writes(dc1_cql, rf, ConsistencyLevel.LOCAL_QUORUM, concurrency=3, ks_name=ks_name)
 
@@ -194,7 +194,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
 
     # After increasing RF back to 3 in dc2 (if remove_dead_nodes_with == "remove"), we can start sending writes to dc2.
     dc2_cql = cluster_con(
-            [srv.ip_addr for srv in new_servers], 9042, False,
+            [srv.ip_addr for srv in new_servers],
             load_balancing_policy=WhiteListRoundRobinPolicy([srv.ip_addr for srv in new_servers])).connect()
     finish_writes_dc2 = await start_writes(dc2_cql, rf, ConsistencyLevel.LOCAL_QUORUM, concurrency=3, ks_name=ks_name)
 

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -83,7 +83,7 @@ async def test_raft_voters_multidc_kill_dc(manager: ManagerClient, num_nodes: in
     logging.info('Creating connections to all DCs')
     dc_cqls = []
     for servers in dc_servers:
-        dc_cqls.append(cluster_con([servers[0].ip_addr], 9042, False,
+        dc_cqls.append(cluster_con([servers[0].ip_addr],
                                    load_balancing_policy=WhiteListRoundRobinPolicy([servers[0].ip_addr])).connect())
 
     assert len(dc_cqls) == len(dc_servers)

--- a/test/cluster/test_topology_recovery_basic.py
+++ b/test/cluster/test_topology_recovery_basic.py
@@ -37,9 +37,9 @@ async def test_topology_recovery_basic(request, build_mode: str, manager: Manage
     # The zero-token node requires a different cql session not to be ignored by the driver because of empty tokens in
     # the system.peers table.
     # We need one cql session for both token-owning nodes to continue the write workload during the rolling restart.
-    cql_normal = cluster_con([servers[0].ip_addr, servers[2].ip_addr], 9042, False, load_balancing_policy=
+    cql_normal = cluster_con([servers[0].ip_addr, servers[2].ip_addr], load_balancing_policy=
                              WhiteListRoundRobinPolicy([servers[0].ip_addr, servers[2].ip_addr])).connect()
-    cql_zero_token = cluster_con([servers[1].ip_addr], 9042, False, load_balancing_policy=
+    cql_zero_token = cluster_con([servers[1].ip_addr], load_balancing_policy=
                                  WhiteListRoundRobinPolicy([servers[1].ip_addr])).connect()
     # In the whole test, cqls[i] and hosts[i] correspond to servers[i].
     cqls = [cql_normal, cql_zero_token, cql_normal]
@@ -90,9 +90,9 @@ async def test_topology_recovery_basic(request, build_mode: str, manager: Manage
         nonlocal cqls
         cql_normal.shutdown()
         cql_zero_token.shutdown()
-        cql_normal = cluster_con([servers[0].ip_addr, servers[2].ip_addr], 9042, False, load_balancing_policy=
+        cql_normal = cluster_con([servers[0].ip_addr, servers[2].ip_addr], load_balancing_policy=
                                  WhiteListRoundRobinPolicy([servers[0].ip_addr, servers[2].ip_addr])).connect()
-        cql_zero_token = cluster_con([servers[1].ip_addr], 9042, False, load_balancing_policy=
+        cql_zero_token = cluster_con([servers[1].ip_addr], load_balancing_policy=
                                      WhiteListRoundRobinPolicy([servers[1].ip_addr])).connect()
         cqls = [cql_normal, cql_zero_token, cql_normal]
 
@@ -153,7 +153,7 @@ async def test_topology_recovery_basic(request, build_mode: str, manager: Manage
 
     logging.info("Booting new node")
     servers += [await manager.server_add(config=normal_cfg)]
-    cqls += [cluster_con([servers[3].ip_addr], 9042, False,
+    cqls += [cluster_con([servers[3].ip_addr],
                          load_balancing_policy=WhiteListRoundRobinPolicy([servers[3].ip_addr])).connect()]
     hosts += [cqls[3].hosts[0]]
     await asyncio.gather(*(wait_for_cql(cql, h, time.time() + 60) for cql, h in zip(cqls, hosts)))

--- a/test/cluster/test_topology_recovery_majority_loss.py
+++ b/test/cluster/test_topology_recovery_majority_loss.py
@@ -36,7 +36,7 @@ async def test_topology_recovery_after_majority_loss(request, manager: ManagerCl
         # In order to get the Host instance of a zero-token node, connect to it directly.
         # We cannot use the ManagerClient's session because it is connected to non-zero-token
         # nodes and, in that case, the zero-token nodes are ignored.
-        zero_token_node_session = cluster_con([server.ip_addr], 9042, False, load_balancing_policy=
+        zero_token_node_session = cluster_con([server.ip_addr], load_balancing_policy=
                                           WhiteListRoundRobinPolicy([server.ip_addr])).connect()
         return zero_token_node_session.hosts[0]
 

--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -40,9 +40,9 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
         servers.append(await manager.server_add(config=normal_cfg, property_file=property_file_dc2))
 
     logging.info('Creating connections to dc1 and dc2')
-    dc1_cql = cluster_con([servers[0].ip_addr], 9042, False,
+    dc1_cql = cluster_con([servers[0].ip_addr],
                           load_balancing_policy=WhiteListRoundRobinPolicy([servers[0].ip_addr])).connect()
-    dc2_cql = cluster_con([servers[2].ip_addr], 9042, False,
+    dc2_cql = cluster_con([servers[2].ip_addr],
                           load_balancing_policy=WhiteListRoundRobinPolicy([servers[2].ip_addr])).connect()
 
     ks_names = list[str]()

--- a/test/cluster/test_zero_token_nodes_no_replication.py
+++ b/test/cluster/test_zero_token_nodes_no_replication.py
@@ -29,9 +29,9 @@ async def test_zero_token_nodes_no_replication(manager: ManagerClient):
     await manager.server_add(property_file={"dc": "dc1", "rack": "r3"})
 
     logging.info(f'Initiating connections to {server_a} and {server_b}')
-    cql_a = cluster_con([server_a.ip_addr], 9042, False,
+    cql_a = cluster_con([server_a.ip_addr],
                         load_balancing_policy=WhiteListRoundRobinPolicy([server_a.ip_addr])).connect()
-    cql_b = cluster_con([server_b.ip_addr], 9042, False,
+    cql_b = cluster_con([server_b.ip_addr],
                         load_balancing_policy=WhiteListRoundRobinPolicy([server_b.ip_addr])).connect()
 
     logging.info('Creating tables for each replication strategy and tablets combination')


### PR DESCRIPTION
Some cluster tests use `cluster_con` when they need a different load
balancing policy or auth provider. However, no test uses a port
other than 9042 or enables SSL, but all tests must pass `9042, False`
because these parameters don't have default values. This makes the code
more verbose. Also, it's quite obvious that 9042 stands for port, but
it's not obvious what `False` is related to, so there is a need to check
the definition of `cluster_con` while reading any test that uses it.

No reason to backport, it's only a minor refactoring.