### PR TITLE
treewide: include boost headers as "system" headers

### DIFF
--- a/serializer.hh
+++ b/serializer.hh
@@ -13,7 +13,7 @@
 #include "utils/managed_bytes.hh"
 #include "bytes_ostream.hh"
 #include <seastar/core/simple-stream.hh>
-#include "boost/variant/variant.hpp"
+#include <boost/variant/variant.hpp>
 #include "bytes_ostream.hh"
 #include "utils/fragment_range.hh"
 #include <variant>

--- a/test/boost/nonwrapping_interval_test.cc
+++ b/test/boost/nonwrapping_interval_test.cc
@@ -9,8 +9,8 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include "boost/icl/interval.hpp"
-#include "boost/icl/interval_map.hpp"
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
 #include <unordered_set>
 

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -24,7 +24,7 @@
 #include "test/lib/tmpdir.hh"
 #include "test/lib/exception_utils.hh"
 #include "test/lib/test_utils.hh"
-#include "boost/date_time/gregorian/gregorian_types.hpp"
+#include <boost/date_time/gregorian/gregorian_types.hpp>
 
 BOOST_AUTO_TEST_SUITE(user_function_test)
 

--- a/test/boost/wrapping_interval_test.cc
+++ b/test/boost/wrapping_interval_test.cc
@@ -9,7 +9,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include "boost/icl/interval_map.hpp"
+#include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 #include <fmt/ranges.h>


### PR DESCRIPTION
Boost is external to the project so treat its headers as "system" headers and include them with angle brackets.

Ultra-tiny cleanup, not backporting.