### PR TITLE
disk_space_monitor_test.cc: Start a monitor after fake space source function is registered

### DIFF
--- a/test/boost/disk_space_monitor_test.cc
+++ b/test/boost/disk_space_monitor_test.cc
@@ -99,7 +99,6 @@ SEASTAR_THREAD_TEST_CASE(test_subscription_options) {
 
     utils::disk_space_monitor dsm(as, data_dir_path, dsm_cfg);
     auto stop_dsm = defer([&dsm] { dsm.stop().get(); });
-    dsm.start().get();
 
     float disk_utilization = 0.1;
     auto registration = dsm.set_space_source([&] {
@@ -110,6 +109,8 @@ SEASTAR_THREAD_TEST_CASE(test_subscription_options) {
         };
         return make_ready_future<std::filesystem::space_info>(space);
     });
+
+    dsm.start().get();
 
     struct stats {
         size_t constant_updates = 0;


### PR DESCRIPTION
When the monitor is started, the first disk utilization value is obtained from the actual host filesystem and not from the fake space source function.

Thus, register a fake space source function before the monitor is started.

Fixes: https://github.com/scylladb/scylladb/issues/26036

Backport is not required. The test has been added recently.