### PR TITLE
vector_store_client: Add support for multiple IPs in DNS responses

### DIFF
--- a/test/boost/vector_store_client_test.cc
+++ b/test/boost/vector_store_client_test.cc
@@ -129,7 +129,6 @@ public:
         : vs_ref(vs) {
         with_dns_refresh_interval(seconds(2));
         with_wait_for_client_timeout(milliseconds(100));
-        with_http_request_retries(3);
         with_dns_resolver([](auto const& host) -> future<std::optional<inet_address>> {
             co_return inet_address("127.0.0.1");
         });
@@ -142,11 +141,6 @@ public:
 
     configure& with_wait_for_client_timeout(milliseconds timeout) {
         vector_store_client_tester::set_wait_for_client_timeout(vs_ref.get(), timeout);
-        return *this;
-    }
-
-    configure& with_http_request_retries(int retries) {
-        vector_store_client_tester::set_http_request_retries(vs_ref.get(), retries);
         return *this;
     }
 

--- a/test/boost/vector_store_client_test.cc
+++ b/test/boost/vector_store_client_test.cc
@@ -456,9 +456,10 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
             },
-            cfg);
-
-    co_await server->stop();
+            cfg)
+            .finally([&server] {
+                return server->stop();
+            });
 }
 
 SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
@@ -482,9 +483,10 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::aborted>(keys.error()));
             },
-            cfg);
-
-    co_await server->stop();
+            cfg)
+            .finally([&server] {
+                return server->stop();
+            });
 }
 
 
@@ -594,8 +596,10 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).partition.key().explode()), "[06, 08]");
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(1).clustering.explode()), "[01, 03]");
             },
-            cfg);
-    co_await server->stop();
+            cfg)
+            .finally([&server] {
+                return server->stop();
+            });
 }
 
 SEASTAR_TEST_CASE(vector_store_client_uri_update_to_empty) {
@@ -703,7 +707,9 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update) {
                     co_return is_s2_response(co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, as.as));
                 }));
             },
-            cfg);
-    co_await s1->stop();
-    co_await s2->stop();
+            cfg)
+            .finally(seastar::coroutine::lambda([&s1, &s2] -> future<> {
+                co_await s1->stop();
+                co_await s2->stop();
+            }));
 }

--- a/vector_search/dns.hh
+++ b/vector_search/dns.hh
@@ -17,6 +17,7 @@
 #include "utils/log.hh"
 #include <chrono>
 #include <optional>
+#include <vector>
 #include <functional>
 #include <seastar/net/inet_address.hh>
 
@@ -24,7 +25,7 @@ namespace vector_search {
 
 class dns {
 public:
-    using address_type = std::optional<seastar::net::inet_address>;
+    using address_type = std::vector<seastar::net::inet_address>;
     using resolver_type = std::function<seastar::future<address_type>(seastar::sstring const&)>;
     using listener_type = std::function<seastar::future<>(address_type const&)>;
 
@@ -37,7 +38,7 @@ public:
     }
 
     void host(std::optional<seastar::sstring> h) {
-        current_addr = std::nullopt;
+        current_addrs.clear();
         _host = std::move(h);
         trigger_refresh();
     }
@@ -69,7 +70,7 @@ private:
     seastar::condition_variable refresh_cv;
     resolver_type _resolver;
     std::optional<seastar::sstring> _host;
-    std::optional<seastar::net::inet_address> current_addr;
+    std::vector<seastar::net::inet_address> current_addrs;
     listener_type _listener;
 };
 

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -122,9 +122,9 @@ struct vector_store_client_tester {
     static void set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval);
     static void set_wait_for_client_timeout(vector_store_client& vsc, std::chrono::milliseconds timeout);
     static void set_http_request_retries(vector_store_client& vsc, unsigned retries);
-    static void set_dns_resolver(vector_store_client& vsc, std::function<future<std::optional<net::inet_address>>(sstring const&)> resolver);
+    static void set_dns_resolver(vector_store_client& vsc, std::function<future<std::vector<net::inet_address>>(sstring const&)> resolver);
     static void trigger_dns_resolver(vector_store_client& vsc);
-    static auto resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::optional<net::inet_address>>;
+    static auto resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::vector<net::inet_address>>;
 };
 
 } // namespace vector_search

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -121,7 +121,6 @@ private:
 struct vector_store_client_tester {
     static void set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval);
     static void set_wait_for_client_timeout(vector_store_client& vsc, std::chrono::milliseconds timeout);
-    static void set_http_request_retries(vector_store_client& vsc, unsigned retries);
     static void set_dns_resolver(vector_store_client& vsc, std::function<future<std::vector<net::inet_address>>(sstring const&)> resolver);
     static void trigger_dns_resolver(vector_store_client& vsc);
     static auto resolve_hostname(vector_store_client& vsc, abort_source& as) -> future<std::vector<net::inet_address>>;


### PR DESCRIPTION
vector_store_client: Add support for multiple IPs in DNS responses

The DNS resolution logic now processes all IP addresses returned in a DNS
response, not just the primary one.

The client will iterate through the list of resolved IPs, attempting to
query the next one if a request fails. This improves high availability
by allowing the client to query other available nodes if one is down.

References: VECTOR-187

As this is a new feature no backport is needed.