### PR TITLE
alternator: nicer error message for integer overflow in list index

### DIFF
--- a/alternator/expressions.g
+++ b/alternator/expressions.g
@@ -184,7 +184,13 @@ path_component: NAME | NAMEREF;
 path returns [parsed::path p]:
     root=path_component           { $p.set_root($root.text); }
     (   '.' name=path_component   { $p.add_dot($name.text); }
-      | '[' INTEGER ']'           { $p.add_index(std::stoi($INTEGER.text)); }
+      | '[' INTEGER ']'           {
+                try {
+                    $p.add_index(std::stoi($INTEGER.text));
+                } catch(std::out_of_range&) {
+                    throw expressions_syntax_error("list index out of integer range");
+                }
+            }
     )*;
 
 /* See comment above why the "depth" counter was needed here */


### PR DESCRIPTION
In the DynamoDB API, when "a" is a list attribute, a[999] returns the 1000th element. But if the list isn't that long (e.g., it only has 5 elements), a[999] returns nothing - it's not an error.

But it turns out that when the index is so long that it can't even be parsed as an integer, e.g., 99999999999999, DynamoDB does report an error:

    Invalid ProjectionExpression: List index is not within the allowable range; index: [99999999999999]

Before this patch, Alternator also returned an error in this case, with the right type (ValidationException), but with a strange low-level error text:

    Failed parsing ProjectionExpression 'a[99999999999999]': std::out_of_range (stoi)

The problem was that the code (in alternator/expressions.g) ran stoi() without converting its std::out_of_range error to better a user-facing message. We do this in this patch, and the error message now looks like:

    Failed parsing ProjectionExpression 'a[99999999999999]': list index out of integer range

This patch also includes a test reproducing this error, which passes on DynamDB and on Alternator it fails before this patch and passes with the patch.

Trivial error-message improvement of unlikely error scenario, no need to backport.