### PR TITLE
scylla-gdb: add `scylla prepared-statements`

### DIFF
--- a/test/scylla_gdb/test_misc.py
+++ b/test/scylla_gdb/test_misc.py
@@ -212,6 +212,9 @@ def test_read_stats(gdb, sstable):
 def test_get_config_value(gdb):
     scylla(gdb, f'get-config-value compaction_static_shares')
 
+def test_prepared_statements(gdb):
+    scylla(gdb, f'prepared-statements')
+
 @pytest.mark.without_scylla
 def test_run_without_scylla(scylla_gdb):
     # just try to load the scylla-gdb module without attaching to scylla.


### PR DESCRIPTION
Add a helper which prints all prepared statements currently present in the query processor.

Example output:
```
(gdb) scylla prepared-statements
(cql3::cql_statement*)(0x600003d71050): SELECT * FROM ks.ks WHERE pk = ?
(cql3::cql_statement*)(0x600003972b50): SELECT pk FROM ks.ks WHERE pk = ?
```

`scylla-gdb.py` enhancement, no backporting.