### PR TITLE
repair: Add incremental_mode option for tablet repair

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2921,6 +2921,14 @@
                      "allowMultiple":false,
                      "type":"string",
                      "paramType":"query"
+                  },
+                  {
+                     "name":"incremental_mode",
+                     "description":"Set the incremental repair mode. Can be 'disabled', 'regular', or 'full'. 'regular': The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair. 'full': The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair. 'disabled': The incremental repair logic is disabled completely. The incremental repair states, e.g., repaired_at in sstables and sstables_repaired_at in the system.tablets table, will not be updated after repair. When the option is not provided, it defaults to regular.",
+                     "required":false,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
                   }
                ]
             }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1730,6 +1730,10 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
         if (!await.empty()) {
             await_completion = validate_bool(await);
         }
+
+        // Use regular mode if the incremental_mode option is not provided by user.
+        auto incremental = req->get_query_param("incremental_mode");
+        auto incremental_mode = incremental.empty() ? locator::default_tablet_repair_incremental_mode : locator::tablet_repair_incremental_mode_from_string(incremental);
         auto table_id = validate_table(ctx.db.local(), ks, table);
         std::variant<utils::chunked_vector<dht::token>, service::storage_service::all_tokens_tag> tokens_variant;
         if (all_tokens) {
@@ -1752,7 +1756,7 @@ rest_repair_tablet(http_context& ctx, sharded<service::storage_service>& ss, std
             }) | std::ranges::to<std::unordered_set>();
         }
         auto dcs_filter = locator::tablet_task_info::deserialize_repair_dcs_filter(dcs);
-        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant, hosts_filter, dcs_filter, await_completion);
+        auto res = co_await ss.local().add_repair_tablet_request(table_id, tokens_variant, hosts_filter, dcs_filter, await_completion, incremental_mode);
         co_return json::json_return_type(res);
 }
 

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -240,6 +240,7 @@ CREATE TABLE system.tablets (
     stage text,
     transition text,
     sstables_repaired_at bigint,
+    repair_incremental_mode text,
     PRIMARY KEY (table_id, last_token)
 )
 
@@ -283,6 +284,11 @@ Only tables which use tablet-based replication strategy have an entry here.
 `repair_time` is the last time the tablet has been repaired.
 
 `sstables_repaired_at` is the reapired_at number for the tablet. When repaired_at <= sstables_repaired_at (repaired_at is the on disk field of a SSTable), it means the sstable is repaired.
+
+`repair_incremental_mode` - The mode for incremental repair. Can be 'disabled', 'regular', or 'full'.
+  * `regular`: The incremental repair logic is enabled. Unrepaired sstables will be included for repair. Repaired sstables will be skipped. The incremental repair states will be updated after repair.
+  * `full`: The incremental repair logic is enabled. Both repaired and unrepaired sstables will be included for repair. The incremental repair states will be updated after repair.
+  * `disabled`: The incremental repair logic is disabled completely. The incremental repair states, e.g., `repaired_at` in sstables and `sstables_repaired_at` in the `system.tablets` table, will not be updated after repair.
 
 `repair_task_info` contains the metadata for the task manager. It contains the following values:
   * `request_type` - The type of the request. It could be user_repair and auto_repair.

--- a/idl/repair.idl.hh
+++ b/idl/repair.idl.hh
@@ -74,6 +74,14 @@ struct repair_row_level_start_response {
     repair_row_level_start_status status;
 };
 
