### PR TITLE
test_out_of_space_prevention.py: Fix flaky test_user_writes_rejection test

### DIFF
--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -74,7 +74,8 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
 
                     logger.info("Write data and verify it did not reach the target node")
                     query = next(write_generator(cf, 1))
-                    await cql.run_async(query)
+                    cl_quorum_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.QUORUM)
+                    await cql.run_async(query, execution_profile=cl_quorum_profile)
 
                     cl_one_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.ONE)
                     res = cql.execute(f"SELECT * from {cf} where pk = 0;", host=hosts[0], execution_profile=cl_one_profile)


### PR DESCRIPTION
The test starts a 3-node cluster and immediately creates a big file on one of the nodes, to trigger the out of space prevention to start rejecting writes on this node. Then a write is executed and checked it did not reach the node with critical disk utilization but reached the remaining nodes.

When not specified, a default LOCAL_ONE consistency level is used. This can cause the test to fail sporadically. At the time the check is executed, the data might not yet reach the node.

Use CL=QUORUM, with cql.run_async()

Fixes: https://github.com/scylladb/scylladb/issues/26004

No backport is required. The test has been introduced recently.