### PR TITLE
load_sketch: load should be computed from tablet sizes instead of tablet count

### DIFF
--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -369,7 +369,7 @@ CREATE TABLE system.load_per_node (
 Columns:
 * `dc` - The name of the data center to which the node belongs.
 * `rack` - The name of the rack to which the node belongs.
-* `storage_allocated_load` - Disk space allocated for tablets, assuming each tablet has a fixed size (target_tablet_size).
+* `storage_allocated_load` - Disk space allocated for tablets.
 * `storage_allocated_utilization` - Fraction of node's disk capacity taken for `storage_allocated_load`, where 1.0 means full utilization.
 * `storage_capacity` - Total disk capacity in bytes. Used to compute `storage_allocated_utilization`. By default equal to file system's capacity.
 * `tablets_allocated` - Number of tablet replicas on the node. Migrating tablets are accounted as if migration already finished.

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -24,14 +24,27 @@ struct table_load_stats final {
     int64_t split_ready_seq_number;
 };
 
+struct range_based_tablet_id final {
+    ::table_id table;
+    dht::token_range range;
+};
+
 struct load_stats_v1 final {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
+};
+
+struct tablet_load_stats final {
+    // Sum of all tablet sizes on a node and available disk space.
+    uint64_t effective_capacity;
+
+    std::unordered_map<locator::range_based_tablet_id, uint64_t> tablet_sizes;
 };
 
 struct load_stats {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
     std::unordered_map<locator::host_id, uint64_t> capacity;
     std::unordered_map<locator::host_id, bool> critical_disk_utilization [[version 2025.3]];
+    std::unordered_map<locator::host_id, locator::tablet_load_stats> tablet_stats [[version 2025.4]];
 };
 
 }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include "service/tablet_allocator_fwd.hh"
 #include "locator/topology.hh"
 #include "locator/token_metadata.hh"
 #include "locator/tablets.hh"
 #include "utils/stall_free.hh"
 #include "utils/extremum_tracking.hh"
 #include "utils/div_ceil.hh"
+#include "utils/pretty_printers.hh"
 
 #include <absl/container/btree_set.h>
 
