### PR TITLE
Cleanup: use angle brackets for boost includes

### DIFF
--- a/serializer.hh
+++ b/serializer.hh
@@ -13,7 +13,7 @@
 #include "utils/managed_bytes.hh"
 #include "bytes_ostream.hh"
 #include <seastar/core/simple-stream.hh>
-#include "boost/variant/variant.hpp"
+#include <boost/variant/variant.hpp>
 #include "bytes_ostream.hh"
 #include "utils/fragment_range.hh"
 #include <variant>

--- a/test/boost/nonwrapping_interval_test.cc
+++ b/test/boost/nonwrapping_interval_test.cc
@@ -9,8 +9,8 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include "boost/icl/interval.hpp"
-#include "boost/icl/interval_map.hpp"
+#include <boost/icl/interval.hpp>
+#include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
 #include <unordered_set>
 

--- a/test/boost/user_function_test.cc
+++ b/test/boost/user_function_test.cc
@@ -24,7 +24,7 @@
 #include "test/lib/tmpdir.hh"
 #include "test/lib/exception_utils.hh"
 #include "test/lib/test_utils.hh"
-#include "boost/date_time/gregorian/gregorian_types.hpp"
+#include <boost/date_time/gregorian/gregorian_types.hpp>
 
 BOOST_AUTO_TEST_SUITE(user_function_test)
 

--- a/test/boost/wrapping_interval_test.cc
+++ b/test/boost/wrapping_interval_test.cc
@@ -9,7 +9,7 @@
 #define BOOST_TEST_MODULE core
 
 #include <boost/test/unit_test.hpp>
-#include "boost/icl/interval_map.hpp"
+#include <boost/icl/interval_map.hpp>
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 #include <fmt/ranges.h>


### PR DESCRIPTION
Initially suggested by Avi in PR #25593, this patch goes over the remaining exceptions of this rule and switches the boost includes from `"` to `<` brackets.
