### PR TITLE
tools/scylla-sstable-scripts: introduce purgeable.lua and writetime-histogram.lua

### DIFF
--- a/tools/scylla-sstable-scripts/purgeable.lua
+++ b/tools/scylla-sstable-scripts/purgeable.lua
@@ -1,0 +1,127 @@
+--
+-- Copyright (C) 2025-present ScyllaDB
+--
+-- SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+--
+
+-- Print statistics on what how much data is purgeable in the sstable(s).
+--
+-- Assumes tombstone_gc = {'mode': 'timeout'}
+-- gc_grace_seconds is hardcoded below, see the tombstone_gc_grace_seconds variable.
+-- Can be overridden by setting the GC_GRACE_SECONDS environment variable.
+
+partition = {total=0, live=0, purgeable=0}
+partitions = {total=0, live=0, purgeable=0}
+rows = {total=0, live=0, purgeable=0}
+cells = {total=0, live=0, purgeable=0}
+tombstones = {total=0, live=0, purgeable=0}
+
+now = os.time()
+tombstone_gc_grace_seconds = 1 * 24 * 60 * 60 -- 10 days
+
+gc_grace_seconds_env = os.getenv('GC_GRACE_SECONDS')
+if gc_grace_seconds_env then
+    tombstone_gc_grace_seconds = gc_grace_seconds_env
+end
+
+function handle_tombstone(tomb, stats)
+    stats.total = stats.total + 1
+    if os.time(tomb.deletion_time) + tombstone_gc_grace_seconds < now then
+        stats.purgeable = stats.purgeable + 1
+    end
+end
+
+function handle_atomic_cell(cell)
+    if cell.is_live then
+        cells.total = cells.total + 1
+        cells.live = cells.live + 1
+    else
+        handle_tombstone(cell.tombstone, tombstones)
+    end
+end
+
+function handle_collection(cell)
+    if cell.tombstone then
+        handle_tombstone(cell.tombstone, tombstones)
+    end
+    for _, v in ipairs(cell.values) do
+        handle_atomic_cell(v.value)
+    end
+end
+
+function handle_cells(cells, has_live_marker)
+    rows.total = rows.total + 1
+    partition.total = partition.total + 1
+
+    total = 0
+    live = 0
+    purgeable = 0
+
+    for name, cell in pairs(cells) do
+        if cell.type == "collection" then
+            handle_collection(cell)
+        else
+            handle_atomic_cell(cell)
+        end
+    end
+
+    if live > 0 or has_live_marker then
+        rows.live = rows.live + 1
+        partition.live = partition.live + 1
+    elseif purgeable == total then
+        rows.purgeable = rows.purgeable + 1
+        partition.purgeable = partition.purgeable + 1
+    else
+        -- dead, can be derived from total - (live + purgeable)
+    end
+end
+
+function consume_sstable_start(sst)
+    if sst == nil then
+        print("Sstable (combined)")
+    else
+        print("Sstable " .. sst.filename)
+    end
+end
+
+function consume_partition_start(ps)
+    partitions.total = partitions.total + 1
+    partition = {total = 0, live = 0, purgeable = 0}
+    if ps.tombstone then
+        handle_tombstone(ps.tombstone, tombstones)
+    end
+end
+
+function consume_static_row(sr)
+    handle_cells(sr.cells, false)
+end
+
+function consume_clustering_row(cr)
+    if cr.tombstone then
+        handle_tombstone(cr.tombstone, tombstones)
+        handle_tombstone(cr.shadowable_tombstone, tombstones)
+    end
+    handle_cells(cr.cells, cr.marker and cr.marker.is_live)
+end
+
+function consume_range_tombstone_change(rtc)
+    if rtc.tombstone then
+        handle_tombstone(rtc.tombstone, tombstones)
+    end
+end
+
+function consume_partition_end()
+    if partition.live > 0 then
+        partitions.live = partitions.live + 1
+    elseif partition.purgeable == partition.total then
+        partitions.purgeable = partitions.purgeable + 1
+    end
+end
+
+function consume_sstable_end()
+    print(string.format("             %9s %9s %9s %9s", "total", "live", "dead", "purgeable"))
+    print(string.format("  cells      %9d %9d %9d %9d", cells.total, cells.live, cells.total - (cells.live + cells.purgeable), cells.purgeable))
+    print(string.format("  tombstones %9d %9d %9d %9d", tombstones.total, tombstones.live, tombstones.total - (tombstones.live + tombstones.purgeable), tombstones.purgeable))
+    print(string.format("  rows       %9d %9d %9d %9d", rows.total, rows.live, rows.total - (rows.live + rows.purgeable), rows.purgeable))
+    print(string.format("  partitions %9d %9d %9d %9d", partitions.total, partitions.live, partitions.total - (partitions.live + partitions.purgeable), partitions.purgeable))
+end

