### PR TITLE
test.py: add pytest-sugar plugin to the dependencies

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -42,6 +42,7 @@ debian_base_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-timeout
+    python3-pytest-sugar
     libsnappy-dev
     libjsoncpp-dev
     rapidjson-dev
@@ -94,6 +95,7 @@ fedora_packages=(
     python3-pytest
     python3-pytest-asyncio
     python3-pytest-timeout
+    python3-pytest-sugar
     python3-unidiff
     python3-humanfriendly
     python3-jinja2

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-42-20250729
+docker.io/scylladb/scylla-toolchain:fedora-42-20250907


### PR DESCRIPTION
This plugin allows having better terminal output with progress bar for the tests.

Closes scylladb/scylladb#25845

[avi: regenerate frozen toolchain]

no backport, since the improvements this is serving will not be backported either.