### PR TITLE
vector_store_client: Extract DNS logic into a dedicated class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,7 @@ add_subdirectory(tracing)
 add_subdirectory(transport)
 add_subdirectory(types)
 add_subdirectory(utils)
+add_subdirectory(vector_search)
 add_version_library(scylla_version
     release.cc)
 
@@ -323,7 +324,8 @@ set(scylla_libs
     tracing
     transport
     types
-    utils)
+    utils
+    vector_search)
 target_link_libraries(scylla PRIVATE
     ${scylla_libs})
 

--- a/configure.py
+++ b/configure.py
@@ -1257,6 +1257,7 @@ scylla_core = (['message/messaging_service.cc',
                 'reader_concurrency_semaphore_group.cc',
                 'utils/disk_space_monitor.cc',
                 'vector_search/vector_store_client.cc',
+                'vector_search/dns.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] \
                   + scylla_raft_core
                )

--- a/configure.py
+++ b/configure.py
@@ -1256,7 +1256,7 @@ scylla_core = (['message/messaging_service.cc',
                 'node_ops/task_manager_module.cc',
                 'reader_concurrency_semaphore_group.cc',
                 'utils/disk_space_monitor.cc',
-                'service/vector_store_client.cc',
+                'vector_search/vector_store_client.cc',
                 ] + [Antlr3Grammar('cql3/Cql.g')] \
                   + scylla_raft_core
                )

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -27,7 +27,6 @@
 #include "cql3/untyped_result_set.hh"
 #include "db/config.hh"
 #include "data_dictionary/data_dictionary.hh"
-#include "service/vector_store_client.hh"
 #include "utils/hashers.hh"
 #include "utils/error_injection.hh"
 #include "service/migration_manager.hh"
@@ -69,7 +68,7 @@ static service::query_state query_state_for_internal_call() {
     return {service::client_state::for_internal_calls(), empty_service_permit()};
 }
 
-query_processor::query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, service::vector_store_client& vsc, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm)
+query_processor::query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, vector_search::vector_store_client& vsc, query_processor::memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm)
         : _migration_subscriber{std::make_unique<migration_subscriber>(this)}
         , _proxy(proxy)
         , _db(db)

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -28,7 +28,7 @@
 #include "transport/messages/result_message.hh"
 #include "service/client_state.hh"
 #include "service/broadcast_tables/experimental/query_result.hh"
-#include "service/vector_store_client.hh"
+#include "vector_search/vector_store_client.hh"
 #include "utils/assert.hh"
 #include "utils/observable.hh"
 #include "service/raft/raft_group0_client.hh"
@@ -109,7 +109,7 @@ private:
     service::storage_proxy& _proxy;
     data_dictionary::database _db;
     service::migration_notifier& _mnotifier;
-    service::vector_store_client& _vector_store_client;
+    vector_search::vector_store_client& _vector_store_client;
     memory_config _mcfg;
     const cql_config& _cql_config;
 
@@ -149,7 +149,8 @@ public:
     static std::unique_ptr<statements::raw::parsed_statement> parse_statement(const std::string_view& query, dialect d);
     static std::vector<std::unique_ptr<statements::raw::parsed_statement>> parse_statements(std::string_view queries, dialect d);
 
-    query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, service::vector_store_client& vsc, memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm);
+    query_processor(service::storage_proxy& proxy, data_dictionary::database db, service::migration_notifier& mn, vector_search::vector_store_client& vsc,
+            memory_config mcfg, cql_config& cql_cfg, utils::loading_cache_config auth_prep_cache_cfg, lang::manager& langm);
 
     ~query_processor();
 
@@ -179,11 +180,11 @@ public:
 
     lang::manager& lang() { return _lang_manager; }
 
