### PR TITLE
tools/scylla-sstable: introduce the upgrade command

### DIFF
--- a/docs/operating-scylla/admin-tools/scylla-sstable.rst
+++ b/docs/operating-scylla/admin-tools/scylla-sstable.rst
@@ -31,6 +31,7 @@ The command syntax is as follows:
 
 You can specify more than one SSTable. Additionally, the path to SSTable can point to an S3 fully qualified path in the form of s3://bucket-name/prefix/of/your/sstable/sstable-TOC.txt. To use this feature, you need to have AWS credentials set up in your environment. For more information, see :ref:`Configuring AWS S3 access <aws-s3-configuration>`. Additionally, you must ensure the tool is able to load the correct Scylla YAML file, which can be done using the --scylla-yaml-file parameter or by placing the YAML file in one of the default locations the tool checks.
 
+.. _scylla-sstable-schema:
 
 Schema
 ------
@@ -1333,6 +1334,29 @@ Examples
 ~~~~~~~~
 
 You can find example scripts at https://github.com/scylladb/scylladb/tree/master/tools/scylla-sstable-scripts.
+
+upgrade
+^^^^^^^
+
+Offline, scylla-sstable variant of `nodetool upgradesstables </operating-scylla/nodetool-commands/upgradesstables/>`_.
+Rewrites the input SSTable(s) to the latest supported version and latest schema version.
+The SSTable version to be used can be overridden with the ``--version`` flag, allowing for switching sstables between all versions supported for writing (some SSTable versions are supported for reading only).
+
+SSTables which are already on the designated version are skipped. To force rewriting *all* SSTables, use the ``--all`` flag. 
+
+Output SSTables are written to the path provided by the ``--output-dir`` flag, or to the current directory if not specified.
+This directory is expected to exist and be empty. If not empty the tool will refuse to run. This can be overridden with the ``--unsafe-accept-nonempty-output-dir`` flag.
+
+It is strongly recommended to use the system schema tables as the schema source for this command, see the `schema options <scylla-sstable-schema_>`_ for more details.
+A schema which is good enough to read the SSTable and dump its content, may not be good enough to write its content back verbatim.
+An incomplete or incorrect schema can lead to the tool crashing or even data loss.
+
+Altering the schema deliberately to alter the SSTable content or options is possible, by using the ``--schema-file`` schema source and providing the schema with the desired alterations.
+This is dangerous and can lead to data loss, use with caution. In general, altering the table options (the part after the ``WITH``) is safe.
+But even an altered schema which changed only the table options can lead to data loss, since not all schema column options are expressible via CQL.
+
+The mapping of input SSTables to output SSTables is printed to ``stdout``.
+
 
 Examples
 --------


### PR DESCRIPTION
An offline, scylla-sstable variant of nodetool upgradesstables command. Applies latest (or selected) sstable version and latest schema.

New functionality, no backport.