### PR TITLE
sstables/trie: prepare for integrating BTI indexes with sstable readers and writers

### DIFF
--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -7674,67 +7674,6 @@ future<> storage_service::force_remove_completion() {
     return make_exception_future<>(std::runtime_error("The unsafe nodetool removenode force is not supported anymore"));
 }
 
-/**
- * Takes an ordered list of adjacent tokens and divides them in the specified number of ranges.
- */
-static std::vector<std::pair<dht::token_range, uint64_t>>
-calculate_splits(std::vector<dht::token> tokens, uint64_t split_count, replica::column_family& cf) {
-    auto sstables = cf.get_sstables();
-    const double step = static_cast<double>(tokens.size() - 1) / split_count;
-    auto prev_token_idx = 0;
-    std::vector<std::pair<dht::token_range, uint64_t>> splits;
-    splits.reserve(split_count);
-    for (uint64_t i = 1; i <= split_count; ++i) {
-        auto index = static_cast<uint32_t>(std::round(i * step));
-        dht::token_range range({{ std::move(tokens[prev_token_idx]), false }}, {{ tokens[index], true }});
-        // always return an estimate > 0 (see CASSANDRA-7322)
-        uint64_t estimated_keys_for_range = 0;
-        for (auto&& sst : *sstables) {
-            estimated_keys_for_range += sst->estimated_keys_for_range(range);
-        }
-        splits.emplace_back(std::move(range), std::max(static_cast<uint64_t>(cf.schema()->min_index_interval()), estimated_keys_for_range));
-        prev_token_idx = index;
-    }
-    return splits;
-};
-
-std::vector<std::pair<dht::token_range, uint64_t>>
-storage_service::get_splits(const sstring& ks_name, const sstring& cf_name, wrapping_interval<dht::token> range, uint32_t keys_per_split) {
-    using range_type = dht::token_range;
-    auto& cf = _db.local().find_column_family(ks_name, cf_name);
-    auto schema = cf.schema();
-    auto sstables = cf.get_sstables();
-    uint64_t total_row_count_estimate = 0;
-    std::vector<dht::token> tokens;
-    std::vector<range_type> unwrapped;
-    if (range.is_wrap_around(dht::token_comparator())) {
-        auto uwr = range.unwrap();
-        unwrapped.emplace_back(std::move(uwr.second));
-        unwrapped.emplace_back(std::move(uwr.first));
-    } else {
-        unwrapped.emplace_back(std::move(range));
-    }
-    tokens.push_back(std::move(unwrapped[0].start_copy().value_or(range_type::bound(dht::minimum_token()))).value());
-    for (auto&& r : unwrapped) {
-        std::vector<dht::token> range_tokens;
-        for (auto &&sst : *sstables) {
-            total_row_count_estimate += sst->estimated_keys_for_range(r);
-            auto keys = sst->get_key_samples(*cf.schema(), r);
-            std::transform(keys.begin(), keys.end(), std::back_inserter(range_tokens), [](auto&& k) { return std::move(k.token()); });
-        }
-        std::sort(range_tokens.begin(), range_tokens.end());
-        std::move(range_tokens.begin(), range_tokens.end(), std::back_inserter(tokens));
-    }
-    tokens.push_back(std::move(unwrapped[unwrapped.size() - 1].end_copy().value_or(range_type::bound(dht::maximum_token()))).value());
-
-    // split_count should be much smaller than number of key samples, to avoid huge sampling error
-    constexpr uint32_t min_samples_per_split = 4;
-    uint64_t max_split_count = tokens.size() / min_samples_per_split + 1;
-    uint64_t split_count = std::max(uint64_t(1), std::min(max_split_count, total_row_count_estimate / keys_per_split));
-
-    return calculate_splits(std::move(tokens), split_count, cf);
-};
-
 future<dht::token_range_vector>
 storage_service::get_ranges_for_endpoint(const locator::effective_replication_map& erm, const locator::host_id& ep) const {
     return erm.get_ranges(ep);

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -685,14 +685,6 @@ public:
     inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace,
             const sstring& cf, const sstring& key) const;
 
