### PR TITLE
Update urgent_issue_reminder.yml - run daily

### DIFF
--- a/.github/workflows/urgent_issue_reminder.yml
+++ b/.github/workflows/urgent_issue_reminder.yml
@@ -2,7 +2,7 @@ name: Urgent Issue Reminder
 
 on:
   schedule:
-    - cron: '10 8 * * 1' # Runs every Monday at 8 AM
+    - cron: '10 8 * * *' # Runs daily at 8 AM
 
 jobs:
   reminder:


### PR DESCRIPTION
The action will run daily, alerting about urgent issues not touched in the last 7 days.

No need to backport github actions.