### PR TITLE
test/cqlpy: fix run-cassandra to run with Java 21

### DIFF
--- a/test/cqlpy/README.md
+++ b/test/cqlpy/README.md
@@ -241,14 +241,18 @@ install it manually, and this section explains how. It's very easy, and
 don't worry - you don't even need to learn how to run Cassandra, as the
 "test/cqlpy/run-cassandra" tool will do it for you.
 
-To be able to run Cassandra, you'll need either Java 8 or 11 installed on
-your system - Cassandra does not support more recent versions of Java.
+To be able to run Cassandra, it is recommended that you have either Java 8
+or 11 installed on your system. run-cassandra can actually run Cassandra 5
+(under protest) on Java 21, Cassandra 3 or 4 cannot.
 However, this old Java only needs to be installed *alongside* your favorite
 version of Java - it does not need to be the default Java on your system.
 The "run-cassandra" script will automatically pick the right version of
-Java from multiple versions installed on your system. On modern Fedora,
-installing Java 11 as a secondary Java is as simple as
-`sudo dnf install java-11`.
+Java from multiple versions installed on your system.
+
+On Fedora 41 and earlier, installing Java 11 as a secondary Java is as
+simple as `dnf install java-11`. On Fedora 42, to install java-11 alongside
+the system's default Java you need to ask to install it from Fedora 41:
+`dnf install --releasever=41 java-11-openjdk-headless.x86_64`
 
 ## Precompiled Cassandra
 The easiest way to get Cassandra is to get a pre-compiled tar.

--- a/test/cqlpy/run-cassandra
+++ b/test/cqlpy/run-cassandra
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
 
+# This script makes it easy to start Cassandra an run cqlpy tests against
+# it. This capability is useful for checking that a new cqlpy test that aims
+# to ensure behavior compatible with Cassandra - is actually compatible with
+# Cassandra.
+# Please refer to README.md for instructions how to get your choice of
+# Cassandra version and the Java needed to run it, and how to run this script.
+
 import sys
 import os
 import shutil
@@ -132,6 +139,42 @@ def run_cassandra_cmd(pid, dir):
               '--add-opens java.base/jdk.internal.util.jar=ALL-UNNAMED\n'
               '--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED\n',
               file=f)
+    # On JVM 17 and above, Cassandra 5's cassandra.in.sh reads the
+    # following file instead:
+    with open(os.path.join(confdir, 'jvm17-server.options'), 'w') as f:
+        print('-Djdk.attach.allowAttachSelf=true\n'
+              '-Djava.security.manager=allow\n'
+              '--add-exports java.base/jdk.internal.misc=ALL-UNNAMED\n'
+              '--add-exports java.base/jdk.internal.ref=ALL-UNNAMED\n'
+              '--add-exports java.base/sun.nio.ch=ALL-UNNAMED\n'
+              '--add-exports java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED\n'
+              '--add-exports java.rmi/sun.rmi.registry=ALL-UNNAMED\n'
+              '--add-exports java.rmi/sun.rmi.server=ALL-UNNAMED\n'
+              '--add-exports java.sql/java.sql=ALL-UNNAMED\n'
+              '--add-exports java.base/java.lang.ref=ALL-UNNAMED\n'
+              '--add-exports java.base/java.lang.reflect=ALL-UNNAMED\n'
+              '--add-opens java.base/java.lang.module=ALL-UNNAMED\n'
+              '--add-opens java.base/jdk.internal.loader=ALL-UNNAMED\n'
+              '--add-opens java.base/jdk.internal.ref=ALL-UNNAMED\n'
+              '--add-opens java.base/jdk.internal.reflect=ALL-UNNAMED\n'
+              '--add-opens java.base/jdk.internal.math=ALL-UNNAMED\n'
+              '--add-opens java.base/jdk.internal.module=ALL-UNNAMED\n'
+              '--add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED\n'
+              '--add-opens java.base/sun.nio.ch=ALL-UNNAMED\n'
+              '--add-opens java.base/java.io=ALL-UNNAMED\n'
+              '--add-opens java.base/java.nio=ALL-UNNAMED\n'
+              '--add-opens java.base/java.util.concurrent=ALL-UNNAMED\n'
+              '--add-opens java.base/java.util=ALL-UNNAMED\n'
+              '--add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED\n'
+              '--add-opens java.base/java.lang=ALL-UNNAMED\n'
+              '--add-opens java.base/java.math=ALL-UNNAMED\n'
+              '--add-opens java.base/java.lang.reflect=ALL-UNNAMED\n'
+              '--add-opens java.base/java.net=ALL-UNNAMED\n'
+              '--add-opens java.rmi/sun.rmi.transport.tcp=ALL-UNNAMED\n'
+              ,file=f)
+    # Current versions of Cassandra 5 refuse to run on Java 21
+    # without this environment variable.
+    env['CASSANDRA_JDK_UNSUPPORTED'] = 'true'
     return ([cassandra, '-f'], env)
 
 # Same as run_cassandra_cmd, just use SSL encryption for the CQL port (same


### PR DESCRIPTION
The script test/cqpy/run-cassandra aims to make it easy to run any version of Cassandra using whatever version of Java the user has installed. Sadly, the fact that Java keeps changing and the Cassandra developers are very slow to adapt to new Javas makes doing this non-trivial.

This patch makes it possible for run-cassandra to run Cassandra 5 on the Java 21 that is now the default on Fedora 42. Fedora 42 no longer carries antique version of Java (like Java 8 or 11), not even as an optional package.

Sadly, even with this patch it is not possible to run older versions of Cassandra (4 and 3) with Java 21, because the new Java is missing features such as Netty that the older Cassandra require. But at least it restores the ability to run our cqlpy tests against Cassandra 5.

Fixes #25822