+namespace locator {
+enum class tablet_repair_incremental_mode : uint8_t {
+    regular,
+    full,
+    disabled,
+};
+}
+
 struct repair_update_system_table_request {
     tasks::task_id repair_uuid;
     table_id table_uuid;
@@ -104,7 +112,7 @@ verb [[with_client_info]] repair_get_combined_row_hash (uint32_t repair_meta_id,
 verb [[with_client_info]] repair_get_sync_boundary (uint32_t repair_meta_id, std::optional<repair_sync_boundary> skipped_sync_boundary, shard_id dst_shard_id [[version 5.2]]) -> get_sync_boundary_response;
 verb [[with_client_info]] repair_get_row_diff (uint32_t repair_meta_id, repair_hash_set set_diff, bool needs_all_rows, shard_id dst_shard_id [[version 5.2]]) -> repair_rows_on_wire;
 verb [[with_client_info]] repair_put_row_diff (uint32_t repair_meta_id, repair_rows_on_wire row_diff, shard_id dst_shard_id [[version 5.2]]);
-verb [[with_client_info]] repair_row_level_start (uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason [[version 4.1.0]], gc_clock::time_point compaction_time [[version 5.2]], shard_id dst_shard_id [[version 5.2]], service::frozen_topology_guard topo_guard [[version 2025.1]], std::optional<int64_t> repaired_at [[version 2025.4]]) -> repair_row_level_start_response [[version 4.2.0]];
+verb [[with_client_info]] repair_row_level_start (uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, row_level_diff_detect_algorithm algo, uint64_t max_row_buf_size, uint64_t seed, unsigned remote_shard, unsigned remote_shard_count, unsigned remote_ignore_msb, sstring remote_partitioner_name, table_schema_version schema_version, streaming::stream_reason reason [[version 4.1.0]], gc_clock::time_point compaction_time [[version 5.2]], shard_id dst_shard_id [[version 5.2]], service::frozen_topology_guard topo_guard [[version 2025.1]], std::optional<int64_t> repaired_at [[version 2025.4]], locator::tablet_repair_incremental_mode incremental_mode [[version 2025.4]]) -> repair_row_level_start_response [[version 4.2.0]];
 verb [[with_client_info]] repair_row_level_stop (uint32_t repair_meta_id, sstring keyspace_name, sstring cf_name, dht::token_range range, shard_id dst_shard_id [[version 5.2]], bool mark_as_repaired [[2025.4]]);
 verb [[with_client_info]] repair_get_estimated_partitions (uint32_t repair_meta_id, shard_id dst_shard_id [[version 5.2]]) -> uint64_t;
 verb [[with_client_info]] repair_set_estimated_partitions (uint32_t repair_meta_id, uint64_t estimated_partitions, shard_id dst_shard_id [[version 5.2]]);

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -2263,6 +2263,7 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     auto& topology = guard.get_token_metadata()->get_topology();
     auto hosts_filter = info.repair_task_info.repair_hosts_filter;
     auto dcs_filter = info.repair_task_info.repair_dcs_filter;
+    auto incremental_mode = info.repair_task_info.repair_incremental_mode;
     for (auto& r : replicas) {
         auto shard = r.shard;
         if (r.host != myhostid) {
@@ -2295,7 +2296,7 @@ future<gc_clock::time_point> repair_service::repair_tablet(gms::gossip_address_m
     auto ranges_parallelism = std::nullopt;
     auto start = std::chrono::steady_clock::now();
     bool sched_by_scheduler = true;
-    tablet_repair_sched_info sched_info{sched_by_scheduler, stage == locator::tablet_transition_stage::rebuild_repair};
+    tablet_repair_sched_info sched_info{sched_by_scheduler, stage == locator::tablet_transition_stage::rebuild_repair, incremental_mode};
     task_metas.push_back(tablet_repair_task_meta{keyspace_name, table_name, table_id, *master_shard_id, range, repair_neighbors(nodes, shards), replicas});
     auto task = co_await _repair_module->make_and_start_task<repair::tablet_repair_task_impl>(global_tablet_repair_task_info, id, keyspace_name, global_tablet_repair_task_info.id, table_names, streaming::stream_reason::repair, std::move(task_metas), ranges_parallelism, topo_guard, std::move(sched_info), rebuild_replicas.has_value());
     co_await task->done();

--- a/repair/repair.hh
+++ b/repair/repair.hh
@@ -54,6 +54,8 @@ class migration_manager;
 }
 namespace gms { class gossiper; }
 
+namespace locator { enum class tablet_repair_incremental_mode : uint8_t; }
+
 class repair_exception : public std::exception {
 private:
     sstring _what;
@@ -293,6 +295,7 @@ struct tablet_repair_task_meta {
 struct tablet_repair_sched_info {
     bool sched_by_scheduler = false;
     bool for_tablet_rebuild = false;
+    locator::tablet_repair_incremental_mode incremental_mode;
 };
 
 namespace std {

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -286,7 +286,8 @@ public:
             gc_clock::time_point compaction_time,
             abort_source& as,
             service::frozen_topology_guard topo_guard,
-            std::optional<int64_t> repaired_at);
+            std::optional<int64_t> repaired_at,
+            locator::tablet_repair_incremental_mode incremental_mode);
 
     future<>
     remove_repair_meta(const locator::host_id& from,

--- a/replica/tablet_mutation_builder.hh
+++ b/replica/tablet_mutation_builder.hh
@@ -43,8 +43,8 @@ public:
     tablet_mutation_builder& set_repair_scheduler_config(locator::repair_scheduler_config);
     tablet_mutation_builder& set_repair_time(dht::token last_token, db_clock::time_point repair_time);
     tablet_mutation_builder& set_sstables_repair_at(dht::token last_token, int64_t sstables_repaired_at);
-    tablet_mutation_builder& set_repair_task_info(dht::token last_token, locator::tablet_task_info info);
-    tablet_mutation_builder& del_repair_task_info(dht::token last_token);
+    tablet_mutation_builder& set_repair_task_info(dht::token last_token, locator::tablet_task_info info, const gms::feature_service& features);
+    tablet_mutation_builder& del_repair_task_info(dht::token last_token, const gms::feature_service& features);
     tablet_mutation_builder& set_migration_task_info(dht::token last_token, locator::tablet_task_info info, const gms::feature_service& features);
     tablet_mutation_builder& del_migration_task_info(dht::token last_token, const gms::feature_service& features);
     tablet_mutation_builder& set_resize_task_info(locator::tablet_task_info info, const gms::feature_service& features);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6608,13 +6608,13 @@ replica::tablet_mutation_builder storage_service::tablet_mutation_builder_for_ba
 // Repair the tablets contain the tokens and wait for the repair to finish
 // This is used to run a manual repair requested by user from the restful API.
 future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant,
-        std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion) {
+        std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion, locator::tablet_repair_incremental_mode incremental_mode) {
     auto holder = _async_gate.hold();
 
     if (this_shard_id() != 0) {
         // group0 is only set on shard 0.
         co_return co_await container().invoke_on(0, [&] (auto& ss) {
-            return ss.add_repair_tablet_request(table, std::move(tokens_variant), std::move(hosts_filter), std::move(dcs_filter), await_completion);
+            return ss.add_repair_tablet_request(table, std::move(tokens_variant), std::move(hosts_filter), std::move(dcs_filter), await_completion, incremental_mode);
         });
     }
 
@@ -6628,12 +6628,12 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         throw std::runtime_error("The TABLET_REPAIR_SCHEDULER feature is not enabled on the cluster yet");
     }
 
-    auto repair_task_info = locator::tablet_task_info::make_user_repair_request(hosts_filter, dcs_filter);
+    auto repair_task_info = locator::tablet_task_info::make_user_repair_request(hosts_filter, dcs_filter, incremental_mode);
     auto res = std::unordered_map<sstring, sstring>{{sstring("tablet_task_id"), repair_task_info.tablet_task_id.to_sstring()}};
 
     auto start = std::chrono::steady_clock::now();
-    slogger.info("Starting tablet repair by API request table_id={} tokens={} all_tokens={} tablet_task_id={} hosts_filter={} dcs_filter={}",
-            table, tokens, all_tokens, repair_task_info.tablet_task_id, hosts_filter, dcs_filter);
+    slogger.info("Starting tablet repair by API request table_id={} tokens={} all_tokens={} tablet_task_id={} hosts_filter={} dcs_filter={} incremental_mode={}",
+            table, tokens, all_tokens, repair_task_info.tablet_task_id, hosts_filter, dcs_filter, incremental_mode);
 
     while (true) {
         auto guard = co_await get_guard_for_tablet_update();
@@ -6666,7 +6666,7 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
             auto last_token = tmap.get_last_token(tid);
             updates.emplace_back(
                 tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
-                    .set_repair_task_info(last_token, repair_task_info)
+                    .set_repair_task_info(last_token, repair_task_info, _feature_service)
                     .build());
         }
 
@@ -6735,7 +6735,7 @@ future<> storage_service::del_repair_tablet_request(table_id table, locator::tab
             auto last_token = tmap.get_last_token(tid);
             auto* trinfo = tmap.get_tablet_transition_info(tid);
             auto update = tablet_mutation_builder_for_base_table(guard.write_timestamp(), table)
-                            .del_repair_task_info(last_token);
+                            .del_repair_task_info(last_token, _feature_service);
             if (trinfo && trinfo->transition == locator::tablet_transition_kind::repair) {
                 update.del_session(last_token);
             }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -981,7 +981,7 @@ private:
     future<bool> exec_tablet_update(service::group0_guard guard, utils::chunked_vector<canonical_mutation> updates, sstring reason);
 public:
     struct all_tokens_tag {};
-    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion);
+    future<std::unordered_map<sstring, sstring>> add_repair_tablet_request(table_id table, std::variant<utils::chunked_vector<dht::token>, all_tokens_tag> tokens_variant, std::unordered_set<locator::host_id> hosts_filter, std::unordered_set<sstring> dcs_filter, bool await_completion, locator::tablet_repair_incremental_mode incremental_mode);
     future<> del_repair_tablet_request(table_id table, locator::tablet_task_id);
     future<> move_tablet(table_id, dht::token, locator::tablet_replica src, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -288,13 +288,15 @@ class ScyllaRESTAPIClient:
             "token": str(token)
         })
 
-    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int, hosts_filter: Optional[str] = None, dcs_filter: Optional[str] = None, timeout: Optional[float] = None, await_completion: bool = True) -> None:
+    async def tablet_repair(self, node_ip: str, ks: str, table: str, token : int, hosts_filter: Optional[str] = None, dcs_filter: Optional[str] = None, timeout: Optional[float] = None, await_completion: bool = True, incremental_mode: Optional[str] = None) -> None:
         params={
             "ks": ks,
             "table": table,
             "tokens": str(token),
             "await_completion": str(await_completion).lower()
         }
+        if incremental_mode is not None:
+            params["incremental_mode"] = str(incremental_mode).lower()
         if hosts_filter:
             params["hosts_filter"] = hosts_filter
         if dcs_filter:


### PR DESCRIPTION
This patch introduces a new `incremental_mode` parameter to the tablet repair REST API, providing more fine-grained control over the incremental repair process.

Previously, incremental repair was on and could not be turned off. This change allows users to select from three distinct modes:

- `regular`: This is the default mode. It performs a standard incremental repair, processing only unrepaired sstables and skipping those that are already repaired. The repair state (`repaired_at`, `sstables_repaired_at`) is updated.

- `full`: This mode forces the repair to process all sstables, including those that have been previously repaired. This is useful when a full data validation is needed without disabling the incremental repair feature. The repair state is updated.

- `disabled`: This mode completely disables the incremental repair logic for the current repair operation. It behaves like a classic (pre-incremental) repair, and it does not update any incremental repair state (`repaired_at` in sstables or `sstables_repaired_at` in the system.tablets table).

The implementation includes:

- Adding the `incremental_mode` parameter to the `/storage_service/repair/tablet` API endpoint.
- Updating the internal repair logic to handle the different modes.
- Adding a new test case to verify the behavior of each mode.
- Updating the API documentation and developer documentation.

Fixes #25605

No backport needed. This code should go together with the main incremental PR into 2025.4. 