### PR TITLE
test_out_of_space_prevention.py: Fix flaky test_node_restart_while_tablet_split test

### DIFF
--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -347,7 +347,7 @@ async def test_node_restart_while_tablet_split(manager: ManagerClient, volumes_f
         mark = await log.mark()
 
         logger.info("Create and populate test table")
-        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
             async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
                 table = cf.split('.')[-1]
                 table_id = (await cql.run_async(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = '{table}'"))[0].id


### PR DESCRIPTION
The test starts a 3-node cluster and immediately creates a big file on the first nodes in order to trigger the out of space prevention to disable compaction, including the SPLIT compaction.

In order to trigger a SPLIT compaction, a keyspace with 1 initial tablet is created followed by alter statement with `tablets = {'min_tablet_count': 2}`. This triggers a resize decision that should not finalize due to disabled compaction on the first node.

The test is flaky because, the keyspace is created with RF=1 and there is no guarantee that the tablet replica will be located on the first node with critical disk utilization. If that is not the case, the split is finalized and the test fails, because it expect the split to be blocked.

Change to RF=3. This ensures there is exactly one tablet replica on each node, including the one with critical disk utilization. So SPLIT is blocked until the disk utilization on the first node, drops below the critical level.

Fixes: https://github.com/scylladb/scylladb/issues/25861

No backport required. The test being fixed has been recently added and not backported.