### PR TITLE
test.py: dtest/commitlog_test: add test_pinned_cl_segment_doesnt_resurrect_data

### DIFF
--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -557,6 +557,13 @@ class ScyllaNode:
             cmd.append(table)
         self.nodetool(" ".join(cmd), **kwargs)
 
+    def compact(self, keyspace: str = "", tables: str | None = ()) -> None:
+        compact_cmd = ["compact"]
+        if keyspace:
+            compact_cmd.append(keyspace)
+        compact_cmd += tables
+        self.nodetool(" ".join(compact_cmd))
+
     def drain(self, block_on_log: bool = False) -> None:
         mark = self.mark_log()
         self.nodetool("drain")


### PR DESCRIPTION
`test_pinned_cl_segment_doesnt_resurrect_data` was not moved in #24946 from scylla-dtest to this repo, because it's marked as xfail (#14879), but actually the issue is fixed and there is no reason to keep the test in scylla-dtest.

Also remove unused imports.
