### PR TITLE
sstables/trie: integrate BTI indexes with sstable readers and writers

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1510,7 +1510,7 @@ public:
 
         // Deduce the estimated keys based on the token range that will end up in this new sstable after the split.
         auto token_range_of_new_sst = _table_s.get_token_range_after_split(dk.token());
-        const auto estimated_keys = _sstables[0]->estimated_keys_for_range(token_range_of_new_sst);
+        const auto estimated_keys = _sstables[0]->estimated_keys_for_range(token_range_of_new_sst).get();
 
         auto monitor = std::make_unique<compaction_write_monitor>(sst, _table_s, maximum_timestamp(), _sstable_level);
         sstable_writer_config cfg = make_sstable_writer_config(_type);

--- a/db/cache_tracker.hh
+++ b/db/cache_tracker.hh
@@ -81,6 +81,8 @@ public:
 private:
     stats _stats{};
     cached_file_stats _index_cached_file_stats{};
+    cached_file_stats _partitions_cached_file_stats{};
+    cached_file_stats _rows_cached_file_stats{};
     partition_index_cache_stats _partition_index_cache_stats{};
     seastar::metrics::metric_groups _metrics;
     logalloc::region _region;
@@ -138,6 +140,8 @@ public:
     void set_compaction_scheduling_group(seastar::scheduling_group);
     lru& get_lru() { return _lru; }
     cached_file_stats& get_index_cached_file_stats() { return _index_cached_file_stats; }
+    cached_file_stats& get_partitions_cached_file_stats() { return _partitions_cached_file_stats; }
+    cached_file_stats& get_rows_cached_file_stats() { return _rows_cached_file_stats; }
     partition_index_cache_stats& get_partition_index_cache_stats() { return _partition_index_cache_stats; }
     seastar::memory::reclaiming_result evict_from_lru_shallow() noexcept;
 };

--- a/db/config.cc
+++ b/db/config.cc
@@ -1517,7 +1517,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , tablet_load_stats_refresh_interval_in_seconds(this, "tablet_load_stats_refresh_interval_in_seconds", liveness::LiveUpdate, value_status::Used, 60,
         "Tablet load stats refresh rate in seconds.")
     , sstable_index_write_formats(this, "sstable_index_write_formats", liveness::LiveUpdate, value_status::Used, {},
-        "SSTable index file formats for newly created sstables. This must be a subset of set {`big`, `bti`}. `big` is always implicitly added to the set.")
+        "SSTable index file formats for newly created sstables. This must be a subset of set {`big`, `bti`}. If empty, defaults to {`big`}.")
     , sstable_index_preferred_read_formats(this, "sstable_index_preferred_read_formats", liveness::LiveUpdate, value_status::Used, {},
         "Preferred SSTable index file for use during reads, in order of decreasing preference. This is a list with elements `big` and/or `bti`. Unlisted formats are implicitly appended to the end of the list, in order: `big`, `bti`.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")

--- a/db/config.hh
+++ b/db/config.hh
@@ -162,6 +162,14 @@ struct tablets_mode_t {
     static std::unordered_map<sstring, mode> map(); // for enum_option<>
 };
 
+struct sstable_index_format_t {
+    enum class mode : int8_t {
+        big,
+        bti,
+    };
+    static std::unordered_map<sstring, mode> map(); // for enum_option<>
+};
+
 class config final : public utils::config_file {
 public:
     config();
@@ -602,6 +610,9 @@ public:
     named_value<bool> rf_rack_valid_keyspaces;
 
     named_value<uint32_t> tablet_load_stats_refresh_interval_in_seconds;
+
+    named_value<std::vector<enum_option<sstable_index_format_t>>> sstable_index_write_formats;
+    named_value<std::vector<enum_option<sstable_index_format_t>>> sstable_index_preferred_read_formats;
 
     static const sstring default_tls_priority;
 private:

--- a/db/size_estimates_virtual_reader.cc
+++ b/db/size_estimates_virtual_reader.cc
@@ -158,7 +158,7 @@ static dht::partition_range as_ring_position_range(dht::token_range& r) {
 /**
  * Add a new range_estimates for the specified range, considering the sstables associated with `cf`.
  */
-static system_keyspace::range_estimates estimate(const replica::column_family& cf, const token_range& r) {
+static future<system_keyspace::range_estimates> estimate(const replica::column_family& cf, const token_range& r) {
     int64_t count{0};
     utils::estimated_histogram hist{0};
     auto from_bytes = [] (auto& b) {
@@ -172,11 +172,11 @@ static system_keyspace::range_estimates estimate(const replica::column_family& c
     for (auto&& r : ranges) {
         auto rp_range = as_ring_position_range(r);
         for (auto&& sstable : cf.select_sstables(rp_range)) {
-            count += sstable->estimated_keys_for_range(r);
+            count += co_await sstable->estimated_keys_for_range(r);
             hist.merge(sstable->get_stats_metadata().estimated_partition_size);
         }
     }
-    return {cf.schema(), r.start, r.end, count, count > 0 ? hist.mean() : 0};
+    co_return system_keyspace::range_estimates{cf.schema(), r.start, r.end, count, count > 0 ? hist.mean() : 0};
 }
 
 /**
@@ -235,22 +235,20 @@ future<> size_estimates_mutation_reader::get_next_partition() {
     }
     if (_current_partition == _keyspaces->end()) {
         _end_of_stream = true;
-        return make_ready_future<>();
+        co_return;
     }
-    return do_with(reader_permit::awaits_guard(_permit), [this] (reader_permit::awaits_guard&) {
-        return get_local_ranges(_db, _sys_ks);
-    }).then([this] (auto&& ranges) {
-        auto estimates = this->estimates_for_current_keyspace(std::move(ranges));
-        auto mutations = db::system_keyspace::make_size_estimates_mutation(*_current_partition, std::move(estimates));
-        ++_current_partition;
-        utils::chunked_vector<mutation> ms;
-        ms.emplace_back(std::move(mutations));
-        auto reader = make_mutation_reader_from_mutations(_schema, _permit, std::move(ms), _fwd);
-        auto close_partition_reader = _partition_reader ? _partition_reader->close() : make_ready_future<>();
-        return close_partition_reader.then([this, reader = std::move(reader)] () mutable {
-            _partition_reader = std::move(reader);
-        });
-    });
+    auto guard = reader_permit::awaits_guard(_permit);
+    auto ranges = co_await get_local_ranges(_db, _sys_ks);
+    auto estimates = co_await this->estimates_for_current_keyspace(std::move(ranges));
+    auto mutations = db::system_keyspace::make_size_estimates_mutation(*_current_partition, std::move(estimates));
+    ++_current_partition;
+    utils::chunked_vector<mutation> ms;
+    ms.emplace_back(std::move(mutations));
+    auto reader = make_mutation_reader_from_mutations(_schema, _permit, std::move(ms), _fwd);
+    if (_partition_reader) {
+        co_await close_partition_reader();
+    }
+    _partition_reader = std::move(reader);
 }
 
 future<> size_estimates_mutation_reader::close_partition_reader() noexcept {
@@ -303,7 +301,7 @@ future<> size_estimates_mutation_reader::close() noexcept {
     return close_partition_reader();
 }
 
-std::vector<db::system_keyspace::range_estimates>
+future<std::vector<db::system_keyspace::range_estimates>>
 size_estimates_mutation_reader::estimates_for_current_keyspace(std::vector<token_range> local_ranges) const {
     // For each specified range, estimate (crudely) mean partition size and partitions count.
     auto pkey = partition_key::from_single_value(*_schema, utf8_type->decompose(*_current_partition));
@@ -323,13 +321,13 @@ size_estimates_mutation_reader::estimates_for_current_keyspace(std::vector<token
         auto rows_to_estimate = range.slice(rows, virtual_row_comparator(_schema));
         for (auto&& r : rows_to_estimate) {
             auto& cf = _db.find_column_family(*_current_partition, utf8_type->to_string(r.cf_name));
-            estimates.push_back(estimate(cf, r.tokens));
+            estimates.push_back(co_await estimate(cf, r.tokens));
             if (estimates.size() >= _slice.partition_row_limit()) {
-                return estimates;
+                co_return estimates;
             }
         }
     }
-    return estimates;
+    co_return estimates;
 }
 
 } // namespace size_estimates

--- a/db/size_estimates_virtual_reader.hh
+++ b/db/size_estimates_virtual_reader.hh
@@ -50,7 +50,7 @@ private:
     future<> get_next_partition();
     future<> close_partition_reader() noexcept;
 
-    std::vector<db::system_keyspace::range_estimates>
+    future<std::vector<db::system_keyspace::range_estimates>>
     estimates_for_current_keyspace(std::vector<token_range> local_ranges) const;
 };
 

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -661,6 +661,7 @@ public:
                             sstables::component_type::TemporaryStatistics,
                             sstables::component_type::Partitions,
                             sstables::component_type::Rows,
+                            sstables::component_type::TemporaryHashes,
             }) {
                 if (mask & (1 << int(c))) {
                     ccs.emplace_back(c);
@@ -829,6 +830,7 @@ public:
         case sstables::component_type::TemporaryStatistics:
         case sstables::component_type::Partitions:
         case sstables::component_type::Rows:
+        case sstables::component_type::TemporaryHashes:
         case sstables::component_type::Unknown:
             break;
         }
@@ -859,6 +861,7 @@ public:
         case sstables::component_type::TemporaryStatistics:
         case sstables::component_type::Rows:
         case sstables::component_type::Partitions:
+        case sstables::component_type::TemporaryHashes:
         case sstables::component_type::Unknown:
             auto [id, esx] = get_encryption_schema_extension(sst, type);
             if (esx) {

--- a/ent/encryption/encryption.cc
+++ b/ent/encryption/encryption.cc
@@ -648,7 +648,7 @@ public:
 
         if (exta->map.count(encrypted_components_attribute_ds)) {
             std::vector<sstables::component_type> ccs;
-            ccs.reserve(9);
+            ccs.reserve(11);
             auto mask = ser::deserialize_from_buffer(exta->map.at(encrypted_components_attribute_ds).value, std::type_identity<uint32_t>{}, 0);
             for (auto c : { sstables::component_type::Index,
                             sstables::component_type::CompressionInfo,
@@ -659,6 +659,8 @@ public:
                             sstables::component_type::Filter,
                             sstables::component_type::Statistics,
                             sstables::component_type::TemporaryStatistics,
+                            sstables::component_type::Partitions,
+                            sstables::component_type::Rows,
             }) {
                 if (mask & (1 << int(c))) {
                     ccs.emplace_back(c);
@@ -825,6 +827,8 @@ public:
         case sstables::component_type::Filter:
         case sstables::component_type::Statistics:
         case sstables::component_type::TemporaryStatistics:
+        case sstables::component_type::Partitions:
+        case sstables::component_type::Rows:
         case sstables::component_type::Unknown:
             break;
         }
@@ -853,6 +857,8 @@ public:
         case sstables::component_type::Statistics:
         case sstables::component_type::Summary:
         case sstables::component_type::TemporaryStatistics:
+        case sstables::component_type::Rows:
+        case sstables::component_type::Partitions:
         case sstables::component_type::Unknown:
             auto [id, esx] = get_encryption_schema_extension(sst, type);
             if (esx) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -170,6 +170,7 @@ public:
     gms::feature lwt_with_tablets { *this, "LWT_WITH_TABLETS"sv };
     gms::feature repair_msg_split { *this, "REPAIR_MSG_SPLIT"sv };
     gms::feature view_building_coordinator { *this, "VIEW_BUILDING_COORDINATOR"sv };
+    gms::feature bti_sstable_index { *this, "BTI_SSTABLE_INDEX"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -629,9 +629,8 @@ future<uint64_t> estimate_partitions(seastar::sharded<replica::database>& db, co
             // not trivial sum). We shouldn't have this ugly code here...
             // FIXME: If sstables are shared, they will be accounted more than
             // once. However, shared sstables should exist for a short-time only.
-            auto sstables = db.find_column_family(keyspace, cf).get_sstables();
-            return std::ranges::fold_left(*sstables, uint64_t(0),
-                [&range] (uint64_t x, auto&& sst) { return x + sst->estimated_keys_for_range(range); });
+            const auto& table = db.find_column_family(keyspace, cf);
+            return table.estimated_partitions_in_range(range);
         },
         uint64_t(0),
         std::plus<uint64_t>()

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -1066,13 +1066,7 @@ private:
 
     future<uint64_t> do_estimate_partitions_on_local_shard() {
         auto& cf = _db.local().find_column_family(_schema->id());
-        lw_shared_ptr<const sstable_list> sstables = cf.get_sstables();
-        uint64_t partition_count = 0;
-        for (const sstables::shared_sstable& sst : *sstables) {
-            partition_count += sst->estimated_keys_for_range(_range);
-            co_await coroutine::maybe_yield();
-        }
-        co_return partition_count;
+        return cf.estimated_partitions_in_range(_range);
     }
 
     future<uint64_t> get_estimated_partitions() {

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1364,6 +1364,7 @@ public:
 
     future<compaction_reenablers_and_lock_holders> get_compaction_reenablers_and_lock_holders_for_repair(replica::database& db,
             const service::frozen_topology_guard& guard, dht::token_range range);
+    future<uint64_t> estimated_partitions_in_range(dht::token_range tr) const;
 private:
     future<std::vector<compaction::compaction_group_view*>> get_compaction_group_views_for_repair(dht::token_range range);
 };

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4562,8 +4562,7 @@ future<uint64_t> table::estimated_partitions_in_range(dht::token_range tr) const
     auto sstables = select_sstables(dht::to_partition_range(tr));
     uint64_t partition_count = 0;
     co_await seastar::max_concurrent_for_each(sstables, 10, [&partition_count, &tr] (sstables::shared_sstable sst) -> future<> {
-        partition_count += sst->estimated_keys_for_range(tr);
-        co_return;
+        partition_count += co_await sst->estimated_keys_for_range(tr);
     });
     co_return partition_count;
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -7674,67 +7674,6 @@ future<> storage_service::force_remove_completion() {
     return make_exception_future<>(std::runtime_error("The unsafe nodetool removenode force is not supported anymore"));
 }
 
-/**
- * Takes an ordered list of adjacent tokens and divides them in the specified number of ranges.
- */
-static std::vector<std::pair<dht::token_range, uint64_t>>
-calculate_splits(std::vector<dht::token> tokens, uint64_t split_count, replica::column_family& cf) {
-    auto sstables = cf.get_sstables();
-    const double step = static_cast<double>(tokens.size() - 1) / split_count;
-    auto prev_token_idx = 0;
-    std::vector<std::pair<dht::token_range, uint64_t>> splits;
-    splits.reserve(split_count);
-    for (uint64_t i = 1; i <= split_count; ++i) {
-        auto index = static_cast<uint32_t>(std::round(i * step));
-        dht::token_range range({{ std::move(tokens[prev_token_idx]), false }}, {{ tokens[index], true }});
-        // always return an estimate > 0 (see CASSANDRA-7322)
-        uint64_t estimated_keys_for_range = 0;
-        for (auto&& sst : *sstables) {
-            estimated_keys_for_range += sst->estimated_keys_for_range(range);
-        }
-        splits.emplace_back(std::move(range), std::max(static_cast<uint64_t>(cf.schema()->min_index_interval()), estimated_keys_for_range));
-        prev_token_idx = index;
-    }
-    return splits;
-};
-
-std::vector<std::pair<dht::token_range, uint64_t>>
-storage_service::get_splits(const sstring& ks_name, const sstring& cf_name, wrapping_interval<dht::token> range, uint32_t keys_per_split) {
-    using range_type = dht::token_range;
-    auto& cf = _db.local().find_column_family(ks_name, cf_name);
-    auto schema = cf.schema();
-    auto sstables = cf.get_sstables();
-    uint64_t total_row_count_estimate = 0;
-    std::vector<dht::token> tokens;
-    std::vector<range_type> unwrapped;
-    if (range.is_wrap_around(dht::token_comparator())) {
-        auto uwr = range.unwrap();
-        unwrapped.emplace_back(std::move(uwr.second));
-        unwrapped.emplace_back(std::move(uwr.first));
-    } else {
-        unwrapped.emplace_back(std::move(range));
-    }
-    tokens.push_back(std::move(unwrapped[0].start_copy().value_or(range_type::bound(dht::minimum_token()))).value());
-    for (auto&& r : unwrapped) {
-        std::vector<dht::token> range_tokens;
-        for (auto &&sst : *sstables) {
-            total_row_count_estimate += sst->estimated_keys_for_range(r);
-            auto keys = sst->get_key_samples(*cf.schema(), r);
-            std::transform(keys.begin(), keys.end(), std::back_inserter(range_tokens), [](auto&& k) { return std::move(k.token()); });
-        }
-        std::sort(range_tokens.begin(), range_tokens.end());
-        std::move(range_tokens.begin(), range_tokens.end(), std::back_inserter(tokens));
-    }
-    tokens.push_back(std::move(unwrapped[unwrapped.size() - 1].end_copy().value_or(range_type::bound(dht::maximum_token()))).value());
-
-    // split_count should be much smaller than number of key samples, to avoid huge sampling error
-    constexpr uint32_t min_samples_per_split = 4;
-    uint64_t max_split_count = tokens.size() / min_samples_per_split + 1;
-    uint64_t split_count = std::max(uint64_t(1), std::min(max_split_count, total_row_count_estimate / keys_per_split));
-
-    return calculate_splits(std::move(tokens), split_count, cf);
-};
-
 future<dht::token_range_vector>
 storage_service::get_ranges_for_endpoint(const locator::effective_replication_map& erm, const locator::host_id& ep) const {
     return erm.get_ranges(ep);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -685,14 +685,6 @@ public:
     inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace,
             const sstring& cf, const sstring& key) const;
 
-    /**
-     * @return Vector of Token ranges (_not_ keys!) together with estimated key count,
-     *      breaking up the data this node is responsible for into pieces of roughly keys_per_split
-     */
-    std::vector<std::pair<dht::token_range, uint64_t>> get_splits(const sstring& ks_name,
-            const sstring& cf_name,
-            wrapping_interval<dht::token> range,
-            uint32_t keys_per_split);
 public:
     future<> decommission();
 

--- a/sstables/abstract_index_reader.hh
+++ b/sstables/abstract_index_reader.hh
@@ -165,7 +165,7 @@ public:
     // Returns data file positions corresponding to the bounds.
     // End position may be unset
     virtual data_file_positions_range data_file_positions() const = 0;
-    // Returns the offset in the data file of the first row in the last promoted index block
+    // Returns the offset (from partition start) of the first row in the last promoted index block
     // in the current partition or nullopt if there are no blocks in the current partition.
     //
     // Preconditions: partition_data_ready()

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -27,6 +27,8 @@ enum class component_type {
     TemporaryTOC,
     TemporaryStatistics,
     Scylla,
+    Rows,
+    Partitions,
     Unknown,
 };
 
@@ -73,6 +75,10 @@ struct fmt::formatter<sstables::component_type> : fmt::formatter<string_view> {
             return formatter<string_view>::format("TemporaryStatistics", ctx);
         case Scylla:
             return formatter<string_view>::format("Scylla", ctx);
+        case Partitions:
+            return formatter<string_view>::format("Partitions", ctx);
+        case Rows:
+            return formatter<string_view>::format("Rows", ctx);
         case Unknown:
             return formatter<string_view>::format("Unknown", ctx);
         }

--- a/sstables/component_type.hh
+++ b/sstables/component_type.hh
@@ -29,6 +29,7 @@ enum class component_type {
     Scylla,
     Rows,
     Partitions,
+    TemporaryHashes,
     Unknown,
 };
 
@@ -79,6 +80,8 @@ struct fmt::formatter<sstables::component_type> : fmt::formatter<string_view> {
             return formatter<string_view>::format("Partitions", ctx);
         case Rows:
             return formatter<string_view>::format("Rows", ctx);
+        case TemporaryHashes:
+            return formatter<string_view>::format("TemporaryHashes", ctx);
         case Unknown:
             return formatter<string_view>::format("Unknown", ctx);
         }

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -977,6 +977,9 @@ public:
             });
         });
     }