@@ -22,62 +24,119 @@
 
 namespace locator {
 
+struct disk_usage {
+    using load_type = double; // Disk usage factor (0.0 to 1.0)
+
+    uint64_t capacity = 0;
+    uint64_t used = 0;
+
+    load_type get_load() const {
+        if (capacity == 0) {
+            return 0;
+        }
+        return load_type(used) / capacity;
+    }
+};
+
 /// A data structure which keeps track of load associated with data ownership
 /// on shards of the whole cluster.
 class load_sketch {
     using shard_id = seastar::shard_id;
-    using load_type = ssize_t; // In tablets.
+    using load_type = disk_usage::load_type;
 
     struct shard_load {
         shard_id id;
-        load_type load;
+        disk_usage du;
+        size_t tablet_count = 0;
+
+        load_type get_load() const {
+            return du.get_load();
+        }
     };
 
     // Less-comparator which orders by load first (ascending), and then by shard id (ascending).
     struct shard_load_cmp {
-        bool operator()(const shard_load& a, const shard_load& b) const {
-            return a.load == b.load ? a.id < b.id : a.load < b.load;
+        const std::vector<shard_load>& shards;
+        shard_load_cmp(const std::vector<shard_load>& sl)
+            : shards(sl) {
+        }
+
+        bool operator()(shard_id aid, shard_id bid) const {
+            auto load_a = shards[aid].get_load();
+            auto load_b = shards[bid].get_load();
+            return load_a == load_b ? aid < bid : load_a < load_b;
         }
     };
 
     struct node_load {
-        absl::btree_set<shard_load, shard_load_cmp> _shards_by_load;
-        std::vector<load_type> _shards;
-        load_type _load = 0;
+        std::vector<shard_load> _shards;
+        absl::btree_set<shard_id, shard_load_cmp> _shards_by_load;
+        disk_usage _du;
+        size_t _tablet_count = 0;
 
-        node_load(size_t shard_count) : _shards(shard_count) {
+        node_load(const node_load& c)
+                : _shards(c._shards)
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du(c._du) {
+        }
+
+        node_load(node_load&& m)
+                : _shards(std::move(m._shards))
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du(std::move(m._du)) {
+        }
+
+        node_load(size_t shard_count, uint64_t capacity)
+                : _shards(shard_count)
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du({capacity, 0}) {
+            uint64_t shard_capacity = capacity / shard_count;
             for (shard_id i = 0; i < shard_count; ++i) {
-                _shards[i] = 0;
+                _shards[i].du.capacity = shard_capacity;
             }
         }
 
-        void update_shard_load(shard_id shard, load_type load_delta) {
-            _load += load_delta;
+        node_load& operator=(node_load&& m) {
+            _shards = std::move(m._shards);
+            _du = std::move(m._du);
+            return *this;
+        }
 
-            auto old_load = _shards[shard];
-            auto new_load = old_load + load_delta;
-            _shards_by_load.erase(shard_load{shard, old_load});
-            _shards[shard] = new_load;
-            _shards_by_load.insert(shard_load{shard, new_load});
+        node_load& operator=(const node_load& m) {
+            _shards = m._shards;
+            _du = m._du;
+            return *this;
+        }
+
+        void update_shard_load(shard_id shard, int count_delta, uint64_t tablet_size_delta) {
+            _shards_by_load.erase(shard);
+            _shards[shard].tablet_count += count_delta;
+            if (count_delta > 0) {
+                _shards[shard].du.used += tablet_size_delta;
+            } else {
+                _shards[shard].du.used -= tablet_size_delta;
+            }
+            _shards_by_load.insert(shard);
+            _du.used += tablet_size_delta;
+            _tablet_count += count_delta;
         }
 
         void populate_shards_by_load() {
             _shards_by_load.clear();
             for (shard_id i = 0; i < _shards.size(); ++i) {
-                _shards_by_load.insert(shard_load{i, _shards[i]});
+                _shards_by_load.insert(i);
             }
         }
 
-        load_type& load() noexcept {
-            return _load;
-        }
-
-        const load_type& load() const noexcept {
-            return _load;
+        load_type get_load() const noexcept {
+            return _du.get_load();
         }
     };
     std::unordered_map<host_id, node_load> _nodes;
     token_metadata_ptr _tm;
+    load_stats_ptr _load_stats;
+    uint64_t _default_tablet_size = service::default_target_tablet_size;
+
 private:
     tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
         // We reflect migrations in the load as if they already happened,
@@ -85,7 +144,26 @@ private:
         return trinfo ? trinfo->next : ti.replicas;
     }
 
-    future<> populate_table(const tablet_map& tmap, std::optional<host_id> host, std::optional<sstring> only_dc) {
+    uint64_t get_disk_capacity_for_node(host_id node) {
+        if (_load_stats) {
+            if (_load_stats->tablet_stats.contains(node)) {
+                return _load_stats->tablet_stats.at(node).effective_capacity;
+            } else if (_load_stats->capacity.contains(node)) {
+                return _load_stats->capacity.at(node);
+            }
+        }
+        return service::default_target_tablet_size;
+    }
+
+    uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid) const {
+        uint64_t tablet_size = _default_tablet_size;
+        if (_load_stats) {
+            tablet_size = _load_stats->get_tablet_size(host, rb_tid, _default_tablet_size);
+        }
+        return std::max(tablet_size, uint64_t(1));
+    }
+
+    future<> populate_table(table_id table, const tablet_map& tmap, std::optional<host_id> host, std::optional<sstring> only_dc) {
         const topology& topo = _tm->get_topology();
         co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) -> future<> {
             for (auto&& replica : get_replicas_for_tablet_load(ti, tmap.get_tablet_transition_info(tid))) {
@@ -97,12 +175,16 @@ private:
                     if (only_dc && node->dc_rack().dc != *only_dc) {
                         continue;
                     }
-                    _nodes.emplace(replica.host, node_load{node->get_shard_count()});
+                    _nodes.emplace(replica.host, node_load{node->get_shard_count(), get_disk_capacity_for_node(replica.host)});
                 }
                 node_load& n = _nodes.at(replica.host);
                 if (replica.shard < n._shards.size()) {
-                    n.load() += 1;
-                    n._shards[replica.shard] += 1;
+                    const range_based_tablet_id rb_tid {table, tmap.get_token_range(tid)};
+                    auto tablet_size = get_tablet_size(replica.host, rb_tid);
+                    n._du.used += tablet_size;
+                    n._tablet_count++;
+                    n._shards[replica.shard].du.used += tablet_size;
+                    n._shards[replica.shard].tablet_count++;
                     // Note: as an optimization, _shards_by_load is populated later in populate_shards_by_load()
                 }
             }
@@ -110,8 +192,10 @@ private:
         });
     }
 public:
-    load_sketch(token_metadata_ptr tm)
-        : _tm(std::move(tm)) {
+    load_sketch(token_metadata_ptr tm, load_stats_ptr load_stats = {}, uint64_t default_tablet_size = service::default_target_tablet_size)
+        : _tm(std::move(tm))
+        , _load_stats(std::move(load_stats))
+        , _default_tablet_size(default_tablet_size) {
     }
 
     future<> populate(std::optional<host_id> host = std::nullopt,
@@ -122,11 +206,11 @@ public:
         if (only_table) {
             if (_tm->tablets().has_tablet_map(*only_table)) {
                 auto& tmap = _tm->tablets().get_tablet_map(*only_table);
-                co_await populate_table(tmap, host, only_dc);
+                co_await populate_table(*only_table, tmap, host, only_dc);
             }
         } else {
             for (const auto& [table, tmap] : _tm->tablets().all_tables_ungrouped()) {
-                co_await populate_table(*tmap, host, only_dc);
+                co_await populate_table(table, *tmap, host, only_dc);
             }
         }
 
@@ -152,7 +236,7 @@ public:
             if (shard_count == 0) {
                 throw std::runtime_error(format("Shard count not known for node {}", node));
             }
-            auto [i, _] = _nodes.emplace(node, node_load{shard_count});
+            auto [i, _] = _nodes.emplace(node, node_load{shard_count, get_disk_capacity_for_node(node)});
             i->second.populate_shards_by_load();
         }
         return _nodes.at(node);
@@ -160,55 +244,61 @@ public:
 
     shard_id get_least_loaded_shard(host_id node) {
         auto& n = ensure_node(node);
-        const shard_load& s = *n._shards_by_load.begin();
-        return s.id;
+        return *n._shards_by_load.begin();
     }
 
     shard_id get_most_loaded_shard(host_id node) {
         auto& n = ensure_node(node);
-        const shard_load& s = *std::prev(n._shards_by_load.end());
-        return s.id;
+        return *std::prev(n._shards_by_load.end());
     }
 
-    void unload(host_id node, shard_id shard) {
+    void unload(host_id node, shard_id shard, std::optional<size_t> tablet_count = std::nullopt, std::optional<uint64_t> tablet_sizes = std::nullopt) {
         auto& n = _nodes.at(node);
-        n.update_shard_load(shard, -1);
+        int count_delta = -int(tablet_count.value_or(1));
+        n.update_shard_load(shard, count_delta, tablet_sizes.value_or(_default_tablet_size));
     }
 
-    void pick(host_id node, shard_id shard) {
+    void pick(host_id node, shard_id shard, std::optional<size_t> tablet_count = std::nullopt, std::optional<uint64_t> tablet_sizes = std::nullopt) {
         auto& n = _nodes.at(node);
-        n.update_shard_load(shard, 1);
+        int count_delta = int(tablet_count.value_or(1));
+        n.update_shard_load(shard, count_delta, tablet_sizes.value_or(_default_tablet_size));
     }
 
     load_type get_load(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
-        return _nodes.at(node).load();
+        return _nodes.at(node).get_load();
     }
 
-    load_type total_load() const {
-        load_type total = 0;
-        for (auto&& n : _nodes) {
-            total += n.second.load();
+    uint64_t get_tablet_count(host_id node) const {
+        if (!_nodes.contains(node)) {
+            return 0;
         }
-        return total;
+        return _nodes.at(node)._tablet_count;
     }
 
-    load_type get_avg_shard_load(host_id node) const {
+    uint64_t get_avg_tablet_count(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
         auto& n = _nodes.at(node);
-        return div_ceil(n.load(), n._shards.size());
+        return div_ceil(n._tablet_count, n._shards.size());
     }
 
-    double get_real_avg_shard_load(host_id node) const {
+    double get_real_avg_tablet_count(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
         auto& n = _nodes.at(node);
-        return double(n.load()) / n._shards.size();
+        return double(n._tablet_count) / n._shards.size();
+    }
+
+    uint64_t get_disk_used(host_id node) {
+        if (!_nodes.contains(node)) {
+            return 0;
+        }
+        return _nodes.at(node)._du.used;
     }
 
     shard_id get_shard_count(host_id node) const {
@@ -230,8 +320,8 @@ public:
         min_max_tracker<load_type> minmax;
         if (_nodes.contains(node)) {
             auto& n = _nodes.at(node);
-            for (auto&& load: n._shards) {
-                minmax.update(load);
+            for (auto&& shard: n._shards) {
+                minmax.update(shard.get_load());
             }
         } else {
             minmax.update(0);
@@ -239,18 +329,22 @@ public:
         return minmax;
     }
 
-    // Returns nullopt if capacity is not known.
-    std::optional<double> get_allocated_utilization(host_id node, const locator::load_stats& stats, uint64_t target_tablet_size) const {
+    // Returns nullopt if node is not known.
+    std::optional<load_type> get_allocated_utilization(host_id node) const {
         if (!_nodes.contains(node)) {
             return std::nullopt;
         }
-        auto& n = _nodes.at(node);
-        if (!stats.capacity.contains(node)) {
-            return std::nullopt;
-        }
-        auto capacity = stats.capacity.at(node);
-        return capacity > 0 ? double(n.load() * target_tablet_size) / capacity : 0;
+        return _nodes.at(node).get_load();
     }
 };
 
 } // namespace locator
+
+template<>
+struct fmt::formatter<locator::disk_usage> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const locator::disk_usage& du, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "cap: {} used: {} load: {}",
+                              utils::pretty_printed_data_size(du.capacity), utils::pretty_printed_data_size(du.used), du.get_load());
+    }
+};

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -401,7 +401,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             }
             const auto& host_id = node.get().host_id();
             if (!existing.contains(host_id)) {
-                candidate.nodes.emplace_back(host_id, load.get_avg_shard_load(host_id));
+                candidate.nodes.emplace_back(host_id, load.get_avg_tablet_count(host_id));
             }
         }
         if (candidate.nodes.empty()) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -838,6 +838,12 @@ table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexce
     return *this;
 }
 
+void tablet_load_stats::add_tablet_sizes(const tablet_load_stats& tls) {
+    for (auto& [rb_tid, tablet_size] : tls.tablet_sizes) {
+        tablet_sizes[rb_tid] = tablet_size;
+    }
+}
+
 load_stats load_stats::from_v1(load_stats_v1&& stats) {
     return { .tables = std::move(stats.tables) };
 }
@@ -852,8 +858,22 @@ load_stats& load_stats::operator+=(const load_stats& s) {
     for (auto& [host, cdu] : s.critical_disk_utilization) {
         critical_disk_utilization[host] = cdu;
     }
-
+    for (auto& [host, tablet_ls] : s.tablet_stats) {
+        tablet_stats[host].effective_capacity = tablet_ls.effective_capacity;
+        tablet_stats[host].add_tablet_sizes(tablet_ls);
+    }
     return *this;
+}
+
+uint64_t load_stats::get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const {
+    if (auto node_i = tablet_stats.find(host); node_i != tablet_stats.end()) {
+        const tablet_load_stats& tls = node_i->second;
+        if (auto ts_i = tls.tablet_sizes.find(rb_tid); ts_i != tls.tablet_sizes.end()) {
+            return ts_i->second;
+        }
+    }
+    tablet_logger.debug("Unable to find tablet size on host: {} for tablet: {}", host, rb_tid);
+    return default_tablet_size;
 }
 
 tablet_range_splitter::tablet_range_splitter(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges)

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -468,6 +468,7 @@ struct load_stats {
     }
 
     uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const;
+    void reconcile_tablets_resize(token_metadata_ptr tmptr);
 };
 
 using load_stats_v2 = load_stats;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -63,6 +63,13 @@ struct global_tablet_id {
     auto operator<=>(const global_tablet_id&) const = default;
 };
 
+struct range_based_tablet_id {
+    table_id table;
+    dht::token_range range;
+
+    bool operator==(const range_based_tablet_id&) const = default;
+};
+
 struct tablet_replica {
     host_id host;
     shard_id shard;
@@ -98,6 +105,15 @@ struct hash<locator::global_tablet_id> {
         return utils::hash_combine(
                 std::hash<table_id>()(id.table),
                 std::hash<locator::tablet_id>()(id.tablet));
+    }
+};
+
+template<>
+struct hash<locator::range_based_tablet_id> {
+    size_t operator()(const locator::range_based_tablet_id& id) const {
+        return utils::hash_combine(
+                std::hash<table_id>()(id.table),
+                std::hash<dht::token_range>()(id.range));
     }
 };
 
@@ -420,6 +436,18 @@ struct load_stats_v1 {
     std::unordered_map<table_id, table_load_stats> tables;
 };
 
+// This is defined as final in the idl layer to limit the amount of encoded data sent via the RPC
+struct tablet_load_stats {
+    // Sum of all tablet sizes on a node and available disk space.
+    uint64_t effective_capacity = 0;
+
+    std::unordered_map<range_based_tablet_id, uint64_t> tablet_sizes;
+
+    void add_tablet_sizes(const tablet_load_stats& tls);
+};
+
+using tablet_load_stats_map = std::unordered_map<host_id, tablet_load_stats>;
+
 struct load_stats {
     std::unordered_map<table_id, table_load_stats> tables;
 
@@ -429,12 +457,17 @@ struct load_stats {
     // Critical disk utilization check for each host.
     std::unordered_map<locator::host_id, bool> critical_disk_utilization;
 
+    // Size-based load balancing data
+    tablet_load_stats_map tablet_stats;
+
     static load_stats from_v1(load_stats_v1&&);
 
     load_stats& operator+=(const load_stats& s);
     friend load_stats operator+(load_stats a, const load_stats& b) {
         return a += b;
     }
+
+    uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const;
 };
 
 using load_stats_v2 = load_stats;
@@ -845,6 +878,13 @@ template <>
 struct fmt::formatter<locator::tablet_replica> : fmt::formatter<string_view> {
     auto format(const locator::tablet_replica& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}:{}", r.host, r.shard);
+    }
+};
+
+template <>
+struct fmt::formatter<locator::range_based_tablet_id> : fmt::formatter<string_view> {
+    auto format(const locator::range_based_tablet_id& rb_tid, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}:{}", rb_tid.table, rb_tid.range);
     }
 };
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -426,7 +426,7 @@ public:
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
     virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
 
-    virtual locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
+    virtual std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
     virtual bool all_storage_groups_split() = 0;
     virtual future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1125,7 +1125,7 @@ public:
 
     // The tablet filter is used to not double account migrating tablets, so it's important that
     // only one of pending or leaving replica is accounted based on current migration stage.
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept;
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept;
 
     const db::view::stats& get_view_stats() const {
         return _view_stats;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -739,12 +739,14 @@ public:
         return *_single_sg;
     }
 
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)>) const noexcept override {
-        return locator::table_load_stats{
-            .size_in_bytes = _single_sg->live_disk_space_used(),
-            .split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min()
-        };
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)>) const noexcept override {
+        return std::make_pair(locator::table_load_stats{
+                .size_in_bytes = _single_sg->live_disk_space_used(),
+                .split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min()},
+            locator::tablet_load_stats{}
+        );
     }
