### PR TITLE
raft: disable caching for raft log.

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -365,6 +365,7 @@ schema_ptr system_keyspace::raft() {
 
             .set_comment("Persisted RAFT log, votes and snapshot info")
             .with_hash_version()
+            .set_caching_options(caching_options::get_disabled_caching_options())
             .build();
     }();
     return schema;


### PR DESCRIPTION
This change disables caching for raft log table due to the following reasons:
* Immediate reason is a deficiency in handling emerging range tombstones in the cache, which causes stalls.
* Long-term reason is that sequential reads from the raft log do not benefit from the cache, making it better to bypass it to free up space and avoid stalls.

Fixes scylladb/scylladb#26027

Backport: since this change fixes potential performance issue with task stalls, backport is needed to 2025.x 