### PR TITLE
cmake: link vector_search library to cql3 library

### DIFF
--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -137,7 +137,8 @@ target_link_libraries(cql3
     ANTLR3::antlr3
   PRIVATE
     lang
-    transport)
+    transport
+    vector_search)
 
 check_headers(check-headers cql3
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)


### PR DESCRIPTION
The `indexed_table_select_statement::actually_do_execute()` method references `vector_search::vector_store_client::ann()`, but the `vector_search` library, which provides its definition, is not linked with the `cql3` library. This causes linker errors when other targets are built, for example linking `comparable_bytes_test`, which links the `types` library that in turn links `cql3` throws the following error :

```
...error: undefined symbol: vector_search::vector_store_client::ann...
```

Fix by adding `vector_search` to the private link libraries of `cql3`.

Fixes #26235

No need to backport as this is only in master.