+
     bool all_storage_groups_split() override { return true; }
     future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) override { return make_ready_future(); }
     future<> maybe_split_compaction_group_of(size_t idx) override { return make_ready_future(); }
@@ -902,7 +904,7 @@ public:
         return storage_group_for_id(storage_group_of(token).first);
     }
 
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept override;
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept override;
     bool all_storage_groups_split() override;
     future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) override;
     future<> maybe_split_compaction_group_of(size_t idx) override;
@@ -2831,20 +2833,25 @@ void table::on_flush_timer() {
     });
 }
 
-locator::table_load_stats tablet_storage_group_manager::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
-    locator::table_load_stats stats;
-    stats.split_ready_seq_number = _split_ready_seq_number;
+std::pair<locator::table_load_stats, locator::tablet_load_stats> tablet_storage_group_manager::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
+    locator::table_load_stats table_stats;
+    table_stats.split_ready_seq_number = _split_ready_seq_number;
+
+    locator::tablet_load_stats tablet_stats;
 
     for_each_storage_group([&] (size_t id, storage_group& sg) {
         locator::global_tablet_id gid { _t.schema()->id(), locator::tablet_id(id) };
         if (tablet_filter(*_tablet_map, gid)) {
-            stats.size_in_bytes += sg.live_disk_space_used();
+            const uint64_t tablet_size = sg.live_disk_space_used();
+            table_stats.size_in_bytes += tablet_size;
+            const locator::range_based_tablet_id rb_tid {gid.table, _tablet_map->get_token_range(gid.tablet)};
+            tablet_stats.tablet_sizes[rb_tid] = tablet_size;
         }
     });
