### PR TITLE
tools: Fix missing source file in CMake target

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,7 +9,8 @@ target_sources(tools
     scylla-nodetool.cc
     schema_loader.cc
     utils.cc
-    lua_sstable_consumer.cc)
+    lua_sstable_consumer.cc
+    json_mutation_stream_parser.cc)
 target_include_directories(tools
   PUBLIC
     ${CMAKE_SOURCE_DIR}


### PR DESCRIPTION
The `json_mutation_stream_parser.cc` file was not included in the `scylla-tools` CMake target. This could lead to "undefined reference" linker errors when building with CMake.

This commit adds the missing source file to the target's source list.

The problem was discovered when working on https://github.com/scylladb/scylladb/pull/26052.

No backport is needed as this issue relates to development tools only.