### PR TITLE
compaction: Use function when filtering compaction tasks for stopping

### DIFF
--- a/api/compaction_manager.cc
+++ b/api/compaction_manager.cc
@@ -117,8 +117,8 @@ void set_compaction_manager(http_context& ctx, routes& r, sharded<compaction_man
             auto& cm = db.get_compaction_manager();
             return parallel_for_each(tables, [&] (const table_info& ti) {
                 auto& t = db.find_column_family(ti.id);
-                return t.parallel_foreach_compaction_group_view([&] (compaction::compaction_group_view& ts) {
-                    return cm.stop_compaction(type, &ts);
+                return cm.stop_compaction(type, [&t] (const compaction::compaction_group_view* x) {
+                    return x->schema() == t.schema();
                 });
             });
         });

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -812,7 +812,7 @@ compaction_reenabler
 compaction_manager::stop_and_disable_compaction_no_wait(compaction_group_view& t, sstring reason) {
     compaction_reenabler cre(*this, t);
     try {
-        do_stop_ongoing_compactions(std::move(reason), &t, {});
+        do_stop_ongoing_compactions(std::move(reason), [&t] (const compaction_group_view* x) { return x == &t; } , {});
     } catch (...) {
         cmlog.error("Stopping ongoing compactions failed: {}.  Ignored", std::current_exception());
     }
@@ -1198,19 +1198,22 @@ future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_
 }
 
 std::vector<shared_ptr<compaction_task_executor>>
-compaction_manager::do_stop_ongoing_compactions(sstring reason, compaction_group_view* t, std::optional<sstables::compaction_type> type_opt) noexcept {
-    auto ongoing_compactions = get_compactions(t).size();
+compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<sstables::compaction_type> type_opt) noexcept {
+    auto ongoing_compactions = get_compactions(filter).size();
     auto tasks = _tasks
-            | std::views::filter([t, type_opt] (const auto& task) {
-                return (!t || task.compacting_table() == t) && (!type_opt || task.compaction_type() == *type_opt);
+            | std::views::filter([&filter, type_opt] (const auto& task) {
+                return filter(task.compacting_table()) && (!type_opt || task.compaction_type() == *type_opt);
             })
             | std::views::transform([] (auto& task) { return task.shared_from_this(); })
             | std::ranges::to<std::vector<shared_ptr<compaction_task_executor>>>();
     logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
     if (cmlog.is_enabled(level)) {
         std::string scope = "";
-        if (t) {
-            scope = fmt::format(" for table {}", *t);
+        if (!tasks.empty()) {
+            const compaction_group_view* t = tasks.front()->compacting_table();
+            if (std::find_if(tasks.begin(), tasks.end(), [t] (auto& x) { return x->compacting_table() != t; }) == tasks.end()) {
+                scope = fmt::format(" for table {}", *t);
+            }
         }
         if (type_opt) {
             scope += fmt::format(" {} type={}", scope.size() ? "and" : "for", *type_opt);
@@ -1222,8 +1225,12 @@ compaction_manager::do_stop_ongoing_compactions(sstring reason, compaction_group
 }
 
 future<> compaction_manager::stop_ongoing_compactions(sstring reason, compaction_group_view* t, std::optional<sstables::compaction_type> type_opt) noexcept {
+    return stop_ongoing_compactions(std::move(reason), [t] (const compaction_group_view* x) { return !t || x == t; }, type_opt);
+}
+
+future<> compaction_manager::stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view* t)> filter, std::optional<sstables::compaction_type> type_opt) noexcept {
     try {
-        auto tasks = do_stop_ongoing_compactions(std::move(reason), t, type_opt);
+        auto tasks = do_stop_ongoing_compactions(std::move(reason), std::move(filter), type_opt);
         bool task_stopped = true;
         co_await await_tasks(std::move(tasks), task_stopped);
     } catch (...) {
@@ -2388,7 +2395,7 @@ future<> compaction_manager::remove(compaction_group_view& t, sstring reason) no
 #endif
 }
 
-const std::vector<sstables::compaction_info> compaction_manager::get_compactions(compaction_group_view* t) const {
+const std::vector<sstables::compaction_info> compaction_manager::get_compactions(std::function<bool(const compaction_group_view*)> filter) const {
     auto to_info = [] (const compaction_task_executor& task) {
         sstables::compaction_info ret;
         ret.compaction_uuid = task.compaction_data().compaction_uuid;
@@ -2399,8 +2406,8 @@ const std::vector<sstables::compaction_info> compaction_manager::get_compactions
         ret.total_keys_written = task.compaction_data().total_keys_written;
         return ret;
     };
-    return _tasks | std::views::filter([t] (const compaction_task_executor& task) {
-                return (!t || task.compacting_table() == t) && task.compaction_running();
+    return _tasks | std::views::filter([&filter] (const compaction_task_executor& task) {
+                return filter(task.compacting_table());
             }) | std::views::transform(to_info) | std::ranges::to<std::vector>();
 }
 
@@ -2422,7 +2429,7 @@ bool compaction_manager::compaction_disabled(compaction_group_view& t) const {
     }
 }
 
-future<> compaction_manager::stop_compaction(sstring type, compaction_group_view* table) {
+future<> compaction_manager::stop_compaction(sstring type, std::function<bool(const compaction_group_view*)> filter) {
     sstables::compaction_type target_type;
     try {
         target_type = sstables::to_compaction_type(type);
@@ -2438,7 +2445,7 @@ future<> compaction_manager::stop_compaction(sstring type, compaction_group_view
     default:
         break;
     }
-    return stop_ongoing_compactions("user request", table, target_type);
+    return stop_ongoing_compactions("user request", std::move(filter), target_type);
 }
 
 void compaction_manager::propagate_replacement(compaction_group_view& t,

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -412,7 +412,7 @@ public:
         return _stats;
     }
 
-    const std::vector<sstables::compaction_info> get_compactions(compaction::compaction_group_view* t = nullptr) const;
+    const std::vector<sstables::compaction_info> get_compactions(std::function<bool(const compaction_group_view*)> filter = [] (auto) { return true; }) const;
 
     // Returns true if table has an ongoing compaction, running on its behalf
     bool has_table_ongoing_compaction(const compaction::compaction_group_view& t) const;
@@ -420,11 +420,12 @@ public:
     bool compaction_disabled(compaction::compaction_group_view& t) const;
 
     // Stops ongoing compaction of a given type.
-    future<> stop_compaction(sstring type, compaction::compaction_group_view* table = nullptr);
+    future<> stop_compaction(sstring type, std::function<bool(const compaction_group_view*)> filter = [] (auto) { return true; });
 
 private:
     std::vector<shared_ptr<compaction_task_executor>>
-    do_stop_ongoing_compactions(sstring reason, compaction_group_view* t, std::optional<sstables::compaction_type> type_opt) noexcept;
+    do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<sstables::compaction_type> type_opt) noexcept;
+    future<> stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<sstables::compaction_type> type_opt = {}) noexcept;
 
 public:
     // Stops ongoing compaction of a given table and/or compaction_type.


### PR DESCRIPTION
The compaction_manager::stop_compaction() method internally walks the list of tasks and compares each task's compacting_table (which is compaction group view pointer) with the given one. In case this stop_compaction() method is called via API for a specific table, the method walks the list of tasks for every compaction group from the table, thus resulting in nr_groups * nr_tasks complexity. Not terrible, but not nice either.

The proposal is to pass filtering function into the inner do_stop_ongoing_compactions() method. Some users will pass a simple "return true" lambda, but those that need to stop compactions for a specitif table (e.g. -- the API handler) will effectively walk the list of tasks once comparing the given compaction group's schema with the target table one (spoiler: eventually this place will also be simplified not to mess with replica::table at all).

One ugliness with the change is the way "scope" for logging message is collected. If all tasks belong to the same table, then "for table ..." is printed in logs. With the change the scope is no longer known instantly and is evaluated dynamically while walking the list of tasks.