### PR TITLE
mv: run view building worker fibers in streaming group

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -104,7 +104,7 @@ view_building_worker::view_building_worker(replica::database& db, db::system_key
     init_messaging_service();
 }
 
-void view_building_worker::start_backgroud_fibers() {
+void view_building_worker::start_background_fibers() {
     SCYLLA_ASSERT(this_shard_id() == 0);
     _staging_sstables_registrator = run_staging_sstables_registrator();
     _view_building_state_observer = run_view_building_state_observer();

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -156,7 +156,7 @@ public:
     view_building_worker(replica::database& db, db::system_keyspace& sys_ks, service::migration_notifier& mnotifier,
             service::raft_group0_client& group0_client, view_update_generator& vug, netw::messaging_service& ms,
             view_building_state_machine& vbsm);
-    void start_backgroud_fibers();
+    void start_background_fibers();
 
     future<> register_staging_sstable_tasks(std::vector<sstables::shared_sstable> ssts, lw_shared_ptr<replica::table> table);
     

--- a/main.cc
+++ b/main.cc
@@ -2430,7 +2430,7 @@ sharded<locator::shared_token_metadata> token_metadata;
 
             checkpoint(stop_signal, "starting view building worker's background fibers");
             with_scheduling_group(maintenance_scheduling_group, [&] {
-                view_building_worker.local().start_backgroud_fibers();
+                view_building_worker.local().start_background_fibers();
             }).get();
             auto drain_view_buiding_worker = defer_verbose_shutdown("draining view building worker", [&] {
                 view_building_worker.invoke_on_all(&db::view::view_building_worker::drain).get();

--- a/main.cc
+++ b/main.cc
@@ -2429,7 +2429,9 @@ sharded<locator::shared_token_metadata> token_metadata;
             });
 
             checkpoint(stop_signal, "starting view building worker's background fibers");
-            view_building_worker.local().start_backgroud_fibers();
+            with_scheduling_group(maintenance_scheduling_group, [&] {
+                view_building_worker.local().start_backgroud_fibers();
+            }).get();
             auto drain_view_buiding_worker = defer_verbose_shutdown("draining view building worker", [&] {
                 view_building_worker.invoke_on_all(&db::view::view_building_worker::drain).get();
             });


### PR DESCRIPTION
The background fibers of the view building worker are indirectly spawned by the main function, thus the fibers inherit the "main" scheduling group. The main scheduling group is not supposed to be used for regular work, only for initialization and deinitialization, so this is wrong.

Wrap the call to `start_backgroud_fibers()` with `with_scheduling_group` and use the streaming scheduling group. The view building worker already handles RPCs in the streaming scheduling group (which do most of the work; background fibers only do some maintenance), so this seems like a good fit.

No need to backport, view build coordinator is not a part of any release yet.