-    return stats;
+    return std::make_pair(std::move(table_stats), std::move(tablet_stats));
 }
 
-locator::table_load_stats table::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
+std::pair<locator::table_load_stats, locator::tablet_load_stats> table::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
     return _sg_manager->table_load_stats(std::move(tablet_filter));
 }
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6962,9 +6962,11 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
     // double accounting (anomaly) in the reported size.
     auto tmlock = co_await get_token_metadata_lock();
 
+    const locator::host_id this_host = _db.local().get_token_metadata().get_my_id();
+
     // Each node combines a per-table load map from all of its shards and returns it to the coordinator.
     // So if there are 1k nodes, there will be 1k RPCs in total.
-    auto load_stats = co_await _db.map_reduce0([&table_ids] (replica::database& db) -> future<locator::load_stats> {
+    auto load_stats = co_await _db.map_reduce0([&table_ids, &this_host] (replica::database& db) -> future<locator::load_stats> {
         locator::load_stats load_stats{};
         auto& tables_metadata = db.get_tables_metadata();
 
@@ -7000,16 +7002,35 @@ future<locator::load_stats> storage_service::load_stats_for_tablet_based_tables(
                        || (is_pending && s == locator::read_replica_set_selector::next);
             };
 
-            load_stats.tables.emplace(id, table->table_load_stats(tablet_filter));
+            locator::table_load_stats table_ls;
+            locator::tablet_load_stats tablet_ls;
+            std::tie(table_ls, tablet_ls) = table->table_load_stats(tablet_filter);
+            load_stats.tables.emplace(id, std::move(table_ls));
+            load_stats.tablet_stats[this_host].add_tablet_sizes(tablet_ls);
+
             co_await coroutine::maybe_yield();
         }
 
         co_return std::move(load_stats);
     }, locator::load_stats{}, std::plus<locator::load_stats>());
 
-    auto this_host = _db.local().get_token_metadata().get_my_id();
     load_stats.capacity[this_host] = _disk_space_monitor->space().capacity;
     load_stats.critical_disk_utilization[this_host] = _disk_space_monitor->disk_utilization() > _db.local().get_config().critical_disk_utilization_level();
+
+    const std::filesystem::space_info si = _disk_space_monitor->space();
+    load_stats.capacity[this_host] = si.capacity;
+
+    if (load_stats.tablet_stats.empty()) {
+        load_stats.tablet_stats = locator::tablet_load_stats_map{{{this_host, locator::tablet_load_stats{}}}};
+    }
+    locator::tablet_load_stats& tls = load_stats.tablet_stats[this_host];
+    const uint64_t total_tablet_size = std::ranges::fold_left(tls.tablet_sizes | std::views::values, 0, std::plus{});
+    const uint64_t config_capacity = _db.local().get_config().data_file_capacity();
+    if (config_capacity != 0) {
+        tls.effective_capacity = config_capacity;
+    } else {
+        tls.effective_capacity = si.available + total_tablet_size;
+    }
 
     co_return std::move(load_stats);
 }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1623,6 +1623,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
                     break;
                 case locator::tablet_transition_stage::end_migration: {
+                    // Move the tablet size in load_stats
+                    auto leaving = locator::get_leaving_replica(tmap.get_tablet_info(gid.tablet), trinfo);
+                    auto pending = trinfo.pending_replica;
+                    locator::range_based_tablet_id rb_tid {gid.table, tmap.get_token_range(gid.tablet)};
+                    handle_tablet_size_migration(leaving->host, pending->host, rb_tid);
+
                     // Need a separate stage and a barrier after cleanup RPC to cut off stale RPCs.
                     // See do_tablet_operation() doc.
                     bool defer_transition = utils::get_local_injector().enter("handle_tablet_migration_end_migration");
@@ -1842,6 +1848,30 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         co_await update_topology_state(std::move(guard), std::move(updates), "Finished tablet migration");
     }
 
