### PR TITLE
load_balancer: fix badness object creation

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1776,10 +1776,10 @@ public:
         }
 
         return {
-            src_badness.shard_badness(),
-            src_badness.node_badness(),
-            dst_badness.shard_badness(),
-            dst_badness.node_badness()
+            src_badness.src_shard_badness,
+            src_badness.src_node_badness,
+            dst_badness.dst_shard_badness,
+            dst_badness.dst_node_badness
         };
     }
 
@@ -2353,10 +2353,10 @@ public:
 
             auto candidate = migration_candidate{
                     tablets, src, *min_dst,
-                    migration_badness{src_badness.shard_badness(),
-                                      src_badness.node_badness(),
-                                      min_dst_badness.shard_badness(),
-                                      min_dst_badness.node_badness()}
+                    migration_badness{src_badness.src_shard_badness,
+                                      src_badness.src_node_badness,
+                                      min_dst_badness.dst_shard_badness,
+                                      min_dst_badness.dst_node_badness}
             };
 
             lblogger.trace("candidate: {}", candidate);


### PR DESCRIPTION
The load balancer introduced the idea of badness, which is a measure of how a tablet migration effects table balance on the source and destination. This is an abbreviated definition of the badness struct:
```
struct migration_badness {
    double src_shard_badness = 0;
    double src_node_badness = 0;
    double dst_shard_badness = 0;
    double dst_node_badness = 0;

    ...

    double node_badness() const {
        return std::max(src_node_badness, dst_node_badness);
    }

    double shard_badness() const {
        return std::max(src_shard_badness, dst_shard_badness);
    }
};
```
A negative value for either of these 4 members signifies a good migration (improves table balance), and a positive signifies a bad migration.

In two places in the balancer, badness for source and destination is computed independently in two objects of type migration_badness (`src_badness` and `dst_badness`), and later combined into a single object similar to this:
```
return migration_badness{
    src_badness.shard_badness(),
    src_badness.node_badness(),
    dst_badness.shard_badness(),
    dst_badness.node_badness()
};
```
This is a problem when, for instance, source shard badness is good (less that 0), `shard_badness()` will return 0 because of `std::max()`. This way the actual computed badness is not set in the final object. This can lead to incorrect decisions made later by the balancer, when it searches for the best migration among a set of candidates.

Fixes: #26090

While this is a problem which is present in all currently supported versions with tablets, it does not lead to imbalance, and should not be backported because of the risk of changing the logic which could lead to unintended consequences.