### PR TITLE
utils/base64: fix misleading code and comment (no functional change)

### DIFF
--- a/utils/base64.cc
+++ b/utils/base64.cc
@@ -127,8 +127,8 @@ bool base64_begins_with(std::string_view base, std::string_view operand) {
     if (unpadded_base_prefix != unpadded_operand) {
         return false;
     }
-    // Decode and compare last 4 bytes of base64-encoded strings
-    const std::string base_remainder = base64_decode_string(base.substr(operand.size() - 4, operand.size()));
+    // Decode and compare next 4 bytes of base64-encoded strings
+    const std::string base_remainder = base64_decode_string(base.substr(operand.size() - 4, 4));
     const std::string operand_remainder = base64_decode_string(operand.substr(operand.size() - 4));
     return base_remainder.starts_with(operand_remainder);
 }


### PR DESCRIPTION
utils/base64.cc had some strange code with a strange comment in base64_begins_with().

The code had

        base.substr(operand.size() - 4, operand.size())

The comment claims that this is "last 4 bytes of base64-encoded string", but this comment is misleading - operand is typically shorter than base (this this whole point of the base64_begins_with()), so the real intention of the code is not to find the *last* 4 bytes of base, but rather the *next* four bytes after the (operand.size() - 4) which we already copied. These four bytes that may need the full power of base64_decode_string() because they may or may not contain padding.

But, if we really want the next 4 bytes, why pass operand.size() as the length of the substring? operand.size() is at least 4 (it's a mutiple of 4, and if it's 0 we returned earlier), but it could me more. We don't need more, we just need 4. It's not really wrong to take more than 4 (so this patch doesn't *fix* any bug), but can be wasteful. So this code should be:

        base.substr(operand.size() - 4, 4)

We already have in test/boost/alternator_unit_test.cc a test, test_base64_begins_with that takes encoded base64 strings up to 12 characters in length (corresponding to decoded strings up to 8 chars), and substrings from length 0 to the base string's length, and check that test_base64_begins_with succeeds.