### PR TITLE
rest_client: set `version` on http::request to avoid invalid state

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -534,6 +534,7 @@ scylla_tests = set([
     'test/boost/recent_entries_map_test',
     'test/boost/reservoir_sampling_test',
     'test/boost/result_utils_test',
+    'test/boost/rest_client_test',
     'test/boost/reusable_buffer_test',
     'test/boost/rust_test',
     'test/boost/s3_test',

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -199,6 +199,8 @@ add_scylla_test(reusable_buffer_test
   KIND SEASTAR)
 add_scylla_test(reservoir_sampling_test
   KIND BOOST)
+add_scylla_test(rest_client_test
+  KIND SEASTAR)
 add_scylla_test(rust_test
   KIND BOOST
   LIBRARIES inc)

--- a/test/boost/rest_client_test.cc
+++ b/test/boost/rest_client_test.cc
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+
+#include "utils/rest/client.hh"
+#include "test/lib/scylla_test_case.hh"
+#include "test/lib/test_utils.hh"
+
+void simple_rest_client() {
+    auto host = tests::getenv_safe("MOCK_S3_SERVER_HOST");
+    auto port = std::stoul(tests::getenv_safe("MOCK_S3_SERVER_PORT"));
+    rest::httpclient client(host, port);
+    for ([[maybe_unused]] auto i : {1, 2}) {
+        BOOST_REQUIRE_NO_THROW([&] {
+            client.add_header("host", host);
+            client.add_header("X-aws-ec2-metadata-token-ttl-seconds", "21600");
+            client.method(rest::httpclient::method_type::PUT);
+            client.target("/latest/api/token");
+            [[maybe_unused]] auto res = client.send().get();
+        }());
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_simple_rest_client) {
+    simple_rest_client();
+}

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -131,6 +131,9 @@ seastar::future<> rest::simple_send(seastar::http::experimental::client& client,
     if (req._url.empty()) {
         req._url = "/";
     }
+    if (req._version.empty()) {
+        req._version = "1.1";
+    }
     if (!req._headers.count(httpclient::CONTENT_TYPE_HEADER)) {
         req._headers[httpclient::CONTENT_TYPE_HEADER] = "application/x-www-form-urlencoded";
     }


### PR DESCRIPTION
Upcoming changes in Seastar cause `rest::simple_send` to move the `http::request` into `seastar::http::experimental::client::make_request` when called multiple times. This leaves the original request in an invalid state. Specifically, the `_version` field becomes empty, causing request validation to fail. This patch ensures `version` is explicitly set to prevent such failures.

Fixes: https://github.com/scylladb/scylladb/issues/26018

No need to backport since it fixes "future" problem