### PR TITLE
tools/schema_loader: disable tablet-related restrictions in the placeholder keyspace

### DIFF
--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -161,7 +161,7 @@ private:
         return is_system_keyspace(unwrap(ks).metadata->name());
     }
     virtual const locator::abstract_replication_strategy& get_replication_strategy(data_dictionary::keyspace ks) const override {
-        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, 0}};
+        static const locator::local_strategy strategy{locator::replication_strategy_params{locator::replication_strategy_config_options{}, {}}};
         return strategy;
     }
     virtual const std::vector<view_ptr>& get_table_views(data_dictionary::table t) const override {


### PR DESCRIPTION
Passing `0` as the `initial_tablets` argument causes `schema_loaders`'s placeholder keyspace to be a tablet keyspace.

This causes `scylla sstable` to reject some table schemas which are legitimate in this context. For example, `scylla sstable` refuses to work with sstables which contains `counter` columns, because tablets don't support counters.

This is undesirable. Let's make `schema_loader`'s keyspace a non-tablet keyspace.

Backports could be considered, but if this wasn't needed so far, there's probably no reason to bother.