### PR TITLE
config: split tri_mode_restriction to a separate header

### DIFF
--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -32,6 +32,7 @@
 #include "db/view/view.hh"
 #include "service/migration_manager.hh"
 #include "replica/database.hh"
+#include "db/config.hh"
 
 namespace cql3 {
 

--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -14,7 +14,7 @@
 #include "cql3/statements/prepared_statement.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/attributes.hh"
-#include "db/config.hh"
+#include "db/tri_mode_restriction.hh"
 #include <seastar/core/shared_ptr.hh>
 
 namespace cql3 {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -57,6 +57,7 @@
 #include "utils/result_loop.hh"
 #include "replica/database.hh"
 #include "replica/mutation_dump.hh"
+#include "db/config.hh"
 
 
 template<typename T = void>

--- a/cql3/util.cc
+++ b/cql3/util.cc
@@ -7,6 +7,7 @@
 #include "utils/assert.hh"
 #include "util.hh"
 #include "cql3/expr/expr-utils.hh"
+#include "db/config.hh"
 
 #ifdef DEBUG
 

--- a/db/config.hh
+++ b/db/config.hh
@@ -25,6 +25,7 @@
 #include "utils/error_injection.hh"
 #include "utils/dict_trainer.hh"
 #include "utils/advanced_rpc_compressor.hh"
+#include "db/tri_mode_restriction.hh"
 
 namespace boost::program_options {
 
@@ -140,15 +141,6 @@ struct experimental_features_t {
     static std::map<sstring, feature> map(); // See enum_option.
     static std::vector<enum_option<experimental_features_t>> all();
 };
-
-/// A restriction that can be in three modes: true (the operation is disabled),
-/// false (the operation is allowed), or warn (the operation is allowed but
-/// produces a warning in the log).
-struct tri_mode_restriction_t {
-    enum class mode { FALSE, TRUE, WARN };
-    static std::unordered_map<sstring, mode> map(); // for enum_option<>
-};
-using tri_mode_restriction = enum_option<tri_mode_restriction_t>;
 
 struct replication_strategy_restriction_t {
     static std::unordered_map<sstring, locator::replication_strategy_type> map(); // for enum_option<>

--- a/db/tri_mode_restriction.hh
+++ b/db/tri_mode_restriction.hh
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2021-present ScyllaDB
+ *
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <unordered_map>
+
+#include <seastar/core/sstring.hh>
+
+#include "seastarx.hh"
+#include "utils/enum_option.hh"
+
+namespace db {
+
+/// A restriction that can be in three modes: true (the operation is
+/// restricted), false (the operation is unrestricted), or warn (the
+/// operation is unrestricted but produces some warning (in the response,
+/// log and/or metric) when the operation would have been forbidden in
+/// "true" mode.
+struct tri_mode_restriction_t {
+    enum class mode { FALSE, TRUE, WARN };
+    static std::unordered_map<sstring, mode> map(); // for enum_option<>
+};
+using tri_mode_restriction = enum_option<tri_mode_restriction_t>;
+
+} // namespace db


### PR DESCRIPTION
Today, any source file or header file that wants to use the tri_mode_restriction type needs to include db/config.hh, which is a large and frequently-changing header file. In this patch we split this type into a separate header file, db/tri_mode_restriction.hh, and avoid a few unnecessary inclusions of db/config.hh. However, a few source files now need to explicitly include db/config.hh, after its transitive inclusion is gone.

Note that the overwhelmingly common inclusion of db/config.hh continues to be a problem after this patch - 128 source files include it directly. So this patch is just the first step in long journey.