### PR TITLE
vector-store: disambiguate call to format()

### DIFF
--- a/service/vector_store_client.cc
+++ b/service/vector_store_client.cc
@@ -258,7 +258,7 @@ auto get_host_port(std::string_view uri) -> std::optional<host_port> {
     }
     auto parsed = parse_service_uri(uri);
     if (!parsed) {
-        throw configuration_exception(format("Invalid Vector Store service URI: {}", uri));
+        throw configuration_exception(fmt::format("Invalid Vector Store service URI: {}", uri));
     }
     vslogger.info("Vector Store service URI is set to '{}'", uri);
     return *parsed;


### PR DESCRIPTION
As explained in commit 3e84d43f9348bde011220353539c11a6ed29e291 two years ago, using just format() instead of seastar::format() or fmt::format() is frowned upon, because it can cause ambiguities - resulting in compile errors - in some cases. The compile errors seem to crop up randomly depending on the exact version of fmt used, so build can work CI using one specific version, but fail on a developer's machine using a different version.

In this patch I fix one such ambiguity that breaks compilation on my development machine's fmt-11.0.2 and clang 19.1.7, but works fine on the slightly newer frozen toolchain.

The error I get before this fix is:

service/vector_store_client.cc:261:39: error: call to 'format' is ambiguous
  261 |         throw configuration_exception(format("Invalid Vector Store service URI: {}", uri));
      |                                       ^~~~~~