### PR TITLE
test: audit: stop using datetime.datetime.now() in syslog converter

### DIFF
--- a/test/cluster/dtest/audit_test.py
+++ b/test/cluster/dtest/audit_test.py
@@ -262,7 +262,10 @@ class AuditBackendSyslog(AuditBackend):
         regexp = ", ".join(f"{field}=\"(?P<{field}>.*)\"" for field in fields)
         match = re.match(regexp, data)
 
-        date = datetime.datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+        # Arbitrary date because we don't really check the field. We just need to fill it with something
+        # and make sure it doesn't change during the test (e.g. when the test is running at 23:59:59)
+        date = datetime.datetime(2000, 1, 1, 0, 0)
+
         node = match.group("node").split(":")[0]
         statement = match.group("query").replace("\\", "") 
         source = match.group("client_ip").split(":")[0]


### PR DESCRIPTION
`line_to_row` is a test function that converts `syslog` audit log to the format of `table` audit log so tests can use the same checks for both types of audit. Because `syslog` audit doesn't have `date` information, the field was filled with the current date. This behavior broke the tests running at 23:59:59 because `line_to_row` returned different results on different days.

Fixes: scylladb/scylladb#25509

CI failure fix, need to backport to 2025.3, earlier version doesn't have `audit_test.py` in `master`.