### PR TITLE
test: fix test_one_big_mutation_corrupted_on_startup

### DIFF
--- a/test/cluster/dtest/tools/files.py
+++ b/test/cluster/dtest/tools/files.py
@@ -8,14 +8,18 @@ import os
 import random
 
 
-def corrupt_file(file_path):
+def corrupt_file(file_path: str, chunk_size: int = 1024, percentage: float = 0.2) -> None:
     """
-    Corrupt a file by writing 1024 bytes of random data in 10 random locations in the file
+    Corrupts a file by overwriting random chunks of its content with random data.
+    Args:
+        file_path (str): The path to the file to be corrupted.
+        chunk_size (int, optional): The size of each random data chunk to write, in bytes.
+        percentage (float, optional): The percentage of the file to corrupt, represented as a float between 0 and 1.
     """
     with open(file_path, "r+b") as f:
         file_size = os.path.getsize(file_path)
-        random_data = os.urandom(1024)
-        for _ in range(10):
-            random_position = random.randint(0, max(file_size - 1024, 0))
+        chunks = int(file_size * percentage / chunk_size) or 1
+        for _ in range(chunks):
+            random_position = random.randint(0, max(file_size - chunk_size, 0))
             f.seek(random_position)
-            f.write(random_data)
+            f.write(os.urandom(chunk_size))


### PR DESCRIPTION
The commitlog in the tests with big mutations were corrupted by overwriting 10 chunks of 1KB with random data, which could not be enough due to randomness and the big size of the commitlog (~65MB).

- change `corrupt_file` to overwrite a based on a percentage of the file's size instead of fixed number of chunks
- fix typos
- cleanup comments for clarity

Closes: #25627

