### PR TITLE
Allow users to SELECT from CDC log tables they created.

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -241,7 +241,10 @@ future<> select_statement::check_access(query_processor& qp, const service::clie
     try {
         const data_dictionary::database db = qp.db();
         auto&& s = db.find_schema(keyspace(), column_family());
-        auto& cf_name = s->is_view() ? s->view_info()->base_name() : column_family();
+        auto cdc = db.get_cdc_base_table(*s);
+        auto& cf_name = s->is_view()
+            ? s->view_info()->base_name()
+            : (cdc ? cdc->cf_name() : column_family());
         co_await state.has_column_family_access(keyspace(), cf_name, auth::permission::SELECT);
     } catch (const data_dictionary::no_such_column_family& e) {
         // Will be validated afterwards.

--- a/test/cqlpy/test_permissions.py
+++ b/test/cqlpy/test_permissions.py
@@ -673,7 +673,6 @@ def test_auto_grant_view(cql, test_keyspace):
 # then enables CDC. Both should work.
 # This is a scylla_only test because it tests the Scylla-only CDC feature.
 # Reproduces #19798:
-@pytest.mark.xfail(reason="issue #19798")
 @pytest.mark.parametrize("test_keyspace",
                          [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
                          indirect=True)
@@ -783,7 +782,7 @@ def test_auto_revoke_cdc(cql, test_keyspace, scylla_only):
             with eventually_new_named_table(user2_session, table, schema, extra):
                 # Now, permissions were auto-granted for user2, but user1
                 # no longer has permissions on this table.
-                #eventually_authorized(lambda: user2_session.execute(f'SELECT * FROM {table}_scylla_cdc_log')) # Reproduces #19798
+                eventually_authorized(lambda: user2_session.execute(f'SELECT * FROM {table}_scylla_cdc_log')) # Reproduces #19798
                 eventually_unauthorized(lambda: user1_session.execute(f'SELECT * FROM {table}_scylla_cdc_log'))
 
 # Test that an unprivileged user can read from *some* system tables, such


### PR DESCRIPTION
Before the patch, user with CREATE access could create a table with CDC or alter the table enabling CDC, but could not query a SELECT on the CDC table they created.
It was due to the fact, the SELECT permission was checked on the CDC log, and later it's "parent" - the keyspace, but not the base table, on which the user had SELECT permission automatically granted on CREATE.

This patch matches the behavior of querying the CDC log to the one implemented for Materialized Views:
1. No new permissions are granted on CREATE.
2. When querying SELECT, the permissions on base table SELECT are checked.

Fixes: https://github.com/scylladb/scylladb/issues/19798
Fixes: VECTOR-151