### PR TITLE
SCYLLADB-1977 docs: Add documentation for picking tombstone GC mode with TWCS

### DIFF
--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -304,6 +304,8 @@ TWCS options
 ``compaction_window_size`` (default: 1)
   The number of units which will make up a window.
 
+ .. include:: /rst_include/warning-windowsize-twcs.rst
+
 =====
 
 ``expired_sstable_check_frequency_seconds`` (default: 600)

--- a/docs/rst_include/warning-ttl-twcs.rst
+++ b/docs/rst_include/warning-ttl-twcs.rst
@@ -6,4 +6,6 @@
    * Tombstone compaction can be enabled to remove data from partially expired SSTables, but this creates additional WA (write amplification).
 
 .. caution::
-   Avoid overwriting data and deleting data explicitly at all costs, as this can potentially block an expired SSTable from being purged, due to the checks that are performed to avoid data resurrection.
+   * Avoid overwriting data and deleting data explicitly at all costs, as this can potentially block an expired SSTable from being purged, due to the checks that are performed to avoid data resurrection.
+   * If a table is guaranteed to have no overwrites or deletions, user can use the :ref:`immediate tombstone GC mode <ddl-tombstones-gc>` for optimal GC efficiency.
+   * If a table has either overwrites or deletions, user must use the :ref:`repair tombstone GC mode <ddl-tombstones-gc>`. It reduces GC efficiency since expired data will be removed only after repair operation completes.

--- a/docs/rst_include/warning-windowsize-twcs.rst
+++ b/docs/rst_include/warning-windowsize-twcs.rst
@@ -1,0 +1,4 @@
+
+.. caution::
+   With :ref:`repair tombstone GC mode <ddl-tombstones-gc>`, window size must be configured carefully, for the table to not exceed the target of 20 windows within the repair interval.
+       For example, if repair interval is usually 3 days, then picking a window size of 4h will ensure the number of windows will meet the target.


### PR DESCRIPTION
Picking the right tombstone GC mode is vital with TWCS, for correctness and GC efficiency. With deletions or overwrites, repair mode must be used in order to ensure correctness. Otherwise, immediate mode and it yields the best GC efficiency. Also recommendation on picking window size such that window count won't exceed the target.

Refs #25540.
