### PR TITLE
Support replication factor rack list for tablet-based keyspaces

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -16,6 +16,7 @@
 #include "cdc/cdc_options.hh"
 #include "auth/service.hh"
 #include "db/config.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "schema/schema_builder.hh"
 #include "exceptions/exceptions.hh"
@@ -5810,8 +5811,8 @@ future<executor::request_return_type> executor::describe_endpoints(client_state&
     co_return rjson::print(std::move(response));
 }
 
-static std::map<sstring, sstring> get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
-    std::map<sstring, sstring> options;
+static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
+    locator::replication_strategy_config_options options;
     for (const auto& dc : sp.get_token_metadata_ptr()->get_topology().get_datacenters()) {
         options.emplace(dc, std::to_string(rf));
     }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1724,7 +1724,8 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
             auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
             if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
                 locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
-                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
+                const auto& topo = sp.local_db().get_token_metadata().get_topology();
+                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
                 if (rs->uses_tablets()) {
                     co_return api_error::validation("Streams not yet supported on a table using tablets (issue #23838). "
                     "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -5853,14 +5853,33 @@ future<executor::request_return_type> executor::describe_continuous_backups(clie
 // A smaller cluster (presumably, a test only), gets RF=1. The user may
 // manually create the keyspace to override this predefined behavior.
 static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts, const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat) {
-    int endpoint_count = gossiper.num_endpoints();
-    int rf = 3;
-    if (endpoint_count < rf) {
-        rf = 1;
-        elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
-                keyspace_name, rf, endpoint_count);
+    auto& topo = sp.get_token_metadata_ptr()->get_topology();
+    locator::replication_strategy_config_options opts;
+    if (sp.local_db().get_config().rf_rack_valid_keyspaces()) {
+        for (const auto& [dc, hosts_by_rack] : topo.get_datacenter_racks()) {
+            auto racks = hosts_by_rack | std::views::keys | std::ranges::to<std::vector>();
+            if (racks.size() > 3) {
+                static thread_local std::default_random_engine rnd_engine{std::random_device{}()};
+                std::shuffle(racks.begin(), racks.end(), rnd_engine);
+                racks.resize(3);
+                elogger.warn("Creating keyspace '{}' for Alternator on a subset of racks in dc {} (has {} racks): {}",
+                             keyspace_name, dc, hosts_by_rack.size(), racks);
+            } else if (racks.size() < 3) {
+                elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} in dc {} because it has this many racks.",
+                             keyspace_name, racks.size(), dc);
+            }
+            opts.emplace(dc, std::move(racks));
+        }
+    } else {
+        int endpoint_count = gossiper.num_endpoints();
+        int rf = 3;
+        if (endpoint_count < rf) {
+            rf = 1;
+            elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
+                         keyspace_name, rf, endpoint_count);
+        }
+        opts = get_network_topology_options(sp, gossiper, rf);
     }
-    auto opts = get_network_topology_options(sp, gossiper, rf);
 
     // Even if the "tablets" experimental feature is available, we currently
     // do not enable tablets by default on Alternator tables because LWT is

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -65,7 +65,7 @@ future<> audit_cf_storage_helper::migrate_audit_table(service::group0_guard grou
             data_dictionary::database db = _qp.db();
             cql3::statements::ks_prop_defs old_ks_prop_defs;
             auto old_ks_metadata = old_ks_prop_defs.as_ks_metadata_update(
-                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features());
+                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features(), db.get_config());
             locator::replication_strategy_config_options strategy_opts;
             for (const auto &dc: _qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                 strategy_opts[dc] = "3";

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -16,6 +16,7 @@
 #include "cql3/statements/ks_prop_defs.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 namespace audit {
 
@@ -65,7 +66,7 @@ future<> audit_cf_storage_helper::migrate_audit_table(service::group0_guard grou
             cql3::statements::ks_prop_defs old_ks_prop_defs;
             auto old_ks_metadata = old_ks_prop_defs.as_ks_metadata_update(
                     ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features());
-            std::map<sstring, sstring> strategy_opts;
+            locator::replication_strategy_config_options strategy_opts;
             for (const auto &dc: _qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                 strategy_opts[dc] = "3";
 

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -219,44 +219,12 @@ using uexpression = uninitialized<expression>;
         return token->getText();
     }
 
+    error_sink_fn get_error_sink() {
+        return [this] (const std::string& msg) { add_recognition_error(msg); };
+    }
+
     std::map<sstring, sstring> convert_property_map(const collection_constructor& map) {
-        if (map.elements.empty()) {
-            return std::map<sstring, sstring>{};
-        }
-        std::map<sstring, sstring> res;
-        for (auto&& entry : map.elements) {
-            auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
-            // Because the parser tries to be smart and recover on error (to
-            // allow displaying more than one error I suppose), we have default-constructed
-            // entries in map.elements. Just skip those, a proper error will be thrown in the end.
-            if (!entry_tuple || entry_tuple->elements.size() != 2) {
-                break;
-            }
-            auto left = expr::as_if<untyped_constant>(&entry_tuple->elements[0]);
-            if (!left) {
-                sstring msg = fmt::format("Invalid property name: {}", entry_tuple->elements[0]);
-                if (expr::is<bind_variable>(entry_tuple->elements[0])) {
-                    msg += " (bind variables are not supported in DDL queries)";
-                }
-                add_recognition_error(msg);
-                break;
-            }
-            auto right = expr::as_if<untyped_constant>(&entry_tuple->elements[1]);
-            if (!right) {
-                sstring msg = fmt::format("Invalid property value: {} for property: {}", entry_tuple->elements[0], entry_tuple->elements[1]);
-                if (expr::is<bind_variable>(entry_tuple->elements[1])) {
-                    msg += " (bind variables are not supported in DDL queries)";
-                }
-                add_recognition_error(msg);
-                break;
-            }
-            if (!res.emplace(left->raw_text, right->raw_text).second) {
-                sstring msg = fmt::format("Multiple definition for property {}", left->raw_text);
-                add_recognition_error(msg);
-                break;
-            }
-        }
-        return res;
+        return cql3::expr::convert_property_map(map, get_error_sink());
     }
 
     sstring to_lower(std::string_view s) {

--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -227,6 +227,11 @@ using uexpression = uninitialized<expression>;
         return cql3::expr::convert_property_map(map, get_error_sink());
     }
 
+    property_definitions::extended_map_type
+    convert_extended_property_map(const collection_constructor& map) {
+        return cql3::expr::convert_extended_property_map(map, get_error_sink());
+    }
+
     sstring to_lower(std::string_view s) {
         sstring lower_s(s.size(), '\0');
         std::transform(s.cbegin(), s.cend(), lower_s.begin(), &::tolower);
@@ -1802,7 +1807,7 @@ properties[cql3::statements::property_definitions& props]
 
 property[cql3::statements::property_definitions& props]
     : k=ident '=' simple=propertyValue { try { $props.add_property(k->to_string(), simple); } catch (exceptions::syntax_exception e) { add_recognition_error(e.what()); } }
-    | k=ident '=' map=mapLiteral { try { $props.add_property(k->to_string(), convert_property_map(map)); } catch (exceptions::syntax_exception e) { add_recognition_error(e.what()); } }
+    | k=ident '=' map=mapLiteral { try { $props.add_property(k->to_string(), convert_extended_property_map(map)); } catch (exceptions::syntax_exception e) { add_recognition_error(e.what()); } }
     ;
 
 propertyValue returns [sstring str]

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2437,6 +2437,67 @@ std::map<sstring, sstring> convert_property_map(const collection_constructor& ma
     return res;
 }
 
+std::map<sstring, std::variant<sstring, std::vector<sstring>>>
+convert_extended_property_map(const collection_constructor& map, error_sink_fn add_recognition_error) {
+    if (map.elements.empty()) {
+        return {};
+    }
+    std::map<sstring, std::variant<sstring, std::vector<sstring>>> res;
+    for (auto&& entry : map.elements) {
+        auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
+        // Because the parser tries to be smart and recover on error (to
+        // allow displaying more than one error I suppose), we have default-constructed
+        // entries in map.elements. Just skip those, a proper error will be thrown in the end.
+        if (!entry_tuple || entry_tuple->elements.size() != 2) {
+            break;
+        }
+        auto left = expr::as_if<untyped_constant>(&entry_tuple->elements[0]);
+        if (!left) {
+            sstring msg = fmt::format("Invalid property name: {}", entry_tuple->elements[0]);
+            if (expr::is<bind_variable>(entry_tuple->elements[0])) {
+                msg += " (bind variables are not supported in DDL queries)";
+            }
+            add_recognition_error(msg);
+            break;
+        }
+        auto right_str = expr::as_if<untyped_constant>(&entry_tuple->elements[1]);
+        if (right_str) {
+            if (!res.emplace(left->raw_text, right_str->raw_text).second) {
+                sstring msg = fmt::format("Multiple definition for property {}", left->raw_text);
+                add_recognition_error(msg);
+                break;
+            }
+        } else {
+            auto right_vec = expr::as_if<collection_constructor>(&entry_tuple->elements[1]);
+            if (!right_vec) {
+                sstring msg = fmt::format("Invalid property value: {} for property: {}", entry_tuple->elements[1], entry_tuple->elements[0]);
+                if (expr::is<bind_variable>(entry_tuple->elements[1])) {
+                    msg += " (bind variables are not supported in DDL queries)";
+                }
+                add_recognition_error(msg);
+                break;
+            }
+            auto values = right_vec->elements | std::views::transform([&] (const auto& x) -> sstring {
+                auto elem = expr::as_if<untyped_constant>(&x);
+                if (!elem) {
+                    sstring msg = fmt::format("Invalid property vector value: {} for property: {}", x, entry_tuple->elements[0]);
+                    if (expr::is<bind_variable>(x)) {
+                        msg += " (bind variables are not supported in DDL queries)";
+                    }
+                    add_recognition_error(msg);
+                    return "<invalid>";
+                }
+                return elem->raw_text;
+            }) | std::ranges::to<std::vector<sstring>>();
+            if (!res.emplace(left->raw_text, std::move(values)).second) {
+                sstring msg = fmt::format("Multiple definition for property {}", left->raw_text);
+                add_recognition_error(msg);
+                break;
+            }
+        }
+    }
+    return res;
+}
 
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2397,6 +2397,46 @@ split_aggregation(std::span<const expression> aggregation) {
     };
 }
 
+std::map<sstring, sstring> convert_property_map(const collection_constructor& map, error_sink_fn add_recognition_error) {
+    if (map.elements.empty()) {
+        return std::map<sstring, sstring>{};
+    }
+    std::map<sstring, sstring> res;
+    for (auto&& entry : map.elements) {
+        auto entry_tuple = expr::as_if<tuple_constructor>(&entry);
+        // Because the parser tries to be smart and recover on error (to
+        // allow displaying more than one error I suppose), we have default-constructed
+        // entries in map.elements. Just skip those, a proper error will be thrown in the end.
+        if (!entry_tuple || entry_tuple->elements.size() != 2) {
+            break;
+        }
+        auto left = expr::as_if<untyped_constant>(&entry_tuple->elements[0]);
+        if (!left) {
+            sstring msg = fmt::format("Invalid property name: {}", entry_tuple->elements[0]);
+            if (expr::is<bind_variable>(entry_tuple->elements[0])) {
+                msg += " (bind variables are not supported in DDL queries)";
+            }
+            add_recognition_error(msg);
+            break;
+        }
+        auto right = expr::as_if<untyped_constant>(&entry_tuple->elements[1]);
+        if (!right) {
+            sstring msg = fmt::format("Invalid property value: {} for property: {}", entry_tuple->elements[0], entry_tuple->elements[1]);
+            if (expr::is<bind_variable>(entry_tuple->elements[1])) {
+                msg += " (bind variables are not supported in DDL queries)";
+            }
+            add_recognition_error(msg);
+            break;
+        }
+        if (!res.emplace(left->raw_text, right->raw_text).second) {
+            sstring msg = fmt::format("Multiple definition for property {}", left->raw_text);
+            add_recognition_error(msg);
+            break;
+        }
+    }
+    return res;
+}
+
 
 } // namespace expr
 } // namespace cql3

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -430,6 +430,11 @@ struct collection_constructor {
     friend bool operator==(const collection_constructor&, const collection_constructor&) = default;
 };
 
+// Called with error message string.
+using error_sink_fn = std::function<void(const std::string&)>;
+
+std::map<sstring, sstring> convert_property_map(const collection_constructor&, error_sink_fn);
+
 // Constructs an object of a user-defined type
 // For example: "{field1: 23343, field2: ?}"
 // During preparation usertype constructors with constant values are converted to expr::constant.

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -435,6 +435,9 @@ using error_sink_fn = std::function<void(const std::string&)>;
 
 std::map<sstring, sstring> convert_property_map(const collection_constructor&, error_sink_fn);
 
+std::map<sstring, std::variant<sstring, std::vector<sstring>>>
+convert_extended_property_map(const collection_constructor&, error_sink_fn);
+
 // Constructs an object of a user-defined type
 // For example: "{field1: 23343, field2: ?}"
 // During preparation usertype constructors with constant values are converted to expr::constant.

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -51,15 +51,7 @@ future<> cql3::statements::alter_keyspace_statement::check_access(query_processo
 }
 
 static unsigned get_abs_rf_diff(const locator::replication_strategy_config_option& curr_rf, const locator::replication_strategy_config_option& new_rf) {
-    try {
-        return std::abs(std::stoi(curr_rf) - std::stoi(new_rf));
-    } catch (std::invalid_argument const& ex) {
-        on_internal_error(mylogger, fmt::format("get_abs_rf_diff expects integer arguments, "
-                                                "but got curr_rf:{} and new_rf:{}", curr_rf, new_rf));
-    } catch (std::out_of_range const& ex) {
-        on_internal_error(mylogger, fmt::format("get_abs_rf_diff expects integer arguments to fit into `int` type, "
-                                                "but got curr_rf:{} and new_rf:{}", curr_rf, new_rf));
-    }
+    return std::abs(ssize_t(locator::get_replication_factor(curr_rf)) - ssize_t(locator::get_replication_factor(new_rf)));
 }
 
 void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, const service::client_state& state) const {

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -87,6 +87,9 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
 
             auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features());
 