--- a/tools/scylla-sstable-scripts/writetime-histogram.lua
+++ b/tools/scylla-sstable-scripts/writetime-histogram.lua
@@ -1,0 +1,165 @@
+--
+-- Copyright (C) 2025-present ScyllaDB
+--
+-- SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+--
+
+-- Produce a histogram of write times (timestamps) in the sstable(s).
+--
+-- Crawl over all timestamps in the data component and add them to a histogram.
+-- The bucket size by default is a month, tunable with the --bucket option.
+-- The timestamp of all objects that have one are added to the histogram:
+-- * cells (atomic and collection cells)
+-- * tombstones (partition-tombstone, range-tombstone, row-tombstone,
+--   shadowable-tombstone, cell-tombstone, collection-tombstone, cell-tombstone)
+-- * row-marker
+-- 
+-- This allows determining when the data was written, provided the writer of the
+-- data didn't mangle with the timestamps.
+-- This produces two lines of output:
+-- 1) Stats about the histogram and the collected data.
+-- 2) A JSON object containing the histogram, with two arrays: "buckets" and "counts".
+--
+-- following example python script:
+-- 
+--      import datetime
+--      import json
+--      import matplotlib.pyplot as plt # requires the matplotlib python package
+-- 
+--      with open('histogram.json', 'r') as f:
+--          data = json.load(f)
+-- 
+--      x = data['buckets']
+--      y = data['counts']
+-- 
+--      max_y = max(y)
+-- 
+--      x = [datetime.date.fromtimestamp(i / 1000000).strftime('%Y.%m') for i in x]
+--      y = [i / max_y for i in y]
+-- 
+--      fig, ax = plt.subplots()
+-- 
+--      ax.set_xlabel('Timestamp')
+--      ax.set_ylabel('Normalized cell count')
+--      ax.set_title('Histogram of data write-time')
+--      ax.bar(x, y)
+-- 
+--      plt.show()
+
+-- the unit of time to use as bucket, one of (years, months, weeks, days, hours)
+BUCKET = "months"
+
+partitions = 0
+rows = 0
+cells = 0
+timestamps = 0
+histogram = {}
+
+function timestamp_bucket(ts)
+    date = os.date("*t", ts // 1000000)
+    bucket_start_date = {}
+    if BUCKET == "years" then
+        bucket_start_date = {year = date.year, month = 1, day = 1}
+    elseif BUCKET == "months" then
+        bucket_start_date = {year = date.year, month = date.month, day = 1}
+    elseif BUCKET == "weeks" then
+        bucket_start_date = {year = date.year, month = date.month, day = 1 + date.day // 7}
+    elseif BUCKET == "days" then
+        bucket_start_date = {year = date.year, month = date.month, day = date.day}
+    elseif BUCKET == "hours" then
+        bucket_start_date = {year = date.year, month = date.month, day = date.day, hour = date.hour}
+    else
+        error("Invalid BUCKET value: " .. BUCKET)
+    end
+
+    return os.time(bucket_start_date) * 1000000
+end
+
+function collect_timestamp(ts)
+    ts = timestamp_bucket(ts)
+
+    timestamps = timestamps + 1
+
+    if histogram[ts] == nil then
+        histogram[ts] = 1
+    else
+        histogram[ts] = histogram[ts] + 1
+    end
+end
+
+function collect_column(cell)
+    if cell.type == "collection" then
+        if cell.tombstone then
+            collect_timestamp(cell.tombstone.timestamp)
+        end
+        for _, v in ipairs(cell.values) do
+            cells = cells + 1
+            collect_timestamp(cell.timestamp)
+        end
+    else
+        cells = cells + 1
+        collect_timestamp(cell.timestamp)
+    end
+end
+
+function collect_row(row)
+    for name, cell in pairs(row) do
+        rows = rows + 1
+        collect_column(cell)
+    end
+end
+
+-- Consume API hooks
+
+function consume_partition_start(ps)
+    partitions = partitions + 1
+    if ps.tombstone then
+        collect_timestamp(ps.tombstone.timestamp)
+    end
+end
+
+function consume_static_row(sr)
+    collect_row(sr.cells)
+end
+
+function consume_clustering_row(cr)
+    if cr.marker then
+        collect_timestamp(cr.marker.timestamp)
+    end
+
+    if cr.tombstone then
+        collect_timestamp(cr.tombstone.timestamp)
+    end
+
+    collect_row(cr.cells)
+end
+
+function consume_range_tombstone_change(crt)
+    if crt.tombstone then
+        collect_timestamp(crt.tombstone.timestamp)
+    end
+end
+
+function consume_stream_end()
+    print(string.format("Histogram has %d entries, collected from %d partitions, %d rows, %d cells: %d timestamps total", #histogram, partitions, rows, cells, timestamps))
+
+    writer = Scylla.new_json_writer()
+
+    writer:start_object()
+
+    writer:key("buckets")
+    writer:start_array()
+    for bucket, _ in pairs(histogram) do
+        writer:int(bucket)
+    end
+    writer:end_array()
+
+    writer:key("counts")
+    writer:start_array()
+    for _, count in pairs(histogram) do
+        writer:int(count)
+    end
+    writer:end_array()
+
+    writer:end_object()
+end


### PR DESCRIPTION
`purgeable.lua` was written for a specific investigation a few years ago.
`writetime-histogram.lua` is an sstable script transcription of the former scylla-sstable writetime-histogram command. This was also written for an investigation (before script command existed) and is too specific to be a native command, so was removed by https://github.com/scylladb/scylladb/commit/edaf67edcbfcb8a6d0baae0e1ee6bb41610681b8.

Add both scripts to the sample script library, they can be useful, either for a future investigation, or as samples to copy+edit to write new scripts (and train AI).

New sstable scripts, no backport