### PR TITLE
build: drop -fvisibility=hidden compiler flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2130,8 +2130,8 @@ if not args.staticboost:
 for pkg in pkgs:
     user_cflags += ' ' + pkg_config(pkg, '--cflags')
     libs += ' ' + pkg_config(pkg, '--libs')
-user_cflags += ' -fvisibility=hidden'
-user_ldflags += ' -fvisibility=hidden'
+user_cflags += ' -fvisibility-inlines-hidden'
+user_ldflags += ' -fvisibility-inlines-hidden'
 if args.staticcxx:
     user_ldflags += " -static-libstdc++"
 


### PR DESCRIPTION
The -fvisibility=hidden flag removes a shared library's symbols from the dynamic symbol table, reducing the shared object size and the dynamic linking time. In return, the user promises not to rely on the uniqueness of objects declared with exactly the same name in the shared libary and the main executable.

However, we violate this assumption. In Seatar's noncopyable_function, we compare _vtable to _s_empty_vtable (in operator bool()). The full name of this _s_empty_vtable is
seastar::noncopyable_function<Signature>::_s_empty_vtable. Since it can be instantiated in both the main executable and in libseastar.so, the comparison can fail even though we're comparing what is, in C++ view, the address of a unique object to itself.

To solve the problem, we can either:
 - reimplement noncopyable_function::operator bool in a way that does not depent on the object name (for exaple, 'return _vtable->empty;') where _empty is a boolean initialized to true for the empty vtable), and be careful not to repeat the mistake elsewhere
 - drop -fvisibility=hidden

Here, we choose the second option. The benefit of -fvisibility=hidden is important, but we only use shared libraries in debug mode, and the time spent chasing these apparent one-definition-rule violations is more important than some milliseconds during launch time and a few megabytes in libseastar.so.

We do trade it in for -fvisibility-inlines-hidden. This is similar to -fvisibility=hidden, but applies only to addresses of inline functions. Since comparing functions by address is very rare, and inline functions are very common, it seems like a reasonable tradeoff to make.

Fixes #25286.

While the bug applies to older versions, it's unlikely we'll backport something that hits them, and the bug only hits dev/debug modes, not release.