+            auto tmptr = qp.proxy().get_token_metadata_ptr();
+            const auto& topo = tmptr->get_topology();
+
             if (ks.get_replication_strategy().uses_tablets()) {
                 const std::map<sstring, sstring>& current_rf_per_dc = ks.metadata()->strategy_options();
                 auto new_rf_per_dc = _attrs->get_replication_options();
@@ -97,7 +100,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                     if (auto new_dc_in_current_mapping = current_rf_per_dc.find(new_dc);
                              new_dc_in_current_mapping != current_rf_per_dc.end()) {
                         old_rf = new_dc_in_current_mapping->second;
-                    } else if (!qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters().contains(new_dc)) {
+                    } else if (!topo.get_datacenters().contains(new_dc)) {
                         // This means that the DC listed in ALTER doesn't exist. This error will be reported later,
                         // during validation in abstract_replication_strategy::validate_replication_strategy.
                         // We can't report this error now, because it'd change the order of errors reported:
@@ -111,7 +114,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
             }
 
             locator::replication_strategy_params params(new_ks->strategy_options(), new_ks->initial_tablets());
-            auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), params);
+            auto new_rs = locator::abstract_replication_strategy::create_replication_strategy(new_ks->strategy_name(), params, topo);
             if (new_rs->is_per_table() != ks.get_replication_strategy().is_per_table()) {
                 throw exceptions::invalid_request_exception(format("Cannot alter replication strategy vnode/tablets flavor"));
             }
@@ -199,6 +202,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         auto ks = qp.db().find_keyspace(_name);
         auto ks_md = ks.metadata();
         const auto tmptr = qp.proxy().get_token_metadata_ptr();
+        const auto& topo = tmptr->get_topology();
         const auto& feat = qp.proxy().features();
         auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat);
         utils::chunked_vector<mutation> muts;
@@ -278,7 +282,8 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
 
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(
                 ks_md_update->strategy_name(),
-                locator::replication_strategy_params(ks_md_update->strategy_options(), ks_md_update->initial_tablets()));
+                locator::replication_strategy_params(ks_md_update->strategy_options(), ks_md_update->initial_tablets()),
+                topo);
 
         // If `rf_rack_valid_keyspaces` is enabled, it's forbidden to perform a schema change that
         // would lead to an RF-rack-valid keyspace. Verify that this change does not.

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -79,7 +79,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                         current_options.type_string(), new_options.type_string()));
             }
 
-            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features());
+            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features(), qp.db().get_config());
 
             auto tmptr = qp.proxy().get_token_metadata_ptr();
             const auto& topo = tmptr->get_topology();
@@ -142,7 +142,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         const auto tmptr = qp.proxy().get_token_metadata_ptr();
         const auto& topo = tmptr->get_topology();
         const auto& feat = qp.proxy().features();
-        auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat);
+        auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat, qp.db().get_config());
         utils::chunked_vector<mutation> muts;
         std::vector<sstring> warnings;
 

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <vector>
 #include "alter_keyspace_statement.hh"
+#include "cql3/statements/property_definitions.hh"
 #include "locator/tablets.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "mutation/canonical_mutation.hh"
