### PR TITLE
gossiper: check for a race condition in `do_apply_state_locally`

### DIFF
--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -15,7 +15,6 @@ from test.pylib.manager_client import ManagerClient
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-@pytest.mark.xfail(reason="https://github.com/scylladb/scylladb/issues/25621")
 async def test_gossiper_race_on_decommission(manager: ManagerClient):
     """
     Test for gossiper race scenario (https://github.com/scylladb/scylladb/issues/25621):


### PR DESCRIPTION
In `do_apply_state_locally`, a race condition can occur if a task is suspended at a preemption point while the node entry is not locked.
During this time, the host may be removed from `_endpoint_state_map`. When the task resumes, this can lead to inserting an entry with an empty host ID into the map, causing various errors, including a node crash.

This change adds a check after locking the map entry: if a gossip ACK update does not contain a host ID, we verify that an entry with that host ID still exists in the gossiper’s `_endpoint_state_map`.
    
Fixes scylladb/scylladb#25702
Fixes scylladb/scylladb#25621
Ref scylladb/scylla-enterprise#5613

Backport: this issue may affect all the existing versions, so need backports to 2025.1, 2025.2, 2025.3
