### PR TITLE
treewide: move away from accessing httpd::request::query_parameters

### DIFF
--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -1066,7 +1066,7 @@ void set_column_family(http_context& ctx, routes& r, sharded<replica::database>&
     });
 
     cf::force_major_compaction.set(r, [&ctx, &db](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
-        if (req->query_parameters.contains("split_output")) {
+        if (!req->get_query_param("split_output").empty()) {
             fail(unimplemented::cause::API);
         }
         auto [ks, cf] = parse_fully_qualified_cf_name(req->get_path_param("name"));

--- a/test/boost/aws_error_injection_test.cc
+++ b/test/boost/aws_error_injection_test.cc
@@ -51,8 +51,8 @@ static void register_policy(const std::string& key, failure_policy policy) {
     auto close_client = deferred_close(cln);
     auto req = http::request::make("PUT", get_address(), "/");
     req._headers["Content-Length"] = "0";
-    req.query_parameters["Key"] = key;
-    req.query_parameters["Policy"] = std::to_string(std::to_underlying(policy));
+    req.set_query_param("Key", key);
+    req.set_query_param("Policy", std::to_string(std::to_underlying(policy)));
     cln.make_request(std::move(req), [](const http::reply&, input_stream<char>&&) -> future<> { return seastar::make_ready_future(); }).get();
 }
 

--- a/test/boost/encryption_at_rest_test.cc
+++ b/test/boost/encryption_at_rest_test.cc
@@ -1807,9 +1807,9 @@ static future<> configure_azure_mock_server(const std::string& host, const unsig
     auto close_client = deferred_close(cln);
     auto req = http::request::make("POST", host, "/config/error");
     req._headers["Content-Length"] = "0";
-    req.query_parameters["service"] = service;
-    req.query_parameters["error_type"] = error_type;
-    req.query_parameters["repeat"] = std::to_string(repeat);
+    req.set_query_param("service", service);
+    req.set_query_param("error_type", error_type);
+    req.set_query_param("repeat", std::to_string(repeat));
     co_await cln.make_request(std::move(req), [](const http::reply&, input_stream<char>&&) -> future<> { return seastar::make_ready_future(); });
 }
 

--- a/test/pylib/s3_server_mock.py
+++ b/test/pylib/s3_server_mock.py
@@ -87,11 +87,7 @@ class InjectingHandler(BaseHTTPRequestHandler):
 
     def parsed_qs(self):
         parsed_url = urlparse(self.path)
-        query_components = parse_qs(parsed_url.query)
-        for key in parsed_url.query.split('&'):
-            if '=' not in key:
-                query_components[key] = ['']
-        return query_components
+        return parse_qs(parsed_url.query, keep_blank_values=True)
 
     def do_GET(self):
         content_length = self.headers['Content-Length']
@@ -250,6 +246,8 @@ class InjectingHandler(BaseHTTPRequestHandler):
                                 </Error>"""
                 case _:
                     raise ValueError("Unknown policy")
+
+        raise ValueError(f"No matching response for POST request: path={path}, query={query}")
 
 
 # Mock server to setup `ThreadingHTTPServer` instance with custom request handler (see above), managing requests state

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -163,7 +163,11 @@ class scylla_rest_client {
                             std::optional<request_body> body = {}) {
         auto req = http::request::make(type, _host_name, path);
         auto url = req.get_url();
-        req.query_parameters = params;
+
+        for (const auto& [k, v] : params) {
+            req.set_query_param(k, v);
+        }
+
         if (body) {
             req.write_body(body->content_type, body->content);
         }

--- a/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
+++ b/utils/s3/credentials_providers/sts_assume_role_credentials_provider.cc
@@ -36,11 +36,11 @@ future<> sts_assume_role_credentials_provider::update_credentials() {
     auto req = http::request::make("POST", sts_host, "/");
     // Just set this version
     // https://github.com/aws/aws-sdk-cpp/blob/8d68be52dcad85095753e069a4355e241f1edb1c/generated/src/aws-cpp-sdk-sts/source/model/AssumeRoleRequest.cpp#L143
-    req.query_parameters["Version"] = "2011-06-15";
-    req.query_parameters["DurationSeconds"] = format("{}", session_duration);
-    req.query_parameters["Action"] = "AssumeRole";
-    req.query_parameters["RoleSessionName"] = format("{}", utils::make_random_uuid());
-    req.query_parameters["RoleArn"] = role_arn;
+    req.set_query_param("Version", "2011-06-15");
+    req.set_query_param("DurationSeconds", format("{}", session_duration));
+    req.set_query_param("Action", "AssumeRole");
+    req.set_query_param("RoleSessionName", format("{}", utils::make_random_uuid()));
+    req.set_query_param("RoleArn", role_arn);
     auto factory = std::make_unique<utils::http::dns_connection_factory>(sts_host, port, is_secured, sts_logger);
     retryable_http_client http_client(std::move(factory), 1, retryable_http_client::ignore_exception, http::experimental::client::retry_requests::yes, retry_strategy);
     co_await http_client.make_request(


### PR DESCRIPTION
Acecssing this member directly is deprecated, migrate code to use {get,set}_query_param() and friends instead.

Fixes: https://github.com/scylladb/scylladb/issues/26023

Preparation for seastar update, no backport required.