### PR TITLE
tablet: scheduler: Do not emit conflicting migrations in the plan

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -659,6 +659,8 @@ class load_balancer {
     replica::database& _db;
     token_metadata_ptr _tm;
     std::optional<locator::load_sketch> _load_sketch;
+    // Holds the set of tablets already scheduled for transition during plan-making.
+    std::unordered_set<global_tablet_id> _scheduled_tablets;
     // Holds tablet replica count per table in the balanced node set (within a single DC).
     absl::flat_hash_map<table_id, size_t> _tablet_count_per_table;
     dc_name _dc;
@@ -1161,6 +1163,7 @@ public:
                 apply_load(nodes, mig_streaming_info);
 
                 lblogger.info("Created migration for replica ({}, {}) to co-habit same shard as ({}, {})", t2_id, src, t1_id, dst);
+                mark_as_scheduled(mig);
                 plan.add(std::move(mig));
                 return make_ready_future<>();
             });
@@ -1972,6 +1975,16 @@ public:
         }
     }
 
+    void mark_as_scheduled(const tablet_migration_info& mig) {
+        _scheduled_tablets.insert(mig.tablet);
+    }
+
+    void mark_as_scheduled(const migration_plan::migrations_vector& migs) {
+        for (auto&& mig : migs) {
+            mark_as_scheduled(mig);
+        }
+    }
+
     future<migration_plan> make_node_plan(node_load_map& nodes, host_id host, node_load& node_load) {
         migration_plan plan;
         const tablet_metadata& tmeta = _tm->tablets();
@@ -2071,6 +2084,7 @@ public:
             lblogger.debug("Adding migration: {}", mig);
             _stats.for_dc(node_load.dc()).migrations_produced++;
             _stats.for_dc(node_load.dc()).intranode_migrations_produced++;
+            mark_as_scheduled(mig);
             plan.add(std::move(mig));
 
             erase_candidates(nodes, tmap, tablets);
@@ -2727,6 +2741,7 @@ public:
                 apply_load(nodes, mig_streaming_info);
                 lblogger.debug("Adding migration: {}", mig);
                 _stats.for_dc(dc).migrations_produced++;
+                mark_as_scheduled(mig);
                 plan.add(std::move(mig));
             } else {
                 // Shards are overloaded with streaming. Do not include the migration in the plan, but
@@ -3051,8 +3066,8 @@ public:
             auto get_replicas = [this] (std::optional<tablet_desc> t) -> tablet_replica_set {
                 return t ? sorted_replicas_for_tablet_load(*t->info, t->transition) : tablet_replica_set{};
             };
-            auto migrating = [] (std::optional<tablet_desc> t) {
-                return t && bool(t->transition);
+            auto migrating = [&] (std::optional<tablet_desc> t) {
+                return t && (bool(t->transition) || _scheduled_tablets.contains(global_tablet_id{table, t->tid}));
             };
             auto maybe_apply_load = [&] (std::optional<tablet_desc> t) {
                 if (t && is_streaming(t->transition)) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1725,6 +1725,61 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
   }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_no_conflicting_migrations_in_the_plan) {
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 1;
+        auto dc1 = topo.dc();
+        [[maybe_unused]] auto host1 = topo.add_node(node_state::normal, shard_count);
+        [[maybe_unused]] auto host2 = topo.add_node(node_state::normal, shard_count);
+        topo.start_new_rack();
+        [[maybe_unused]] auto host3 = topo.add_node(node_state::normal, shard_count);
+        [[maybe_unused]] auto host4 = topo.add_node(node_state::normal, shard_count);
+        auto dc2 = topo.start_new_dc().dc;
+        [[maybe_unused]] auto host5 = topo.add_node(node_state::normal, shard_count);
+        [[maybe_unused]] auto host6 = topo.add_node(node_state::normal, shard_count);
+
+        auto ks_name = add_keyspace(e, {{dc1, 2}, {dc2, 1}}, 2);
+        auto table1 = add_table(e, ks_name).get();
+
+        // Create imbalance in dc1::rack1, dc1::rack2, and dc2::rack1
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
+            tablet_map tmap(2);
+            auto tid = tmap.first_tablet();
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica{host1, 0},
+                    tablet_replica{host3, 0},
+                    tablet_replica{host5, 0},
+                }
+            });
+            tid = *tmap.next_tablet(tid);
+            tmap.set_tablet(tid, tablet_info {
+                tablet_replica_set {
+                    tablet_replica{host1, 0},
+                    tablet_replica{host3, 0},
+                    tablet_replica{host5, 0},
+                }
+            });
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            co_return;
+        });
+
+        auto& stm = e.shared_token_metadata().local();
+        auto& talloc = e.get_tablet_allocator().local();
+        talloc.set_load_stats(topo.get_load_stats());
+        migration_plan plan = talloc.balance_tablets(stm.get()).get();
+
+        BOOST_REQUIRE(!plan.empty());
+        std::set<global_tablet_id> tablets;
+        for (auto&& mig : plan.migrations()) {
+            BOOST_REQUIRE(!tablets.contains(mig.tablet));
+            tablets.insert(mig.tablet);
+        }
+    }).get();
+}
+
 // Throws if tablets have more than 1 replica in a given rack.
 // Run in seastar thread.
 void check_no_rack_overload(const token_metadata& tm) {


### PR DESCRIPTION
Plan-making is invoked independently for different DCs (and in the future, racks) and then plans are merged. It could be that the same tablets are selected for migration in different DCs. Only one migration will prevail and be committed to group0, so it's not a correctness problem. Next cycle will recognize that the tablet is in transition and will not be selected by plan-maker. But it makes plan-making less efficient.

It may also surprise consumers of the plan, like we saw in #25912.

So we should make plan-maker be aware of already scheduled transitions and not consider those tablets as candidates.

Fixes #26038

Backport-none: Doesn't fix any preexisting field issue.
