### PR TITLE
db: optimize cache invalidation following repair/streaming

### DIFF
--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -133,6 +133,8 @@ public:
     bool is_dummy_entry() const noexcept { return _flags._dummy_entry; }
 };
 
+using cache_invalidation_filter = std::function<bool(const dht::decorated_key&)>;
+
 //
 // A data source which wraps another data source such that data obtained from the underlying data source
 // is cached in-memory in order to serve queries faster.
@@ -454,8 +456,8 @@ public:
     // completes will see all writes from the underlying
     // mutation source made prior to the call to invalidate().
     future<> invalidate(external_updater, const dht::decorated_key&);
-    future<> invalidate(external_updater, const dht::partition_range& = query::full_partition_range);
-    future<> invalidate(external_updater, dht::partition_range_vector&&);
+    future<> invalidate(external_updater, const dht::partition_range& = query::full_partition_range, cache_invalidation_filter filter = [] (const auto&) { return true; });
+    future<> invalidate(external_updater, dht::partition_range_vector&&, cache_invalidation_filter filter = [] (const auto&) { return true; });
 
     // Evicts entries from cache.
     //


### PR DESCRIPTION
Currently, if a new sstable is created during repair/streaming, we invalidate its whole token range in cache. If the sstable is sparse, we unnecessarily clear too much data.

Modify cache invalidation, so that only the partitions present in the sstable are cleared.

To check whether a partition is present in the sstable, we use bloom filters. Bloom filters may return false positives and show that an sstable contains a partition, even though it does not. Due to that we may invalidate a bit more than we need to, but the cache will be in valid state.

An issue arises when we do not invalidate two consecutive partitions that are continuous. The sstable may contain a token that falls between these partitions, breaking the continuity. To check that, we would need to scan sstable index. However, such a change would noticeably complicate the invalidation, both performance and code. In this change, sstable index reader isn't used. Instead, the continuity flag is unset for all scanned partitions. This comes at a cost of heavier reads, as we will need to verify continuity when reading more than one partition from cache.

Fixes: https://github.com/scylladb/scylladb/issues/9136.

Optimization; no backport