### PR TITLE
[Backport 2025.1] encryption_at_rest_test: Improve exception handling and increase verbosity in fake proxy

### DIFF
--- a/ent/encryption/encryption_exceptions.hh
+++ b/ent/encryption/encryption_exceptions.hh
@@ -27,15 +27,15 @@ public:
     using mybase::mybase;
 };
 
-class service_error : public base_error {
-public:
-    using base_error::base_error;
-};
-
-class missing_resource_error : public db::extension_storage_resource_unavailable {
+class service_error : public db::extension_storage_resource_unavailable {
 public:
     using mybase = db::extension_storage_resource_unavailable;
     using mybase::mybase;
+};
+
+class missing_resource_error : public service_error {
+public:
+    using service_error::service_error;
 };
 
 // #4970 - not 100% correct, but network errors are 

--- a/ent/encryption/gcp_host.cc
+++ b/ent/encryption/gcp_host.cc
@@ -295,6 +295,8 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::gcp_host::i
         throw;
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_or_create_key: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_or_create_key: {}", std::current_exception())));
     }
@@ -318,6 +320,8 @@ future<shared_ptr<encryption::symmetric_key>> encryption::gcp_host::impl::get_ke
         throw;
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_key_by_id: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(fmt::format("get_or_create_key: {}", e.what())));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -431,6 +431,8 @@ future<std::tuple<shared_ptr<encryption::symmetric_key>, encryption::kms_host::i
         throw;
     } catch (std::system_error& e) {
         std::throw_with_nested(network_error(e.what()));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }
@@ -455,6 +457,8 @@ future<shared_ptr<encryption::symmetric_key>> encryption::kms_host::impl::get_ke
         std::throw_with_nested(network_error(e.what()));
     } catch (std::invalid_argument& e) {
         std::throw_with_nested(configuration_error(fmt::format("get_key_by_id: {}", e.what())));
+    } catch (rjson::malformed_value& e) {
+        std::throw_with_nested(malformed_response_error(e.what()));
     } catch (...) {
         std::throw_with_nested(service_error(fmt::format("get_key_by_id: {}", std::current_exception())));
     }

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -469,31 +469,30 @@ class fake_proxy {
                     auto& ldst = dst;
                     auto addr = client.remote_address;
 
-                    auto do_io = [this, &addr, &dst_addr, port](connected_socket& src, connected_socket& dst) -> future<> {
-                        auto sin = src.input();
-                        auto dout = dst.output();
-                        // note: have to have differing conditions for proxying
-                        // and shutdown, and need to check inside look, because
-                        // kmip connector caches connection -> not new socket.
-                        while (_go_on && _do_proxy && !sin.eof()) {
-                            auto buf = co_await sin.read();
-                            auto n = buf.size();
-                            testlog.trace("Read {} bytes: {}->{}:{}", n, addr, dst_addr, port);
-                            if (_do_proxy) {
-                                co_await dout.write(std::move(buf));
-                                co_await dout.flush();
-                                testlog.trace("Wrote {} bytes: {}->{}:{}", n, addr, dst_addr, port);
+                    auto do_io = [this, &addr, &dst_addr, port](connected_socket& src, connected_socket& dst) noexcept -> future<> {
+                        try {
+                            auto sin = src.input();
+                            auto dout = dst.output();
+                            // note: have to have differing conditions for proxying
+                            // and shutdown, and need to check inside look, because
+                            // kmip connector caches connection -> not new socket.
+                            while (_go_on && _do_proxy && !sin.eof()) {
+                                auto buf = co_await sin.read();
+                                auto n = buf.size();
+                                testlog.trace("Read {} bytes: {}->{}:{}", n, addr, dst_addr, port);
+                                if (_do_proxy) {
+                                    co_await dout.write(std::move(buf));
+                                    co_await dout.flush();
+                                    testlog.trace("Wrote {} bytes: {}->{}:{}", n, addr, dst_addr, port);
+                                }
                             }
+                            co_await dout.close();
+                            co_await sin.close();
+                        } catch (...) {
+                            testlog.warn("Exception running proxy {}:{}->{}: {}", dst_addr, port, _address, std::current_exception());
                         }
-                        co_await dout.close();
-                        co_await sin.close();
                     };
-                    try {
-                        co_await when_all(do_io(s, ldst), do_io(ldst, s));
-                    } catch (...) {
-                        testlog.warn("Exception running proxy {}:{}->{}: {}", dst_addr, port, _address, std::current_exception());
-                        throw;
-                    }
+                    co_await when_all(do_io(s, ldst), do_io(ldst, s));
                 }();
 
                 work.emplace_back(std::move(f));


### PR DESCRIPTION
PRs included:
* #22810 (encryption_at_rest_test/encryption: Add some verbosity etc to help diagnose test run issues)
* #23778 (encryption_at_rest_test: Make fake_proxy read/write loop noexcept)

Backporting them together because the latter needs the former to avoid conflicts, but the former cannot be backported individually due to not fixing an issue.

* (cherry picked from commit 83aa66da1a7b0a27746bdf6c48ae6e8067819ca5)
* (cherry picked from commit 5905c19ab468e2475c75939aeaed4ef99a9709f7)
* (cherry picked from commit 00263aa57a7723636dc56f3eb6eadf900c6de269)
* (cherry picked from commit 4a44651fce0f253dfef83af4de4399d1c507d449)

Refs #22628.
Fixes #23774.