### PR TITLE
api: storage_service: fix token_range documentation

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3345,11 +3345,11 @@
          "properties":{
             "start_token":{
                "type":"string",
-               "description":"The range start token"
+               "description":"The range start token (exclusive)"
             },
             "end_token":{
                "type":"string",
-               "description":"The range start token"
+               "description":"The range end token (inclusive)"
             },
             "endpoints":{
                "type":"array",


### PR DESCRIPTION
Note that the token_range type is used only by describe_ring.

* doc issues exists in all releases, backport required