### PR TITLE
alternator: improve error handling of incorrect ARN

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1123,7 +1123,7 @@ static schema_ptr get_table_from_arn(service::storage_proxy& proxy, std::string_
         // FIXME: remove sstring creation once find_schema gains a view-based interface
         return proxy.data_dictionary().find_schema(sstring(keyspace_name), sstring(table_name));
     } catch (const data_dictionary::no_such_column_family& e) {
-        throw api_error::access_denied("Incorrect resource identifier");
+        throw api_error::resource_not_found(fmt::format("ResourceArn '{}' not found", arn));
     } catch (const std::out_of_range& e) {
         throw api_error::access_denied("Incorrect resource identifier");
     }

--- a/test/alternator/test_tag.py
+++ b/test/alternator/test_tag.py
@@ -136,6 +136,22 @@ def test_tag_resource_incorrect(test_table):
         with pytest.raises(ClientError, match='ValidationException'):
             test_table.meta.client.tag_resource(ResourceArn=arn, Tags=[{'Key':incorrect_tag[0],'Value':incorrect_tag[1]}])
 
+# The previous test, test_tag_resource_incorrect, tried several cases of
+# misformatted or obviously incorrect ARNs and checked the appropriate
+# errors. Here we try a more subtle error - an ARN that looks like it could
+# have been a real one - it's close to an existing table's ARN - but isn't.
+def test_tag_resource_subtly_incorrect_arn(test_table):
+    arn = test_table.meta.client.describe_table(TableName=test_table.name)['Table']['TableArn']
+    # The very last component of the ARN, on both Alternator and DynamoDB,
+    # is the table's name. If we add one character at the end of the ARN,
+    # it will look like it might be correct, but the table would not found.
+    incorrect_arn = arn + 'x'
+    # In this case, where the ARN is well-formatted but refers to a non-
+    # existent table, DynamoDB returns ResourceNotFoundException and not
+    # AccessDeniedException or ValidationException as in other cases.
+    with pytest.raises(ClientError, match='ResourceNotFoundException'):
+        test_table.meta.client.tag_resource(ResourceArn=incorrect_arn, Tags=[{'Key':'x', 'Value':'y'}])
+
 # Test that only specific values are allowed for write isolation (system:write_isolation tag)
 def test_tag_resource_write_isolation_values(scylla_only, test_table):
     got = test_table.meta.client.describe_table(TableName=test_table.name)['Table']


### PR DESCRIPTION
Before this patch, if an ARN that is passed to Alternator requests like TagResource is well-formatted but points to non-existent table, Alternator returns the unhelpful error:

  (AccessDeniedException) when calling the TagResource operation:
  Incorrect resource identifier

This patch modifies this error to be:

  (ResourceNotFoundException) when calling the TagResource operation:
  ResourceArn 'arn:scylla:alternator:alternator_alternator_Test_
  1758532308880:scylla:table/alternator_Test_1758532308880x' not found

This is the same error type (ResourceNotFoundException) that DynamoDB returns in that case - and a more helpful error message.

This patch also includes a regression test that checks the error type in this case. The new test fails on Alternator before this patch, and passes afterwards (and also passes on DyanamoDB).

This is a small change to the generation of errors that never bothered any user, no need to backport.