### PR TITLE
test.py: don't fail if use multiple tests from one dir in commandline

### DIFF
--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 TEST_CONFIG_FILENAME = "test_config.yaml"
 
-REPEATED_FILES = pytest.StashKey[set[pathlib.Path]]()
+REPEATING_FILES = pytest.StashKey[set[pathlib.Path]]()
 BUILD_MODE = pytest.StashKey[str]()
 RUN_ID = pytest.StashKey[int]()
 
@@ -205,8 +205,8 @@ def pytest_collect_file(file_path: pathlib.Path,
                         parent: pytest.Collector) -> Generator[None, list[pytest.Collector], list[pytest.Collector]]:
     collectors = yield
 
-    if len(collectors) == 1 and file_path not in parent.stash.setdefault(REPEATED_FILES, set()):
-        parent.stash[REPEATED_FILES].add(file_path)
+    if len(collectors) == 1 and file_path not in parent.stash.setdefault(REPEATING_FILES, set()):
+        parent.stash[REPEATING_FILES].add(file_path)
 
         build_modes = parent.config.build_modes
         if suite_config := TestSuiteConfig.from_pytest_node(node=collectors[0]):
@@ -227,6 +227,8 @@ def pytest_collect_file(file_path: pathlib.Path,
             collector.stash[BUILD_MODE] = build_mode
             collector.stash[RUN_ID] = run_id
             collector.stash[TEST_SUITE] = suite_config
+
+        parent.stash[REPEATING_FILES].remove(file_path)
 
     return collectors
 


### PR DESCRIPTION
There is the stash item `REPEATED_FILES` for directory items which used to cut recursion.  But if multiple tests from one directory added to `./test.py` commandline this solution prevents handling non-first tests well because it was already collected for the first one.  Change behavior to not store all repeated files in the stash but just files which are in the process of repetition.  Rename the stash item to `REPEATING_FILES` to reflect this change.

Example of failure: 

```python
$ ./test.py --list test/boost/cql_query_test.cc test/boost/group0_cmd_merge_test.cc
...
_______________ ERROR collecting boost/group0_cmd_merge_test.cc ________________
test/pylib/cpp/base.py:127: in collect
    custom_args = self.suite_config.get("custom_args", {}).get(self.test_name, DEFAULT_CUSTOM_ARGS)
/usr/lib64/python3.13/functools.py:1026: in __get__
    val = self.func(instance)
test/pylib/cpp/base.py:85: in suite_config
    return self.stash[TEST_SUITE].cfg
/usr/lib/python3.13/site-packages/_pytest/stash.py:84: in __getitem__
    return cast(T, self._storage[key])
E   KeyError: <_pytest.stash.StashKey object at 0x7387a87ddbc0>
```