### PR TITLE
compaction: handle exception in expected_total_workload

### DIFF
--- a/tasks/task_manager.cc
+++ b/tasks/task_manager.cc
@@ -122,7 +122,7 @@ future<std::optional<double>> task_manager::task::impl::expected_total_workload(
 }
 
 future<task_manager::task::progress> task_manager::task::impl::get_progress() const {
-    if (is_done()) {
+    if (is_complete()) {
         co_return co_await _children.get_progress(_status.progress_units);
     }
 


### PR DESCRIPTION
expected_total_workload methods of scrub compaction tasks create a vector of table_info based on table names. If any table was already dropped, then the exception is thrown. It leaves table_info in corrupted state and node crashes with `free(): invalid size`.

Return std::nullopt if an exception was thrown to indicate that total workload cannot be found.

Fixes: #25941.

No release branches affected