### PR TITLE
Repair fast stream for bootstrap and decommission

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1241,6 +1241,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "The multishard reader has a read-ahead feature to improve latencies of range-scans. This feature can be detrimental when the multishard reader is used under repair, as is the case with repair in mixed-shard clusters."
         " This configuration option is disabled by default and it serves as a fall-back, to re-enable read-ahead in case it turns out that some mixed-shard repair suffer from disabling it.")
     , enable_small_table_optimization_for_rbno(this, "enable_small_table_optimization_for_rbno", liveness::LiveUpdate, value_status::Used, true, "Set true to enable small table optimization for repair based node operations")
+    , enable_fast_stream_for_rbno(this, "enable_fast_stream_for_rbno", liveness::LiveUpdate, value_status::Used, true, "Set true to use streaming when sync data with only one peer node for repair based node operations")
     , ring_delay_ms(this, "ring_delay_ms", value_status::Used, 30 * 1000, "Time a node waits to hear from other nodes before joining the ring in milliseconds. Same as -Dcassandra.ring_delay_ms in cassandra.")
     , shadow_round_ms(this, "shadow_round_ms", value_status::Used, 300 * 1000, "The maximum gossip shadow round time. Can be used to reduce the gossip feature check time during node boot up.")
     , fd_max_interval_ms(this, "fd_max_interval_ms", value_status::Used, 2 * 1000, "The maximum failure_detector interval time in milliseconds. Interval larger than the maximum will be ignored. Larger cluster may need to increase the default.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -401,6 +401,7 @@ public:
     named_value<uint64_t> repair_multishard_reader_buffer_hint_size;
     named_value<uint64_t> repair_multishard_reader_enable_read_ahead;
     named_value<bool> enable_small_table_optimization_for_rbno;
+    named_value<bool> enable_fast_stream_for_rbno;
     named_value<uint32_t> ring_delay_ms;
     named_value<uint32_t> shadow_round_ms;
     named_value<uint32_t> fd_max_interval_ms;

--- a/dht/range_streamer.hh
+++ b/dht/range_streamer.hh
@@ -148,7 +148,7 @@ private:
         return *_token_metadata_ptr;
     }
 public:
-    future<> stream_async();
+    future<> stream_async(std::function<void(size_t)> progress_updater = nullptr);
     size_t nr_ranges_to_stream();
 private:
     distributed<replica::database>& _db;

--- a/main.cc
+++ b/main.cc
@@ -1782,7 +1782,7 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             checkpoint(stop_signal, "starting repair service");
             auto max_memory_repair = memory::stats().total_memory() * 0.1;
-            repair.start(std::ref(tsm), std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(proxy), std::ref(bm), std::ref(sys_ks), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(mm), max_memory_repair).get();
+            repair.start(std::ref(tsm), std::ref(gossiper), std::ref(messaging), std::ref(db), std::ref(stream_manager), std::ref(proxy), std::ref(bm), std::ref(sys_ks), std::ref(view_builder), std::ref(view_building_worker), std::ref(task_manager), std::ref(mm), max_memory_repair).get();
             auto stop_repair_service = defer_verbose_shutdown("repair service", [&repair] {
                 repair.stop().get();
             });

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -21,6 +21,8 @@
 #include "streaming/table_check.hh"
 #include "replica/database.hh"
 #include "service/migration_manager.hh"
+#include "streaming/stream_manager.hh"
+#include "dht/range_streamer.hh"
 #include "service/storage_service.hh"
 #include "sstables/sstables.hh"
 #include "partition_range_compat.hh"
