### PR TITLE
docs: fix sidebar on local preview

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -179,7 +179,8 @@ html_theme_options = {
     'banner_button_text': 'Register for Free',
     'banner_button_url': 'https://lp.scylladb.com/university-live-2023-03-registration?siteplacement=docs',
     'banner_title_text': 'ScyllaDB University LIVE, FREE Virtual Training Event | March 21',
-    "collapse_navigation": 'true',
+    "navigation_depth": 3,
+    "collapse_navigation": 'false',
     "brand": "open-source" if FLAG == 'opensource' else "self-hosted",
 }
 


### PR DESCRIPTION
Before, the sidebar appeared misaligned when running locally:

<img width="767" height="884" alt="image" src="https://github.com/user-attachments/assets/64feeac9-0fa2-44ce-8aee-46d2cfaf87dd" />

Now:

<img width="1196" height="710" alt="image" src="https://github.com/user-attachments/assets/aa89ce36-9649-4a75-961a-d11e1190da3e" />
