### PR TITLE
replica: Fix split compaction when tablet boundaries change

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -284,6 +284,15 @@ const tablet_map& tablet_metadata::get_tablet_map(table_id id) const {
     }
 }
 
+future<tablet_metadata::tablet_map_ptr> tablet_metadata::get_tablet_map_ptr(table_id id) const {
+    try {
+        // lightweight since it only copies the shared ptr, not the map itself.
+        co_return co_await _tablets.at(id).copy();
+    } catch (const std::out_of_range&) {
+        throw_with_backtrace<no_such_tablet_map>(id);
+    }
+}
+
 bool tablet_metadata::has_tablet_map(table_id id) const {
     return _tablets.contains(id);
 }

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -664,6 +664,8 @@ private:
 public:
     bool balancing_enabled() const { return _balancing_enabled; }
     const tablet_map& get_tablet_map(table_id id) const;
+    // Gets shared ownership of tablet map
+    future<tablet_map_ptr> get_tablet_map_ptr(table_id id) const;
     bool has_tablet_map(table_id id) const;
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;

--- a/mutation_writer/token_group_based_splitting_writer.cc
+++ b/mutation_writer/token_group_based_splitting_writer.cc
@@ -12,6 +12,7 @@
 #include <seastar/core/on_internal_error.hh>
 
 #include "mutation_writer/feed_writers.hh"
+#include "utils/error_injection.hh"
 
 namespace mutation_writer {
 
@@ -44,6 +45,7 @@ private:
         auto wr = std::exchange(_current_writer, std::nullopt);
         co_await wr->close();
         allocate_new_writer_if_needed();
+        co_await utils::get_local_injector().inject("splitting_mutation_writer_switch_wait", utils::wait_for_message(std::chrono::seconds(60)));
     }
 
     // Called frequently, hence yields (and allocates)


### PR DESCRIPTION
Consider the following:
1) balancer emits split decision
2) split compaction starts
3) split decision is revoked
4) emits merge decision
5) completes merge, before compaction in step 2 finishes

After last step, split compaction initiated in step 2 can fail because it works with the global tablet map, rather than the map when the compaction started. With the global state changing under its feet, on merge, the mutation splitting writer will think it's going backwards since sibling tablets are merged.

This problem was also seen when running load-and-stream, where split initiated by the sstable writer failed, split completed, and the unsplit sstable is left in the table dir, causing problems in the restart.

To fix this, let's make split compaction always work with the state when it started, not a global state.

Fixes #24153.

All 2025.* versions are vulnerable, so fix must be backported to them.