@@ -1473,6 +1475,7 @@ future<> repair_service::abort_all() {
 
 future<> repair_service::sync_data_using_repair(
         sstring keyspace,
+        size_t nr_tables,
         locator::effective_replication_map_ptr erm,
         dht::token_range_vector ranges,
         std::unordered_map<dht::token_range, repair_neighbors> neighbors,
@@ -1483,6 +1486,50 @@ future<> repair_service::sync_data_using_repair(
     }
 
     SCYLLA_ASSERT(this_shard_id() == 0);
+
+    bool small_table_optimization = should_enable_small_table_optimization_for_rbno(_db.local(), keyspace, reason);
+    auto fast_stream = _db.local().get_config().enable_fast_stream_for_rbno();
+    if (fast_stream && !small_table_optimization && (reason == streaming::stream_reason::bootstrap || reason == streaming::stream_reason::decommission)) {
+        abort_source as;
+        size_t max_neighbors = 0;
+        auto ranges_per_endpoint = std::unordered_map<locator::host_id, dht::token_range_vector>();
+        for (auto& [range, rn]: neighbors) {
+            max_neighbors = std::max(max_neighbors, rn.all.size());
+            if (max_neighbors != 1) {
+                rlogger.info("Skip using stream to sync data keyspace={} max_neighbors={} reason={}", keyspace, max_neighbors, reason);
+                break;
+            }
+            ranges_per_endpoint[rn.all.front()].push_back(range);
+            co_await coroutine::maybe_yield();
+        }
+
+        if (max_neighbors == 1) {
+            auto tmptr = erm->get_token_metadata_ptr();
+            const auto& my_location = tmptr->get_topology().get_location();
+            for (auto& [host, ranges] : ranges_per_endpoint) {
+                rlogger.info("Using stream to sync data with host={} local={} keyspace={} nr_ranges={} ranges={} reason={}", host, tmptr->get_my_id(), keyspace, ranges.size(), ranges, reason);
+            }
+            auto streamer = dht::range_streamer(_db, _stream_manager, tmptr, as, tmptr->get_my_id(), my_location, fmt::to_string(reason), reason, service::null_topology_guard);
+            if (reason == streaming::stream_reason::bootstrap) {
+                streamer.add_rx_ranges(keyspace, std::move(ranges_per_endpoint));
+            } else if (reason == streaming::stream_reason::decommission) {
+                streamer.add_tx_ranges(keyspace, std::move(ranges_per_endpoint));
+            }
+            auto& c = container();
+            auto progress_updater = [&c, reason, nr_tables] (size_t nr_ranges) -> future<> {
+                co_await c.invoke_on_all([reason, nr_ranges, nr_tables] (repair_service& rs) {
+                    if (reason == streaming::stream_reason::bootstrap) {
+                        rs.get_metrics().bootstrap_finished_ranges += nr_ranges * nr_tables;
+                    } else if (reason == streaming::stream_reason::decommission) {
+                        rs.get_metrics().decommission_finished_ranges += nr_ranges * nr_tables;
+                    }
+                });
+            };
+            co_await streamer.stream_async(progress_updater);
+            co_return;
+        }
+    }
+
     auto task = co_await _repair_module->make_and_start_task<repair::data_sync_repair_task_impl>({}, _repair_module->new_repair_uniq_id(), std::move(keyspace), "", std::move(ranges), std::move(neighbors), reason, ops_info);
     co_await task->done();
 }
@@ -1626,6 +1673,7 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             //Collects the source that will have its range moved to the new node
             std::unordered_map<dht::token_range, repair_neighbors> range_sources;
             auto nr_tables = get_nr_tables(db, keyspace_name);
+            auto start_time = std::chrono::steady_clock::now();
           if (small_table_optimization) {
             try {
                 auto germs = make_lw_shared(locator::make_global_static_effective_replication_map(get_db(), keyspace_name).get());
@@ -1777,8 +1825,9 @@ future<> repair_service::bootstrap_with_repair(locator::token_metadata_ptr tmptr
             }
           }
             auto nr_ranges = desired_ranges.size();
-            sync_data_using_repair(keyspace_name, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
-            rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}, nr_tables={}", keyspace_name, nr_ranges * nr_tables, nr_tables);
+            sync_data_using_repair(keyspace_name, nr_tables, erm, std::move(desired_ranges), std::move(range_sources), reason, nullptr).get();
+            auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now() - start_time);
+            rlogger.info("bootstrap_with_repair: finished with keyspace={}, nr_ranges={}, nr_tables={}, duration={}", keyspace_name, nr_ranges * nr_tables, nr_tables, duration);
         }
         rlogger.info("bootstrap_with_repair: finished with keyspaces={}", ks_erms | std::views::keys);
     });
@@ -1970,7 +2019,7 @@ future<> repair_service::do_decommission_removenode_with_repair(locator::token_m
                 ranges.swap(ranges_for_removenode);
             }
             auto nr_ranges_synced = ranges.size();
-            sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, ops).get();
+            sync_data_using_repair(keyspace_name, nr_tables, erm, std::move(ranges), std::move(range_sources), reason, ops).get();
             rlogger.info("{}: finished with keyspace={}, leaving_node={}, nr_ranges={}, nr_ranges_synced={}, nr_ranges_skipped={}",
                 op, keyspace_name, leaving_node_id, nr_ranges_total, nr_ranges_synced * nr_tables, nr_ranges_skipped * nr_tables);
         }
@@ -2190,7 +2239,7 @@ future<> repair_service::do_rebuild_replace_with_repair(std::unordered_map<sstri
                 }).get();
             }
             auto nr_ranges = ranges.size();
-            sync_data_using_repair(keyspace_name, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
+            sync_data_using_repair(keyspace_name, nr_tables, erm, std::move(ranges), std::move(range_sources), reason, nullptr).get();
             rlogger.info("{}: finished with keyspace={}, source_dc={}, nr_ranges={}", op, keyspace_name, source_dc_for_keyspace, nr_ranges * nr_tables);
         }
         rlogger.info("{}: finished with keyspaces={}, source_dc={}", op, ks_erms | std::views::keys, source_dc);

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -44,6 +44,7 @@
 #include "utils/to_string.hh"
 #include "service/migration_manager.hh"
 #include "streaming/consumer.hh"
