### PR TITLE
cas: pass timeout_if_partially_accepted := write to accept_proposal()

### DIFF
--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -8,7 +8,7 @@ from cassandra import WriteFailure
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement, ConsistencyLevel
-from cassandra.protocol import InvalidRequest, ReadTimeout
+from cassandra.protocol import InvalidRequest, WriteTimeout
 from cassandra import Unauthorized
 
 from test.cluster.util import new_test_keyspace, unique_name, reconnect_driver
@@ -684,7 +684,7 @@ async def test_lwt_coordinator_shard(manager: ManagerClient):
 @pytest.mark.asyncio
 @skip_mode('debug', 'dev is enought: the test checks non-critical functionality')
 @skip_mode('release', 'error injections are not supported in release mode')
-async def test_error_message_for_timeout_due_to_uncertainty(manager: ManagerClient):
+async def test_error_message_for_timeout_due_to_write_uncertainty(manager: ManagerClient):
     # LWT can sometimes return WriteTimeout when it is uncertain whether the transaction
     # was applied. In this case, the user should retry the transaction.
     #
@@ -725,7 +725,66 @@ async def test_error_message_for_timeout_due_to_uncertainty(manager: ManagerClie
         log0 = await manager.server_open_log(servers[0].server_id)
 
         logger.info(f"Start LWT1 on {hosts[0]}")
-        lwt_task = cql.run_async(SimpleStatement(f"SELECT * FROM {ks}.test WHERE pk = 1;",
+        lwt_task = cql.run_async(SimpleStatement(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 1) IF NOT EXISTS;"),
+                                 host=hosts[0])
+
+        logger.info(
+            "Wait for the coordinator to process error from the first node")
+        await log0.wait_for('accept_proposal: failure while sending proposal')
+
+        logger.info(f"Run LWT2 on {hosts[1]}")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 2) IF NOT EXISTS", host=hosts[1])
+
+        logger.info("Trigger paxos_accept_proposal_wait")
+        await manager.api.message_injection(servers[1].ip_addr, "paxos_accept_proposal_wait")
+
+        with pytest.raises(WriteTimeout, match="write timeout due to uncertainty(.*)injected_error_before_save_proposal"):
+            await lwt_task
+
+
+@pytest.mark.asyncio
+@skip_mode('debug', 'dev is enought')
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_no_uncertainty_for_reads(manager: ManagerClient):
+    # This test verifies that LWT reads do not produce 'uncertainty' timeouts.
+    #
+    # The scenario is similar to the write-uncertainty test:
+    # 1. The cluster has three nodes. The first node is configured to fail on accept,
+    #    and the second node is configured to block until explicitly signaled by the test.
+    # 2. Run a read LWT on the first node and wait until the coordinator processes an accept error
+    #    from the first node.
+    # 3. Run another LWT, which should invalidate all promises from the first one.
+    # 4. Signal the second node to proceed with accept; it must return a reject.
+    # 5. At this point, the coordinator is uncertain about the outcome of the first LWT. Any subsequent LWT
+    #    might either complete its Paxos round (if a quorum of promises observed the accept) or
+    #    overwrite it (if a quorum did not). Since the first LWT is read-only, the coordinator retries it
+    #    transparently and returns the effects of the second LWT to the client.
+
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'paxos=trace'
+    ]
+    servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="mydc")
+    (cql, hosts) = await manager.get_ready_cql(servers)
+
+    logger.info("Create a keyspace")
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+        logger.info("Create a table")
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+
+        # accept on the first node returns an error
+        logger.info("Inject paxos_error_before_save_proposal")
+        await inject_error_one_shot_on(manager, "paxos_error_before_save_proposal", [servers[0]])
+
+        # accept on the second node returns reject
+        logger.info("Inject paxos_accept_proposal_wait")
+        await inject_error_one_shot_on(manager, "paxos_accept_proposal_wait", [servers[1]])
+
+        logger.info("Open log")
+        log0 = await manager.server_open_log(servers[0].server_id)
+
+        logger.info(f"Start LWT1 on {hosts[0]}")
+        lwt_read = cql.run_async(SimpleStatement(f"SELECT * FROM {ks}.test WHERE pk = 1;",
                                                  consistency_level=ConsistencyLevel.SERIAL),
                                  host=hosts[0])
 
@@ -739,5 +798,8 @@ async def test_error_message_for_timeout_due_to_uncertainty(manager: ManagerClie
         logger.info("Trigger paxos_accept_proposal_wait")
         await manager.api.message_injection(servers[1].ip_addr, "paxos_accept_proposal_wait")
 
-        with pytest.raises(ReadTimeout, match="write timeout due to uncertainty(.*)injected_error_before_save_proposal"):
-            await lwt_task
+        rows = await lwt_read
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.pk == 1
+        assert row.c == 2


### PR DESCRIPTION
Write requests cannot be safely retried if some replicas respond with accepts and others with rejects. In this case, the coordinator is uncertain about the outcome of the LWT: a subsequent LWT may either complete the Paxos round (if a quorum observed the accept) or overwrite it (if a quorum did not). If the original LWT was actually completed by later rounds and the coordinator retried it, the write could be applied twice, potentially overwriting effects of other LWTs that slipped in between. Read requests do not have this problem, so they can be safely retried.

Before this PR, handler->accept_proposal was called with timeout_if_partially_accepted := true. This caused both read and write requests to throw an "uncertainty" timeout to the user in the case of the contention described above. After this commit, we throw an "uncertainty" timeout only for write requests, while read requests are instead retried in the loop in sp::cas.

backport: not needed -- this is an improvement, not a bug fix.