### PR TITLE
secondary index: fix xfailing test to pass on Cassandra

### DIFF
--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2076,7 +2076,7 @@ def test_limit_partition(cql, test_keyspace):
         assert rs.has_more_pages == False
         # Test LIMIT across partitions - reproduces #22158.
         rs = cql.execute(f'SELECT pk1, ck FROM {table} WHERE pk2 = 1 LIMIT 3')
-        assert sorted(list(rs)) == [(1,1), (1,2), (2,1)]
+        assert sorted(list(rs)) == [(1,1), (2,1), (2,2)]
         assert rs.has_more_pages == False
 
 


### PR DESCRIPTION
We have an xfailing test test_secondary_index.py::test_limit_partition which reproduces a Scylla bug in LIMIT when scanning a secondary index (Refs #22158). The point of such a reproducer is to demonstrate the bug by passing on Cassandra but failing on Scylla - yet this specific test doesn't pass on Cassandra because it expects the wrong 3 out of 4 results to be returned:

The test begins with LIMIT 1 and sees the first result is (2,1), so we expect when we increase the LIMIT to 3 to see more results from the same partition (2) - and yet the test mistakenly expected the next results to come from partition 1, which is not a reasonable expectation, and doesn't happen in Cassandra (I checked both Cassandra 5 and 4).

After this patch, the test passes on Cassandra (I tried 4 and 5), and continues to fail on Scylla - which returns 4 rows despite the LIMIT 3.

Note that it is debatable whether this test should insist at all on which 3 items are returned by "LIMIT 3" - In Cassandra the ordering of a SELECT with a secondary index is not well defined (see discussion in Refs #23392). So an alternative implementation of this test would be to just check that LIMIT 3 returns 3 items without insisting which:

    # In Cassandra the ordering of a SELECT with a secondary index is not
    # defined (see discussion in #23392), so we don't know which three
    # results to expect - just that it must be a 3-item subset.
    rows = list(rs)
    assert len(rows) == 3
    assert set(rows).issubset({(1,1), (1,2), (2,1), (2,2)})

However, as of yet, I did not modify this test to do this. I still believe there is value in secondary index scans having the same order as a scan without a secondary index has - and not an undefined order, and if both Scylla and Cassandra implement that in practice, it's useful for tests to validate this so we'll know if this guarantee is ever broken.