### PR TITLE
Fix getendpoints command for compound keys containing ':'

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -595,6 +595,50 @@
          ]
       },
       {
+         "path": "/storage_service/natural_endpoints/v2/{keyspace}",
+         "operations": [
+            {
+               "method": "GET",
+               "summary":"This method returns the N endpoints that are responsible for storing the specified key i.e for replication. the endpoint responsible for this key",
+               "type": "array",
+               "items": {
+                  "type": "string"
+               },
+               "nickname": "get_natural_endpoints_v2",
+               "produces": [
+                  "application/json"
+               ],
+               "parameters": [
+                  {
+                     "name": "keyspace",
+                     "description": "The keyspace to query about.",
+                     "required": true,
+                     "allowMultiple": false,
+                     "type": "string",
+                     "paramType": "path"
+                  },
+                  {
+                     "name": "cf",
+                     "description": "Column family name.",
+                     "required": true,
+                     "allowMultiple": false,
+                     "type": "string",
+                     "paramType": "query"
+                  },
+                  {
+                     "name": "key_component",
+                     "description": "Each component of the key for which we need to find the endpoint (e.g. ?key_component=part1&key_component=part2).",
+                     "required": true,
+                     "allowMultiple": true,
+                     "type": "string",
+                     "paramType": "query"
+                  }
+               ]
+            }
+         ]
+      },
+
+      {
          "path":"/storage_service/cdc_streams_check_and_repair",
          "operations":[
             {

--- a/docs/operating-scylla/nodetool-commands/getendpoints.rst
+++ b/docs/operating-scylla/nodetool-commands/getendpoints.rst
@@ -8,17 +8,20 @@ For example:
 
 ``nodetool getendpoints nba player_name Russell``
 
-==========  ==============  
-Parameter   Description  
-==========  ==============  
-keyspace    keyspace name       
-----------  --------------  
-table       table name           
-----------  --------------  
-key         partition key  
-==========  ==============  
+==============  ==============
+Parameter       Description
+==============  ==============
+keyspace        keyspace name
+--------------  --------------
+table           table name
+--------------  --------------
+key             partition key
+--------------  --------------
+key-components  partition key (alternative to key)
+==============  ==============
 
 In a case of a composite partition key, use ``:`` between columns in the key. All columns in the partition key are required.
+Alternatively, you can use the ``--key-components`` option to specify each component of the partition key separately.
 For example:
 
 .. code:: 

--- a/keys/keys.cc
+++ b/keys/keys.cc
@@ -44,14 +44,19 @@ partition_key partition_key::from_nodetool_style_string(const schema_ptr s, cons
         vec.push_back(key);
     } else {
         boost::split(vec, key, boost::is_any_of(":"));
-        if (vec.size() != s->partition_key_type()->types().size()) {
-            throw std::invalid_argument(fmt::format("partition key '{}' has mismatch number of components: expected {}, got {}", key, s->partition_key_type()->types().size(), vec.size()));
-        }
     }
 
-    auto it = std::begin(vec);
+    return from_string_components(s, vec);
+}
+
+partition_key partition_key::from_string_components(const schema_ptr s, const std::vector<sstring>& components) {
+    if (components.size() != s->partition_key_type()->types().size()) {
+        throw std::invalid_argument(fmt::format("partition key '{}' has mismatch number of components: expected {}, got {}", components, s->partition_key_type()->types().size(), components.size()));
+    }
+
+    auto it = std::begin(components);
     std::vector<bytes> r;
-    r.reserve(vec.size());
+    r.reserve(components.size());
     for (auto t : s->partition_key_type()->types()) {
         r.emplace_back(t->from_string(*it++));
     }

--- a/keys/keys.hh
+++ b/keys/keys.hh
@@ -704,6 +704,15 @@ public:
      */
     static partition_key from_nodetool_style_string(const schema_ptr s, const sstring& key);
 
+    /*!
+    * \brief Create a partition_key from a vector of string components.
+    * Takes a vector of string representations of each component of the partition key,
+    * and returns a partition_key.
+    * For example, if a composite key has two columns (col1, col2), and you want the partition key
+    * for col1 = "val1" and col2 = "val2", pass {"val1", "val2"} as the components.
+    */
+    static partition_key from_string_components(const schema_ptr s, const std::vector<sstring>& components);
+
     partition_key(std::vector<bytes> v)
         : compound_wrapper(managed_bytes(c_type::serialize_value(std::move(v))))
     { }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -7743,16 +7743,28 @@ storage_service::get_all_ranges(const std::vector<token>& sorted_tokens) const {
 }
 
 inet_address_vector_replica_set
-storage_service::get_natural_endpoints(const sstring& keyspace,
-        const sstring& cf, const sstring& key) const {
+storage_service::get_natural_endpoints(const sstring& keyspace, const sstring& cf, const sstring& key) const {
     auto& table = _db.local().find_column_family(keyspace, cf);
     const auto schema = table.schema();
-    partition_key pk = partition_key::from_nodetool_style_string(schema, key);
+    auto pk = partition_key::from_nodetool_style_string(schema, key);
+    return get_natural_endpoints(keyspace, schema, table, pk);
+}
+
+inet_address_vector_replica_set
+storage_service::get_natural_endpoints(const sstring& keyspace, const sstring& cf, const std::vector<sstring>& key_components) const {
+    auto& table = _db.local().find_column_family(keyspace, cf);
+    const auto schema = table.schema();
+    auto pk = partition_key::from_string_components(schema, key_components);
+    return get_natural_endpoints(keyspace, schema, table, pk);
+}
+
+inet_address_vector_replica_set
+storage_service::get_natural_endpoints(const sstring& keyspace, const schema_ptr& schema, const replica::column_family& cf, const partition_key& pk) const {
     dht::token token = schema->get_partitioner().get_token(*schema, pk.view());
     const auto& ks = _db.local().find_keyspace(keyspace);
     host_id_vector_replica_set replicas;
     if (ks.uses_tablets()) {
-        replicas = table.get_effective_replication_map()->get_natural_replicas(token);
+        replicas = cf.get_effective_replication_map()->get_natural_replicas(token);
     } else {
         replicas = ks.get_static_effective_replication_map()->get_natural_replicas(token);
     }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -685,11 +685,23 @@ public:
      *
      * @param keyspaceName keyspace name also known as keyspace
      * @param cf Column family name
-     * @param key key for which we need to find the endpoint
+     * @param key Nodetool style key for which we need to find the endpoint
      * @return the endpoint responsible for this key
      */
-    inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace,
-            const sstring& cf, const sstring& key) const;
+    inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace, const sstring& cf, const sstring& key) const;
+    /**
+     * This method returns the N endpoints that are responsible for storing the
+     * specified key i.e for replication.
+     *
+     * @param keyspaceName keyspace name also known as keyspace
+     * @param cf Column family name
+     * @param key_components the components of the partition key for which we need to find the endpoint
+     * @return the endpoint responsible for this key
+     */
+    inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace, const sstring& cf, const std::vector<sstring>& key_components) const;
+
+private:
+    inet_address_vector_replica_set get_natural_endpoints(const sstring& keyspace, const schema_ptr& schema, const replica::column_family& cf, const partition_key& pk) const;
 
 public:
     future<> decommission();

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -148,7 +148,16 @@ class rest_server():
             # only JSON-encoded payload is supported
             body = await request.json()
 
-        this_req = expected_request(request.method, request.path, params=dict(request.query), body=body)
+        params = {}
+        for key, value in request.query.items():
+            if key in params:
+                # Convert single value to list if we encounter a duplicate key
+                if not isinstance(params[key], list):
+                    params[key] = [params[key]]
+                params[key].append(value)
+            else:
+                params[key] = value
+        this_req = expected_request(request.method, request.path, params=params, body=body)
 
         if len(expected_requests) == 0:
             self.unexpected_requests += 1

--- a/test/nodetool/test_getendpoints.py
+++ b/test/nodetool/test_getendpoints.py
@@ -23,3 +23,26 @@ def test_getendpoints(nodetool, num_endpoints):
 
     expected_output = ''.join(f"{endpoint}\n" for endpoint in endpoints)
     assert actual_output == expected_output
+
+@pytest.mark.parametrize("num_endpoints", [1, 2])
+@pytest.mark.parametrize("key_components", [[("--key-components", "part1")],
+                                   [("--key-components", "part1"), ("--key-components", "part2")]])
+def test_getendpoints_key_components_param(nodetool, num_endpoints, key_components):
+    keyspace = 'ks'
+    table = 'cf0'
+    endpoints = [f"127.0.0.{i}" for i in range(num_endpoints)]
+    key_components_values = []
+    args = [keyspace, table]
+    for arg, value in key_components:
+        key_components_values.append(value)
+        args += [arg, value]
+    key_component_param = key_components_values if len(key_components_values) > 1 else key_components_values[0]
+    res = nodetool("getendpoints",  *args, expected_requests=[
+        expected_request("GET", f"/storage_service/natural_endpoints/v2/{keyspace}",
+                         params={"cf": table, "key_component": key_component_param},
+                         response=endpoints),
+    ])
+    actual_output = res.stdout
+
+    expected_output = ''.join(f"{endpoint}\n" for endpoint in endpoints)
+    assert actual_output == expected_output

--- a/test/rest_api/conftest.py
+++ b/test/rest_api/conftest.py
@@ -37,8 +37,13 @@ class RestApiSession:
         if params:
             sep = '?'
             for key, value in params.items():
-                url += f"{sep}{key}={value}"
-                sep = '&'
+                if isinstance(value, list):
+                    for v in value:
+                        url += f"{sep}{key}={v}"
+                        sep = '&'
+                else:
+                    url += f"{sep}{key}={value}"
+                    sep = '&'
         req = self.session.prepare_request(requests.Request(method, url))
         return self.session.send(req)
 


### PR DESCRIPTION
Before, the `nodetool getendpoints` expected the key as one string separated by : (for example 1:val:ue). This caused errors if any part of the key had a colon because it was unclear whether a colon was a separator or part of the key.

This change adds a new API endpoint, `/storage_service/natural_endpoints/v2/{keyspace}`, which accepts composite partition keys as multiple key_component query parameters (e.g., ?key_component=1&key_component=val:ue). The `nodetool getendpoints` command was updated to support a new `--key-components` option, allowing users to pass key components as an array. The client and test infrastructure were extended to support multiple values for a query parameter, and tests were added to verify correct behavior with composite keys.

The previous method of passing partition keys as colon-separated strings is preserved for backward compatibility.

Backport is not required, since this change relies on recent Seastar updates

Fixes #16596