### PR TITLE
stall_free_test: use REQUIRE_EVENTUALLY to possibly wait for foreign_ptr destroyal

### DIFF
--- a/test/boost/stall_free_test.cc
+++ b/test/boost/stall_free_test.cc
@@ -11,7 +11,9 @@
 #include <set>
 #include <unordered_set>
 
+#include "seastar/core/lowres_clock.hh"
 #include "test/lib/scylla_test_case.hh"
+#include "test/lib/eventually.hh"
 #include "utils/stall_free.hh"
 #include "utils/small_vector.hh"
 #include "utils/chunked_vector.hh"
@@ -230,7 +232,9 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_foreign_shared_ptr) {
 
     p0.reset();
     utils::clear_gently(p1).get();
-    BOOST_REQUIRE_EQUAL(cleared_gently, 2);
+
+    // p0's payload is destroyed in the background so allow it some time to complete
+    REQUIRE_EVENTUALLY_EQUAL<int>([&] { return cleared_gently; }, 2);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_clear_gently_foreign_shared_ptr_const_payload) {
@@ -260,7 +264,9 @@ SEASTAR_THREAD_TEST_CASE(test_clear_gently_foreign_shared_ptr_const_payload) {
 
     p0.reset();
     utils::clear_gently(p1).get();
-    BOOST_REQUIRE_EQUAL(cleared_gently, 2);
+
+    // p0's payload is destroyed in the background so allow it some time to complete
+    REQUIRE_EVENTUALLY_EQUAL<int>([&] { return cleared_gently; }, 2);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_clear_gently_shared_ptr) {


### PR DESCRIPTION
In the foreign_*_ptr_const_payload test case we reset() the foreign_ptr on the calling shard, but the payload is destroyed in the background.  In debug mode, the continuation may be executed ou-of-order causing flakiness, so use REQUIRE_EVENTUALLY_EQUAL after reset() to wait for a while for the background task to compelte.

Fixes #25723

* The const_payload test cases currently exist only on master (2025.4.0-dev) so no backport required