+    void handle_tablet_size_migration(locator::host_id leaving, locator::host_id pending, locator::range_based_tablet_id rb_tid) {
+        if (leaving != pending) {
+            auto old_load_stats = _tablet_allocator.get_load_stats();
+            if (old_load_stats) {
+                const locator::load_stats& stats = *old_load_stats;
+                auto leaving_i = stats.tablet_stats.find(leaving);
+                auto pending_i = stats.tablet_stats.find(pending);
+                if (leaving_i != stats.tablet_stats.end() && pending_i != stats.tablet_stats.end()) {
+                    auto& leaving_ts = leaving_i->second.tablet_sizes;
+                    auto& pending_ts = pending_i->second.tablet_sizes;
+                    if (leaving_ts.contains(rb_tid) && !pending_ts.contains(rb_tid)) {
+                        rtlogger.debug("Moving tablet size for: {} from: {} to: {}", rb_tid, leaving, pending);
+                        auto new_load_stats = make_lw_shared<locator::load_stats>(*old_load_stats);
+                        auto& new_leaving_ts = new_load_stats->tablet_stats.at(leaving);
+                        auto& new_pending_ts = new_load_stats->tablet_stats.at(pending);
+                        auto map_node = new_leaving_ts.tablet_sizes.extract(rb_tid);
+                        new_pending_ts.tablet_sizes.insert(std::move(map_node));
+                        _tablet_allocator.set_load_stats(std::move(new_load_stats));
+                    }
+                }
+            }
+        }
+    }
+
     future<> handle_tablet_resize_finalization(group0_guard g) {
         co_await utils::get_local_injector().inject("handle_tablet_resize_finalization_wait", [] (auto& handler) -> future<> {
             rtlogger.info("handle_tablet_resize_finalization: waiting");
@@ -1906,6 +1936,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 .set_version(_topo_sm._topology.version + 1)
                 .build());
         co_await update_topology_state(std::move(guard), std::move(updates), format("Finished tablet split finalization"));
+
+        // Reconcile tablet sizes
+        auto old_load_stats = _tablet_allocator.get_load_stats();
+        if (old_load_stats) {
+            rtlogger.debug("Reconciling tablet sizes after resize");
+            lw_shared_ptr<locator::load_stats> new_load_stats { make_lw_shared<locator::load_stats>(*old_load_stats) };
+            new_load_stats->reconcile_tablets_resize(tm);
+            _tablet_allocator.set_load_stats(std::move(new_load_stats));
+        }
     }
 
     future<> handle_truncate_table(group0_guard guard) {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3223,6 +3223,92 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
     }, cfg).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_load_stats_tablet_reconcile) {
+    auto cfg = tablet_cql_test_config();
+
+    // This test checks the correctness of the load_stats reconciliation algorithm.
+    // We only attempt to reconcile tablet_sizes after a merge or a split.
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+        auto dc = topo.dc();
+        const size_t tablet_count = 16;
+
+        auto host = topo.add_node(node_state::normal, 4);
+        auto ks_name = add_keyspace(e, {{dc, 1}}, tablet_count);
+        std::vector<table_id> tables;
+
+        sstring table_name = "table_1";
+        e.execute_cql(fmt::format("CREATE TABLE {}.{} (p1 text, r1 int, PRIMARY KEY (p1))", ks_name, table_name)).get();
+        table_id table = e.local_db().find_schema(ks_name, table_name)->id();
+
+        auto get_token_range = [] (size_t id, size_t tablet_count) {
+            const auto log2_tablets = log2ceil(tablet_count);
+
+            if (id == 0) {
+                return dht::token_range::make({dht::minimum_token(), false}, {dht::last_token_of_compaction_group(log2_tablets, id), true});
+            } else {
+                return dht::token_range::make({dht::last_token_of_compaction_group(log2_tablets, id - 1), false}, {dht::last_token_of_compaction_group(log2_tablets, id), true});
+            }
+        };
+
+        auto& tmap = e.shared_token_metadata().local().get()->tablets().get_tablet_map(table);
+
+        // This checks if the tablet sizes have been correctly reconciled after a merge
+        auto check_merge = [&] (size_t merge_factor) {
+            locator::load_stats stats;
+            locator::tablet_load_stats& tls = stats.tablet_stats[host];
+            const size_t before_merge_tablet_count = tablet_count * merge_factor;
+            for (size_t i = 0; i < before_merge_tablet_count; ++i) {
+                const range_based_tablet_id rb_tid {table, get_token_range(i, before_merge_tablet_count)};
+                tls.tablet_sizes[rb_tid] = i;
+            }
+
+            stats.reconcile_tablets_resize(e.shared_token_metadata().local().get());
+
+            BOOST_REQUIRE_EQUAL(tls.tablet_sizes.size(), tablet_count);
+
+            for (size_t i = 0; i < tablet_count; ++i) {
+                const auto reconciled_tablet_size = tls.tablet_sizes.at({table, tmap.get_token_range(locator::tablet_id{i})});
+                uint64_t expected_sum = 0;
+                for (uint64_t i_sum = 0; i_sum < merge_factor; ++i_sum) {
+                    expected_sum += i * merge_factor + i_sum;
+                }
+                BOOST_REQUIRE_EQUAL(reconciled_tablet_size, expected_sum);
+            }
+        };
+        check_merge(2);
+        check_merge(4);
+        check_merge(8);
+        check_merge(16);
+
+        // This checks if the tablet sizes have been correctly reconciled after a split
+        auto check_split = [&] (size_t split_factor) {
+            locator::load_stats stats;
+            locator::tablet_load_stats& tls = stats.tablet_stats[host];
+            const size_t before_split_tablet_count = tablet_count / split_factor;
+            for (size_t i = 0; i < before_split_tablet_count; ++i) {
+                const range_based_tablet_id rb_tid {table, get_token_range(i, before_split_tablet_count)};
+                tls.tablet_sizes[rb_tid] = i * split_factor;
+            }
+
+            stats.reconcile_tablets_resize(e.shared_token_metadata().local().get());
+
+            BOOST_REQUIRE_EQUAL(tls.tablet_sizes.size(), tablet_count);
+
+            for (size_t i = 0; i < tablet_count; ++i) {
+                const auto reconciled_tablet_size = tls.tablet_sizes.at({table, tmap.get_token_range(locator::tablet_id{i})});
+                BOOST_REQUIRE_EQUAL(reconciled_tablet_size, i / split_factor);
+            }
+        };
+
+        check_split(2);
+        check_split(4);
+        check_split(8);
+        check_split(16);
+
+    }, cfg).get();
+}
+
 SEASTAR_TEST_CASE(test_tablet_id_and_range_side) {
     static constexpr size_t tablet_count = 128;
     locator::tablet_map tmap(tablet_count);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1701,11 +1701,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host1), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host2), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
 
     rebalance_tablets(e);
