### PR TITLE
test: deflake test_restart_leaving_replica_during_cleanup

### DIFF
--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -452,7 +452,7 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
 
         await asyncio.gather(*[manager.api.disable_injection(s.ip_addr, injection) for s in servers])
 
-        await asyncio.gather(*[manager.api.enable_tablet_balancing(s.ip_addr) for s in servers])
+        await manager.api.enable_tablet_balancing(servers[0].ip_addr)
 
         # Trigger tablet merge to reproduce #23481
         table_id = await manager.get_table_id(ks, 'test')

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -470,6 +470,10 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
                 return True
         await wait_for(tablets_merged, time.time() + 60)
 
+        # Workaround for https://github.com/scylladb/scylladb/issues/21779. We don't want the keyspace drop at the end
+        # of new_test_keyspace to fail because of concurrent tablet migrations.
+        await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):


### PR DESCRIPTION
The test started hitting #21779 recently. We deflake it in this commit
by disabling the tablet load balancing before dropping the keyspace at
the end of the test.

We still have to understand why the test started hitting #21779, so we
keep #25938 open.

Refs #25938

The test was flaky only on master, so no backport needed.