### PR TITLE
interval: fix ambiguous copy constructor in interval_bound

### DIFF
--- a/utils/interval.hh
+++ b/utils/interval.hh
@@ -53,9 +53,13 @@ public:
               : _value(std::move(value))
               , _inclusive(inclusive)
     { }
-    interval_bound(interval_bound<const T&> b) requires (!std::is_reference_v<T>)
+    interval_bound(const interval_bound& b) = default;
+    interval_bound(interval_bound&& b) = default;
+    interval_bound(const interval_bound<const T&>& b) requires (!std::is_reference_v<T>)
               : interval_bound(b.value(), b.is_inclusive())
     { }
+    interval_bound& operator=(const interval_bound&) = default;
+    interval_bound& operator=(interval_bound&&) = default;
     operator interval_bound<const T&>() const requires (!std::is_reference_v<T>) {
         return interval_bound<const T&>(_value, _inclusive);
     }


### PR DESCRIPTION
interval_bound<T> has a converting constructor from interval_bound<const T&>. Since, if T itself is a const reference (say, const int&), this looks like a copy constructor, it is constrained to only be available if T is not a reference type.

Clang 21.1 checks that copy constructors take their inputs by reference, and apparently performs this check before evaluating the constraint. As a result, it complains that this is an invalid copy constructor, even though it would be rejected by the constraint.

Fix this by massaging the converting constructor to look like a copy constructor, and add defaulted copy/move constructors/assignment to avoid the compiler omitting them (rule of 5).

The clang bug is tracked in https://github.com/llvm/llvm-project/issues/158475.

Preparing for a toolchain update; so no backport.