+    future<bool> advance_lower_and_check_if_present(dht::ring_position_view key, const utils::hashed_key&) override {
+        return advance_lower_and_check_if_present(key);
+    }
 
     // Advances the upper bound to the partition immediately following the partition of the lower bound.
     //

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -2234,7 +2234,7 @@ future<uint64_t> validate(
     validating_consumer consumer(schema, permit, sstable, std::move(error_handler));
     auto context = co_await data_consume_rows<data_consume_rows_context_m<validating_consumer>>(*schema, sstable, consumer, integrity_check::yes);
 
-    auto idx_reader = sstable->make_index_reader(permit, tracing::trace_state_ptr{}, sstables::use_caching::no, false);
+    auto idx_reader = sstable->make_index_reader(permit, tracing::trace_state_ptr{}, prefer_bti_index::no, sstables::use_caching::no, false);
     auto big_index_reader = dynamic_cast<index_reader*>(idx_reader.get());
 
     try {

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -30,7 +30,8 @@ mutation_reader make_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor,
-        integrity_check integrity);
+        integrity_check integrity,
+        std::unique_ptr<abstract_index_reader>);
 
 // Same as above but the slice is moved and stored inside the reader.
 mutation_reader make_reader(
@@ -39,18 +40,6 @@ mutation_reader make_reader(
         reader_permit permit,
         const dht::partition_range& range,
         query::partition_slice&& slice,
-        tracing::trace_state_ptr trace_state,
-        streamed_mutation::forwarding fwd,
-        mutation_reader::forwarding fwd_mr,
-        read_monitor& monitor,
-        integrity_check integrity);
-
-mutation_reader make_reader_with_index_reader(
-        shared_sstable sstable,
-        schema_ptr schema,
-        reader_permit permit,
-        const dht::partition_range& range,
-        const query::partition_slice& slice,
         tracing::trace_state_ptr trace_state,
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -31,7 +31,9 @@ mutation_reader make_reader(
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor,
         integrity_check integrity,
-        std::unique_ptr<abstract_index_reader>);
+        std::unique_ptr<abstract_index_reader>,
+        const utils::hashed_key* single_partition_read_murmur_hash
+);
 
 // Same as above but the slice is moved and stored inside the reader.
 mutation_reader make_reader(
@@ -45,7 +47,9 @@ mutation_reader make_reader(
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor,
         integrity_check integrity,
-        std::unique_ptr<abstract_index_reader>);
+        std::unique_ptr<abstract_index_reader>,
+        const utils::hashed_key* single_partition_read_murmur_hash
+);
 
 // A reader which doesn't use the index at all. It reads everything from the
 // sstable and it doesn't support skipping.

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1576,6 +1576,7 @@ stop_iteration writer::consume_end_of_partition() {
 
 void writer::consume_end_of_stream() {
     _cfg.monitor->on_data_write_completed();
+    SCYLLA_ASSERT(_num_partitions_consumed > 0);
 
     seal_summary(_sst._components->summary, std::move(_first_key), std::move(_last_key), _index_sampling_state).get();
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1596,6 +1596,7 @@ stop_iteration writer::consume_end_of_partition() {
         _bti_partition_index_writer->add(
             _schema,
             *std::exchange(_current_dk_for_bti, std::nullopt),
+            _current_murmur_hash,
             partitions_db_payload
         );
     }

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -8,6 +8,7 @@
 
 #include "sstables/mx/writer.hh"
 #include "sstables/writer.hh"
+#include "sstables/trie/bti_index.hh"
 #include "encoding_stats.hh"
 #include "schema/schema.hh"
 #include "mutation/mutation_fragment.hh"
@@ -534,6 +535,16 @@ private:
     std::unique_ptr<file_writer> _index_writer;
     std::unique_ptr<file_writer> _rows_writer;
     std::unique_ptr<file_writer> _partitions_writer;
+    optimized_optional<trie::bti_row_index_writer> _bti_row_index_writer;
+    optimized_optional<trie::bti_partition_index_writer> _bti_partition_index_writer;
+    // The key of the last `consume_new_partition` call.
+    // A partition key can only be inserted into Partitions.db
+    // after its intra-partition index is written to Rows.db.
+    // So we need to hold onto the key until `consume_end_of_partition`.
+    std::optional<dht::decorated_key> _current_dk_for_bti;
+    // Position of the Data writer at the moment of the last
+    // `consume_new_partition` call.
+    uint64_t _current_partition_position = 0;
     bool _tombstone_written = false;
     bool _static_row_written = false;
     // The length of partition header (partition key, partition deletion and static row, if present)
@@ -565,6 +576,10 @@ private:
         uint64_t offset;
         uint64_t width;
         std::optional<tombstone> open_marker;
+        // The range tombstone active between this block
+        // and its predecessor.
+        // (If there's no predecessor, this is a "live" tombstone).
+        tombstone preceding_range_tombstone;
     };
     // _pi_write_m is used temporarily for building the promoted
     // index (column sample) of one partition when writing a new sstable.
@@ -577,6 +592,7 @@ private:
         bytes_ostream offsets; // Serialized block offsets (uint32_t) relative to the start of "blocks".
         uint64_t promoted_index_size = 0; // Number of pi_blocks inside blocks and first_entry;
         tombstone partition_tombstone;
+        tombstone range_tombstone_preceding_current_block;
         uint64_t block_start_offset;
         uint64_t block_next_start_offset;
         std::optional<clustering_info> first_clustering;
@@ -624,7 +640,7 @@ private:
             _index_writer->offset(), _index_sampling_state);
     }
 
