### PR TITLE
alternator: make number of backlog connections for server sockets configurable

### DIFF
--- a/alternator/controller.cc
+++ b/alternator/controller.cc
@@ -153,7 +153,8 @@ future<> controller::start_server() {
                     _config.alternator_warn_authorization,
                     _config.alternator_max_users_query_size_in_trace_output,
                     &_memory_limiter.local().get_semaphore(),
-                    _config.max_concurrent_requests_per_shard);
+                    _config.max_concurrent_requests_per_shard,
+                    _config.alternator_listen_socket_backlog);
         }).handle_exception([this, addr, alternator_port, alternator_https_port, alternator_port_proxy_protocol, alternator_https_port_proxy_protocol] (std::exception_ptr ep) {
             logger.error("Failed to set up Alternator HTTP server on {} port {}, TLS port {}, proxy-protocol port {}, TLS proxy-protocol port {}: {}",
                     addr,

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -908,7 +908,7 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
         std::optional<uint16_t> port_proxy_protocol, std::optional<uint16_t> https_port_proxy_protocol,
         std::optional<tls::credentials_builder> creds,
         utils::updateable_value<bool> enforce_authorization, utils::updateable_value<bool> warn_authorization, utils::updateable_value<uint64_t> max_users_query_size_in_trace_output,
-        semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests) {
+        semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests, utils::updateable_value<uint32_t> listen_socket_backlog) {
     _memory_limiter = memory_limiter;
     _enforce_authorization = std::move(enforce_authorization);
     _warn_authorization = std::move(warn_authorization);
@@ -918,18 +918,26 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
         return make_exception_future<>(std::runtime_error("Either regular port or TLS port"
                 " must be specified in order to init an alternator HTTP server instance"));
     }
-    return seastar::async([this, addr, port, https_port, port_proxy_protocol, https_port_proxy_protocol, creds] {
+    return seastar::async([this, addr, port, https_port, port_proxy_protocol, https_port_proxy_protocol, creds, listen_socket_backlog = std::move(listen_socket_backlog)] {
         _executor.start().get();
 
+        _listen_socket_backlog_observer.emplace(listen_socket_backlog.observe([this] (const uint32_t& backlog_val) {
+            for (auto& server : _enabled_servers) {
+                server.get().set_listen_backlog(static_cast<int>(std::min(backlog_val, uint32_t(INT_MAX))));
+            }
+        }));
+        listen_options socket_listen_opts {
+            .reuse_address = true,
+            .listen_backlog = static_cast<int>(std::min(listen_socket_backlog(), uint32_t(INT_MAX))),
+        };
         if (port || port_proxy_protocol) {
             set_routes(_http_server._routes);
             _http_server.set_content_streaming(true);
             if (port) {
-                _http_server.listen(socket_address{addr, *port}).get();
+                _http_server.listen(socket_address{addr, *port}, socket_listen_opts).get();
             }
             if (port_proxy_protocol) {
-                listen_options lo;
-                lo.reuse_address = true;
+                listen_options lo = socket_listen_opts;
                 lo.proxy_protocol = true;
                 _http_server.listen(socket_address{addr, *port_proxy_protocol}, lo).get();
             }
@@ -956,11 +964,10 @@ future<> server::init(net::inet_address addr, std::optional<uint16_t> port, std:
                 _credentials = creds->build_server_credentials();
             }
             if (https_port) {
-                _https_server.listen(socket_address{addr, *https_port}, _credentials).get();
+                _https_server.listen(socket_address{addr, *https_port}, socket_listen_opts, _credentials).get();
             }
             if (https_port_proxy_protocol) {
-                listen_options lo;
-                lo.reuse_address = true;
+                listen_options lo = socket_listen_opts;
                 lo.proxy_protocol = true;
                 _https_server.listen(socket_address{addr, *https_port_proxy_protocol}, lo, _credentials).get();
             }

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -56,6 +56,7 @@ class server : public peering_sharded_service<server> {
     // timeouts separately. We can create this object only once.
     updateable_timeout_config _timeout_config;
     client_options_cache_type _connection_options_keys_and_values;
+    std::optional<utils::observer<uint32_t>> _listen_socket_backlog_observer;
 
     alternator_callbacks_map _callbacks;
 
@@ -104,7 +105,7 @@ public:
             std::optional<uint16_t> port_proxy_protocol, std::optional<uint16_t> https_port_proxy_protocol,
             std::optional<tls::credentials_builder> creds,
             utils::updateable_value<bool> enforce_authorization, utils::updateable_value<bool> warn_authorization, utils::updateable_value<uint64_t> max_users_query_size_in_trace_output,
-            semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests);
+            semaphore* memory_limiter, utils::updateable_value<uint32_t> max_concurrent_requests, utils::updateable_value<uint32_t> listen_socket_backlog);
     future<> stop();
     // get_client_data() is called (on each shard separately) when the virtual
     // table "system.clients" is read. It is expected to generate a list of

--- a/db/config.cc
+++ b/db/config.cc
@@ -1514,6 +1514,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "\t1-9: Compression levels (1 = fastest, 9 = best compression)")
     , alternator_response_compression_threshold_in_bytes(this, "alternator_response_compression_threshold_in_bytes", liveness::LiveUpdate, value_status::Used, uint64_t(4096),
             "When the compression is enabled, this value indicates the minimum size of data to compress. Smaller responses will not be compressed.")
+    , alternator_listen_socket_backlog(this, "alternator_listen_socket_backlog", liveness::LiveUpdate, value_status::Used, 1024, "The max. queue length of pending connections for socket listening to Alternator requests.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
             "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -495,6 +495,7 @@ public:
     named_value<uint32_t> alternator_describe_table_info_cache_validity_in_seconds;
     named_value<int> alternator_response_gzip_compression_level;
     named_value<uint32_t> alternator_response_compression_threshold_in_bytes;
+    named_value<uint32_t> alternator_listen_socket_backlog;
 
     named_value<bool> abort_on_ebadf;
 

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -26,6 +26,7 @@ from cassandra.auth import PlainTextAuthProvider
 import threading
 import random
 import re
+import subprocess
 
 from test.cluster.util import get_replication
 from test.pylib.manager_client import ManagerClient
@@ -63,6 +64,15 @@ def full_query(table, ConsistentRead=True, **kwargs):
             ConsistentRead=ConsistentRead, **kwargs)
         items.extend(response['Items'])
     return items
+
+def get_listen_backlog(ip: str, port: int) -> int:
+    """Get the TCP listen backlog (Send-Q) for a LISTEN socket via ss."""
+    result = subprocess.check_output(['ss', '-tlnH', f'src {ip}:{port}'], text=True)
+    for line in result.strip().split('\n'):
+        cols = line.split()
+        if len(cols) >= 4:
+            return int(cols[2])  # Send-Q = listen backlog for LISTEN sockets
+    raise RuntimeError(f"No LISTEN socket found on {ip}:{port}")
 
 # FIXME: boto3 is NOT async. So all tests that use it are not really async.
 # We could use the aioboto3 library to write a really asynchronous test, or
@@ -1393,3 +1403,45 @@ async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
 
     stop_event.set()
     t.join()
+
+@pytest.mark.asyncio
+async def test_alternator_listen_socket_backlog(manager: ManagerClient):
+    """Verify that alternator_listen_socket_backlog correctly sets the OS
+       socket backlog, and that live-updating it takes effect.
+       This also serves as a sanity check that reasonable backlog values
+       (e.g. 1111, 2048) are successfully settable and accepted by the
+       kernel without being silently clamped or rejected."""
+    initial_backlog = 1111
+    https_port = 8043
+    config = {
+        **alternator_config,
+        'alternator_listen_socket_backlog': initial_backlog,
+        'alternator_https_port': https_port,
+        'alternator_encryption_options': {
+            'certificate': 'conf/scylla.crt',
+            'keyfile': 'conf/scylla.key',
+        },
+    }
+    servers = await manager.servers_add(1, config=config)
+    server = servers[0]
+    port = alternator_config['alternator_port']
+
+    # Verify the initial backlog value was applied to both HTTP and HTTPS
+    backlog = get_listen_backlog(server.ip_addr, port)
+    assert backlog == initial_backlog, \
+        f"Expected initial backlog {initial_backlog}, got {backlog}"
+    https_backlog = get_listen_backlog(server.ip_addr, https_port)
+    assert https_backlog == initial_backlog, \
+        f"Expected initial HTTPS backlog {initial_backlog}, got {https_backlog}"
+
+    # Live-update the backlog and verify it takes effect on both ports
+    updated_backlog = 2048
+    await manager.server_update_config(
+        server.server_id, 'alternator_listen_socket_backlog', updated_backlog)
+
+    async def backlog_updated():
+        if (get_listen_backlog(server.ip_addr, port) == updated_backlog and
+                get_listen_backlog(server.ip_addr, https_port) == updated_backlog):
+            return True
+        return None
+    await wait_for(backlog_updated, deadline=time.time() + 5, period=0.1)


### PR DESCRIPTION
Add new config variable `alternator_listen_socket_backlog` that is subsequently passed as a parameter to calls to `listen()`. The parameter influences HTTP and HTTPS server sockets of Alternator. Before the patch, the default Seastar limit of up to 100 backlog connections was used.
The default value (for Alternator) is now 1024.

refs: scylladb/scylla-enterprise#5614
refs: https://github.com/scylladb/seastar/pull/3312

The fix is required by a customer, therefore it needs to be backported.