### PR TITLE
[Backport 2025.1] s3: Export memory usage gauge (metrics)

### DIFF
--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -11,6 +11,7 @@
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/core/metrics.hh>
 
 #include "utils/assert.hh"
 #include "utils/disk-error-handler.hh"
@@ -61,12 +62,14 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     semaphore _s3_clients_memory;
     std::unordered_map<sstring, s3_endpoint> _s3_endpoints;
     std::unique_ptr<config_updater> _config_updater;
+    seastar::metrics::metric_groups metrics;
 
     void update_config(const db::config&);
 
 public:
     struct config {
         size_t s3_clients_memory = 16 << 20; // 16M by default
+        bool skip_metrics_registration = false;
     };
 
     storage_manager(const db::config&, config cfg);


### PR DESCRIPTION
The memory usage is tracked with the help of a semaphore, so just export its "consumed" units.

One tricky place here is the need to skip metrics registration for scylla-sstable tool. The thing is that the tools starts the storage manager and sstables manager on start and then some of tool's operations may want to start both managers again (via cql environment) causing double metrics registration exception.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>

backport note: in 2025.1 scylla-sstable tool doesn't start storage manager (because #22321 is not there), so the whole "skip_metrics_reg." bit is not needed. Still it's here, always OFF

Fixes #25862

    (cherry picked from commit @b26816f80d7185a0fdff6b5b92d0d9c09b49aa27)

Parent PR: #25769
Conflicts resolved for #25863