### PR TITLE
replica/mutation_dump: include empty/dead partitions in the scan results

### DIFF
--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -714,9 +714,10 @@ future<page_consume_result<ResultBuilder>> read_page(
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
+        bool tombstone_gc_enabled,
         noncopyable_function<ResultBuilder()> result_builder_factory) {
     auto compaction_state = make_lw_shared<compact_for_query_state>(*s, cmd.timestamp, cmd.slice, cmd.get_row_limit(),
-            cmd.partition_limit);
+            cmd.partition_limit, mutation_fragment_stream_validation_level::token, tombstone_gc_enabled);
 
     auto reader = make_multishard_combining_reader(ctx, s, ctx->erm(), ctx->permit(), ranges.front(), cmd.slice,
             trace_state, mutation_reader::forwarding(ranges.size() > 1));
@@ -726,7 +727,7 @@ future<page_consume_result<ResultBuilder>> read_page(
 
     // Use coroutine::as_future to prevent exception on timesout.
     auto f = co_await coroutine::as_future(query::consume_page(reader, compaction_state, cmd.slice, result_builder_factory(), cmd.get_row_limit(),
-                cmd.partition_limit, cmd.timestamp));
+                cmd.partition_limit, cmd.timestamp, tombstone_gc_enabled));
     if (!f.failed()) {
         // no exceptions are thrown in this block
         auto result = std::move(f).get();
@@ -761,6 +762,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled,
         noncopyable_function<ResultBuilder()> result_builder_factory) {
     auto& table = db.local().find_column_family(s);
     auto erm = table.get_effective_replication_map();
@@ -768,7 +770,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
 
     // Use coroutine::as_future to prevent exception on timesout.
     auto f = co_await coroutine::as_future(ctx->lookup_readers(timeout).then([&, result_builder_factory = std::move(result_builder_factory)] () mutable {
-        return read_page<ResultBuilder>(ctx, s, cmd, ranges, trace_state, std::move(result_builder_factory));
+        return read_page<ResultBuilder>(ctx, s, cmd, ranges, trace_state, tombstone_gc_enabled, std::move(result_builder_factory));
     }).then([&] (page_consume_result<ResultBuilder> r) -> future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> {
         if (r.compaction_state->are_limits_reached() || r.result.is_short_read()) {
             // Must call before calling `detach_state()`.
@@ -792,6 +794,7 @@ future<foreign_ptr<lw_shared_ptr<typename ResultBuilder::result_type>>> do_query
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled,
         noncopyable_function<ResultBuilder()> result_builder_factory) {
     auto& table = db.local().find_column_family(s);
     auto erm = table.get_effective_replication_map();
@@ -830,6 +833,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled,
         std::function<ResultBuilder(query::result_memory_accounter&&)> result_builder_factory) {
     if (cmd.get_row_limit() == 0 || cmd.slice.partition_row_limit() == 0 || cmd.partition_limit == 0) {
         co_return std::tuple(
@@ -847,7 +851,7 @@ static future<std::tuple<foreign_ptr<lw_shared_ptr<typename ResultBuilder::resul
     try {
         auto accounter = co_await local_db.get_result_memory_limiter().new_mutation_read(*cmd.max_result_size, short_read_allowed);
 
-        auto result = co_await query_method(db, s, cmd, ranges, std::move(trace_state), timeout,
+        auto result = co_await query_method(db, s, cmd, ranges, std::move(trace_state), timeout, tombstone_gc_enabled,
                 [result_builder_factory, accounter = std::move(accounter)] () mutable {
 			return result_builder_factory(std::move(accounter));
 		});
@@ -871,11 +875,13 @@ public:
 private:
     reconcilable_result_builder _builder;
     schema_ptr _s;
+    bool _tombstone_gc_enabled;
 
 public:
-    mutation_query_result_builder(const schema& s, const query::partition_slice& slice, query::result_memory_accounter&& accounter)
+    mutation_query_result_builder(const schema& s, const query::partition_slice& slice, query::result_memory_accounter&& accounter, bool tombstone_gc_enabled)
         : _builder(s, slice, std::move(accounter))
         , _s(s.shared_from_this())
+        , _tombstone_gc_enabled(tombstone_gc_enabled)
      { }
 
     void consume_new_partition(const dht::decorated_key& dk) { _builder.consume_new_partition(dk); }
@@ -893,7 +899,7 @@ public:
             const dht::partition_range& range,
             tracing::trace_state_ptr trace_state,
             db::timeout_clock::time_point timeout) {
-        auto res = co_await db.query_mutations(std::move(schema), cmd, range, std::move(trace_state), timeout);
+        auto res = co_await db.query_mutations(std::move(schema), cmd, range, std::move(trace_state), timeout, _tombstone_gc_enabled);
         co_return make_foreign(make_lw_shared<result_type>(std::get<0>(std::move(res))));
     }
 
@@ -987,10 +993,11 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout) {
-    return do_query_on_all_shards<mutation_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
-            [query_schema, &cmd] (query::result_memory_accounter&& accounter) {
-        return mutation_query_result_builder(*query_schema, cmd.slice, std::move(accounter));
+        db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled) {
+    return do_query_on_all_shards<mutation_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout, tombstone_gc_enabled,
+            [query_schema, &cmd, tombstone_gc_enabled] (query::result_memory_accounter&& accounter) {
+        return mutation_query_result_builder(*query_schema, cmd.slice, std::move(accounter), tombstone_gc_enabled);
     });
 }
 
@@ -1002,7 +1009,7 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<query::result>>, cache_temperature>>
         query::result_options opts,
         tracing::trace_state_ptr trace_state,
         db::timeout_clock::time_point timeout) {
-    return do_query_on_all_shards<data_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout,
+    return do_query_on_all_shards<data_query_result_builder>(db, query_schema, cmd, ranges, std::move(trace_state), timeout, true,
             [query_schema, &cmd, opts] (query::result_memory_accounter&& accounter) {
         return data_query_result_builder(*query_schema, cmd.slice, opts, std::move(accounter), cmd.tombstone_limit);
     });

--- a/multishard_mutation_query.hh
+++ b/multishard_mutation_query.hh
@@ -71,7 +71,8 @@ future<std::tuple<foreign_ptr<lw_shared_ptr<reconcilable_result>>, cache_tempera
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
         tracing::trace_state_ptr trace_state,
-        db::timeout_clock::time_point timeout);
+        db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled = true);
 
 /// Run the data query on all shards.
 ///

--- a/querier.hh
+++ b/querier.hh
@@ -38,11 +38,12 @@ auto consume_page(mutation_reader& reader,
         Consumer&& consumer,
         uint64_t row_limit,
         uint32_t partition_limit,
-        gc_clock::time_point query_time) {
+        gc_clock::time_point query_time,
+        bool tombstone_gc_enabled) {
     return reader.peek().then([=, &reader, consumer = std::move(consumer)] (
                 mutation_fragment_v2* next_fragment) mutable {
         const auto next_fragment_region = next_fragment ? next_fragment->position().region() : partition_region::partition_start;
-        compaction_state->start_new_page(row_limit, partition_limit, query_time, next_fragment_region, consumer);
+        compaction_state->start_new_page(row_limit, partition_limit, query_time, tombstone_gc_enabled, next_fragment_region, consumer);
 
         auto reader_consumer = compact_for_query<Consumer>(compaction_state, std::move(consumer));
 
@@ -175,9 +176,10 @@ public:
             uint64_t row_limit,
             uint32_t partition_limit,
             gc_clock::time_point query_time,
-            tracing::trace_state_ptr trace_ptr = {}) {
+            tracing::trace_state_ptr trace_ptr = {},
+            bool tombstone_gc_enabled = true) {
         return ::query::consume_page(std::get<mutation_reader>(_reader), _compaction_state, *_slice, std::move(consumer), row_limit,
-                partition_limit, query_time).then_wrapped([this, trace_ptr = std::move(trace_ptr)] (auto&& fut) {
+                partition_limit, query_time, tombstone_gc_enabled).then_wrapped([this, trace_ptr = std::move(trace_ptr)] (auto&& fut) {
             const auto& cstats = _compaction_state->stats();
             tracing::trace(trace_ptr, "Page stats: {} partition(s), {} static row(s) ({} live, {} dead), {} clustering row(s) ({} live, {} dead), {} range tombstone(s) and {} cell(s) ({} live, {} dead)",
                     cstats.partitions,

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1751,7 +1751,7 @@ database::query(schema_ptr query_schema, const query::read_command& cmd, query::
 
 future<std::tuple<reconcilable_result, cache_temperature>>
 database::query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout) {
+                          tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled) {
     const auto short_read_allwoed = query::short_read(cmd.slice.options.contains<query::partition_slice::option::allow_short_read>());
     auto& semaphore = get_reader_concurrency_semaphore();
     auto max_result_size = cmd.max_result_size ? *cmd.max_result_size : get_query_max_result_size();
@@ -1770,7 +1770,8 @@ database::query_mutations(schema_ptr query_schema, const query::read_command& cm
         reader_permit::need_cpu_guard ncpu_guard{permit};
         permit.set_max_result_size(max_result_size);
         return cf.mutation_query(std::move(query_schema), std::move(permit), cmd, range,
-                std::move(trace_state), std::move(accounter), timeout, &querier_opt).then([&result, ncpu_guard = std::move(ncpu_guard)] (reconcilable_result res) {
+                std::move(trace_state), std::move(accounter), timeout, tombstone_gc_enabled, &querier_opt)
+        .then([&result, ncpu_guard = std::move(ncpu_guard)] (reconcilable_result res) {
             result = std::move(res);
         });
     };
@@ -3374,14 +3375,15 @@ future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> query_mutations(
         schema_ptr s,
         const dht::partition_range& pr,
         const query::partition_slice& ps,
-        db::timeout_clock::time_point timeout) {
+        db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled) {
     auto max_res_size = db.local().get_query_max_result_size();
     auto cmd = query::read_command(s->id(), s->version(), ps, max_res_size, query::tombstone_limit::max);
     auto erm = s->table().get_effective_replication_map();
     if (auto shard_opt = dht::is_single_shard(erm->get_sharder(*s), *s, pr)) {
         auto shard = *shard_opt;
-        co_return co_await db.invoke_on(shard, [gs = global_schema_ptr(s), &cmd, &pr, timeout] (replica::database& db) mutable {
-            return db.query_mutations(gs, cmd, pr, {}, timeout).then([] (std::tuple<reconcilable_result, cache_temperature>&& res) {
+        co_return co_await db.invoke_on(shard, [gs = global_schema_ptr(s), &cmd, &pr, timeout, tombstone_gc_enabled] (replica::database& db) mutable {
+            return db.query_mutations(gs, cmd, pr, {}, timeout, tombstone_gc_enabled).then([] (std::tuple<reconcilable_result, cache_temperature>&& res) {
                 return make_foreign(make_lw_shared<reconcilable_result>(std::move(std::get<0>(res))));
             });
         });

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1009,6 +1009,7 @@ public:
             tracing::trace_state_ptr trace_state,
             query::result_memory_accounter accounter,
             db::timeout_clock::time_point timeout,
+            bool tombstone_gc_enabled = true,
             std::optional<query::querier>* saved_querier = { });
 
     void start();
@@ -1894,7 +1895,7 @@ public:
                                                                   const dht::partition_range_vector& ranges, tracing::trace_state_ptr trace_state,
                                                                   db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{});
     future<std::tuple<reconcilable_result, cache_temperature>> query_mutations(schema_ptr query_schema, const query::read_command& cmd, const dht::partition_range& range,
-                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout);
+                                                tracing::trace_state_ptr trace_state, db::timeout_clock::time_point timeout, bool tombstone_gc_enabled = true);
     // Apply the mutation atomically.
     // Throws timed_out_error when timeout is reached.
     future<> apply(schema_ptr, const frozen_mutation&, tracing::trace_state_ptr tr_state, db::commitlog_force_sync sync, db::timeout_clock::time_point timeout, db::per_partition_rate_limit::info rate_limit_info = std::monostate{});

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -468,7 +468,7 @@ private:
 
     future<> read_next_page() {
         const dht::partition_range_vector prs{_prs.front()};
-        auto res = co_await query_mutations_on_all_shards(_db, _schema, _cmd, prs, _ts, _timeout);
+        auto res = co_await query_mutations_on_all_shards(_db, _schema, _cmd, prs, _ts, _timeout, false);
         const auto& rr = std::get<0>(res);
         for (const auto& p : rr->partitions()) {
             auto mut = p.mut().unfreeze(_schema);

--- a/replica/query.hh
+++ b/replica/query.hh
@@ -45,7 +45,8 @@ future<foreign_ptr<lw_shared_ptr<reconcilable_result>>> query_mutations(
         schema_ptr s,
         const dht::partition_range& pr,
         const query::partition_slice& ps,
-        db::timeout_clock::time_point timeout);
+        db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled = true);
 
 /// Reads the specified range and slice of the given table, from the local replica.
 ///

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3986,6 +3986,7 @@ table::mutation_query(schema_ptr query_schema,
         tracing::trace_state_ptr trace_state,
         query::result_memory_accounter accounter,
         db::timeout_clock::time_point timeout,
+        bool tombstone_gc_enabled,
         std::optional<query::querier>* saved_querier) {
     if (cmd.get_row_limit() == 0 || cmd.slice.partition_row_limit() == 0 || cmd.partition_limit == 0) {
         co_return reconcilable_result();
@@ -4006,7 +4007,7 @@ table::mutation_query(schema_ptr query_schema,
     std::exception_ptr ex;
   try {
     auto rrb = reconcilable_result_builder(*query_schema, cmd.slice, std::move(accounter));
-    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, trace_state);
+    auto r = co_await q.consume_page(std::move(rrb), cmd.get_row_limit(), cmd.partition_limit, cmd.timestamp, trace_state, tombstone_gc_enabled);
 
     if (!saved_querier || (!q.are_limits_reached() && !r.is_short_read())) {
         co_await q.close();

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -3512,7 +3512,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
 
         while (!reader.is_buffer_empty() || !reader.is_end_of_stream()) {
             auto c = consumer{permit, res_mut, max_rows};
-            compaction_state->start_new_page(1, max_partitions, query_time, reader.peek().get()->position().region(), c);
+            compaction_state->start_new_page(1, max_partitions, query_time, true, reader.peek().get()->position().region(), c);
             reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
         }
 
@@ -3528,7 +3528,7 @@ SEASTAR_THREAD_TEST_CASE(test_compactor_range_tombstone_spanning_many_pages) {
 
         while (!reader.is_buffer_empty() || !reader.is_end_of_stream()) {
             auto c = consumer{permit, res_mut, 2};
-            compaction_state->start_new_page(max_rows, max_partitions, query_time, reader.peek().get()->position().region(), c);
+            compaction_state->start_new_page(max_rows, max_partitions, query_time, true, reader.peek().get()->position().region(), c);
             reader.consume(compact_for_query<consumer>(compaction_state, std::move(c))).get();
         }
 


### PR DESCRIPTION
`select * from mutation_fragment()` queries don't return partitions which are completely empty or are only contain tombstones which are garbage collectible. This is because the underlying `mutation_dump` mechanism has a separate query to discover partitions for scans. This query is a regular mutation scan, which is subject to query compaction and garbage collection. Disable the query compaction for mutation queries executed on behalf of mutation fragment queries, so *all* data is visible in the result, even that which is fully garbage collectible.

Fixes scylladb/scylladb#23707.

Scans for mutation-fragment are very rare, so a backport is not necessary. We can backport on-demand. 