### PR TITLE
configure.py: fix passing of user linker flags to cmake

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2920,7 +2920,7 @@ def configure_using_cmake(args):
         'CMAKE_C_COMPILER': args.cc,
         'CMAKE_CXX_COMPILER': args.cxx,
         'CMAKE_CXX_FLAGS': args.user_cflags,
-        'CMAKE_EXE_LINKER_FLAGS': semicolon_separated(args.user_ldflags),
+        'CMAKE_EXE_LINKER_FLAGS': args.user_ldflags,
         'CMAKE_EXPORT_COMPILE_COMMANDS': 'ON',
         'Scylla_CHECK_HEADERS': 'ON',
         'Scylla_DIST': 'ON' if args.enable_dist in (None, True) else 'OFF',

--- a/configure.py
+++ b/configure.py
@@ -1808,7 +1808,7 @@ for mode in modes:
     # Those flags are passed not only to Scylla objects, but also to libraries
     # that we compile ourselves.
     modes[mode]['lib_cflags'] = user_cflags
-    modes[mode]['lib_ldflags'] = user_ldflags + linker_flags
+    modes[mode]['lib_ldflags'] = user_ldflags + ' ' + linker_flags
 
 
 def prepare_advanced_optimizations(*, modes, build_modes, args):


### PR DESCRIPTION
Any user provided linker flags are converted to a semicolon separated
string by the `configure.py` script and then passed to cmake via the
`CMAKE_EXE_LINKER_FLAGS` option. But `CMAKE_EXE_LINKER_FLAGS` expects
semicolon separated values only when set from within CMakeLists. When
the option is set from the shell, which is the case with `configure.py`
executing cmake, the values should be separated by space. So, pass the
flags as it is instead of separating them with semicolons.

`configure.py` also incorrectly concatenates the user linker flags and
internal linker flags without a space in between causing flags like
'-gz' and '-fuse-ld=lld' to merge into a single invalid argument. Fix
that by using a proper space when concatenating these two flags.

Fixes #26232

Fix to a dev build option. Backport not required. 
