### PR TITLE
sstables/types.hh: fix fmt::formatter<sstables::deletion_time>

### DIFF
--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -835,6 +835,6 @@ struct fmt::formatter<sstables::deletion_time> {
     auto format(const sstables::deletion_time& dt, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(),
                               "{{timestamp={}, deletion_time={}}}",
-                              dt.marked_for_delete_at, dt.marked_for_delete_at);
+                              dt.marked_for_delete_at, dt.local_deletion_time);
     }
 };


### PR DESCRIPTION
Obvious typo.

Fixes scylladb/scylladb#25556

Should be backported to all supported versions, but this is only used in debug logs, so it's not urgent.