### PR TITLE
build: suppress linker pgo hash mismatch warnings

### DIFF
--- a/cmake/mode.RelWithDebInfo.cmake
+++ b/cmake/mode.RelWithDebInfo.cmake
@@ -30,5 +30,6 @@ if(_slp_vectorize_supported)
 endif()
 
 add_link_options($<$<CONFIG:RelWithDebInfo>:LINKER:--gc-sections>)
+add_link_options($<$<CONFIG:RelWithDebInfo>:LINKER:--no-lto-pgo-warn-mismatch>)
 
 maybe_limit_stack_usage_in_KB(13 RelWithDebInfo)

--- a/configure.py
+++ b/configure.py
@@ -384,7 +384,7 @@ modes = {
     },
     'release': {
         'cxxflags': '-ffunction-sections -fdata-sections ',
-        'cxx_ld_flags': '-Wl,--gc-sections',
+        'cxx_ld_flags': '-Wl,--gc-sections -Wl,--no-lto-pgo-warn-mismatch',
         'stack-usage-threshold': 1024*13,
         'optimization-level': '3',
         'per_src_extra_cxxflags': {},


### PR DESCRIPTION
Since we generage pgo profiles once a fortnight (and not every build), pgo hash mismatches are expected as the code built diverges from the code measured. The warnings about hash mismatches don't provide any value (they cannot be acted upon) and are only distracting.

A possible downside is that we'll miss the pgo training process failing (it is visible in the warnings list getting longer and longer), but that's not a proper indication.

Suppress them with the appropriate linker switch.

Ref #26010.

Build cosmetics; not backporting.