### PR TITLE
streaming/stream_blob: generate view updates from staging sstables

### DIFF
--- a/streaming/stream_blob.hh
+++ b/streaming/stream_blob.hh
@@ -27,6 +27,12 @@
 #include <fmt/core.h>
 #include <fmt/ostream.h>
 
+namespace db {
+namespace view {
+class view_building_worker;
+}
+}
+
 namespace streaming {
 
 using file_stream_id = utils::tagged_uuid<struct file_stream_id_tag>;
@@ -116,7 +122,7 @@ struct stream_blob_info {
 };
 
 // The handler for the STREAM_BLOB verb.
-seastar::future<> stream_blob_handler(replica::database& db, netw::messaging_service& ms, locator::host_id from, streaming::stream_blob_meta meta, rpc::sink<streaming::stream_blob_cmd_data> sink, rpc::source<streaming::stream_blob_cmd_data> source);
+seastar::future<> stream_blob_handler(replica::database& db, db::view::view_building_worker& vbw, netw::messaging_service& ms, locator::host_id from, streaming::stream_blob_meta meta, rpc::sink<streaming::stream_blob_cmd_data> sink, rpc::source<streaming::stream_blob_cmd_data> source);
 
 // Exposed mainly for testing
 

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -307,7 +307,7 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
     ms.register_stream_blob([this] (const rpc::client_info& cinfo, streaming::stream_blob_meta meta, rpc::source<streaming::stream_blob_cmd_data> source) {
         const auto& from = cinfo.retrieve_auxiliary<locator::host_id>("host_id");
         auto sink = _ms.local().make_sink_for_stream_blob(source);
-        (void)stream_blob_handler(_db.local(), _ms.local(), from, meta, sink, source).handle_exception([ms = _ms.local().shared_from_this()] (std::exception_ptr eptr) {
+        (void)stream_blob_handler(_db.local(), _view_building_worker.local(), _ms.local(), from, meta, sink, source).handle_exception([ms = _ms.local().shared_from_this()] (std::exception_ptr eptr) {
             sslog.warn("Failed to run stream blob handler: {}", eptr);
         });
         return make_ready_future<rpc::sink<streaming::stream_blob_cmd_data>>(sink);


### PR DESCRIPTION
After https://github.com/scylladb/scylladb/pull/22034, staging status of sstables streamed
via file streaming was ignored and view updates were never generated.

This patch fixes it and now staging sstables are registered to
`view_building_worker`. Then, the worker create view building tasks
for those sstables, so the view building coordinator can schedule them
once the tablet migration is finished.

Fixes https://github.com/scylladb/scylla-enterprise/issues/4572

This fix affects only views on tablets, which are still experimental, so no backport needed.