### PR TITLE
test.py: fix dumping big logs to output

### DIFF
--- a/test/cqlpy/suite.yaml
+++ b/test/cqlpy/suite.yaml
@@ -2,6 +2,8 @@ type: Python
 pool_size: 4
 dirties_cluster:
   - test_native_transport
+  - test_describe # Broke CQL connections for next tests
+  - cassandra_tests/validation/operations/alter_test # Do not clean keyspaces after test that might affect next tests
 extra_scylla_cmdline_options:
   - '--rf-rack-valid-keyspaces=1'
   - '--experimental-features=udf'

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -249,15 +249,14 @@ class PythonTest(Test):
             cluster.after_test(self.uname, self.success)
             self.is_after_test_ok = True
         except Exception as e:
-            self.server_log = cluster.read_server_log()
             if not self.is_before_test_ok:
-                print("Test {} pre-check failed: {}".format(self.name, str(e)))
-                print("Server log of the first server:\n{}".format(self.server_log))
+                print(f"Test {self.name} pre-check failed: {str(e)}\ncheck server logs: {self.server_log_filename}")
                 logger.info(f"Discarding cluster after failed start for test %s...", self.name)
             elif not self.is_after_test_ok:
-                print("Test {} post-check failed: {}".format(self.name, str(e)))
-                print("Server log of the first server:\n{}".format(self.server_log))
+                print(f"Test {self.name} post-check failed: {str(e)}\ncheck server logs: {self.server_log_filename}")
                 logger.info(f"Discarding cluster after failed test %s...", self.name)
+            self.success = False
+            cluster.is_dirty = True
         await self.suite.clusters.put(cluster, is_dirty=cluster.is_dirty)
         logger.info("Test %s %s", self.uname, "succeeded" if self.success else "failed ")
 


### PR DESCRIPTION
1. Remove dumping cluster logs and print only the link to the log.
2. Fail the test (to fail CI and not ignore the problem) and mark the cluster as dirty (to avoid affecting subsequent tests) in case setup/teardown fails.
3. Add 2 cqlpy tests that fail after applying step 2 to the dirties_cluster list so the cluster is discarded afterward.

fixes: https://github.com/scylladb/scylladb/issues/26010
fixes: https://github.com/scylladb/scylladb/issues/25905