@@ -145,7 +146,13 @@ void add_prefixed_key(const sstring& prefix,
     for (const auto& [in_key, in_value]: in) {
         out[prefix + ":" + in_key] = in_value;
     }
-};
+}
+
+void add_prefixed_key(const sstring& prefix,
+                      const cql3::statements::property_definitions::extended_map_type& in,
+                      cql3::statements::property_definitions::map_type& out) {
+    add_prefixed_key(prefix, cql3::statements::to_flattened_map(in), out);
+}
 
 cql3::statements::property_definitions::map_type get_current_options_flattened(
         const shared_ptr<cql3::statements::ks_prop_defs>& ks,

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -22,6 +22,7 @@
 #include "cql3/query_processor.hh"
 #include "db/config.hh"
 #include "gms/feature_service.hh"
+#include "replica/database.hh"
 
 #include <boost/regex.hpp>
 #include <stdexcept>
@@ -109,7 +110,8 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
         // remove this check.
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(
             ksm->strategy_name(),
-            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()));
+            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()),
+            tmptr->get_topology());
         if (rs->uses_tablets()) {
             warnings.push_back(
                 "Tables in this keyspace will be replicated using Tablets "
@@ -205,7 +207,8 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     locator::replication_strategy_params params(opts, std::nullopt);
     auto replication_strategy = locator::abstract_replication_strategy::create_replication_strategy(
             locator::abstract_replication_strategy::to_qualified_class_name(
-                    *attrs.get_replication_strategy_class()), params)->get_type();
+                    *attrs.get_replication_strategy_class()), params,
+                    qp.db().real_database().get_token_metadata().get_topology())->get_type();
     auto rs_warn_list = qp.db().get_config().replication_strategy_warn_list();
     auto rs_fail_list = qp.db().get_config().replication_strategy_fail_list();
 

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -252,7 +252,12 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     // these are checked and reported elsewhere.
     for (auto opt : attrs.get_replication_options()) {
         try {
-            auto rf = std::stol(opt.second);
+            long rf = 0;
+            try {
+                rf = locator::get_replication_factor(opt.second);
+            } catch (const exceptions::configuration_exception&) {
+            }
+
             if (rf > 0) {
                 if (auto min_fail = qp.proxy().data_dictionary().get_config().minimum_replication_factor_fail_threshold();
                     min_fail >= 0 && rf < min_fail) {

--- a/cql3/statements/index_prop_defs.hh
+++ b/cql3/statements/index_prop_defs.hh
@@ -12,7 +12,7 @@
 
 #include "property_definitions.hh"
 #include <seastar/core/sstring.hh>
-#include "schema/schema.hh"
+#include "schema/schema_fwd.hh"
 
 #include <unordered_map>
 #include <optional>

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -148,7 +148,11 @@ ks_prop_defs::ks_prop_defs(std::map<sstring, sstring> options) {
     std::map<sstring, sstring> replication_opts, storage_opts, tablets_opts, durable_writes_opts;
 
     auto read_property_into = [] (auto& map, const sstring& name, const sstring& value, const sstring& tag) {
-        map[name.substr(sstring(tag).size() + 1)] = value;
+        auto prefix = sstring(tag) + ":";
+        if (!name.starts_with(prefix)) {
+            throw std::runtime_error(seastar::format("ks_prop_defs: Expected name to start with \"{}\", but got: \"{}\"", prefix, name));
+        }
+        map[name.substr(prefix.size())] = value;
     };
 
     for (const auto& [name, value] : options) {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -29,7 +29,9 @@ static locator::replication_strategy_config_options prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
         locator::replication_strategy_config_options options,
-        const locator::replication_strategy_config_options& old_options = {}) {
+        const locator::replication_strategy_config_options& old_options,
+        bool rack_list_enabled,
+        bool uses_tablets) {
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
     auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
@@ -49,21 +51,61 @@ static locator::replication_strategy_config_options prepare_options(
     auto it = options.find(ks_prop_defs::REPLICATION_FACTOR_KEY);
     if (it != options.end()) {
         // Expand: the user explicitly provided a 'replication_factor'.
-        rf = it->second;
+        try {
+            rf = std::get<sstring>(it->second);
+        } catch (...) {
+            throw exceptions::configuration_exception(fmt::format("Invalid replication factor: {}: must be a string holding a numerical value", it->second));
+        }
         options.erase(it);
     } else if (options.empty()) {
         auto it = old_options.find(ks_prop_defs::REPLICATION_FACTOR_KEY);
         if (it != old_options.end()) {
             // Expand: the user switched from another strategy that specified a 'replication_factor'
             // and didn't provide any additional options.
-            rf = it->second;
+            rf = std::get<sstring>(it->second);
+        }
+    }
+
+    // Validate options.
+    for (auto&& [dc, opt] : options) {
+        locator::replication_factor_data rf(opt);
+        if (!rf.is_rack_based()) {
+            if (old_options.contains(dc)) {
+                auto old_rf = locator::replication_factor_data(old_options.at(dc));
+                if (old_rf.is_rack_based() && rf.count() != 0 && old_rf.count() != rf.count()) {
+                    throw exceptions::configuration_exception(fmt::format(
+                            "Cannot change replication factor for '{}' from {} to {} when the old value was a rack list",
+                            dc, old_options.at(dc), opt));
+                }
+            }
+            continue;
+        }
+        if (!rack_list_enabled) {
+            throw exceptions::configuration_exception(fmt::format(
+                    "Using rack list for '{}' is not allowed because the 'rf_rack_list' feature is disabled", dc));
+        }
+        if (!uses_tablets) {
+            throw exceptions::configuration_exception(fmt::format(
+                    "Using rack list for '{}' is not allowed because the keyspace is not using tablets", dc));
+        }
+        auto& racks = rf.get_rack_list();
+        if (std::unordered_set<sstring>(racks.begin(), racks.end()).size() != rf.count()) {
+            throw exceptions::configuration_exception(fmt::format(
+                    "Rack list for '{}' contains duplicate entries", dc));
+        }
+        if (old_options.contains(dc)) {
+            auto old_rf = locator::replication_factor_data(old_options.at(dc));
+            if (!old_rf.is_rack_based() && old_rf.count() != 0) {
+                // FIXME: Allow this if replicas already conform to the given rack list.
+                // FIXME: Implement automatic colocation to allow transition to rack list.
+                throw exceptions::configuration_exception(fmt::format(
+                        "Cannot change replication factor from numeric to rack list for '{}'", dc));
+            }
         }
     }
 
     if (rf.has_value()) {
-        // The code below may end up not using "rf" at all (if all the DCs
-        // already have rf settings), so let's validate it once (#8880).
-        locator::abstract_replication_strategy::parse_replication_factor(*rf);
+        locator::replication_factor_data::parse(*rf);
 
         // We keep previously specified DC factors for safety.
         for (const auto& opt : old_options) {
@@ -122,7 +164,7 @@ ks_prop_defs::ks_prop_defs(std::map<sstring, sstring> options) {
     }
 
     if (!replication_opts.empty())
-        add_property(KW_REPLICATION, replication_opts);
+        add_property(KW_REPLICATION, from_flattened_map(replication_opts));
     if (!storage_opts.empty())
         add_property(KW_STORAGE, storage_opts);
     if (!tablets_opts.empty())
@@ -143,12 +185,16 @@ void ks_prop_defs::validate() {
 
     auto replication_options = get_replication_options();
     if (replication_options.contains(REPLICATION_STRATEGY_CLASS_KEY)) {
-        _strategy_class = replication_options[REPLICATION_STRATEGY_CLASS_KEY];
+        const auto& class_name = replication_options[REPLICATION_STRATEGY_CLASS_KEY];
+        if (!std::holds_alternative<sstring>(class_name)) {
+            throw exceptions::configuration_exception(seastar::format("Invalid replication strategy class: {}", class_name));
+        }
+        _strategy_class = std::get<sstring>(class_name);
     }
 }
 
 locator::replication_strategy_config_options ks_prop_defs::get_replication_options() const {
-    auto replication_options = get_map(KW_REPLICATION);
+    auto replication_options = get_extended_map(KW_REPLICATION);
     if (replication_options) {
         return replication_options.value();
     }
@@ -234,7 +280,9 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
     std::optional<unsigned> default_initial_tablets = enable_tablets && locator::abstract_replication_strategy::to_qualified_class_name(sc) == "org.apache.cassandra.locator.NetworkTopologyStrategy"
             ? std::optional<unsigned>(0) : std::nullopt;
     auto initial_tablets = get_initial_tablets(default_initial_tablets, cfg.enforce_tablets());
-    auto options = prepare_options(sc, tm, get_replication_options());
+    bool uses_tablets = initial_tablets.has_value();
+    bool rack_list_enabled = feat.rack_list_rf;
+    auto options = prepare_options(sc, tm, get_replication_options(), {}, rack_list_enabled, uses_tablets);
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
             std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
@@ -249,8 +297,9 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         throw exceptions::invalid_request_exception("Cannot alter replication strategy vnode/tablets flavor");
     }
     auto sc = get_replication_strategy_class();
+    bool rack_list_enabled = feat.rack_list_rf;
     if (sc) {
-        options = prepare_options(*sc, tm, get_replication_options(), old_options);
+        options = prepare_options(*sc, tm, get_replication_options(), old_options, rack_list_enabled, uses_tablets);
     } else {
         sc = old->strategy_name();
         options = old_options;

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -144,8 +144,8 @@ static locator::replication_strategy_config_options prepare_options(
     return options;
 }
 
-ks_prop_defs::ks_prop_defs(std::map<sstring, sstring> options) {
-    std::map<sstring, sstring> replication_opts, storage_opts, tablets_opts, durable_writes_opts;
+ks_prop_defs::ks_prop_defs(property_definitions::map_type options) {
+    map_type replication_opts, storage_opts, tablets_opts, durable_writes_opts;
 
     auto read_property_into = [] (auto& map, const sstring& name, const sstring& value, const sstring& tag) {
         auto prefix = sstring(tag) + ":";
@@ -311,6 +311,41 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
     return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
+namespace {
+
+void add_prefixed_key(const sstring& prefix, const property_definitions::map_type& in, property_definitions::map_type& out) {
+    for (const auto& [in_key, in_value]: in) {
+        out[fmt::format("{}:{}", prefix, in_key)] = in_value;
+    }
+}
+
+void add_prefixed_key(const sstring& prefix, const property_definitions::extended_map_type& in, property_definitions::map_type& out) {
+    add_prefixed_key(prefix, to_flattened_map(in), out);
+}
+
+} // namespace
+
+property_definitions::map_type ks_prop_defs::flattened() const {
+    map_type result;
+
+    for (auto kw : {
+            ks_prop_defs::KW_REPLICATION,
+            ks_prop_defs::KW_STORAGE,
+            ks_prop_defs::KW_TABLETS}) {
+        if (auto val_opt = get_extended_map(kw)) {
+            add_prefixed_key(kw, *val_opt, result);
+        }
+    }
+
+    for (auto kw : {ks_prop_defs::KW_DURABLE_WRITES}) {
+        if (auto val_opt = get_simple(kw)) {
+            // Use nested map for backwards compatibility, ks_prop_defs() constructor expects this.
+            add_prefixed_key(kw, std::map<sstring, sstring>({{sstring(kw), to_sstring(*val_opt)}}), result);
+        }
+    }
+
+    return {result};
+}
 
 }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -23,6 +23,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger logger("ks_prop_defs");
+
 static std::map<sstring, sstring> prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
@@ -30,7 +32,11 @@ static std::map<sstring, sstring> prepare_options(
         const std::map<sstring, sstring>& old_options = {}) {
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
-    if (locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) != "org.apache.cassandra.locator.NetworkTopologyStrategy") {
+    auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
+
+    logger.debug("prepare_options: {}: is_nts={} old_options={} new_options={}", strategy_class, is_nts, old_options, options);
+
+    if (!is_nts) {
         return options;
     }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -150,6 +150,13 @@ static locator::replication_strategy_config_options prepare_options(
         }
     }
 
+    // #22688 - filter out any dc*:0 entries - consider these
+    // null and void (removed).
+    std::erase_if(options, [] (const auto& e) {
+        auto& [dc, rf] = e;
+        return locator::replication_factor_data(rf).count() == 0;
+    });
+
     return options;
 }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -18,6 +18,7 @@
 #include "exceptions/exceptions.hh"
 #include "gms/feature_service.hh"
 #include "db/config.hh"
+#include <random>
 
 namespace cql3 {
 
@@ -28,6 +29,7 @@ static logging::logger logger("ks_prop_defs");
 static locator::replication_strategy_config_options prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
+        bool rf_rack_valid_keyspaces,
         locator::replication_strategy_config_options options,
         const locator::replication_strategy_config_options& old_options,
         bool rack_list_enabled,
@@ -35,8 +37,11 @@ static locator::replication_strategy_config_options prepare_options(
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
     auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
+    const auto& all_dcs = tm.get_datacenter_racks_token_owners();
+    auto force_racks = uses_tablets && rf_rack_valid_keyspaces && rack_list_enabled;
 
-    logger.debug("prepare_options: {}: is_nts={} old_options={} new_options={}", strategy_class, is_nts, old_options, options);
+    logger.debug("prepare_options: {}: is_nts={} force_racks={} rack_list_enabled={} old_options={} new_options={} all_dcs={}",
+                 strategy_class, is_nts, force_racks, rack_list_enabled, old_options, options, all_dcs);
 
     if (!is_nts) {
         return options;
@@ -46,7 +51,6 @@ static locator::replication_strategy_config_options prepare_options(
     // If the user simply switches from another strategy without providing any options,
     // but the other strategy used the 'replication_factor' option, it will also be expanded.
     // See issue CASSANDRA-14303.
-
     std::optional<sstring> rf;
     auto it = options.find(ks_prop_defs::REPLICATION_FACTOR_KEY);
     if (it != options.end()) {
@@ -65,6 +69,74 @@ static locator::replication_strategy_config_options prepare_options(
             rf = std::get<sstring>(it->second);
         }
     }
+
+    auto expand_dc_racks = [&] (const sstring& dc, const locator::replication_strategy_config_option& rf) {
+        logger.debug("expand_dc_racks: dc={} rf={} all_dcs={}", dc, rf, all_dcs);
+
+        std::unordered_set<sstring> allowed_racks;
+        std::vector<sstring> dc_racks;
+        auto it = all_dcs.find(dc);
+        if (it != all_dcs.end()) {
+            dc_racks = it->second | std::views::keys | std::ranges::to<std::vector<sstring>>();
+            allowed_racks = std::ranges::to<std::unordered_set<sstring>>(dc_racks);
+        } else if (!tm.get_topology().get_datacenters().contains(dc)) {
+            throw exceptions::configuration_exception(fmt::format("Unrecognized datacenter name '{}'", dc));
+        }
+
+        auto& topo = tm.get_topology();
+        auto normal_nodes = [&] (const sstring& rack) {
+            int count = 0;
+            for (auto n : it->second.at(rack)) {
+                count += int(topo.get_node(n).is_normal());
+            }
+            return count;
+        };
+
+        auto data = locator::abstract_replication_strategy::parse_replication_factor(rf);
+        data.validate(allowed_racks);
+
+        if (data.is_rack_based()) {
+            options[dc] = data.get_rack_list();
+        } else if (data.count() == 0) {
+            options.emplace(dc, "0");
+        } else if (force_racks) {
+            if (data.count() > dc_racks.size()) {
+                throw exceptions::configuration_exception(fmt::format(
+                        "Replication factor {} exceeds the number of racks ({}) in dc {}", data.count(), dc_racks.size(), dc));
+            }
+            if (old_options.count(dc)) {
+                auto& old_rf_val = old_options.at(dc);
+                auto old_rf = locator::abstract_replication_strategy::parse_replication_factor(old_rf_val);
+                if (old_rf.is_rack_based()) {
+                    if (old_rf.count() == data.count()) {
+                        options[dc] = old_rf_val;
+                        return;
+                    } else if (old_rf.count() > 0) {
+                        throw exceptions::configuration_exception(fmt::format(
+                                "Cannot change replication factor for '{}' from {} to numeric {}, use rack list instead",
+                                dc, old_rf_val, data.count()));
+                    }
+                } else if (old_rf.count() > 0) {
+                    throw exceptions::configuration_exception(fmt::format(
+                            "Cannot change replication factor for '{}' from {} to {}, only rack list is allowed",
+                            dc, old_rf_val, data.count()));
+                }
+            }
+            // If the replication factor is less than the number of racks, pick rf racks at random.
+            if (data.count() < dc_racks.size()) {
+                static thread_local auto gen = std::default_random_engine(std::random_device{}());
+                std::ranges::shuffle(dc_racks, gen);
+                // Prefer placing into racks which have more normal nodes.
+                std::sort(dc_racks.begin(), dc_racks.end(), [&](const sstring& a, const sstring& b) {
+                    return normal_nodes(a) > normal_nodes(b);
+                });
+                dc_racks.resize(data.count());
+            }
+            options[dc] = dc_racks;
+        } else {
+            options.emplace(dc, std::get<sstring>(rf));
+        }
+    };
 
     // Validate options.
     for (auto&& [dc, opt] : options) {
@@ -104,6 +176,18 @@ static locator::replication_strategy_config_options prepare_options(
         }
     }
 
+    if (!rf && options.empty() && old_options.empty()) {
+        if (all_dcs.empty()) {
+            throw request_validations::invalid_request("No data centers found in the cluster, cannot determine replication factor");
+        }
+        for (const auto& [dc, racks_map] : all_dcs) {
+            if (racks_map.empty()) {
+                continue;
+            }
+            options.emplace(dc, std::to_string(racks_map.size()));
+        }
+    }
+
     // #22688 / #20039 - check for illegal, empty options
     // moved to here. We want to be able to remove dc:s once rf=0,
     // in which case, the options actually serialized in result mutations
@@ -117,27 +201,23 @@ static locator::replication_strategy_config_options prepare_options(
     if (rf.has_value()) {
         locator::replication_factor_data::parse(*rf);
 
+        for (const auto& dc : tm.get_topology().get_datacenters()) {
+            auto i = options.find(dc);
+            if (i != options.end()) {
+                expand_dc_racks(dc, i->second);
+            } else if (!old_options.contains(dc)) {
+                expand_dc_racks(dc, *rf);
+            }
+        }
         // We keep previously specified DC factors for safety.
         for (const auto& opt : old_options) {
             if (opt.first != ks_prop_defs::REPLICATION_FACTOR_KEY) {
                 options.insert(opt);
             }
         }
-
-        for (const auto& dc : tm.get_topology().get_datacenters()) {
-            options.emplace(dc, *rf);
-        }
-    } else if (options.empty() && old_options.empty()) {
-        // For default replication factor consider only racks with nodes that are NOT zero-token only nodes,
-        auto dc_racks = tm.get_datacenter_racks_token_owners();
-        if (dc_racks.empty()) {
-            throw request_validations::invalid_request("No data centers found in the cluster, cannot determine replication factor");
-        }
-        for (const auto& [dc, racks_map] : dc_racks) {
-            if (racks_map.empty()) {
-                continue;
-            }
-            options.emplace(dc, std::to_string(racks_map.size()));
+    } else if (force_racks) {
+        for (const auto& [dc, dc_rf] : options) {
+            expand_dc_racks(dc, dc_rf);
         }
     }
 
@@ -302,12 +382,12 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
     auto initial_tablets = get_initial_tablets(default_initial_tablets, cfg.enforce_tablets());
     bool uses_tablets = initial_tablets.has_value();
     bool rack_list_enabled = feat.rack_list_rf;
-    auto options = prepare_options(sc, tm, get_replication_options(), {}, rack_list_enabled, uses_tablets);
+    auto options = prepare_options(sc, tm, cfg.rf_rack_valid_keyspaces(), get_replication_options(), {}, rack_list_enabled, uses_tablets);
     return data_dictionary::keyspace_metadata::new_keyspace(ks_name, sc,
             std::move(options), initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
-lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat) {
+lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat, const db::config& cfg) {
     locator::replication_strategy_config_options options;
     const auto& old_options = old->strategy_options();
     // if tablets options have not been specified, inherit them if it's tablets-enabled KS
@@ -319,7 +399,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
     auto sc = get_replication_strategy_class();
     bool rack_list_enabled = feat.rack_list_rf;
     if (sc) {
-        options = prepare_options(*sc, tm, get_replication_options(), old_options, rack_list_enabled, uses_tablets);
+        options = prepare_options(*sc, tm, cfg.rf_rack_valid_keyspaces(), get_replication_options(), old_options, rack_list_enabled, uses_tablets);
     } else {
         sc = old->strategy_name();
         options = old_options;

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -25,11 +25,11 @@ namespace statements {
 
 static logging::logger logger("ks_prop_defs");
 
-static std::map<sstring, sstring> prepare_options(
+static locator::replication_strategy_config_options prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
-        std::map<sstring, sstring> options,
-        const std::map<sstring, sstring>& old_options = {}) {
+        locator::replication_strategy_config_options options,
+        const locator::replication_strategy_config_options& old_options = {}) {
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
     auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
@@ -147,12 +147,12 @@ void ks_prop_defs::validate() {
     }
 }
 
-std::map<sstring, sstring> ks_prop_defs::get_replication_options() const {
+locator::replication_strategy_config_options ks_prop_defs::get_replication_options() const {
     auto replication_options = get_map(KW_REPLICATION);
     if (replication_options) {
         return replication_options.value();
     }
-    return std::map<sstring, sstring>{};
+    return {};
 }
 
 data_dictionary::storage_options ks_prop_defs::get_storage_options() const {
@@ -240,7 +240,7 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
 }
 
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat) {
-    std::map<sstring, sstring> options;
+    locator::replication_strategy_config_options options;
     const auto& old_options = old->strategy_options();
     auto sc = get_replication_strategy_class();
     if (sc) {

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -12,6 +12,7 @@
 
 #include "cql3/statements/property_definitions.hh"
 #include "data_dictionary/storage_options.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -60,7 +61,7 @@ public:
     explicit ks_prop_defs(std::map<sstring, sstring> options);
 
     void validate();
-    std::map<sstring, sstring> get_replication_options() const;
+    locator::replication_strategy_config_options get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
     void set_default_replication_strategy_class_option();
     std::optional<unsigned> get_initial_tablets(std::optional<unsigned> default_value, bool enforce_tablets = false) const;

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -58,7 +58,16 @@ private:
     std::optional<sstring> _strategy_class;
 public:
     ks_prop_defs() = default;
-    explicit ks_prop_defs(std::map<sstring, sstring> options);
+
+    explicit ks_prop_defs(map_type options);
+
+    /// Converts options to a flattened map of properties.
+    ///
+    /// It holds that:
+    ///
+    ///   ks_prop_defs(flattened()) == *this
+    ///
+    map_type flattened() const;
 
     void validate();
     locator::replication_strategy_config_options get_replication_options() const;

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -77,7 +77,7 @@ public:
     data_dictionary::storage_options get_storage_options() const;
     bool get_durable_writes() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&, const db::config&);
-    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&, const db::config&);
 };
 
 }

--- a/cql3/statements/property_definitions.cc
+++ b/cql3/statements/property_definitions.cc
@@ -8,9 +8,12 @@
  * SPDX-License-Identifier: (LicenseRef-ScyllaDB-Source-Available-1.0 and Apache-2.0)
  */
 
+#include <ranges>
+
 #include <seastar/core/format.hh>
 #include "cql3/statements/property_definitions.hh"
 #include "exceptions/exceptions.hh"
+#include "utils/overloaded_functor.hh"
 
 namespace cql3 {
 
@@ -26,7 +29,7 @@ void property_definitions::add_property(const sstring& name, sstring value) {
     }
 }
 
-void property_definitions::add_property(const sstring& name, const std::map<sstring, sstring>& value) {
+void property_definitions::add_property(const sstring& name, const extended_map_type& value) {
     if (auto [ignored, added] = _properties.try_emplace(name, value); !added) {
         throw exceptions::syntax_exception(format("Multiple definition for property '{}'", name));
     }
@@ -60,16 +63,39 @@ std::optional<sstring> property_definitions::get_simple(const sstring& name) con
     }
 }
 
-std::optional<std::map<sstring, sstring>> property_definitions::get_map(const sstring& name) const {
+std::optional<property_definitions::extended_map_type> property_definitions::get_extended_map(const sstring& name) const {
     auto it = _properties.find(name);
     if (it == _properties.end()) {
         return std::nullopt;
     }
     try {
-        return std::get<map_type>(it->second);
+        return std::get<extended_map_type>(it->second);
     } catch (const std::bad_variant_access& e) {
         throw exceptions::syntax_exception(format("Invalid value for property '{}'. It should be a map.", name));
     }
+}
+
+std::optional<property_definitions::map_type> property_definitions::get_map(const sstring& name) const {
+    auto xmap = get_extended_map(name);
+    if (!xmap) {
+        return std::nullopt;
+    }
+    return to_simple_map(std::move(*xmap));
+}
+
+property_definitions::map_type property_definitions::to_simple_map(const extended_map_type& xmap) {
+    return xmap | std::views::transform([](const auto& x) {
+        // Convert each pair to a string key and value
+        try {
+            return std::make_pair(x.first, std::get<sstring>(x.second));
+        } catch (const std::bad_variant_access& e) {
+            throw exceptions::syntax_exception(seastar::format("Invalid map value '{}' for key '{}'. It should be a simple string.", std::get<list_type>(x.second), x.first));
+        }
+    }) | std::ranges::to<map_type>();
+}
+
+property_definitions::extended_map_type property_definitions::to_extended_map(const map_type& map) {
+    return map | std::ranges::to<extended_map_type>();
 }
 
 bool property_definitions::has_property(const sstring& name) const {
@@ -166,12 +192,74 @@ void property_definitions::remove_from_map_if_exists(const sstring& name, const 
         return;
     }
     try {
-        auto map = std::get<map_type>(it->second);
+        auto map = std::get<extended_map_type>(it->second);
         map.erase(key);
         _properties[name] = map;
     } catch (const std::bad_variant_access& e) {
         throw exceptions::syntax_exception(format("Invalid value for property '{}'. It should be a map.", name));
     }
+}
+
+/// Converts extended map into a flat map.
+///
+/// Values which are lists are represented as multiple entries in the map
+/// with the list index appended to the key, with ':' as a separator.
+/// Empty list is represented as a single entry with index -1 and empty string as value.
+///
+/// For example:
+///
+///    {'dc1': '3', 'dc2': ['rack1', 'rack2'], 'dc3': []}
+///
+/// has a flattened representation of:
+///
+///   {'dc1': '3', 'dc2:0': 'rack1', 'dc2:1': 'rack2', 'dc3:-1': ''}
+///
+property_definitions::map_type to_flattened_map(const property_definitions::extended_map_type& in) {
+    property_definitions::map_type out;
+    for (const auto& [in_key, in_value]: in) {
+        if (in_key.find(':') != sstring::npos) {
+            throw std::invalid_argument(fmt::format("key '{}' contains reserved character ':'", in_key));
+        }
+        std::visit(overloaded_functor{
+            [&] (const sstring& value) {
+                out[in_key] = value;
+            },
+            [&] (const std::vector<sstring>& list) {
+                if (list.empty()) {
+                    out[fmt::format("{}:{}", in_key, -1)] = "";
+                } else {
+                    // flatten the rack list in multiple entries
+                    for (size_t i = 0; i < list.size(); ++i) {
+                        const auto& v = list[i];
+                        out[fmt::format("{}:{}", in_key, i)] = v;
+                    }
+                }
+            }
+        }, in_value);
+    }
+    return out;
+}
+
+property_definitions::extended_map_type from_flattened_map(const property_definitions::map_type& in) {
+    property_definitions::extended_map_type out;
+    for (const auto& [key, value] : in) {
+        auto pos = key.find(':');
+        if (pos == sstring::npos) {
+            out.emplace(key, value);
+        } else {
+            auto dc = key.substr(0, pos);
+            auto index = std::stol(key.substr(pos + 1));
+            auto [it, empty] = out.try_emplace(dc, std::vector<sstring>());
+            auto& vec = std::get<std::vector<sstring>>(it->second);
+            if (index >= 0) {
+                if (vec.size() <= size_t(index)) {
+                    vec.resize(index + 1);
+                }
+                vec[index] = value;
+            }
+        }
+    }
+    return out;
 }
 
 }

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -27,19 +27,26 @@ namespace statements {
 class property_definitions {
 public:
     using map_type = std::map<sstring, sstring>;
-    using value_type = std::variant<sstring, map_type>;
+    using list_type = std::vector<sstring>;
+    using extended_map_type = std::map<sstring, std::variant<sstring, list_type>>;
+    using value_type = std::variant<sstring, extended_map_type>;
+    using properties_map_type = std::unordered_map<sstring, value_type>;
 protected:
 #if 0
     protected static final Logger logger = LoggerFactory.getLogger(PropertyDefinitions.class);
 #endif
 
-    mutable std::unordered_map<sstring, value_type> _properties;
+    mutable properties_map_type _properties;
 
     property_definitions();
 public:
     void add_property(const sstring& name, sstring value);
 
-    void add_property(const sstring& name, const std::map<sstring, sstring>& value);
+    void add_property(const sstring& name, const map_type& value) {
+        add_property(name, to_extended_map(value));
+    }
+
+    void add_property(const sstring& name, const extended_map_type& value);
 
     void validate(const std::set<sstring>& keywords, const std::set<sstring>& exts = {}, const std::set<sstring>& obsolete = {}) const;
 
@@ -54,7 +61,11 @@ public:
 
     std::optional<value_type> get(const sstring& name) const;
 
-    std::optional<std::map<sstring, sstring>> get_map(const sstring& name) const;
+    std::optional<extended_map_type> get_extended_map(const sstring& name) const;
+    std::optional<map_type> get_map(const sstring& name) const;
+
+    static map_type to_simple_map(const extended_map_type&);
+    static extended_map_type to_extended_map(const map_type&);
 
     sstring get_string(sstring key, sstring default_value) const;
 
@@ -77,6 +88,9 @@ public:
         return _properties.size();
     }
 };
+
+property_definitions::map_type to_flattened_map(const property_definitions::extended_map_type&);
+property_definitions::extended_map_type from_flattened_map(const property_definitions::map_type&);
 
 }
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -233,7 +233,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
     locator::replication_strategy_params params(strategy_options(), initial_tablets());
-    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params);
+    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params, topology);
     strategy->validate_options(fs, topology);
 }
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -22,6 +22,7 @@
 #include <ostream>
 #include <array>
 #include "replica/database.hh"
+#include "utils/overloaded_functor.hh"
 
 namespace data_dictionary {
 
@@ -318,7 +319,7 @@ bool storage_options::is_local_type() const noexcept {
     return std::holds_alternative<local>(value);
 }
 
-storage_options::value_type storage_options::from_map(std::string_view type, std::map<sstring, sstring> values) {
+storage_options::value_type storage_options::from_map(std::string_view type, const std::map<sstring, sstring>& values) {
     if (type == local::name) {
         return local::from_map(values);
     }
@@ -414,7 +415,22 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
         os << "CREATE KEYSPACE " << cql3::util::maybe_quote(_name)
            << " WITH replication = {'class': " << cql3::util::single_quote(_strategy_name);
         for (const auto& opt: _strategy_options) {
-            os << ", " << cql3::util::single_quote(opt.first) << ": " << cql3::util::single_quote(opt.second);
+            os << ", " << cql3::util::single_quote(opt.first) << ": ";
+            std::visit(overloaded_functor{
+                [&os] (const sstring& str) {
+                    os << cql3::util::single_quote(str);
+                },
+                [&os] (const std::vector<sstring>& vec) {
+                    os << "[";
+                    for (auto it = vec.begin(); it != vec.end(); ++it) {
+                        if (it != vec.begin()) {
+                            os << ", ";
+                        }
+                        os << cql3::util::single_quote(*it);
+                    }
+                    os << "]";
+                }
+            }, opt.second);
         }
         if (!_storage_options->is_local_type()) {
             os << "} AND storage = {'type': " << cql3::util::single_quote(sstring(_storage_options->type_string()));

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -53,7 +53,7 @@ struct storage_options {
 
     bool can_update_to(const storage_options& new_options);
 
-    static value_type from_map(std::string_view type, std::map<sstring, sstring> values);
+    static value_type from_map(std::string_view type, const std::map<sstring, sstring>& values);
 
     storage_options append_to_s3_prefix(const sstring& s) const;
 };

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -35,7 +35,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/util.hh"
-#include "types/user.hh"
+#include "cql3/statements/property_definitions.hh"
 
 static seastar::logger mlogger("legacy_schema_migrator");
 
@@ -541,7 +541,7 @@ public:
         for (auto& ks : _keyspaces) {
             auto ksm = ::make_lw_shared<keyspace_metadata>(ks.name
                             , ks.replication_params["class"] // TODO, make ksm like c3?
-                            , ks.replication_params
+                            , cql3::statements::property_definitions::to_extended_map(ks.replication_params)
                             , std::nullopt
                             , ks.durable_writes);
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1295,7 +1295,7 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
     // (or screw up shared pointers)
     const auto& replication = row.get_nonnull<map_type_impl::native_type>("replication");
 
-    std::map<sstring, sstring> strategy_options;
+    cql3::statements::property_definitions::map_type strategy_options;
     for (auto& p : replication) {
         strategy_options.emplace(value_cast<sstring>(p.first), value_cast<sstring>(p.second));
     }

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -180,6 +180,18 @@ then every rack in every datacenter receives a replica, except for racks compris
 of only :doc:`zero-token nodes </architecture/zero-token-nodes>`. Racks added after
 the keyspace creation do not receive replicas.
 
+When ``rf_rack_valid_keyspaces``` is enabled in the config and the keyspace is tablet-based,
+the numeric replication factor is automatically expanded into a rack list when the statement is
+executed, which can be observed in the DESCRIBE output afterwards. If the numeric RF is smaller than
+the number of racks in a DC, a subset of racks is chosen arbitrarily.
+
+Altering from a rack list to a numeric replication factor is not supported, except
+for two cases. One is setting replication factor to 0, in which case the number of replicas is reduced to 0 in that DC.
+The other is when the numeric replication factor is equal to the current number of replicas
+for a given datacanter, in which case the current rack list is preserved.
+
+Altering from a numeric replication factor to a rack list is not supported yet.
+
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
 auto-expansion will only *add* new datacenters for safety, it will not alter
 existing datacenters or remove any even if they are no longer in the cluster.

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -104,7 +104,7 @@ For example:
 .. code-block:: cql
 
    CREATE KEYSPACE Excalibur
-   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : 1, 'DC2' : 3}
+   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : ['RAC1', 'RAC2', 'RAC3'], 'DC2' : 3}
    AND durable_writes = true;
 
 The supported ``options`` are:
@@ -157,23 +157,26 @@ factor independently for each data-center. The rest of the sub-options are
 key-value pairs where a key is a data-center name and its value is the
 associated replication factor. Options:
 
-===================================== ====== =============================================
-sub-option                             type  description
-===================================== ====== =============================================
-``'<datacenter>'``                     int   The number of replicas to store per range in
-                                             the provided datacenter.
-``'replication_factor'``               int   The number of replicas to use as a default
-                                             per datacenter if not specifically provided.
-                                             Note that this always defers to existing
-                                             definitions or explicit datacenter settings.
-                                             For example, to have three replicas per
-                                             datacenter, supply this with a value of 3.
+===================================== ========= =============================================
+sub-option                             type      description
+===================================== ========= =============================================
+``'<datacenter>'``                     int|list The number of replicas to store per range in
+                                                the provided datacenter, or a list of rack names
+                                                to place replicas.
 
-                                             The replication factor configured for a DC
-                                             should be equal to or lower than the number
-                                             of nodes in that DC. Configuring a higher RF 
-                                             may prevent creating tables in that keyspace. 
-===================================== ====== =============================================
+``'replication_factor'``               int      The number of replicas to use as a default
+                                                per datacenter if not specifically provided.
+
+                                                Note that this always defers to existing
+                                                definitions or explicit datacenter settings.
+                                                For example, to have three replicas per
+                                                datacenter, supply this with a value of 3.
+
+                                                The replication factor configured for a DC
+                                                should be equal to or lower than the number
+                                                of nodes in that DC. Configuring a higher RF
+                                                may prevent creating tables in that keyspace.
+===================================== ========= =============================================
 
 If no datacenters are specified, and ``replication_factor`` is left unspecified,
 then every rack in every datacenter receives a replica, except for racks comprised
@@ -204,7 +207,7 @@ An example of auto-expanding datacenters with two datacenters: ``DC1`` and ``DC2
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '3'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1-1', 'RAC1-2', 'RAC1-3' ], 'DC2': [ 'RAC2-1', 'RAC2-2', 'RAC2-3' ]} AND durable_writes = true;
 
 
 An example of auto-expanding and overriding a datacenter::
@@ -213,7 +216,7 @@ An example of auto-expanding and overriding a datacenter::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 2}
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '2'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1-1', 'RAC1-2', 'RAC1-3' ], 'DC2': [ 'RAC2-1', 'RAC2-2' ]} AND durable_writes = true;
 
 An example that excludes a datacenter while using ``replication_factor``::
 
@@ -221,7 +224,7 @@ An example that excludes a datacenter while using ``replication_factor``::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 0} ;
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1', 'RAC2', 'RAC3' ]} AND durable_writes = true;
 
 An example that excludes class and uses only datacenter options::
 

--- a/docs/dev/system_schema_keyspace.md
+++ b/docs/dev/system_schema_keyspace.md
@@ -2,6 +2,64 @@
 
 This section describes layouts and usage of system\_schema.* tables.
 
+## system\_schema.keyspaces
+
+This table contains one row per keyspaces.
+
+Schema:
+
+```
+CREATE TABLE system_schema.keyspaces (
+    keyspace_name text PRIMARY KEY,
+    durable_writes boolean,
+    replication frozen<map<text, text>>
+)
+```
+
+Columns:
+
+* `keyspace_name` - name of the keyspace
+* `durable_writes` - whether writes to the keyspace are using commitlog.
+* `replication` - replication settings for the keyspace. The value for the `"class"` key determines
+   replication strategy name. The structure of other options depends
+   on the replication strategy.
+
+   For `NetworkTopologyStrategy` the other options specify replication factors for datacenters,
+   stored as a flattened map of the extended options map (see below).
+
+   For `SimpleStrategy` there is a single option `"replication_factor"` specifying the replication factor.
+
+Extended options map used by NetworkTopologyStrategy is a map where values can be either strings or lists of strings.
+
+For example:
+
+
+```
+   {
+      'dc1': '3',
+      'dc2': ['rack1', 'rack2'],
+      'dc3': []
+   }
+```
+
+The options above mean that the replication factor for datacenter `dc1` is 3, for datacenter `dc2` it is 2,
+with replicas placed on racks `rack1` and `rack2`. For 'dc3' the replication factor is 0, expressed as an empty list of racks.
+
+The extended map is stored in the "replication" column in a flattened form, where values which are lists
+are represented as multiple entries in the map with the list index appended to the key, with `:` as the separator.
+The index can be negative, which is used to indicate that the list is empty.
+
+The example extended options map from above has a flattened representation of:
+
+```
+  {
+    'dc1': '3',
+    'dc2:0': 'rack1',
+    'dc2:1': 'rack2',
+    'dc3:-1': ''
+  }
+```
+
 ## system\_schema.computed\_columns
 
 Computed columns are a special kind of columns. Rather than having their value provided directly

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -723,7 +723,9 @@ There are also a few static columns for cluster-global properties:
 - `new_cdc_generation_data_uuid` - used in `commit_cdc_generation` state, the time UUID of the generation to be committed
 - `upgrade_state` - describes the progress of the upgrade to raft-based topology.
 - `new_keyspace_rf_change_ks_name` - the name of the KS that is being the target of the scheduled ALTER KS statement
-- `new_keyspace_rf_change_data` - the KS options to be used when executing the scheduled ALTER KS statement
+- `new_keyspace_rf_change_data` - the KS options to be used when executing the scheduled ALTER KS statement.
+        Same format as that of the `replication` column of `system_schema.keyspaces`. See docs/dev/system_schema_keyspace.md
+        Contains only the subset of options which are changed.
 - `global_requests` - contains a list of ids of pending global requests, the information about requests (type and parameters)
                       can be obtained from topology_requests table by using request's id as a look up key.
 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -171,6 +171,7 @@ public:
     gms::feature lwt_with_tablets { *this, "LWT_WITH_TABLETS"sv };
     gms::feature repair_msg_split { *this, "REPAIR_MSG_SPLIT"sv };
     gms::feature view_building_coordinator { *this, "VIEW_BUILDING_COORDINATOR"sv };
+    gms::feature rack_list_rf { *this, "RACK_LIST_RF"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -154,8 +154,7 @@ const tablet_aware_replication_strategy* abstract_replication_strategy::maybe_as
     return dynamic_cast<const tablet_aware_replication_strategy*>(this);
 }
 
-long abstract_replication_strategy::parse_replication_factor(sstring rf)
-{
+size_t replication_factor_data::parse(const sstring& rf) {
     if (rf.empty() || std::any_of(rf.begin(), rf.end(), [] (char c) {return !isdigit(c);})) {
         throw exceptions::configuration_exception(
                 format("Replication factor must be numeric and non-negative, found '{}'", rf));
@@ -166,6 +165,11 @@ long abstract_replication_strategy::parse_replication_factor(sstring rf)
         throw exceptions::configuration_exception(
             sstring("Replication factor must be numeric; found ") + rf);
     }
+}
+
+replication_factor_data abstract_replication_strategy::parse_replication_factor(sstring rf)
+{
+    return replication_factor_data(rf);
 }
 
 static
@@ -711,4 +715,8 @@ auto fmt::formatter<locator::static_effective_replication_map::factory_key>::for
         sep = ',';
     }
     return out;
+}
+
+auto fmt::formatter<locator::replication_factor_data>::format(const locator::replication_factor_data& rf, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", rf.count());
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -174,6 +174,10 @@ replication_factor_data abstract_replication_strategy::parse_replication_factor(
     return replication_factor_data(rf);
 }
 
+size_t get_replication_factor(const replication_strategy_config_option& opt) {
+    return replication_factor_data(opt).count();
+}
+
 static
 void
 insert_token_range_to_sorted_container_while_unwrapping(

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -68,17 +68,19 @@ abstract_replication_strategy::abstract_replication_strategy(
     }
 }
 
-abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params) {
+abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology* topo) {
     try {
-        return create_object<abstract_replication_strategy, replication_strategy_params>(strategy_name, std::move(params));
+        return create_object<abstract_replication_strategy, replication_strategy_params, const locator::topology*>(strategy_name, std::move(params), std::move(topo));
     } catch (const no_such_class& e) {
         throw exceptions::configuration_exception(e.what());
     }
 }
 
+// class registry signature must match the actual replication strategies' signature
 using strategy_class_registry = class_registry<
     locator::abstract_replication_strategy,
-    replication_strategy_params>;
+    replication_strategy_params,
+    const topology*>;
 
 sstring abstract_replication_strategy::to_qualified_class_name(std::string_view strategy_class_name) {
     return strategy_class_registry::to_qualified_class_name(strategy_class_name);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -178,6 +178,34 @@ size_t get_replication_factor(const replication_strategy_config_option& opt) {
     return replication_factor_data(opt).count();
 }
 
+replication_factor_data::replication_factor_data(const replication_strategy_config_option& rf) {
+    std::visit(overloaded_functor {
+            [&] (const sstring& rf) {
+                auto rf_value = parse(rf);
+                _data.emplace<size_t>(rf_value);
+                _count = rf_value;
+            },
+            [&] (const std::vector<sstring>& racks) {
+                _data.emplace<std::vector<sstring>>(racks);
+                _count = racks.size();
+            }
+    }, rf);
+}
+
+void replication_factor_data::validate(const std::unordered_set<sstring>& allowed_racks) {
+    std::visit(overloaded_functor {
+            [&] (const size_t& rf) {},
+            [&] (const std::vector<sstring>& racks) {
+                for (const auto& rack : racks) {
+                    if (!allowed_racks.contains(rack) && !allowed_racks.empty()) {
+                        throw exceptions::configuration_exception(
+                                fmt::format("Unrecognized rack name '{}'. allowed_racks={}", rack, allowed_racks));
+                    }
+                }
+            }
+    }, _data);
+}
+
 static
 void
 insert_token_range_to_sorted_container_while_unwrapping(

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -169,7 +169,7 @@ size_t replication_factor_data::parse(const sstring& rf) {
     }
 }
 
-replication_factor_data abstract_replication_strategy::parse_replication_factor(sstring rf)
+replication_factor_data abstract_replication_strategy::parse_replication_factor(const replication_strategy_config_option& rf)
 {
     return replication_factor_data(rf);
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -206,6 +206,16 @@ void replication_factor_data::validate(const std::unordered_set<sstring>& allowe
     }, _data);
 }
 
+rack_diff diff_racks(const rack_list& old_racks, const rack_list& new_racks) {
+    std::set<sstring> old_racks_set(old_racks.begin(), old_racks.end());
+    std::set<sstring> new_racks_set(new_racks.begin(), new_racks.end());
+
+    rack_diff diff;
+    std::ranges::set_difference(new_racks_set, old_racks_set, std::back_inserter(diff.added));
+    std::ranges::set_difference(old_racks_set, new_racks_set, std::back_inserter(diff.removed));
+    return diff;
+}
+
 static
 void
 insert_token_range_to_sorted_container_while_unwrapping(

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -44,7 +44,9 @@ enum class replication_strategy_type {
     everywhere_topology,
 };
 
-using replication_strategy_config_options = std::map<sstring, sstring>;
+using replication_strategy_config_option = sstring;
+using replication_strategy_config_options = std::map<sstring, replication_strategy_config_option>;
+
 struct replication_strategy_params {
     const replication_strategy_config_options options;
     std::optional<unsigned> initial_tablets;
@@ -130,7 +132,7 @@ public:
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
         return create_replication_strategy(strategy_name, std::move(params), &topo);
     }
-    static replication_factor_data parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(const replication_strategy_config_option& rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -126,7 +126,10 @@ public:
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
 
     virtual ~abstract_replication_strategy() {}
-    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology*);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
+        return create_replication_strategy(strategy_name, std::move(params), &topo);
+    }
     static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -61,6 +61,22 @@ class per_table_replication_strategy;
 class tablet_aware_replication_strategy;
 class effective_replication_map;
 
+class replication_factor_data {
+    size_t _count = 0;
+
+public:
+    explicit replication_factor_data(const sstring& rf)
+        : _count(parse(rf))
+    { }
+
+    size_t count() const noexcept {
+        return _count;
+    }
+
+public:
+    // Parses a numeric replication factor.
+    static size_t parse(const sstring& rf);
+};
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
     friend class static_effective_replication_map;
@@ -111,7 +127,7 @@ public:
 
     virtual ~abstract_replication_strategy() {}
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
-    static long parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
@@ -563,6 +579,11 @@ struct appending_hash<locator::static_effective_replication_map::factory_key> {
             h.update(val.c_str(), val.size());
         }
     }
+};
+
+template <>
+struct fmt::formatter<locator::replication_factor_data> : fmt::formatter<string_view> {
+    auto format(const locator::replication_factor_data&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 namespace std {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -108,6 +108,21 @@ public:
     void validate(const std::unordered_set<sstring>& allowed_racks);
 };
 
+struct rack_diff {
+    rack_list added;
+    rack_list removed;
+
+    bool empty() const {
+        return added.empty() && removed.empty();
+    }
+
+    operator bool() const {
+        return !empty();
+    }
+};
+
+rack_diff diff_racks(const rack_list& old_racks, const rack_list& new_racks);
+
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
     friend class static_effective_replication_map;
     friend class per_table_replication_strategy;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -47,6 +47,10 @@ enum class replication_strategy_type {
 using replication_strategy_config_option = sstring;
 using replication_strategy_config_options = std::map<sstring, replication_strategy_config_option>;
 
+// Returns the number of replicas inferred by the option.
+// Throws configuration_exception when option is not a valid replication factor specifier.
+size_t get_replication_factor(const replication_strategy_config_option&);
+
 struct replication_strategy_params {
     const replication_strategy_config_options options;
     std::optional<unsigned> initial_tablets;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -44,7 +44,9 @@ enum class replication_strategy_type {
     everywhere_topology,
 };
 
-using replication_strategy_config_option = sstring;
+using rack_list = std::vector<sstring>;
+
+using replication_strategy_config_option = std::variant<sstring, rack_list>;
 using replication_strategy_config_options = std::map<sstring, replication_strategy_config_option>;
 
 // Returns the number of replicas inferred by the option.
@@ -68,20 +70,42 @@ class tablet_aware_replication_strategy;
 class effective_replication_map;
 
 class replication_factor_data {
-    size_t _count = 0;
+    std::variant<size_t, std::vector<sstring>> _data;
+    size_t _count;
 
 public:
-    explicit replication_factor_data(const sstring& rf)
-        : _count(parse(rf))
+    explicit replication_factor_data(const replication_strategy_config_option& rf);
+
+    explicit replication_factor_data(size_t rf)
+        : _data(rf)
+        , _count(rf)
+    { }
+
+    explicit replication_factor_data(rack_list rf)
+        : _data(std::move(rf))
+        , _count(rf.size())
     { }
 
     size_t count() const noexcept {
         return _count;
     }
 
-public:
+    bool is_rack_based() const noexcept {
+        return std::holds_alternative<rack_list>(_data);
+    }
+
+    bool is_numeric() const noexcept {
+        return std::holds_alternative<size_t>(_data);
+    }
+
+    const rack_list& get_rack_list() const {
+        return std::get<rack_list>(_data);
+    }
+
     // Parses a numeric replication factor.
     static size_t parse(const sstring& rf);
+
+    void validate(const std::unordered_set<sstring>& allowed_racks);
 };
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
@@ -149,7 +173,7 @@ public:
     // appear in the pending_endpoints.
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const = 0;
     replication_strategy_type get_type() const noexcept { return _my_type; }
-    const replication_strategy_config_options get_config_options() const noexcept { return _config_options; }
+    const replication_strategy_config_options& get_config_options() const noexcept { return _config_options; }
 
     // If returns true then tables governed by this replication strategy have separate
     // effective_replication_maps.
@@ -585,7 +609,15 @@ struct appending_hash<locator::static_effective_replication_map::factory_key> {
         feed_hash(h, key.ring_version);
         for (const auto& [opt, val] : key.rs_config_options) {
             h.update(opt.c_str(), opt.size());
-            h.update(val.c_str(), val.size());
+            feed_hash(h, val.index());
+            std::visit(overloaded_functor {
+                [&h] (const sstring& str) {
+                    feed_hash(h, str);
+                },
+                [&h] (const std::vector<sstring>& vec) {
+                    feed_hash(h, vec);
+                }
+            }, val);
         }
     }
 };
@@ -642,4 +674,30 @@ private:
     friend class vnode_effective_replication_map;
 };
 
-}
+} // namespace locator
+
+template <>
+struct fmt::formatter<locator::replication_strategy_config_option> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const locator::replication_strategy_config_option& opt, FormatContext& ctx) const {
+        return std::visit(overloaded_functor{
+            [&ctx] (const sstring& s) {
+                return fmt::format_to(ctx.out(), "'{}'", s);
+            },
+            [&ctx] (const std::vector<sstring>& v) {
+                return fmt::format_to(ctx.out(), "[{}]", fmt::join(v | std::views::transform([] (auto& s) { return fmt::format("'{}'", s); }), ","));
+            }
+        }, opt);
+    }
+};
+
+template <>
+struct fmt::formatter<locator::replication_strategy_config_options> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const locator::replication_strategy_config_options& opts, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(opts |
+                std::views::transform([] (const auto& x) { return fmt::format("'{}':{}", x.first, x.second); }), ", "));
+    }
+};

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -16,7 +16,7 @@
 
 namespace locator {
 
-everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params) :
+everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::everywhere_topology) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -49,7 +49,8 @@ sstring everywhere_replication_strategy::sanity_check_read_replicas(const effect
 }
 
 
-using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.EverywhereStrategy");
 static registry registrator_short_name("EverywhereStrategy");
 }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -16,7 +16,7 @@
 namespace locator {
 class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
-    everywhere_replication_strategy(replication_strategy_params params);
+    everywhere_replication_strategy(replication_strategy_params params, const locator::topology*);
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -15,7 +15,7 @@
 
 namespace locator {
 
-local_strategy::local_strategy(replication_strategy_params params) :
+local_strategy::local_strategy(replication_strategy_params params, const topology*) :
         abstract_replication_strategy(params, replication_strategy_type::local) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -102,7 +102,7 @@ future<dht::token_range_vector> local_effective_replication_map::get_ranges(host
     return make_ready_future<dht::token_range_vector>();
 }
 
-using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params>;
+using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");
 

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -22,7 +22,7 @@ using token = dht::token;
 
 class local_strategy : public abstract_replication_strategy {
 public:
-    local_strategy(replication_strategy_params params);
+    local_strategy(replication_strategy_params params, const topology*);
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -338,30 +338,122 @@ future<tablet_replica_set> network_topology_strategy::reallocate_tablets(schema_
     std::unordered_map<sstring, size_t> nodes_per_dc;
     // Current replicas per dc/rack
     std::unordered_map<sstring, std::map<sstring, std::unordered_set<locator::host_id>>> replicas_per_dc_rack;
+    std::unordered_map<sstring, rack_list> old_racks_per_dc;
 
     replicas = cur_tablets.get_tablet_info(tb).replicas;
     for (const auto& tr : replicas) {
         const auto& node = tm->get_topology().get_node(tr.host);
         replicas_per_dc_rack[node.dc_rack().dc][node.dc_rack().rack].insert(tr.host);
         ++nodes_per_dc[node.dc_rack().dc];
+        old_racks_per_dc[node.dc_rack().dc].push_back(node.dc_rack().rack);
     }
 
     // #22688 - take all dcs in topology into account when determining migration.
     // Any change should still have been pre-checked to never exceed rf factor one.
     for (const auto& dc : tm->get_topology().get_datacenters()) {
-        auto dc_rf = get_replication_factor(dc);
-        auto dc_node_count = nodes_per_dc[dc];
-        if (dc_rf == dc_node_count) {
-            continue;
-        }
-        if (dc_rf > dc_node_count) {
-            replicas = co_await add_tablets_in_dc(s, tm, load, tb, replicas_per_dc_rack[dc], replicas, dc, dc_node_count, dc_rf);
+        auto new_rf = get_replication_factor_data(dc);
+
+        if (new_rf && new_rf->is_rack_based()) {
+            auto diff = diff_racks(old_racks_per_dc[dc], new_rf->get_rack_list());
+
+            tablet_logger.debug("reallocate_tablets {}.{} tablet_id={} dc={} old_racks={} add_racks={} del_racks={}",
+                    s->ks_name(), s->cf_name(), tb, dc, old_racks_per_dc[dc], diff.added, diff.removed);
+
+            if (!diff) {
+                continue;
+            }
+
+            if (!diff.added.empty() && !diff.removed.empty()) {
+                // FIXME: Support replace
+                throw std::runtime_error("replacing racks unsupported");
+            } else if (!diff.added.empty()) {
+                replicas = add_tablets_in_racks(s, tm, load, tb, replicas, dc, diff.added);
+            } else { // diff.removed
+                replicas = drop_tablets_in_racks(s, tm, load, tb, replicas, dc, diff.removed);
+            }
         } else {
-            replicas = drop_tablets_in_dc(s, tm->get_topology(), load, tb, replicas, dc, dc_node_count, dc_rf);
+            auto dc_rf = new_rf ? new_rf->count() : 0;
+            auto dc_node_count = nodes_per_dc[dc];
+            if (dc_rf == dc_node_count) {
+                continue;
+            }
+            if (dc_rf > dc_node_count) {
+                replicas = co_await add_tablets_in_dc(s, tm, load, tb, replicas_per_dc_rack[dc], replicas, dc, dc_node_count, dc_rf);
+            } else {
+                replicas = drop_tablets_in_dc(s, tm->get_topology(), load, tb, replicas, dc, dc_node_count, dc_rf);
+            }
         }
     }
 
     co_return replicas;
+}
+
+tablet_replica_set network_topology_strategy::drop_tablets_in_racks(schema_ptr s,
+                                                                    token_metadata_ptr tm,
+                                                                    load_sketch& load,
+                                                                    tablet_id tb,
+                                                                    const tablet_replica_set& cur_replicas,
+                                                                    const sstring& dc,
+                                                                    const rack_list& racks_to_drop) const {
+    auto& topo = tm->get_topology();
+    tablet_replica_set filtered;
+    auto is_rack_to_drop = [&racks_to_drop] (const sstring& rack) {
+        return std::ranges::contains(racks_to_drop, rack);
+    };
+    for (const auto& tr : cur_replicas) {
+        auto& node = topo.get_node(tr.host);
+        if (node.dc_rack().dc == dc && is_rack_to_drop(node.dc_rack().rack)) {
+            tablet_logger.debug("drop_tablets_in_rack {}.{} tablet_id={} dc={} rack={} removing replica: {}",
+                            s->ks_name(), s->cf_name(), tb, node.dc_rack().dc, node.dc_rack().rack, tr);
+            load.unload(tr.host, tr.shard);
+        } else {
+            filtered.emplace_back(tr);
+        }
+    }
+    return filtered;
+}
+
+tablet_replica_set network_topology_strategy::add_tablets_in_racks(schema_ptr s,
+                                                                   token_metadata_ptr tm,
+                                                                   load_sketch& load,
+                                                                   tablet_id tb,
+                                                                   const tablet_replica_set& cur_replicas,
+                                                                   const sstring& dc,
+                                                                   const rack_list& racks_to_add) const {
+    auto nodes = tm->get_datacenter_racks_token_owners_nodes();
+    auto& dc_nodes = nodes.at(dc);
+    auto new_replicas = cur_replicas;
+
+    for (auto&& rack: racks_to_add) {
+        host_id min_node;
+        double min_load = std::numeric_limits<double>::max();
+
+        for (auto&& node: dc_nodes.at(rack)) {
+            if (!node.get().is_normal()) {
+                continue;
+            }
+            // Assume that if there was a diff to add a rack, we don't already have a replica
+            // in the target rack so all nodes in the rack are eligible.
+            // FIXME: pick based on storage utilization.
+            auto node_load = load.get_real_avg_shard_load(node.get().host_id());
+            if (node_load < min_load) {
+                min_load = node_load;
+                min_node = node.get().host_id();
+            }
+        }
+
+        if (!min_node) {
+            throw std::runtime_error(
+                    fmt::format("No candidate node in rack {}.{} to allocate tablet replica", dc, rack));
+        }
+
+        auto new_replica = tablet_replica{min_node, load.next_shard(min_node)};
+        new_replicas.push_back(new_replica);
+
+        tablet_logger.trace("add_tablet_in_rack {}.{} tablet_id={} dc={} rack={} load={} new_replica={}",
+                            s->ks_name(), s->cf_name(), tb.id, dc, rack, min_load, new_replica);
+    }
+    return new_replicas;
 }
 
 future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_ptr s, token_metadata_ptr tm, load_sketch& load, tablet_id tb,

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -38,10 +38,15 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
+static logging::logger logger("network_topology_strategy");
+
 network_topology_strategy::network_topology_strategy(replication_strategy_params params, const topology* topo) :
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
+
+    logger.debug("options={}", opts);
+
     process_tablet_options(*this, opts, params);
 
     size_t rep_factor = 0;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -38,7 +38,7 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-network_topology_strategy::network_topology_strategy(replication_strategy_params params) :
+network_topology_strategy::network_topology_strategy(replication_strategy_params params, const topology* topo) :
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
@@ -551,7 +551,8 @@ sstring network_topology_strategy::sanity_check_read_replicas(const effective_re
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.NetworkTopologyStrategy");
 static registry registrator_short_name("NetworkTopologyStrategy");
 }

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -31,7 +31,7 @@ public:
 
     size_t get_replication_factor(const sstring& dc) const override {
         auto dc_factor = _dc_rep_factor.find(dc);
-        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second;
+        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second.count();
     }
 
     const std::vector<sstring>& get_datacenters() const {
@@ -58,6 +58,9 @@ protected:
 
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;
 
+public:
+    using dc_rep_factor_map = std::unordered_map<sstring, replication_factor_data>;
+
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, token_metadata_ptr, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
     future<tablet_replica_set> add_tablets_in_dc(schema_ptr, token_metadata_ptr, load_sketch&, tablet_id,
@@ -69,7 +72,7 @@ private:
             sstring dc, size_t dc_node_count, size_t dc_rf) const;
 
     // map: data centers -> replication factor
-    std::unordered_map<sstring, size_t> _dc_rep_factor;
+    dc_rep_factor_map _dc_rep_factor;
 
     std::vector<sstring> _datacenteres;
     size_t _rep_factor;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -23,7 +23,7 @@ class load_sketch;
 class network_topology_strategy : public abstract_replication_strategy
                                 , public tablet_aware_replication_strategy {
 public:
-    network_topology_strategy(replication_strategy_params params);
+    network_topology_strategy(replication_strategy_params params, const topology* topo);
 
     virtual size_t get_replication_factor(const token_metadata&) const override {
         return _rep_factor;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -34,6 +34,21 @@ public:
         return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second.count();
     }
 
+    const replication_factor_data* get_replication_factor_data(const sstring& dc) const {
+        auto dc_factor = _dc_rep_factor.find(dc);
+        if (dc_factor == _dc_rep_factor.end()) {
+            return nullptr;
+        }
+        return &dc_factor->second;
+    }
+
+    bool is_rack_based(const sstring& dc) const override {
+        if (auto rf = get_replication_factor_data(dc)) {
+            return rf->is_rack_based();
+        }
+        return false;
+    }
+
     const std::vector<sstring>& get_datacenters() const {
         return _datacenteres;
     }
@@ -70,6 +85,22 @@ private:
     tablet_replica_set drop_tablets_in_dc(schema_ptr, const locator::topology&, load_sketch&, tablet_id,
             const tablet_replica_set& cur_replicas,
             sstring dc, size_t dc_node_count, size_t dc_rf) const;
+
+    tablet_replica_set drop_tablets_in_racks(schema_ptr,
+                                             token_metadata_ptr,
+                                             load_sketch&,
+                                             tablet_id,
+                                             const tablet_replica_set& cur_replicas,
+                                             const sstring& dc,
+                                             const rack_list& racks_to_drop) const;
+
+    tablet_replica_set add_tablets_in_racks(schema_ptr,
+                                            token_metadata_ptr,
+                                            load_sketch&,
+                                            tablet_id,
+                                            const tablet_replica_set& cur_replicas,
+                                            const sstring& dc,
+                                            const rack_list& racks_to_add) const;
 
     // map: data centers -> replication factor
     dc_rep_factor_map _dc_rep_factor;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -18,7 +18,7 @@
 
 namespace locator {
 
-simple_strategy::simple_strategy(replication_strategy_params params) :
+simple_strategy::simple_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::simple) {
     for (auto& config_pair : _config_options) {
         auto& key = config_pair.first;
@@ -86,7 +86,8 @@ sstring simple_strategy::sanity_check_read_replicas(const effective_replication_
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.SimpleStrategy");
 static registry registrator_short_name("SimpleStrategy");
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -70,7 +70,10 @@ void simple_strategy::validate_options(const gms::feature_service&, const locato
     if (it == _config_options.end()) {
         throw exceptions::configuration_exception("SimpleStrategy requires a replication_factor strategy option.");
     }
-    parse_replication_factor(it->second);
+    auto rf = parse_replication_factor(it->second);
+    if (!rf.is_numeric()) {
+        throw exceptions::configuration_exception("'replication_factor' option must be numeric.");
+    }
     if (_uses_tablets) {
         throw exceptions::configuration_exception("SimpleStrategy doesn't support tablet replication");
     }

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -25,7 +25,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            _replication_factor = parse_replication_factor(val);
+            _replication_factor = parse_replication_factor(val).count();
             break;
         }
     }

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -16,7 +16,7 @@ namespace locator {
 
 class simple_strategy : public abstract_replication_strategy {
 public:
-    simple_strategy(replication_strategy_params params);
+    simple_strategy(replication_strategy_params params, const topology*);
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -52,6 +52,8 @@ public:
     /// current replica list, as replication factor changes involve table rebuilding transitions
     /// which are not instantaneous.
     virtual size_t get_replication_factor(const sstring& dc) const = 0;
+
+    virtual bool is_rack_based(const sstring& dc) const = 0;
 };
 
 } // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1283,7 +1283,12 @@ void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr
             }
         }
 
-        const size_t rf = nts.get_replication_factor(dc);
+        auto rf_data = nts.get_replication_factor_data(dc);
+        if (!rf_data || rf_data->is_rack_based()) {
+            continue;
+        }
+
+        auto rf = rf_data->count();
 
         // We must not allow for a keyspace to become RF-rack-invalid. Any attempt at that must be rejected.
         // For more context, see: scylladb/scylladb#23276.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1038,7 +1038,7 @@ future<> database::create_local_system_table(
         bool durable = _cfg.data_file_directories().size() > 0;
         auto ksm = make_lw_shared<keyspace_metadata>(ks_name,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 durable
                 );

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -887,7 +887,7 @@ future<> database::modify_keyspace_on_all_shards(sharded<database>& sharded_db, 
 }
 
 future<keyspace_change> database::prepare_update_keyspace(const keyspace& ks, lw_shared_ptr<keyspace_metadata> metadata) const {
-    auto strategy = keyspace::create_replication_strategy(metadata);
+    auto strategy = keyspace::create_replication_strategy(metadata, get_token_metadata().get_topology());
     locator::static_effective_replication_map_ptr erm = nullptr;
     if (!strategy->is_per_table()) {
         erm = co_await ks.create_static_effective_replication_map(strategy,
@@ -1428,12 +1428,12 @@ bool database::column_family_exists(const table_id& uuid) const {
 }
 
 locator::replication_strategy_ptr
-keyspace::create_replication_strategy(lw_shared_ptr<keyspace_metadata> metadata) {
+keyspace::create_replication_strategy(lw_shared_ptr<keyspace_metadata> metadata, const locator::topology& topology) {
     using namespace locator;
     replication_strategy_params params(metadata->strategy_options(), metadata->initial_tablets());
     rslogger.debug("replication strategy for keyspace {} is {}, opts={}",
             metadata->name(), metadata->strategy_name(), metadata->strategy_options());
-    return abstract_replication_strategy::create_replication_strategy(metadata->strategy_name(), params);
+    return abstract_replication_strategy::create_replication_strategy(metadata->strategy_name(), params, topology);
 }
 
 future<locator::static_effective_replication_map_ptr> keyspace::create_static_effective_replication_map(locator::replication_strategy_ptr strategy, const locator::shared_token_metadata& stm) const {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1430,7 +1430,8 @@ public:
     lw_shared_ptr<keyspace_metadata> metadata() const;
 
     static locator::replication_strategy_ptr create_replication_strategy(
-            lw_shared_ptr<keyspace_metadata> metadata);
+            lw_shared_ptr<keyspace_metadata> metadata,
+            const locator::topology& topology);
     future<locator::static_effective_replication_map_ptr> create_static_effective_replication_map(
             locator::replication_strategy_ptr strategy,
             const locator::shared_token_metadata& stm) const;

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -17,6 +17,7 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "cql3/column_specification.hh"
+#include "cql3/statements/index_prop_defs.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/core/sstring.hh>
@@ -174,8 +175,6 @@ public:
     }
     bool operator==(const speculative_retry& other) const = default;
 };
-
-typedef std::unordered_map<sstring, sstring> index_options_map;
 
 enum class index_metadata_kind {
     keys,

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3252,10 +3252,9 @@ public:
     // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
     void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) {
         locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
-        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
+        auto tm = _db.get_shared_token_metadata().get();
+        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params, tm->get_topology());
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
-            auto tm = _db.get_shared_token_metadata().get();
-
             std::unordered_map<table_id, schema_ptr> new_cfms_map;
             for (auto s : cfms) {
                 new_cfms_map[s->id()] = s;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -944,7 +944,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     auto tmptr = get_token_metadata_ptr();
                     cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
                     new_ks_props.validate();
-                    auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features());
+                    auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features(), _db.get_config());
                     size_t unimportant_init_tablet_count = 2; // must be a power of 2
                     locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -961,7 +961,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
-                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
                     } catch (const std::exception& e) {
                         error = e.what();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -935,15 +935,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 ks_name = *req_entry.new_keyspace_rf_change_ks_name;
                 saved_ks_props = *req_entry.new_keyspace_rf_change_data;
             }
-            cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
 
-            auto repl_opts = new_ks_props.get_replication_options();
-            repl_opts.erase(cql3::statements::ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
             utils::chunked_vector<canonical_mutation> updates;
             sstring error;
             if (_db.has_keyspace(ks_name)) {
                 auto& ks = _db.find_keyspace(ks_name);
                 auto tmptr = get_token_metadata_ptr();
+                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
+                new_ks_props.validate();
+                auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features());
                 size_t unimportant_init_tablet_count = 2; // must be a power of 2
                 locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
@@ -960,7 +960,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             continue;
                         }
                         old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
-                        locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
+                        locator::replication_strategy_params params{ks_md->strategy_options(), old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
                     } catch (const std::exception& e) {
@@ -995,6 +995,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         co_await coroutine::maybe_yield();
                     });
                 }
+
+                if (error.empty()) {
+                    const sstring strategy_name = "NetworkTopologyStrategy";
+                    auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                    for (auto& m: schema_muts) {
+                        updates.emplace_back(m);
+                    }
+                }
             } else {
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
             }
@@ -1009,16 +1017,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
                                                          .done(error)
                                                          .build()));
-            if (error.empty()) {
-                const sstring strategy_name = "NetworkTopologyStrategy";
-                auto ks_md = keyspace_metadata::new_keyspace(ks_name, strategy_name, repl_opts,
-                                                             new_ks_props.get_initial_tablets(std::nullopt),
-                                                             new_ks_props.get_durable_writes(), new_ks_props.get_storage_options());
-                auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
-                for (auto& m: schema_muts) {
-                    updates.emplace_back(m);
-                }
-            }
 
             sstring reason = seastar::format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
             rtlogger.trace("do update {} reason {}", updates, reason);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -939,6 +939,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             utils::chunked_vector<canonical_mutation> updates;
             sstring error;
             if (_db.has_keyspace(ks_name)) {
+              try {
                 auto& ks = _db.find_keyspace(ks_name);
                 auto tmptr = get_token_metadata_ptr();
                 cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
@@ -951,25 +952,16 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 auto views = ks.metadata()->views();
                 tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
                 for (const auto& table_or_mv : tables_with_mvs) {
-                    locator::tablet_map old_tablets{unimportant_init_tablet_count};
-                    try {
                         if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
                             // Apply the transition only on base tables.
                             // If this table has a base table then the transition will be applied on the base table, and
                             // the base table will coordinate the transition for the entire group.
                             continue;
                         }
-                        old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
+                        auto old_tablets = co_await tmptr->tablets().get_tablet_map(table_or_mv->id()).clone_gently();
                         locator::replication_strategy_params params{ks_md->strategy_options(), old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, co_await old_tablets.clone_gently());
-                    } catch (const std::exception& e) {
-                        error = e.what();
-                        rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
-                                       "desired new ks opts: {}", error, new_ks_props.get_replication_options());
-                        updates.clear(); // remove all tablets mutations ...
-                        break;           // ... and only create mutations deleting the global req
-                    }
 
                     replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
                     co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
@@ -996,13 +988,17 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     });
                 }
 
-                if (error.empty()) {
                     const sstring strategy_name = "NetworkTopologyStrategy";
                     auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                     for (auto& m: schema_muts) {
                         updates.emplace_back(m);
                     }
-                }
+              } catch (const std::exception& e) {
+                    error = e.what();
+                    rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, desired new ks opts: {}, error: {}",
+                                   saved_ks_props, std::current_exception());
+                    updates.clear(); // remove all tablets mutations and only create mutations deleting the global req
+              }
             } else {
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
             }

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "cql3/statements/property_definitions.hh"
 #include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -158,7 +159,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     data_dictionary::database db = qp.db();
 
-    std::map<sstring, sstring> opts;
+    locator::replication_strategy_config_options opts;
     opts["replication_factor"] = replication_factor;
     auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt);
 
@@ -167,7 +168,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
         auto ts = group0_guard.write_timestamp();
 
         if (!db.has_keyspace(keyspace_name)) {
-            std::map<sstring, sstring> opts;
+            locator::replication_strategy_config_options opts;
             if (replication_strategy_name == "org.apache.cassandra.locator.NetworkTopologyStrategy") {
                 for (const auto &dc: qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                     opts[dc] = replication_factor;

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -10,6 +10,7 @@
 #include <fmt/ranges.h>
 #include "db/tablet_options.hh"
 #include "gms/inet_address.hh"
+#include "gms/feature_service.hh"
 #include "inet_address_vectors.hh"
 #include "locator/abstract_replication_strategy.hh"
 #include "locator/host_id.hh"
@@ -42,8 +43,10 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"
+#include "test/lib/topology_builder.hh"
 #include <seastar/core/coroutine.hh>
 #include "db/schema_tables.hh"
+#include "db/config.hh"
 
 using namespace locator;
 
@@ -939,6 +942,167 @@ SEASTAR_TEST_CASE(test_invalid_dcs) {
                     exceptions::configuration_exception);
         };
     });
+}
+
+static
+sstring describe(cql_test_env& e, sstring ks_name) {
+    auto& ks = e.local_db().find_keyspace(ks_name);
+    cql3::description desc = ks.metadata()->describe(e.local_db(), cql3::with_create_statement::yes);
+    auto result = desc.create_statement->linearize();
+    testlog.info("DESCRIBE KEYSPACE {}: {}", ks_name, result);
+    return result;
+}
+
+SEASTAR_TEST_CASE(test_rack_list_rf) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        topo.start_new_dc({"dc1", "rack1a"});
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_rack("rack1b");
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_dc({"dc2", "rack2a"});
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_rack("rack2b");
+        topo.add_node(service::node_state::normal, shard_count);
+
+        // Single rack
+        e.execute_cql("CREATE KEYSPACE ks11 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']}").get();
+        BOOST_REQUIRE(describe(e, "ks11").contains("'dc1': ['rack1a']"));
+
+        // Two racks
+        e.execute_cql("CREATE KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b']}").get();
+        BOOST_REQUIRE(describe(e, "ks12").contains("'dc1': ['rack1a', 'rack1b']"));
+
+        // Two DCs, two racks each
+        {
+            e.execute_cql("CREATE KEYSPACE ks22 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b'], "
+                "'dc2': ['rack2a', 'rack2b']} AND tablets = {'enabled':true}").get();
+            auto& opts = e.local_db().find_keyspace("ks22").get_replication_strategy().get_config_options();
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc1")).get_rack_list(),
+                                std::vector<sstring>({"rack1a", "rack1b"}));
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc2")).get_rack_list(),
+                                std::vector<sstring>({"rack2a", "rack2b"}));
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc1")).count(), 2);
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc2")).count(), 2);
+            BOOST_REQUIRE(describe(e, "ks22").contains("'dc1': ['rack1a', 'rack1b']"));
+            BOOST_REQUIRE(describe(e, "ks22").contains("'dc2': ['rack2a', 'rack2b']"));
+        }
+
+        // Two DCs, one using rack list, one using numeric RF (auto-expanded)
+        {
+            e.execute_cql("CREATE KEYSPACE ks2n2 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 2, "
+                "'dc2': ['rack2a', 'rack2b']} AND tablets = {'enabled':true}").get();
+            auto& opts = e.local_db().find_keyspace("ks2n2").get_replication_strategy().get_config_options();
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc1")).get_rack_list(),
+                                std::vector<sstring>({"rack1a", "rack1b"}));
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc2")).get_rack_list(),
+                                std::vector<sstring>({"rack2a", "rack2b"}));
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc1")).count(), 2);
+            BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at("dc2")).count(), 2);
+            BOOST_REQUIRE(describe(e, "ks2n2").contains("'dc1': ['rack1a', 'rack1b']"));
+            BOOST_REQUIRE(describe(e, "ks2n2").contains("'dc2': ['rack2a', 'rack2b']"));
+        }
+
+        // Non-existent DC
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc3': ['rack2a']}").get(),
+            exceptions::configuration_exception);
+
+        // Rack from the wrong DC
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack2a']}").get(),
+            exceptions::configuration_exception);
+
+        // Duplicated racks
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1a']}").get(),
+            exceptions::configuration_exception);
+
+        // Duplicated racks
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "CREATE KEYSPACE fail WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1a']}").get(),
+            exceptions::configuration_exception);
+
+        // Alter to numeric with different count
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "ALTER KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 3}").get(),
+            exceptions::configuration_exception);
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "ALTER KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}").get(),
+            exceptions::configuration_exception);
+    }, cfg);
+}
+
+SEASTAR_TEST_CASE(test_altering_to_numeric_forbidden) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    cfg.disabled_features.insert("RACK_LIST_RF");
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 1;
+        topo.start_new_dc({"dc1", "rack1a"});
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_rack("rack1b");
+        topo.add_node(service::node_state::normal, shard_count);
+
+        e.execute_cql("CREATE KEYSPACE ks1 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 1}").get();
+        e.get_feature_service().local().rack_list_rf.enable();
+
+        // Only altering to rack list should be allowed once rf_rack_valid is enabled.
+        BOOST_REQUIRE_THROW(e.execute_cql(
+            "ALTER KEYSPACE ks1 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': 2}").get(),
+            exceptions::configuration_exception);
+    }, cfg);
+}
+
+SEASTAR_TEST_CASE(test_rack_list_rejected_when_feature_not_enabled) {
+    auto cfg = cql_test_config();
+    cfg.db_config->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    cfg.disabled_features.insert("RACK_LIST_RF");
+    return do_with_cql_env_thread([] (auto& e) {
+        auto& topo = e.get_shared_token_metadata().local().get()->get_topology();
+        auto loc = topo.get_location();
+        auto create_stmt = fmt::format("CREATE KEYSPACE test WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"
+                    " '{}': ['{}']}}", loc.dc, loc.rack);
+        BOOST_REQUIRE_THROW(e.execute_cql(create_stmt).get(), exceptions::configuration_exception);
+
+        // Auto-expansion to numeric RF should not happen
+        e.execute_cql(fmt::format("CREATE KEYSPACE test2 WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', '{}': 1}}", loc.dc)).get();
+        auto& opts = e.local_db().find_keyspace("test2").get_replication_strategy().get_config_options();
+        BOOST_REQUIRE(replication_factor_data(opts.at(loc.dc)).is_numeric());
+        BOOST_REQUIRE_EQUAL(replication_factor_data(opts.at(loc.dc)).count(), 1);
+        BOOST_REQUIRE(describe(e, "test2").contains(fmt::format("'{}': '1'", loc.dc)));
+
+        // When feature is enabled, rack list is accepted.
+        e.get_feature_service().local().rack_list_rf.enable();
+        e.execute_cql(create_stmt).get();
+
+        // Altering numeric RF to rack list is not supported yet.
+        BOOST_REQUIRE_THROW(e.execute_cql(fmt::format("ALTER KEYSPACE test2 WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"
+                                                      " '{}': ['{}']}}", loc.dc, loc.rack)).get(),
+                            exceptions::configuration_exception);
+    }, cfg);
+}
+
+SEASTAR_TEST_CASE(test_rack_list_rejected_when_using_vnodes) {
+    auto cfg = cql_test_config();
+    return do_with_cql_env_thread([] (auto& e) {
+        auto& topo = e.get_shared_token_metadata().local().get()->get_topology();
+        auto loc = topo.get_location();
+        auto create_stmt = [&] (bool tablets) {
+            return fmt::format("CREATE KEYSPACE abc WITH REPLICATION = {{'class': 'NetworkTopologyStrategy',"
+                               " '{}': ['{}']}} and TABLETS = {{'enabled': {}}}",
+                               loc.dc, loc.rack, tablets ? "true" : "false");
+        };
+
+        BOOST_REQUIRE_THROW(e.execute_cql(create_stmt(false)).get(), exceptions::configuration_exception);
+        e.execute_cql(create_stmt(true)).get();
+    }, cfg);
 }
 
 } // namespace network_topology_strategy_test

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -224,34 +224,27 @@ void check_tablets_balance(const tablet_map& tmap,
     testlog.debug("load_map={}", load_map);
 
     for (const auto& [dc, dc_racks] : load_map) {
-        size_t replicas_in_dc = 0;
-        size_t num_racks = dc_racks.size();
-        size_t num_shards = 0;
+        std::unordered_map<sstring, double> avg_replicas_per_shard;
+
         for (const auto& [rack, rack_nodes] : dc_racks) {
+            size_t num_shards = 0;
             for (const auto& [host, shards] : rack_nodes) {
                 num_shards += shards.size();
                 for (const auto& [shard, n] : shards) {
-                    replicas_in_dc += n;
+                    avg_replicas_per_shard[rack] += n;
                 }
             }
+            testlog.debug("dc={} rack={}: replicas={} num_shards={} avg_replicas_per_shard={}", dc, rack, avg_replicas_per_shard[rack], num_shards, avg_replicas_per_shard[rack] / num_shards);
+            avg_replicas_per_shard[rack] /= num_shards;
         }
 
-        auto avg_replicas_per_rack = double(replicas_in_dc) / num_racks;
-        auto avg_replicas_per_shard = double(replicas_in_dc) / num_shards;
-
         for (const auto& [rack, rack_nodes] : dc_racks) {
-            size_t replicas_in_rack = 0;
             for (const auto& [host, shards] : rack_nodes) {
-                size_t replicas_in_node = 0;
                 for (const auto& [shard, n] : shards) {
-                    BOOST_REQUIRE_GE(n, floor(avg_replicas_per_shard - 1));
-                    BOOST_REQUIRE_LE(n, ceil(avg_replicas_per_shard + 1));
-                    replicas_in_node += n;
+                    BOOST_REQUIRE_GE(n, floor(avg_replicas_per_shard[rack] - 1));
+                    BOOST_REQUIRE_LE(n, ceil(avg_replicas_per_shard[rack] + 1));
                 }
-                replicas_in_rack += replicas_in_node;
             }
-            BOOST_REQUIRE_GE(replicas_in_rack, floor(avg_replicas_per_rack - 1));
-            BOOST_REQUIRE_LE(replicas_in_rack, ceil(avg_replicas_per_rack + 1));
         }
     }
 }

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -11,6 +11,7 @@
 #include "db/tablet_options.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "locator/host_id.hh"
 #include "locator/types.hh"
 #include "locator/snitch_base.hh"
@@ -95,7 +96,7 @@ void strategy_sanity_check(
     //
     size_t total_rf = 0;
     for (auto& val : options) {
-        size_t rf = std::stol(val.second);
+        auto rf = locator::get_replication_factor(val.second);
         BOOST_CHECK(nts_ptr->get_replication_factor(val.first) == rf);
 
         total_rf += rf;
@@ -1529,7 +1530,7 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
         }
     }
     for (const auto& [dc, rf_opt] : options) {
-        auto rf = std::stol(rf_opt);
+        auto rf = locator::get_replication_factor(rf_opt);
         BOOST_REQUIRE_EQUAL(same_rack_pairs[dc] + cross_rack_pairs[dc], rf);
     }
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3912,7 +3912,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
 
     std::map<sstring, size_t> initial_rep_factor;
     for (auto const& [dc, shard_count] : test_config.options) {
-        initial_rep_factor[dc] = std::stoul(shard_count);
+        initial_rep_factor[dc] = locator::get_replication_factor(shard_count);
     }
 
     auto tablets = stm.get()->tablets().get_tablet_map(s->id()).clone_gently().get();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3872,7 +3872,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     locator::replication_strategy_params params(test_config.options, tablet_count);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params);
+        "NetworkTopologyStrategy", params, stm.get()->get_topology());
 
     auto tablet_aware_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tablet_aware_ptr);
@@ -3934,7 +3934,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     try {
         tablet_map old_tablets = stm.get()->tablets().get_tablet_map(s->id()).clone_gently().get();
         locator::replication_strategy_params params{test_config.new_dc_rep_factor, old_tablets.tablet_count()};
-        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto tmap = new_strategy->maybe_as_tablet_aware()->reallocate_tablets(s, stm.get(), std::move(old_tablets)).get();
 
         auto const& ts = tmap.tablets();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3829,8 +3829,8 @@ struct calculate_tablet_replicas_for_new_rf_config
         host_id id = host_id::create_random_id();
     };
     std::vector<ring_point> ring_points;
-    std::map<sstring, sstring> options;
-    std::map<sstring, sstring> new_dc_rep_factor;
+    replication_strategy_config_options options;
+    replication_strategy_config_options new_dc_rep_factor;
     std::map<sstring, size_t> expected_rep_factor;
 };
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3032,32 +3032,27 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbala
 
 SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
     cql_test_config cfg = tablet_cql_test_config();
-    // FIXME: This test creates two keyspaces with two different replication factors.
-    //        What's more, we distribute the nodes across only two racks. Because of that,
-    //        we won't be able to enable `rf_rack_valid_keyspaces`. That would require
-    //        increasing the number of racks to three, as well as implementing scylladb/scylladb#23426.
-    cfg.db_config->rf_rack_valid_keyspaces.set(false);
 
     do_with_cql_env_thread([] (auto& e) {
         auto per_shard_goal = e.local_db().get_config().tablets_per_shard_goal();
 
         topology_builder topo(e);
 
-        std::vector<endpoint_dc_rack> racks = {
-            topo.rack(),
-            topo.start_new_dc(),
-        };
-
         std::vector<host_id> hosts;
-        hosts.push_back(topo.add_node(node_state::normal, 2, racks[0]));
-        hosts.push_back(topo.add_node(node_state::normal, 2, racks[0]));
-        hosts.push_back(topo.add_node(node_state::normal, 2, racks[0]));
+        sstring dc1 = topo.dc();
+        hosts.push_back(topo.add_node(node_state::normal, 2));
+        topo.start_new_rack();
+        hosts.push_back(topo.add_node(node_state::normal, 2));
+        topo.start_new_rack();
+        hosts.push_back(topo.add_node(node_state::normal, 2));
 
-        hosts.push_back(topo.add_node(node_state::normal, 1, racks[1]));
-        hosts.push_back(topo.add_node(node_state::normal, 1, racks[1]));
+        auto dc2 = topo.start_new_dc().dc;
+        hosts.push_back(topo.add_node(node_state::normal, 1));
+        topo.start_new_rack();
+        hosts.push_back(topo.add_node(node_state::normal, 1));
 
-        auto ks_name1 = add_keyspace(e, {{racks[0].dc, 3}});
-        auto ks_name2 = add_keyspace(e, {{racks[1].dc, 2}});
+        auto ks_name1 = add_keyspace(e, {{dc1, 3}});
+        auto ks_name2 = add_keyspace(e, {{dc2, 2}});
 
         // table1 overflows per-shard goal in dc1, should be scaled down.
         // wants 400 tablets (3 nodes * 2 shards * 200 tablets/shard / rf=3 = 400 tablets)

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -43,7 +43,8 @@ namespace {
     mutable_static_erm_ptr create_erm(mutable_token_metadata_ptr tmptr, replication_strategy_config_options opts = {}) {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
-        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt));
+        auto& topo = tmptr->get_topology();
+        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt), &topo);
         return calculate_vnode_effective_replication_map(std::move(strategy), tmptr).get();
     }
 }

--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -64,14 +64,12 @@ class ScyllaCluster:
                 self.manager.servers_add(servers_num=nodes, config=self._config_options, start=False, auto_rack_dc="dc1")
             case list():
                 for dc, n_nodes in enumerate(nodes, start=1):
+                    dc_name = f"dc{dc}"
                     self.manager.servers_add(
                         servers_num=n_nodes,
                         config=self._config_options,
-                        property_file={
-                            "dc": f"dc{dc}",
-                            "rack": "RAC1",
-                        },
                         start=False,
+                        auto_rack_dc=dc_name
                     )
             case dict():
                 # Supported spec: {"dc1": {"rack1": 3, "rack2": 2}, "dc2": {"rack1": 2}}

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -668,7 +668,7 @@ async def check_data_is_back(manager, logger, cql, ks, cf, keys, servers, topolo
 @pytest.mark.parametrize("topology_rf_validity", [
         (topo(rf = 1, nodes = 3, racks = 1, dcs = 1), True),
         (topo(rf = 3, nodes = 5, racks = 1, dcs = 1), False),
-        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), True),
+        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), False), # Test assumes that rf=1 uses both racks so need to inhibit rack-based RF
         (topo(rf = 3, nodes = 6, racks = 2, dcs = 1), False),
         (topo(rf = 3, nodes = 6, racks = 3, dcs = 1), True),
         (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), True)

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -92,7 +92,7 @@ async def test_alternator_ttl_scheduling_group(manager: ManagerClient):
        in the wrong scheduling group. We can assume this because we don't
        run multiple tests in parallel on the same cluster.
     """
-    servers = await manager.servers_add(3, config=alternator_config)
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
     alternator = get_alternator(servers[0].ip_addr)
     table = alternator.create_table(TableName=unique_table_name(),
         BillingMode='PAY_PER_REQUEST',

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -312,7 +312,7 @@ async def test_upgrade(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logger.info("Creating keyspace and table")
-    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks_name:
+    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks_name:
         table = f"{ks_name}.t"
         await verify_table_versions_synced(cql, hosts)
         await cql.run_async(f"create table {table} (pk int primary key)")

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -127,7 +127,8 @@ async def test_schema_versioning_with_recovery(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(3)]
+    # Must bootstrap sequentially because of gossip topology changes
+    servers = [await manager.server_add(config=cfg, property_file={"dc":"dc1", "rack":f"rack{i+1}"}) for i in range(3)]
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -297,7 +298,7 @@ async def test_upgrade(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(2)]
+    servers = [await manager.server_add(config=cfg, property_file={"dc":"dc1", "rack":f"rack{i+1}"}) for i in range(3)]
     cql = manager.get_cql()
 
     logging.info("Waiting until driver connects to every server")

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -189,10 +189,7 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
 
     async def alter_fail(ks: str, rfs: List[int], failed_dc: int, rack_count: int) -> None:
         rf = rfs[failed_dc - 1]
-        err = rf"Replication factor {rf} exceeds the number of racks|The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
-              f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
-
-        with pytest.raises((ConfigurationException, InvalidRequest), match=err):
+        with pytest.raises((ConfigurationException, InvalidRequest)):
             await alter_ok(ks, rfs)
 
     # Step 1.
@@ -289,14 +286,16 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
         for task in tasks:
             _ = tg.create_task(task)
 
-    await alter_ok(ks1, [2, 1])
+    # Altering from rack list to numeric not supported.
+    await alter_fail(ks1, [2, 1], 1, 2)
+    # await alter_ok(ks1, [2, 1])
     await alter_fail(ks1, [2, 2], 2, 1)
 
-    await alter_ok(ks2, [2, 1])
+    await alter_fail(ks2, [2, 1], 1, 2)
     await alter_ok(ks3, [2, 1])
-    await alter_ok(ks4, [2, 1])
+    await alter_fail(ks4, [2, 1], 1, 2)
     # RF = 1 is always OK!
-    await alter_ok(ks3, [1, 1])
+    await alter_fail(ks3, [1, 1], 1, 2)
 
 @pytest.mark.asyncio
 async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
@@ -350,6 +349,7 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     valid_keyspaces = [
         create_ok([0, 0]),
         create_ok([1, 0]),
+        create_ok([2, 0]),
         create_ok([3, 0]),
         create_ok(0)
     ]
@@ -358,7 +358,6 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     # because then we can't predict what error will say.
     invalid_keyspaces = [
         create_fail([4, 0], 1, 4, 3),
-        create_fail([2, 0], 1, 2, 3),
         create_fail([0, 1], 2, 1, 0),
         create_fail([0, 2], 2, 2, 0),
         create_fail([0, 3], 2, 3, 0),

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("topology_rf_validity", [
         (topo(rf = 1, nodes = 3, racks = 1, dcs = 1), True),
         (topo(rf = 3, nodes = 5, racks = 1, dcs = 1), False),
-        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), True),
+        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), False), # Test assumes that rf=1 uses both racks so need to inhibit rack-based RF
         (topo(rf = 3, nodes = 6, racks = 2, dcs = 1), False),
         (topo(rf = 3, nodes = 6, racks = 3, dcs = 1), True),
         (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), True)

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -12,7 +12,7 @@ from cassandra.protocol import InvalidRequest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 from test.cluster.conftest import skip_mode
-from test.cluster.util import disable_schema_agreement_wait, create_new_test_keyspace, new_test_keyspace
+from test.cluster.util import disable_schema_agreement_wait, parse_replication_options, create_new_test_keyspace, new_test_keyspace
 
 logger = logging.getLogger(__name__)
 
@@ -76,13 +76,14 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
     }
 
     logger.info("starting a node (the leader)")
-    servers = [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r1"})]
+    this_dc = "dc1"
+    servers = [await manager.server_add(config=config, property_file={"dc": this_dc, "rack": "r1"})]
 
     logger.info("starting a second node (the follower)")
-    servers += [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r2"})]
+    servers += [await manager.server_add(config=config, property_file={"dc": this_dc, "rack": "r2"})]
 
     async with new_test_keyspace(manager, "with "
-                                      "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "
+                                      "replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1']} and "
                                       "tablets = {'initial': 2}") as ks:
         await manager.get_cql().run_async(f"create table {ks}.t (pk int primary key)")
 
@@ -90,14 +91,10 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
         injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
                                                         'wait-before-committing-rf-change-event')
 
-        # ALTER tablets KS only accepts a specific DC, it rejects the generic 'replication_factor' tag
-        res = await manager.get_cql().run_async("select data_center from system.local")
-        this_dc = res[0].data_center
-
         async def alter_tablets_ks_without_waiting_to_complete():
             logger.info("scheduling ALTER KS to change the RF from 1 to 2")
             await manager.get_cql().run_async(f"alter keyspace {ks} "
-                                            f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
+                                            f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': ['r1','r2']}}")
 
         # by creating a task this way we ensure it's immediately executed,
         # but we don't want to wait until the task is completed here,
@@ -128,6 +125,6 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
 
         # ensure that the ALTER has eventually succeeded and we changed RF from 1 to 2
         res = manager.get_cql().execute(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks}'")
-        assert res[0].replication[this_dc] == '2'
+        assert parse_replication_options(res[0].replication)[this_dc] == ['r1', 'r2']
 
         await manager.get_cql().run_async(f"drop keyspace {ks2}")

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -225,11 +225,12 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
+        pattern = re.compile("Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy|Unrecognized datacenter name 'INVALID_DC'")
         # try modifying the keyspace
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
         execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -161,13 +161,13 @@ def test_alter_keyspace(cql, this_dc, scylla_only):
 # Test trying to ALTER RF of tablets-enabled KS by more than 1 at a time
 def test_alter_keyspace_rf_by_more_than_1(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
-        with pytest.raises(InvalidRequest):
+        with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 3 }} AND DURABLE_WRITES = false")
 
 # Test trying to ALTER a tablets-enabled KS by providing the 'replication_factor' tag
 def test_alter_keyspace_with_replication_factor_tag(cql):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }") as keyspace:
-        with pytest.raises(InvalidRequest):
+        with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }}")
 
 # Test trying to ALTER a keyspace with invalid options.

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -71,6 +71,7 @@ public:
 private:
     cql_test_env& _env;
     int _nr_nodes = 0;
+    int _dc_id;
     int _rack_id;
     sstring _dc;
     sstring _rack;
@@ -151,8 +152,7 @@ public:
     // Starts building a new rack in the current DC.
     // Returns location of the new rack.
     endpoint_dc_rack start_new_rack() {
-        _rack_id++;
-        _rack = fmt::format("rack{}", _rack_id);
+        _rack = fmt::format("rack{}{:c}", _dc_id, 'a' + _rack_id++);
         return rack();
     }
 
@@ -160,7 +160,8 @@ public:
     // DC is named uniquely in the scope of the process, not just this object.
     endpoint_dc_rack start_new_dc() {
         static std::atomic<int> next_id = 1;
-        _dc = fmt::format("dc{}", next_id.fetch_add(1));
+        _dc_id = next_id.fetch_add(1);
+        _dc = fmt::format("dc{}", _dc_id);
         _rack_id = 0;
         return start_new_rack();
     }

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -156,6 +156,13 @@ public:
         return rack();
     }
 
+    // Starts building a new rack in the current DC.
+    // Returns location of the new rack.
+    endpoint_dc_rack start_new_rack(sstring rack_name) {
+        _rack = std::move(rack_name);
+        return rack();
+    }
+
     // Starts building a new DC.
     // DC is named uniquely in the scope of the process, not just this object.
     endpoint_dc_rack start_new_dc() {
@@ -164,6 +171,13 @@ public:
         _dc = fmt::format("dc{}", _dc_id);
         _rack_id = 0;
         return start_new_rack();
+    }
+
+    // Starts building a new DC.
+    endpoint_dc_rack start_new_dc(endpoint_dc_rack dc_and_rack) {
+        _dc = dc_and_rack.dc;
+        _rack = dc_and_rack.rack;
+        return rack();
     }
 
     locator::load_stats_ptr get_load_stats() const {

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
 
+#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "data_dictionary/keyspace_metadata.hh"
 #include "db/cql_type_parser.hh"
@@ -71,7 +72,7 @@ tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
 
     auto ks = make_lw_shared<data_dictionary::keyspace_metadata>(keyspace_name,
                                                                  "org.apache.cassandra.locator.LocalStrategy",
-                                                                 std::map<sstring, sstring>{},
+                                                                 locator::replication_strategy_config_options{},
                                                                  std::nullopt, false);
     db::cql_type_parser::raw_builder ut_builder(*ks);
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -259,7 +259,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
     real_db.keyspaces.emplace_back(make_lw_shared<keyspace_metadata>(
                 db::schema_tables::NAME,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 false));
     real_db.tables.emplace_back(dd_impl, real_db.keyspaces.back(), db::schema_tables::dropped_columns(), false);
@@ -445,7 +445,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     if (types_mut) {
         query::result_set result(*types_mut);
 
-        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", std::map<sstring, sstring>{}, std::nullopt, false);
+        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", locator::replication_strategy_config_options{}, std::nullopt, false);
         db::cql_type_parser::raw_builder ut_builder(*ks);
 
         auto get_list = [] (const query::result_set_row& row, const char* name) {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -161,7 +161,7 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, {}}};
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, {}}, nullptr};
         return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {


### PR DESCRIPTION
This change extends the CQL replication options syntax so the replication factor can be stated as a list of rack names.
For example: { 'mydatacenter': [ 'myrack1', 'myrack2', 'myrack4' ] }

When providing a numeric replication factor like the {'replication_factor': '3'} "wildcard" or {'dc1': '3'} for a specific datacenter, if the keyspace is rf-rack-valid, the replication factor options are expended and RF racks are selected at random for the affected datacenters racks (if there are enough racks, otherwise an error is returned).

Specifying the rack list also allows to add replicas on the specified racks (increasing the replication factor), or decommissioning certain racks from their replicas (by omitting them from the current datacenter rack-list), or replacing a single rack from a datacenter rack-list to migrate all replicas from the dropped rack onto the new rack.

It is intended that ALTER KEYSPACE with a given rack-list could be used for migrating replicas in rf-rack invalid keyspaces, where RF < nr_racks in a datacenter and the replicas may be allocated across all available racks. In this case, the existing replicas will be migrated into the specified rack-list which specifies a subset of the available racks, and when done, the keyspace will become rf-rack-valid.

New feature, no backport required.

Co-authored with @bhalevy 

Fixes #25269
Fixes #23525
