### PR TITLE
utils: mark crc barrett tables const

### DIFF
--- a/utils/gz/crc_combine_table.cc
+++ b/utils/gz/crc_combine_table.cc
@@ -53,10 +53,10 @@ static constexpr int radix_bits = 8;
 static constexpr uint32_t one = 0x80000000; // x^0
 static constexpr auto pows = make_crc32_power_table<bits>(); // pows[i] = x^(2^i*8) mod G(x)
 
-constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_0 = make_crc32_table(0, radix_bits, one, pows);
-constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8 = make_crc32_table(8, radix_bits, one, pows);
-constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16 = make_crc32_table(16, radix_bits, one, pows);
-constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24 = make_crc32_table(24, radix_bits, one, pows);
+const constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_0 = make_crc32_table(0, radix_bits, one, pows);
+const constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8 = make_crc32_table(8, radix_bits, one, pows);
+const constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16 = make_crc32_table(16, radix_bits, one, pows);
+const constinit std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24 = make_crc32_table(24, radix_bits, one, pows);
 
 #else
 

--- a/utils/gz/crc_combine_table.hh
+++ b/utils/gz/crc_combine_table.hh
@@ -37,7 +37,7 @@
  *                                                (u >> 6) & 1,
  *                                                (u >> 7) & 1)
  */
-extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_0;
-extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8;
-extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16;
-extern std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24;
+extern const std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_0;
+extern const std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_8;
+extern const std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_16;
+extern const std::array<uint32_t, 256> crc32_x_pow_radix_8_table_base_24;


### PR DESCRIPTION
They're marked constinit, but constinit does not imply const. Since they're not supposed to be modified, mark them const too.

Tiny cleanup, not backporting.