### PR TITLE
auth: allow dropping roles in saslauthd_authenticator

### DIFF
--- a/auth/saslauthd_authenticator.cc
+++ b/auth/saslauthd_authenticator.cc
@@ -182,7 +182,7 @@ future<> saslauthd_authenticator::alter(std::string_view role_name, const authen
 }
 
 future<> saslauthd_authenticator::drop(std::string_view name, ::service::group0_batch& mc) {
-    throw exceptions::authentication_exception("Cannot delete passwords with SaslauthdAuthenticator");
+    return make_ready_future<>();
 }
 
 future<custom_options> saslauthd_authenticator::query_custom_options(std::string_view role_name) const {

--- a/test/ldap/saslauthd_authenticator_test.cc
+++ b/test/ldap/saslauthd_authenticator_test.cc
@@ -187,7 +187,7 @@ SEASTAR_TEST_CASE(alter) {
 
 SEASTAR_TEST_CASE(drop) {
     return do_with_authenticator_thread([] (auth::authenticator& authr, service::group0_batch& b) {
-        BOOST_REQUIRE_EXCEPTION(authr.drop("jdoe", b).get(), authentication_exception, message_contains("Cannot delete"));
+        authr.drop("jdoe", b).get(); // Just wait for empty future
     });
 }
 


### PR DESCRIPTION
Before this change, `saslauthd_authenticator` prevented dropping roles. The current documentation instructs users to `Ensure Scylla has the same users and roles as listed in the LDAP directory`. Therefore, ScyllaDB should allow dropping roles so administrators can remove obsolete roles from both LDAP and ScyllaDB.

The code change is minimal — dropping a role is a no-op, similar to the existing no-op implementations for successful `create` and `alter` operations.

Fixes: scylladb/scylladb#25571

New feature, no backport.