### PR TITLE
s3: Export memory usage gauge (metrics)

### DIFF
--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -75,6 +75,14 @@ storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     for (auto& e : cfg.object_storage_endpoints()) {
         _s3_endpoints.emplace(std::make_pair(std::move(e.endpoint), make_lw_shared<s3::endpoint_config>(std::move(e.config))));
     }
+
+    if (!stm_cfg.skip_metrics_registration) {
+        namespace sm = seastar::metrics;
+        metrics.add_group("s3", {
+            sm::make_gauge("memory_usage", [this, limit = stm_cfg.s3_clients_memory] { return limit - _s3_clients_memory.available_units(); },
+                    sm::description("Total number of bytes consumed by S3 client"), {}),
+        });
+    }
 }
 
 future<> storage_manager::stop() {

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -12,6 +12,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/metrics.hh>
 
 #include "utils/assert.hh"
 #include "utils/disk-error-handler.hh"
@@ -65,12 +66,14 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     semaphore _s3_clients_memory;
     std::unordered_map<sstring, s3_endpoint> _s3_endpoints;
     std::unique_ptr<config_updater> _config_updater;
+    seastar::metrics::metric_groups metrics;
 
     future<> update_config(const db::config&);
 
 public:
     struct config {
         size_t s3_clients_memory = 16 << 20; // 16M by default
+        bool skip_metrics_registration = false;
     };
 
     storage_manager(const db::config&, config cfg);

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3572,6 +3572,7 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
 
         sstables::storage_manager::config stm_cfg;
         stm_cfg.s3_clients_memory = 100_MiB;
+        stm_cfg.skip_metrics_registration = true;
         sharded<sstables::storage_manager> sstm;
         sstm.start(std::ref(dbcfg), stm_cfg).get();
         auto stop_sstm = defer([&sstm] { sstm.stop().get(); });


### PR DESCRIPTION
The memory usage is tracked with the help of a semaphore, so just export its "consumed" units.

Useful metrics, good to have in older versions as well