### PR TITLE
[Backport 2025.3] s3: Fix chunked download source metrics calculations

### DIFF
--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1182,11 +1182,13 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 s3l.trace("Fiber for object '{}' will make HTTP request within range {}", _object_name, current_range);
                 co_await _client->make_request(
                     std::move(req),
-                    [this](group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
+                    [this, start = s3_clock::now()](group_client& gc, const http::reply& reply, input_stream<char>&& in_) mutable -> future<> {
                         if (reply._status != http::reply::status_type::ok && reply._status != http::reply::status_type::partial_content) {
                             s3l.warn("Fiber for object '{}' failed: {}. Exiting", _object_name, reply._status);
                             throw httpd::unexpected_status_error(reply._status);
                         }
+                        gc.read_stats.ops++;
+                        gc.read_stats.duration += s3_clock::now() - start;
                         if (_range == s3::full_range && !reply.get_header("Content-Range").empty()) {
                             auto content_range_header = parse_content_range(reply.get_header("Content-Range"));
                             _range = range{content_range_header.start, content_range_header.total};
@@ -1202,7 +1204,6 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                                     // Inject non-retryable error to emulate source failure
                                     throw aws::aws_exception(aws::aws_error::get_errors().at("ResourceNotFound"));
                                 });
-                                auto start = s3_clock::now();
                                 s3l.trace("Fiber for object '{}' will try to read within range {}", _object_name, _range);
                                 temporary_buffer<char> buf;
                                 auto units = try_get_units(_client->_memory, _socket_buff_size);
@@ -1216,7 +1217,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                                     break;
                                 }
                                 auto buff_size = buf.size();
-                                gc.read_stats.update(buff_size, s3_clock::now() - start);
+                                gc.read_stats.bytes += buff_size;
                                 _range += buff_size;
                                 _buffers_size += buff_size;
                                 if (buff_size == 0 && _range.length() == 0) {


### PR DESCRIPTION
In S3 client both read and write metrics have three counters -- number of requests made, number of bytes processed and request latency. In most of the cases all three counters are updated at once -- upon response arrival.

However, in case of chunked download source this way of accounting metrics is misleading. In this code the request is made once, and then the obtained bytes are consumed eventually as the data arrive.

Currently, each time a new portion of data is read from the socket the number of read requests is incremented. That's wrong, the request is made once, and this counter should also be incremented once, not for every data buffer that arrived in response.

Same for read request latency -- it's "added" for every data buffer that arrives, but it's a lenghy process, the _request_ latency should be accounted once per responce. Maybe later we'll want to have "data latency" metrics as well, but for what we have now it's request latency.

The number of read bytes is accounted properly, so not touched here.

Fixes #25875
Parent PR: #25770