-    void maybe_set_pi_first_clustering(const clustering_info& info);
+    void maybe_set_pi_first_clustering(const clustering_info& info, tombstone range_tombstone);
     void maybe_add_pi_block();
     void add_pi_block();
     void write_pi_block(const pi_block&);
@@ -729,9 +745,9 @@ private:
 
     template <typename T>
     requires Clustered<T>
-    void write_clustered(const T& clustered) {
+    void write_clustered(const T& clustered, tombstone preceding_range_tombstone) {
         clustering_info info {clustered.key(), get_kind(clustered)};
-        maybe_set_pi_first_clustering(info);
+        maybe_set_pi_first_clustering(info, preceding_range_tombstone);
         uint64_t pos = _data_writer->offset();
         write_clustered(clustered, pos - _prev_row_start);
         _pi_write_m.last_clustering = info;
@@ -739,7 +755,7 @@ private:
         maybe_add_pi_block();
     }
     void write_promoted_index();
-    void consume(rt_marker&& marker);
+    void consume(rt_marker&& marker, tombstone preceding_range_tombstone);
 
     // Must be called in a seastar thread.
     void flush_tmp_bufs(file_writer& writer) {
@@ -837,10 +853,11 @@ writer::~writer() {
     close_writer(_rows_writer);
 }
 
-void writer::maybe_set_pi_first_clustering(const clustering_info& info) {
+void writer::maybe_set_pi_first_clustering(const clustering_info& info, tombstone preceding_range_tombstone) {
     uint64_t pos = _data_writer->offset();
     if (!_pi_write_m.first_clustering) {
         _pi_write_m.first_clustering = info;
+        _pi_write_m.range_tombstone_preceding_current_block = preceding_range_tombstone;
         _pi_write_m.block_start_offset = pos;
         _pi_write_m.block_next_start_offset = pos + _pi_write_m.desired_block_size;
     }
@@ -852,16 +869,24 @@ void writer::add_pi_block() {
         *_pi_write_m.last_clustering,
         _pi_write_m.block_start_offset - _c_stats.start_offset,
         _data_writer->offset() - _pi_write_m.block_start_offset,
-        (_current_tombstone ? std::make_optional(_current_tombstone) : std::optional<tombstone>{})};
+        (_current_tombstone ? std::make_optional(_current_tombstone) : std::optional<tombstone>{}),
+        _pi_write_m.range_tombstone_preceding_current_block,
+    };
 
-    if (_pi_write_m.blocks.empty()) {
-        if (!_pi_write_m.first_entry) {
-            _pi_write_m.first_entry.emplace(std::move(block));
-            ++_pi_write_m.promoted_index_size;
-            return;
-        } else {
-            write_pi_block(*_pi_write_m.first_entry);
-        }
+    // An index with only one block (that spans the entire partition)
+    // would be relatively useless, and wouldn't carry its weight.
+    // So if we are adding the first block, we don't write it out yet --
+    // we only remember it in `first_entry`, and we wait until another
+    // entry appears. (If it doesn't, then there will be no row index
+    // for this partition).
+    // If this is a second block, we write out the deferred `first_entry`
+    // first, and then we proceed normally.
+    if (_pi_write_m.promoted_index_size == 0) {
+        _pi_write_m.first_entry.emplace(std::move(block));
+        ++_pi_write_m.promoted_index_size;
+        return;
+    } else if (_pi_write_m.promoted_index_size == 1) {
+        write_pi_block(*_pi_write_m.first_entry);
     }
 
     write_pi_block(block);
@@ -880,6 +905,7 @@ void writer::maybe_add_pi_block() {
     if (pos >= _pi_write_m.block_next_start_offset) {
         add_pi_block();
         _pi_write_m.first_clustering.reset();
+        _pi_write_m.range_tombstone_preceding_current_block = tombstone();
         _pi_write_m.block_next_start_offset = pos + _pi_write_m.desired_block_size;
     }
 }
@@ -904,8 +930,10 @@ void writer::init_file_writers() {
     if (_sst.has_component(component_type::Partitions) && _sst.has_component(component_type::Rows)) {
         out = _sst._storage->make_data_or_index_sink(_sst, component_type::Rows).get();
         _rows_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), component_name(_sst, component_type::Rows));
+        _bti_row_index_writer = trie::bti_row_index_writer(*_rows_writer);
         out = _sst._storage->make_data_or_index_sink(_sst, component_type::Partitions).get();
         _partitions_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), component_name(_sst, component_type::Partitions));
+        _bti_partition_index_writer = trie::bti_partition_index_writer(*_partitions_writer);
     }
 }
 
