### PR TITLE
treewide: avoid including gms/feature_service.hh from headers

### DIFF
--- a/index/secondary_index_manager.hh
+++ b/index/secondary_index_manager.hh
@@ -10,7 +10,6 @@
 
 #pragma once
 
-#include "gms/feature_service.hh"
 #include "schema/schema.hh"
 
 #include "data_dictionary/data_dictionary.hh"
@@ -23,6 +22,12 @@
 namespace cql3::expr {
 
 enum class oper_t;
+
+}
+
+namespace gms {
+
+class feature_service;
 
 }
 

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -15,7 +15,6 @@
 
 #include "utils/log.hh"
 #include "raft/raft.hh"
-#include "gms/feature_service.hh"
 #include "service/endpoint_lifecycle_subscriber.hh"
 #include "service/topology_state_machine.hh"
 
@@ -26,6 +25,7 @@ class system_distributed_keyspace;
 
 namespace gms {
 class gossiper;
+class feature_service;
 }
 
 namespace netw {


### PR DESCRIPTION
To avoid dependency proliferation, switch to forward declarations.

In one case, we introduce indirection via std::unique_ptr and deinline the constructor and destructor.

Ref #1

Tiny build time improvement, no backport.