### PR TITLE
alternator: update references to alternator streams issue

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1719,14 +1719,14 @@ static future<executor::request_return_type> create_table_on_shard0(service::cli
         auto ts = group0_guard.write_timestamp();
         utils::chunked_vector<mutation> schema_mutations;
         auto ksm = create_keyspace_metadata(keyspace_name, sp, gossiper, ts, tags_map, sp.features());
-        // Alternator Streams doesn't yet work when the table uses tablets (#16317)
+        // Alternator Streams doesn't yet work when the table uses tablets (#23838)
         if (stream_specification && stream_specification->IsObject()) {
             auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
             if (stream_enabled && stream_enabled->IsBool() && stream_enabled->GetBool()) {
                 locator::replication_strategy_params params(ksm->strategy_options(), ksm->initial_tablets());
                 auto rs = locator::abstract_replication_strategy::create_replication_strategy(ksm->strategy_name(), params);
                 if (rs->uses_tablets()) {
-                    co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
+                    co_return api_error::validation("Streams not yet supported on a table using tablets (issue #23838). "
                     "If you want to use streams, create a table with vnodes by setting the tag 'experimental:initial_tablets' set to 'none'.");
                 }
             }
@@ -1874,12 +1874,12 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                 if (add_stream_options(*stream_specification, builder, p.local())) {
                     validate_cdc_log_name_length(builder.cf_name());
                 }
-                // Alternator Streams doesn't yet work when the table uses tablets (#16317)
+                // Alternator Streams doesn't yet work when the table uses tablets (#23838)
                 auto stream_enabled = rjson::find(*stream_specification, "StreamEnabled");
                 if (stream_enabled && stream_enabled->IsBool()) {
                     if (stream_enabled->GetBool()) {
                         if (p.local().local_db().find_keyspace(tab->ks_name()).get_replication_strategy().uses_tablets()) {
-                        co_return api_error::validation("Streams not yet supported on a table using tablets (issue #16317). "
+                        co_return api_error::validation("Streams not yet supported on a table using tablets (issue #23838). "
                             "If you want to enable streams, re-create this table with vnodes (with the tag 'experimental:initial_tablets' set to 'none').");
                         }
                         if (tab->cdc_options().enabled()) {

--- a/docs/alternator/new-apis.md
+++ b/docs/alternator/new-apis.md
@@ -209,4 +209,4 @@ Alternator table, the following features will not work for this table:
 
 * Enabling Streams with CreateTable or UpdateTable doesn't work
   (results in an error).
-  See <https://github.com/scylladb/scylla/issues/16317>.
+  See <https://github.com/scylladb/scylla/issues/23838>.

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -403,7 +403,7 @@ def test_streams_latency(dynamodb, dynamodbstreams, metrics):
     # latency metrics are only updated for *successful* operations so we
     # need to use a real Alternator Stream in this test.
     with new_test_table(dynamodb,
-        # Alternator Streams is expected to fail with tablets due to #16317.
+        # Alternator Streams is expected to fail with tablets due to #23838.
         # To ensure that this test still runs, instead of xfailing it, we
         # temporarily coerce Altenator to avoid using default tablets
         # setting, even if it's available. We do this by using the following

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -16,7 +16,7 @@ from botocore.exceptions import ClientError
 
 from test.alternator.util import unique_table_name, create_test_table, new_test_table, random_string, freeze, list_tables, get_region
 
-# All tests in this file are expected to fail with tablets due to #16317.
+# All tests in this file are expected to fail with tablets due to #23838.
 # To ensure that Alternator Streams is still being tested, instead of
 # xfailing these tests, we temporarily coerce the tests below to avoid
 # using default tablets setting, even if it's available. We do this by

--- a/test/alternator/test_tablets.py
+++ b/test/alternator/test_tablets.py
@@ -84,9 +84,9 @@ def test_initial_tablets_number(dynamodb):
     with new_test_table(dynamodb, **schema) as table:
         assert not uses_tablets(dynamodb, table)
 
-# Before Alternator Streams is supported with tablets (#16317), let's verify
+# Before Alternator Streams is supported with tablets (#23838), let's verify
 # that enabling Streams results in an orderly error. This test should be
-# deleted when #16317 is fixed.
+# deleted when #23838 is fixed.
 def test_streams_enable_error_with_tablets(dynamodb):
     # Test attempting to create a table already with streams
     with pytest.raises(ClientError, match='ValidationException.*tablets'):

--- a/test/cqlpy/test_permissions.py
+++ b/test/cqlpy/test_permissions.py
@@ -816,9 +816,6 @@ def test_view_permissions_from_base(cql, test_keyspace):
 # table instead of those on the CDC log table. To make a CDC log readable
 # you need to give read permissions on the base table.
 # Reproduces #19798 and #25800.
-@pytest.mark.parametrize("test_keyspace",
-                         [pytest.param("tablets", marks=[pytest.mark.xfail(reason="issue #16317")]), "vnodes"],
-                         indirect=True)
 def test_cdc_permissions_from_base(cql, test_keyspace, scylla_only):
     with new_test_table(cql, test_keyspace, 'a int primary key', "with cdc={'enabled':true}") as table:
         cdc_log = table + '_scylla_cdc_log'


### PR DESCRIPTION
update all the references about the issue of tablets support for
alternator streams to issue https://github.com/scylladb/scylladb/issues/23838 instead of https://github.com/scylladb/scylladb/issues/16317.

The issue https://github.com/scylladb/scylladb/issues/16317 is about support of CDC with tablets, but it is now
closed and it didn't address alternator streams. the remaining issues
about alternator streams should be addressed as part of https://github.com/scylladb/scylladb/issues/23838, so fix
the references in order for them not to be missed.

backport is not needed