### PR TITLE
raft_topology: Modify the conditional logic in remove node operation …

### DIFF
--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -807,7 +807,20 @@ public:
 
     template <typename Func>
     auto run_with_api_lock_conditionally(sstring operation, bool lock, Func&& func) {
-        return lock ? run_with_api_lock(std::move(operation), std::forward<Func>(func)) : run_with_no_api_lock(std::forward<Func>(func));
+        return container().invoke_on(0, [operation = std::move(operation),
+                func = std::forward<Func>(func)] (storage_service& ss) mutable {
+            if (ss.raft_topology_change_enabled()) {
+                return func(ss);
+            }
+
+            if (!ss._operation_in_progress.empty()) {
+                throw std::runtime_error(format("Operation {} is in progress, try again", ss._operation_in_progress));
+            }
+            ss._operation_in_progress = std::move(operation);
+            return func(ss).finally([&ss] {
+                ss._operation_in_progress = sstring();
+            });
+       });
     }
 
 private:

--- a/test/cluster/test_concurrent_remove_node_ops.py
+++ b/test/cluster/test_concurrent_remove_node_ops.py
@@ -1,0 +1,23 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import asyncio
+import pytest
+
+from test.pylib.manager_client import ManagerClient
+
+
+@pytest.mark.asyncio
+async def test_concurrent_removenode(manager: ManagerClient):
+    await manager.servers_add(5)
+    servers = await manager.running_servers()
+    assert len(servers) >= 5
+
+    await manager.server_stop_gracefully(servers[2].server_id)
+    await manager.server_stop_gracefully(servers[1].server_id)
+
+    await asyncio.gather(*[manager.remove_node(servers[0].server_id, servers[2].server_id),
+            manager.remove_node(servers[0].server_id, servers[1].server_id)])


### PR DESCRIPTION
In the current scenario, the shard receiving the remove node REST api request performs condional lock depending on whether raft is enabled or not. Since non-zero shard returns false for `raft_topology_enabled()`, the requests routed to non zero shards are prone to this lock which is unnecessary and hampers the ability to perform concurrent operations, which is possible for raft enabled nodes.

This pr modifies the conditional lock logic and orchestrates the remove node execution logic directly to the shard0, hence the `raft_topology_enabled()` is now checked on the shard0 and execution is performed accordingly.

A test is also added to confirm the new behaviour, where concurrent remove node operations are now being performed seamlessly.

This pr fixes a bug. Hence we need to backport it.

Fixes: scylladb/scylladb#24737