### PR TITLE
alternator: fix bug in combination of AttributeUpdates + ReturnValues

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -4179,9 +4179,6 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
             }
         }
     }
-    if (_returnvalues == returnvalues::ALL_OLD && previous_item) {
-        _return_attributes = std::move(*previous_item);
-    }
     if (_attribute_updates) {
         for (auto it = _attribute_updates->MemberBegin(); it != _attribute_updates->MemberEnd(); ++it) {
             // Note that it.key() is the name of the column, *it is the operation
@@ -4290,6 +4287,9 @@ update_item_operation::apply(std::unique_ptr<rjson::value> previous_item, api::t
         // There was no pre-existing item, and we're not creating one, so
         // don't report the new item in the returned Attributes.
         _return_attributes = rjson::null_value();
+    }
+    if (_returnvalues == returnvalues::ALL_OLD && previous_item) {
+        _return_attributes = std::move(*previous_item);
     }
     // ReturnValues=UPDATED_OLD/NEW never return an empty Attributes field,
     // even if a new item was created. Instead it should be missing entirely.

--- a/test/alternator/test_returnvalues.py
+++ b/test/alternator/test_returnvalues.py
@@ -258,6 +258,43 @@ def test_update_item_returnvalues_all_old(test_table_s):
         ExpressionAttributeValues={':val': 'cat'})
     assert not 'Attributes' in ret
 
+# UpdateItem has a separate code path for the new-style UpdateExpression,
+# and for the old style AttributeUpdates. The above test was for the new-
+# style, Let's also test the old-style code path - it may have separate bugs.
+# Specifically we had bug #25894 in cases where both the AttributeUpdates
+# handling and the ReturnValues need the same old item, and this test
+# reproduces this bug.
+def test_update_item_returnvalues_all_old_attributeupdates(test_table_s):
+    # With ReturnValues=ALL_OLD, the entire old value of the item (even
+    # attributes we did not modify) is returned in an "Attributes" attribute:
+    p = random_string()
+    # The AttributeUpdates "ADD" operation is one of the operations that
+    # needs the value of the previous item, and ReturnValues='ALL_OLD'
+    # needs it too, so it reproduces #25894.
+    test_table_s.put_item(Item={'p': p, 'a': 3, 'b': 'dog'})
+    ret=test_table_s.update_item(Key={'p': p}, ReturnValues='ALL_OLD',
+        AttributeUpdates={'a': {'Action': 'ADD', 'Value': 2}})
+    assert ret['Attributes'] == {'p': p, 'a': 3, 'b': 'dog'}
+    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {
+        'p': p, 'a': 5, 'b': 'dog'}
+    # The "DELETE" operation for sets is another operation that needs the
+    # value of the previous item, and reproduces #25894.
+    test_table_s.put_item(Item={'p': p, 'a': set([2, 4, 6, 7]), 'b': 'dog'})
+    ret=test_table_s.update_item(Key={'p': p}, ReturnValues='ALL_OLD',
+        AttributeUpdates={'a': {'Action': 'DELETE', 'Value': set([4, 5])}})
+    assert ret['Attributes'] == {'p': p, 'a': set([2, 4, 6, 7]), 'b': 'dog'}
+    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {
+        'p': p, 'a': set([2, 6, 7]), 'b': 'dog'}
+    # The "PUT" operation doesn't need the value of the previous item,
+    # so does not reproduce #25894, but still ReturnValues requires the
+    # previous item, so we mustn't forget to fetch it in this case too.
+    test_table_s.put_item(Item={'p': p, 'a': 'hi', 'c': 7})
+    ret=test_table_s.update_item(Key={'p': p}, ReturnValues='ALL_OLD',
+        AttributeUpdates={'a': {'Action': 'PUT', 'Value': 17}})
+    assert ret['Attributes'] == {'p': p, 'a': 'hi', 'c': 7}
+    assert test_table_s.get_item(Key={'p': p}, ConsistentRead=True)['Item'] == {
+            'p': p, 'a': 17, 'c': 7}
+
 def test_update_item_returnvalues_updated_old(test_table_s):
     # With ReturnValues=UPDATED_OLD, only the overwritten attributes of the
     # old item are returned in an "Attributes" attribute:


### PR DESCRIPTION
In test/alternator/test_returnvalues.py we had tests for the ReturnValues feature on UpdateItem requests - but we only tested UpdateItem requests with the "modern" UpdateExpression, and forgot to test the combination of ReturnValues with the old AttributeUpdates API.

It turns out this combination is buggy: when both ReturnValues=ALL_OLD and AttributeUpdates need the previous value of the item, we may wrongly std::move() the value out, and the operation will fail with a strange error:

    An error occurred (ValidationException) when calling the UpdateItem
    operation: JSON assert failed on condition 'IsObject()'

The fix in this patch is trivial - just move the std::move() to the correct place, after both UpdateExpression and AttributeUpdates handling is done.

This patch also includes a reproducing test, which fails before this patch and passes with it - and of course passes on DynamoDB. This test reproduces two cases where the bug happened, as well as one case where it didn't (to make sure we don't regress in what already worked).

Fixes #25894

This patch fixes a real bug, so should be backported to live branches. The bug requires very esoteric circumstances to reach (must use the old AttributeUpdates and specifically their "ADD" or "DELETE" operations,  and must also use ReturnValues specifically with ALL_OLD) but a specific application might be using exactly this combination and see this bug consistently.