### PR TITLE
service/storage_service: drain `view_building_worker` earlier

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1819,7 +1819,7 @@ sharded<locator::shared_token_metadata> token_metadata;
                 std::ref(feature_service), std::ref(mm), std::ref(token_metadata), std::ref(erm_factory),
                 std::ref(messaging), std::ref(repair),
                 std::ref(stream_manager), std::ref(lifecycle_notifier), std::ref(bm), std::ref(snitch),
-                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(qp), std::ref(sl_controller),
+                std::ref(tablet_allocator), std::ref(cdc_generation_service), std::ref(view_builder), std::ref(view_building_worker), std::ref(qp), std::ref(sl_controller),
                 std::ref(tsm), std::ref(vbsm), std::ref(task_manager), std::ref(gossip_address_map),
                 compression_dict_updated_callback,
                 only_on_shard0(&*disk_space_monitor_shard0)

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -77,6 +77,7 @@ class system_keyspace;
 class batchlog_manager;
 namespace view {
 class view_builder;
+class view_building_worker;
 }
 }
 
@@ -240,6 +241,7 @@ public:
         sharded<service::tablet_allocator>& tablet_allocator,
         sharded<cdc::generation_service>& cdc_gs,
         sharded<db::view::view_builder>& view_builder,
+        sharded<db::view::view_building_worker>& view_building_worker,
         cql3::query_processor& qp,
         sharded<qos::service_level_controller>& sl_controller,
         topology_state_machine& topology_state_machine,
@@ -581,6 +583,7 @@ private:
     sharded<service::tablet_allocator>& _tablet_allocator;
     sharded<cdc::generation_service>& _cdc_gens;
     sharded<db::view::view_builder>& _view_builder;
+    sharded<db::view::view_building_worker>& _view_building_worker;
     bool _isolated = false;
 private:
     /**

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -948,7 +948,7 @@ private:
                 std::ref(_snitch),
                 std::ref(_tablet_allocator),
                 std::ref(_cdc_generation_service),
-                std::ref(_view_builder),
+                std::ref(_view_builder), std::ref(_view_building_worker),
                 std::ref(_qp),
                 std::ref(_sl_controller),
                 std::ref(_topology_state_machine),


### PR DESCRIPTION
Similarly to view builder, view building worker needs to be drained in `storage_service::do_drain()`.

Storage service drain is happening at the same beginning of shutdown procedure. Before this patch, the worker was still building views after the storage service was drained and this caused errors like: `Error applying view update to (named_gate_closed_exception)` and `locator::no_such_tablet_map`.

Fixes scylladb/scylladb#25908

View building coordinator wasn't released yet, no backport needed.