### PR TITLE
cdc: fix create table with cdc if not exists

### DIFF
--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -664,8 +664,6 @@ static future<utils::chunked_vector<mutation>> do_prepare_new_column_families_an
     auto& db = sp.local_db();
 
     return seastar::async([&db, &ksm, timestamp, cfms = std::move(cfms)] mutable {
-        db.get_notifier().pre_create_column_families(ksm, cfms);
-
         for (auto cfm : cfms) {
             if (db.has_schema(cfm->ks_name(), cfm->cf_name())) {
                 throw exceptions::already_exists_exception(cfm->ks_name(), cfm->cf_name());
@@ -678,6 +676,8 @@ static future<utils::chunked_vector<mutation>> do_prepare_new_column_families_an
         for (auto cfm : cfms) {
             mlogger.info("Create new ColumnFamily: {}", cfm);
         }
+
+        db.get_notifier().pre_create_column_families(ksm, cfms);
 
         utils::chunked_vector<mutation> mutations;
         for (schema_ptr cfm : cfms) {

--- a/test/cqlpy/test_cdc.py
+++ b/test/cqlpy/test_cdc.py
@@ -365,3 +365,14 @@ def test_desc_log_table_properties_preserved_after_noop_alter(cql, test_keyspace
         new_log_stmt = get_log_alter_stmt(cdc_log_table)
 
         assert old_log_stmt == new_log_stmt
+
+
+def test_create_if_not_exists_with_cdc(scylla_only, cql, test_keyspace):
+    table_name = f"{test_keyspace}.{unique_name()}"
+    create_table_query = f"CREATE TABLE IF NOT EXISTS {table_name} (p int PRIMARY KEY) WITH cdc = {{ 'enabled': true }}"
+    cql.execute(create_table_query)
+    try:
+        # Creating again should be a no-op and not fail.
+        cql.execute(create_table_query)
+    finally:
+        cql.execute(f"DROP TABLE IF EXISTS {table_name}")


### PR DESCRIPTION
Fix an issue where executing a CREATE TABLE IF NOT EXISTS statement with
CDC enabled fails with an error if the table already exists. Instead,
the query should succeed and be a no-op.

This regression was introduced by commit https://github.com/scylladb/scylladb/commit/fed104805994f28e2c2a9a5cfb58c573d4251db4. Previously, when
executing the query, we would first check if the table exists in
do_prepare_new_column_families_announcement. If it did, we would throw
an already_exists_exception, which was handled correctly; otherwise, we
would continue and create the CDC table in the
before_create_column_families notification.

The order of operations was changed in https://github.com/scylladb/scylladb/commit/fed104805994f28e2c2a9a5cfb58c573d4251db4, causing the
regression. Now, we first create the CDC schema and add it to the schema
list for creation, and then check for each of them if they already
exist. The problem is that when we create the CDC schema in
on_pre_create_column_families, it also checks if the CDC table already
exists. If it does, it throws an invalid_request_exception, which is not
caught and handled as expected.

This patch restores the previous order of operations: we first check if
the tables exist, and only then add the CDC schema in pre_create.

Fixes https://github.com/scylladb/scylladb/issues/26142

no backport - recent regression, not released yet