### PR TITLE
docs/snitch: Document default DC and rack

### DIFF
--- a/docs/operating-scylla/system-configuration/snitch.rst
+++ b/docs/operating-scylla/system-configuration/snitch.rst
@@ -36,12 +36,16 @@ SimpleSnitch
 Use the SimpleSnitch when working with single cluster deployments and all the nodes are under the same datacenter.
 The SimpleSnitch binds all the nodes to the same Rack and datacenter and is recommended to be used only in single datacenter deployments.
 
+The name of the datacenter is set to ``datacenter1``, while the name of the rack—to ``rack1``.
+
 .. _snitch-rack-inferring-snitch:
 
 RackInferringSnitch
 ...................
 
 RackInferringSnitch binds nodes to DCs and racks according to their broadcast IP addresses.
+The name of the DC will correspond to the number represented by the second octet of bits
+in the address, while the name of the rack—to the third octet.
 
 
 For Example:
@@ -67,6 +71,7 @@ For Example:
    dc=my_data_center 
    rack=my_rack
 
+When using this snitch, it is mandatory to provide both the name of the datacenter and the name of the rack.
 
 Setting *prefer_local* to *true* instructs ScyllaDB to use an internal IP address for interactions with nodes in the same DC.
 


### PR DESCRIPTION
The existing article is already extensive and covers pretty much all of the details useful to the user. However, the document lacked minute information like the default names of the DC and rack in case of SimpleSnitch or it didn't explicitly specify the behavior of RackInferringSnitch (though arguably the existing example was more than sufficient).

Fixes scylladb/scylladb#23528

Backport: not necessary. The changes are minute.