### PR TITLE
utils/config_file: fix a missing `allowed_values` propagation in one of `named_value` constructors

### DIFF
--- a/utils/config_file.hh
+++ b/utils/config_file.hh
@@ -205,7 +205,7 @@ public:
         }
         named_value(config_file* file, std::string_view name, liveness liveness_, value_status vs, const T& t = T(), std::string_view desc = {},
                 std::initializer_list<T> allowed_values = {})
-            : named_value(file, name, {}, liveness_, vs, t, desc) {
+            : named_value(file, name, {}, liveness_, vs, t, desc, std::move(allowed_values)) {
         }
         named_value(config_file* file, std::string_view name, std::string_view alias, value_status vs, const T& t = T(), std::string_view desc = {},
                 std::initializer_list<T> allowed_values = {})


### PR DESCRIPTION
In one of the constructors of `named_value`, the `allowed_values` argument isn't used.

(This means that if some config entry uses this constructor, the values aren't validated on the config layer,
and might give some lower layer a bad surprise).

Fix that.

Fixes scylladb/scylladb#26371

I want this backported to 2025.4, because I want `scylla.yaml` to reject unknown sstable versions. 
I'm not sure if a further backport is desirable. This is technically a bug, but it's not clear if it has any important user-visible effects, and the fix might be carrying a mild regression risk.