### PR TITLE
cql3: reject ALTER KEYSPACE if rf of datacenter with tablets is omitted

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1646,7 +1646,8 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
             auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
             if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
                 locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
-                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
+                const auto& topo = sp.local_db().get_token_metadata().get_topology();
+                auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params, topo);
                 if (rs->uses_tablets()) {
                     co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
                     "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -16,6 +16,7 @@
 #include "cdc/cdc_options.hh"
 #include "auth/service.hh"
 #include "db/config.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "schema/schema_builder.hh"
 #include "exceptions/exceptions.hh"
@@ -5653,8 +5654,8 @@ future<executor::request_return_type> executor::describe_endpoints(client_state&
     co_return rjson::print(std::move(response));
 }
 
-static std::map<sstring, sstring> get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
-    std::map<sstring, sstring> options;
+static locator::replication_strategy_config_options get_network_topology_options(service::storage_proxy& sp, gms::gossiper& gossiper, int rf) {
+    locator::replication_strategy_config_options options;
     for (const auto& dc : sp.get_token_metadata_ptr()->get_topology().get_datacenters()) {
         options.emplace(dc, std::to_string(rf));
     }

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -5696,14 +5696,33 @@ future<executor::request_return_type> executor::describe_continuous_backups(clie
 // A smaller cluster (presumably, a test only), gets RF=1. The user may
 // manually create the keyspace to override this predefined behavior.
 static lw_shared_ptr<keyspace_metadata> create_keyspace_metadata(std::string_view keyspace_name, service::storage_proxy& sp, gms::gossiper& gossiper, api::timestamp_type ts, const std::map<sstring, sstring>& tags_map, const gms::feature_service& feat) {
-    int endpoint_count = gossiper.num_endpoints();
-    int rf = 3;
-    if (endpoint_count < rf) {
-        rf = 1;
-        elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
-                keyspace_name, rf, endpoint_count);
+    auto& topo = sp.get_token_metadata_ptr()->get_topology();
+    locator::replication_strategy_config_options opts;
+    if (sp.local_db().get_config().rf_rack_valid_keyspaces()) {
+        for (const auto& [dc, hosts_by_rack] : topo.get_datacenter_racks()) {
+            auto racks = hosts_by_rack | std::views::keys | std::ranges::to<std::vector>();
+            if (racks.size() > 3) {
+                static thread_local std::default_random_engine rnd_engine{std::random_device{}()};
+                std::shuffle(racks.begin(), racks.end(), rnd_engine);
+                racks.resize(3);
+                elogger.warn("Creating keyspace '{}' for Alternator on a subset of racks in dc {} (has {} racks): {}",
+                             keyspace_name, dc, hosts_by_rack.size(), racks);
+            } else if (racks.size() < 3) {
+                elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} in dc {} because it has this many racks.",
+                             keyspace_name, racks.size(), dc);
+            }
+            opts.emplace(dc, std::move(racks));
+        }
+    } else {
+        int endpoint_count = gossiper.num_endpoints();
+        int rf = 3;
+        if (endpoint_count < rf) {
+            rf = 1;
+            elogger.warn("Creating keyspace '{}' for Alternator with unsafe RF={} because cluster only has {} nodes.",
+                         keyspace_name, rf, endpoint_count);
+        }
+        opts = get_network_topology_options(sp, gossiper, rf);
     }
-    auto opts = get_network_topology_options(sp, gossiper, rf);
 
     // Even if the "tablets" experimental feature is available, we currently
     // do not enable tablets by default on Alternator tables because LWT is

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -65,7 +65,7 @@ future<> audit_cf_storage_helper::migrate_audit_table(service::group0_guard grou
             data_dictionary::database db = _qp.db();
             cql3::statements::ks_prop_defs old_ks_prop_defs;
             auto old_ks_metadata = old_ks_prop_defs.as_ks_metadata_update(
-                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features());
+                    ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features(), db.get_config());
             locator::replication_strategy_config_options strategy_opts;
             for (const auto &dc: _qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                 strategy_opts[dc] = "3";

--- a/audit/audit_cf_storage_helper.cc
+++ b/audit/audit_cf_storage_helper.cc
@@ -16,6 +16,7 @@
 #include "cql3/statements/ks_prop_defs.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 namespace audit {
 
@@ -65,7 +66,7 @@ future<> audit_cf_storage_helper::migrate_audit_table(service::group0_guard grou
             cql3::statements::ks_prop_defs old_ks_prop_defs;
             auto old_ks_metadata = old_ks_prop_defs.as_ks_metadata_update(
                     ks->metadata(), *_qp.proxy().get_token_metadata_ptr(), db.features());
-            std::map<sstring, sstring> strategy_opts;
+            locator::replication_strategy_config_options strategy_opts;
             for (const auto &dc: _qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                 strategy_opts[dc] = "3";
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -159,7 +159,7 @@ public:
         });
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
+    void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) override {
         if (schema.cdc_options().enabled()) {
             auto& db = _ctxt._proxy.get_db().local();
             auto logname = log_name(schema.cf_name());

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -79,7 +79,7 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
                         current_options.type_string(), new_options.type_string()));
             }
 
-            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features());
+            auto new_ks = _attrs->as_ks_metadata_update(ks.metadata(), *qp.proxy().get_token_metadata_ptr(), qp.proxy().features(), qp.db().get_config());
 
             auto tmptr = qp.proxy().get_token_metadata_ptr();
             const auto& topo = tmptr->get_topology();
@@ -142,7 +142,7 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         const auto tmptr = qp.proxy().get_token_metadata_ptr();
         const auto& topo = tmptr->get_topology();
         const auto& feat = qp.proxy().features();
-        auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat);
+        auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat, qp.db().get_config());
         utils::chunked_vector<mutation> muts;
         std::vector<sstring> warnings;
 

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -132,73 +132,6 @@ bool cql3::statements::alter_keyspace_statement::changes_tablets(query_processor
     return ks.get_replication_strategy().uses_tablets() && !_attrs->get_replication_options().empty();
 }
 
