### PR TITLE
Move "cache" API endpoints registration closer to column_family ones 

### DIFF
--- a/api/api.cc
+++ b/api/api.cc
@@ -225,7 +225,7 @@ future<> unset_server_gossip(http_context& ctx) {
 }
 
 future<> set_server_column_family(http_context& ctx, sharded<replica::database>& db, sharded<db::system_keyspace>& sys_ks) {
-    return register_api(ctx, "column_family",
+    co_await register_api(ctx, "column_family",
                 "The column family API", [&db, &sys_ks] (http_context& ctx, routes& r) {
                     set_column_family(ctx, r, db, sys_ks);
                 });

--- a/api/api.cc
+++ b/api/api.cc
@@ -230,7 +230,9 @@ future<> set_server_column_family(http_context& ctx, sharded<replica::database>&
                     set_column_family(ctx, r, db, sys_ks);
                 });
     co_await register_api(ctx, "cache_service",
-            "The cache service API", set_cache_service);
+            "The cache service API", [&db] (http_context& ctx, routes& r) {
+                    set_cache_service(ctx, db, r);
+                });
 }
 
 future<> unset_server_column_family(http_context& ctx) {

--- a/api/api.cc
+++ b/api/api.cc
@@ -229,10 +229,15 @@ future<> set_server_column_family(http_context& ctx, sharded<replica::database>&
                 "The column family API", [&db, &sys_ks] (http_context& ctx, routes& r) {
                     set_column_family(ctx, r, db, sys_ks);
                 });
+    co_await register_api(ctx, "cache_service",
+            "The cache service API", set_cache_service);
 }
 
 future<> unset_server_column_family(http_context& ctx) {
-    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_column_family(ctx, r); });
+    return ctx.http_server.set_routes([&ctx] (routes& r) {
+        unset_column_family(ctx, r);
+        unset_cache_service(ctx, r);
+    });
 }
 
 future<> set_server_messaging_service(http_context& ctx, sharded<netw::messaging_service>& ms) {
@@ -262,15 +267,6 @@ future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_
 
 future<> unset_server_stream_manager(http_context& ctx) {
     return ctx.http_server.set_routes([&ctx] (routes& r) { unset_stream_manager(ctx, r); });
-}
-
-future<> set_server_cache(http_context& ctx) {
-    return register_api(ctx, "cache_service",
-            "The cache service API", set_cache_service);
-}
-
-future<> unset_server_cache(http_context& ctx) {
-    return ctx.http_server.set_routes([&ctx] (routes& r) { unset_cache_service(ctx, r); });
 }
 
 future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& proxy, sharded<gms::gossiper>& g) {

--- a/api/api_init.hh
+++ b/api/api_init.hh
@@ -126,8 +126,6 @@ future<> set_server_stream_manager(http_context& ctx, sharded<streaming::stream_
 future<> unset_server_stream_manager(http_context& ctx);
 future<> set_hinted_handoff(http_context& ctx, sharded<service::storage_proxy>& p, sharded<gms::gossiper>& g);
 future<> unset_hinted_handoff(http_context& ctx);
-future<> set_server_cache(http_context& ctx);
-future<> unset_server_cache(http_context& ctx);
 future<> set_server_compaction_manager(http_context& ctx, sharded<compaction_manager>& cm);
 future<> unset_server_compaction_manager(http_context& ctx);
 future<> set_server_done(http_context& ctx);

--- a/api/cache_service.cc
+++ b/api/cache_service.cc
@@ -16,7 +16,7 @@ using namespace json;
 using namespace seastar::httpd;
 namespace cs = httpd::cache_service_json;
 
-void set_cache_service(http_context& ctx, routes& r) {
+void set_cache_service(http_context& ctx, sharded<replica::database>& db, routes& r) {
     cs::get_row_cache_save_period_in_seconds.set(r, [](std::unique_ptr<http::request> req) {
         // We never save the cache
         // Origin uses 0 for never

--- a/api/cache_service.hh
+++ b/api/cache_service.hh
@@ -7,15 +7,20 @@
  */
 
 #pragma once
+#include <seastar/core/sharded.hh>
 
 namespace seastar::httpd {
 class routes;
 }
 
+namespace replica {
+class database;
+}
+
 namespace api {
 
 struct http_context;
-void set_cache_service(http_context& ctx, seastar::httpd::routes& r);
+void set_cache_service(http_context& ctx, seastar::sharded<replica::database>& db, seastar::httpd::routes& r);
 void unset_cache_service(http_context& ctx, seastar::httpd::routes& r);
 
 }

--- a/main.cc
+++ b/main.cc
@@ -2080,11 +2080,6 @@ sharded<locator::shared_token_metadata> token_metadata;
                 api::unset_server_tasks_compaction_module(ctx).get();
             });
 
-            api::set_server_cache(ctx).get();
-            auto stop_cache_api = defer_verbose_shutdown("cache API", [&ctx] {
-                api::unset_server_cache(ctx).get();
-            });
-
             api::set_server_commitlog(ctx, db).get();
             auto stop_commitlog_api = defer_verbose_shutdown("commitlog API", [&ctx] {
                 api::unset_server_commitlog(ctx).get();


### PR DESCRIPTION
These two "blocks" of endpoints have different URL prefixes, but work with the same "service", which is sharded<replica::database>. The latter block had already been fixed to carry the sharded<database>& around (#25467), now it's the "cache" turn. However, since these endpoints also work with the database, there's no need in dedicated top-level set/unset machinery (similarly, gossiper has two API set/unset blocks that come together, see #19425), it's enough to just set/unset them next to each other.

Ongoing http_context dependency cleanup, no need to backport