### PR TITLE
tools/scylla-sstable: Enable `rf_rack_valid_keyspaces`

### DIFF
--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -3536,6 +3536,14 @@ $ scylla sstable validate /path/to/md-123456-big-Data.db /path/to/md-123457-big-
         dbcfg.enable_cache(false);
         dbcfg.volatile_system_keyspace_for_testing(true);
 
+        // Override whatever value the option has. Setting this to `true` is correct because
+        // schema loader doesn't attempt to create any keyspace and doesn't go through any
+        // validation code; there is no topology either. Thanks to that, we won't run into
+        // any problems due to enforcing RF-rack-valid keyspaces.
+        //
+        // On the other hand, we gain access to the code hidden behind the option
+        dbcfg.rf_rack_valid_keyspaces(true, ::utils::config_file::config_source::CommandLine);
+
         {
             unsigned schema_sources = 0;
             schema_sources += !app_config["schema-file"].defaulted();


### PR DESCRIPTION
Enabling the configuration option should have no negative impact on how the tool
behaves. There is no topology and we do not create any keyspaces (except for
trivial ones using `SimpleStrategy` and RF=1), only their metadata. Thanks to
that, we don't go through validation logic that could fail in presence of an
RF-rack-invalid keyspace.

On the other hand, enabling `rf_rack_valid_keyspaces` lets the tool access code
hidden behind that option. While that might not be of any consequence right now,
in the future it might be crucial (for instance, see: scylladb/scylladb#23030).

Note that other tools don't need an adjustment:

* scylla-types: it uses schema_builder, but it doesn't reuse any other
  relevant part of Scylla.
* nodetool: it manages Scylla instances but is not an instance itself, and it
  does not reuse any codepaths.
* local-file-key-generator: it has nothing to do with Scylla's logic.

Other files in the `tools` directory are auxiliary and are instructed with an
already created instance of `db::config`. Hence, no need to modify them either.

Fixes scylladb/scylladb#25792


Backport: not needed. This is an enhancement.