### PR TITLE
Move some compaction manager API handlers from storage_service.cc to tasks.cc

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -771,18 +771,6 @@ rest_cleanup_all(http_context& ctx, sharded<service::storage_service>& ss, std::
 
 static
 future<json::json_return_type>
-rest_perform_keyspace_offstrategy_compaction(http_context& ctx, std::unique_ptr<http::request> req) {
-        auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
-        apilog.info("perform_keyspace_offstrategy_compaction: keyspace={} tables={}", keyspace, table_infos);
-        bool res = false;
-        auto& compaction_module = ctx.db.local().get_compaction_manager().get_task_manager_module();
-        auto task = co_await compaction_module.make_and_start_task<offstrategy_keyspace_compaction_task_impl>({}, std::move(keyspace), ctx.db, table_infos, &res);
-        co_await task->done();
-        co_return json::json_return_type(res);
-}
-
-static
-future<json::json_return_type>
 rest_upgrade_sstables(http_context& ctx, std::unique_ptr<http::request> req) {
         auto& db = ctx.db;
         auto [keyspace, table_infos] = parse_table_infos(ctx, *req);
@@ -1779,7 +1767,6 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::cdc_streams_check_and_repair.set(r, rest_bind(rest_cdc_streams_check_and_repair, ss));
     ss::force_compaction.set(r, rest_bind(rest_force_compaction, ctx));
     ss::cleanup_all.set(r, rest_bind(rest_cleanup_all, ctx, ss));
-    ss::perform_keyspace_offstrategy_compaction.set(r, rest_bind(rest_perform_keyspace_offstrategy_compaction, ctx));
     ss::upgrade_sstables.set(r, rest_bind(rest_upgrade_sstables, ctx));
     ss::force_flush.set(r, rest_bind(rest_force_flush, ctx));
     ss::force_keyspace_flush.set(r, rest_bind(rest_force_keyspace_flush, ctx));
@@ -1859,7 +1846,6 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::cdc_streams_check_and_repair.unset(r);
     ss::force_compaction.unset(r);
     ss::cleanup_all.unset(r);
-    ss::perform_keyspace_offstrategy_compaction.unset(r);
     ss::upgrade_sstables.unset(r);
     ss::force_flush.unset(r);
     ss::force_keyspace_flush.unset(r);

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -140,6 +140,18 @@ void set_tasks_compaction_module(http_context& ctx, routes& r, sharded<service::
         co_return json::json_return_type(task->get_status().id.to_sstring());
     }));
 
+    ss::upgrade_sstables.set(r, wrap_ks_cf(ctx, [] (http_context& ctx, std::unique_ptr<http::request> req, sstring keyspace, std::vector<table_info> table_infos) -> future<json::json_return_type> {
+        auto& db = ctx.db;
+        bool exclude_current_version = req_param<bool>(*req, "exclude_current_version", false);
+
+        apilog.info("upgrade_sstables: keyspace={} tables={} exclude_current_version={}", keyspace, table_infos, exclude_current_version);
+
+        auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
+        auto task = co_await compaction_module.make_and_start_task<upgrade_sstables_compaction_task_impl>({}, std::move(keyspace), db, table_infos, exclude_current_version);
+        co_await task->done();
+        co_return json::json_return_type(0);
+    }));
+
     t::scrub_async.set(r, [&ctx, &snap_ctl] (std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         auto& db = ctx.db;
         auto info = parse_scrub_options(ctx, std::move(req));
@@ -163,6 +175,7 @@ void unset_tasks_compaction_module(http_context& ctx, httpd::routes& r) {
     t::perform_keyspace_offstrategy_compaction_async.unset(r);
     ss::perform_keyspace_offstrategy_compaction.unset(r);
     t::upgrade_sstables_async.unset(r);
+    ss::upgrade_sstables.unset(r);
     t::scrub_async.unset(r);
 }
 


### PR DESCRIPTION
There's a bunch of /storage_service/... endpoints that start compaction manager tasks and wait for it. Most of them have async peer in /tasks/... that start the very same task, but return to the caller with the task ID.

This patch moves those handlers' code from storage_service.cc to tasks.cc, next to the corresponding async peers, to keep handlers that need compaction_manager in one place.

That's preparation for more future changes. Later all those endpoints will stop using database from http_context and will capture the compaction_manager they need from main, like it was done in #20962 for /compaction_manager/... endpoints. Even "more later", the former and the latter blocks of endpoints will be registered and unregistered together, e.g. like database endpoints were collected in one reg/unreg sequence by #25674.

Part of http_context dependencies cleanup effort, no need to backport.