### PR TITLE
interval: specialize for trivially copyable types

### DIFF
--- a/test/boost/nonwrapping_interval_test.cc
+++ b/test/boost/nonwrapping_interval_test.cc
@@ -370,3 +370,5 @@ BOOST_AUTO_TEST_CASE(range_deoverlap_tests) {
         BOOST_REQUIRE_EQUAL(interval<unsigned>({{4, false}}, {5}), deoverlapped[1]);
     }
 }
+
+static_assert(std::is_trivially_copyable_v<interval<dht::token>>);

--- a/utils/interval.hh
+++ b/utils/interval.hh
@@ -73,22 +73,12 @@ public:
 template <typename T>
 using interval_bound_const_ref = interval_bound<const T&>;
 
-template<typename T>
-class interval;
-
-// An interval which can have inclusive, exclusive or open-ended bounds on each end.
-// The end bound can be smaller than the start bound.
-template<typename T>
-class wrapping_interval {
+template <class T>
+class interval_data {
+    using bound = interval_bound<T>;
     template <typename U>
     using optional = std::optional<U>;
-public:
-    using bound = interval_bound<T>;
-    using bound_const_ref = interval_bound_const_ref<T>;
-
-    template <typename Transformer>
-    using transformed_type = typename std::remove_cv_t<std::remove_reference_t<std::invoke_result_t<Transformer, T>>>;
-private:
+protected:
     bool _start_exists = false;
     bool _start_inclusive = false;
     bool _end_exists = false;
@@ -110,7 +100,8 @@ private:
 #endif
     };
 public:
-    wrapping_interval(optional<bound> start, optional<bound> end, bool singular = false) {
+    constexpr interval_data() noexcept {}
+    interval_data(optional<bound> start, optional<bound> end, bool singular = false) {
 #ifdef DEBUG
         _start_poison = 0xDEADBEEFDEADBEEF;
         _end_poison = 0xDEADBEEFDEADBEEF;
@@ -136,7 +127,7 @@ public:
             }
         }
     }
-    wrapping_interval(T value) {
+    interval_data(T value) {
 #ifdef DEBUG
         _start_poison = 0xDEADBEEFDEADBEEF;
         _end_poison = 0xDEADBEEFDEADBEEF;
@@ -146,7 +137,7 @@ public:
         _singular = true;
         std::construct_at(&_start_value, std::move(value));
     }
-    wrapping_interval(const wrapping_interval& o)
+    interval_data(const interval_data& o)
             : _start_exists(o._start_exists)
             , _start_inclusive(o._start_inclusive)
             , _end_exists(o._end_exists)
@@ -170,7 +161,7 @@ public:
             }
         }
     }
-    wrapping_interval(wrapping_interval&& o) noexcept(std::is_nothrow_move_constructible_v<T>)
+    interval_data(interval_data&& o) noexcept(std::is_nothrow_move_constructible_v<T>)
             : _start_exists(o._start_exists)
             , _start_inclusive(o._start_inclusive)
             , _end_exists(o._end_exists)
@@ -194,7 +185,7 @@ public:
             }
         }
     }
-    wrapping_interval& operator=(const wrapping_interval& o) {
+    interval_data& operator=(const interval_data& o) {
         if (this != &o) {
             if (_start_exists) {
                 std::destroy_at(&_start_value);
@@ -226,7 +217,7 @@ public:
         }
         return *this;
     }
-    wrapping_interval& operator=(wrapping_interval&& o) noexcept(std::is_nothrow_move_constructible_v<T>) {
+    interval_data& operator=(interval_data&& o) noexcept(std::is_nothrow_move_constructible_v<T>) {
         if (this != &o) {
             if (_start_exists) {
                 std::destroy_at(&_start_value);
@@ -256,7 +247,7 @@ public:
         }
         return *this;
     }
-    ~wrapping_interval() {
+    ~interval_data() {
         if (_start_exists) {
             std::destroy_at(&_start_value);
         }
@@ -264,6 +255,35 @@ public:
             std::destroy_at(&_end_value);
         }
     }
+};
+
+template<typename T>
+class interval;
+
+// An interval which can have inclusive, exclusive or open-ended bounds on each end.
+// The end bound can be smaller than the start bound.
+template<typename T>
+class wrapping_interval : public interval_data<T> {
+    template <typename U>
+    using optional = std::optional<U>;
+protected:
+    // Bring base class members into scope
+    using interval_data<T>::_start_exists;
+    using interval_data<T>::_start_inclusive;
+    using interval_data<T>::_end_exists;
+    using interval_data<T>::_end_inclusive;
+    using interval_data<T>::_singular;
+    using interval_data<T>::_start_value;
+    using interval_data<T>::_end_value;
+public:
+    using bound = interval_bound<T>;
+    using bound_const_ref = interval_bound_const_ref<T>;
+
+    template <typename Transformer>
+    using transformed_type = typename std::remove_cv_t<std::remove_reference_t<std::invoke_result_t<Transformer, T>>>;
+public:
+    wrapping_interval(optional<bound> start, optional<bound> end, bool singular = false) : interval_data<T>(std::move(start), std::move(end), singular) {}
+    wrapping_interval(T value) : interval_data<T>(std::move(value)) {}
     constexpr wrapping_interval() : wrapping_interval({}, {}) { }
 private:
     // Bound wrappers for compile-time dispatch and safety.


### PR DESCRIPTION
Interval's copy and move constructors are full of branches since the two payload T:s are
optional and therefore have to be optionally-constructed. This can be eliminated for
trivially copyable types (like dht::token) by eliminating interval's user-defined special member
functions (constructors etc) in that special case.

In turn, this enables optimizations in the standard library (and our own containers) that
convert moves/copies of spans of such types into memcpy().

Minor optimization, not a candidate to backport.