### PR TITLE
Fix label parsing logic in backport check script

### DIFF
--- a/.github/workflows/add-label-when-promoted.yaml
+++ b/.github/workflows/add-label-when-promoted.yaml
@@ -54,10 +54,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AUTO_BACKPORT_TOKEN }}
         run: python .github/scripts/auto-backport.py --repo ${{ github.repository }} --base-branch ${{ github.ref }} --commits ${{ github.event.before }}..${{ github.sha }}
       - name: Check if a valid backport label exists and no backport_error
+        env:
+          LABELS_JSON: ${{ toJson(github.event.pull_request.labels) }}
         id: check_label
         run: |
-          labels_json='${{ toJson(github.event.pull_request.labels) }}'
-          echo "Checking labels: $(echo "$labels_json" | jq -r '.[].name')"
+          labels_json="$LABELS_JSON"
+          echo "Checking labels:"
+          echo "$labels_json" | jq -r '.[].name'
 
           # Check if a valid backport label exists
           if echo "$labels_json" | jq -e 'any(.[] | .name; test("backport/[0-9]+\\.[0-9]+$"))' > /dev/null; then


### PR DESCRIPTION
Previously, the script attempted to assign GitHub Actions expressions directly within a Bash string using '${{ ... }}', which is invalid syntax in shell scripts. This caused the label JSON to be treated as a literal string instead of actual data, leading to parsing failures and incorrect backport readiness checks.

This update ensures the label data is passed correctly via the LABELS_JSON environment variable, allowing jq to properly evaluate label names and conditions.

Fixes: PKG-74

**Bug fix for adding label action, no need for backporting**