@@ -1718,8 +1718,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
             testlog.debug("Checking host {}", h);
             BOOST_REQUIRE_LE(load.get_load(h), 3);
             BOOST_REQUIRE_GT(load.get_load(h), 1);
-            BOOST_REQUIRE_LE(load.get_avg_shard_load(h), 2);
-            BOOST_REQUIRE_GT(load.get_avg_shard_load(h), 0);
+            BOOST_REQUIRE_LE(load.get_avg_tablet_count(h), 2);
+            BOOST_REQUIRE_GT(load.get_avg_tablet_count(h), 0);
         }
     }
   }).get();
@@ -1859,11 +1859,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host1), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host2), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
 
     rebalance_tablets(e, &topo.get_shared_load_stats(), {host3});
@@ -1872,7 +1872,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
   }).get();
 }
@@ -2003,9 +2003,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
         }
 
         topo.set_node_state(host3, node_state::left);
@@ -2015,9 +2015,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
         }
     }).get();
 }
@@ -2145,10 +2145,10 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host3), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host4), 0);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host3), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host4), 0);
         }
 
         // Verify replicas are not collocated on racks
@@ -2307,7 +2307,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
 
         for (auto h : {host1, host2, host3}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 2);
         }
     }
 
@@ -2400,7 +2400,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
 
         for (auto h : {host1, host2, host3, host4}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 4);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 4);
             BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
         }
     }
