### PR TITLE
Fix dbuild boost::gregorian usage error

### DIFF
--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -24,6 +24,7 @@
 #include "test/lib/tmpdir.hh"
 #include "test/lib/exception_utils.hh"
 #include "test/lib/test_utils.hh"
+#include "boost/date_time/gregorian/gregorian_types.hpp"
 
 BOOST_AUTO_TEST_SUITE(user_function_test)
 


### PR DESCRIPTION
On my dbuild runs, compiler complained about no member "gregorian" in namespace boost in the
`user_function_test.cc` file. Was also noticed in CI at https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/19055/console