-namespace {
-// These functions are used to flatten all the options in the keyspace definition into a single-level map<string, string>.
-// (Currently options are stored in a nested structure that looks more like a map<string, map<string, string>>).
-// Flattening is simply joining the keys of maps from both levels with a colon ':' character,
-// or in other words: prefixing the keys in the output map with the option type, e.g. 'replication', 'storage', etc.,
-// so that the output map contains entries like: "replication:dc1" -> "3".
-// This is done to avoid key conflicts and to be able to de-flatten the map back into the original structure.
-
-void add_prefixed_key(const sstring& prefix,
-                      const cql3::statements::property_definitions::map_type& in,
-                      cql3::statements::property_definitions::map_type& out) {
-    for (const auto& [in_key, in_value]: in) {
-        out[prefix + ":" + in_key] = in_value;
-    }
-}
-
-void add_prefixed_key(const sstring& prefix,
-                      const cql3::statements::property_definitions::extended_map_type& in,
-                      cql3::statements::property_definitions::map_type& out) {
-    add_prefixed_key(prefix, cql3::statements::to_flat_map(in), out);
-}
-
-cql3::statements::property_definitions::map_type get_current_options_flattened(
-        const shared_ptr<cql3::statements::ks_prop_defs>& ks,
-        const gms::feature_service& feat) {
-    cql3::statements::property_definitions::map_type all_options;
-
-    add_prefixed_key(ks->KW_REPLICATION, ks->get_replication_options(), all_options);
-    add_prefixed_key(ks->KW_STORAGE, ks->get_storage_options().to_map(), all_options);
-    // if no tablet options are specified in ATLER KS statement,
-    // we want to preserve the old ones and hence cannot overwrite them with defaults
-    if (ks->has_property(ks->KW_TABLETS)) {
-        auto initial_tablets = ks->get_initial_tablets(std::nullopt);
-        add_prefixed_key(ks->KW_TABLETS,
-                         cql3::statements::property_definitions::map_type{
-                            {"enabled", initial_tablets ? "true" : "false"},
-                            {"initial", std::to_string(initial_tablets.value_or(0))}},
-                         all_options);
-    }
-    add_prefixed_key(ks->KW_DURABLE_WRITES,
-                     cql3::statements::property_definitions::map_type{{sstring(ks->KW_DURABLE_WRITES), to_sstring(ks->get_boolean(ks->KW_DURABLE_WRITES, true))}},
-                     all_options);
-
-    return all_options;
-}
-
-cql3::statements::property_definitions::map_type get_old_options_flattened(const data_dictionary::keyspace& ks) {
-    cql3::statements::property_definitions::map_type all_options;
-
-    using namespace cql3::statements;
-    add_prefixed_key(ks_prop_defs::KW_REPLICATION, ks.get_replication_strategy().get_config_options(), all_options);
-    add_prefixed_key(ks_prop_defs::KW_STORAGE, ks.metadata()->get_storage_options().to_map(), all_options);
-    if (ks.metadata()->initial_tablets()) {
-        add_prefixed_key(ks_prop_defs::KW_TABLETS,
-                         cql3::statements::property_definitions::map_type{
-                            {"enabled", ks.metadata()->initial_tablets() ? "true" : "false"},
-                            {"initial", std::to_string(ks.metadata()->initial_tablets().value_or(0))}},
-                         all_options);
-    }
-    add_prefixed_key(ks_prop_defs::KW_DURABLE_WRITES,
-                     cql3::statements::property_definitions::map_type{{sstring(ks_prop_defs::KW_DURABLE_WRITES), to_sstring(ks.metadata()->durable_writes())}},
-                     all_options);
-
-    return all_options;
-}
-} // <anonymous> namespace
-
 future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, cql3::cql_warnings_vec>>
 cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_processor& qp, service::query_state& state, const query_options& options, service::group0_batch& mc) const {
     using namespace cql_transport;
@@ -212,31 +145,9 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
         auto ks_md_update = _attrs->as_ks_metadata_update(ks_md, *tmptr, feat);
         utils::chunked_vector<mutation> muts;
         std::vector<sstring> warnings;
-        auto old_ks_options = get_old_options_flattened(ks);
-        auto ks_options = get_current_options_flattened(_attrs, feat);
-        ks_options.merge(old_ks_options);
 
         auto ts = mc.write_timestamp();
         auto global_request_id = mc.new_group0_state_id();
-
-        // #22688 - filter out any dc*:0 entries - consider these
-        // null and void (removed). Migration planning will treat it
-        // as dc*=0 still.
-        std::erase_if(ks_options, [](const auto& i) {
-            static constexpr std::string replication_prefix = ks_prop_defs::KW_REPLICATION + ":"s;
-            // Flattened map, replication entries starts with "replication:".
-            // Only valid options are replication_factor, class and per-dc rf:s. We want to
-            // filter out any dcN=0 entries.
-            auto& [key, val] = i;
-            if (key.starts_with(replication_prefix) && val == "0") {
-                std::string_view v(key);
-                v.remove_prefix(replication_prefix.size());
-                return v != ks_prop_defs::REPLICATION_FACTOR_KEY 
-                    && v != ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY
-                    ;
-            }
-            return false;
-        });
 
         // we only want to run the tablets path if there are actually any tablets changes, not only schema changes
         // TODO: the current `if (changes_tablets(qp))` is insufficient: someone may set the same RFs as before,
@@ -260,11 +171,11 @@ cql3::statements::alter_keyspace_statement::prepare_schema_mutations(query_proce
             if (!qp.proxy().features().topology_global_request_queue) {
                 builder.set_global_topology_request(service::global_topology_request::keyspace_rf_change);
                 builder.set_global_topology_request_id(global_request_id);
-                builder.set_new_keyspace_rf_change_data(_name, ks_options);
+                builder.set_new_keyspace_rf_change_data(_name, _attrs->flattened());
             } else {
                 builder.queue_global_topology_request_id(global_request_id);
                 rtbuilder.set("request_type", service::global_topology_request::keyspace_rf_change)
-                         .set_new_keyspace_rf_change_data(_name, ks_options);
+                         .set_new_keyspace_rf_change_data(_name, _attrs->flattened());
 
             };
             service::topology_change change{{builder.build()}};

--- a/cql3/statements/alter_keyspace_statement.cc
+++ b/cql3/statements/alter_keyspace_statement.cc
@@ -14,7 +14,9 @@
 #include <stdexcept>
 #include <vector>
 #include "alter_keyspace_statement.hh"
+#include "cql3/statements/property_definitions.hh"
 #include "locator/tablets.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "mutation/canonical_mutation.hh"
 #include "prepared_statement.hh"
 #include "service/migration_manager.hh"
@@ -49,16 +51,8 @@ future<> cql3::statements::alter_keyspace_statement::check_access(query_processo
     return state.has_keyspace_access(_name, auth::permission::ALTER);
 }
 
-static unsigned get_abs_rf_diff(const std::string& curr_rf, const std::string& new_rf) {
-    try {
-        return std::abs(std::stoi(curr_rf) - std::stoi(new_rf));
-    } catch (std::invalid_argument const& ex) {
-        on_internal_error(mylogger, fmt::format("get_abs_rf_diff expects integer arguments, "
-                                                "but got curr_rf:{} and new_rf:{}", curr_rf, new_rf));
-    } catch (std::out_of_range const& ex) {
-        on_internal_error(mylogger, fmt::format("get_abs_rf_diff expects integer arguments to fit into `int` type, "
-                                                "but got curr_rf:{} and new_rf:{}", curr_rf, new_rf));
-    }
+static unsigned get_abs_rf_diff(const locator::replication_strategy_config_option& curr_rf, const locator::replication_strategy_config_option& new_rf) {
+    return std::abs(ssize_t(locator::get_replication_factor(curr_rf)) - ssize_t(locator::get_replication_factor(new_rf)));
 }
 
 void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, const service::client_state& state) const {
@@ -91,12 +85,12 @@ void cql3::statements::alter_keyspace_statement::validate(query_processor& qp, c
             const auto& topo = tmptr->get_topology();
 
             if (ks.get_replication_strategy().uses_tablets()) {
-                const std::map<sstring, sstring>& current_rf_per_dc = ks.metadata()->strategy_options();
+                auto& current_rf_per_dc = ks.metadata()->strategy_options();
                 auto new_rf_per_dc = _attrs->get_replication_options();
                 new_rf_per_dc.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
                 unsigned total_abs_rfs_diff = 0;
                 for (const auto& [new_dc, new_rf] : new_rf_per_dc) {
-                    sstring old_rf = "0";
+                    auto old_rf = locator::replication_strategy_config_option(sstring("0"));
                     if (auto new_dc_in_current_mapping = current_rf_per_dc.find(new_dc);
                              new_dc_in_current_mapping != current_rf_per_dc.end()) {
                         old_rf = new_dc_in_current_mapping->second;
@@ -146,15 +140,24 @@ namespace {
 // so that the output map contains entries like: "replication:dc1" -> "3".
 // This is done to avoid key conflicts and to be able to de-flatten the map back into the original structure.
 
-void add_prefixed_key(const sstring& prefix, const std::map<sstring, sstring>& in, std::map<sstring, sstring>& out) {
+void add_prefixed_key(const sstring& prefix,
+                      const cql3::statements::property_definitions::map_type& in,
+                      cql3::statements::property_definitions::map_type& out) {
     for (const auto& [in_key, in_value]: in) {
         out[prefix + ":" + in_key] = in_value;
     }
-};
+}
 
-std::map<sstring, sstring> get_current_options_flattened(const shared_ptr<cql3::statements::ks_prop_defs>& ks,
-                                                         const gms::feature_service& feat) {
-    std::map<sstring, sstring> all_options;
+void add_prefixed_key(const sstring& prefix,
+                      const cql3::statements::property_definitions::extended_map_type& in,
+                      cql3::statements::property_definitions::map_type& out) {
+    add_prefixed_key(prefix, cql3::statements::to_flat_map(in), out);
+}
+
+cql3::statements::property_definitions::map_type get_current_options_flattened(
+        const shared_ptr<cql3::statements::ks_prop_defs>& ks,
+        const gms::feature_service& feat) {
+    cql3::statements::property_definitions::map_type all_options;
 
     add_prefixed_key(ks->KW_REPLICATION, ks->get_replication_options(), all_options);
     add_prefixed_key(ks->KW_STORAGE, ks->get_storage_options().to_map(), all_options);
@@ -163,31 +166,33 @@ std::map<sstring, sstring> get_current_options_flattened(const shared_ptr<cql3::
     if (ks->has_property(ks->KW_TABLETS)) {
         auto initial_tablets = ks->get_initial_tablets(std::nullopt);
         add_prefixed_key(ks->KW_TABLETS,
-                         {{"enabled", initial_tablets ? "true" : "false"},
-                         {"initial", std::to_string(initial_tablets.value_or(0))}},
+                         cql3::statements::property_definitions::map_type{
+                            {"enabled", initial_tablets ? "true" : "false"},
+                            {"initial", std::to_string(initial_tablets.value_or(0))}},
                          all_options);
     }
     add_prefixed_key(ks->KW_DURABLE_WRITES,
-                     {{sstring(ks->KW_DURABLE_WRITES), to_sstring(ks->get_boolean(ks->KW_DURABLE_WRITES, true))}},
+                     cql3::statements::property_definitions::map_type{{sstring(ks->KW_DURABLE_WRITES), to_sstring(ks->get_boolean(ks->KW_DURABLE_WRITES, true))}},
                      all_options);
 
     return all_options;
 }
 
-std::map<sstring, sstring> get_old_options_flattened(const data_dictionary::keyspace& ks) {
-    std::map<sstring, sstring> all_options;
+cql3::statements::property_definitions::map_type get_old_options_flattened(const data_dictionary::keyspace& ks) {
+    cql3::statements::property_definitions::map_type all_options;
 
     using namespace cql3::statements;
     add_prefixed_key(ks_prop_defs::KW_REPLICATION, ks.get_replication_strategy().get_config_options(), all_options);
     add_prefixed_key(ks_prop_defs::KW_STORAGE, ks.metadata()->get_storage_options().to_map(), all_options);
     if (ks.metadata()->initial_tablets()) {
         add_prefixed_key(ks_prop_defs::KW_TABLETS,
-                         {{"enabled", ks.metadata()->initial_tablets() ? "true" : "false"},
-                          {"initial", std::to_string(ks.metadata()->initial_tablets().value_or(0))}},
+                         cql3::statements::property_definitions::map_type{
+                            {"enabled", ks.metadata()->initial_tablets() ? "true" : "false"},
+                            {"initial", std::to_string(ks.metadata()->initial_tablets().value_or(0))}},
                          all_options);
     }
     add_prefixed_key(ks_prop_defs::KW_DURABLE_WRITES,
-                     {{sstring(ks_prop_defs::KW_DURABLE_WRITES), to_sstring(ks.metadata()->durable_writes())}},
+                     cql3::statements::property_definitions::map_type{{sstring(ks_prop_defs::KW_DURABLE_WRITES), to_sstring(ks.metadata()->durable_writes())}},
                      all_options);
 
     return all_options;

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -22,6 +22,7 @@
 #include "cql3/query_processor.hh"
 #include "db/config.hh"
 #include "gms/feature_service.hh"
+#include "replica/database.hh"
 
 #include <boost/regex.hpp>
 #include <stdexcept>
@@ -109,7 +110,8 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, utils::chun
         // remove this check.
         auto rs = locator::abstract_replication_strategy::create_replication_strategy(
             ksm->strategy_name(),
-            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()));
+            locator::replication_strategy_params(ksm->strategy_options(), ksm->initial_tablets()),
+            tmptr->get_topology());
         if (rs->uses_tablets()) {
             warnings.push_back(
                 "Tables in this keyspace will be replicated using Tablets "
@@ -193,7 +195,8 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     locator::replication_strategy_params params(opts, std::nullopt);
     auto replication_strategy = locator::abstract_replication_strategy::create_replication_strategy(
             locator::abstract_replication_strategy::to_qualified_class_name(
-                    *attrs.get_replication_strategy_class()), params)->get_type();
+                    *attrs.get_replication_strategy_class()), params,
+                    qp.db().real_database().get_token_metadata().get_topology())->get_type();
     auto rs_warn_list = qp.db().get_config().replication_strategy_warn_list();
     auto rs_fail_list = qp.db().get_config().replication_strategy_fail_list();
 

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -240,7 +240,12 @@ std::vector<sstring> check_against_restricted_replication_strategies(
     // these are checked and reported elsewhere.
     for (auto opt : attrs.get_replication_options()) {
         try {
-            auto rf = std::stol(opt.second);
+            long rf = 0;
+            try {
+                rf = locator::get_replication_factor(opt.second);
+            } catch (const exceptions::configuration_exception&) {
+            }
+
             if (rf > 0) {
                 if (auto min_fail = qp.proxy().data_dictionary().get_config().minimum_replication_factor_fail_threshold();
                     min_fail >= 0 && rf < min_fail) {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -230,6 +230,12 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata(s
 lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata& tm, const gms::feature_service& feat) {
     locator::replication_strategy_config_options options;
     const auto& old_options = old->strategy_options();
+    // if tablets options have not been specified, inherit them if it's tablets-enabled KS
+    auto initial_tablets = get_initial_tablets(old->initial_tablets());
+    auto uses_tablets = initial_tablets.has_value();
+    if (old->uses_tablets() != uses_tablets) {
+        throw exceptions::invalid_request_exception("Cannot alter replication strategy vnode/tablets flavor");
+    }
     auto sc = get_replication_strategy_class();
     if (sc) {
         options = prepare_options(*sc, tm, get_replication_options(), old_options);
@@ -237,8 +243,6 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
         sc = old->strategy_name();
         options = old_options;
     }
-    // if tablets options have not been specified, inherit them if it's tablets-enabled KS
-    auto initial_tablets = get_initial_tablets(old->initial_tablets());
     return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -95,7 +95,11 @@ ks_prop_defs::ks_prop_defs(std::map<sstring, sstring> options) {
     std::map<sstring, sstring> replication_opts, storage_opts, tablets_opts, durable_writes_opts;
 
     auto read_property_into = [] (auto& map, const sstring& name, const sstring& value, const sstring& tag) {
-        map[name.substr(sstring(tag).size() + 1)] = value;
+        auto prefix = sstring(tag) + ":";
+        if (!name.starts_with(prefix)) {
+            throw std::runtime_error(seastar::format("ks_prop_defs: Expected name to start with \"{}\", but got: \"{}\"", prefix, name));
+        }
+        map[name.substr(prefix.size())] = value;
     };
 
     for (const auto& [name, value] : options) {

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -22,6 +22,8 @@ namespace cql3 {
 
 namespace statements {
 
+static logging::logger logger("ks_prop_defs");
+
 static std::map<sstring, sstring> prepare_options(
         const sstring& strategy_class,
         const locator::token_metadata& tm,
@@ -29,7 +31,11 @@ static std::map<sstring, sstring> prepare_options(
         const std::map<sstring, sstring>& old_options = {}) {
     options.erase(ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
 
-    if (locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) != "org.apache.cassandra.locator.NetworkTopologyStrategy") {
+    auto is_nts = locator::abstract_replication_strategy::to_qualified_class_name(strategy_class) == "org.apache.cassandra.locator.NetworkTopologyStrategy";
+
+    logger.debug("prepare_options: {}: is_nts={} old_options={} new_options={}", strategy_class, is_nts, old_options, options);
+
+    if (!is_nts) {
         return options;
     }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -97,6 +97,13 @@ static locator::replication_strategy_config_options prepare_options(
         }
     }
 
+    // #22688 - filter out any dc*:0 entries - consider these
+    // null and void (removed).
+    std::erase_if(options, [] (const auto& e) {
+        auto& [dc, rf] = e;
+        return locator::replication_factor_data(rf).count() == 0;
+    });
+
     return options;
 }
 

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -63,6 +63,16 @@ static locator::replication_strategy_config_options prepare_options(
         }
     }
 
+    // #22688 / #20039 - check for illegal, empty options
+    // moved to here. We want to be able to remove dc:s once rf=0,
+    // in which case, the options actually serialized in result mutations
+    // will in extreme cases in fact be empty -> cannot do this check in
+    // verify_options. We only want to apply this constraint on the input
+    // provided by the user
+    if (!rf && options.empty() && !tm.get_topology().get_datacenters().empty()) {
+        throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
+    }
+
     if (rf.has_value()) {
         locator::replication_factor_data::parse(*rf);
 
@@ -78,14 +88,13 @@ static locator::replication_strategy_config_options prepare_options(
         }
     }
 
-    // #22688 / #20039 - check for illegal, empty options (after above expand)
-    // moved to here. We want to be able to remove dc:s once rf=0,
-    // in which case, the options actually serialized in result mutations
-    // will in extreme cases in fact be empty -> cannot do this check in
-    // verify_options. We only want to apply this constraint on the input
-    // provided by the user
-    if (options.empty() && !tm.get_topology().get_datacenters().empty()) {
-        throw exceptions::configuration_exception("Configuration for at least one datacenter must be present");
+    if (uses_tablets) {
+        // We keep previously specified DC factors for safety.
+        for (const auto& opt: old_options) {
+            if (opt.first != ks_prop_defs::REPLICATION_FACTOR_KEY) {
+                options.insert(opt);
+            }
+        }
     }
 
     return options;

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -45,6 +45,17 @@ static locator::replication_strategy_config_options prepare_options(
         return options;
     }
 
+    if (uses_tablets) {
+        for (const auto& opt: old_options) {
+            if (opt.first == ks_prop_defs::REPLICATION_FACTOR_KEY) {
+                on_internal_error(logger, "prepare_options: for tablet keyspaces replication_factor parameter is extended to per-DC options");
+            }
+            if (!options.contains(opt.first)) {
+                throw exceptions::configuration_exception(fmt::format("Attempted to implicitly drop replicas in datacenter {}. If this is the desired behavior, set replication factor to 0 in {} explicitly.", opt.first, opt.first));
+            }
+        }
+    }
+
     // For users' convenience, expand the 'replication_factor' option into a replication factor for each DC.
     // If the user simply switches from another strategy without providing any options,
     // but the other strategy used the 'replication_factor' option, it will also be expanded.

--- a/cql3/statements/ks_prop_defs.cc
+++ b/cql3/statements/ks_prop_defs.cc
@@ -91,8 +91,8 @@ static locator::replication_strategy_config_options prepare_options(
     return options;
 }
 
-ks_prop_defs::ks_prop_defs(std::map<sstring, sstring> options) {
-    std::map<sstring, sstring> replication_opts, storage_opts, tablets_opts, durable_writes_opts;
+ks_prop_defs::ks_prop_defs(property_definitions::map_type options) {
+    map_type replication_opts, storage_opts, tablets_opts, durable_writes_opts;
 
     auto read_property_into = [] (auto& map, const sstring& name, const sstring& value, const sstring& tag) {
         auto prefix = sstring(tag) + ":";
@@ -246,6 +246,41 @@ lw_shared_ptr<data_dictionary::keyspace_metadata> ks_prop_defs::as_ks_metadata_u
     return data_dictionary::keyspace_metadata::new_keyspace(old->name(), *sc, options, initial_tablets, get_boolean(KW_DURABLE_WRITES, true), get_storage_options());
 }
 
+namespace {
+
+void add_prefixed_key(const sstring& prefix, const property_definitions::map_type& in, property_definitions::map_type& out) {
+    for (const auto& [in_key, in_value]: in) {
+        out[prefix + ":" + in_key] = in_value;
+    }
+}
+
+void add_prefixed_key(const sstring& prefix, const property_definitions::extended_map_type& in, property_definitions::map_type& out) {
+    add_prefixed_key(prefix, to_flat_map(in), out);
+}
+
+} // namespace
+
+property_definitions::map_type ks_prop_defs::flattened() const {
+    map_type result;
+
+    for (auto kw : {
+            ks_prop_defs::KW_REPLICATION,
+            ks_prop_defs::KW_STORAGE,
+            ks_prop_defs::KW_TABLETS}) {
+        if (auto val_opt = get_extended_map(kw)) {
+            add_prefixed_key(kw, *val_opt, result);
+        }
+    }
+
+    for (auto kw : {ks_prop_defs::KW_DURABLE_WRITES}) {
+        if (auto val_opt = get_simple(kw)) {
+            // Use nested map for backwards compatibility, ks_prop_defs() constructor expects this.
+            add_prefixed_key(kw, std::map<sstring, sstring>({{sstring(kw), to_sstring(*val_opt)}}), result);
+        }
+    }
+
+    return {result};
+}
 
 }
 

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -74,7 +74,7 @@ public:
     data_dictionary::storage_options get_storage_options() const;
     bool get_durable_writes() const;
     lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata(sstring ks_name, const locator::token_metadata&, const gms::feature_service&, const db::config&);
-    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&);
+    lw_shared_ptr<data_dictionary::keyspace_metadata> as_ks_metadata_update(lw_shared_ptr<data_dictionary::keyspace_metadata> old, const locator::token_metadata&, const gms::feature_service&, const db::config&);
 };
 
 }

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -56,7 +56,16 @@ private:
     std::optional<sstring> _strategy_class;
 public:
     ks_prop_defs() = default;
-    explicit ks_prop_defs(std::map<sstring, sstring> options);
+
+    explicit ks_prop_defs(map_type options);
+
+    /// Converts options to a flat map of properties.
+    ///
+    /// It holds that:
+    ///
+    ///   ks_prop_defs(flattened()) == *this
+    ///
+    map_type flattened() const;
 
     void validate();
     locator::replication_strategy_config_options get_replication_options() const;

--- a/cql3/statements/ks_prop_defs.hh
+++ b/cql3/statements/ks_prop_defs.hh
@@ -12,6 +12,7 @@
 
 #include "cql3/statements/property_definitions.hh"
 #include "data_dictionary/storage_options.hh"
+#include "locator/abstract_replication_strategy.hh"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
@@ -58,7 +59,7 @@ public:
     explicit ks_prop_defs(std::map<sstring, sstring> options);
 
     void validate();
-    std::map<sstring, sstring> get_replication_options() const;
+    locator::replication_strategy_config_options get_replication_options() const;
     std::optional<sstring> get_replication_strategy_class() const;
     std::optional<unsigned> get_initial_tablets(std::optional<unsigned> default_value, bool enforce_tablets = false) const;
     data_dictionary::storage_options get_storage_options() const;

--- a/cql3/statements/property_definitions.hh
+++ b/cql3/statements/property_definitions.hh
@@ -27,19 +27,26 @@ namespace statements {
 class property_definitions {
 public:
     using map_type = std::map<sstring, sstring>;
-    using value_type = std::variant<sstring, map_type>;
+    using list_type = std::vector<sstring>;
+    using extended_map_type = std::map<sstring, std::variant<sstring, list_type>>;
+    using value_type = std::variant<sstring, extended_map_type>;
+    using properties_map_type = std::unordered_map<sstring, value_type>;
 protected:
 #if 0
     protected static final Logger logger = LoggerFactory.getLogger(PropertyDefinitions.class);
 #endif
 
-    mutable std::unordered_map<sstring, value_type> _properties;
+    mutable properties_map_type _properties;
 
     property_definitions();
 public:
     void add_property(const sstring& name, sstring value);
 
-    void add_property(const sstring& name, const std::map<sstring, sstring>& value);
+    void add_property(const sstring& name, const map_type& value) {
+        add_property(name, to_extended_map(value));
+    }
+
+    void add_property(const sstring& name, const extended_map_type& value);
 
     void validate(const std::set<sstring>& keywords, const std::set<sstring>& exts = {}, const std::set<sstring>& obsolete = {}) const;
 
@@ -52,7 +59,11 @@ public:
 
     std::optional<value_type> get(const sstring& name) const;
 
-    std::optional<std::map<sstring, sstring>> get_map(const sstring& name) const;
+    std::optional<extended_map_type> get_extended_map(const sstring& name) const;
+    std::optional<map_type> get_map(const sstring& name) const;
+
+    static map_type to_simple_map(const extended_map_type&);
+    static extended_map_type to_extended_map(const map_type&);
 
     sstring get_string(sstring key, sstring default_value) const;
 
@@ -75,6 +86,9 @@ public:
         return _properties.size();
     }
 };
+
+property_definitions::map_type to_flat_map(const property_definitions::extended_map_type&);
+property_definitions::extended_map_type from_flat_map(const property_definitions::map_type&);
 
 }
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -233,7 +233,7 @@ keyspace_metadata::keyspace_metadata(std::string_view name,
 void keyspace_metadata::validate(const gms::feature_service& fs, const locator::topology& topology) const {
     using namespace locator;
     locator::replication_strategy_params params(strategy_options(), initial_tablets());
-    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params);
+    auto strategy = locator::abstract_replication_strategy::create_replication_strategy(strategy_name(), params, topology);
     strategy->validate_options(fs, topology);
 }
 

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -22,6 +22,7 @@
 #include <ostream>
 #include <array>
 #include "replica/database.hh"
+#include "utils/overloaded_functor.hh"
 
 namespace data_dictionary {
 
@@ -318,7 +319,7 @@ bool storage_options::is_local_type() const noexcept {
     return std::holds_alternative<local>(value);
 }
 
-storage_options::value_type storage_options::from_map(std::string_view type, std::map<sstring, sstring> values) {
+storage_options::value_type storage_options::from_map(std::string_view type, const std::map<sstring, sstring>& values) {
     if (type == local::name) {
         return local::from_map(values);
     }
@@ -414,7 +415,22 @@ cql3::description keyspace_metadata::describe(const replica::database& db, cql3:
         os << "CREATE KEYSPACE " << cql3::util::maybe_quote(_name)
            << " WITH replication = {'class': " << cql3::util::single_quote(_strategy_name);
         for (const auto& opt: _strategy_options) {
-            os << ", " << cql3::util::single_quote(opt.first) << ": " << cql3::util::single_quote(opt.second);
+            os << ", " << cql3::util::single_quote(opt.first) << ": ";
+            std::visit(overloaded_functor{
+                [&os] (const sstring& str) {
+                    os << cql3::util::single_quote(str);
+                },
+                [&os] (const std::vector<sstring>& vec) {
+                    os << "[";
+                    for (auto it = vec.begin(); it != vec.end(); ++it) {
+                        if (it != vec.begin()) {
+                            os << ", ";
+                        }
+                        os << cql3::util::single_quote(*it);
+                    }
+                    os << "]";
+                }
+            }, opt.second);
         }
         if (!_storage_options->is_local_type()) {
             os << "} AND storage = {'type': " << cql3::util::single_quote(sstring(_storage_options->type_string()));

--- a/data_dictionary/storage_options.hh
+++ b/data_dictionary/storage_options.hh
@@ -53,7 +53,7 @@ struct storage_options {
 
     bool can_update_to(const storage_options& new_options);
 
-    static value_type from_map(std::string_view type, std::map<sstring, sstring> values);
+    static value_type from_map(std::string_view type, const std::map<sstring, sstring>& values);
 
     storage_options append_to_s3_prefix(const sstring& s) const;
 };

--- a/db/legacy_schema_migrator.cc
+++ b/db/legacy_schema_migrator.cc
@@ -35,7 +35,7 @@
 #include "cql3/query_processor.hh"
 #include "cql3/untyped_result_set.hh"
 #include "cql3/util.hh"
-#include "types/user.hh"
+#include "cql3/statements/property_definitions.hh"
 
 static seastar::logger mlogger("legacy_schema_migrator");
 
@@ -541,7 +541,7 @@ public:
         for (auto& ks : _keyspaces) {
             auto ksm = ::make_lw_shared<keyspace_metadata>(ks.name
                             , ks.replication_params["class"] // TODO, make ksm like c3?
-                            , ks.replication_params
+                            , cql3::statements::property_definitions::to_extended_map(ks.replication_params)
                             , std::nullopt
                             , ks.durable_writes);
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1224,7 +1224,7 @@ utils::chunked_vector<mutation> make_create_keyspace_mutations(schema_features f
 
     auto map = keyspace->strategy_options();
     map["class"] = keyspace->strategy_name();
-    store_map(m, ckey, "replication", timestamp, map);
+    store_map(m, ckey, "replication", timestamp, cql3::statements::to_flat_map(map));
 
     if (features.contains<schema_feature::SCYLLA_KEYSPACES>()) {
         schema_ptr scylla_keyspaces_s = scylla_keyspaces();
@@ -1295,11 +1295,15 @@ future<lw_shared_ptr<keyspace_metadata>> create_keyspace_metadata(
     // (or screw up shared pointers)
     const auto& replication = row.get_nonnull<map_type_impl::native_type>("replication");
 
-    std::map<sstring, sstring> strategy_options;
-    for (auto& p : replication) {
-        strategy_options.emplace(value_cast<sstring>(p.first), value_cast<sstring>(p.second));
+    cql3::statements::property_definitions::map_type flat_strategy_options;
+    for (const auto& p : replication) {
+        auto key = value_cast<sstring>(p.first);
+        auto value = value_cast<sstring>(p.second);
+        flat_strategy_options[key] = std::move(value);
     }
-    auto strategy_name = strategy_options["class"];
+
+    auto strategy_options = cql3::statements::from_flat_map(flat_strategy_options);
+    auto strategy_name = std::get<sstring>(strategy_options["class"]);
     strategy_options.erase("class");
     bool durable_writes = row.get_nonnull<bool>("durable_writes");
 

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1911,7 +1911,7 @@ static void make_update_indices_mutations(
             continue;
         }
         auto ksm = db.find_keyspace(new_table->ks_name()).metadata();
-        db.get_notifier().before_create_column_family(*ksm, *view, mutations, timestamp);
+        db.get_notifier().before_create_column_family(db, *ksm, *view, mutations, timestamp);
     }
 
     mutations.emplace_back(std::move(indices_mutation));

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -104,7 +104,7 @@ For example:
 .. code-block:: cql
 
    CREATE KEYSPACE Excalibur
-   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : 1, 'DC2' : 3}
+   WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1' : ['RAC1', 'RAC2', 'RAC3'], 'DC2' : 3}
    AND durable_writes = true;
 
 The supported ``options`` are:
@@ -154,22 +154,25 @@ factor independently for each data-center. The rest of the sub-options are
 key-value pairs where a key is a data-center name and its value is the
 associated replication factor. Options:
 
-===================================== ====== =============================================
-sub-option                             type  description
-===================================== ====== =============================================
-``'<datacenter>'``                     int   The number of replicas to store per range in
-                                             the provided datacenter.
-``'replication_factor'``               int   The number of replicas to use as a default
-                                             per datacenter if not specifically provided.
-                                             Note that this always defers to existing
-                                             definitions or explicit datacenter settings.
-                                             For example, to have three replicas per
-                                             datacenter, supply this with a value of 3.
+===================================== ========= =============================================
+sub-option                             type      description
+===================================== ========= =============================================
+``'<datacenter>'``                     int|list The number of replicas to store per range in
+                                                the provided datacenter, or a list of rack names
+                                                to place replicas.
 
-                                             The replication factor configured for a DC
-                                             should be equal to or lower than the number
-                                             of nodes in that DC. Configuring a higher RF 
-                                             may prevent creating tables in that keyspace. 
+``'replication_factor'``               int      The number of replicas to use as a default
+                                                per datacenter if not specifically provided.
+
+                                                Note that this always defers to existing
+                                                definitions or explicit datacenter settings.
+                                                For example, to have three replicas per
+                                                datacenter, supply this with a value of 3.
+
+                                                The replication factor configured for a DC
+                                                should be equal to or lower than the number
+                                                of nodes in that DC. Configuring a higher RF
+                                                may prevent creating tables in that keyspace.
 ===================================== ====== =============================================
 
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
@@ -184,7 +187,7 @@ An example of auto-expanding datacenters with two datacenters: ``DC1`` and ``DC2
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3}
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '3'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1-1', 'RAC1-2', 'RAC1-3' ], 'DC2': [ 'RAC2-1', 'RAC2-2', 'RAC2-3' ]} AND durable_writes = true;
 
 
 An example of auto-expanding and overriding a datacenter::
@@ -193,7 +196,7 @@ An example of auto-expanding and overriding a datacenter::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 2}
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3', 'DC2': '2'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1-1', 'RAC1-2', 'RAC1-3' ], 'DC2': [ 'RAC2-1', 'RAC2-2' ]} AND durable_writes = true;
 
 An example that excludes a datacenter while using ``replication_factor``::
 
@@ -201,7 +204,7 @@ An example that excludes a datacenter while using ``replication_factor``::
         WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor' : 3, 'DC2': 0} ;
 
     DESCRIBE KEYSPACE excalibur
-        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': '3'} AND durable_writes = true;
+        CREATE KEYSPACE excalibur WITH replication = {'class': 'NetworkTopologyStrategy', 'DC1': [ 'RAC1', 'RAC2', 'RAC3' ]} AND durable_writes = true;
 
 .. _tablets:
 

--- a/docs/cql/ddl.rst
+++ b/docs/cql/ddl.rst
@@ -175,6 +175,18 @@ sub-option                             type      description
                                                 may prevent creating tables in that keyspace.
 ===================================== ====== =============================================
 
+When ``rf_rack_valid_keyspaces``` is enabled in the config and the keyspace is tablet-based,
+the numeric replication factor is automatically expanded into a rack list when the statement is
+executed, which can be observed in the DESCRIBE output afterwards. If the numeric RF is smaller than
+the number of racks in a DC, a subset of racks is chosen arbitrarily.
+
+Altering from a rack list to a numeric replication factor is not supported, except
+for two cases. One is setting replication factor to 0, in which case the number of replicas is reduced to 0 in that DC.
+The other is when the numeric replication factor is equal to the current number of replicas
+for a given datacanter, in which case the current rack list is preserved.
+
+Altering from a numeric replication factor to a rack list is not supported yet.
+
 Note that when ``ALTER`` ing keyspaces and supplying ``replication_factor``,
 auto-expansion will only *add* new datacenters for safety, it will not alter
 existing datacenters or remove any even if they are no longer in the cluster.

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -67,17 +67,19 @@ abstract_replication_strategy::abstract_replication_strategy(
     }
 }
 
-abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params) {
+abstract_replication_strategy::ptr_type abstract_replication_strategy::create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology* topo) {
     try {
-        return create_object<abstract_replication_strategy, replication_strategy_params>(strategy_name, std::move(params));
+        return create_object<abstract_replication_strategy, replication_strategy_params, const locator::topology*>(strategy_name, std::move(params), std::move(topo));
     } catch (const no_such_class& e) {
         throw exceptions::configuration_exception(e.what());
     }
 }
 
+// class registry signature must match the actual replication strategies' signature
 using strategy_class_registry = class_registry<
     locator::abstract_replication_strategy,
-    replication_strategy_params>;
+    replication_strategy_params,
+    const topology*>;
 
 sstring abstract_replication_strategy::to_qualified_class_name(std::string_view strategy_class_name) {
     return strategy_class_registry::to_qualified_class_name(strategy_class_name);

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -153,18 +153,22 @@ const tablet_aware_replication_strategy* abstract_replication_strategy::maybe_as
     return dynamic_cast<const tablet_aware_replication_strategy*>(this);
 }
 
-long abstract_replication_strategy::parse_replication_factor(sstring rf)
-{
+void replication_factor_data::parse(const sstring& rf) {
     if (rf.empty() || std::any_of(rf.begin(), rf.end(), [] (char c) {return !isdigit(c);})) {
         throw exceptions::configuration_exception(
                 format("Replication factor must be numeric and non-negative, found '{}'", rf));
     }
     try {
-        return std::stol(rf);
+        _count = std::stol(rf);
     } catch (...) {
         throw exceptions::configuration_exception(
             sstring("Replication factor must be numeric; found ") + rf);
     }
+}
+
+replication_factor_data abstract_replication_strategy::parse_replication_factor(sstring rf)
+{
+    return replication_factor_data(rf);
 }
 
 static
@@ -693,4 +697,8 @@ auto fmt::formatter<locator::vnode_effective_replication_map::factory_key>::form
         sep = ',';
     }
     return out;
+}
+
+auto fmt::formatter<locator::replication_factor_data>::format(const locator::replication_factor_data& rf, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", rf.count());
 }

--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -208,6 +208,15 @@ size_t get_replication_factor(const replication_strategy_config_option& opt) {
     }, opt);
 }
 
+rack_diff diff_racks(const rack_list& old_racks, const rack_list& new_racks) {
+    rack_diff diff;
+    std::set_difference(new_racks.begin(), new_racks.end(), old_racks.begin(), old_racks.end(),
+                        std::back_inserter(diff.added));
+    std::set_difference(old_racks.begin(), old_racks.end(), new_racks.begin(), new_racks.end(),
+                        std::back_inserter(diff.removed));
+    return diff;
+}
+
 static
 void
 insert_token_range_to_sorted_container_while_unwrapping(

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -63,6 +63,21 @@ class per_table_replication_strategy;
 class tablet_aware_replication_strategy;
 class effective_replication_map;
 
+class replication_factor_data {
+    size_t _count = 0;
+
+public:
+    explicit replication_factor_data(const sstring& rf) {
+        parse(rf);
+    }
+
+    size_t count() const noexcept {
+        return _count;
+    }
+
+private:
+    void parse(const sstring& rf);
+};
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
     friend class vnode_effective_replication_map;
@@ -113,7 +128,7 @@ public:
 
     virtual ~abstract_replication_strategy() {}
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
-    static long parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
@@ -476,6 +491,11 @@ struct appending_hash<locator::vnode_effective_replication_map::factory_key> {
             h.update(val.c_str(), val.size());
         }
     }
+};
+
+template <>
+struct fmt::formatter<locator::replication_factor_data> : fmt::formatter<string_view> {
+    auto format(const locator::replication_factor_data&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 namespace std {

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -112,6 +112,21 @@ private:
     void parse(const replication_strategy_config_option& rf, const std::unordered_set<sstring>& allowed_racks);
 };
 
+struct rack_diff {
+    rack_list added;
+    rack_list removed;
+
+    bool empty() const {
+        return added.empty() && removed.empty();
+    }
+
+    operator bool() const {
+        return !empty();
+    }
+};
+
+rack_diff diff_racks(const rack_list& old_racks, const rack_list& new_racks);
+
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
     friend class vnode_effective_replication_map;
     friend class per_table_replication_strategy;

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -127,7 +127,10 @@ public:
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const  = 0;
 
     virtual ~abstract_replication_strategy() {}
-    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology*);
+    static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
+        return create_replication_strategy(strategy_name, std::move(params), &topo);
+    }
     static replication_factor_data parse_replication_factor(sstring rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -46,7 +46,14 @@ enum class replication_strategy_type {
 
 using can_yield = utils::can_yield;
 
-using replication_strategy_config_options = std::map<sstring, sstring>;
+using rack_list = std::vector<sstring>;
+
+using replication_strategy_config_option = std::variant<sstring, rack_list>;
+using replication_strategy_config_options = std::map<sstring, replication_strategy_config_option>;
+
+// Returns the number of replicas inferred by the option.
+size_t get_replication_factor(const replication_strategy_config_option&);
+
 struct replication_strategy_params {
     const replication_strategy_config_options options;
     std::optional<unsigned> initial_tablets;
@@ -67,16 +74,17 @@ class replication_factor_data {
     size_t _count = 0;
 
 public:
-    explicit replication_factor_data(const sstring& rf) {
-        parse(rf);
-    }
+    explicit replication_factor_data(const sstring& rf)
+        : _count(parse(rf))
+    { }
 
     size_t count() const noexcept {
         return _count;
     }
 
-private:
-    void parse(const sstring& rf);
+public:
+    // Parses a numeric replication factor.
+    static size_t parse(const sstring& rf);
 };
 
 class abstract_replication_strategy : public seastar::enable_shared_from_this<abstract_replication_strategy> {
@@ -131,7 +139,7 @@ public:
     static ptr_type create_replication_strategy(const sstring& strategy_name, replication_strategy_params params, const locator::topology& topo) {
         return create_replication_strategy(strategy_name, std::move(params), &topo);
     }
-    static replication_factor_data parse_replication_factor(sstring rf);
+    static replication_factor_data parse_replication_factor(const replication_strategy_config_option& rf);
 
     static sstring to_qualified_class_name(std::string_view strategy_class_name);
 
@@ -144,7 +152,7 @@ public:
     // appear in the pending_endpoints.
     virtual bool allow_remove_node_being_replaced_from_natural_endpoints() const = 0;
     replication_strategy_type get_type() const noexcept { return _my_type; }
-    const replication_strategy_config_options get_config_options() const noexcept { return _config_options; }
+    const replication_strategy_config_options& get_config_options() const noexcept { return _config_options; }
 
     // If returns true then tables governed by this replication strategy have separate
     // effective_replication_maps.
@@ -491,7 +499,15 @@ struct appending_hash<locator::vnode_effective_replication_map::factory_key> {
         feed_hash(h, key.ring_version);
         for (const auto& [opt, val] : key.rs_config_options) {
             h.update(opt.c_str(), opt.size());
-            h.update(val.c_str(), val.size());
+            feed_hash(h, val.index());
+            std::visit(overloaded_functor {
+                [&h] (const sstring& str) {
+                    feed_hash(h, str);
+                },
+                [&h] (const std::vector<sstring>& vec) {
+                    feed_hash(h, vec);
+                }
+            }, val);
         }
     }
 };
@@ -547,4 +563,30 @@ private:
     friend class vnode_effective_replication_map;
 };
 
-}
+} // namespace locator
+
+template <>
+struct fmt::formatter<locator::replication_strategy_config_option> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const locator::replication_strategy_config_option& opt, FormatContext& ctx) const {
+        return std::visit(overloaded_functor{
+            [&ctx] (const sstring& s) {
+                return fmt::format_to(ctx.out(), "'{}'", s);
+            },
+            [&ctx] (const std::vector<sstring>& v) {
+                return fmt::format_to(ctx.out(), "[{}]", fmt::join(v | std::views::transform([] (auto& s) { return fmt::format("'{}'", s); }), ","));
+            }
+        }, opt);
+    }
+};
+
+template <>
+struct fmt::formatter<locator::replication_strategy_config_options> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    template <typename FormatContext>
+    auto format(const locator::replication_strategy_config_options& opts, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(opts |
+                std::views::transform([] (const auto& x) { return fmt::format("'{}':{}", x.first, x.second); }), ", "));
+    }
+};

--- a/locator/everywhere_replication_strategy.cc
+++ b/locator/everywhere_replication_strategy.cc
@@ -16,7 +16,7 @@
 
 namespace locator {
 
-everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params) :
+everywhere_replication_strategy::everywhere_replication_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::everywhere_topology) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -49,7 +49,8 @@ sstring everywhere_replication_strategy::sanity_check_read_replicas(const effect
 }
 
 
-using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, everywhere_replication_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.EverywhereStrategy");
 static registry registrator_short_name("EverywhereStrategy");
 }

--- a/locator/everywhere_replication_strategy.hh
+++ b/locator/everywhere_replication_strategy.hh
@@ -16,7 +16,7 @@
 namespace locator {
 class everywhere_replication_strategy : public abstract_replication_strategy {
 public:
-    everywhere_replication_strategy(replication_strategy_params params);
+    everywhere_replication_strategy(replication_strategy_params params, const locator::topology*);
 
     virtual future<host_id_set> calculate_natural_endpoints(const token& search_token, const token_metadata& tm) const override;
 

--- a/locator/local_strategy.cc
+++ b/locator/local_strategy.cc
@@ -14,7 +14,7 @@
 
 namespace locator {
 
-local_strategy::local_strategy(replication_strategy_params params) :
+local_strategy::local_strategy(replication_strategy_params params, const topology*) :
         abstract_replication_strategy(params, replication_strategy_type::local) {
     _natural_endpoints_depend_on_token = false;
 }
@@ -40,7 +40,8 @@ sstring local_strategy::sanity_check_read_replicas(const effective_replication_m
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, local_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.LocalStrategy");
 static registry registrator_short_name("LocalStrategy");
 

--- a/locator/local_strategy.hh
+++ b/locator/local_strategy.hh
@@ -22,7 +22,7 @@ using token = dht::token;
 
 class local_strategy : public abstract_replication_strategy {
 public:
-    local_strategy(replication_strategy_params params);
+    local_strategy(replication_strategy_params params, const topology*);
     virtual ~local_strategy() {};
     virtual size_t get_replication_factor(const token_metadata&) const override;
 

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -38,10 +38,15 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
+static logging::logger logger("network_topology_strategy");
+
 network_topology_strategy::network_topology_strategy(replication_strategy_params params, const topology* topo) :
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
+
+    logger.debug("options={}", opts);
+
     process_tablet_options(*this, opts, params);
 
     size_t rep_factor = 0;

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -38,7 +38,7 @@ struct hash<locator::endpoint_dc_rack> {
 
 namespace locator {
 
-network_topology_strategy::network_topology_strategy(replication_strategy_params params) :
+network_topology_strategy::network_topology_strategy(replication_strategy_params params, const topology* topo) :
         abstract_replication_strategy(params,
                                       replication_strategy_type::network_topology) {
     auto opts = _config_options;
@@ -551,7 +551,8 @@ sstring network_topology_strategy::sanity_check_read_replicas(const effective_re
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, network_topology_strategy, replication_strategy_params, const topology*>;
 static registry registrator("org.apache.cassandra.locator.NetworkTopologyStrategy");
 static registry registrator_short_name("NetworkTopologyStrategy");
 }

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -284,6 +284,10 @@ void network_topology_strategy::validate_options(const gms::feature_service& fs,
     auto dcs = topology.get_datacenters();
     validate_tablet_options(*this, fs, _config_options);
     for (auto& c : _config_options) {
+        if (c.first == sstring("class")) {
+            on_internal_error(rslogger, fmt::format("'class' tag should be dropped by now."
+                                                    "_config_options:{}", _config_options));
+        }
         if (c.first == sstring("replication_factor")) {
             on_internal_error(rslogger, fmt::format("'replication_factor' tag should be unrolled into a list of DC:RF by now."
                                                     "_config_options:{}", _config_options));

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -338,7 +338,8 @@ future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, t
     load_sketch load(tm);
     co_await load.populate(std::nullopt, s->id());
 
-    tablet_logger.debug("Allocating tablets for {}.{} ({}): dc_rep_factor={} tablet_count={}", s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets.tablet_count());
+    tablet_logger.debug("Allocating tablets for {}.{} ({}): dc_rep_factor={} tablet_count={}",
+                        s->ks_name(), s->cf_name(), s->id(), _dc_rep_factor, tablets.tablet_count());
 
     for (tablet_id tb : tablets.tablet_ids()) {
         auto tinfo = tablets.get_tablet_info(tb);
@@ -350,36 +351,133 @@ future<tablet_map> network_topology_strategy::reallocate_tablets(schema_ptr s, t
     co_return tablets;
 }
 
-future<tablet_replica_set> network_topology_strategy::reallocate_tablets(schema_ptr s, token_metadata_ptr tm, load_sketch& load, const tablet_map& cur_tablets, tablet_id tb) const {
+future<tablet_replica_set> network_topology_strategy::reallocate_tablets(schema_ptr s,
+    token_metadata_ptr tm,
+    load_sketch& load,
+    const tablet_map& cur_tablets,
+    tablet_id tb) const
+{
     tablet_replica_set replicas;
     // Current number of replicas per dc
     std::unordered_map<sstring, size_t> nodes_per_dc;
     // Current replicas per dc/rack
     std::unordered_map<sstring, std::map<sstring, std::unordered_set<locator::host_id>>> replicas_per_dc_rack;
+    std::unordered_map<sstring, rack_list> old_racks_per_dc;
 
     replicas = cur_tablets.get_tablet_info(tb).replicas;
     for (const auto& tr : replicas) {
         const auto& node = tm->get_topology().get_node(tr.host);
         replicas_per_dc_rack[node.dc_rack().dc][node.dc_rack().rack].insert(tr.host);
         ++nodes_per_dc[node.dc_rack().dc];
+        old_racks_per_dc[node.dc_rack().dc].push_back(node.dc_rack().rack);
     }
 
     // #22688 - take all dcs in topology into account when determining migration.
     // Any change should still have been pre-checked to never exceed rf factor one.
     for (const auto& dc : tm->get_topology().get_datacenters()) {
-        auto dc_rf = get_replication_factor(dc);
-        auto dc_node_count = nodes_per_dc[dc];
-        if (dc_rf == dc_node_count) {
-            continue;
-        }
-        if (dc_rf > dc_node_count) {
-            replicas = co_await add_tablets_in_dc(s, tm, load, tb, replicas_per_dc_rack[dc], replicas, dc, dc_node_count, dc_rf);
+        auto new_rf = get_replication_factor_data(dc);
+
+        if (new_rf && new_rf->is_rack_based()) {
+            auto diff = diff_racks(old_racks_per_dc[dc], new_rf->get_rack_list());
+
+            tablet_logger.debug("reallocate_tablets {}.{} tablet_id={} dc={} old_racks={} add_racks={} del_racks={}",
+                    s->ks_name(), s->cf_name(), tb, dc, old_racks_per_dc[dc], diff.added, diff.removed);
+
+            if (!diff) {
+                continue;
+            }
+
+            if (!diff.added.empty() && !diff.removed.empty()) {
+                // FIXME: Support replace
+                throw std::runtime_error("replacing racks unsupported");
+            } else if (!diff.added.empty()) {
+                replicas = add_tablets_in_racks(s, tm, load, tb, replicas, dc, diff.added);
+            } else { // diff.removed
+                replicas = drop_tablets_in_racks(s, tm, load, tb, replicas, dc, diff.removed);
+            }
         } else {
-            replicas = drop_tablets_in_dc(s, tm->get_topology(), load, tb, replicas, dc, dc_node_count, dc_rf);
+            auto dc_rf = new_rf ? new_rf->count() : 0;
+            auto dc_node_count = nodes_per_dc[dc];
+            if (dc_rf == dc_node_count) {
+                continue;
+            }
+            if (dc_rf > dc_node_count) {
+                replicas = co_await add_tablets_in_dc(s, tm, load, tb, replicas_per_dc_rack[dc], replicas, dc, dc_node_count, dc_rf);
+            } else {
+                replicas = drop_tablets_in_dc(s, tm->get_topology(), load, tb, replicas, dc, dc_node_count, dc_rf);
+            }
         }
     }
 
     co_return replicas;
+}
+
+tablet_replica_set network_topology_strategy::drop_tablets_in_racks(schema_ptr s,
+                                                                    token_metadata_ptr tm,
+                                                                    load_sketch& load,
+                                                                    tablet_id tb,
+                                                                    const tablet_replica_set& cur_replicas,
+                                                                    const sstring& dc,
+                                                                    const rack_list& racks_to_drop) const {
+    auto& topo = tm->get_topology();
+    tablet_replica_set filtered;
+    auto is_rack_to_drop = [&racks_to_drop] (const sstring& rack) {
+        return std::find(racks_to_drop.begin(), racks_to_drop.end(), rack) != racks_to_drop.end();
+    };
+    for (const auto& tr : cur_replicas) {
+        auto& node = topo.get_node(tr.host);
+        if (node.dc_rack().dc == dc && is_rack_to_drop(node.dc_rack().rack)) {
+            tablet_logger.debug("drop_tablets_in_rack {}.{} tablet_id={} dc={} rack={} removing replica: {}",
+                            s->ks_name(), s->cf_name(), tb, node.dc_rack().dc, node.dc_rack().rack, tr);
+            load.unload(tr.host, tr.shard);
+        } else {
+            filtered.emplace_back(tr);
+        }
+    }
+    return filtered;
+}
+
+tablet_replica_set network_topology_strategy::add_tablets_in_racks(schema_ptr s,
+                                                                   token_metadata_ptr tm,
+                                                                   load_sketch& load,
+                                                                   tablet_id tb,
+                                                                   const tablet_replica_set& cur_replicas,
+                                                                   const sstring& dc,
+                                                                   const rack_list& racks_to_add) const {
+    auto nodes = tm->get_datacenter_racks_token_owners_nodes();
+    auto& dc_nodes = nodes.at(dc);
+    auto new_replicas = cur_replicas;
+
+    for (auto&& rack: racks_to_add) {
+        host_id min_node;
+        double min_load = std::numeric_limits<double>::max();
+
+        for (auto&& node: dc_nodes.at(rack)) {
+            if (!node.get().is_normal()) {
+                continue;
+            }
+            // Assume that if there was a diff to add a rack, we don't already have a replica
+            // in the target rack so all nodes in the rack are eligible.
+            // FIXME: pick based on storage utilization.
+            auto node_load = load.get_real_avg_shard_load(node.get().host_id());
+            if (node_load < min_load) {
+                min_load = node_load;
+                min_node = node.get().host_id();
+            }
+        }
+
+        if (!min_node) {
+            throw std::runtime_error(
+                    fmt::format("No candidate node in rack {}.{} to allocate tablet replica", dc, rack));
+        }
+
+        auto new_replica = tablet_replica{min_node, load.next_shard(min_node)};
+        new_replicas.push_back(new_replica);
+
+        tablet_logger.trace("add_tablet_in_rack {}.{} tablet_id={} dc={} rack={} load={} new_replica={}",
+                            s->ks_name(), s->cf_name(), tb.id, dc, rack, min_load, new_replica);
+    }
+    return new_replicas;
 }
 
 future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_ptr s, token_metadata_ptr tm, load_sketch& load, tablet_id tb,

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -31,7 +31,7 @@ public:
 
     size_t get_replication_factor(const sstring& dc) const override {
         auto dc_factor = _dc_rep_factor.find(dc);
-        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second;
+        return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second.count();
     }
 
     const std::vector<sstring>& get_datacenters() const {
@@ -58,6 +58,9 @@ protected:
 
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;
 
+public:
+    using dc_rep_factor_map = std::unordered_map<sstring, replication_factor_data>;
+
 private:
     future<tablet_replica_set> reallocate_tablets(schema_ptr, token_metadata_ptr, load_sketch&, const tablet_map& cur_tablets, tablet_id tb) const;
     future<tablet_replica_set> add_tablets_in_dc(schema_ptr, token_metadata_ptr, load_sketch&, tablet_id,
@@ -69,7 +72,7 @@ private:
             sstring dc, size_t dc_node_count, size_t dc_rf) const;
 
     // map: data centers -> replication factor
-    std::unordered_map<sstring, size_t> _dc_rep_factor;
+    dc_rep_factor_map _dc_rep_factor;
 
     std::vector<sstring> _datacenteres;
     size_t _rep_factor;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -23,7 +23,7 @@ class load_sketch;
 class network_topology_strategy : public abstract_replication_strategy
                                 , public tablet_aware_replication_strategy {
 public:
-    network_topology_strategy(replication_strategy_params params);
+    network_topology_strategy(replication_strategy_params params, const topology* topo);
 
     virtual size_t get_replication_factor(const token_metadata&) const override {
         return _rep_factor;

--- a/locator/network_topology_strategy.hh
+++ b/locator/network_topology_strategy.hh
@@ -34,6 +34,21 @@ public:
         return (dc_factor == _dc_rep_factor.end()) ? 0 : dc_factor->second.count();
     }
 
+    const replication_factor_data* get_replication_factor_data(const sstring& dc) const {
+        auto dc_factor = _dc_rep_factor.find(dc);
+        if (dc_factor == _dc_rep_factor.end()) {
+            return nullptr;
+        }
+        return &dc_factor->second;
+    }
+
+    bool is_rack_based(const sstring& dc) const override {
+        if (auto rf = get_replication_factor_data(dc)) {
+            return rf->is_rack_based();
+        }
+        return false;
+    }
+
     const std::vector<sstring>& get_datacenters() const {
         return _datacenteres;
     }
@@ -70,6 +85,22 @@ private:
     tablet_replica_set drop_tablets_in_dc(schema_ptr, const locator::topology&, load_sketch&, tablet_id,
             const tablet_replica_set& cur_replicas,
             sstring dc, size_t dc_node_count, size_t dc_rf) const;
+
+    tablet_replica_set drop_tablets_in_racks(schema_ptr,
+                                             token_metadata_ptr,
+                                             load_sketch&,
+                                             tablet_id,
+                                             const tablet_replica_set& cur_replicas,
+                                             const sstring& dc,
+                                             const rack_list& racks_to_drop) const;
+
+    tablet_replica_set add_tablets_in_racks(schema_ptr,
+                                            token_metadata_ptr,
+                                            load_sketch&,
+                                            tablet_id,
+                                            const tablet_replica_set& cur_replicas,
+                                            const sstring& dc,
+                                            const rack_list& racks_to_add) const;
 
     // map: data centers -> replication factor
     dc_rep_factor_map _dc_rep_factor;

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -24,7 +24,7 @@ simple_strategy::simple_strategy(replication_strategy_params params, const locat
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            _replication_factor = parse_replication_factor(val).count();
+            _replication_factor = parse_replication_factor(val, {}).count();
             break;
         }
     }
@@ -69,7 +69,7 @@ void simple_strategy::validate_options(const gms::feature_service&, const locato
     if (it == _config_options.end()) {
         throw exceptions::configuration_exception("SimpleStrategy requires a replication_factor strategy option.");
     }
-    parse_replication_factor(it->second);
+    parse_replication_factor(it->second, {});
     if (_uses_tablets) {
         throw exceptions::configuration_exception("SimpleStrategy doesn't support tablet replication");
     }

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -17,7 +17,7 @@
 
 namespace locator {
 
-simple_strategy::simple_strategy(replication_strategy_params params) :
+simple_strategy::simple_strategy(replication_strategy_params params, const locator::topology*) :
         abstract_replication_strategy(params, replication_strategy_type::simple) {
     for (auto& config_pair : _config_options) {
         auto& key = config_pair.first;
@@ -85,7 +85,8 @@ sstring simple_strategy::sanity_check_read_replicas(const effective_replication_
     return {};
 }
 
-using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params>;
+// Note: signature must match the class_registry signature defined and used by abstract_replication_strategy::to_qualified_class_name
+using registry = class_registrator<abstract_replication_strategy, simple_strategy, replication_strategy_params, const locator::topology*>;
 static registry registrator("org.apache.cassandra.locator.SimpleStrategy");
 static registry registrator_short_name("SimpleStrategy");
 

--- a/locator/simple_strategy.cc
+++ b/locator/simple_strategy.cc
@@ -24,7 +24,7 @@ simple_strategy::simple_strategy(replication_strategy_params params) :
         auto& val = config_pair.second;
 
         if (boost::iequals(key, "replication_factor")) {
-            _replication_factor = parse_replication_factor(val);
+            _replication_factor = parse_replication_factor(val).count();
             break;
         }
     }

--- a/locator/simple_strategy.hh
+++ b/locator/simple_strategy.hh
@@ -16,7 +16,7 @@ namespace locator {
 
 class simple_strategy : public abstract_replication_strategy {
 public:
-    simple_strategy(replication_strategy_params params);
+    simple_strategy(replication_strategy_params params, const topology*);
     virtual ~simple_strategy() {};
     virtual size_t get_replication_factor(const token_metadata& tm) const override;
     virtual void validate_options(const gms::feature_service&, const locator::topology& topology) const override;

--- a/locator/tablet_replication_strategy.hh
+++ b/locator/tablet_replication_strategy.hh
@@ -52,6 +52,8 @@ public:
     /// current replica list, as replication factor changes involve table rebuilding transitions
     /// which are not instantaneous.
     virtual size_t get_replication_factor(const sstring& dc) const = 0;
+
+    virtual bool is_rack_based(const sstring& dc) const = 0;
 };
 
 } // namespace locator

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1242,7 +1242,12 @@ void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr
             }
         }
 
-        const size_t rf = nts.get_replication_factor(dc);
+        auto rf_data = nts.get_replication_factor_data(dc);
+        if (!rf_data || rf_data->is_rack_based()) {
+            continue;
+        }
+
+        auto rf = rf_data->count();
 
         // We must not allow for a keyspace to become RF-rack-invalid. Any attempt at that must be rejected.
         // For more context, see: scylladb/scylladb#23276.

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -990,7 +990,7 @@ future<> database::create_local_system_table(
         bool durable = _cfg.data_file_directories().size() > 0;
         auto ksm = make_lw_shared<keyspace_metadata>(ks_name,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 durable
                 );

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1394,6 +1394,7 @@ public:
     lw_shared_ptr<keyspace_metadata> metadata() const;
 
     static locator::replication_strategy_ptr create_replication_strategy(
+            const locator::topology& topology,
             lw_shared_ptr<keyspace_metadata> metadata);
     future<locator::vnode_effective_replication_map_ptr> create_effective_replication_map(
             locator::replication_strategy_ptr strategy,

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -17,6 +17,7 @@
 #include <boost/dynamic_bitset.hpp>
 
 #include "cql3/column_specification.hh"
+#include "cql3/statements/index_prop_defs.hh"
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/backtrace.hh>
 #include <seastar/core/sstring.hh>
@@ -174,8 +175,6 @@ public:
     }
     bool operator==(const speculative_retry& other) const = default;
 };
-
-typedef std::unordered_map<sstring, sstring> index_options_map;
 
 enum class index_metadata_kind {
     keys,

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -33,6 +33,9 @@ class function_name;
 namespace locator {
 class tablet_metadata_change_hint;
 }
+namespace replica {
+    class database;
+}
 
 #include "timestamp.hh"
 
@@ -80,8 +83,8 @@ public:
     // of the column family's keyspace. The reason for this is that we sometimes create a keyspace
     // and its column families together. Therefore, listeners can't load the keyspace from the
     // database. Instead, they should use the `ksm` parameter if needed.
-    virtual void on_before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
-    virtual void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp);
+    virtual void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
+    virtual void on_before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp);
     virtual void on_before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type) {}
     virtual void on_before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type) {}
@@ -145,8 +148,8 @@ public:
     future<> drop_function(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
     future<> drop_aggregate(const db::functions::function_name& fun_name, const std::vector<data_type>& arg_types);
 
-    void before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
-    void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    void before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3260,11 +3260,11 @@ public:
         }
     }
 
-    void on_before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_families(const replica::database& db, const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, cfms, muts, ts);
     }
 
-    void on_before_create_column_family(const keyspace_metadata& ksm, const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
+    void on_before_create_column_family(const replica::database& db, const keyspace_metadata& ksm, const schema& s, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) override {
         allocate_tablets_for_new_tables(ksm, {s.shared_from_this()}, muts, ts);
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1187,6 +1187,11 @@ public:
         return {s, rs};
     }
 
+    const tablet_aware_replication_strategy* get_rs(table_id id) {
+        auto [s, rs] = get_schema_and_rs(id);
+        return rs;
+    }
+
     struct table_sizing {
         size_t current_tablet_count; // Tablet count in group0.
         size_t target_tablet_count; // Tablet count wanted by scheduler.
@@ -2107,11 +2112,16 @@ public:
         int max_rack_load;
         std::unordered_map<sstring, int> rack_load;
 
+        auto rs = get_rs(tablet.table);
+
         auto get_viable_targets = [&] () {
             std::unordered_set<host_id> viable_targets;
 
             for (auto&& [id, node] : nodes) {
                 if (node.dc() != src_info.dc() || node.drained) {
+                    continue;
+                }
+                if (rs->is_rack_based(_dc) && node.rack() != src_info.rack()) {
                     continue;
                 }
                 viable_targets.emplace(id);
@@ -2126,6 +2136,10 @@ public:
                         rack_load[node.rack()] += 1;
                     }
                 }
+            }
+
+            if (rs->is_rack_based(_dc)) {
+                return viable_targets;
             }
 
             // Drop targets which would increase max rack load.
@@ -2150,7 +2164,7 @@ public:
 
         if (dst_info.rack() != src_info.rack()) {
             auto targets = get_viable_targets();
-            if (!targets.contains(dst_info.id)) {
+            if (rs->is_rack_based(_dc) || !targets.contains(dst_info.id)) {
                 auto new_rack_load = rack_load[dst_info.rack()] + 1;
                 lblogger.debug("candidate tablet {} skipped because it would increase load on rack {} to {}, max={}",
                                tablet, dst_info.rack(), new_rack_load, max_rack_load);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -3204,10 +3204,9 @@ public:
     // Allocate tablets for multiple new tables, which may be co-located with each other, or co-located with an existing base table.
     void allocate_tablets_for_new_tables(const keyspace_metadata& ksm, const std::vector<schema_ptr>& cfms, utils::chunked_vector<mutation>& muts, api::timestamp_type ts) {
         locator::replication_strategy_params params(ksm.strategy_options(), ksm.initial_tablets());
-        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params);
+        auto tm = _db.get_shared_token_metadata().get();
+        auto rs = abstract_replication_strategy::create_replication_strategy(ksm.strategy_name(), params, tm->get_topology());
         if (auto&& tablet_rs = rs->maybe_as_tablet_aware()) {
-            auto tm = _db.get_shared_token_metadata().get();
-
             std::unordered_map<table_id, schema_ptr> new_cfms_map;
             for (auto s : cfms) {
                 new_cfms_map[s->id()] = s;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -959,7 +959,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         }
                         locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
                         locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
-                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+                        auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
                     } catch (const std::exception& e) {
                         error = e.what();

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -938,19 +938,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             utils::chunked_vector<canonical_mutation> updates;
             sstring error;
             if (_db.has_keyspace(ks_name)) {
-                auto& ks = _db.find_keyspace(ks_name);
-                auto tmptr = get_token_metadata_ptr();
-                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
-                new_ks_props.validate();
-                auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features(), _db.get_config());
-                size_t unimportant_init_tablet_count = 2; // must be a power of 2
-                locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
+                try {
+                    auto& ks = _db.find_keyspace(ks_name);
+                    auto tmptr = get_token_metadata_ptr();
+                    cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
+                    new_ks_props.validate();
+                    auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features(), _db.get_config());
+                    size_t unimportant_init_tablet_count = 2; // must be a power of 2
+                    locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
-                auto tables_with_mvs = ks.metadata()->tables();
-                auto views = ks.metadata()->views();
-                tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
-                for (const auto& table_or_mv : tables_with_mvs) {
-                    try {
+                    auto tables_with_mvs = ks.metadata()->tables();
+                    auto views = ks.metadata()->views();
+                    tables_with_mvs.insert(tables_with_mvs.end(), views.begin(), views.end());
+                    for (const auto& table_or_mv : tables_with_mvs) {
                         if (!tmptr->tablets().is_base_table(table_or_mv->id())) {
                             // Apply the transition only on base tables.
                             // If this table has a base table then the transition will be applied on the base table, and
@@ -961,34 +961,31 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         locator::replication_strategy_params params{ks_md->strategy_options(), old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
-                    } catch (const std::exception& e) {
-                        error = e.what();
-                        rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, error: {},"
-                                       "desired new ks opts: {}", error, new_ks_props.get_replication_options());
-                        updates.clear(); // remove all tablets mutations ...
-                        break;           // ... and only create mutations deleting the global req
+
+                        replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
+                        co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
+                            auto last_token = new_tablet_map.get_last_token(tablet_id);
+                            updates.emplace_back(co_await make_canonical_mutation_gently(
+                                    replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
+                                            .set_new_replicas(last_token, tablet_info.replicas)
+                                            .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
+                                            .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
+                                            .build()
+                            ));
+                            co_await coroutine::maybe_yield();
+                        });
                     }
 
-                    replica::tablet_mutation_builder tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id());
-                    co_await new_tablet_map.for_each_tablet([&](locator::tablet_id tablet_id, const locator::tablet_info& tablet_info) -> future<> {
-                        auto last_token = new_tablet_map.get_last_token(tablet_id);
-                        updates.emplace_back(co_await make_canonical_mutation_gently(
-                                replica::tablet_mutation_builder(guard.write_timestamp(), table_or_mv->id())
-                                        .set_new_replicas(last_token, tablet_info.replicas)
-                                        .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-                                        .set_transition(last_token, locator::choose_rebuild_transition_kind(_feature_service))
-                                        .build()
-                        ));
-                        co_await coroutine::maybe_yield();
-                    });
-                }
-
-                if (error.empty()) {
                     const sstring strategy_name = "NetworkTopologyStrategy";
                     auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
                     for (auto& m: schema_muts) {
                         updates.emplace_back(m);
                     }
+                } catch (const std::exception& e) {
+                    error = e.what();
+                    rtlogger.error("Couldn't process global_topology_request::keyspace_rf_change, desired new ks opts: {}, error: {}",
+                                   saved_ks_props, std::current_exception());
+                    updates.clear(); // remove all tablets mutations and only create mutations deleting the global req
                 }
             } else {
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -934,15 +934,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 ks_name = *req_entry.new_keyspace_rf_change_ks_name;
                 saved_ks_props = *req_entry.new_keyspace_rf_change_data;
             }
-            cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
 
-            auto repl_opts = new_ks_props.get_replication_options();
-            repl_opts.erase(cql3::statements::ks_prop_defs::REPLICATION_STRATEGY_CLASS_KEY);
             utils::chunked_vector<canonical_mutation> updates;
             sstring error;
             if (_db.has_keyspace(ks_name)) {
                 auto& ks = _db.find_keyspace(ks_name);
                 auto tmptr = get_token_metadata_ptr();
+                cql3::statements::ks_prop_defs new_ks_props{std::map<sstring, sstring>{saved_ks_props.begin(), saved_ks_props.end()}};
+                new_ks_props.validate();
+                auto ks_md = new_ks_props.as_ks_metadata_update(ks.metadata(), *tmptr, _db.features(), _db.get_config());
                 size_t unimportant_init_tablet_count = 2; // must be a power of 2
                 locator::tablet_map new_tablet_map{unimportant_init_tablet_count};
 
@@ -958,7 +958,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                             continue;
                         }
                         locator::tablet_map old_tablets = tmptr->tablets().get_tablet_map(table_or_mv->id());
-                        locator::replication_strategy_params params{repl_opts, old_tablets.tablet_count()};
+                        locator::replication_strategy_params params{ks_md->strategy_options(), old_tablets.tablet_count()};
                         auto new_strategy = locator::abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, tmptr->get_topology());
                         new_tablet_map = co_await new_strategy->maybe_as_tablet_aware()->reallocate_tablets(table_or_mv, tmptr, old_tablets);
                     } catch (const std::exception& e) {
@@ -982,6 +982,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         co_await coroutine::maybe_yield();
                     });
                 }
+
+                if (error.empty()) {
+                    const sstring strategy_name = "NetworkTopologyStrategy";
+                    auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
+                    for (auto& m: schema_muts) {
+                        updates.emplace_back(m);
+                    }
+                }
             } else {
                 error = "Can't ALTER keyspace " + ks_name + ", keyspace doesn't exist";
             }
@@ -996,16 +1004,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             updates.push_back(canonical_mutation(topology_request_tracking_mutation_builder(req_id)
                                                          .done(error)
                                                          .build()));
-            if (error.empty()) {
-                const sstring strategy_name = "NetworkTopologyStrategy";
-                auto ks_md = keyspace_metadata::new_keyspace(ks_name, strategy_name, repl_opts,
-                                                             new_ks_props.get_initial_tablets(std::nullopt),
-                                                             new_ks_props.get_durable_writes(), new_ks_props.get_storage_options());
-                auto schema_muts = prepare_keyspace_update_announcement(_db, ks_md, guard.write_timestamp());
-                for (auto& m: schema_muts) {
-                    updates.emplace_back(m);
-                }
-            }
 
             sstring reason = seastar::format("ALTER tablets KEYSPACE called with options: {}", saved_ks_props);
             rtlogger.trace("do update {} reason {}", updates, reason);

--- a/table_helper.cc
+++ b/table_helper.cc
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
+#include "cql3/statements/property_definitions.hh"
 #include "utils/assert.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
@@ -158,7 +159,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
 
     data_dictionary::database db = qp.db();
 
-    std::map<sstring, sstring> opts;
+    locator::replication_strategy_config_options opts;
     opts["replication_factor"] = replication_factor;
     auto ksm = keyspace_metadata::new_keyspace(keyspace_name, "org.apache.cassandra.locator.SimpleStrategy", std::move(opts), std::nullopt);
 
@@ -167,7 +168,7 @@ future<> table_helper::setup_keyspace(cql3::query_processor& qp, service::migrat
         auto ts = group0_guard.write_timestamp();
 
         if (!db.has_keyspace(keyspace_name)) {
-            std::map<sstring, sstring> opts;
+            locator::replication_strategy_config_options opts;
             if (replication_strategy_name == "org.apache.cassandra.locator.NetworkTopologyStrategy") {
                 for (const auto &dc: qp.proxy().get_token_metadata_ptr()->get_topology().get_datacenters())
                     opts[dc] = replication_factor;

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -3872,6 +3872,12 @@ SEASTAR_TEST_CASE(test_rf_expand) {
     constexpr static auto simple = "org.apache.cassandra.locator.SimpleStrategy";
     constexpr static auto network_topology = "org.apache.cassandra.locator.NetworkTopologyStrategy";
 
+    cql_test_config cfg;
+
+    // FIXME: Auto-expand with rack-valid keyspaces requires constructing a proper topology where
+    // it can be done, but we don't have infrastructure to do that yet. The default datacenter1 has one rack.
+    cfg.db_config->rf_rack_valid_keyspaces.set(false);
+
     return do_with_cql_env_thread([] (cql_test_env& e) {
         auto get_replication = [&] (const sstring& ks) {
             auto msg = e.execute_cql(
@@ -3932,7 +3938,7 @@ SEASTAR_TEST_CASE(test_rf_expand) {
             {"class", network_topology},
             {"datacenter1", "2"}
         });
-    });
+    }, std::move(cfg));
 }
 
 SEASTAR_TEST_CASE(test_int_sum_overflow) {
@@ -4367,6 +4373,12 @@ SEASTAR_TEST_CASE(test_describe_simple_schema) {
 }
 
 SEASTAR_TEST_CASE(test_describe_view_schema) {
+    cql_test_config cfg = describe_test_config();
+
+    // FIXME: Auto-expand with rack-valid keyspaces requires constructing a proper topology where
+    // it can be done, but we don't have infrastructure to do that yet. The default datacenter1 has one rack.
+    cfg.db_config->rf_rack_valid_keyspaces.set(false);
+
     return do_with_cql_env_thread([] (cql_test_env& e) {
         std::string base_table = "CREATE TABLE \"KS\".\"cF\" (\n"
                 "    pk blob,\n"
@@ -4434,7 +4446,7 @@ SEASTAR_TEST_CASE(test_describe_view_schema) {
 
             BOOST_CHECK_EQUAL(normalize_white_space(base_schema_desc.create_statement.value().linearize()), normalize_white_space(base_table));
         }
-    }, describe_test_config());
+    }, std::move(cfg));
 }
 
 shared_ptr<cql_transport::messages::result_message> cql_func_require_nofail(

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -42,6 +42,7 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/random_utils.hh"
 #include "test/lib/test_utils.hh"
+#include "test/lib/topology_builder.hh"
 #include <seastar/core/coroutine.hh>
 #include "db/schema_tables.hh"
 
@@ -956,6 +957,32 @@ SEASTAR_TEST_CASE(test_invalid_dcs) {
                     "= {'class': 'SimpleStrategy', 'replication_factor':'" + incorrect + "'}").get(),
                     exceptions::configuration_exception);
         };
+    });
+}
+
+SEASTAR_TEST_CASE(test_rack_aware_rf) {
+    return do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        topo.add_node(service::node_state::normal, shard_count);
+        auto s = "CREATE KEYSPACE ks11 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']} AND tablets = {'enabled':true}";
+        testlog.info("{}", s);
+        e.execute_cql(s).get();
+
+        topo.start_new_rack();
+        topo.add_node(service::node_state::normal, shard_count);
+        s = "CREATE KEYSPACE ks12 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b']} AND tablets = {'enabled':true}";
+        testlog.info("{}", s);
+        e.execute_cql(s).get();
+
+        topo.start_new_dc();
+        topo.add_node(service::node_state::normal, shard_count);
+        topo.start_new_rack();
+        topo.add_node(service::node_state::normal, shard_count);
+        s = "CREATE KEYSPACE ks22 WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b'], 'dc2': ['rack2a', 'rack2b']} AND tablets = {'enabled':true}";
+        testlog.info("{}", s);
+        e.execute_cql(s).get();
     });
 }
 

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -11,6 +11,7 @@
 #include "db/tablet_options.hh"
 #include "gms/inet_address.hh"
 #include "inet_address_vectors.hh"
+#include "locator/abstract_replication_strategy.hh"
 #include "locator/host_id.hh"
 #include "locator/types.hh"
 #include "locator/snitch_base.hh"
@@ -94,10 +95,10 @@ void strategy_sanity_check(
     //
     size_t total_rf = 0;
     for (auto& val : options) {
-        size_t rf = std::stol(val.second);
-        BOOST_CHECK(nts_ptr->get_replication_factor(val.first) == rf);
+        auto rf = locator::replication_factor_data(val.second, {});
+        BOOST_CHECK(nts_ptr->get_replication_factor(val.first) == rf.count());
 
-        total_rf += rf;
+        total_rf += rf.count();
     }
 
     BOOST_CHECK(ars_ptr->get_replication_factor(*tm) == total_rf);

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -83,7 +83,7 @@ static future<> check_ranges_are_sorted(vnode_effective_replication_map_ptr erm,
 void strategy_sanity_check(
     replication_strategy_ptr ars_ptr,
     const token_metadata_ptr& tm,
-    const std::map<sstring, sstring>& options) {
+    const replication_strategy_config_options& options) {
 
     const network_topology_strategy* nts_ptr =
         dynamic_cast<const network_topology_strategy*>(ars_ptr.get());
@@ -156,7 +156,7 @@ void endpoints_check(
  * Run in a seastar thread.
  */
 void full_ring_check(const std::vector<ring_point>& ring_points,
-                     const std::map<sstring, sstring>& options,
+                     replication_strategy_config_options& options,
                      replication_strategy_ptr ars_ptr,
                      locator::token_metadata_ptr tmptr) {
     auto& tm = *tmptr;
@@ -255,10 +255,8 @@ void check_tablets_balance(const tablet_map& tmap,
 }
 
 locator::endpoint_dc_rack make_endpoint_dc_rack(gms::inet_address endpoint) {
-    // This resembles rack_inferring_snitch dc/rack generation which is
-    // still in use by this test via token_metadata internals
-    auto dc = std::to_string(uint8_t(endpoint.bytes()[1]));
-    auto rack = std::to_string(uint8_t(endpoint.bytes()[2]));
+    auto dc = "dc" + std::to_string(uint8_t(endpoint.bytes()[1]));
+    auto rack = "rack" + std::to_string(uint8_t(endpoint.bytes()[2]));
     return locator::endpoint_dc_rack{dc, rack};
 }
 
@@ -309,10 +307,10 @@ void simple_test() {
 
     /////////////////////////////////////
     // Create the replication strategy
-    std::map<sstring, sstring> options323 = {
-        {"100", "3"},
-        {"101", "2"},
-        {"102", "3"}
+    replication_strategy_config_options options323 = {
+        {"dc100", std::vector<sstring>{"rack10", "rack20", "rack30"}},
+        {"dc101", std::vector<sstring>{"rack10", "rack20"}},
+        {"dc102", std::vector<sstring>{"rack10", "rack20", "rack30"}}
     };
     locator::replication_strategy_params params323(options323, std::nullopt);
 
@@ -323,10 +321,10 @@ void simple_test() {
 
     ///////////////
     // Create the replication strategy
-    std::map<sstring, sstring> options320 = {
-        {"100", "3"},
-        {"101", "2"},
-        {"102", "0"}
+    replication_strategy_config_options options320 = {
+        {"dc100", std::vector<sstring>{"rack10", "rack20", "rack30"}},
+        {"dc101", std::vector<sstring>{"rack10", "rack20"}},
+        {"dc102", "0"}
     };
     locator::replication_strategy_params params320(options320, std::nullopt);
 
@@ -368,9 +366,13 @@ void heavy_origin_test() {
 
     std::vector<int> dc_racks = {2, 4, 8};
     std::vector<int> dc_endpoints = {128, 256, 512};
-    std::vector<int> dc_replication = {2, 6, 6};
+    std::vector<std::vector<sstring>> dc_replication = {
+        {"rack0", "rack1"},
+        {"rack0", "rack1", "rack2", "rack3"},
+        {"rack0", "rack1", "rack2", "rack3", "rack4", "rack5"}
+    };
 
-    std::map<sstring, sstring> config_options;
+    replication_strategy_config_options config_options;
     std::unordered_map<inet_address, std::unordered_set<token>> tokens;
     std::vector<ring_point> ring_points;
 
@@ -387,8 +389,7 @@ void heavy_origin_test() {
     std::shuffle(token_points.begin(), token_points.end(), random_engine);
     auto token_point_iterator = token_points.begin();
     for (size_t dc = 0; dc < dc_racks.size(); ++dc) {
-        config_options.emplace(to_sstring(dc),
-                                to_sstring(dc_replication[dc]));
+        config_options.emplace("dc" + to_sstring(dc), dc_replication[dc]);
         for (int rack = 0; rack < dc_racks[dc]; ++rack) {
             for (int ep = 1; ep <= dc_endpoints[dc]/dc_racks[dc]; ++ep) {
                 double token_point = *token_point_iterator++;
@@ -433,6 +434,31 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_heavy) {
     return heavy_origin_test();
 }
 
+namespace {
+
+auto& random_engine = seastar::testing::local_random_engine;
+
+replication_strategy_config_options make_random_options(const std::map<sstring, size_t>& rack_count_per_dc) {
+    auto option_dcs = rack_count_per_dc | std::views::keys | std::ranges::to<std::vector>();
+    replication_strategy_config_options options;
+    std::ranges::shuffle(option_dcs, random_engine);
+    size_t num_option_dcs = 1 + tests::random::get_int(option_dcs.size() - 1);
+    for (size_t i = 0; i < num_option_dcs; ++i) {
+        const auto& dc = option_dcs[i];
+        std::vector<sstring> racks;
+        size_t num_racks = rack_count_per_dc.at(dc);
+        racks.reserve(num_racks);
+        for (size_t rack = 0; rack < num_racks; ++rack) {
+            racks.emplace_back(fmt::format("rack{}", 10 + rack));
+        }
+        std::ranges::shuffle(racks, random_engine);
+        options.emplace(fmt::format("dc{}", dc), racks);
+    }
+    return options;
+};
+
+} // namespace
+
 SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     auto my_address = gms::inet_address("localhost");
 
@@ -451,10 +477,8 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
 
     // Generate a random cluster
-    auto& random_engine = seastar::testing::local_random_engine;
     for (unsigned shard_count = 1; shard_count <= 4; ++shard_count) {
-        std::map<sstring, size_t> node_count_per_dc;
-        std::map<sstring, std::map<sstring, size_t>> node_count_per_rack;
+        std::map<sstring, size_t> rack_count_per_dc;
         std::vector<ring_point> ring_points;
 
         double point = 1;
@@ -462,19 +486,18 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         for (size_t dc = 0; dc < num_dcs; ++dc) {
             sstring dc_name = fmt::format("{}", 100 + dc);
             size_t num_racks = 1 + tests::random::get_int(5);
+            rack_count_per_dc[dc_name] = num_racks;
             for (size_t rack = 0; rack < num_racks; ++rack) {
                 sstring rack_name = fmt::format("{}", 10 + rack);
                 size_t rack_nodes = 1 + tests::random::get_int(2);
                 for (size_t i = 1; i <= rack_nodes; ++i) {
                     ring_points.emplace_back(point, inet_address(format("192.{}.{}.{}", dc_name, rack_name, i)));
-                    node_count_per_dc[dc_name]++;
-                    node_count_per_rack[dc_name][rack_name]++;
                     point++;
                 }
             }
         }
 
-        testlog.debug("node_count_per_rack={}", node_count_per_rack);
+        testlog.debug("rack_count_per_dc={}", rack_count_per_dc);
 
         // Initialize the token_metadata
         locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -497,21 +520,8 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             .with_column("v", utf8_type)
             .build();
 
-        auto make_random_options = [&] () {
-            auto option_dcs = node_count_per_dc | std::views::keys | std::ranges::to<std::vector>();
-            std::map<sstring, sstring> options;
-            std::shuffle(option_dcs.begin(), option_dcs.end(), random_engine);
-            size_t num_option_dcs = 1 + tests::random::get_int(option_dcs.size() - 1);
-            for (size_t i = 0; i < num_option_dcs; ++i) {
-                const auto& dc = option_dcs[i];
-                size_t node_count = tests::random::get_int(node_count_per_dc[dc]);
-                options.emplace(dc, fmt::to_string(node_count));
-            }
-            return options;
-        };
-
         // Create the replication strategy
-        auto options = make_random_options();
+        auto options = make_random_options(rack_count_per_dc);
         size_t tablet_count = 1 + tests::random::get_int(99);
         testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
         locator::replication_strategy_params params(options, tablet_count);
@@ -523,7 +533,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         full_ring_check(tmap, ars_ptr, stm.get());
 
         // Test reallocate_tablets after randomizing a different set of options
-        auto realloc_options = make_random_options();
+        auto realloc_options = make_random_options(rack_count_per_dc);
         locator::replication_strategy_params realloc_params(realloc_options, tablet_count);
         auto realloc_ars_ptr = abstract_replication_strategy::create_replication_strategy(
                 "NetworkTopologyStrategy", params, topo);
@@ -593,11 +603,16 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
         .build();
 
     auto rf_per_dc = tests::random::get_int<size_t>(1, nodes_per_dc, rand);
+    std::vector<sstring> rf_racks;
+    rf_racks.reserve(rf_per_dc);
+    for (size_t i = 0; i < rf_per_dc; ++i) {
+        rf_racks.emplace_back(fmt::format("rack{}", 10 + (i % num_racks)));
+    }
 
     auto make_options = [&] (size_t rf_per_dc) {
-        std::map<sstring, sstring> options;
+        replication_strategy_config_options options;
         for (const auto& dc : dcs) {
-            options.emplace(dc, fmt::to_string(rf_per_dc));
+            options.emplace(fmt::format("dc{}", dc), std::move(rf_racks));
         }
         return options;
     };
@@ -815,19 +830,23 @@ static locator::host_id_set calculate_natural_endpoints(
 }
 
 // Called in a seastar thread.
-static void test_equivalence(const shared_token_metadata& stm, const locator::topology& topo, const std::unordered_map<sstring, size_t>& datacenters) {
+static void test_equivalence(const shared_token_metadata& stm, const locator::topology& topo, std::unordered_map<sstring, size_t>& datacenters) {
     class my_network_topology_strategy : public network_topology_strategy {
     public:
         using network_topology_strategy::network_topology_strategy;
         using network_topology_strategy::calculate_natural_endpoints;
     };
 
-    my_network_topology_strategy nts(replication_strategy_params(
-                                    datacenters | std::views::transform(
-                                                                    [](const std::pair<sstring, size_t>& p) {
-                                                                        return std::make_pair(p.first, to_sstring(p.second));
-                                                                    })
-                                                | std::ranges::to<std::map<sstring, sstring>>(),
+    replication_strategy_config_options rf_options;
+    const auto& dc_racks = topo.get_datacenter_racks();
+    for (auto& [dc, dc_rf] : datacenters) {
+        auto racks = dc_racks.at(dc) | std::views::keys | std::ranges::to<std::vector<sstring>>();
+        dc_rf = std::min(dc_rf, racks.size());
+        racks.resize(dc_rf);
+        rf_options.emplace(dc, racks);
+    }
+
+    my_network_topology_strategy nts(replication_strategy_params(rf_options,
                                     std::nullopt),
                                     &topo);
 
@@ -1232,11 +1251,9 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     tm_cfg.topo_cfg.this_endpoint = my_address;
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
 
-    std::map<sstring, size_t> node_count_per_dc;
-    std::map<sstring, std::map<sstring, size_t>> node_count_per_rack;
+    std::map<sstring, size_t> rack_count_per_dc;
     std::vector<ring_point> ring_points;
 
-    auto& random_engine = seastar::testing::local_random_engine;
     unsigned shard_count = 2;
     size_t num_dcs = 1 + tests::random::get_int(3);
 
@@ -1245,19 +1262,18 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     for (size_t dc = 0; dc < num_dcs; ++dc) {
         sstring dc_name = fmt::format("{}", 100 + dc);
         size_t num_racks = 1 + tests::random::get_int(5);
+        rack_count_per_dc[dc_name] = num_racks;
         for (size_t rack = 0; rack < num_racks; ++rack) {
             sstring rack_name = fmt::format("{}", 10 + rack);
             size_t rack_nodes = 1 + tests::random::get_int(2);
             for (size_t i = 1; i <= rack_nodes; ++i) {
                 ring_points.emplace_back(point, inet_address(format("192.{}.{}.{}", dc_name, rack_name, i)));
-                node_count_per_dc[dc_name]++;
-                node_count_per_rack[dc_name][rack_name]++;
                 point++;
             }
         }
     }
 
-    testlog.debug("node_count_per_rack={}", node_count_per_rack);
+    testlog.debug("rack_count_per_dc={}", rack_count_per_dc);
 
     // Initialize the token_metadata
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -1285,20 +1301,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     auto tmptr = stm.get();
 
     // Create the replication strategy
-    auto make_random_options = [&] () {
-        auto option_dcs = node_count_per_dc | std::views::keys | std::ranges::to<std::vector>();
-        std::shuffle(option_dcs.begin(), option_dcs.end(), random_engine);
-        std::map<sstring, sstring> options;
-        for (const auto& dc : option_dcs) {
-            auto num_racks = node_count_per_rack.at(dc).size();
-            auto max_rf_factor = std::ranges::min(std::ranges::views::transform(node_count_per_rack.at(dc), [] (auto& x) { return x.second; }));
-            auto rf = num_racks * tests::random::get_int(1UL, max_rf_factor);
-            options.emplace(dc, fmt::to_string(rf));
-        }
-        return options;
-    };
-
-    auto options = make_random_options();
+    auto options = make_random_options(rack_count_per_dc);
     size_t tablet_count = 1 + tests::random::get_int(99);
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
@@ -1368,7 +1371,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
 }
 
 // Called in a seastar thread
-void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
+void test_complex_rack_aware_view_pairing_test() {
     auto my_address = gms::inet_address("localhost");
 
     // Create the RackInferringSnitch
@@ -1385,11 +1388,9 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
     tm_cfg.topo_cfg.this_endpoint = my_address;
     tm_cfg.topo_cfg.local_dc_rack = { snitch.local()->get_datacenter(), snitch.local()->get_rack() };
 
-    std::map<sstring, size_t> node_count_per_dc;
-    std::map<sstring, std::map<sstring, size_t>> node_count_per_rack;
+    std::map<sstring, size_t> rack_count_per_dc;
     std::vector<ring_point> ring_points;
 
-    auto& random_engine = seastar::testing::local_random_engine;
     unsigned shard_count = 2;
     size_t num_dcs = 1 + tests::random::get_int(3);
 
@@ -1398,19 +1399,18 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
     for (size_t dc = 0; dc < num_dcs; ++dc) {
         sstring dc_name = fmt::format("{}", 100 + dc);
         size_t num_racks = 2 + tests::random::get_int(4);
+        rack_count_per_dc[dc_name] = num_racks;
         for (size_t rack = 0; rack < num_racks; ++rack) {
             sstring rack_name = fmt::format("{}", 10 + rack);
             size_t rack_nodes = 1 + tests::random::get_int(2);
             for (size_t i = 1; i <= rack_nodes; ++i) {
                 ring_points.emplace_back(point, inet_address(format("192.{}.{}.{}", dc_name, rack_name, i)));
-                node_count_per_dc[dc_name]++;
-                node_count_per_rack[dc_name][rack_name]++;
                 point++;
             }
         }
     }
 
-    testlog.debug("node_count_per_rack={}", node_count_per_rack);
+    testlog.debug("rack_count_per_dc={}", rack_count_per_dc);
 
     // Initialize the token_metadata
     locator::shared_token_metadata stm([] () noexcept { return db::schema_tables::hold_merge_lock(); }, tm_cfg);
@@ -1438,21 +1438,7 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
     auto tmptr = stm.get();
 
     // Create the replication strategy
-    auto make_random_options = [&] () {
-        auto option_dcs = node_count_per_dc | std::views::keys | std::ranges::to<std::vector>();
-        std::shuffle(option_dcs.begin(), option_dcs.end(), random_engine);
-        std::map<sstring, sstring> options;
-        for (const auto& dc : option_dcs) {
-            auto num_racks = node_count_per_rack.at(dc).size();
-            auto rf = more_or_less ?
-                    tests::random::get_int(num_racks, node_count_per_dc[dc]) :
-                    tests::random::get_int(1UL, num_racks);
-            options.emplace(dc, fmt::to_string(rf));
-        }
-        return options;
-    };
-
-    auto options = make_random_options();
+    auto options = make_random_options(rack_count_per_dc);
     size_t tablet_count = 1 + tests::random::get_int(99);
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
@@ -1530,17 +1516,13 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
         }
     }
     for (const auto& [dc, rf_opt] : options) {
-        auto rf = std::stol(rf_opt);
-        BOOST_REQUIRE_EQUAL(same_rack_pairs[dc] + cross_rack_pairs[dc], rf);
+        auto rf = locator::replication_factor_data(rf_opt, {});
+        BOOST_REQUIRE_EQUAL(same_rack_pairs[dc] + cross_rack_pairs[dc], rf.count());
     }
 }
 
 SEASTAR_THREAD_TEST_CASE(tablets_complex_rack_aware_view_pairing_test_rf_lt_racks) {
-    test_complex_rack_aware_view_pairing_test(false);
-}
-
-SEASTAR_THREAD_TEST_CASE(tablets_complex_rack_aware_view_pairing_test_rf_gt_racks) {
-    test_complex_rack_aware_view_pairing_test(true);
+    test_complex_rack_aware_view_pairing_test();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -317,7 +317,7 @@ void simple_test() {
     locator::replication_strategy_params params323(options323, std::nullopt);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params323);
+        "NetworkTopologyStrategy", params323, stm.get()->get_topology());
 
     full_ring_check(ring_points, options323, ars_ptr, stm.get());
 
@@ -331,7 +331,7 @@ void simple_test() {
     locator::replication_strategy_params params320(options320, std::nullopt);
 
     ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params320);
+        "NetworkTopologyStrategy", params320, stm.get()->get_topology());
 
     full_ring_check(ring_points, options320, ars_ptr, stm.get());
 
@@ -418,7 +418,7 @@ void heavy_origin_test() {
 
     locator::replication_strategy_params params(config_options, std::nullopt);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params);
+        "NetworkTopologyStrategy", params, stm.get()->get_topology());
 
     full_ring_check(ring_points, config_options, ars_ptr, stm.get());
 }
@@ -489,6 +489,9 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
             }
         }).get();
 
+        auto tmptr = stm.get();
+        const auto& topo = tmptr->get_topology();
+
         auto s = schema_builder("ks", "tb")
             .with_column("pk", utf8_type, column_kind::partition_key)
             .with_column("v", utf8_type)
@@ -513,7 +516,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
         locator::replication_strategy_params params(options, tablet_count);
         auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, topo);
         auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(tab_awr_ptr);
         auto tmap = tab_awr_ptr->allocate_tablets_for_new_table(s, stm.get(), tablet_count).get();
@@ -523,7 +526,7 @@ SEASTAR_THREAD_TEST_CASE(NetworkTopologyStrategy_tablets_test) {
         auto realloc_options = make_random_options();
         locator::replication_strategy_params realloc_params(realloc_options, tablet_count);
         auto realloc_ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, topo);
         auto realloc_tab_awr_ptr = realloc_ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(realloc_tab_awr_ptr);
         auto realloc_tmap = tab_awr_ptr->reallocate_tablets(s, stm.get(), tmap).get();
@@ -605,7 +608,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
     testlog.debug("tablet_count={} options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, topo);
     auto nts_ptr = dynamic_cast<const network_topology_strategy*>(ars_ptr.get());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
@@ -618,7 +621,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
         testlog.debug("Increasing rf_per_dc={}", rf_per_dc);
         locator::replication_strategy_params inc_params(inc_options, tablet_count);
         auto inc_ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, topo);
         auto inc_nts_ptr = dynamic_cast<const network_topology_strategy*>(inc_ars_ptr.get());
         auto inc_tab_awr_ptr = inc_ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(inc_tab_awr_ptr);
@@ -632,7 +635,7 @@ static void test_random_balancing(sharded<snitch_ptr>& snitch, gms::inet_address
         testlog.debug("Increasing rf_per_dc={}", rf_per_dc);
         locator::replication_strategy_params dec_params(dec_options, tablet_count);
         auto dec_ars_ptr = abstract_replication_strategy::create_replication_strategy(
-                "NetworkTopologyStrategy", params);
+                "NetworkTopologyStrategy", params, topo);
         auto dec_nts_ptr = dynamic_cast<const network_topology_strategy*>(dec_ars_ptr.get());
         auto dec_tab_awr_ptr = dec_ars_ptr->maybe_as_tablet_aware();
         BOOST_REQUIRE(dec_tab_awr_ptr);
@@ -825,7 +828,8 @@ static void test_equivalence(const shared_token_metadata& stm, const locator::to
                                                                         return std::make_pair(p.first, to_sstring(p.second));
                                                                     })
                                                 | std::ranges::to<std::map<sstring, sstring>>(),
-                                    std::nullopt));
+                                    std::nullopt),
+                                    &topo);
 
     const token_metadata& tm = *stm.get();
     for (size_t i = 0; i < 1000; ++i) {
@@ -1299,7 +1303,7 @@ SEASTAR_THREAD_TEST_CASE(tablets_simple_rack_aware_view_pairing_test) {
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, tmptr->get_topology());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
     auto base_tmap = tab_awr_ptr->allocate_tablets_for_new_table(base_schema, tmptr, 1).get();
@@ -1453,7 +1457,7 @@ void test_complex_rack_aware_view_pairing_test(bool more_or_less) {
     testlog.debug("tablet_count={} rf_options={}", tablet_count, options);
     locator::replication_strategy_params params(options, tablet_count);
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-            "NetworkTopologyStrategy", params);
+            "NetworkTopologyStrategy", params, tmptr->get_topology());
     auto tab_awr_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tab_awr_ptr);
     auto base_tmap = tab_awr_ptr->allocate_tablets_for_new_table(base_schema, tmptr, 1).get();

--- a/test/boost/network_topology_strategy_test.cc
+++ b/test/boost/network_topology_strategy_test.cc
@@ -223,34 +223,27 @@ void check_tablets_balance(const tablet_map& tmap,
     testlog.debug("load_map={}", load_map);
 
     for (const auto& [dc, dc_racks] : load_map) {
-        size_t replicas_in_dc = 0;
-        size_t num_racks = dc_racks.size();
-        size_t num_shards = 0;
+        std::unordered_map<sstring, double> avg_replicas_per_shard;
+
         for (const auto& [rack, rack_nodes] : dc_racks) {
+            size_t num_shards = 0;
             for (const auto& [host, shards] : rack_nodes) {
                 num_shards += shards.size();
                 for (const auto& [shard, n] : shards) {
-                    replicas_in_dc += n;
+                    avg_replicas_per_shard[rack] += n;
                 }
             }
+            testlog.debug("dc={} rack={}: replicas={} num_shards={} avg_replicas_per_shard={}", dc, rack, avg_replicas_per_shard[rack], num_shards, avg_replicas_per_shard[rack] / num_shards);
+            avg_replicas_per_shard[rack] /= num_shards;
         }
 
-        auto avg_replicas_per_rack = double(replicas_in_dc) / num_racks;
-        auto avg_replicas_per_shard = double(replicas_in_dc) / num_shards;
-
         for (const auto& [rack, rack_nodes] : dc_racks) {
-            size_t replicas_in_rack = 0;
             for (const auto& [host, shards] : rack_nodes) {
-                size_t replicas_in_node = 0;
                 for (const auto& [shard, n] : shards) {
-                    BOOST_REQUIRE_GE(n, floor(avg_replicas_per_shard - 1));
-                    BOOST_REQUIRE_LE(n, ceil(avg_replicas_per_shard + 1));
-                    replicas_in_node += n;
+                    BOOST_REQUIRE_GE(n, floor(avg_replicas_per_shard[rack] - 1));
+                    BOOST_REQUIRE_LE(n, ceil(avg_replicas_per_shard[rack] + 1));
                 }
-                replicas_in_rack += replicas_in_node;
             }
-            BOOST_REQUIRE_GE(replicas_in_rack, floor(avg_replicas_per_rack - 1));
-            BOOST_REQUIRE_LE(replicas_in_rack, ceil(avg_replicas_per_rack + 1));
         }
     }
 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -25,6 +25,7 @@
 #include "test/lib/test_utils.hh"
 #include "test/lib/topology_builder.hh"
 #include "db/config.hh"
+#include "cql3/util.hh"
 #include "db/schema_tables.hh"
 #include "schema/schema_builder.hh"
 
@@ -110,17 +111,47 @@ future<table_id> add_table(cql_test_env& e, sstring test_ks_name = "") {
 
 // Run in a seastar thread
 static
-sstring add_keyspace(cql_test_env& e, std::unordered_map<sstring, int> dc_rf, int initial_tablets = 0) {
+sstring do_add_keyspace(cql_test_env& e, std::unordered_map<sstring, std::variant<int, std::vector<sstring>>> dc_rf, int initial_tablets = 0) {
     static std::atomic<int> ks_id = 0;
     auto ks_name = fmt::format("keyspace{}", ks_id.fetch_add(1));
+
     sstring rf_options;
     for (auto& [dc, rf] : dc_rf) {
-        rf_options += format(", '{}': {}", dc, rf);
+        auto rf_fmt = std::visit(overloaded_functor(
+            [] (int rf) { return fmt::format("{}", rf); },
+            [] (const std::vector<sstring>& racks) {
+                return fmt::format("[{}]", fmt::join(racks | std::views::transform(&cql3::util::single_quote), ", "));
+            }), rf);
+        rf_options += fmt::format(", '{}': {}", dc, rf_fmt);
     }
+
+    testlog.info("Adding keyspace {} with replication factor options: {}", ks_name, rf_options);
+
     e.execute_cql(fmt::format("create keyspace {} with replication = {{'class': 'NetworkTopologyStrategy'{}}}"
                               " and tablets = {{'enabled': true, 'initial': {}}}",
                               ks_name, rf_options, initial_tablets)).get();
+
     return ks_name;
+}
+
+// Run in a seastar thread
+static
+sstring add_keyspace(cql_test_env& e, std::unordered_map<sstring, int> dc_rf, int initial_tablets = 0) {
+    std::unordered_map<sstring, std::variant<int, std::vector<sstring>>> dc_rf_expanded;
+    for (auto& [dc, rf] : dc_rf) {
+        dc_rf_expanded[dc] = rf;
+    }
+    return do_add_keyspace(e, std::move(dc_rf_expanded), initial_tablets);
+}
+
+// Run in a seastar thread
+static
+sstring add_keyspace_racks(cql_test_env& e, std::unordered_map<sstring, std::vector<sstring>> dc_rf, int initial_tablets = 0) {
+    std::unordered_map<sstring, std::variant<int, std::vector<sstring>>> dc_rf_expanded;
+    for (auto& [dc, rf] : dc_rf) {
+        dc_rf_expanded[dc] = rf;
+    }
+    return do_add_keyspace(e, std::move(dc_rf_expanded), initial_tablets);
 }
 
 // Run in a seastar thread
@@ -2166,12 +2197,14 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rack_load_failure) {
         auto host1 = topo.add_node(node_state::normal);
         auto host2 = topo.add_node(node_state::normal);
         auto host3 = topo.add_node(node_state::normal);
-        topo.start_new_rack();
+        auto rack2 = topo.start_new_rack();
         racks.push_back(topo.rack());
-        auto host4 = topo.add_node(node_state::decommissioning);
+        auto host4 = topo.add_node(node_state::normal);
 
-        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+        auto ks_name = add_keyspace_racks(e, {{rack2.dc, {rack2.rack}}}, 4);
         auto table1 = add_table(e, ks_name).get();
+
+        topo.set_node_state(host4, node_state::decommissioning);
 
         mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
             tablet_map tmap(4);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3798,7 +3798,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     locator::replication_strategy_params params(test_config.options, tablet_count);
 
     auto ars_ptr = abstract_replication_strategy::create_replication_strategy(
-        "NetworkTopologyStrategy", params);
+        "NetworkTopologyStrategy", params, stm.get()->get_topology());
 
     auto tablet_aware_ptr = ars_ptr->maybe_as_tablet_aware();
     BOOST_REQUIRE(tablet_aware_ptr);
@@ -3860,7 +3860,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
     try {
         tablet_map old_tablets = stm.get()->tablets().get_tablet_map(s->id());
         locator::replication_strategy_params params{test_config.new_dc_rep_factor, old_tablets.tablet_count()};
-        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params);
+        auto new_strategy = abstract_replication_strategy::create_replication_strategy("NetworkTopologyStrategy", params, stm.get()->get_topology());
         auto tmap = new_strategy->maybe_as_tablet_aware()->reallocate_tablets(s, stm.get(), old_tablets).get();
 
         auto const& ts = tmap.tablets();

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3755,8 +3755,8 @@ struct calculate_tablet_replicas_for_new_rf_config
         host_id id = host_id::create_random_id();
     };
     std::vector<ring_point> ring_points;
-    std::map<sstring, sstring> options;
-    std::map<sstring, sstring> new_dc_rep_factor;
+    replication_strategy_config_options options;
+    replication_strategy_config_options new_dc_rep_factor;
     std::map<sstring, size_t> expected_rep_factor;
 };
 
@@ -3838,7 +3838,7 @@ static void execute_tablet_for_new_rf_test(calculate_tablet_replicas_for_new_rf_
 
     std::map<sstring, size_t> initial_rep_factor;
     for (auto const& [dc, shard_count] : test_config.options) {
-        initial_rep_factor[dc] = std::stoul(shard_count);
+        initial_rep_factor[dc] = locator::get_replication_factor(shard_count);
     }
 
     auto tablets = stm.get()->tablets().get_tablet_map(s->id());

--- a/test/boost/token_metadata_test.cc
+++ b/test/boost/token_metadata_test.cc
@@ -43,7 +43,8 @@ namespace {
     mutable_vnode_erm_ptr create_erm(mutable_token_metadata_ptr tmptr, replication_strategy_config_options opts = {}) {
         dc_rack_fn get_dc_rack_fn = get_dc_rack;
         tmptr->update_topology_change_info(get_dc_rack_fn).get();
-        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt));
+        auto& topo = tmptr->get_topology();
+        auto strategy = seastar::make_shared<Strategy>(replication_strategy_params(opts, std::nullopt), &topo);
         return calculate_effective_replication_map(std::move(strategy), tmptr).get();
     }
 }

--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -64,14 +64,12 @@ class ScyllaCluster:
                 self.manager.servers_add(servers_num=nodes, config=self._config_options, start=False, auto_rack_dc="dc1")
             case list():
                 for dc, n_nodes in enumerate(nodes, start=1):
+                    dc_name = f"dc{dc}"
                     self.manager.servers_add(
                         servers_num=n_nodes,
                         config=self._config_options,
-                        property_file={
-                            "dc": f"dc{dc}",
-                            "rack": "RAC1",
-                        },
                         start=False,
+                        auto_rack_dc=dc_name
                     )
             case dict():
                 # Supported spec: {"dc1": {"rack1": 3, "rack2": 2}, "dc2": {"rack1": 2}}

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -668,10 +668,10 @@ async def check_data_is_back(manager, logger, cql, ks, cf, keys, servers, topolo
 @pytest.mark.parametrize("topology_rf_validity", [
         (topo(rf = 1, nodes = 3, racks = 1, dcs = 1), True),
         (topo(rf = 3, nodes = 5, racks = 1, dcs = 1), False),
-        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), True),
+        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), False), # Test assumes that rf=1 uses both racks so need to inhibit rack-based RF
         (topo(rf = 3, nodes = 6, racks = 2, dcs = 1), False),
         (topo(rf = 3, nodes = 6, racks = 3, dcs = 1), True),
-        (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), True)
+        (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), False) # Test assumes that rf=2 uses all racks so need to inhibit rack-based RF
     ])
 async def test_restore_with_streaming_scopes(manager: ManagerClient, s3_server, topology_rf_validity):
     '''Check that restoring of a cluster with stream scopes works'''

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -92,7 +92,7 @@ async def test_alternator_ttl_scheduling_group(manager: ManagerClient):
        in the wrong scheduling group. We can assume this because we don't
        run multiple tests in parallel on the same cluster.
     """
-    servers = await manager.servers_add(3, config=alternator_config)
+    servers = await manager.servers_add(3, config=alternator_config, auto_rack_dc='dc1')
     alternator = get_alternator(servers[0].ip_addr)
     table = alternator.create_table(TableName=unique_table_name(),
         BillingMode='PAY_PER_REQUEST',

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -312,7 +312,7 @@ async def test_upgrade(manager: ManagerClient):
     await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logger.info("Creating keyspace and table")
-    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks_name:
+    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks_name:
         table = f"{ks_name}.t"
         await verify_table_versions_synced(cql, hosts)
         await cql.run_async(f"create table {table} (pk int primary key)")

--- a/test/cluster/test_group0_schema_versioning.py
+++ b/test/cluster/test_group0_schema_versioning.py
@@ -127,7 +127,8 @@ async def test_schema_versioning_with_recovery(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(3)]
+    # Must bootstrap sequentially because of gossip topology changes
+    servers = [await manager.server_add(config=cfg, property_file={"dc":"dc1", "rack":f"rack{i+1}"}) for i in range(3)]
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
@@ -297,7 +298,7 @@ async def test_upgrade(manager: ManagerClient):
            'force_gossip_topology_changes': True,
            'tablets_mode_for_new_keyspaces': 'disabled'}
     logger.info("Booting cluster")
-    servers = [await manager.server_add(config=cfg) for _ in range(2)]
+    servers = await manager.servers_add(2, config=cfg, auto_rack_dc='dc1')
     cql = manager.get_cql()
 
     logging.info("Waiting until driver connects to every server")

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -348,6 +348,7 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     valid_keyspaces = [
         create_ok([0, 0]),
         create_ok([1, 0]),
+        create_ok([2, 0]),
         create_ok([3, 0]),
         create_ok(0)
     ]
@@ -356,7 +357,6 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     # because then we can't predict what error will say.
     invalid_keyspaces = [
         create_fail([4, 0], 1, 4, 3),
-        create_fail([2, 0], 1, 2, 3),
         create_fail([0, 1], 2, 1, 0),
         create_fail([0, 2], 2, 2, 0),
         create_fail([0, 3], 2, 3, 0),

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -14,7 +14,7 @@ from cassandra.policies import WhiteListRoundRobinPolicy
 
 from test.cqlpy import nodetool
 from cassandra import ConsistencyLevel
-from cassandra.protocol import InvalidRequest
+from cassandra.protocol import InvalidRequest, ConfigurationException
 from cassandra.query import SimpleStatement
 from test.pylib.manager_client import ManagerClient
 from test.pylib.random_tables import RandomTables, TextType, Column
@@ -177,9 +177,9 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
 
     async def create_fail(rfs: Union[List[int], int], failed_dc: int, rf: int, rack_count: int):
         ks = unique_name()
-        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+        err = rf"Replication factor {rf} exceeds the number of racks|The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
               f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
-        with pytest.raises(InvalidRequest, match=err):
+        with pytest.raises((ConfigurationException, InvalidRequest), match=err):
             await create_aux(ks, rfs)
 
     async def alter_ok(ks: str, rfs: List[int]) -> None:
@@ -188,10 +188,10 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
 
     async def alter_fail(ks: str, rfs: List[int], failed_dc: int, rack_count: int) -> None:
         rf = rfs[failed_dc - 1]
-        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+        err = rf"Replication factor {rf} exceeds the number of racks|The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
               f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
 
-        with pytest.raises(InvalidRequest, match=err):
+        with pytest.raises((ConfigurationException, InvalidRequest), match=err):
             await alter_ok(ks, rfs)
 
     # Step 1.
@@ -340,10 +340,11 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
 
     async def create_fail(rfs: Union[List[int], int], failed_dc: int, rf: int, rack_count: int):
         ks = unique_name()
-        err = r"The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
+        err = rf"Replication factor {rf} exceeds the number of racks|The option `rf_rack_valid_keyspaces` is enabled. It requires that all keyspaces are RF-rack-valid. " \
               f"That condition is violated: keyspace '{ks}' doesn't satisfy it for DC 'dc{failed_dc}': RF={rf} vs. rack count={rack_count}."
-        with pytest.raises(InvalidRequest, match=err):
+        with pytest.raises((ConfigurationException, InvalidRequest), match=err):
             await create_aux(ks, rfs)
+            logger.error(f"create_aux({ks}, {rfs}) should have failed")
 
     valid_keyspaces = [
         create_ok([0, 0]),

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -464,3 +464,53 @@ async def test_restart_with_prefer_local(request: pytest.FixtureRequest, manager
 
     await manager.server_stop_gracefully(s_info.server_id)
     await manager.server_start(s_info.server_id)
+
+async def test_create_keyspace_with_rack_names(manager: ManagerClient):
+    """
+    This test verifies that rack names can be specified for NetworkTopologyStrategy replication options.
+    """
+
+    cfg_false = {"rf_rack_valid_keyspaces": "false", "tablets_mode_for_new_keyspaces": "enabled"}
+
+    s1 = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r1"})
+    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r2"})
+    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r3"})
+    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc2", "rack": "r4"})
+    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc2", "rack": "r5"})
+
+    cql = manager.get_cql()
+
+    def format_rf(rf: Union[List[str], str]) -> str:
+        if isinstance(rf, list):
+            return "[" + ', '.join([f"'{rack}'" for rack in rf]) + "]"
+        return f"'{rf}'"
+
+    async def create_keyspace(rfs: List[List[str] | str]) -> str:
+        dcs = ", ".join([f"'dc{i + 1}': {format_rf(rf)}" for i, rf in enumerate(rfs)])
+        name = unique_name()
+        stmt = f"CREATE KEYSPACE {name} WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', {dcs}}}"
+        logger.info(stmt)
+        await cql.run_async(stmt)
+        res = await cql.run_async(f"DESCRIBE KEYSPACE {name}")
+        cr_stmt = res[0].create_statement
+        desc_dcs = ", ".join([f"'dc{i + 1}': {format_rf(rf)}" for i, rf in enumerate(rfs) if rf])
+        assert desc_dcs in cr_stmt
+        return name
+
+    valid_keyspaces = [
+        # For each DC: RF \in {0, 1, #racks}.
+        ([['r1']]),
+        ([['r1'], []]),
+        ([['r1'], 1]),
+        ([['r1', 'r2']]),
+        ([['r1', 'r3']]),
+        ([['r1', 'r2', 'r3']]),
+        ([['r1'], ['r4']]),
+        ([3, ['r4']]),
+        ([['r2', 'r3'], ['r4', 'r5']]),
+    ]
+
+    # Populate valid keyspaces.
+    async with asyncio.TaskGroup() as tg:
+        for rfs in valid_keyspaces:
+            _ = tg.create_task(create_keyspace(rfs))

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -30,10 +30,10 @@ logger = logging.getLogger(__name__)
 @pytest.mark.parametrize("topology_rf_validity", [
         (topo(rf = 1, nodes = 3, racks = 1, dcs = 1), True),
         (topo(rf = 3, nodes = 5, racks = 1, dcs = 1), False),
-        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), True),
+        (topo(rf = 1, nodes = 4, racks = 2, dcs = 1), False), # Test assumes that rf=1 uses both racks so need to inhibit rack-based RF
         (topo(rf = 3, nodes = 6, racks = 2, dcs = 1), False),
         (topo(rf = 3, nodes = 6, racks = 3, dcs = 1), True),
-        (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), True)
+        (topo(rf = 2, nodes = 8, racks = 4, dcs = 2), False) # Test assumes that rf=2 uses all racks so need to inhibit rack-based RF
     ])
 async def test_refresh_with_streaming_scopes(manager: ManagerClient, topology_rf_validity):
     '''

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -287,11 +287,11 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
         await cql.run_async(f"create table {ks}.t (pk int primary key)")
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
             # changing RF of dc2 from 0 to 2 should fail
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': ['rack1', 'rack2']}}")
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': ['rack1', 'rack2']}}")
 
         # changing RF of dc2 from 0 to 1 should succeed
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': ['rack1']}}")
-        # ensure that RFs of both DCs are equal to 1 now, i.e. that omitting dc1 in above command didn't change it
+        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': ['rack1']}}")
+        # ensure that RFs of both DCs are equal to 1 now
         res = await cql.run_async(f"SELECT * FROM system_schema.keyspaces  WHERE keyspace_name = '{ks}'")
         repl = parse_replication_options(res[0].replication)
         logger.info(f"repl = {repl}")
@@ -312,10 +312,47 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
             await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': ['rack1', 'rack2']}}")
 
         # check that we can remove all replicas from dc2 by changing RF from 1 to 0
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': 0}}")
+        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 0}}")
         # check that we can remove all replicas from the cluster, i.e. change RF of dc1 from 1 to 0 as well:
         await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0}}")
 
+
+@pytest.mark.asyncio
+async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    config = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled"}
+
+    logger.info("Creating a new cluster of 2 nodes in 1st DC and 2 nodes in 2nd DC")
+    # we have to have at least 2 nodes in each DC if we want to try setting RF to 2 in each DC
+    await manager.servers_add(2, config=config, auto_rack_dc="dc1")
+    await manager.servers_add(2, config=config, auto_rack_dc="dc2")
+
+    async def check_rf(ks: str, expected_dc1_rf: int, expected_dc2_rf: int):
+        res = await cql.run_async(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks}'")
+        repl = parse_replication_options(res[0].replication)
+        logger.info(f"repl = {repl}")
+        assert len(repl['dc1']) == expected_dc1_rf if expected_dc1_rf > 0 else 'dc1' not in repl
+        assert len(repl['dc2']) == expected_dc2_rf if expected_dc2_rf > 0 else 'dc2' not in repl
+        return repl
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
+        await cql.run_async(f"create table {ks}.t (pk int primary key)")
+
+        await check_rf(ks=ks, expected_dc1_rf=1, expected_dc2_rf=1)
+
+        with pytest.raises(ConfigurationException, match="Attempted to implicitly drop replicas in datacenter dc2. If this is the desired behavior, set replication factor to 0 in dc2 explicitly."):
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1', 'rack2']}}")
+        repl = await check_rf(ks=ks, expected_dc1_rf=1, expected_dc2_rf=1)
+
+        dc1_rf = repl['dc1']
+        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': {dc1_rf}, 'dc2': 0}}")
+        await check_rf(ks=ks, expected_dc1_rf=1, expected_dc2_rf=0)
+
+        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1', 'rack2']}}")
+        await check_rf(ks=ks, expected_dc1_rf=2, expected_dc2_rf=0)
+
+        await cql.run_async(f"alter keyspace {ks} with durable_writes = true")
+        await check_rf(ks=ks, expected_dc1_rf=2, expected_dc2_rf=0)
 
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -14,7 +14,8 @@ from test.pylib.scylla_cluster import ReplaceConfig
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
 from test.pylib.util import unique_name
 from test.cluster.conftest import skip_mode
-from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, get_topology_coordinator
+from test.cluster.util import wait_for_cql_and_get_hosts, create_new_test_keyspace, new_test_keyspace, reconnect_driver, \
+    get_topology_coordinator, parse_replication_options
 from contextlib import nullcontext as does_not_raise
 import time
 import pytest
@@ -152,16 +153,22 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     this_dc = res[0].data_center
 
     if direction == 'up':
+        rf_from_opt = "['rack1']"
+        rf_to_opt = "['rack1', 'rack2']"
         rf_from = 1
         rf_to = 2
     if direction == 'down':
-        rf_from = 2
+        rf_from_opt = "['rack1', 'rack2']"
+        rf_to_opt = "['rack1']"
+        rf_from= 2
         rf_to = 1
     if direction == 'none':
+        rf_from_opt = "['rack1']"
+        rf_to_opt = "['rack1']"
         rf_from = 1
         rf_to = 1
 
-    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_from}}}") as ks:
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_from_opt}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.test_mv AS SELECT pk FROM {ks}.test WHERE pk IS NOT NULL PRIMARY KEY (pk)")
 
@@ -179,7 +186,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
         await check_allocated_replica(rf_from)
 
         logger.info(f"Altering RF {rf_from} -> {rf_to}")
-        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_to}}}")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': {rf_to_opt}}}")
 
         logger.info(f"Checking {rf_to} re-allocated replicas")
         await check_allocated_replica(rf_to)
@@ -271,8 +278,8 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
 
     logger.info("Creating a new cluster of 2 nodes in 1st DC and 2 nodes in 2nd DC")
     # we have to have at least 2 nodes in each DC if we want to try setting RF to 2 in each DC
-    await manager.servers_add(2, config=config, property_file={'dc': f'dc1', 'rack': 'myrack'})
-    await manager.servers_add(2, config=config, property_file={'dc': f'dc2', 'rack': 'myrack'})
+    await manager.servers_add(2, config=config, auto_rack_dc="dc1")
+    await manager.servers_add(2, config=config, auto_rack_dc="dc2")
 
     cql = manager.get_cql()
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}") as ks:
@@ -280,27 +287,29 @@ async def test_multidc_alter_tablets_rf(request: pytest.FixtureRequest, manager:
         await cql.run_async(f"create table {ks}.t (pk int primary key)")
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
             # changing RF of dc2 from 0 to 2 should fail
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': 2}}")
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': ['rack1', 'rack2']}}")
 
         # changing RF of dc2 from 0 to 1 should succeed
-        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': 1}}")
+        await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': ['rack1']}}")
         # ensure that RFs of both DCs are equal to 1 now, i.e. that omitting dc1 in above command didn't change it
         res = await cql.run_async(f"SELECT * FROM system_schema.keyspaces  WHERE keyspace_name = '{ks}'")
-        assert res[0].replication['dc1'] == '1'
-        assert res[0].replication['dc2'] == '1'
+        repl = parse_replication_options(res[0].replication)
+        logger.info(f"repl = {repl}")
+        assert len(repl['dc1']) == 1
+        assert repl['dc2'] == ['rack1']
 
         # incrementing RF of 2 DCs at once should NOT succeed, because it'd leave 2 pending tablets replicas
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 2}}")
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1', 'rack2'], 'dc2': ['rack1', 'rack2']}}")
         # as above, but decrementing
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
             await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': 0}}")
         # as above, but decrement 1 RF and increment the other
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 0}}")
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1','rack2'], 'dc2': 0}}")
         # as above, but RFs are swapped
         with pytest.raises(InvalidRequest, match="Only one DC's RF can be changed at a time and not by more than 1"):
-            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': 2}}")
+            await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 0, 'dc2': ['rack1', 'rack2']}}")
 
         # check that we can remove all replicas from dc2 by changing RF from 1 to 0
         await cql.run_async(f"alter keyspace {ks} with replication = {{'class': 'NetworkTopologyStrategy', 'dc2': 0}}")

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -12,7 +12,7 @@ from cassandra.protocol import InvalidRequest
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot
 from test.cluster.conftest import skip_mode
-from test.cluster.util import disable_schema_agreement_wait, create_new_test_keyspace, new_test_keyspace
+from test.cluster.util import disable_schema_agreement_wait, parse_replication_options, create_new_test_keyspace, new_test_keyspace
 
 logger = logging.getLogger(__name__)
 
@@ -76,13 +76,14 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
     }
 
     logger.info("starting a node (the leader)")
-    servers = [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r1"})]
+    this_dc = "dc1"
+    servers = [await manager.server_add(config=config, property_file={"dc": this_dc, "rack": "r1"})]
 
     logger.info("starting a second node (the follower)")
-    servers += [await manager.server_add(config=config, property_file={"dc": "dc1", "rack": "r2"})]
+    servers += [await manager.server_add(config=config, property_file={"dc": this_dc, "rack": "r2"})]
 
     async with new_test_keyspace(manager, "with "
-                                      "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "
+                                      "replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1']} and "
                                       "tablets = {'initial': 2}") as ks:
         await manager.get_cql().run_async(f"create table {ks}.t (pk int primary key)")
 
@@ -90,14 +91,10 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
         injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
                                                         'wait-before-committing-rf-change-event')
 
-        # ALTER tablets KS only accepts a specific DC, it rejects the generic 'replication_factor' tag
-        res = await manager.get_cql().run_async("select data_center from system.local")
-        this_dc = res[0].data_center
-
         async def alter_tablets_ks_without_waiting_to_complete():
             logger.info("scheduling ALTER KS to change the RF from 1 to 2")
             await manager.get_cql().run_async(f"alter keyspace {ks} "
-                                            f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 2}}")
+                                            f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': ['r1','r2']}}")
 
         # by creating a task this way we ensure it's immediately executed,
         # but we don't want to wait until the task is completed here,
@@ -128,6 +125,6 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
 
         # ensure that the ALTER has eventually succeeded and we changed RF from 1 to 2
         res = manager.get_cql().execute(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks}'")
-        assert res[0].replication[this_dc] == '2'
+        assert parse_replication_options(res[0].replication)[this_dc] == ['r1', 'r2']
 
         await manager.get_cql().run_async(f"drop keyspace {ks2}")

--- a/test/cluster/test_zero_token_nodes_multidc.py
+++ b/test/cluster/test_zero_token_nodes_multidc.py
@@ -28,16 +28,15 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
     """
     normal_cfg = {'endpoint_snitch': 'GossipingPropertyFileSnitch', 'rf_rack_valid_keyspaces': rf_rack_valid_keyspaces}
     zero_token_cfg = normal_cfg | {'join_ring': False}
-    property_file_dc2 = {'dc': 'dc2', 'rack': 'rack'}
 
     logging.info('Creating dc1 with 2 token-owning nodes')
     servers = await manager.servers_add(2, config=normal_cfg, auto_rack_dc='dc1')
 
     normal_nodes_in_dc2 = 2 - zero_token_nodes
     logging.info(f'Creating dc2 with {normal_nodes_in_dc2} token-owning and {zero_token_nodes} zero-token nodes')
-    servers += await manager.servers_add(zero_token_nodes, config=zero_token_cfg, property_file=property_file_dc2)
+    servers += await manager.servers_add(zero_token_nodes, config=zero_token_cfg, property_file={'dc': 'dc2', 'rack': 'rack1'})
     if zero_token_nodes == 1:
-        servers.append(await manager.server_add(config=normal_cfg, property_file=property_file_dc2))
+        servers.append(await manager.server_add(config=normal_cfg, property_file={'dc': 'dc2', 'rack': 'rack2'}))
 
     logging.info('Creating connections to dc1 and dc2')
     dc1_cql = cluster_con([servers[0].ip_addr], 9042, False,
@@ -59,11 +58,11 @@ async def test_zero_token_nodes_multidc_basic(manager: ManagerClient, zero_token
 
     for rf in range(rf_range):
         failed = False
-        ks_name = await create_new_test_keyspace(dc2_cql, f"""WITH replication =
-                                     {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2, 'dc2': {rf}}}
-                                     AND tablets = {{ 'enabled': true }}""")
-        ks_names.append(ks_name)
         try:
+            ks_name = await create_new_test_keyspace(dc2_cql, f"""WITH replication =
+                                         {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2, 'dc2': {rf}}}
+                                         AND tablets = {{ 'enabled': true }}""")
+            ks_names.append(ks_name)
             await dc2_cql.run_async(
                 f'CREATE TABLE {ks_names[rf]}.tbl (cl int, zero_token boolean, v int, PRIMARY KEY (cl, zero_token))')
         except Exception:

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -595,3 +595,22 @@ def disable_schema_agreement_wait(cql: Session):
         yield
     finally:
         cql.cluster.max_schema_agreement_wait = old_value
+
+
+def parse_replication_options(replication_column) -> dict:
+    """
+    Parses the value of the "replication" column from system_schema.keyspaces, which is a flattened map of options,
+     into an expanded map.
+    Expands a flattened map like {"dc0:0": "r1", "dc0:1": "r2"} into {"dc0": ["r1", "r2"]}.
+    """
+    result = {}
+    for key, value in replication_column.items():
+        if ':' in key:
+            sub_key, index = key.split(':', 1)
+            if sub_key not in result:
+                result[sub_key] = []
+            result[sub_key].append(value)
+            assert len(result[sub_key]) == int(index) + 1
+        else:
+            result[key] = value
+    return result

--- a/test/cql/locator_test.result
+++ b/test/cql/locator_test.result
@@ -3,7 +3,7 @@
 > -- Fail on wrong DC name
 > --
 > CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'nosuchdc' : 3 } AND DURABLE_WRITES = true;
-<Error from server: code=2300 [Query invalid because of configuration issue] message="Unrecognized strategy option {nosuchdc} passed to NetworkTopologyStrategy">
+<Error from server: code=2300 [Query invalid because of configuration issue] message="Unrecognized datacenter name 'nosuchdc'">
 > CREATE KEYSPACE t WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'datacenter1' : 3 } AND DURABLE_WRITES = true;
 OK
 > DROP KEYSPACE t;

--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -225,11 +225,12 @@ def testAlterKeyspaceWithNoOptionThrowsConfigurationException(cql, test_keyspace
 def testAlterKeyspaceWithNTSOnlyAcceptsConfiguredDataCenterNames(cql, test_keyspace, this_dc):
     # Create a keyspace with expected DC name.
     with create_keyspace(cql, "replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as ks:
+        pattern = re.compile("Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy|Unrecognized datacenter name 'INVALID_DC'")
         # try modifying the keyspace
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', 'INVALID_DC' : 2 }")
         execute(cql, ks, "ALTER KEYSPACE %s WITH replication = {'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }")
         # Mix valid and invalid, should throw an exception
-        assert_invalid_throw_message_re(cql, ks, "Unrecognized strategy option {INVALID_DC} passed to .*NetworkTopologyStrategy", ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
+        assert_invalid_throw_message_re(cql, ks, pattern, ConfigurationException, "ALTER KEYSPACE %s WITH replication={ 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 , 'INVALID_DC': 1}")
 
 def testAlterKeyspaceWithMultipleInstancesOfSameDCThrowsSyntaxException(cql, test_keyspace, this_dc):
     # Create a keyspace

--- a/test/cqlpy/test_keyspace.py
+++ b/test/cqlpy/test_keyspace.py
@@ -128,13 +128,13 @@ def test_alter_keyspace(cql, this_dc, scylla_only):
 # Test trying to ALTER RF of tablets-enabled KS by more than 1 at a time
 def test_alter_keyspace_rf_by_more_than_1(cql, this_dc):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', '" + this_dc + "' : 1 }") as keyspace:
-        with pytest.raises(InvalidRequest):
+        with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', '{this_dc}' : 3 }} AND DURABLE_WRITES = false")
 
 # Test trying to ALTER a tablets-enabled KS by providing the 'replication_factor' tag
 def test_alter_keyspace_with_replication_factor_tag(cql):
     with new_test_keyspace(cql, "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 1 }") as keyspace:
-        with pytest.raises(InvalidRequest):
+        with pytest.raises((InvalidRequest, ConfigurationException)):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH REPLICATION = {{ 'class' : 'NetworkTopologyStrategy', 'replication_factor' : 2 }}")
 
 # Test trying to ALTER a keyspace with invalid options.

--- a/test/lib/topology_builder.hh
+++ b/test/lib/topology_builder.hh
@@ -71,6 +71,7 @@ public:
 private:
     cql_test_env& _env;
     int _nr_nodes = 0;
+    int _dc_id;
     int _rack_id;
     sstring _dc;
     sstring _rack;
@@ -150,8 +151,7 @@ public:
     // Starts building a new rack in the current DC.
     // Returns location of the new rack.
     endpoint_dc_rack start_new_rack() {
-        _rack_id++;
-        _rack = fmt::format("rack{}", _rack_id);
+        _rack = fmt::format("rack{}{:c}", _dc_id, 'a' + _rack_id++);
         return rack();
     }
 
@@ -159,7 +159,8 @@ public:
     // DC is named uniquely in the scope of the process, not just this object.
     endpoint_dc_rack start_new_dc() {
         static std::atomic<int> next_id = 1;
-        _dc = fmt::format("dc{}", next_id.fetch_add(1));
+        _dc_id = next_id.fetch_add(1);
+        _dc = fmt::format("dc{}", _dc_id);
         _rack_id = 0;
         return start_new_rack();
     }

--- a/tools/load_system_tablets.cc
+++ b/tools/load_system_tablets.cc
@@ -11,6 +11,7 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/closeable.hh>
 
+#include "locator/abstract_replication_strategy.hh"
 #include "utils/log.hh"
 #include "data_dictionary/keyspace_metadata.hh"
 #include "db/cql_type_parser.hh"
@@ -71,7 +72,7 @@ tools::tablets_t do_load_system_tablets(const db::config& dbcfg,
 
     auto ks = make_lw_shared<data_dictionary::keyspace_metadata>(keyspace_name,
                                                                  "org.apache.cassandra.locator.LocalStrategy",
-                                                                 std::map<sstring, sstring>{},
+                                                                 locator::replication_strategy_config_options{},
                                                                  std::nullopt, false);
     db::cql_type_parser::raw_builder ut_builder(*ks);
 

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -161,7 +161,7 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}};
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}, nullptr};
         return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -259,7 +259,7 @@ std::vector<schema_ptr> do_load_schemas(const db::config& cfg, std::string_view 
     real_db.keyspaces.emplace_back(make_lw_shared<keyspace_metadata>(
                 db::schema_tables::NAME,
                 "org.apache.cassandra.locator.LocalStrategy",
-                std::map<sstring, sstring>{},
+                locator::replication_strategy_config_options{},
                 std::nullopt,
                 false));
     real_db.tables.emplace_back(dd_impl, real_db.keyspaces.back(), db::schema_tables::dropped_columns(), false);
@@ -445,7 +445,7 @@ schema_ptr do_load_schema_from_schema_tables(const db::config& dbcfg, std::files
     if (types_mut) {
         query::result_set result(*types_mut);
 
-        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", std::map<sstring, sstring>{}, std::nullopt, false);
+        auto ks = make_lw_shared<keyspace_metadata>(keyspace, "org.apache.cassandra.locator.LocalStrategy", locator::replication_strategy_config_options{}, std::nullopt, false);
         db::cql_type_parser::raw_builder ut_builder(*ks);
 
         auto get_list = [] (const query::result_set_row& row, const char* name) {


### PR DESCRIPTION
In ALTER KEYSPACE, when a datacenter name is omitted, its replication
factor is implicitly set to zero with vnodes, while with tablets,
it remains unchanged.

ALTER KEYSPACE should behave the same way for tablets as it does
for vnodes. However, this can be dangerous as we may mistakenly
drop the whole datacenter.

Reject ALTER KEYSPACE if it changes replication factor, but omits
a datacenter that currently contains tablet replicas.

Fixes: https://github.com/scylladb/scylladb/issues/25549.

Breaking change; no backport