### PR TITLE
test.py: adjust framework verbosity default settings

### DIFF
--- a/test.py
+++ b/test.py
@@ -65,6 +65,10 @@ class TabularConsoleOutput:
 
     def __init__(self, verbose: bool, test_count: int) -> None:
         self.verbose = verbose
+
+        if not output_is_a_tty:
+            self.verbose = True
+
         self.test_count = test_count
         self.last_test_no = 0
 
@@ -250,9 +254,6 @@ def parse_cmd_line() -> argparse.Namespace:
         testmem = 6e9 if os.sysconf('SC_PAGE_SIZE') > 4096 else 2e9
         default_num_jobs_mem = ((sysmem - 4e9) // testmem)
         args.jobs = min(default_num_jobs_mem, nr_cpus // cpus_per_test_job)
-
-    if not output_is_a_tty:
-        args.verbose = True
 
     if not args.modes:
         try:


### PR DESCRIPTION
Currently, test.py always runs in verbose mode in non-TTY due to the custom reporter TabularConsoleOutput( custom-implemented test reporter in test.py) limitations, because in non-verbose mode, it  "Use ANSI Escape sequences for manipulating console," which is not possible in non-TTY

So, it also affects the new pure pytest runner (now only boosts tests run under it), but it should not, since pytest standard output does not depend on TTY


This commit changes the logic to increase only TabularConsoleOutput verbosity for CI(non-TTY) run instead of the whole framework