@@ -2445,7 +2445,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
 
           for (auto h: {host2, host3}) {
               testlog.debug("Checking host {}", h);
-              BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2); // 16 tablets / 8 shards = 2 tablets / shard
+              BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 2); // 16 tablets / 8 shards = 2 tablets / shard
               BOOST_REQUIRE_EQUAL(load.get_shard_imbalance(h), 0);
           }
         }
@@ -2631,7 +2631,7 @@ SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
 
             for (auto h : {host2, host3}) {
                 testlog.debug("Checking host {}", h);
-                BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 1);
+                BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 1);
             }
         }
     }).get();
@@ -2751,7 +2751,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
 
             min_max_tracker<unsigned> min_max_load;
             for (auto h: hosts) {
-                auto l = load.get_avg_shard_load(h);
+                auto l = load.get_avg_tablet_count(h);
                 testlog.info("Load on host {}: {}", h, l);
                 min_max_load.update(l);
                 BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
@@ -2810,10 +2810,10 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         std::unordered_map<host_id, double> initial_utilization;
         auto& hosts = topo.hosts();
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 initial_utilization[h] = *u;
             }
@@ -2824,16 +2824,14 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack1");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            auto u0 = *load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size);
+            auto u0 = *load.get_allocated_utilization(hosts[0]);
             BOOST_REQUIRE_LT(u0, initial_utilization[hosts[0]]);
             initial_utilization[hosts[0]] = u0;
             // rack2 and rack3 are not changed, to keep racks not overloaded (RF=rack_count)
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[1]]);
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[2]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1]), initial_utilization[hosts[1]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2]), initial_utilization[hosts[2]]);
         }
 
         topo.add_i4i_large(rack2);