@@ -946,6 +974,8 @@ void writer::consume_new_partition(const dht::decorated_key& dk) {
     // and collecting the sample of columns.
     write(_sst.get_version(), *_index_writer, p_key);
     write_vint(*_index_writer, _data_writer->offset());
+    _current_dk_for_bti = dk;
+    _current_partition_position = _data_writer->offset();
 
     _pi_write_m.first_entry.reset();
     _pi_write_m.blocks.clear();
@@ -1352,7 +1382,7 @@ stop_iteration writer::consume(clustering_row&& cr) {
 
     ensure_tombstone_is_written();
     ensure_static_row_is_written_if_needed();
-    write_clustered(cr);
+    write_clustered(cr, _current_tombstone);
 
     auto can_split_partition_at_clustering_boundary = [this] {
         // will allow size limit to be exceeded for 10%, so we won't perform unnecessary split
@@ -1420,6 +1450,15 @@ void writer::write_pi_block(const pi_block& block) {
     if (block.open_marker) {
         write(_sst.get_version(), blocks, to_deletion_time(*block.open_marker));
     }
+    if (_bti_row_index_writer) {
+        _bti_row_index_writer->add(
+            _schema,
+            block.first,
+            block.last,
+            block.offset,
+            to_deletion_time(block.preceding_range_tombstone)
+        );
+    }
 }
 
 void writer::write_clustered(const rt_marker& marker, uint64_t prev_row_size) {
@@ -1443,8 +1482,8 @@ void writer::write_clustered(const rt_marker& marker, uint64_t prev_row_size) {
     collect_range_tombstone_stats();
 }
 
-void writer::consume(rt_marker&& marker) {
-    write_clustered(marker);
+void writer::consume(rt_marker&& marker, tombstone preceding_range_tombstone) {
+    write_clustered(marker, preceding_range_tombstone);
 }
 
 stop_iteration writer::consume(range_tombstone_change&& rtc) {
@@ -1457,15 +1496,21 @@ stop_iteration writer::consume(range_tombstone_change&& rtc) {
     tombstone prev_tombstone = std::exchange(_current_tombstone, rtc.tombstone());
     if (!prev_tombstone) { // start bound
         auto bv = pos.as_start_bound_view();
-        consume(rt_marker{pos.key(), to_bound_kind_m(bv.kind()), rtc.tombstone(), {}});
+        consume(
+            rt_marker{pos.key(), to_bound_kind_m(bv.kind()), rtc.tombstone(), {}},
+            prev_tombstone);
     } else if (!rtc.tombstone()) { // end bound
         auto bv = pos.as_end_bound_view();
-        consume(rt_marker{pos.key(), to_bound_kind_m(bv.kind()), prev_tombstone, {}});
+        consume(
+            rt_marker{pos.key(), to_bound_kind_m(bv.kind()), prev_tombstone, {}},
+        prev_tombstone);
     } else { // boundary
         auto bk = pos.get_bound_weight() == bound_weight::before_all_prefixed
             ? bound_kind_m::excl_end_incl_start
             : bound_kind_m::incl_end_excl_start;
-        consume(rt_marker{pos.key(), bk, prev_tombstone, rtc.tombstone()});
+        consume(
+            rt_marker{pos.key(), bk, prev_tombstone, rtc.tombstone()},
+            prev_tombstone);
     }
     return stop_iteration::no;
 }
@@ -1473,6 +1518,8 @@ stop_iteration writer::consume(range_tombstone_change&& rtc) {
 stop_iteration writer::consume_end_of_partition() {
     ensure_tombstone_is_written();
     ensure_static_row_is_written_if_needed();
+
+    uint64_t end_of_partition_position = _data_writer->offset();
 
     auto write_end_of_partition = [&] {
         write(_sst.get_version(), *_data_writer, row_flags::end_of_partition);
@@ -1493,6 +1540,22 @@ stop_iteration writer::consume_end_of_partition() {
     }
 
     write_promoted_index();
+
+    if (_bti_partition_index_writer) {
+        auto partitions_db_payload = _bti_row_index_writer->finish(
+            _sst.get_version(),
+            _schema,
+            _current_partition_position,
+            end_of_partition_position,
+            *_partition_key,
+            to_deletion_time(_pi_write_m.partition_tombstone)
+        );
+        _bti_partition_index_writer->add(
+            _schema,
+            *std::exchange(_current_dk_for_bti, std::nullopt),
+            partitions_db_payload
+        );
+    }
 
     // compute size of the current row.
     _c_stats.partition_size = _data_writer->offset() - _c_stats.start_offset;
@@ -1523,9 +1586,20 @@ void writer::consume_end_of_stream() {
     close_writer(_index_writer);
 
     if (_partitions_writer) {
+        _sst._partitions_db_footer = std::move(*_bti_partition_index_writer).finish(
+            _sst.get_version(),
+            _first_key.value(),
+            _last_key.value());
         close_writer(_partitions_writer);
     }
     if (_rows_writer) {
+        // Append some garbage padding to the file just to ensure that it's never empty.
+        // (Otherwise it would be empty if the sstable contains only small partitions).
+        // This is a hack to work around some bad interactions between zero-sized files
+        // and object storage. (It seems that e.g. minio considers a zero-sized file
+        // upload to be a no-op, which breaks some assumptions).
+        uint32_t garbage = seastar::cpu_to_be(0x13371337);
+        _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
         close_writer(_rows_writer);
     }
 

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -55,7 +55,7 @@ struct foreign_sstable_open_info {
     foreign_ptr<lw_shared_ptr<shareable_components>> components;
     std::vector<shard_id> owners;
     seastar::file_handle data;
-    seastar::file_handle index;
+    std::optional<seastar::file_handle> index;
     std::optional<seastar::file_handle> partitions;
     std::optional<seastar::file_handle> rows;
     generation_type generation;

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -56,6 +56,8 @@ struct foreign_sstable_open_info {
     std::vector<shard_id> owners;
     seastar::file_handle data;
     seastar::file_handle index;
+    std::optional<seastar::file_handle> partitions;
+    std::optional<seastar::file_handle> rows;
     generation_type generation;
     sstable_version_types version;
     sstable_format_types format;

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -193,6 +193,16 @@ void sstable_directory::filesystem_components_lister::handle(sstables::entry_des
         // and we'll go with it.
         _state->files_for_removal.insert(filename.native());
         break;
+    case component_type::TemporaryHashes:
+        // We generate TemporaryHashes when writing the sstable,
+        // and it's removed before the sstable is sealed.
+        // If it's present, then it's a leftover from a partially-written sstable,
+        // and should be removed.
+        // This file isn't included in the TOC, so we can't remove on the "usual"
+        // mechanism for partially-written components, and instead we have to explicitly
+        // mark it for removal here.
+        _state->files_for_removal.insert(filename.native());
+        break;
     case component_type::TOC:
         _state->descriptors.emplace(desc.generation, std::move(desc));
         break;

--- a/sstables/sstable_version.cc
+++ b/sstables/sstable_version.cc
@@ -50,6 +50,7 @@ sstable_version_constants::component_map_t sstable_version_constants::create_com
         { component_type::TemporaryStatistics, "Statistics.db.tmp" },
         { component_type::Rows, "Rows.db" },
         { component_type::Partitions, "Partitions.db" },
+        { component_type::TemporaryHashes, "TemporaryHashes.db.tmp" },
     };
 }
 

--- a/sstables/sstable_version.cc
+++ b/sstables/sstable_version.cc
@@ -48,6 +48,8 @@ sstable_version_constants::component_map_t sstable_version_constants::create_com
         { component_type::Scylla, "Scylla.db" },
         { component_type::TemporaryTOC, TEMPORARY_TOC_SUFFIX },
         { component_type::TemporaryStatistics, "Statistics.db.tmp" },
+        { component_type::Rows, "Rows.db" },
+        { component_type::Partitions, "Partitions.db" },
     };
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1299,6 +1299,12 @@ future<> sstable::read_statistics() {
     return read_simple<component_type::Statistics>(_components->statistics);
 }
 
+future<> sstable::read_partitions_db_footer() {
+    if (_partitions_file) {
+        _partitions_db_footer = co_await trie::read_bti_partitions_db_footer(*_schema, _version, _partitions_file, _partitions_file_size);
+    }
+}
+
 void sstable::write_statistics() {
     write_simple<component_type::Statistics>(_components->statistics);
 }
@@ -1430,6 +1436,7 @@ future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
             component_name(*this, component_type::Partitions).format()
         );
         _partitions_file = make_cached_seastar_file(*_cached_partitions_file);
+        co_await read_partitions_db_footer();
     }
     if (_rows_file) {
         auto size = co_await _rows_file.size();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2353,8 +2353,12 @@ sstable::make_reader(
         read_monitor& mon,
         integrity_check integrity) {
     const auto reversed = slice.is_reversed();
+
+    auto index_caching = use_caching(global_cache_index_pages && !slice.options.contains(query::partition_slice::option::bypass_cache));
+    auto index_reader = make_index_reader(permit, trace_state, index_caching, range.is_singular());
+
     if (_version >= version_types::mc && (!reversed || range.is_singular())) {
-        return mx::make_reader(shared_from_this(), std::move(query_schema), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr, mon, integrity);
+        return mx::make_reader(shared_from_this(), std::move(query_schema), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr, mon, integrity, std::move(index_reader));
     }
 
     // Multi-partition reversed queries are not yet supported natively in the mx reader.
@@ -2365,7 +2369,7 @@ sstable::make_reader(
     if (_version >= version_types::mc) {
         // The only mx case falling through here is reversed multi-partition reader
         auto rd = make_reversing_reader(mx::make_reader(shared_from_this(), query_schema->make_reversed(), std::move(permit),
-                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon, integrity),
+                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon, integrity, std::move(index_reader)),
             max_result_size);
         if (fwd) {
             rd = make_forwardable(std::move(rd));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3094,17 +3094,17 @@ std::optional<std::pair<uint64_t, uint64_t>> sstable::get_index_pages_for_range(
     return std::nullopt;
 }
 
-uint64_t sstable::estimated_keys_for_range(const dht::token_range& range) {
+future<uint64_t> sstable::estimated_keys_for_range(const dht::token_range& range) {
     auto page_range = get_index_pages_for_range(range);
     if (!page_range) {
-        return 0;
+        co_return 0;
     }
     using uint128_t = unsigned __int128;
     uint64_t range_pages = page_range->second - page_range->first;
     auto total_keys = get_estimated_key_count();
     auto total_pages = _components->summary.entries.size();
     uint64_t estimated_keys = (uint128_t)range_pages * total_keys / total_pages;
-    return std::max(uint64_t(1), estimated_keys);
+    co_return std::max(uint64_t(1), estimated_keys);
 }
 
 std::vector<unsigned>

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3008,18 +3008,6 @@ std::optional<std::pair<uint64_t, uint64_t>> sstable::get_index_pages_for_range(
     return std::nullopt;
 }
 
-std::vector<dht::decorated_key> sstable::get_key_samples(const schema& s, const dht::token_range& range) {
-    auto index_range = get_sample_indexes_for_range(range);
-    std::vector<dht::decorated_key> res;
-    if (index_range) {
-        for (auto idx = index_range->first; idx < index_range->second; ++idx) {
-            auto pkey = _components->summary.entries[idx].get_key().to_partition_key(s);
-            res.push_back(dht::decorate_key(s, std::move(pkey)));
-        }
-    }
-    return res;
-}
-
 uint64_t sstable::estimated_keys_for_range(const dht::token_range& range) {
     auto page_range = get_index_pages_for_range(range);
     if (!page_range) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2493,7 +2493,9 @@ sstable::make_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor& mon,
-        integrity_check integrity) {
+        integrity_check integrity,
+        const utils::hashed_key* single_partition_read_murmur_hash
+) {
     const auto reversed = slice.is_reversed();
 
     auto index_caching = use_caching(global_cache_index_pages && !slice.options.contains(query::partition_slice::option::bypass_cache));
@@ -2504,7 +2506,19 @@ sstable::make_reader(
     auto index_reader = make_index_reader(permit, trace_state, prefer_bti, index_caching, range.is_singular());
 
     if (_version >= version_types::mc && (!reversed || range.is_singular())) {
-        return mx::make_reader(shared_from_this(), std::move(query_schema), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr, mon, integrity, std::move(index_reader));
+        return mx::make_reader(
+            shared_from_this(),
+            std::move(query_schema),
+            std::move(permit),
+            range,
+            slice,
+            std::move(trace_state),
+            fwd,
+            fwd_mr,
+            mon,
+            integrity,
+            std::move(index_reader),
+            single_partition_read_murmur_hash);
     }
 
     // Multi-partition reversed queries are not yet supported natively in the mx reader.
@@ -2515,7 +2529,8 @@ sstable::make_reader(
     if (_version >= version_types::mc) {
         // The only mx case falling through here is reversed multi-partition reader
         auto rd = make_reversing_reader(mx::make_reader(shared_from_this(), query_schema->make_reversed(), std::move(permit),
-                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon, integrity, std::move(index_reader)),
+                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon,
+                integrity, std::move(index_reader), single_partition_read_murmur_hash),
             max_result_size);
         if (fwd) {
             rd = make_forwardable(std::move(rd));

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -550,7 +550,7 @@ private:
     file _rows_file;
     seastar::shared_ptr<cached_file> _cached_rows_file;
     uint64_t _data_file_size;
-    uint64_t _index_file_size;
+    uint64_t _index_file_size = 0;
     uint64_t _partitions_file_size = 0;
     uint64_t _rows_file_size = 0;
     // on-disk size of components but data and index.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -768,7 +768,6 @@ public:
 private:
     future<summary_entry&> read_summary_entry(size_t i);
 
-    // FIXME: pending on Bloom filter implementation
     bool filter_has_key(const schema& s, const dht::decorated_key& dk) { return filter_has_key(key::from_partition_key(s, dk._key)); }
 
     std::optional<std::pair<uint64_t, uint64_t>> get_sample_indexes_for_range(const dht::token_range& range);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -713,6 +713,7 @@ private:
     void validate_max_local_deletion_time();
     void validate_partitioner();
 
+    // Loads first and last partition keys from appropriate components into `_first` and `_last`.
     void set_first_and_last_keys();
 
     // Create a position range based on the min/max_column_names metadata of this sstable.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -1055,7 +1055,8 @@ public:
     std::unique_ptr<abstract_index_reader> make_index_reader(
         reader_permit permit,
         tracing::trace_state_ptr trace_state = {},
-        use_caching caching = use_caching::yes,
+        prefer_bti_index = prefer_bti_index::no,
+        use_caching = use_caching::yes,
         bool single_partition_read = false);
 
     // Allow the test cases from sstable_test.cc to test private methods. We use

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -378,6 +378,8 @@ public:
         return _index_file;
     }
     file uncached_index_file();
+    file uncached_partitions_file();
+    file uncached_rows_file();
     // Returns size of bloom filter data.
     uint64_t filter_size() const;
 
@@ -544,8 +546,14 @@ private:
     file _index_file;
     seastar::shared_ptr<cached_file> _cached_index_file;
     file _data_file;
+    file _partitions_file;
+    seastar::shared_ptr<cached_file> _cached_partitions_file;
+    file _rows_file;
+    seastar::shared_ptr<cached_file> _cached_rows_file;
     uint64_t _data_file_size;
     uint64_t _index_file_size;
+    uint64_t _partitions_file_size = 0;
+    uint64_t _rows_file_size = 0;
     // on-disk size of components but data and index.
     uint64_t _metadata_size_on_disk = 0;
     db_clock::time_point _data_file_write_time;

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -338,7 +338,7 @@ public:
         return get_stats_metadata().estimated_partition_size.count();
     }
 
-    uint64_t estimated_keys_for_range(const dht::token_range& range);
+    future<uint64_t> estimated_keys_for_range(const dht::token_range& range);
 
     // mark_for_deletion() specifies that a sstable isn't relevant to the
     // current shard, and thus can be deleted by the deletion manager, if

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -45,6 +45,7 @@
 #include "utils/updateable_value.hh"
 #include "dht/decorated_key.hh"
 #include "service/session.hh"
+#include "sstables/trie/bti_index.hh"
 
 #include <seastar/util/optimized_optional.hh>
 
@@ -548,6 +549,7 @@ private:
     file _data_file;
     file _partitions_file;
     seastar::shared_ptr<cached_file> _cached_partitions_file;
+    std::optional<trie::bti_partitions_db_footer> _partitions_db_footer;
     file _rows_file;
     seastar::shared_ptr<cached_file> _cached_rows_file;
     uint64_t _data_file_size;
@@ -691,6 +693,8 @@ private:
     // To be called when we try to load an SSTable that lacks a Summary. Could
     // happen if old tools are being used.
     future<> generate_summary();
+
+    future<> read_partitions_db_footer();
 
     future<> read_statistics();
     void write_statistics();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -329,16 +329,13 @@ public:
 
     future<> seal_sstable(bool backup);
 
-    static uint64_t get_estimated_key_count(const uint32_t size_at_full_sampling, const uint32_t min_index_interval) {
-        return ((uint64_t)size_at_full_sampling + 1) * min_index_interval;
-    }
     // Size at full sampling is calculated as if sampling were static, using minimum index as a strict sampling interval.
     static uint64_t get_size_at_full_sampling(const uint64_t key_count, const uint32_t min_index_interval) {
         return std::ceil(float(key_count) / min_index_interval) - 1;
     }
 
     uint64_t get_estimated_key_count() const {
-        return get_estimated_key_count(_components->summary.header.size_at_full_sampling, _components->summary.header.min_index_interval);
+        return get_stats_metadata().estimated_partition_size.count();
     }
 
     uint64_t estimated_keys_for_range(const dht::token_range& range);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -288,7 +288,9 @@ public:
             streamed_mutation::forwarding fwd = streamed_mutation::forwarding::no,
             mutation_reader::forwarding fwd_mr = mutation_reader::forwarding::yes,
             read_monitor& monitor = default_read_monitor(),
-            integrity_check integrity = integrity_check::no);
+            integrity_check integrity = integrity_check::no,
+            const utils::hashed_key* single_partition_read_murmur_hash = nullptr
+        );
 
     // A reader which doesn't use the index at all. It reads everything from the
     // sstable and it doesn't support skipping.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -653,6 +653,8 @@ private:
 
     future<file> new_sstable_component_file(const io_error_handler& error_handler, component_type f, open_flags flags, file_open_options options = {}) const noexcept;
 
+    future<> unlink_component(component_type type) noexcept;
+
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
@@ -677,6 +679,8 @@ private:
     // filter initialisation was not good.
     // This should be called only before an sstable is sealed.
     void maybe_rebuild_filter_from_index(uint64_t num_partitions);
+
+    void build_delayed_filter(uint64_t num_partitions);
 
     future<> update_info_for_opened_data(sstable_open_config cfg = {});
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -342,8 +342,6 @@ public:
 
     uint64_t estimated_keys_for_range(const dht::token_range& range);
 
-    std::vector<dht::decorated_key> get_key_samples(const schema& s, const dht::token_range& range);
-
     // mark_for_deletion() specifies that a sstable isn't relevant to the
     // current shard, and thus can be deleted by the deletion manager, if
     // all shards sharing it agree. In case the sstable is unshared, it's

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -68,6 +68,11 @@ void sstables_manager::subscribe(sstables_manager_event_handler& handler) {
     }));
 }
 
+bool sstables_manager::is_bti_index_enabled() const {
+    return _features.bti_sstable_index
+        && std::ranges::contains(_db_config.sstable_index_write_formats(), enum_option<db::sstable_index_format_t>(db::sstable_index_format_t::mode::bti));
+}
+
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _s3_clients_memory(stm_cfg.s3_clients_memory)
     , _config_updater(this_shard_id() == 0 ? std::make_unique<config_updater>(cfg, *this) : nullptr)

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -73,6 +73,15 @@ bool sstables_manager::is_bti_index_enabled() const {
         && std::ranges::contains(_db_config.sstable_index_write_formats(), enum_option<db::sstable_index_format_t>(db::sstable_index_format_t::mode::bti));
 }
 
+bool sstables_manager::is_big_index_enabled() const {
+    // We need at least one index formats.
+    // If BTI index isn't enabled, then we have to default
+    // to writing a BIG index regardless of what the config says.
+    auto bti_enabled = is_bti_index_enabled();
+    auto config_contains_big = std::ranges::contains(_db_config.sstable_index_write_formats(), enum_option<db::sstable_index_format_t>(db::sstable_index_format_t::mode::big));
+    return !bti_enabled || config_contains_big;
+}
+
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _s3_clients_memory(stm_cfg.s3_clients_memory)
     , _config_updater(this_shard_id() == 0 ? std::make_unique<config_updater>(cfg, *this) : nullptr)

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -237,6 +237,7 @@ public:
     void subscribe(sstables_manager_event_handler& handler);
 
     bool is_bti_index_enabled() const;
+    bool is_big_index_enabled() const;
 
 private:
     void add(sstable* sst);

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -236,6 +236,8 @@ public:
     // unsubscribe happens automatically when the handler is destroyed
     void subscribe(sstables_manager_event_handler& handler);
 
+    bool is_bti_index_enabled() const;
+
 private:
     void add(sstable* sst);
     // Transition the sstable to the "inactive" state. It has no

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -114,6 +114,7 @@ public:
     virtual future<> remove_by_registry_entry(entry_descriptor desc) = 0;
     // Free space available in the underlying storage.
     virtual future<uint64_t> free_space() const = 0;
+    virtual future<> unlink_component(const sstable& sst, component_type) noexcept = 0;
 
     virtual sstring prefix() const  = 0;
 };

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -46,6 +46,13 @@ namespace sstables::trie {
 // until a cluster feature guarding the new page size is set.
 constexpr static uint64_t BTI_PAGE_SIZE = 4096;
 
+struct bti_partitions_db_footer {
+    sstables::key first_key;
+    sstables::key last_key;
+    uint64_t partition_count;
+    uint64_t trie_root_position;
+};
+
 // Transforms a stream of (partition key, offset in Data.db, hash bits) tuples
 // into a stream of trie nodes fed into bti_trie_sink.
 // Used to populate the Partitions.db file of the BTI format
@@ -71,14 +78,7 @@ public:
     // Flushes all remaining contents, and returns the position of the root node in the output stream.
     // If add() was never called, returns -1.
     // The writer mustn't be used again after this.
-    void finish(sstable_version_types ver, disk_string_view<uint16_t> first_key, disk_string_view<uint16_t> last_key) &&;
-};
-
-struct bti_partitions_db_footer {
-    sstables::key first_key;
-    sstables::key last_key;
-    uint64_t partition_count;
-    uint64_t trie_root_position;
+    std::optional<bti_partitions_db_footer> finish(sstable_version_types ver, const sstables::key& first_key, const sstables::key& last_key) &&;
     operator bool() const { return bool(_impl); }
 };
 

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -144,6 +144,7 @@ std::unique_ptr<sstables::abstract_index_reader> make_bti_index_reader(
     uint64_t partitions_db_root_pos,
     uint64_t total_data_db_file_size,
     schema_ptr,
-    reader_permit);
+    reader_permit,
+    tracing::trace_state_ptr);
 
 } // namespace sstables::trie

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -26,6 +26,10 @@ namespace seastar {
     class file;
 }
 
+namespace utils {
+    class hashed_key;
+}
+
 class schema;
 class cached_file;
 class reader_permit;
@@ -74,7 +78,7 @@ public:
     bti_partition_index_writer& operator=(bti_partition_index_writer&&) noexcept;
     ~bti_partition_index_writer();
     // Add a new partition key to the index.
-    void add(const schema&, dht::decorated_key, int64_t data_or_rowsdb_file_pos);
+    void add(const schema&, dht::decorated_key, const utils::hashed_key&, int64_t data_or_rowsdb_file_pos);
     // Flushes all remaining contents, and returns the position of the root node in the output stream.
     // If add() was never called, returns -1.
     // The writer mustn't be used again after this.

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -139,8 +139,8 @@ public:
 // `partitions_db_root_pos` should have been read from the Partitions.db footer beforehand.
 // (As we don't want to repeat that for every query).
 std::unique_ptr<sstables::abstract_index_reader> make_bti_index_reader(
-    cached_file& partitions_db,
-    cached_file& rows_db,
+    seastar::shared_ptr<cached_file> partitions_db,
+    seastar::shared_ptr<cached_file> rows_db,
     uint64_t partitions_db_root_pos,
     uint64_t total_data_db_file_size,
     schema_ptr,

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -55,7 +55,7 @@ class bti_partition_index_writer {
     std::unique_ptr<impl> _impl;
 private:
     friend class optimized_optional<bti_partition_index_writer>;
-    bti_partition_index_writer();
+    bti_partition_index_writer() noexcept;
 public:
     // The trie will be written to the given file writer.
     // Note: the file doesn't have to be empty,
@@ -63,6 +63,8 @@ public:
     // because `finish()` writes a footer which is used by the reader
     // to find the root of the trie.
     explicit bti_partition_index_writer(sstables::file_writer&);
+    bti_partition_index_writer(bti_partition_index_writer&&) noexcept;
+    bti_partition_index_writer& operator=(bti_partition_index_writer&&) noexcept;
     ~bti_partition_index_writer();
     // Add a new partition key to the index.
     void add(const schema&, dht::decorated_key, int64_t data_or_rowsdb_file_pos);
@@ -77,6 +79,7 @@ struct bti_partitions_db_footer {
     sstables::key last_key;
     uint64_t partition_count;
     uint64_t trie_root_position;
+    operator bool() const { return bool(_impl); }
 };
 
 future<bti_partitions_db_footer> read_bti_partitions_db_footer(const schema& s, sstable_version_types v, const seastar::file& f, uint64_t file_size);
@@ -90,13 +93,15 @@ class bti_row_index_writer {
     std::unique_ptr<impl> _impl;
 private:
     friend class optimized_optional<bti_row_index_writer>;
-    bti_row_index_writer();
+    bti_row_index_writer() noexcept;
 public:
     ~bti_row_index_writer();
     // The trie will be written to the given file writer.
     // Note: the file doesn't have to be empty,
     // and it can be extended later.
     explicit bti_row_index_writer(sstables::file_writer&);
+    bti_row_index_writer(bti_row_index_writer&&) noexcept;
+    bti_row_index_writer& operator=(bti_row_index_writer&&) noexcept;
     // Add a new row index entry.
     // Must be called in ascending order.
     // (`first_ck` must be strictly greater than the previous `last_ck`).
@@ -127,6 +132,7 @@ public:
         int64_t partition_data_end,
         const sstables::key&,
         const sstables::deletion_time& partition_tombstone);
+    operator bool() const { return bool(_impl); }
 };
 
 // Creates a BTI index reader over the Partitions.db file and the matching Rows.db file.

--- a/sstables/trie/bti_index_internal.hh
+++ b/sstables/trie/bti_index_internal.hh
@@ -36,7 +36,13 @@ struct row_index_header {
     uint64_t number_of_blocks = 0;
 };
 
-future<row_index_header> read_row_index_header(input_stream<char>&& input, uint64_t start, uint64_t maxlen, reader_permit rp);
+future<row_index_header> read_row_index_header(
+    input_stream<char>&& input,
+    uint64_t start,
+    uint64_t maxlen,
+    reader_permit rp
+);
+
 void write_row_index_header(
     sstable_version_types sst_ver,
     sstables::file_writer& fw,

--- a/sstables/trie/bti_index_reader.cc
+++ b/sstables/trie/bti_index_reader.cc
@@ -264,11 +264,11 @@ enum class set_result {
 // An index cursor, which is effectively a pair of trie cursors -- one into Partitions.db, one into Rows.db.
 class index_cursor {
     // A cursor into Partitions.db.
-    // Starts unintialized, gets initialized by set_before_partition/set_after_partition.
+    // Starts uninitialized, gets initialized by set_before_partition/set_after_partition.
     trie_cursor _partition_cursor;
     // A cursor into Rows.db.
-    // Starts unintialized, gets initialized by set_before_row/set_after_row,
-    // becomes unitialized again after partition cursor is moved.
+    // Starts uninitialized, gets initialized by set_before_row/set_after_row,
+    // becomes uninitialized again after partition cursor is moved.
     trie_cursor _row_cursor;
     // Holds the row index header for the current partition, iff the current partition has a row index.
     // This is kept in sync with the partition cursor.

--- a/sstables/trie/bti_index_reader.cc
+++ b/sstables/trie/bti_index_reader.cc
@@ -568,7 +568,7 @@ future<std::optional<uint64_t>> index_cursor::last_block_offset() const {
     co_await cur.step_back(_permit, _trace_state);
     co_await cur.step_back(_permit, _trace_state);
 
-    auto result = _partition_metadata->data_file_offset + row_payload_to_offset(cur.payload());
+    auto result = row_payload_to_offset(cur.payload());
     expensive_log("last_block_offset: {}", result);
     co_return result;
 }

--- a/sstables/trie/bti_node_reader.cc
+++ b/sstables/trie/bti_node_reader.cc
@@ -438,11 +438,11 @@ bool bti_node_reader::cached(int64_t pos) const {
     return _cached_page && _cached_page->pos() / cached_file::page_size == pos / cached_file::page_size;
 }
 
-seastar::future<> bti_node_reader::load(int64_t pos) {
+seastar::future<> bti_node_reader::load(int64_t pos, const reader_permit& permit, const tracing::trace_state_ptr& trace_ptr) {
     if (cached(pos)) {
         return make_ready_future<>();
     }
-    return _file.get().get_shared_page(pos, nullptr).then([this](auto page) {
+    return _file.get().get_shared_page(pos, permit, trace_ptr).then([this](cached_file::page_read_result page) {
         _cached_page = std::move(page.ptr);
     });
 }

--- a/sstables/trie/bti_node_reader.cc
+++ b/sstables/trie/bti_node_reader.cc
@@ -439,6 +439,9 @@ bool bti_node_reader::cached(int64_t pos) const {
 }
 
 seastar::future<> bti_node_reader::load(int64_t pos) {
+    if (cached(pos)) {
+        return make_ready_future<>();
+    }
     return _file.get().get_shared_page(pos, nullptr).then([this](auto page) {
         _cached_page = std::move(page.ptr);
     });

--- a/sstables/trie/bti_node_reader.hh
+++ b/sstables/trie/bti_node_reader.hh
@@ -54,7 +54,7 @@ struct bti_node_reader {
 
     bti_node_reader(cached_file& f);
     bool cached(int64_t pos) const;
-    future<> load(int64_t pos);
+    future<> load(int64_t pos, const reader_permit&, const tracing::trace_state_ptr&);
     trie::load_final_node_result read_node(int64_t pos);
     trie::node_traverse_result walk_down_along_key(int64_t pos, const_bytes key);
     trie::node_traverse_sidemost_result walk_down_leftmost_path(int64_t pos);

--- a/sstables/trie/bti_partition_index_writer.cc
+++ b/sstables/trie/bti_partition_index_writer.cc
@@ -210,7 +210,7 @@ struct bti_partition_index_writer::impl
     impl(impl&&) = delete;
 };
 
-bti_partition_index_writer::bti_partition_index_writer() = default;
+bti_partition_index_writer::bti_partition_index_writer() noexcept = default;
 
 bti_partition_index_writer::~bti_partition_index_writer() = default;
 
@@ -223,6 +223,8 @@ void bti_partition_index_writer::add(const schema& s, dht::decorated_key dk, int
 void bti_partition_index_writer::finish(sstable_version_types ver, disk_string_view<uint16_t> first_key, disk_string_view<uint16_t> last_key) && {
     _impl->finish(ver, first_key, last_key);
 }
+bti_partition_index_writer::bti_partition_index_writer(bti_partition_index_writer&&) noexcept = default;
+bti_partition_index_writer& bti_partition_index_writer::operator=(bti_partition_index_writer&&) noexcept = default;
 
 std::byte hash_byte_from_key(const schema &s, const partition_key& x) {
     auto hk = utils::make_hashed_key(static_cast<bytes_view>(key::from_partition_key(s, x)));

--- a/sstables/trie/bti_row_index_writer.cc
+++ b/sstables/trie/bti_row_index_writer.cc
@@ -359,13 +359,15 @@ struct bti_row_index_writer::impl
     impl(impl&&) = delete;
 };
 
-bti_row_index_writer::bti_row_index_writer() = default;
+bti_row_index_writer::bti_row_index_writer() noexcept = default;
 
 bti_row_index_writer::~bti_row_index_writer() = default;
 
 bti_row_index_writer::bti_row_index_writer(sstables::file_writer& fw)
     : _impl(std::make_unique<impl>(fw))
 {}
+bti_row_index_writer::bti_row_index_writer(bti_row_index_writer&&) noexcept = default;
+bti_row_index_writer& bti_row_index_writer::operator=(bti_row_index_writer&&) noexcept = default;
 
 int64_t bti_row_index_writer::finish(
     sstable_version_types version,

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -38,6 +38,7 @@ inline bytes_view to_bytes_view(const temporary_buffer<char>& b) {
 namespace sstables {
 
 using use_caching = bool_class<struct use_caching_tag>;
+using prefer_bti_index = bool_class<struct prefer_bti_index_tag>;
 
 template<typename T>
 concept Writer =

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -421,7 +421,7 @@ future<> sstable_streamer::stream_sstable_mutations(streaming::plan_id ops_uuid,
     auto sst_set = make_lw_shared<sstables::sstable_set>(sstables::make_partitioned_sstable_set(s, std::move(token_range)));
     size_t estimated_partitions = 0;
     for (auto& sst : sstables) {
-        estimated_partitions += sst->estimated_keys_for_range(token_range);
+        estimated_partitions += co_await sst->estimated_keys_for_range(token_range);
         sst_set->insert(sst);
     }
 

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -34,6 +34,7 @@
 #include "gms/feature_service.hh"
 #include "utils/error_injection.hh"
 #include "idl/streaming.dist.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace streaming {
 
@@ -101,15 +102,15 @@ struct send_info {
         });
     }
     future<size_t> estimate_partitions() {
-        return do_with(cf->get_sstables(), size_t(0), [this] (auto& sstables, size_t& partition_count) {
-            return do_for_each(*sstables, [this, &partition_count] (auto& sst) {
-                return do_for_each(ranges, [&sst, &partition_count] (auto& range) {
-                    partition_count += sst->estimated_keys_for_range(range);
-                });
-            }).then([&partition_count] {
-                return partition_count;
-            });
-        });
+        auto sstables = cf->get_sstables();
+        size_t partition_count = 0;
+        for (auto& sst : *sstables) {
+            for (auto& range : ranges) {
+                partition_count += sst->estimated_keys_for_range(range);
+            }
+            co_await coroutine::maybe_yield();
+        }
+        co_return partition_count;
     }
 };
 

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -104,10 +104,8 @@ struct send_info {
     future<size_t> estimate_partitions() {
         auto sstables = cf->get_sstables();
         size_t partition_count = 0;
-        for (auto& sst : *sstables) {
-            for (auto& range : ranges) {
-                partition_count += sst->estimated_keys_for_range(range);
-            }
+        for (auto& range : ranges) {
+            partition_count += co_await cf->estimated_partitions_in_range(range);
             co_await coroutine::maybe_yield();
         }
         co_return partition_count;

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1017,14 +1017,14 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         // Step 4: run the reader test on the opened readers.
         test_index(dataset, [&] {
             return sstables::trie::make_bti_index_reader(
-            partitions_db_cached,
-            rows_db_cached,
-            partitions_db_root_pos,
-            std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
-            the_schema,
-            semaphore.make_permit(),
-            trace_state
-        );
+                partitions_db_cached,
+                rows_db_cached,
+                partitions_db_root_pos,
+                std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
+                the_schema,
+                semaphore.make_permit(),
+                trace_state
+            );
         }, max_ops);
     }
 }

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -989,7 +989,7 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
                 },
             }, entry);
         }
-        std::move(partition_index_writer).finish(sst_ver, {}, {});
+        std::move(partition_index_writer).finish(sst_ver, sstables::key::from_bytes({}), sstables::key::from_bytes({}));
     }
 
     // Step 3: create the reader (or, more precisely, a factory of readers) over the index files.

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1008,8 +1008,8 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
         auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
-        auto p = partitions_db_cached.get_file().dma_read_exactly<char>(partitions_db_size - 24, 24).get();
-        auto partitions_db_root_pos = read_be<uint64_t>(p.get() + 16);
+        auto partitions_db_footer = sstables::trie::read_bti_partitions_db_footer(*the_schema, sst_ver, partitions_db, partitions_db_size).get();
+        auto partitions_db_root_pos = partitions_db_footer.trie_root_position;
 
         auto semaphore = tests::reader_concurrency_semaphore_wrapper();
 

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1012,6 +1012,7 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto partitions_db_root_pos = partitions_db_footer.trie_root_position;
 
         auto semaphore = tests::reader_concurrency_semaphore_wrapper();
+        auto trace_state = tracing::trace_state_ptr();
 
         // Step 4: run the reader test on the opened readers.
         test_index(dataset, [&] {
@@ -1021,7 +1022,9 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
             partitions_db_root_pos,
             std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
             the_schema,
-            semaphore.make_permit());
+            semaphore.make_permit(),
+            trace_state
+        );
         }, max_ops);
     }
 }

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -609,7 +609,7 @@ struct reference_index {
         }
         for (uint64_t idx = curpar + 1; idx < _entries.size(); ++idx) {
             if (std::holds_alternative<partition_end_entry>(_entries[idx + 1])) {
-                return _data_file_offsets[idx];
+                return _data_file_offsets[idx] - _data_file_offsets[curpar];
             }
         }
         abort();

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1005,8 +1005,8 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto region = logalloc::region();
         auto partitions_db_size = partitions_db.size().get();
         auto rows_db_size = rows_db.size().get();
-        auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
-        auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
+        auto partitions_db_cached = seastar::make_shared<cached_file>(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
+        auto rows_db_cached = seastar::make_shared<cached_file>(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
         auto partitions_db_footer = sstables::trie::read_bti_partitions_db_footer(*the_schema, sst_ver, partitions_db, partitions_db_size).get();
         auto partitions_db_root_pos = partitions_db_footer.trie_root_position;

--- a/test/boost/comparable_bytes_test.cc
+++ b/test/boost/comparable_bytes_test.cc
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_bigint) {
     byte_comparable_test(generate_integer_test_data<int64_t>());
 }
 
-BOOST_AUTO_TEST_CASE(test_date) {
+BOOST_AUTO_TEST_CASE(test_simple_date) {
     byte_comparable_test(generate_integer_test_data<uint32_t>([] (uint32_t days) {
         return data_value(simple_date_native_type{days});
     }));
@@ -209,6 +209,12 @@ BOOST_AUTO_TEST_CASE(test_time) {
 BOOST_AUTO_TEST_CASE(test_timestamp) {
     byte_comparable_test(generate_integer_test_data<db_clock::rep>([] (db_clock::rep milliseconds) {
         return data_value(db_clock::time_point(db_clock::duration(milliseconds)));
+    }));
+}
+
+BOOST_AUTO_TEST_CASE(test_date) {
+    byte_comparable_test(generate_integer_test_data<db_clock::rep>([] (db_clock::rep milliseconds) {
+        return data_value(date_type_native_type{db_clock::time_point{db_clock::duration(milliseconds)}});
     }));
 }
 

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -19,7 +19,7 @@
 // in the Data file.
 std::vector<uint64_t> get_ck_positions(shared_sstable sst, reader_permit permit) {
     std::vector<uint64_t> result;
-    auto abstract_r = sst->make_index_reader(permit, nullptr, use_caching::no, false);
+    auto abstract_r = sst->make_index_reader(permit, nullptr, prefer_bti_index::no, use_caching::no, false);
     auto& r = dynamic_cast<index_reader&>(*abstract_r);
     r.advance_to(dht::partition_range::make_open_ended_both_sides()).get();
     r.read_partition_data().get();
@@ -40,7 +40,7 @@ std::vector<uint64_t> get_ck_positions(shared_sstable sst, reader_permit permit)
 std::vector<uint64_t> get_partition_positions(shared_sstable sst, reader_permit permit) {
     std::vector<uint64_t> result;
     {
-        auto ir = sst->make_index_reader(permit, nullptr, use_caching::no, false);
+        auto ir = sst->make_index_reader(permit, nullptr, prefer_bti_index::no, use_caching::no, false);
         ir->advance_to(dht::partition_range::make_open_ended_both_sides()).get();
         ir->read_partition_data().get();
         auto close_ir = deferred_close(*ir);

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -428,7 +428,8 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_range_query) {
                         mutation_reader::forwarding::yes,
                         default_read_monitor(),
                         sstables::integrity_check::no,
-                        std::make_unique<inexact_partition_index>(ncs, partition_positions, ck_positions, present_dks, cks, table.schema())
+                        std::make_unique<inexact_partition_index>(ncs, partition_positions, ck_positions, present_dks, cks, table.schema()),
+                        static_cast<utils::hashed_key*>(nullptr)
                     ));
                 }
                 // Check that the reader produces correct output for the chosen partition range.
@@ -519,7 +520,8 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_singular_query) {
                     std::span<uint64_t>(),
                     present_dks,
                     std::span<clustering_key>(),
-                    table.schema())
+                    table.schema()),
+                static_cast<utils::hashed_key*>(nullptr)
             ));
             testlog.debug("Check that the reader produces nothing");
             reader.produces_end_of_stream();

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -117,6 +117,9 @@ struct inexact_partition_index : abstract_index_reader {
         testlog.trace("<inexact_partition_index/advance_lower_and_check_if_present: _lower={}, _upper={}, pk_idx={}", _lower, _upper, pk_idx);
         return make_ready_future<bool>(true);
     }
+    future<bool> advance_lower_and_check_if_present(dht::ring_position_view rpv, const utils::hashed_key& hash) override {
+        return advance_lower_and_check_if_present(rpv);
+    }
     future<> advance_upper_past(position_in_partition_view pos) override {
         auto cmp = position_in_partition::less_compare(*_s);
         auto pk_idx = pos_idx_to_pk_idx(_lower);

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -414,7 +414,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_range_query) {
                         end_inclusive ? ']' : ')',
                         pr
                     );
-                    reader = assert_that(sstables::mx::make_reader_with_index_reader(
+                    reader = assert_that(sstables::mx::make_reader(
                         sst,
                         table.schema(),
                         permit,
@@ -499,7 +499,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_singular_query) {
             auto pr = dht::partition_range::make_singular(all_dks[1]);
 
             testlog.debug("Create for pr={}", pr);
-            mutation_reader_assertions reader = assert_that(sstables::mx::make_reader_with_index_reader(
+            mutation_reader_assertions reader = assert_that(sstables::mx::make_reader(
                 sst,
                 table.schema(),
                 permit,

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1178,14 +1178,14 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
             testlog.trace("est = {}", max_est);
 
             {
-                auto est = sst->estimated_keys_for_range(dht::token_range::make_open_ended_both_sides());
+                auto est = sst->estimated_keys_for_range(dht::token_range::make_open_ended_both_sides()).get();
                 testlog.trace("est([-inf; +inf]) = {}", est);
                 BOOST_REQUIRE_EQUAL(est, sst->get_estimated_key_count());
             }
 
             for (int size : {1, 64, 256, 512, 1024, 4096, count}) {
                 auto r = dht::token_range::make(pks[0].token(), pks[size - 1].token());
-                auto est = sst->estimated_keys_for_range(r);
+                auto est = sst->estimated_keys_for_range(r).get();
                 testlog.trace("est([0; {}] = {}", size - 1, est);
                 BOOST_REQUIRE_GE(est, size);
                 BOOST_REQUIRE_LE(est, max_est);
@@ -1195,7 +1195,7 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
                 auto lower = 5000;
                 auto upper = std::min(count - 1, lower + size - 1);
                 auto r = dht::token_range::make(pks[lower].token(), pks[upper].token());
-                auto est = sst->estimated_keys_for_range(r);
+                auto est = sst->estimated_keys_for_range(r).get();
                 testlog.trace("est([{}; {}]) = {}", lower, upper, est);
                 BOOST_REQUIRE_GE(est, upper - lower + 1);
                 BOOST_REQUIRE_LE(est, max_est);
@@ -1203,14 +1203,14 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
 
             {
                 auto r = dht::token_range::make(all_pks[0].token(), all_pks[0].token());
-                auto est = sst->estimated_keys_for_range(r);
+                auto est = sst->estimated_keys_for_range(r).get();
                 testlog.trace("est(non-overlapping to the left) = {}", est);
                 BOOST_REQUIRE_EQUAL(est, 0);
             }
 
             {
                 auto r = dht::token_range::make(all_pks[all_pks.size() - 1].token(), all_pks[all_pks.size() - 1].token());
-                auto est = sst->estimated_keys_for_range(r);
+                auto est = sst->estimated_keys_for_range(r).get();
                 testlog.trace("est(non-overlapping to the right) = {}", est);
                 BOOST_REQUIRE_EQUAL(est, 0);
             }

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -1154,6 +1154,10 @@ SEASTAR_TEST_CASE(test_no_index_reads_when_rows_fall_into_range_boundaries) {
 
 SEASTAR_TEST_CASE(test_key_count_estimation) {
     return test_env::do_with_async([] (test_env& env) {
+      for (const auto enable_bti : {false, true}) {
+        if (enable_bti) {
+            env.force_bti_index().get();
+        }
         for (const auto version : writable_sstable_versions) {
             auto s = schema_builder("ks", "cf")
                 .with_column("pk", bytes_type, column_kind::partition_key)
@@ -1215,6 +1219,7 @@ SEASTAR_TEST_CASE(test_key_count_estimation) {
                 BOOST_REQUIRE_EQUAL(est, 0);
             }
         }
+      }
     });
 }
 

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -1,0 +1,149 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import pytest
+import asyncio
+import random
+import os
+import glob
+import json
+import logging
+from typing import Any
+from test.cluster.conftest import skip_mode
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+
+# main logger
+logger = logging.getLogger(__name__)
+
+async def live_update_config(manager: ManagerClient, servers: list[ServerInfo], key: str, value: Any):
+    cql, hosts = await manager.get_ready_cql(servers)
+    await asyncio.gather(*[manager.server_update_config(s.server_id, key, value) for s in servers])
+    stmt = cql.prepare("UPDATE system.config SET value=? WHERE name=?")
+    await asyncio.gather(*[cql.run_async(stmt, [json.dumps(value), key], host=host) for host in hosts])
+
+async def get_sstable_files_for_server(data_dir, ks, cf):
+    base_pattern = os.path.join(data_dir, "data", f"{ks}", f"{cf}-????????????????????????????????", "*.*")
+    sstables = glob.glob(base_pattern)
+    return sstables
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_bti_index_enable(manager: ManagerClient) -> None:
+    cassandra_logger = logging.getLogger('cassandra')
+    cassandra_logger.setLevel(logging.INFO)
+
+    n_servers = 1
+    ks_name = "ks"
+    cf_name = "t"
+
+    servers = await manager.servers_add(n_servers, config = {
+        'sstable_index_write_formats': ['bti'],
+        'error_injections_at_startup': [
+            {
+                'name': 'suppress_features',
+                'value': 'BTI_SSTABLE_INDEX',
+            }
+        ],
+        'column_index_size_in_kb': 1,
+    })
+    cql = manager.get_cql()
+    workdirs = await asyncio.gather(*[manager.server_get_workdir(s.server_id) for s in servers])
+
+    logger.info("Step 1: Creating keyspace and table")
+    await cql.run_async(
+        f"CREATE KEYSPACE {ks_name} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {n_servers}}};"
+    )
+    await cql.run_async(f"CREATE TABLE {ks_name}.{cf_name} (pk int, ck int, v blob, primary key (pk, ck));")
+
+    logger.info("Step 2: Populating the table")
+    insert = cql.prepare(f"INSERT INTO {ks_name}.{cf_name} (pk, ck, v) VALUES (?, ?, ?);")
+    n_pks = 3;
+    n_cks = 32;
+    pks = [i for i in range(n_pks)]
+    cks = [i for i in range(n_cks)]
+    vs = [random.randbytes(1024) for _ in range(n_cks)]
+    for pk in pks:
+        for ck, v in zip(cks, vs):
+            await cql.run_async(insert, (pk, ck, v))
+    await asyncio.gather(*[manager.api.keyspace_flush(s.ip_addr, ks_name, cf_name) for s in servers])
+
+    async def test_files_presence(bti_should_exist: bool, big_should_exist: bool):
+        sstable_sets = await asyncio.gather(*[get_sstable_files_for_server(wd, ks_name, cf_name) for wd in workdirs])
+        for sstable_set in sstable_sets:
+            partitions = [x for x in sstable_set if x.endswith('Partitions.db')]
+            rows = [x for x in sstable_set if x.endswith('Rows.db')]
+            index = [x for x in sstable_set if x.endswith('Index.db')]
+            summary = [x for x in sstable_set if x.endswith('Summary.db')]
+            if bti_should_exist:
+                assert len(partitions) > 0
+                assert len(rows) > 0
+            else:
+                assert len(partitions) == 0
+                assert len(rows) == 0
+            if big_should_exist:
+                assert len(index) > 0
+                assert len(summary) > 0
+            else:
+                assert len(index) == 0
+                assert len(summary) == 0
+
+    select_without_cache = cql.prepare(f"SELECT pk, ck, v FROM {ks_name}.{cf_name} WHERE pk=? and ck=? BYPASS CACHE;")
+    select_with_cache = cql.prepare(f"SELECT pk, ck, v FROM {ks_name}.{cf_name} WHERE pk=? and ck=?;")
+    chosen_pk = pks[len(pks) // 2]
+    chosen_ck_idx = len(cks) // 2
+    chosen_ck = cks[chosen_ck_idx]
+    chosen_v = vs[chosen_ck_idx]
+
+    async def test_bti_usage_during_reads(should_use_bti: bool, use_cache: bool):
+        select = select_with_cache if use_cache else select_without_cache
+        select_result = cql.execute(select, (chosen_pk, chosen_ck), trace=True)
+        row = select_result.one()
+        assert row.pk == chosen_pk
+        assert row.ck == chosen_ck
+        assert row.v == chosen_v
+
+        trace = select_result.get_query_trace()
+        seen_index = False
+        seen_partitions = False
+        seen_rows = False
+        for event in trace.events:
+            logger.info(f"Trace event: {event.description}")
+            seen_partitions = seen_partitions or "Partitions.db" in event.description
+            seen_rows = seen_rows or "Rows.db" in event.description
+            seen_index = seen_index or "Index.db" in event.description
+        if should_use_bti:
+            assert not seen_index, "Index.db was used despite BTI preference"
+            assert seen_partitions, "Partitions.db was not used despite BTI preference"
+            assert seen_rows, "Rows.db was not used despite BTI preference"
+        else:
+            assert seen_index, "Index.db was not used despite BIG preference"
+            assert not seen_partitions, "Partitions.db was used despite BIG preference"
+            assert not seen_rows, "Rows.db was used despite BIG preference"
+
+    logger.info("Step 3: Checking for BTI files (should not exist, because cluster feature is suppressed)")
+    await test_files_presence(bti_should_exist=False, big_should_exist=True)
+    await test_bti_usage_during_reads(should_use_bti=False, use_cache=False)
+
+    logger.info("Step 4: Updating config to ['big'], unsuppressing the cluster feature")
+    await live_update_config(manager, servers, 'sstable_index_write_formats', ['big'])
+    await asyncio.gather(*[manager.server_update_config(s.server_id, "error_injections_at_startup", []) for s in servers])
+    manager.driver_close()
+    await manager.rolling_restart(servers)
+    await manager.driver_connect()
+    cql, hosts = await manager.get_ready_cql(servers)
+    logger.info("Step 5: Checking for BTI files (should not exist, because BTI is not enabled in the config)")
+    await asyncio.gather(*[manager.api.keyspace_upgrade_sstables(s.ip_addr, ks_name) for s in servers])
+    await test_files_presence(bti_should_exist=False, big_should_exist=True)
+    await test_bti_usage_during_reads(should_use_bti=False, use_cache=False)
+
+    logger.info("Step 6: Updating write config to ['big', 'bti']")
+    await live_update_config(manager, servers, 'sstable_index_write_formats', ['big', 'bti'])
+    await asyncio.gather(*[manager.api.keyspace_upgrade_sstables(s.ip_addr, ks_name) for s in servers])
+    logger.info("Step 7: Checking for BTI files (should exist)")
+    await test_files_presence(bti_should_exist=True, big_should_exist=True)
+    await test_bti_usage_during_reads(should_use_bti=False, use_cache=False)
+
+    manager.driver_close()

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -151,4 +151,11 @@ async def test_bti_index_enable(manager: ManagerClient) -> None:
     await live_update_config(manager, servers, 'sstable_index_preferred_read_formats', ['bti'])
     await test_bti_usage_during_reads(should_use_bti=True, use_cache=False)
 
+    logger.info("Step 9: Updating write config to ['bti']")
+    await live_update_config(manager, servers, 'sstable_index_write_formats', ['bti'])
+    await asyncio.gather(*[manager.api.keyspace_upgrade_sstables(s.ip_addr, ks_name) for s in servers])
+    await test_files_presence(bti_should_exist=True, big_should_exist=False)
+    await test_bti_usage_during_reads(should_use_bti=True, use_cache=False)
+    await test_bti_usage_during_reads(should_use_bti=True, use_cache=True)
+
     manager.driver_close()

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -146,4 +146,9 @@ async def test_bti_index_enable(manager: ManagerClient) -> None:
     await test_files_presence(bti_should_exist=True, big_should_exist=True)
     await test_bti_usage_during_reads(should_use_bti=False, use_cache=False)
 
+    logger.info("Step 8: Enabling BTI preference for reads, checking that BTI is used.")
+    await test_bti_usage_during_reads(should_use_bti=False, use_cache=False)
+    await live_update_config(manager, servers, 'sstable_index_preferred_read_formats', ['bti'])
+    await test_bti_usage_during_reads(should_use_bti=True, use_cache=False)
+
     manager.driver_close()

--- a/test/lib/sstable_test_env.hh
+++ b/test/lib/sstable_test_env.hh
@@ -169,6 +169,7 @@ public:
     test_env_compaction_manager& test_compaction_manager();
     reader_concurrency_semaphore& semaphore();
     db::config& db_config();
+    future<> force_bti_index();
     tmpdir& tempdir() noexcept;
     data_dictionary::storage_options get_storage_options() const noexcept;
 

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -156,9 +156,8 @@ public:
         // scylla component must be present for a sstable to be considered fully expired.
         _sst->_recognized_components.insert(component_type::Scylla);
         _sst->_components->statistics.contents[metadata_type::Stats] = std::make_unique<stats_metadata>(std::move(stats));
-        _sst->_components->summary.first_key.value = sstables::key::from_partition_key(*_sst->_schema, first_key).get_bytes();
-        _sst->_components->summary.last_key.value = sstables::key::from_partition_key(*_sst->_schema, last_key).get_bytes();
-        _sst->set_first_and_last_keys();
+        _sst->_first = dht::decorate_key(*_sst->_schema, first_key);
+        _sst->_last = dht::decorate_key(*_sst->_schema, last_key);
         _sst->_components->statistics.contents[metadata_type::Compaction] = std::make_unique<compaction_metadata>();
         _sst->_run_identifier = run_id::create_random_id();
         _sst->_shards.push_back(this_shard_id());

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -462,6 +462,11 @@ test_env::db_config() {
     return *_impl->db_config;
 }
 
+future<> test_env::force_bti_index() {
+    co_await _impl->feature_service.enable({"BTI_SSTABLE_INDEX"});
+    db_config().sstable_index_write_formats.set({{db::sstable_index_format_t::mode::bti}});
+}
+
 tmpdir&
 test_env::tempdir() noexcept {
     return _impl->dir;

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -559,15 +559,17 @@ void do_test(const test_config& cfg) {
                     if (current_clustering_block) {
                         push_clustering_block();
                     }
+                    auto pk = sstables::key::from_partition_key(*adjusted_schema, current_partition->dk.key());
+                    auto hash = utils::make_hashed_key(bytes_view(pk));
                     auto payload = bti_row_index_writer.finish(
                         sst->get_version(),
                         *adjusted_schema,
                         current_partition->data_file_offset,
                         frag.offset,
-                        sstables::key::from_partition_key(*adjusted_schema, current_partition->dk.key()),
+                        pk,
                         sstable_deletion_time_from_tombstone(current_partition->partition_tombstone)
                     );
-                    bti_partition_index_writer.add(*adjusted_schema, current_partition->dk, payload);
+                    bti_partition_index_writer.add(*adjusted_schema, current_partition->dk, hash, payload);
                     current_partition.reset();
                 }
             }

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -570,8 +570,8 @@ void do_test(const test_config& cfg) {
             }
             std::move(bti_partition_index_writer).finish(
                 sst->get_version(),
-                disk_string_view<uint16_t>(sstables::key::from_partition_key(*adjusted_schema, mutations.front().key()).get_bytes()),
-                disk_string_view<uint16_t>(sstables::key::from_partition_key(*adjusted_schema, mutations.back().key()).get_bytes())
+                sstables::key::from_partition_key(*adjusted_schema, mutations.front().key()),
+                sstables::key::from_partition_key(*adjusted_schema, mutations.back().key())
             );
             testlog.info("Finished BTI index writing");
         }

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -242,11 +242,11 @@ void test_index_files(
     auto region = logalloc::region();
     auto partitions_db_size = partitions_db.size().get();
     auto rows_db_size = rows_db.size().get();
-    auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
-    auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
+    auto partitions_db_cached = seastar::make_shared<cached_file>(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
+    auto rows_db_cached = seastar::make_shared<cached_file>(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
     // Read the Partitions.db footer, check the metadata contained there.
-    auto footer = sstables::trie::read_bti_partitions_db_footer(*s, sstable::version_types::me, partitions_db_cached.get_file(), partitions_db_size).get();
+    auto footer = sstables::trie::read_bti_partitions_db_footer(*s, sstable::version_types::me, partitions_db_cached->get_file(), partitions_db_size).get();
     SCYLLA_ASSERT(footer.partition_count == pm.partition_count);
     SCYLLA_ASSERT(sstables::key_view(footer.first_key) == sstables::key::from_partition_key(*s, pm.first_key.key()));
     SCYLLA_ASSERT(sstables::key_view(footer.last_key) == sstables::key::from_partition_key(*s, pm.last_key.key()));

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -251,13 +251,16 @@ void test_index_files(
     SCYLLA_ASSERT(sstables::key_view(footer.first_key) == sstables::key::from_partition_key(*s, pm.first_key.key()));
     SCYLLA_ASSERT(sstables::key_view(footer.last_key) == sstables::key::from_partition_key(*s, pm.last_key.key()));
 
+    auto trace_state = tracing::trace_state_ptr();
     auto ir = sstables::trie::make_bti_index_reader(
         partitions_db_cached,
         rows_db_cached,
         footer.trie_root_position,
         data_db_size,
         s,
-        env.make_reader_permit());
+        env.make_reader_permit(),
+        trace_state
+    );
 
     // We validate the index by iterating over fragments and checking that
     // the index gives the right results when it's forwarded to the position of each fragment. 

--- a/types/comparable_bytes.cc
+++ b/types/comparable_bytes.cc
@@ -1231,6 +1231,11 @@ struct to_comparable_bytes_visitor {
 
     void operator()(const empty_type_impl&) {}
 
+    void operator()(const date_type_impl&) {
+        out.write(serialized_bytes_view.prefix(sizeof(db_clock::rep)));
+        serialized_bytes_view.remove_prefix(sizeof(db_clock::rep));
+    }
+
     void operator()(const abstract_type& type) {
         // Unimplemented
         on_internal_error(cblogger, fmt::format("byte comparable format not supported for type {}", type.name()));
@@ -1352,6 +1357,11 @@ struct from_comparable_bytes_visitor {
     }
 
     void operator()(const empty_type_impl&) {}
+
+    void operator()(const date_type_impl&) {
+        out.write(comparable_bytes_view.prefix(sizeof(db_clock::rep)));
+        comparable_bytes_view.remove_prefix(sizeof(db_clock::rep));
+    }
 
     void operator()(const abstract_type& type) {
         // Unimplemented

--- a/utils/bloom_filter.cc
+++ b/utils/bloom_filter.cc
@@ -62,7 +62,11 @@ bool bloom_filter::is_present(hashed_key key) {
 }
 
 void bloom_filter::add(const bytes_view& key) {
-    for_each_index(make_hashed_key(key), _hash_count, _bitset.size(), _format, [this] (auto i) {
+    add(make_hashed_key(key));
+}
+
+void bloom_filter::add(const hashed_key& key) {
+    for_each_index(key, _hash_count, _bitset.size(), _format, [this] (auto i) {
         _bitset.set(i);
         return stop_iteration::no;
     });

--- a/utils/bloom_filter.hh
+++ b/utils/bloom_filter.hh
@@ -39,6 +39,7 @@ public:
     ~bloom_filter() noexcept;
 
     virtual void add(const bytes_view& key) override;
+    virtual void add(const hashed_key& key) override;
 
     virtual bool is_present(const bytes_view& key) override;
 
@@ -77,6 +78,7 @@ struct always_present_filter: public i_filter {
     }
 
     virtual void add(const bytes_view& key) override { }
+    virtual void add(const hashed_key& key) override { }
 
     virtual void clear() override { }
 

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -175,6 +175,9 @@ public:
     future<page_read_result> get_shared_page(size_t global_pos, tracing::trace_state_ptr trace_state) {
         return get_page_ptr(global_pos / page_size, 1, trace_state);
     }
+    future<page_read_result> get_shared_page(size_t global_pos, reader_permit permit, tracing::trace_state_ptr trace_state) {
+        return get_page_ptr(global_pos / page_size, 1, trace_state, permit);
+    }
 private:
     future<page_read_result> get_page_ptr(page_idx_type idx,
             page_count_type read_ahead,

--- a/utils/i_filter.hh
+++ b/utils/i_filter.hh
@@ -38,6 +38,7 @@ struct i_filter {
     virtual ~i_filter() {}
 
     virtual void add(const bytes_view& key) = 0;
+    virtual void add(const hashed_key& key) = 0;
     virtual bool is_present(const bytes_view& key) = 0;
     virtual bool is_present(hashed_key) = 0;
     virtual void clear() = 0;


### PR DESCRIPTION
This is yet another part in the BTI index project.

Overarching issue: https://github.com/scylladb/scylladb/issues/19191
Previous part: https://github.com/scylladb/scylladb/pull/25626
Next parts: tweaking the config interface, general improvements

In this part we integrate BTI index readers and writers with `class sstable` and its readers and writers.

After this series, one can use scylla.yaml to enable writing of BTI index files (Partitions.db and Rows.db) in addition to, or as a replacement for, BIG index files (Summary.db and Index.db), and/or to set BTI as the preferred index format for reads if a sstable has indexes in both formats.

Note that this doesn't result in Cassandra compatibility. Cassandra only produces and understands Partitions.db and Rows.db if they appear in BTI-format sstables (version >= `da`). In this PR we are only extending `me` sstables with extra files, not implementing the entire `da` format. (We might eventually do that, but it involves several changes unrelated to the index, and it's outside the scope of this PR). Cassandra won't understand a `me` file extended with `Partitions.db` and `Rows.db`, so what this PR is doing is an abuse of the "versioning" of SSTable formats. But it has some benefits, like the ability to write both index formats and e.g. quickly switch stop using one of them for reads if it turns out problematic. If this abuse of versioning is too controversial or messy, we can think of a different way of adding BTI indexes.

This PR has 4 parts:
- Commits up to and including `sstables/mx/reader: remove mx::make_reader_with_index_reader` are a loose bag of various fixes and improvements to pre-existing code, which either had to or deserved to be done before the main part of the PR.
- Commits from `gms/feature_service: add a cluster feature for BTI-format sstable index files` to `sstables: use BTI index for queries, when present and enabled` add code that writes (during sstable writes) and reads (during queries) the new `Partitions` and `Rows` components. After this part BTI index files can be written and read, but BIG index files are always written too.
- Commits from `sstables/mx: implement sstable::has_partition_key using a regular read` to `sstables/mx: make Index and Summary components optional` adjusts various operations that depend on the existence of `Index` and/or `Summary` components (in particular: estimation of partition count in a given token range, looking up the first and last key in the sstable, the mechanism that rebuilds the bloom filter before sealing the sstable if the filter turns out to be oversized) so that they work with either index format. After this part, sstables can be written with either only BTI, only BIG or both index formats.
- Commits from `sstables/trie/bti_partition_index_writer: in add(), get the key hash from the caller` to `sstables/mx/reader: use the same hashed_key for the bloom filter and the index reader` are (hopefully) an optimization which avoids recomputing the murmur hash of the partition key for each partition for each Partitions.db reader/writer. After this part, Partition.db readers and writers reuse the murmur hash object that is computed for bloom filters anyway.   

Testing note: as of this writing, the new code is very weakly tested with automated tests, because the new index files are disabled by default and tests (besides the barebones Python test added in this series) don't enable them. I'm not sure how to best plug this into existing automated tests. I have tested this series "manually" by tweaking the code so that BTI index files are enabled and preferred by default, and running the whole test suite. There are several tests which fail if you do that, because they expect Index and Summary to exist. But other than that, things seem to work. (No, I don't think that's a good enough level of testing. Adding this to automated testing is something that has to be solved somehow before the PR is merged).

New functionality, no backporting desired.