### PR TITLE
utils, alternator: fix detection of invalid base-64

### DIFF
--- a/test/alternator/test_manual_requests.py
+++ b/test/alternator/test_manual_requests.py
@@ -21,12 +21,16 @@ def gen_json(n):
     return '{"":'*n + '{}' + '}'*n
 
 def get_signed_request(dynamodb, target, payload):
+    # Usually "payload" will be a Python string and we'll write it as UTF-8.
+    # but in some tests we may want to write bytes directly - potentially
+    # bytes which include invalid UTF-8.
+    payload_bytes = payload if isinstance(payload, bytes) else payload.encode(encoding='UTF-8')
     # NOTE: Signing routines use boto3 implementation details and may be prone
     # to unexpected changes
     class Request:
         url=dynamodb.meta.client._endpoint.host
         headers={'X-Amz-Target': 'DynamoDB_20120810.' + target, 'Content-Type': 'application/x-amz-json-1.0'}
-        body=payload.encode(encoding='UTF-8')
+        body=payload_bytes
         method='POST'
         context={}
         params={}
@@ -280,6 +284,25 @@ def test_base64_malformed(dynamodb, test_table_b):
     r = put_item_binary_data_in_key(dynamodb, test_table_b, "YWJj??!!")
     assert r.status_code == 400 and 'SerializationException' in r.text
     r = put_item_binary_data_in_non_key(dynamodb, test_table_b, "YWJj??!!")
+    assert r.status_code == 400 and 'SerializationException' in r.text
+
+# The check for valid base64 encoding had a bug (#25701) where it used a
+# 255-byte lookup-table instead of 256 bytes - so sending a byte 255 as part
+# of an invalid base64 string could lead the code to go beyond this lookup
+# table's bounds, and not recognize the invalid string or worse (the out-of-
+# bound read may be detected and crash Scylla).
+# Reproduces issue #25701.
+def test_base64_malformed_255(dynamodb, test_table_b):
+    # No valid UTF-8 can contain the byte we want to use 255 (0xFF), so we
+    # can't use the function put_item_binary_data_in_key() as in other tests
+    # because that function only writes UTF-8. So we need to compose the
+    # payload with the byte 0xFF directly as a Python "bytes" object.
+    # We need to pad the length of that test string to be a multiple of 4 -
+    # e.g., "\xFFdog", so the validation code doesn't fail early.
+    table_name_bytes = test_table_b.name.encode('UTF-8')
+    payload_bytes = b'{"TableName": "' + table_name_bytes + b'", "Item": {"p": {"B": "\xFFdog"}}}'
+    req = get_signed_request(dynamodb, 'PutItem', payload_bytes)
+    r = requests.post(req.url, headers=req.headers, data=req.body, verify=True)
     assert r.status_code == 400 and 'SerializationException' in r.text
 
 def update_item_binary_data(dynamodb, test_table_b, item_data):

--- a/utils/base64.cc
+++ b/utils/base64.cc
@@ -17,10 +17,10 @@ public:
     static constexpr const char to[] =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     static constexpr uint8_t invalid_char = 255;
-    uint8_t from[255];
+    uint8_t from[256];
     base64_chars() {
         static_assert(sizeof(to) == 64 + 1);
-        for (int i = 0; i < 255; i++) {
+        for (int i = 0; i < 256; i++) {
             from[i] = invalid_char; // signal invalid character
         }
         for (int i = 0; i < 64; i++) {


### PR DESCRIPTION
This patch fixes an error-path bug in the base-64 decoding code in utils/base64.cc, which among other things is used in Alternator to decode blobs in JSON requests.

The base-64 decoding code has a lookup table, which was wrongly sized 255 bytes, but needed to be 256 bytes. This meant that if the byte 255 (0xFF) was included in an invalid base-64 string, instead of detecting that this is an invalid byte (since the only valid bytes in a base-64 string are A-Z,a-z,0-9,+,/ and =), the code would either think it's valid with a nonsense 6-bit part, or even crash on an out-of-bounds read.

Besides the trivial fix, this patch also includes a reproducing test, which tries to write a blob as a supposedly base-64 encoded string with a 0xFF byte in it. The test fails before this patch (the write succeeds, unexpectedly), and passes after this patch (the write fails as expected). The test also passes on DynamoDB.

Fixes #25701

This is a trivial patch, with some theoretical (but unlikely to work in practice) ability to crash Scylla, so I recommend backporting it.