@@ -2841,15 +2839,13 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack2");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[0]]);
-            auto u1 = *load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0]), initial_utilization[hosts[0]]);
+            auto u1 = *load.get_allocated_utilization(hosts[1]);
             BOOST_REQUIRE_LT(u1, initial_utilization[hosts[1]]);
             initial_utilization[hosts[1]] = u1;
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[2]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2]), initial_utilization[hosts[2]]);
         }
 
         topo.add_i4i_large(rack3);
@@ -2857,20 +2853,18 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack3");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[0]]);
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[1]]);
-            auto u2 = *load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0]), initial_utilization[hosts[0]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1]), initial_utilization[hosts[1]]);
+            auto u2 = *load.get_allocated_utilization(hosts[2]);
             BOOST_REQUIRE_LT(u2, initial_utilization[hosts[2]]);
             initial_utilization[hosts[2]] = u2;
 
             // Check that utilization difference is < 1%
             min_max_tracker<double> node_utilization;
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 node_utilization.update(*u);
             }
@@ -2911,13 +2905,13 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
         auto& hosts = topo.hosts();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate(std::nullopt, table2).get();
 
             // Check that utilization difference is < 4%
             min_max_tracker<double> node_utilization;
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 testlog.info("table2: {}: {}", h, u);
                 node_utilization.update(*u);
@@ -2961,12 +2955,12 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbala
         auto& hosts = topo.hosts();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate(std::nullopt, table2).get();
 
             min_max_tracker<double> node_utilization;
             for (auto h : hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 testlog.info("table2: {}: {}", h, u);
                 node_utilization.update(u.value_or(0));
             }
@@ -2987,6 +2981,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
         auto per_shard_goal = e.local_db().get_config().tablets_per_shard_goal();
 
         topology_builder topo(e);
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
 
         std::vector<endpoint_dc_rack> racks = {
             topo.rack(),
@@ -3025,7 +3020,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table1).tablet_count(), 256);
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table2).tablet_count(), 64);
 
-            load_sketch load(tm);
+            load_sketch load(tm, load_stats.get());
             load.populate().get();
 
             for (auto h: hosts) {
@@ -3205,7 +3200,7 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
         auto& stm = e.shared_token_metadata().local();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             testlog.info("max load: {}", load.get_shard_minmax(host1).max());
             // The value 415 was determined empirically. If there was lack of scaling, it would be 1'600.
@@ -3215,7 +3210,7 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
         rebalance_tablets(e, &load_stats);
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             testlog.info("max load: {}", load.get_shard_minmax(host1).max());
             BOOST_REQUIRE(load.get_shard_minmax(host1).max() <= 200);

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -359,7 +359,7 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
                 for (auto [h, _] : hosts) {
                     auto minmax = load.get_shard_minmax(h);
                     auto node_load = load.get_load(h);
-                    auto avg_shard_load = load.get_real_avg_shard_load(h);
+                    auto avg_shard_load = load.get_real_avg_tablet_count(h);
                     auto overcommit = double(minmax.max()) / avg_shard_load;
                     shard_load_minmax.update(minmax.max());
                     shard_count += load.get_shard_count(h);


### PR DESCRIPTION
This commit changes load_sketch so that it computes node and shard load
based on tablet sizes instead of tablet count.

This is the third chunk of changes in the size based load balancing series. It is based on the top of the previous chunk of changes which are in PR: #26152

This is a new feature and backport is not necessary.