### PR TITLE
cql3: add default replication factor to `create_keyspace_statement`

### DIFF
--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -173,6 +173,11 @@ sub-option                             type  description
                                              may prevent creating tables in that keyspace. 
 ===================================== ====== =============================================
 
+If no datacenters are specified, and ``replication_factor`` is left unspecified,
+then every rack in every datacenter receives a replica, except for racks comprised
+of only :doc:`zero-token nodes </architecture/zero-token-nodes>`. Racks added after
+the keyspace creation do not receive replicas.
+
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
 auto-expansion will only *add* new datacenters for safety, it will not alter
 existing datacenters or remove any even if they are no longer in the cluster.
@@ -211,6 +216,22 @@ An example that excludes class and uses only datacenter options::
 
     DESCRIBE KEYSPACE excalibur
         CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
+
+An example that excludes datacenter options and uses only class::
+
+    CREATE KEYSPACE excalibur
+        WITH replication = {'class': 'NetworkTopologyStrategy'} ;
+
+    DESCRIBE KEYSPACE excalibur
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '2'} AND durable_writes = true;
+
+An example that excludes both class and datacenter options::
+
+    CREATE KEYSPACE excalibur
+        WITH replication = {} ;
+
+    DESCRIBE KEYSPACE excalibur
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '2'} AND durable_writes = true;
 
 .. _tablets:
 

--- a/test/cluster/suite.yaml
+++ b/test/cluster/suite.yaml
@@ -21,6 +21,7 @@ run_first:
   - test_cluster_features
   - test_topology_remove_decom
   - test_mutation_schema_change
+  - test_keyspace_rf
 skip_in_release:
   - test_raft_cluster_features
   - test_cluster_features

--- a/test/cluster/test_keyspace_rf.py
+++ b/test/cluster/test_keyspace_rf.py
@@ -1,0 +1,91 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import pytest
+import logging
+
+from cassandra.policies import WhiteListRoundRobinPolicy
+from cassandra.protocol import ConfigurationException
+
+from test.pylib.manager_client import ManagerClient
+from test.cluster.conftest import cluster_con
+from test.cluster.util import create_new_test_keyspace
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("tablets_enabled", [True, False])
+@pytest.mark.parametrize("rf_rack_valid_keyspaces", [False, True])
+async def test_create_keyspace_with_default_replication_factor(manager: ManagerClient, tablets_enabled: bool, rf_rack_valid_keyspaces: bool):
+    def get_pf(dc: str, rack: str) -> dict:
+        return {'dc': dc, 'rack': rack}
+
+    logging.info("Trying to add a zero-token server in the gossip-based topology")
+    await manager.server_add(config={'join_ring': False,
+                                     'force_gossip_topology_changes': True,
+                                     'tablets_mode_for_new_keyspaces': 'disabled'},
+                             property_file={'dc': 'dc1', 'rack': 'rz'},
+                             expected_error='the raft-based topology is disabled')
+
+    normal_cfg = {
+        'tablets_mode_for_new_keyspaces': 'enabled' if tablets_enabled else 'disabled',
+        'rf_rack_valid_keyspaces': rf_rack_valid_keyspaces
+    }
+    zero_token_cfg = normal_cfg | {'join_ring': False}
+
+    logging.info("Adding the dc1/r1/s1 server")
+    server = await manager.server_add(config=normal_cfg, property_file=get_pf("dc1", "r1"))
+
+    logging.info("Adding dc1/rz rack server as zero-token")
+    await manager.server_add(config=zero_token_cfg, property_file=get_pf("dc1", "rz"))
+
+    logging.info("Adding dc1/r2 rack server")
+    await manager.server_add(config=normal_cfg, property_file=get_pf("dc1", "r2"))
+
+    logging.info("Adding dc2/r1 rack server")
+    await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r1"))
+
+    logging.info("Adding dc2/r2 rack server")
+    await manager.server_add(config=normal_cfg, property_file=get_pf("dc2", "r2"))
+
+    if rf_rack_valid_keyspaces == False:
+        logging.info("Adding dc3/rz1 rack server as zero-token")
+        await manager.server_add(config=zero_token_cfg, property_file=get_pf("dc3", "rz"))
+
+        logging.info("Adding dc3/rz2 rack server as zero-token")
+        await manager.server_add(config=zero_token_cfg, property_file=get_pf("dc3", "r2"))
+
+    cql = cluster_con([server.ip_addr], 9042, False,
+                        load_balancing_policy=WhiteListRoundRobinPolicy([server.ip_addr])).connect()
+
+    logging.info("Create NetworkTopologyStrategy keyspace with default replication factor")
+    ks_name = await create_new_test_keyspace(cql, f"""WITH replication =
+                                                {{'class': 'NetworkTopologyStrategy'}}
+                                                AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
+    rows = await cql.run_async(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks_name}'")
+    assert len(rows) == 1
+    assert rows[0].keyspace_name == ks_name
+    rep = rows[0].replication
+    assert len(rep) == 3
+    assert rep['class'] == 'org.apache.cassandra.locator.NetworkTopologyStrategy'
+    assert rep['dc1'] == '2'
+    assert rep['dc2'] == '2'
+
+    logging.info("Try to create SimpleStrategy keyspace with default replication factor")
+    with pytest.raises(ConfigurationException, match="SimpleStrategy requires a replication_factor strategy option."):
+        await create_new_test_keyspace(cql, f"""WITH replication =
+                                                {{'class': 'SimpleStrategy'}}
+                                                AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
+
+    logging.info("Create keyspace with default replication options")
+    ks_name = await create_new_test_keyspace(cql, f"""WITH replication =
+                                                {{}}
+                                                AND tablets = {{ 'enabled': {str(tablets_enabled).lower()} }}""")
+    rows = await cql.run_async(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks_name}'")
+    assert len(rows) == 1
+    assert rows[0].keyspace_name == ks_name
+    rep = rows[0].replication
+    assert len(rep) == 3
+    assert rep['class'] == 'org.apache.cassandra.locator.NetworkTopologyStrategy'
+    assert rep['dc1'] == '2'
+    assert rep['dc2'] == '2'

--- a/test/cqlpy/cassandra_tests/validation/operations/create_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/create_test.py
@@ -324,7 +324,6 @@ def testCreateKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, this_dc):
     execute(cql, n, "DROP KEYSPACE IF EXISTS %s")
 
 # Test {@link ConfigurationException} is not thrown on create NetworkTopologyStrategy keyspace without any options.
-@pytest.mark.xfail(reason="Issue #16028")
 def testCreateKeyspaceWithNetworkTopologyStrategyNoOptions(cql):
     n = unique_name()
     execute(cql, n, "CREATE KEYSPACE %s with replication = { 'class': 'NetworkTopologyStrategy' }")


### PR DESCRIPTION
When creating a new keyspace, replication factor must be stated.
For example:
`CREATE KEYSPACE ks WITH REPLICATION { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 };`

This patch changes it in the following way - if there is no
replication factor specified, use default replication factor.
Default replication factor is equal to the number of racks that
are not arbiter-only, i.e. racks that have at least one non-arbiter node.
The following syntax is now valid:
`CREATE KEYSPACE ks WITH REPLICATION { 'class': 'NetworkTopologyStrategy' };`
`CREATE KEYSPACE ks WITH REPLICATION { };`

Fixes #16028 

Backport is not needed. This is an enhancement for future releases.