### PR TITLE
cmake: Add missing `incremental.cc` to `repair/CMakeLists.txt`

### DIFF
--- a/repair/CMakeLists.txt
+++ b/repair/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(repair STATIC)
 target_sources(repair
   PRIVATE
     repair.cc
-    row_level.cc)
+    row_level.cc
+    incremental.cc)
 target_include_directories(repair
   PUBLIC
     ${CMAKE_SOURCE_DIR})


### PR DESCRIPTION
Add `incremental.cc` to `repair/CMakeLists.txt` to fix CMake based build

I guess no backport needed since we dont use CMake build in our CI