+#include "dht/range_streamer.hh"
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/all.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -3525,6 +3526,7 @@ repair_service::repair_service(sharded<service::topology_state_machine>& tsm,
         distributed<gms::gossiper>& gossiper,
         netw::messaging_service& ms,
         sharded<replica::database>& db,
+        sharded<streaming::stream_manager>& stream_manager,
         sharded<service::storage_proxy>& sp,
         sharded<db::batchlog_manager>& bm,
         sharded<db::system_keyspace>& sys_ks,
@@ -3537,6 +3539,7 @@ repair_service::repair_service(sharded<service::topology_state_machine>& tsm,
     , _gossiper(gossiper)
     , _messaging(ms)
     , _db(db)
+    , _stream_manager(stream_manager)
     , _sp(sp)
     , _bm(bm)
     , _sys_ks(sys_ks)

--- a/repair/row_level.hh
+++ b/repair/row_level.hh
@@ -32,6 +32,9 @@ namespace service {
 class migration_manager;
 class storage_proxy;
 }
+namespace streaming {
+class stream_manager;
+}
 
 namespace db {
 
@@ -104,6 +107,7 @@ class repair_service : public seastar::peering_sharded_service<repair_service> {
     distributed<gms::gossiper>& _gossiper;
     netw::messaging_service& _messaging;
     sharded<replica::database>& _db;
+    sharded<streaming::stream_manager>& _stream_manager;
     sharded<service::storage_proxy>& _sp;
     sharded<db::batchlog_manager>& _bm;
     sharded<db::system_keyspace>& _sys_ks;
@@ -161,6 +165,7 @@ public:
             distributed<gms::gossiper>& gossiper,
             netw::messaging_service& ms,
             sharded<replica::database>& db,
+            sharded<streaming::stream_manager>& stream_manager,
             sharded<service::storage_proxy>& sp,
             sharded<db::batchlog_manager>& bm,
             sharded<db::system_keyspace>& sys_ks,
@@ -211,6 +216,7 @@ private:
 
     // Must be called on shard 0
     future<> sync_data_using_repair(sstring keyspace,
+            size_t nr_tables,
             locator::effective_replication_map_ptr erm,
             dht::token_range_vector ranges,
             std::unordered_map<dht::token_range, repair_neighbors> neighbors,


### PR DESCRIPTION
repair: Introduce fast_stream for bootstrap and decommission with RBNO

When the peer node to sync data with is only one in rbno, we could use
classic streaming instad of repair to speed up the bootstrap process.

The speed up comes mostly from the fact that classic streaming could
batch the ranges and stream multiple ranges in a stream session, i.e.,
10% of total ranges per stream session. When the number of the ranges is
high, this batch helps a lot, especially in large clusters where the
number of ranges is big and the data in each range is relatively small.

Before:
using rbno, 5m partitions, 88 seconds
```
[asias@hjpc2 scylla]$ cat mycluster/node3.log.txt|grep bootstrap_with_repair|grep keyspace=ks
repair - bootstrap_with_repair: started with keyspace=ks201, nr_ranges=273, nr_tables=1
repair - bootstrap_with_repair: finished with keyspace=ks201, nr_ranges=273, nr_tables=1, duration=88.698s
```

using classic stream, 5m partitions, 45 seconds
```
range_streamer - Bootstrap with [ea424ee8-6059-4159-a9a2-997451c96276, f34358f9-17d8-4380-9282-778568142281] for keyspace=ks201 started, nodes_to_stream=2
range_streamer - Bootstrap with ea424ee8-6059-4159-a9a2-997451c96276 for keyspace=ks201, streaming [0, 13) out of 134 ranges
stream_session - [Stream #ee3f2270-8f86-11f0-a904-ec12ac9fa53d] Executing streaming plan for Bootstrap-ks201-index-0 with peers={ea424ee8-6059-4159-a9a2-997451c96276}, master
range_streamer - Bootstrap with f34358f9-17d8-4380-9282-778568142281 for keyspace=ks201, streaming [0, 13) out of 138 ranges
stream_session - [Stream #ee3f2271-8f86-11f0-a904-ec12ac9fa53d] Executing streaming plan for Bootstrap-ks201-index-0 with peers={f34358f9-17d8-4380-9282-778568142281}, master
...
range_streamer - Bootstrap with f34358f9-17d8-4380-9282-778568142281 for keyspace=ks201 succeeded, took 40.509224 seconds
range_streamer - Bootstrap with ea424ee8-6059-4159-a9a2-997451c96276 for keyspace=ks201 succeeded, took 44.787827 seconds
```

After:
using rbno + fast stream optimization, 5m partitions, 45 seconds
```
[asias@hjpc2 scylla]$ cat mycluster/node3.log.txt|grep bootstrap_with_repair|grep keyspace=ks
repair - bootstrap_with_repair: started with keyspace=ks201, nr_ranges=273, nr_tables=1
repair - bootstrap_with_repair: finished with keyspace=ks201, nr_ranges=273, nr_tables=1, duration=45.1912s
```

With this patch, bootstrap with RBNO enabled and bootstrap with RNBO
disabled have the same level of performance.

Closes #24664


performance optimization, no backport