### PR TITLE
test/alternator: multiple fixes for tests so they would pass on DynamoDB

### DIFF
--- a/test/alternator/conftest.py
+++ b/test/alternator/conftest.py
@@ -346,6 +346,17 @@ def scylla_only(dynamodb):
     if is_aws(dynamodb):
         pytest.skip('Scylla-only feature not supported by AWS')
 
+# "dynamodb_bug" is similar to "scylla_only", except instead of skipping
+# the test, it is expected to fail (xfail) on AWS DynamoDB. It should be
+# used in rare cases where we consider Alternator's behavior to be the
+# corect one, and DynamoDB's to be the bug. Tests using this fixture should
+# have a prominent comment explaining why we believe this to be a bug in
+# DynamoDB.
+@pytest.fixture(scope=testpy_test_fixture_scope)
+def dynamodb_bug(dynamodb):
+    if is_aws(dynamodb):
+        pytest.xfail('A known bug in AWS DynamoDB')
+
 # A fixture allowing to make Scylla-specific REST API requests.
 # If we're not testing Scylla, or the REST API port (10000) is not available,
 # the test using this fixture will be skipped with a message about the REST

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -1919,8 +1919,7 @@ def test_17119a(test_table_gsi_2):
     item = {'p': p, 'x': x, 'z': random_string()}
     test_table_gsi_2.put_item(Item=item)
     assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
     # Change the GSI range key x to a different value.
     newx = random_string()
     test_table_gsi_2.update_item(Key={'p':  p}, AttributeUpdates={'x': {'Value': newx, 'Action': 'PUT'}})
@@ -1928,22 +1927,18 @@ def test_17119a(test_table_gsi_2):
     assert item == test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item']
     # The item newx should appear in the GSI, item x should be gone:
     assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
+        KeyConditions={'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
     assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
     # Change the GSI range key x back to its original value. Item newx
     # should disappear from the GSI, and item x should reappear:
     test_table_gsi_2.update_item(Key={'p':  p}, AttributeUpdates={'x': {'Value': x, 'Action': 'PUT'}})
     item['x'] = x
     assert item == test_table_gsi_2.get_item(Key={'p': p}, ConsistentRead=True)['Item']
     assert_index_query(test_table_gsi_2, 'hello', [],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
+        KeyConditions={'x': {'AttributeValueList': [newx], 'ComparisonOperator': 'EQ'}})
     assert_index_query(test_table_gsi_2, 'hello', [item],
-        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
-                       'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
 
 # The following test checks what happens when we have an LSI and a GSI using
 # the same base-table attribute. We want to verify that if the implementation

--- a/test/alternator/test_health.py
+++ b/test/alternator/test_health.py
@@ -16,7 +16,7 @@ def test_health_works(dynamodb):
 # Test that a health check only works for the root URL ('/')
 def test_health_only_works_for_root_path(dynamodb):
     url = dynamodb.meta.client._endpoint.host
-    for suffix in ['/abc', '/-', '/index.htm', '/health']:
+    for suffix in ['/abc', '/-', '/index.htm']:
         print(url + suffix)
         response = requests.get(url + suffix, verify=False)
         assert response.status_code in range(400, 405)

--- a/test/alternator/util.py
+++ b/test/alternator/util.py
@@ -188,7 +188,11 @@ def list_tables(dynamodb, limit=100):
         else:
             page = dynamodb.meta.client.list_tables(Limit=limit);
         results = page.get('TableNames', None)
-        assert(results)
+        if not results:
+            # DynamoDB may return a last empty page, without TableNames at
+            # all. It seems it doesn't happen on us-east-1, but does happen
+            # on eu-north-1 when limit=1.
+            break;
         ret = ret + results
         newpos = page.get('LastEvaluatedTableName', None)
         if not newpos:


### PR DESCRIPTION
Issue #26079 noted that multiple Alternator tests are failing when run against DynamoDB. This pull request fixes many of them, in several small patches. In one case we need to avoid a DynamoDB bug that wasn't even the point of the original test (and we create a new test specifically for that DynamoDB bug). Another test exposed a real incompatibility with Alternator (#26103) but didn't need to be exposed in this specific test so again we split the test to one that passes, and another one that xfails on Alternator (not on DynamoDB). A bigger changed had to be done to the tags feature test - since August 2024, the TagResource operation became asynchronous which broke our tests, so we fix this.

Each of these changes are described in more detail in the individual patches.

Refs #26079. It doesn't fix it completely because there are some tests which remain flaky, and some tests which, surprisingly, pass on us-east-1 but fail on eu-north-1. We'll need to address the rest later.

No backports needed, we only run tests against DynamDB from master (when we rarely do...), not on old branches.