-    /**
-     * @return Vector of Token ranges (_not_ keys!) together with estimated key count,
-     *      breaking up the data this node is responsible for into pieces of roughly keys_per_split
-     */
-    std::vector<std::pair<dht::token_range, uint64_t>> get_splits(const sstring& ks_name,
-            const sstring& cf_name,
-            wrapping_interval<dht::token> range,
-            uint32_t keys_per_split);
 public:
     future<> decommission();
 

--- a/sstables/abstract_index_reader.hh
+++ b/sstables/abstract_index_reader.hh
@@ -165,7 +165,7 @@ public:
     // Returns data file positions corresponding to the bounds.
     // End position may be unset
     virtual data_file_positions_range data_file_positions() const = 0;
-    // Returns the offset in the data file of the first row in the last promoted index block
+    // Returns the offset (from partition start) of the first row in the last promoted index block
     // in the current partition or nullopt if there are no blocks in the current partition.
     //
     // Preconditions: partition_data_ready()

--- a/sstables/mx/reader.hh
+++ b/sstables/mx/reader.hh
@@ -30,7 +30,8 @@ mutation_reader make_reader(
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,
         read_monitor& monitor,
-        integrity_check integrity);
+        integrity_check integrity,
+        std::unique_ptr<abstract_index_reader>);
 
 // Same as above but the slice is moved and stored inside the reader.
 mutation_reader make_reader(
@@ -39,18 +40,6 @@ mutation_reader make_reader(
         reader_permit permit,
         const dht::partition_range& range,
         query::partition_slice&& slice,
-        tracing::trace_state_ptr trace_state,
-        streamed_mutation::forwarding fwd,
-        mutation_reader::forwarding fwd_mr,
-        read_monitor& monitor,
-        integrity_check integrity);
-
-mutation_reader make_reader_with_index_reader(
-        shared_sstable sstable,
-        schema_ptr schema,
-        reader_permit permit,
-        const dht::partition_range& range,
-        const query::partition_slice& slice,
         tracing::trace_state_ptr trace_state,
         streamed_mutation::forwarding fwd,
         mutation_reader::forwarding fwd_mr,

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2353,8 +2353,12 @@ sstable::make_reader(
         read_monitor& mon,
         integrity_check integrity) {
     const auto reversed = slice.is_reversed();
+
+    auto index_caching = use_caching(global_cache_index_pages && !slice.options.contains(query::partition_slice::option::bypass_cache));
+    auto index_reader = make_index_reader(permit, trace_state, index_caching, range.is_singular());
+
     if (_version >= version_types::mc && (!reversed || range.is_singular())) {
-        return mx::make_reader(shared_from_this(), std::move(query_schema), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr, mon, integrity);
+        return mx::make_reader(shared_from_this(), std::move(query_schema), std::move(permit), range, slice, std::move(trace_state), fwd, fwd_mr, mon, integrity, std::move(index_reader));
     }
 
     // Multi-partition reversed queries are not yet supported natively in the mx reader.
@@ -2365,7 +2369,7 @@ sstable::make_reader(
     if (_version >= version_types::mc) {
         // The only mx case falling through here is reversed multi-partition reader
         auto rd = make_reversing_reader(mx::make_reader(shared_from_this(), query_schema->make_reversed(), std::move(permit),
-                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon, integrity),
+                range, reverse_slice(*query_schema, slice), std::move(trace_state), streamed_mutation::forwarding::no, fwd_mr, mon, integrity, std::move(index_reader)),
             max_result_size);
         if (fwd) {
             rd = make_forwardable(std::move(rd));

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -3008,18 +3008,6 @@ std::optional<std::pair<uint64_t, uint64_t>> sstable::get_index_pages_for_range(
     return std::nullopt;
 }
 
-std::vector<dht::decorated_key> sstable::get_key_samples(const schema& s, const dht::token_range& range) {
-    auto index_range = get_sample_indexes_for_range(range);
-    std::vector<dht::decorated_key> res;
-    if (index_range) {
-        for (auto idx = index_range->first; idx < index_range->second; ++idx) {
-            auto pkey = _components->summary.entries[idx].get_key().to_partition_key(s);
-            res.push_back(dht::decorate_key(s, std::move(pkey)));
-        }
-    }
-    return res;
-}
-
 uint64_t sstable::estimated_keys_for_range(const dht::token_range& range) {
     auto page_range = get_index_pages_for_range(range);
     if (!page_range) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -768,7 +768,6 @@ public:
 private:
     future<summary_entry&> read_summary_entry(size_t i);
 
-    // FIXME: pending on Bloom filter implementation
     bool filter_has_key(const schema& s, const dht::decorated_key& dk) { return filter_has_key(key::from_partition_key(s, dk._key)); }
 
     std::optional<std::pair<uint64_t, uint64_t>> get_sample_indexes_for_range(const dht::token_range& range);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -342,8 +342,6 @@ public:
 
     uint64_t estimated_keys_for_range(const dht::token_range& range);
 
-    std::vector<dht::decorated_key> get_key_samples(const schema& s, const dht::token_range& range);
-
     // mark_for_deletion() specifies that a sstable isn't relevant to the
     // current shard, and thus can be deleted by the deletion manager, if
     // all shards sharing it agree. In case the sstable is unshared, it's

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -144,6 +144,7 @@ std::unique_ptr<sstables::abstract_index_reader> make_bti_index_reader(
     uint64_t partitions_db_root_pos,
     uint64_t total_data_db_file_size,
     schema_ptr,
-    reader_permit);
+    reader_permit,
+    tracing::trace_state_ptr);
 
 } // namespace sstables::trie

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -55,7 +55,7 @@ class bti_partition_index_writer {
     std::unique_ptr<impl> _impl;
 private:
     friend class optimized_optional<bti_partition_index_writer>;
-    bti_partition_index_writer();
+    bti_partition_index_writer() noexcept;
 public:
     // The trie will be written to the given file writer.
     // Note: the file doesn't have to be empty,
@@ -63,7 +63,10 @@ public:
     // because `finish()` writes a footer which is used by the reader
     // to find the root of the trie.
     explicit bti_partition_index_writer(sstables::file_writer&);
-    ~bti_partition_index_writer();
+    bti_partition_index_writer(bti_partition_index_writer&&) noexcept;
+    bti_partition_index_writer& operator=(bti_partition_index_writer&&) noexcept;
+    ~bti_partition_index_writer() noexcept;
+    explicit operator bool() const noexcept { return bool(_impl); }
     // Add a new partition key to the index.
     void add(const schema&, dht::decorated_key, int64_t data_or_rowsdb_file_pos);
     // Flushes all remaining contents, and returns the position of the root node in the output stream.
@@ -90,13 +93,16 @@ class bti_row_index_writer {
     std::unique_ptr<impl> _impl;
 private:
     friend class optimized_optional<bti_row_index_writer>;
-    bti_row_index_writer();
+    bti_row_index_writer() noexcept;
 public:
-    ~bti_row_index_writer();
+    ~bti_row_index_writer() noexcept;
     // The trie will be written to the given file writer.
     // Note: the file doesn't have to be empty,
     // and it can be extended later.
     explicit bti_row_index_writer(sstables::file_writer&);
+    bti_row_index_writer(bti_row_index_writer&&) noexcept;
+    bti_row_index_writer& operator=(bti_row_index_writer&&) noexcept;
+    explicit operator bool() const noexcept { return bool(_impl); }
     // Add a new row index entry.
     // Must be called in ascending order.
     // (`first_ck` must be strictly greater than the previous `last_ck`).

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -139,8 +139,8 @@ public:
 // `partitions_db_root_pos` should have been read from the Partitions.db footer beforehand.
 // (As we don't want to repeat that for every query).
 std::unique_ptr<sstables::abstract_index_reader> make_bti_index_reader(
-    cached_file& partitions_db,
-    cached_file& rows_db,
+    seastar::shared_ptr<cached_file> partitions_db,
+    seastar::shared_ptr<cached_file> rows_db,
     uint64_t partitions_db_root_pos,
     uint64_t total_data_db_file_size,
     schema_ptr,

--- a/sstables/trie/bti_index.hh
+++ b/sstables/trie/bti_index.hh
@@ -46,6 +46,13 @@ namespace sstables::trie {
 // until a cluster feature guarding the new page size is set.
 constexpr static uint64_t BTI_PAGE_SIZE = 4096;
 
+struct bti_partitions_db_footer {
+    sstables::key first_key;
+    sstables::key last_key;
+    uint64_t partition_count;
+    uint64_t trie_root_position;
+};
+
 // Transforms a stream of (partition key, offset in Data.db, hash bits) tuples
 // into a stream of trie nodes fed into bti_trie_sink.
 // Used to populate the Partitions.db file of the BTI format
@@ -72,14 +79,7 @@ public:
     // Flushes all remaining contents, and returns the position of the root node in the output stream.
     // If add() was never called, returns -1.
     // The writer mustn't be used again after this.
-    void finish(sstable_version_types ver, disk_string_view<uint16_t> first_key, disk_string_view<uint16_t> last_key) &&;
-};
-
-struct bti_partitions_db_footer {
-    sstables::key first_key;
-    sstables::key last_key;
-    uint64_t partition_count;
-    uint64_t trie_root_position;
+    std::optional<bti_partitions_db_footer> finish(sstable_version_types ver, const sstables::key& first_key, const sstables::key& last_key) &&;
 };
 
 future<bti_partitions_db_footer> read_bti_partitions_db_footer(const schema& s, sstable_version_types v, const seastar::file& f, uint64_t file_size);

--- a/sstables/trie/bti_index_internal.hh
+++ b/sstables/trie/bti_index_internal.hh
@@ -36,7 +36,13 @@ struct row_index_header {
     uint64_t number_of_blocks = 0;
 };
 
-future<row_index_header> read_row_index_header(input_stream<char>&& input, uint64_t start, uint64_t maxlen, reader_permit rp);
+future<row_index_header> read_row_index_header(
+    input_stream<char>&& input,
+    uint64_t start,
+    uint64_t maxlen,
+    reader_permit rp
+);
+
 void write_row_index_header(
     sstable_version_types sst_ver,
     sstables::file_writer& fw,

--- a/sstables/trie/bti_index_reader.cc
+++ b/sstables/trie/bti_index_reader.cc
@@ -264,11 +264,11 @@ enum class set_result {
 // An index cursor, which is effectively a pair of trie cursors -- one into Partitions.db, one into Rows.db.
 class index_cursor {
     // A cursor into Partitions.db.
-    // Starts unintialized, gets initialized by set_before_partition/set_after_partition.
+    // Starts uninitialized, gets initialized by set_before_partition/set_after_partition.
     trie_cursor _partition_cursor;
     // A cursor into Rows.db.
-    // Starts unintialized, gets initialized by set_before_row/set_after_row,
-    // becomes unitialized again after partition cursor is moved.
+    // Starts uninitialized, gets initialized by set_before_row/set_after_row,
+    // becomes uninitialized again after partition cursor is moved.
     trie_cursor _row_cursor;
     // Holds the row index header for the current partition, iff the current partition has a row index.
     // This is kept in sync with the partition cursor.

--- a/sstables/trie/bti_index_reader.cc
+++ b/sstables/trie/bti_index_reader.cc
@@ -568,7 +568,7 @@ future<std::optional<uint64_t>> index_cursor::last_block_offset() const {
     co_await cur.step_back(_permit, _trace_state);
     co_await cur.step_back(_permit, _trace_state);
 
-    auto result = _partition_metadata->data_file_offset + row_payload_to_offset(cur.payload());
+    auto result = row_payload_to_offset(cur.payload());
     expensive_log("last_block_offset: {}", result);
     co_return result;
 }

--- a/sstables/trie/bti_node_reader.cc
+++ b/sstables/trie/bti_node_reader.cc
@@ -438,11 +438,11 @@ bool bti_node_reader::cached(int64_t pos) const {
     return _cached_page && _cached_page->pos() / cached_file::page_size == pos / cached_file::page_size;
 }
 
-seastar::future<> bti_node_reader::load(int64_t pos) {
+seastar::future<> bti_node_reader::load(int64_t pos, const reader_permit& permit, const tracing::trace_state_ptr& trace_ptr) {
     if (cached(pos)) {
         return make_ready_future<>();
     }
-    return _file.get().get_shared_page(pos, nullptr).then([this](auto page) {
+    return _file.get().get_shared_page(pos, permit, trace_ptr).then([this](cached_file::page_read_result page) {
         _cached_page = std::move(page.ptr);
     });
 }

--- a/sstables/trie/bti_node_reader.cc
+++ b/sstables/trie/bti_node_reader.cc
@@ -439,6 +439,9 @@ bool bti_node_reader::cached(int64_t pos) const {
 }
 
 seastar::future<> bti_node_reader::load(int64_t pos) {
+    if (cached(pos)) {
+        return make_ready_future<>();
+    }
     return _file.get().get_shared_page(pos, nullptr).then([this](auto page) {
         _cached_page = std::move(page.ptr);
     });

--- a/sstables/trie/bti_node_reader.hh
+++ b/sstables/trie/bti_node_reader.hh
@@ -54,7 +54,7 @@ struct bti_node_reader {
 
     bti_node_reader(cached_file& f);
     bool cached(int64_t pos) const;
-    future<> load(int64_t pos);
+    future<> load(int64_t pos, const reader_permit&, const tracing::trace_state_ptr&);
     trie::load_final_node_result read_node(int64_t pos);
     trie::node_traverse_result walk_down_along_key(int64_t pos, const_bytes key);
     trie::node_traverse_sidemost_result walk_down_leftmost_path(int64_t pos);

--- a/sstables/trie/bti_partition_index_writer.cc
+++ b/sstables/trie/bti_partition_index_writer.cc
@@ -210,9 +210,9 @@ struct bti_partition_index_writer::impl
     impl(impl&&) = delete;
 };
 
-bti_partition_index_writer::bti_partition_index_writer() = default;
+bti_partition_index_writer::bti_partition_index_writer() noexcept = default;
 
-bti_partition_index_writer::~bti_partition_index_writer() = default;
+bti_partition_index_writer::~bti_partition_index_writer() noexcept = default;
 
 bti_partition_index_writer::bti_partition_index_writer(sstables::file_writer& fw)
     : _impl(std::make_unique<impl>(fw))
@@ -223,6 +223,8 @@ void bti_partition_index_writer::add(const schema& s, dht::decorated_key dk, int
 void bti_partition_index_writer::finish(sstable_version_types ver, disk_string_view<uint16_t> first_key, disk_string_view<uint16_t> last_key) && {
     _impl->finish(ver, first_key, last_key);
 }
+bti_partition_index_writer::bti_partition_index_writer(bti_partition_index_writer&&) noexcept = default;
+bti_partition_index_writer& bti_partition_index_writer::operator=(bti_partition_index_writer&&) noexcept = default;
 
 std::byte hash_byte_from_key(const schema &s, const partition_key& x) {
     auto hk = utils::make_hashed_key(static_cast<bytes_view>(key::from_partition_key(s, x)));

--- a/sstables/trie/bti_row_index_writer.cc
+++ b/sstables/trie/bti_row_index_writer.cc
@@ -359,13 +359,15 @@ struct bti_row_index_writer::impl
     impl(impl&&) = delete;
 };
 
-bti_row_index_writer::bti_row_index_writer() = default;
+bti_row_index_writer::bti_row_index_writer() noexcept = default;
 
-bti_row_index_writer::~bti_row_index_writer() = default;
+bti_row_index_writer::~bti_row_index_writer() noexcept = default;
 
 bti_row_index_writer::bti_row_index_writer(sstables::file_writer& fw)
     : _impl(std::make_unique<impl>(fw))
 {}
+bti_row_index_writer::bti_row_index_writer(bti_row_index_writer&&) noexcept = default;
+bti_row_index_writer& bti_row_index_writer::operator=(bti_row_index_writer&&) noexcept = default;
 
 int64_t bti_row_index_writer::finish(
     sstable_version_types version,

--- a/streaming/stream_transfer_task.cc
+++ b/streaming/stream_transfer_task.cc
@@ -34,6 +34,7 @@
 #include "gms/feature_service.hh"
 #include "utils/error_injection.hh"
 #include "idl/streaming.dist.hh"
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace streaming {
 
@@ -101,15 +102,15 @@ struct send_info {
         });
     }
     future<size_t> estimate_partitions() {
-        return do_with(cf->get_sstables(), size_t(0), [this] (auto& sstables, size_t& partition_count) {
-            return do_for_each(*sstables, [this, &partition_count] (auto& sst) {
-                return do_for_each(ranges, [&sst, &partition_count] (auto& range) {
-                    partition_count += sst->estimated_keys_for_range(range);
-                });
-            }).then([&partition_count] {
-                return partition_count;
-            });
-        });
+        auto sstables = cf->get_sstables();
+        size_t partition_count = 0;
+        for (auto& sst : *sstables) {
+            for (auto& range : ranges) {
+                partition_count += sst->estimated_keys_for_range(range);
+                co_await coroutine::maybe_yield();
+            }
+        }
+        co_return partition_count;
     }
 };
 

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1017,14 +1017,14 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         // Step 4: run the reader test on the opened readers.
         test_index(dataset, [&] {
             return sstables::trie::make_bti_index_reader(
-            partitions_db_cached,
-            rows_db_cached,
-            partitions_db_root_pos,
-            std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
-            the_schema,
-            semaphore.make_permit(),
-            trace_state
-        );
+                partitions_db_cached,
+                rows_db_cached,
+                partitions_db_root_pos,
+                std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
+                the_schema,
+                semaphore.make_permit(),
+                trace_state
+            );
         }, max_ops);
     }
 }

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -989,7 +989,7 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
                 },
             }, entry);
         }
-        std::move(partition_index_writer).finish(sst_ver, {}, {});
+        std::move(partition_index_writer).finish(sst_ver, sstables::key::from_bytes({}), sstables::key::from_bytes({}));
     }
 
     // Step 3: create the reader (or, more precisely, a factory of readers) over the index files.

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1008,8 +1008,8 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
         auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
-        auto p = partitions_db_cached.get_file().dma_read_exactly<char>(partitions_db_size - 24, 24).get();
-        auto partitions_db_root_pos = read_be<uint64_t>(p.get() + 16);
+        auto partitions_db_footer = sstables::trie::read_bti_partitions_db_footer(*the_schema, sst_ver, partitions_db, partitions_db_size).get();
+        auto partitions_db_root_pos = partitions_db_footer.trie_root_position;
 
         auto semaphore = tests::reader_concurrency_semaphore_wrapper();
 

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1012,6 +1012,7 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto partitions_db_root_pos = partitions_db_footer.trie_root_position;
 
         auto semaphore = tests::reader_concurrency_semaphore_wrapper();
+        auto trace_state = tracing::trace_state_ptr();
 
         // Step 4: run the reader test on the opened readers.
         test_index(dataset, [&] {
@@ -1021,7 +1022,9 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
             partitions_db_root_pos,
             std::get<eof_index_entry>(dataset.entries.back()).data_file_offset,
             the_schema,
-            semaphore.make_permit());
+            semaphore.make_permit(),
+            trace_state
+        );
         }, max_ops);
     }
 }

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -609,7 +609,7 @@ struct reference_index {
         }
         for (uint64_t idx = curpar + 1; idx < _entries.size(); ++idx) {
             if (std::holds_alternative<partition_end_entry>(_entries[idx + 1])) {
-                return _data_file_offsets[idx];
+                return _data_file_offsets[idx] - _data_file_offsets[curpar];
             }
         }
         abort();

--- a/test/boost/bti_index_test.cc
+++ b/test/boost/bti_index_test.cc
@@ -1005,8 +1005,8 @@ SEASTAR_THREAD_TEST_CASE(test_exhaustive) {
         auto region = logalloc::region();
         auto partitions_db_size = partitions_db.size().get();
         auto rows_db_size = rows_db.size().get();
-        auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
-        auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
+        auto partitions_db_cached = seastar::make_shared<cached_file>(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
+        auto rows_db_cached = seastar::make_shared<cached_file>(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
         auto partitions_db_footer = sstables::trie::read_bti_partitions_db_footer(*the_schema, sst_ver, partitions_db, partitions_db_size).get();
         auto partitions_db_root_pos = partitions_db_footer.trie_root_position;

--- a/test/boost/comparable_bytes_test.cc
+++ b/test/boost/comparable_bytes_test.cc
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(test_bigint) {
     byte_comparable_test(generate_integer_test_data<int64_t>());
 }
 
-BOOST_AUTO_TEST_CASE(test_date) {
+BOOST_AUTO_TEST_CASE(test_simple_date) {
     byte_comparable_test(generate_integer_test_data<uint32_t>([] (uint32_t days) {
         return data_value(simple_date_native_type{days});
     }));
@@ -209,6 +209,12 @@ BOOST_AUTO_TEST_CASE(test_time) {
 BOOST_AUTO_TEST_CASE(test_timestamp) {
     byte_comparable_test(generate_integer_test_data<db_clock::rep>([] (db_clock::rep milliseconds) {
         return data_value(db_clock::time_point(db_clock::duration(milliseconds)));
+    }));
+}
+
+BOOST_AUTO_TEST_CASE(test_date) {
+    byte_comparable_test(generate_integer_test_data<db_clock::rep>([] (db_clock::rep milliseconds) {
+        return data_value(date_type_native_type{db_clock::time_point{db_clock::duration(milliseconds)}});
     }));
 }
 

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -414,7 +414,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_range_query) {
                         end_inclusive ? ']' : ')',
                         pr
                     );
-                    reader = assert_that(sstables::mx::make_reader_with_index_reader(
+                    reader = assert_that(sstables::mx::make_reader(
                         sst,
                         table.schema(),
                         permit,
@@ -499,7 +499,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_singular_query) {
             auto pr = dht::partition_range::make_singular(all_dks[1]);
 
             testlog.debug("Create for pr={}", pr);
-            mutation_reader_assertions reader = assert_that(sstables::mx::make_reader_with_index_reader(
+            mutation_reader_assertions reader = assert_that(sstables::mx::make_reader(
                 sst,
                 table.schema(),
                 permit,

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -570,8 +570,8 @@ void do_test(const test_config& cfg) {
             }
             std::move(bti_partition_index_writer).finish(
                 sst->get_version(),
-                disk_string_view<uint16_t>(sstables::key::from_partition_key(*adjusted_schema, mutations.front().key()).get_bytes()),
-                disk_string_view<uint16_t>(sstables::key::from_partition_key(*adjusted_schema, mutations.back().key()).get_bytes())
+                sstables::key::from_partition_key(*adjusted_schema, mutations.front().key()),
+                sstables::key::from_partition_key(*adjusted_schema, mutations.back().key())
             );
             testlog.info("Finished BTI index writing");
         }

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -242,11 +242,11 @@ void test_index_files(
     auto region = logalloc::region();
     auto partitions_db_size = partitions_db.size().get();
     auto rows_db_size = rows_db.size().get();
-    auto partitions_db_cached = cached_file(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
-    auto rows_db_cached = cached_file(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
+    auto partitions_db_cached = seastar::make_shared<cached_file>(partitions_db, stats, cached_file_lru, region, partitions_db_size, "Partitions.db");
+    auto rows_db_cached = seastar::make_shared<cached_file>(rows_db, stats, cached_file_lru, region, rows_db_size, "Rows.db");
 
     // Read the Partitions.db footer, check the metadata contained there.
-    auto footer = sstables::trie::read_bti_partitions_db_footer(*s, sstable::version_types::me, partitions_db_cached.get_file(), partitions_db_size).get();
+    auto footer = sstables::trie::read_bti_partitions_db_footer(*s, sstable::version_types::me, partitions_db_cached->get_file(), partitions_db_size).get();
     SCYLLA_ASSERT(footer.partition_count == pm.partition_count);
     SCYLLA_ASSERT(sstables::key_view(footer.first_key) == sstables::key::from_partition_key(*s, pm.first_key.key()));
     SCYLLA_ASSERT(sstables::key_view(footer.last_key) == sstables::key::from_partition_key(*s, pm.last_key.key()));

--- a/test/manual/bti_cassandra_compatibility_test.cc
+++ b/test/manual/bti_cassandra_compatibility_test.cc
@@ -251,13 +251,16 @@ void test_index_files(
     SCYLLA_ASSERT(sstables::key_view(footer.first_key) == sstables::key::from_partition_key(*s, pm.first_key.key()));
     SCYLLA_ASSERT(sstables::key_view(footer.last_key) == sstables::key::from_partition_key(*s, pm.last_key.key()));
 
+    auto trace_state = tracing::trace_state_ptr();
     auto ir = sstables::trie::make_bti_index_reader(
         partitions_db_cached,
         rows_db_cached,
         footer.trie_root_position,
         data_db_size,
         s,
-        env.make_reader_permit());
+        env.make_reader_permit(),
+        trace_state
+    );
 
     // We validate the index by iterating over fragments and checking that
     // the index gives the right results when it's forwarded to the position of each fragment. 

--- a/types/comparable_bytes.cc
+++ b/types/comparable_bytes.cc
@@ -1231,6 +1231,11 @@ struct to_comparable_bytes_visitor {
 
     void operator()(const empty_type_impl&) {}
 
+    void operator()(const date_type_impl&) {
+        out.write(serialized_bytes_view.prefix(sizeof(db_clock::rep)));
+        serialized_bytes_view.remove_prefix(sizeof(db_clock::rep));
+    }
+
     void operator()(const abstract_type& type) {
         // Unimplemented
         on_internal_error(cblogger, fmt::format("byte comparable format not supported for type {}", type.name()));
@@ -1352,6 +1357,11 @@ struct from_comparable_bytes_visitor {
     }
 
     void operator()(const empty_type_impl&) {}
+
+    void operator()(const date_type_impl&) {
+        out.write(comparable_bytes_view.prefix(sizeof(db_clock::rep)));
+        comparable_bytes_view.remove_prefix(sizeof(db_clock::rep));
+    }
 
     void operator()(const abstract_type& type) {
         // Unimplemented

--- a/utils/cached_file.hh
+++ b/utils/cached_file.hh
@@ -175,6 +175,9 @@ public:
     future<page_read_result> get_shared_page(size_t global_pos, tracing::trace_state_ptr trace_state) {
         return get_page_ptr(global_pos / page_size, 1, trace_state);
     }
+    future<page_read_result> get_shared_page(size_t global_pos, reader_permit permit, tracing::trace_state_ptr trace_state) {
+        return get_page_ptr(global_pos / page_size, 1, trace_state, permit);
+    }
 private:
     future<page_read_result> get_page_ptr(page_idx_type idx,
             page_count_type read_ahead,


### PR DESCRIPTION
This is yet another part in the BTI index project.

Overarching issue: https://github.com/scylladb/scylladb/issues/19191
Previous part: https://github.com/scylladb/scylladb/pull/25626
Next parts: introducing the new components, Partitions.db and Rows.db

This is the preparatory, uncontroversial part of https://github.com/scylladb/scylladb/pull/26039, which was split out to a separate PR to make the main part (which, after a revision, will be posted later) smaller. 

This series contains several small fixes and changes to BTI-related code added earlier, which either have to be done (i.e. propagating `reader_permit` to IO calls in index reads) or just deserved to be done. There's no single theme for the changes in this PR, refer to the individual commits for details.

The changes are for the sake of new and unreleased code. No backporting should be done.