### PR TITLE
vector search: correct column name formatting

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2499,7 +2499,7 @@ select_statement::prepared_ann_ordering_type select_statement::prepare_ann_order
     const column_definition* def = schema.get_column_definition(column->name());
     if (!def) {
         throw exceptions::invalid_request_exception(
-                fmt::format("Undefined column name {}", column->name()));
+                fmt::format("Undefined column name {}", column->text()));
     }
 
     if (!def->type->is_vector() || static_cast<const vector_type_impl*>(def->type.get())->get_elements_type()->get_kind() != abstract_type::kind::float_kind) {

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -126,7 +126,7 @@ def test_invalid_column_name_with_ann(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(k int, c int, v int, PRIMARY KEY (k, c))") as table:
         assert_invalid_message(
             cql, table,
-            f"Undefined column name",
+            f"Undefined column name bad_col",
             "SELECT k FROM %s ORDER BY bad_col ANN OF [1.0] LIMIT 1"
         )
 


### PR DESCRIPTION
This patch corrects the column name formatting whenever
an "Undefined column name" exception is thrown.
Until now we used the name() function which
returns a bytes object. This resulted in a message
with a garbled ascii bytes column name instead of
a proper string. We switch to the text() function
that returns a sstring instead, making the message
readable.
Tests are adjusted to confirm this behavior.

Fixes: VECTOR-228

