### PR TITLE
alternator: Correct RCU undercount in BatchGetItem

### DIFF
--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -235,7 +235,7 @@ public:
         shared_ptr<cql3::selection::selection> selection,
         foreign_ptr<lw_shared_ptr<query::result>> query_result,
         shared_ptr<const std::optional<attrs_to_get>> attrs_to_get,
-        uint64_t& rcu_half_units);
+        uint64_t& response_size);
 
     static void describe_single_item(const cql3::selection::selection&,
         const std::vector<managed_bytes_opt>&,


### PR DESCRIPTION
The `describe_multi_item` function treated the last reference-captured argument as the number of used RCU half units. The caller `batch_get_item`, however, expected this parameter to hold an item size. This RCU value was then passed to
`rcu_consumed_capacity_counter::get_half_units`, treating the already-calculated RCU integer as if it were a size in bytes.

This caused a second conversion that undercounted the true RCU. During conversion, the number of bytes is divided by `RCU_BLOCK_SIZE_LENGTH` (=4KB), so the double conversion divided the number of bytes by 16KB.

The fix removes the second conversion in `describe_multi_item`.

Backport candidate, since it fixes a bug introduced in [88095919d0f5d4075c9d4d448d0e4939b07dc4a9](https://github.com/scylladb/scylladb/commit/88095919d0f5d4075c9d4d448d0e4939b07dc4a9) (>=2025.2).