### PR TITLE
test: avoid #include <boost/test/included/...>

### DIFF
--- a/test/boost/alternator_unit_test.cc
+++ b/test/boost/alternator_unit_test.cc
@@ -7,7 +7,7 @@
  */
 
 #define BOOST_TEST_MODULE alternator
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 
 #include <seastar/util/defer.hh>
 #include <seastar/core/memory.hh>

--- a/test/boost/chunked_vector_test.cc
+++ b/test/boost/chunked_vector_test.cc
@@ -15,7 +15,7 @@
 #include <algorithm>
 #include <fmt/format.h>
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <deque>
 #include <random>
 #include "utils/chunked_vector.hh"

--- a/test/boost/small_vector_test.cc
+++ b/test/boost/small_vector_test.cc
@@ -8,7 +8,7 @@
 
 #define BOOST_TEST_MODULE small_vector
 
-#include <boost/test/included/unit_test.hpp>
+#include <boost/test/unit_test.hpp>
 #include <fmt/ranges.h>
 #include <algorithm>
 #include <functional>


### PR DESCRIPTION
The boost/test/included/... directory is apparently internal and not intended for user consumption.

Including it caused a One-Definition-Rule violation, due to boost/test/impl/unit_test_parameters.ipp containing code like this:

```c++
namespace runtime_config {

// UTF parameters
std::string btrt_auto_start_dbg    = "auto_start_dbg";
std::string btrt_break_exec_path   = "break_exec_path";
std::string btrt_build_info        = "build_info";
std::string btrt_catch_sys_errors  = "catch_system_errors";
std::string btrt_color_output      = "color_output";
std::string btrt_detect_fp_except  = "detect_fp_exceptions";
std::string btrt_detect_mem_leaks  = "detect_memory_leaks";
std::string btrt_list_content      = "list_content";
```

This is defining variables in a header, and so can (and in fact does) create duplicate variable definitions, which later cause trouble.

So far, we were protected from this trouble by -fvisibility=hidden, which caused the duplicate definitions to be in fact not duplicate.

Fix this by correcting the include path away from <boost/test/included/>.

While this bug is present on older versions, it is latent and is unlikely to surface; it is also test-only. Therefore not backporting.