-    const service::vector_store_client& vector_store_client() const noexcept {
+    const vector_search::vector_store_client& vector_store_client() const noexcept {
         return _vector_store_client;
     }
 
-    service::vector_store_client& vector_store_client() noexcept {
+    vector_search::vector_store_client& vector_store_client() noexcept {
         return _vector_store_client;
     }
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -23,7 +23,7 @@
 #include <seastar/coroutine/exception.hh>
 #include "service/broadcast_tables/experimental/lang.hh"
 #include "service/qos/qos_common.hh"
-#include "service/vector_store_client.hh"
+#include "vector_search/vector_store_client.hh"
 #include "transport/messages/result_message.hh"
 #include "cql3/functions/as_json_function.hh"
 #include "cql3/selection/selection.hh"
@@ -1223,9 +1223,8 @@ indexed_table_select_statement::actually_do_execute(query_processor& qp,
         auto as = abort_source();
         auto pkeys = co_await qp.vector_store_client().ann(_schema->ks_name(), _index.metadata().name(), _schema , std::move(ann_vector), limit, as);
         if (!pkeys.has_value()) {
-            co_await coroutine::return_exception(exceptions::invalid_request_exception(
-                std::visit(service::vector_store_client::ann_error_visitor{}, pkeys.error())
-            ));
+            co_await coroutine::return_exception(
+                    exceptions::invalid_request_exception(std::visit(vector_search::vector_store_client::ann_error_visitor{}, pkeys.error())));
         }
 
         // If there are no clustering columns, we have to convert the partition keys to partition ranges.

--- a/main.cc
+++ b/main.cc
@@ -42,7 +42,6 @@
 #include "service/migration_manager.hh"
 #include "service/tablet_allocator.hh"
 #include "service/load_meter.hh"
-#include "service/vector_store_client.hh"
 #include "service/view_update_backlog_broker.hh"
 #include "service/qos/service_level_controller.hh"
 #include "streaming/stream_session.hh"
@@ -64,6 +63,7 @@
 #include "release.hh"
 #include "repair/repair.hh"
 #include "repair/row_level.hh"
+#include "vector_search/vector_store_client.hh"
 #include <cstdio>
 #include <seastar/core/file.hh>
 #include <unistd.h>
@@ -747,7 +747,7 @@ sharded<locator::shared_token_metadata> token_metadata;
     sharded<service::mapreduce_service> mapreduce_service;
     sharded<gms::gossiper> gossiper;
     sharded<locator::snitch_ptr> snitch;
-    sharded<service::vector_store_client> vector_store_client;
+    sharded<vector_search::vector_store_client> vector_store_client;
 
     // This worker wasn't designed to be used from multiple threads.
     // If you are attempting to do that, make sure you know what you are doing.
@@ -1339,7 +1339,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             auto stop_vector_store_client = defer_verbose_shutdown("vector store client", [&vector_store_client] {
                 vector_store_client.stop().get();
             });
-            vector_store_client.invoke_on_all(&service::vector_store_client::start_background_tasks).get();
+            vector_store_client.invoke_on_all(&vector_search::vector_store_client::start_background_tasks).get();
 
             checkpoint(stop_signal, "starting query processor");
             cql3::query_processor::memory_config qp_mcfg = {memory::stats().total_memory() / 256, memory::stats().total_memory() / 2560};

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -33,8 +33,7 @@ target_sources(service
     task_manager_module.cc
     topology_coordinator.cc
     topology_mutation.cc
-    topology_state_machine.cc
-    vector_store_client.cc)
+    topology_state_machine.cc)
 target_include_directories(service
   PUBLIC
     ${CMAKE_SOURCE_DIR})

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -305,7 +305,7 @@ add_scylla_test(wrapping_interval_test
 add_scylla_test(address_map_test
   KIND SEASTAR)
 add_scylla_test(vector_store_client_test
-  KIND SEASTAR)
+  KIND SEASTAR LIBRARIES vector_search)
 
 add_scylla_test(combined_tests
   KIND SEASTAR

--- a/test/boost/vector_store_client_test.cc
+++ b/test/boost/vector_store_client_test.cc
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
  */
 
-#include "service/vector_store_client.hh"
+#include "vector_search/vector_store_client.hh"
 #include "db/config.hh"
 #include "exceptions/exceptions.hh"
 #include "cql3/statements/select_statement.hh"
@@ -33,8 +33,8 @@ namespace {
 
 using namespace seastar;
 
-using vector_store_client = service::vector_store_client;
-using vector_store_client_tester = service::vector_store_client_tester;
+using vector_store_client = vector_search::vector_store_client;
+using vector_store_client_tester = vector_search::vector_store_client_tester;
 using config = vector_store_client::config;
 using configuration_exception = exceptions::configuration_exception;
 using inet_address = seastar::net::inet_address;
@@ -132,10 +132,10 @@ auto create_test_table(cql_test_env& env, const sstring& ks, const sstring& cf) 
 }
 
 class configure {
-    std::reference_wrapper<service::vector_store_client> vs_ref;
+    std::reference_wrapper<vector_search::vector_store_client> vs_ref;
 
 public:
-    explicit configure(service::vector_store_client& vs)
+    explicit configure(vector_search::vector_store_client& vs)
         : vs_ref(vs) {
         with_dns_refresh_interval(seconds(2));
         with_wait_for_client_timeout(milliseconds(100));

--- a/test/boost/vector_store_client_test.cc
+++ b/test/boost/vector_store_client_test.cc
@@ -462,7 +462,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
 
                 // missing primary_keys in the reply - service should return format error
                 ann_replies->emplace(std::make_tuple(R"({"vector":[0.1,0.2,0.3],"limit":2})",
-                            R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"));
+                        R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"));
                 auto const now = lowres_clock::now();
                 for (;;) {
                     as.reset();
@@ -505,16 +505,16 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of pk2 key in the reply - service should return format error
-                ann_replies->emplace(std::make_tuple(R"({"vector":[0.1,0.2,0.3],"limit":2})",
-                        R"({"primary_keys":{"pk1":[5,6],"pk2":[78],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"));
+                ann_replies->emplace(std::make_tuple(
+                        R"({"vector":[0.1,0.2,0.3],"limit":2})", R"({"primary_keys":{"pk1":[5,6],"pk2":[78],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"));
                 as.reset();
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, as.as);
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of ck2 key in the reply - service should return format error
-                ann_replies->emplace(std::make_tuple(R"({"vector":[0.1,0.2,0.3],"limit":2})",
-                        R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[23]},"distances":[0.1,0.2]})"));
+                ann_replies->emplace(std::make_tuple(
+                        R"({"vector":[0.1,0.2,0.3],"limit":2})", R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[23]},"distances":[0.1,0.2]})"));
                 as.reset();
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, as.as);
                 BOOST_REQUIRE(!keys);

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -176,7 +176,7 @@ private:
     sharded<gms::gossip_address_map> _gossip_address_map;
     sharded<service::direct_fd_pinger> _fd_pinger;
     sharded<cdc::cdc_service> _cdc;
-    sharded<service::vector_store_client> _vector_store_client;
+    sharded<vector_search::vector_store_client> _vector_store_client;
     db::config* _db_config;
 
     service::raft_group0_client* _group0_client;

--- a/vector_search/CMakeLists.txt
+++ b/vector_search/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(vector_search STATIC)
 target_sources(vector_search
   PRIVATE
-    vector_store_client.cc)
+    vector_store_client.cc
+    dns.cc)
 target_link_libraries(vector_search
   PUBLIC
     Seastar::seastar

--- a/vector_search/CMakeLists.txt
+++ b/vector_search/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(vector_search STATIC)
+target_sources(vector_search
+  PRIVATE
+    vector_store_client.cc)
+target_link_libraries(vector_search
+  PUBLIC
+    Seastar::seastar
+  PRIVATE
+    cql3
+    db
+    utils
+    schema
+    scylla_dht
+    )
+
+check_headers(check-headers vector_search
+  GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/vector_search/dns.hh
+++ b/vector_search/dns.hh
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/sstring.hh>
+#include "utils/log.hh"
+#include <chrono>
+#include <optional>
+#include <functional>
+#include <seastar/net/inet_address.hh>
+
+namespace vector_search {
+
+class dns {
+public:
+    using address_type = std::optional<seastar::net::inet_address>;
+    using resolver_type = std::function<seastar::future<address_type>(seastar::sstring const&)>;
+    using listener_type = std::function<seastar::future<>(address_type const&)>;
+
+    explicit dns(logging::logger& logger, std::optional<seastar::sstring> host, listener_type listener);
+
+    void start_background_tasks();
+
+    void refresh_interval(std::chrono::milliseconds interval) {
+        _refresh_interval = interval;
+    }
+
+    void host(std::optional<seastar::sstring> h) {
+        current_addr = std::nullopt;
+        _host = std::move(h);
+        trigger_refresh();
+    }
+
+    void resolver(resolver_type r) {
+        _resolver = std::move(r);
+    }
+
+    void trigger_refresh() {
+        refresh_cv.signal();
+    }
+
+    seastar::future<> refresh_addr_task();
+
+    seastar::future<> stop() {
+        abort_refresh.request_abort();
+        refresh_cv.signal();
+        return tasks_gate.close();
+    }
+
+private:
+    seastar::future<> refresh_addr();
+
+    seastar::gate tasks_gate;
+    logging::logger& vslogger;
+    seastar::abort_source abort_refresh;
+    seastar::lowres_clock::time_point last_refresh;
+    std::chrono::milliseconds _refresh_interval;
+    seastar::condition_variable refresh_cv;
+    resolver_type _resolver;
+    std::optional<seastar::sstring> _host;
+    std::optional<seastar::net::inet_address> current_addr;
+    listener_type _listener;
+};
+
+} // namespace vector_search

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -609,8 +609,9 @@ auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_pt
     }
 
     if (resp->status != status_type::ok) {
-        vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status,
-                       seastar::value_of([&resp] {return response_content_to_sstring(resp->content);}));
+        vslogger.error("Vector Store returned error: HTTP status {}: {}", resp->status, seastar::value_of([&resp] {
+            return response_content_to_sstring(resp->content);
+        }));
         co_return std::unexpected{service_error{resp->status}};
     }
 

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -34,21 +34,21 @@ namespace {
 
 using namespace std::chrono_literals;
 
-using ann_error = service::vector_store_client::ann_error;
+using ann_error = vector_search::vector_store_client::ann_error;
 using configuration_exception = exceptions::configuration_exception;
 using duration = lowres_clock::duration;
-using vs_vector = service::vector_store_client::vs_vector;
-using limit = service::vector_store_client::limit;
-using host_name = service::vector_store_client::host_name;
+using vs_vector = vector_search::vector_store_client::vs_vector;
+using limit = vector_search::vector_store_client::limit;
+using host_name = vector_search::vector_store_client::host_name;
 using http_path = sstring;
 using inet_address = seastar::net::inet_address;
 using json_content = sstring;
 using milliseconds = std::chrono::milliseconds;
 using operation_type = httpd::operation_type;
-using port_number = service::vector_store_client::port_number;
-using primary_key = service::vector_store_client::primary_key;
-using primary_keys = service::vector_store_client::primary_keys;
-using service_reply_format_error = service::vector_store_client::service_reply_format_error;
+using port_number = vector_search::vector_store_client::port_number;
+using primary_key = vector_search::vector_store_client::primary_key;
+using primary_keys = vector_search::vector_store_client::primary_keys;
+using service_reply_format_error = vector_search::vector_store_client::service_reply_format_error;
 using tcp_keepalive_params = net::tcp_keepalive_params;
 using time_point = lowres_clock::time_point;
 
@@ -303,7 +303,7 @@ sstring response_content_to_sstring(const std::vector<temporary_buffer<char>>& b
 
 } // namespace
 
-namespace service {
+namespace vector_search {
 
 struct vector_store_client::impl {
 
@@ -650,4 +650,4 @@ auto vector_store_client_tester::resolve_hostname(vector_store_client& vsc, abor
     co_return client.value()->addr();
 }
 
-} // namespace service
+} // namespace vector_search

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -28,7 +28,7 @@ namespace seastar::net {
 class inet_address;
 }
 
-namespace service {
+namespace vector_search {
 
 /// A client with the vector-store service.
 class vector_store_client final {
@@ -71,22 +71,22 @@ public:
     using ann_error = std::variant<disabled, aborted, addr_unavailable, service_unavailable, service_error, service_reply_format_error>;
 
     struct ann_error_visitor {
-        sstring operator()(service::vector_store_client::service_error e) const {
+        sstring operator()(vector_store_client::service_error e) const {
             return fmt::format("Vector Store error: HTTP status {}", e.status);
         }
-        sstring operator()(service::vector_store_client::disabled) const {
+        sstring operator()(vector_store_client::disabled) const {
             return fmt::format("Vector Store is disabled");
         }
-        sstring operator()(service::vector_store_client::aborted) const {
+        sstring operator()(vector_store_client::aborted) const {
             return fmt::format("Vector Store request was aborted");
         }
-        sstring operator()(service::vector_store_client::addr_unavailable) const {
+        sstring operator()(vector_store_client::addr_unavailable) const {
             return fmt::format("Vector Store service address could not be fetched from DNS");
         }
-        sstring operator()(service::vector_store_client::service_unavailable) const {
+        sstring operator()(vector_store_client::service_unavailable) const {
             return fmt::format("Vector Store service is unavailable");
         }
-        sstring operator()(service::vector_store_client::service_reply_format_error) const {
+        sstring operator()(vector_store_client::service_reply_format_error) const {
             return fmt::format("Vector Store returned an invalid JSON");
         }
     };
@@ -127,4 +127,4 @@ struct vector_store_client_tester {
     static auto resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::optional<net::inet_address>>;
 };
 
-} // namespace service
+} // namespace vector_search


### PR DESCRIPTION
Vector search related implementation moved to a new module vector_search.
As the vector search functionality is going to be extended, it is better to keep it in a separate module.

The DNS resolution logic and its background task are moved out of the `vector_store_client` and into a new, dedicated class `vector_search::dns`.

This refactoring is the first step towards supporting DNS hostnames that resolve to multiple IP addresses.

References: VECTOR-187

No backport needed as this is refactoring.