### PR TITLE
build_docker.sh: enable debug symbols installation

### DIFF
--- a/dist/docker/redhat/build_docker.sh
+++ b/dist/docker/redhat/build_docker.sh
@@ -89,6 +89,8 @@ bcp LICENSE-ScyllaDB-Source-Available.md /licenses/
 run microdnf clean all
 run microdnf --setopt=tsflags=nodocs -y update
 run microdnf --setopt=tsflags=nodocs -y install hostname kmod procps-ng python3 python3-pip
+run curl -L --output /etc/yum.repos.d/scylla.repo https://downloads.scylladb.com/unstable/scylla/master/rpm/centos/latest/scylla.repo
+run microdnf --setopt=tsflags=nodocs -y update
 run microdnf clean all
 run pip3 install --no-cache-dir --prefix /usr supervisor
 run bash -ec "echo LANG=C.UTF-8 > /etc/locale.conf"


### PR DESCRIPTION
Adding the latest scylla.repo location to our docker container, this will allow installation scylla-debuginfo package in case it's needed

Fixes: https://github.com/scylladb/scylladb/issues/24271

**This issue was reported in 2025.1, so i assume we should backport this change for 2025.3, 2025.2 and 2025.1**