### PR TITLE
tablets: scheduler: Balance racks separately when rf_rack_valid_keyspaces is true

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -662,6 +662,7 @@ class load_balancer {
     // Holds tablet replica count per table in the balanced node set (within a single DC).
     absl::flat_hash_map<table_id, size_t> _tablet_count_per_table;
     dc_name _dc;
+    std::optional<sstring> _rack; // Set when plan making is limited to a single rack.
     size_t _total_capacity_shards; // Total number of non-drained shards in the balanced node set.
     size_t _total_capacity_nodes; // Total number of non-drained nodes in the balanced node set.
     uint64_t _total_capacity_storage; // Total storage of non-drained nodes in the balanced node set.
@@ -759,10 +760,19 @@ public:
 
         // Prepare plans for each DC separately and combine them to be executed in parallel.
         for (auto&& dc : topo.get_datacenters()) {
-            auto dc_plan = co_await make_plan(dc);
-            auto level = dc_plan.size() > 0 ? seastar::log_level::info : seastar::log_level::debug;
-            lblogger.log(level, "Prepared {} migrations in DC {}", dc_plan.size(), dc);
-            plan.merge(std::move(dc_plan));
+            if (_db.get_config().rf_rack_valid_keyspaces()) {
+                for (auto rack : topo.get_datacenter_racks().at(dc) | std::views::keys) {
+                    auto rack_plan = co_await make_plan(dc, rack);
+                    auto level = rack_plan.size() > 0 ? seastar::log_level::info : seastar::log_level::debug;
+                    lblogger.log(level, "Prepared {} migrations in rack {} in DC {}", rack_plan.size(), rack, dc);
+                    plan.merge(std::move(rack_plan));
+                }
+            } else {
+                auto dc_plan = co_await make_plan(dc);
+                auto level = dc_plan.size() > 0 ? seastar::log_level::info : seastar::log_level::debug;
+                lblogger.log(level, "Prepared {} migrations in DC {}", dc_plan.size(), dc);
+                plan.merge(std::move(dc_plan));
+            }
         }
 
         // Merge table-wide resize decisions, may emit new decisions, revoke or finalize ongoing ones.
@@ -2127,6 +2137,15 @@ public:
 
             for (auto&& r : tmap.get_tablet_info(tablet.tablet).replicas) {
                 viable_targets.erase(r.host);
+            }
+
+            if (_rack) {
+                // "nodes" contains only nodes from a single rack, and so does viable_targets.
+                // Therefore, rack overload constraints cannot possibly exclude any target.
+                return viable_targets;
+            }
+
+            for (auto&& r : tmap.get_tablet_info(tablet.tablet).replicas) {
                 auto* node = _tm->get_topology().find_node(r.host);
                 if (!node) {
                     on_internal_error(lblogger, format("Node {} not found in topology", r.host));
@@ -2156,7 +2175,7 @@ public:
             return viable_targets;
         };
 
-        if (dst_info.rack() != src_info.rack()) {
+        if (!_rack && dst_info.rack() != src_info.rack()) {
             auto targets = get_viable_targets();
             if (!targets.contains(dst_info.id)) {
                 auto new_rack_load = rack_load[dst_info.rack()] + 1;
@@ -2832,17 +2851,22 @@ public:
         }
     };
 
-    future<migration_plan> make_plan(dc_name dc) {
+    future<migration_plan> make_plan(dc_name dc, std::optional<sstring> rack = std::nullopt) {
         migration_plan plan;
 
         _dc = dc;
+        _rack = rack;
+
+        auto node_filter = [&] (const locator::node& node) {
+            return node.dc_rack().dc == dc && (!rack || node.dc_rack().rack == *rack);
+        };
 
         // Causes load balancer to move some tablet even though load is balanced.
         auto shuffle = in_shuffle_mode();
 
         _stats.for_dc(dc).calls++;
-        lblogger.debug("Examining DC {} (shuffle={}, balancing={}, tablets_per_shard_goal={})",
-                dc, shuffle, _tm->tablets().balancing_enabled(), _tablets_per_shard_goal);
+        lblogger.debug("Examining DC {} rack {} (shuffle={}, balancing={}, tablets_per_shard_goal={})",
+                dc, rack, shuffle, _tm->tablets().balancing_enabled(), _tablets_per_shard_goal);
 
         const locator::topology& topo = _tm->get_topology();
 
@@ -2876,7 +2900,7 @@ public:
         };
 
         _tm->for_each_token_owner([&] (const locator::node& node) {
-            if (node.dc_rack().dc != dc) {
+            if (!node_filter(node)) {
                 return;
             }
             bool is_drained = node.get_state() == locator::node::state::being_decommissioned
@@ -2923,7 +2947,7 @@ public:
                         on_internal_error(lblogger, format("Replica {} of tablet {} not found in topology",
                                                            r, global_tablet_id{table, tid}));
                     }
-                    if (node->left() && node->dc_rack().dc == dc) {
+                    if (node->left() && node_filter(*node)) {
                         ensure_node(r.host);
                         nodes_to_drain.insert(r.host);
                         nodes[r.host].drained = true;

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -61,11 +61,11 @@ async def test_not_enough_token_owners(manager: ManagerClient):
         # FIXME: Once scylladb/scylladb#16195 is fixed, we will have to replace the expected error message.
         # A similar change may be needed for remove_node below.
         logging.info(f'Trying to decommission {server_a} - one of the two token owners')
-        await manager.decommission_node(server_a.server_id, expected_error='Unable to find new replica for tablet')
+        await manager.decommission_node(server_a.server_id, expected_error='Decommission failed')
 
         logging.info(f'Stopping {server_a}')
         await manager.server_stop_gracefully(server_a.server_id)
 
         logging.info(f'Trying to remove {server_a}, one of the two token owners, by {server_b}')
         await manager.remove_node(server_b.server_id, server_a.server_id,
-                                  expected_error='Unable to find new replica for tablet')
+                                  expected_error='Removenode failed')

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -889,7 +889,7 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
 
         logger.info("Attempting removenode - expected to fail")
         await manager.remove_node(initiator_node.server_id, server_id=node_to_remove.server_id,
-                                expected_error="Removenode failed. See earlier errors (Rolled back: Failed to drain tablets: std::runtime_error (Unable to find new replica for tablet")
+                                expected_error="Removenode failed")
 
         logger.info(f"Replacing {node_to_remove} with a new node")
         replace_cfg = ReplaceConfig(replaced_id=node_to_remove.server_id, reuse_ip_addr = False, use_host_id=True, wait_replaced_dead=True)

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1466,7 +1466,7 @@ async def test_decommission_not_enough_racks(manager: ManagerClient):
             if s.rack == decommision_rack:
                 logger.debug(f"Decommissioning server={s}")
                 decommision_count += 1
-                expected_error = "Unable to find new replica for tablet" if decommision_count == nodes_per_rack else None
+                expected_error = "Decommission failed" if decommision_count == nodes_per_rack else None
                 await manager.decommission_node(s.server_id, expected_error=expected_error)
                 if not expected_error:
                     dead_servers[s.server_id] = s

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -27,6 +27,7 @@
 #include "schema/schema_builder.hh"
 #include "service/storage_proxy.hh"
 #include "db/system_keyspace.hh"
+#include "tools/utils.hh"
 
 #include "test/perf/perf.hh"
 #include "test/lib/log.hh"
@@ -37,6 +38,9 @@
 using namespace locator;
 using namespace replica;
 using namespace service;
+using namespace tools::utils;
+
+namespace bpo = boost::program_options;
 
 static seastar::abort_source aborted;
 
@@ -486,50 +490,72 @@ future<> run_simulations(const boost::program_options::variables_map& app_cfg) {
 
 namespace perf {
 
+void run_add_dec(const bpo::variables_map& opts) {
+    if (opts.contains("runs")) {
+        run_simulations(opts).get();
+    } else {
+        params p {
+            .iterations = opts["iterations"].as<int>(),
+            .nodes = opts["nodes"].as<int>(),
+            .tablets1 = opts["tablets1"].as<int>(),
+            .tablets2 = opts["tablets2"].as<int>(),
+            .rf1 = opts["rf1"].as<int>(),
+            .rf2 = opts["rf2"].as<int>(),
+            .shards = opts["shards"].as<int>(),
+        };
+        run_simulation(p).get();
+    }
+}
+
+using operation_func = std::function<void(const bpo::variables_map&)>;
+
+const std::vector<operation_option> global_options {};
+const std::vector<operation_option> global_positional_options{};
+
+const std::map<operation, operation_func> operations_with_func{
+    {
+        {{"rolling-add-dec",
+         "Sequence of bootstraps and decommissions with two tables",
+         "",
+         {
+            typed_option<int>("runs", "Number of simulation runs."),
+            typed_option<int>("iterations", 8, "Number of topology-changing cycles in each run."),
+            typed_option<int>("tablets1", 512, "Number of tablets for the first table."),
+            typed_option<int>("tablets2", 128, "Number of tablets for the second table."),
+            typed_option<int>("rf1", 1, "Replication factor for the first table."),
+            typed_option<int>("rf2", 1, "Replication factor for the second table."),
+            typed_option<int>("nodes", 3, "Number of nodes in the cluster."),
+            typed_option<int>("shards", 30, "Number of shards per node.")
+          }
+        }, &run_add_dec}
+    }
+};
+
 int scylla_tablet_load_balancing_main(int argc, char** argv) {
-    namespace bpo = boost::program_options;
-    app_template app;
-    app.add_options()
-            ("runs", bpo::value<int>(), "Number of simulation runs.")
-            ("iterations", bpo::value<int>()->default_value(8), "Number of topology-changing cycles in each run.")
-            ("nodes", bpo::value<int>(), "Number of nodes in the cluster.")
-            ("tablets1", bpo::value<int>(), "Number of tablets for the first table.")
-            ("tablets2", bpo::value<int>(), "Number of tablets for the second table.")
-            ("rf1", bpo::value<int>(), "Replication factor for the first table.")
-            ("rf2", bpo::value<int>(), "Replication factor for the second table.")
-            ("shards", bpo::value<int>(), "Number of shards per node.")
-            ("verbose", "Enables standard logging")
-            ;
-    return app.run(argc, argv, [&] {
-        return seastar::async([&] {
-            if (!app.configuration().contains("verbose")) {
-                auto testlog_level = logging::logger_registry().get_logger_level("testlog");
-                logging::logger_registry().set_all_loggers_level(seastar::log_level::warn);
-                logging::logger_registry().set_logger_level("testlog", testlog_level);
-            }
-            auto stop_test = defer([] {
-                aborted.request_abort();
-            });
-            logalloc::prime_segment_pool(memory::stats().total_memory(), memory::min_free_memory()).get();
-            try {
-                if (app.configuration().contains("runs")) {
-                    run_simulations(app.configuration()).get();
-                } else {
-                    params p {
-                        .iterations = app.configuration()["iterations"].as<int>(),
-                        .nodes = app.configuration()["nodes"].as<int>(),
-                        .tablets1 = app.configuration()["tablets1"].as<int>(),
-                        .tablets2 = app.configuration()["tablets2"].as<int>(),
-                        .rf1 = app.configuration()["rf1"].as<int>(),
-                        .rf2 = app.configuration()["rf2"].as<int>(),
-                        .shards = app.configuration()["shards"].as<int>(),
-                    };
-                    run_simulation(p).get();
-                }
-            } catch (seastar::abort_requested_exception&) {
-                // Ignore
-            }
+    const auto operations = operations_with_func | std::views::keys | std::ranges::to<std::vector>();
+    tool_app_template::config app_cfg{
+            .name = "perf-load-balancing",
+            .description = "Tests tablet load balancer in various scenarios",
+            .logger_name = testlog.name(),
+            .lsa_segment_pool_backend_size_mb = 100,
+            .operations = std::move(operations),
+            .global_options = &global_options,
+            .global_positional_options = &global_positional_options,
+            .db_cfg_ext = db_config_and_extensions()
+    };
+    tool_app_template app(std::move(app_cfg));
+
+    return app.run_async(argc, argv, [] (const operation& operation, const bpo::variables_map& app_config) {
+        auto stop_test = defer([] {
+            aborted.request_abort();
         });
+        try {
+            operations_with_func.at(operation)(app_config);
+            return 0;
+        } catch (seastar::abort_requested_exception&) {
+            // Ignore
+        }
+        return 1;
     });
 }
 


### PR DESCRIPTION
Greatly improves performance of plan making, because we don't consider
candidates in other racks, most of which will fail to be selected due
to replication constraints (no rack overload). Also (but minor)
reduces the overhead of candidate evaluation, as we don't have to
evaluate rack load.

Enabled only for rf_rack_valid_keyspaces because such setups guarantee
that we will not need (because we must not) move tablets across racks,
and we don't need to execute the general algorithm for the whole DC.

Tested with perf-load-balancing, which performs a single scale-out
operation on a cluster which initially has 10 nodes 88 shards each, 2
racks, RF=2, 70 tables, 256 tablets per table. Scale out adds 6 new
nodes (same shard count). Time to reballance the cluster (plan making
only, sum of all iterations, no streaming):

Before:  16 min 25 s
After:    0 min 25 s

Before, plan making cost (single incremental iteration) alternated
between fast (0.1 [s]) and slow (14.1 [s]):

  testlog - Rebalance iteration 7 took 14.156 [s]: mig=88, bad=88, first_bad=17741, eval=93874484, skiplist=0, skip: (load=0, rack=17653, node=0)
  testlog - Rebalance iteration 8 took 0.143 [s]: mig=88, bad=88, first_bad=88, eval=865407, skiplist=0, skip: (load=0, rack=0, node=0)

The slow run chose min and max nodes in different racks, hence the
fast path failed to find any candidates and we switched to exhaustive
search of candidates in other nodes.

After, all iterations are fast (0.1 [s] per rack, 0.2 [s] per plan-making). The plan is twice as large because it combines the output of two subsequent (pre-patch) plan-making calls.  

Fixes #26016
