### PR TITLE
test/perf: Require smp=1 in perf_cache_eviction

### DIFF
--- a/test/perf/perf_cache_eviction.cc
+++ b/test/perf/perf_cache_eviction.cc
@@ -51,6 +51,10 @@ int main(int argc, char** argv) {
         ;
 
     return app.run(argc, argv, [&app] {
+        if (smp::count != 1) {
+            throw std::runtime_error("This test has to be run with --smp=1");
+        }
+
         if (app.configuration().contains("trace")) {
             testlog.set_level(seastar::log_level::trace);
         }


### PR DESCRIPTION
Trying to run the test with more than one shard results in a failure when generating sharding metadata:

```
ERROR 2025-08-27 16:00:17,551 [shard  0:main] table - Memtable flush failed due to: std::runtime_error (Failed to generate sharding metadata for /tmp/scylla-c9fa42fe/ks/cf-2938a030834e11f0a561ffa33feb022d/me-3gt6_12wh_1gifk2ijgeu1ovc1m5-big-Data.db). Aborting
```

Let's require that the test be run with a single shard.

Backport: Not necessary. The test is not part of our CI and it hasn't caused any problems so far.