### PR TITLE
Fix for auth version change during node startup

### DIFF
--- a/auth/password_authenticator.cc
+++ b/auth/password_authenticator.cc
@@ -211,6 +211,10 @@ future<> password_authenticator::start() {
             return async([this] {
                 if (legacy_mode(_qp)) {
                     if (!_superuser_created_promise.available()) {
+                        // Counterintuitively, we mark promise as ready before any startup work
+                        // because wait_for_schema_agreement() below will block indefinitely
+                        // without cluster majority. In that case, blocking node startup
+                        // would lead to a cluster deadlock.
                         _superuser_created_promise.set_value();
                     }
                     _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as).get();

--- a/auth/roles-metadata.cc
+++ b/auth/roles-metadata.cc
@@ -47,7 +47,7 @@ future<bool> default_role_row_satisfies(
         std::function<bool(const cql3::untyped_result_set_row&)> p,
         std::optional<std::string> rolename) {
     const sstring query = seastar::format("SELECT * FROM {}.{} WHERE {} = ?",
-            get_auth_ks_name(qp),
+            meta::legacy::AUTH_KS,
             meta::roles_table::name,
             meta::roles_table::role_col_name);
 
@@ -68,7 +68,7 @@ future<bool> any_nondefault_role_row_satisfies(
         cql3::query_processor& qp,
         std::function<bool(const cql3::untyped_result_set_row&)> p,
         std::optional<std::string> rolename) {
-    const sstring query = seastar::format("SELECT * FROM {}.{}", get_auth_ks_name(qp), meta::roles_table::name);
+    const sstring query = seastar::format("SELECT * FROM {}.{}", meta::legacy::AUTH_KS, meta::roles_table::name);
 
     auto results = co_await qp.execute_internal(query, db::consistency_level::QUORUM
         , internal_distributed_query_state(), cql3::query_processor::cache_internal::no

--- a/auth/roles-metadata.hh
+++ b/auth/roles-metadata.hh
@@ -27,15 +27,15 @@ namespace meta {
 
 namespace roles_table {
 
-std::string_view creation_query();
-
 constexpr std::string_view name{"roles", 5};
 
 constexpr std::string_view role_col_name{"role", 4};
 
-}
+} // namespace roles_table
 
-}
+} // namespace meta
+
+namespace legacy {
 
 ///
 /// Check that the default role satisfies a predicate, or `false` if the default role does not exist.
@@ -55,4 +55,6 @@ future<bool> any_nondefault_role_row_satisfies(
         std::optional<std::string> rolename = {}
         );
 
-}
+} // namespace legacy
+
+} // namespace auth

--- a/auth/standard_role_manager.cc
+++ b/auth/standard_role_manager.cc
@@ -50,22 +50,11 @@ constexpr std::string_view name{"role_members" , 12};
 }
 
 namespace role_attributes_table {
+
 constexpr std::string_view name{"role_attributes", 15};
 
-static std::string_view creation_query() noexcept {
-    static const sstring instance = seastar::format(
-            "CREATE TABLE {}.{} ("
-            "  role text,"
-            "  name text,"
-            "  value text,"
-            "  PRIMARY KEY(role, name)"
-            ")",
-            meta::legacy::AUTH_KS,
-            name);
+}
 
-    return instance;
-}
-}
 }
 
 static logging::logger log("standard_role_manager");
@@ -153,6 +142,17 @@ const resource_set& standard_role_manager::protected_resources() const {
 }
 
 future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const {
+    static const sstring create_roles_query = fmt::format(
+            "CREATE TABLE {}.{} ("
+            "  {} text PRIMARY KEY,"
+            "  can_login boolean,"
+            "  is_superuser boolean,"
+            "  member_of set<text>,"
+            "  salted_hash text"
+            ")",
+            meta::legacy::AUTH_KS,
+            meta::roles_table::name,
+            meta::roles_table::role_col_name);
     static const sstring create_role_members_query = fmt::format(
             "CREATE TABLE {}.{} ("
             "  role text,"
@@ -161,13 +161,20 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
             ")",
             meta::legacy::AUTH_KS,
             meta::role_members_table::name);
-
-
+    static const sstring create_role_attributes_query = seastar::format(
+            "CREATE TABLE {}.{} ("
+            "  role text,"
+            "  name text,"
+            "  value text,"
+            "  PRIMARY KEY(role, name)"
+            ")",
+            meta::legacy::AUTH_KS,
+            meta::role_attributes_table::name);
     return when_all_succeed(
             create_legacy_metadata_table_if_missing(
                     meta::roles_table::name,
                     _qp,
-                    meta::roles_table::creation_query(),
+                    create_roles_query,
                     _migration_manager),
             create_legacy_metadata_table_if_missing(
                     meta::role_members_table::name,
@@ -177,13 +184,13 @@ future<> standard_role_manager::create_legacy_metadata_tables_if_missing() const
             create_legacy_metadata_table_if_missing(
                     meta::role_attributes_table::name,
                     _qp,
-                    meta::role_attributes_table::creation_query(),
+                    create_role_attributes_query,
                     _migration_manager)).discard_result();
 }
 
 future<> standard_role_manager::legacy_create_default_role_if_missing() {
     try {
-        const auto exists = co_await default_role_row_satisfies(_qp, &has_can_login, _superuser);
+        const auto exists = co_await legacy::default_role_row_satisfies(_qp, &has_can_login, _superuser);
         if (exists) {
             co_return;
         }
@@ -312,7 +319,7 @@ future<> standard_role_manager::start() {
                 }
                 co_await _migration_manager.wait_for_schema_agreement(_qp.db().real_database(), db::timeout_clock::time_point::max(), &_as);
 
-                if (co_await any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
+                if (co_await legacy::any_nondefault_role_row_satisfies(_qp, &has_can_login)) {
                     if (legacy_metadata_exists()) {
                         log.warn("Ignoring legacy user metadata since nondefault roles already exist.");
                     }

--- a/auth/standard_role_manager.hh
+++ b/auth/standard_role_manager.hh
@@ -100,7 +100,7 @@ private:
     future<> maybe_create_default_role();
     future<> maybe_create_default_role_with_retries();
 
-    future<> create_or_replace(std::string_view role_name, const role_config&, ::service::group0_batch&);
+    future<> create_or_replace(std::string_view auth_ks_name, std::string_view role_name, const role_config&, ::service::group0_batch&);
 
     future<> legacy_modify_membership(std::string_view role_name, std::string_view grantee_name, membership_change);
 


### PR DESCRIPTION
Before this patch we may trigger `SCYLLA_ASSERT(legacy_mode(_qp))`.
That's because some auth startup is done in the background
and assumes that auth version doesn't change in the middle
of the startup. But topology coordinator may decide to do
the migration at any time, regadless if auth service is
fully started on all nodes.

This change makes sure that in legacy startup flow we'll
always use old auth-v1 keyspace and therefore auth version
change in the middle won't negatively affect the flow.

Fixes https://github.com/scylladb/scylladb/issues/25505