### PR TITLE
fix gossiper empty host id during shadow round

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2084,7 +2084,7 @@ future<> gossiper::start_gossiping(gms::generation_type generation_nbr, applicat
         generation_nbr = gms::generation_type(_gcfg.force_gossip_generation());
         logger.warn("Use the generation number provided by user: generation = {}", generation_nbr);
     }
-    endpoint_state local_state = my_endpoint_state();
+    endpoint_state& local_state = my_endpoint_state();
     local_state.set_heart_beat_state_and_update_timestamp(heart_beat_state(generation_nbr));
     for (auto& entry : preload_local_states) {
         local_state.add_application_state(entry.first, entry.second);
@@ -2094,7 +2094,7 @@ future<> gossiper::start_gossiping(gms::generation_type generation_nbr, applicat
 
     co_await replicate(local_state, permit.id());
 
-    logger.info("Gossip started with local state: {}", local_state);
+    logger.info("Gossip started with local state: {}", my_endpoint_state());
     _enabled = true;
     _nr_run = 0;
     _scheduled_gossip_task.arm(INTERVAL);

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -2090,6 +2090,8 @@ future<> gossiper::start_gossiping(gms::generation_type generation_nbr, applicat
         local_state.add_application_state(entry.first, entry.second);
     }
 
+    co_await utils::get_local_injector().inject("gossiper_publish_local_state_pause", utils::wait_for_message(5min));
+
     co_await replicate(local_state, permit.id());
 
     logger.info("Gossip started with local state: {}", local_state);

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -125,6 +125,7 @@ private:
     future<> _failure_detector_loop_done{make_ready_future<>()} ;
 
     future<rpc::no_wait_type> background_msg(sstring type, noncopyable_function<future<>(gossiper&)> fn);
+    endpoint_state make_initial_endpoint_state(gms::generation_type generation_nbr, const application_state_map& preload_local_states);
 
 public:
     // Get current generation number for the given nodes

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -17,7 +17,6 @@ from test.pylib.manager_client import ManagerClient
 
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-@pytest.mark.xfail(reason="https://github.com/scylladb/scylladb/issues/25831")
 async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
     """
     Test gossiper race condition on bootstrap that can lead to an empty self host ID sent in replies to other nodes.

--- a/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
+++ b/test/cluster/test_gossiper_empty_self_id_on_shadow_round.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+
+from aiohttp import ServerDisconnectedError
+import pytest
+import asyncio
+import logging
+
+from test.cluster.conftest import skip_mode
+from test.cluster.util import get_coordinator_host
+from test.pylib.manager_client import ManagerClient
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+@pytest.mark.xfail(reason="https://github.com/scylladb/scylladb/issues/25831")
+async def test_gossiper_empty_self_id_on_shadow_round(manager: ManagerClient):
+    """
+    Test gossiper race condition on bootstrap that can lead to an empty self host ID sent in replies to other nodes.
+      1. Enable gossiper_publish_local_state_pause on one of the nodes to pause gossiper in
+        `gossiper::start_gossiping` when it has just created a self node entry in `_endpoint_state_map`
+         with an empty state.
+      2. Start nodes normally to allow them join the cluster.
+      3. Restart 1st node, to that will pause in `gossiper::start_gossiping`.
+      4. After it pauses, start second node and make sure it's making a gossip shadow round. At this step
+         if a fix is not in place, the second node will receive an empty host ID (which is a race).
+      5. After shadow round on the 2nd node done, unpause the 1st node.
+      6. Make sure nodes started successfully.
+    """
+
+    cmdline = [
+        '--logger-log-level=gossip=debug'
+    ]
+
+    cfg = {
+        'error_injections_at_startup': [
+            {
+                'name': 'gossiper_publish_local_state_pause'
+            }
+        ]
+    }
+
+    logging.info("Starting cluster normally")
+    node1 = await manager.server_add(cmdline=cmdline, start=False, config=cfg)
+    manager.server_add(cmdline=cmdline, start=False)
+    node1_log = await manager.server_open_log(node1.server_id)
+    node2 = await manager.server_add(cmdline=cmdline, start=False, seeds=[node1.ip_addr])
+    node2_log = await manager.server_open_log(node2.server_id)
+    task1 = asyncio.create_task(manager.server_start(node1.server_id))
+    task2 = asyncio.create_task(manager.server_start(node2.server_id))
+    await node1_log.wait_for("gossiper_publish_local_state_pause: waiting for message")
+    await manager.api.message_injection(node1.ip_addr, 'gossiper_publish_local_state_pause')
+    await task1
+    await task2
+
+    logging.info("Stopping cluster")
+    await manager.server_stop_gracefully(node1.server_id)
+    await manager.server_stop_gracefully(node2.server_id)
+
+    # Remember logs
+    paused_node_mark = await node1_log.mark()
+    reading_node_mark = await node2_log.mark()
+
+    logging.info("Restarting cluster")
+    # Start first node and make sure it's paused on gossiper_publish_local_state_pause
+    task1 = asyncio.create_task(
+        manager.server_start(node1.server_id, wait_interval=120))
+    await node1_log.wait_for("gossiper_publish_local_state_pause: waiting for message", from_mark=paused_node_mark)
+    logging.info("Found gossiper_publish_local_state_pause")
+    # After the first node started and paused in start_gossiping, start the second node/
+    task2 = asyncio.create_task(manager.server_start(node2.server_id))
+    # Make sure the 2nd node received a `get_endpoint_states` request response.
+    await node2_log.wait_for(f"Got get_endpoint_states response from {node1.ip_addr}", from_mark=reading_node_mark)
+    # Unpause the 1st node.
+    await manager.api.message_injection(node1.ip_addr, 'gossiper_publish_local_state_pause')
+    await task1
+    await task2


### PR DESCRIPTION
Populate the local state during gossiper initialization in `start_gossiping`,
preventing an empty state from being added to `_endpoint_state_map` and
returned in `get_endpoint_states` responses, that was causing an 'empty host id issue' on the other nodes during nodes restart.

Fixes scylladb/scylladb#25831
Fixes scylladb/scylladb#25803

Backport: The issue affects all current releases(2025.x), therefore this PR needs to be backported to all 2025.1-2025.3.