### PR TITLE
treewide: seastar module update and fix broken rest client (take two)

### DIFF
--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -399,8 +399,7 @@ future<rjson::value> azure_host::impl::send_request(const sstring& host, unsigne
     client.target(path);
     client.method(httpd::operation_type::POST);
     client.add_header("Authorization", fmt::format("Bearer {}", token.token));
-    client.add_header("Content-Type", "application/json");
-    client.content(std::move(rjson::print(body)));
+    client.content("application/json", std::move(rjson::print(body)));
 
     azlog.trace("Sending request: {}", rest::redacted_request_type{ client.request(), filter });
 

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -808,7 +808,7 @@ future<encryption::kms_host::impl::result_type> encryption::kms_host::impl::post
 
     client.add_header(AWS_AUTHORIZATION_HEADER, awsAuthString);
     client.target("/");
-    client.content(query.content);
+    client.content(query.content_type, query.content);
     client.method(httpclient::method_type::POST);
 
     kms_log.trace("Request: {}", client.request());

--- a/utils/azure/identity/service_principal_credentials.cc
+++ b/utils/azure/identity/service_principal_credentials.cc
@@ -170,8 +170,7 @@ future<sstring> service_principal_credentials::post(const sstring& body) {
     rest::httpclient client{_host, _port, std::move(creds), options};
     client.target(path);
     client.method(op);
-    client.add_header("Content-Type", mime_type);
-    client.content(std::move(body));
+    client.content(mime_type, std::move(body));
 
     if (az_creds_logger.is_enabled(log_level::trace)) {
         az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client.request(), filter });

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -294,13 +294,9 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
             req.add_header(k, v);
         }
 
-        if (!content_type.empty()) {
-            req.add_header(httpclient::CONTENT_TYPE_HEADER, content_type);
-        }
-
         std::visit(overloaded_functor {
-            [&](const std::string& s) { req.content(s); },
-            [&](const writer_and_size& ws) { req.content(ws.first, ws.second); }
+            [&](const std::string& s) { req.content(content_type, s); },
+            [&](const writer_and_size& ws) { req.content(content_type, ws.first, ws.second); }
         }, body);
 
         // GCP storage requires this even if content is empty

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -39,14 +39,12 @@ void rest::request_wrapper::method(method_type type) {
     _req._method = httpd::type2str(type);
 }
 
-void rest::request_wrapper::content(std::string_view content) {
-    _req.content_length = content.size();
-    _req.content = sstring(content);
+void rest::request_wrapper::content(std::string_view content_type, std::string_view content) {
+    _req.write_body(sstring(content_type), sstring(content));
 }
 
-void rest::request_wrapper::content(body_writer w, size_t len) {
-    _req.content_length = len;
-    _req.body_writer = std::move(w);
+void rest::request_wrapper::content(std::string_view content_type, body_writer w, size_t len) {
+    _req.write_body(sstring(content_type), len, std::move(w));
 }
 
 void rest::request_wrapper::target(std::string_view s) {
@@ -222,8 +220,7 @@ future<> rest::send_request(std::string_view uri
         if (content_type.empty()) {
             content_type = "application/x-www-form-urlencoded";
         }
-        client.content(std::move(body));
-        client.add_header(httpclient::CONTENT_TYPE_HEADER, content_type);
+        client.content(content_type, std::move(body));
     }
 
     co_await client.send([&] (const http::reply& rep, std::string_view result) {

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -41,8 +41,8 @@ public:
     using body_writer = decltype(std::declval<seastar::http::request>().body_writer);
 
     void method(method_type);
-    void content(std::string_view);
-    void content(body_writer, size_t);
+    void content(std::string_view content_type, std::string_view);
+    void content(std::string_view content_type, body_writer, size_t);
 
     void target(std::string_view);
 


### PR DESCRIPTION
start using `write_body` in `rest/client` to properly set headers due to changes applied to seastar's http client


Seastar module update
```
b6be384e Merge 'http: generalize Content-Type setting' from Nadav Har'El
74472298 http: generalize request's Content-Type setting
9fd5a1cc http: generalize reply's Content-Type setting
a2665f38 memory: Remove deprecated enable_abort_on_allocation_failure()
d2a5a8a9 resource.cc: Remove some dead code
7ad9f424 http: Add support of multiple key repetitions for the request
a636baca task: Move task::get_backtrace() definition in its class
a0101efa Fixed "doxygen" spelling in error message
db969482 Merge 'http/reply: introduce set_cookie()' from Botond Dénes
5357b434 http/reply: introduce set_cookie()
1ddcf05f http/reply: make write_reply*() public
4b782d73 http/connection: start_response(): fix indentation
720feca0 http/reply: encapsulate reply writing in write_reply()
3e19917d Merge 'exceptions: log thrown and propagated exception with distinct log levels' from Botond Dénes
db9aea93 Merge 'Correctly wrap up abandoned yielding directory lister' from Pavel Emelyanov
dbb2bf3f test: Add test for input_stream::read_exactly()
a5308ec9 file/directory_lister: Correctly wrap up fallback generator
4f0811f4 file/directory_lister: Convert on-stack queue to shared pointer
59801da7 tests: Add directory lister early drop cases
33233032 http/reply: s/write_reply_to_connection/write_reply/
69b93620 http/reply: write_reply_{to_connection,headers}(): pass output stream
56e9bda7 test: Convert directory_test into seastar test
96782358 Merge 'Improve io_tester's seqwrite and append workloads' from Pavel Emelyanov
8b46e3d4 SEASTAR_ASSERT: assert to stderr and flush stream
3370e22a tutorial.md: use current_exception_as_future()
e977453a Add fixture support for seastar::testing
3e70d7f7 io_tester: Do not set append_is_unlikely unconditionally
2a4ae7b4 io_tester: Count file size overflows
5e678bb5 io_tester: Tuneup size overflow check
d5dad8ce io_tester: Move position management code to io_class_data
5586a056 io_tester: Rename seqwrite -> overwrite
92df2fb2 io_tester: Relax return value of create_and_fill_file()
03d9500d io_tester: Dont fill file for APPEND
d6844a7b io_tester: Indentation fix after previous patch
fb9e0088 io_tester: Coroutinize create_and_fill_file()
2f802f57 exceptions: log thrown and propagated exception with distinct log levels
4971fa70 util: move log-level into own header
39448fc1 Merge 'Fix and tune http::request setup by client' from Pavel Emelyanov
52d0c4fb iostream: Move output_stream::write(scattered_message) lower
7a52f734 Merge 'read_first_line: Missing pragma and licence' from Ernest Zaslavsky
d0881b7e read_first_line: Add missing license boilerplate
988a0e99 read_first_line:: Add missing `#pragma once`
42675266 http: Make client::make_request accept const request&
c7709fb5 http: Make request making API return exceptional future not throw
b68ed89b http: Move request content length header setup
1d96dac6 http: Move request version configuration
072e86f6 http: Setup request once
```

No backport needed since it is submodule update