### PR TITLE
api: tasks: task_manager: keep children identities in chunked_{array,…

### DIFF
--- a/api/api-doc/task_manager.json
+++ b/api/api-doc/task_manager.json
@@ -447,7 +447,7 @@
                "description":"The number of units completed so far"
             },
             "children_ids":{
-               "type":"array",
+               "type":"chunked_array",
                "items":{
                   "type":"task_identity"
                },

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -101,7 +101,7 @@ future<std::optional<tasks::task_status>> node_ops_virtual_task::get_status_help
         .entity = "",
         .progress_units = "",
         .progress = tasks::task_manager::task::progress{},
-        .children = started ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{}
+        .children = started ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : utils::chunked_vector<tasks::task_identity>{}
     };
 }
 

--- a/service/task_manager_module.cc
+++ b/service/task_manager_module.cc
@@ -157,7 +157,7 @@ future<std::optional<tasks::task_status>> tablet_virtual_task::wait(tasks::task_
     } else if (is_resize_task(task_type)) {
         auto new_tablet_count = _ss.get_token_metadata().tablets().get_tablet_map(table).tablet_count();
         res->status.state = new_tablet_count == tablet_count ? tasks::task_manager::task_state::suspended : tasks::task_manager::task_state::done;
-        res->status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{};
+        res->status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : utils::chunked_vector<tasks::task_identity>{};
     } else {
         res->status.children = co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper()));
     }
@@ -266,7 +266,7 @@ future<std::optional<status_helper>> tablet_virtual_task::get_status_helper(task
         if (task_info.tablet_task_id.uuid() == id.uuid()) {
             update_status(task_info, res.status, sched_nr);
             res.status.state = tasks::task_manager::task_state::running;
-            res.status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : std::vector<tasks::task_identity>{};
+            res.status.children = task_type == locator::tablet_task_type::split ? co_await get_children(get_module(), id, std::bind_front(&gms::gossiper::is_alive, &_ss.gossiper())) : utils::chunked_vector<tasks::task_identity>{};
             co_return res;
         }
     }

--- a/tasks/task_handler.cc
+++ b/tasks/task_handler.cc
@@ -189,7 +189,7 @@ future<utils::chunked_vector<task_status>> task_handler::get_status_recursively(
                             .host_id = tm.get_host_id(),
                             .task_id = child.task_status.id
                         };
-                    }) | std::ranges::to<std::vector<task_identity>>()
+                    }) | std::ranges::to<utils::chunked_vector<task_identity>>()
                 };
                 res.push_back(status);
 

--- a/tasks/task_handler.hh
+++ b/tasks/task_handler.hh
@@ -37,7 +37,7 @@ struct task_status {
     std::string entity;
     std::string progress_units;
     task_manager::task::progress progress;
-    std::vector<task_identity> children;
+    utils::chunked_vector<task_identity> children;
 };
 
 struct task_stats {


### PR DESCRIPTION
…vector}

task_status contains a vector of children identities. If the number of children is large, we may hit oversized allocation.

Change all types of children-related containers to chunked_vector. Modify the children type returned from task manager API.

Fixes: scylladb#25795.

Optimization; no backport