### PR TITLE
load_balancer: compute node load based on tablet sizes

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1492,6 +1492,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     // Bigger tables will take longer to be resized. similar-sized tables can be batched into same iteration.
     , tablet_load_stats_refresh_interval_in_seconds(this, "tablet_load_stats_refresh_interval_in_seconds", liveness::LiveUpdate, value_status::Used, 60,
         "Tablet load stats refresh rate in seconds.")
+    , force_capacity_based_balancing(this, "force_capacity_based_balancing", liveness::LiveUpdate, value_status::Used, false,
+        "Forces the load balancer to perform capacity based balancing, instead of size based balancing.")
+    , size_based_balance_threshold_percentage(this, "size_based_balance_threshold_percentage", liveness::LiveUpdate, value_status::Used, 1.0,
+        "Sets the maximum difference in percentages between the most loaded and least loaded nodes, below which the load balancer considers nodes balanced.")
     , default_log_level(this, "default_log_level", value_status::Used, seastar::log_level::info, "Default log level for log messages")
     , logger_log_level(this, "logger_log_level", value_status::Used, {}, "Map of logger name to log level. Valid log levels are 'error', 'warn', 'info', 'debug' and 'trace'")
     , log_to_stdout(this, "log_to_stdout", value_status::Used, true, "Send log output to stdout")

--- a/db/config.hh
+++ b/db/config.hh
@@ -602,6 +602,8 @@ public:
     named_value<bool> rf_rack_valid_keyspaces;
 
     named_value<uint32_t> tablet_load_stats_refresh_interval_in_seconds;
+    named_value<bool> force_capacity_based_balancing;
+    named_value<float> size_based_balance_threshold_percentage;
 
     static const sstring default_tls_priority;
 private:

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -369,7 +369,7 @@ CREATE TABLE system.load_per_node (
 Columns:
 * `dc` - The name of the data center to which the node belongs.
 * `rack` - The name of the rack to which the node belongs.
-* `storage_allocated_load` - Disk space allocated for tablets, assuming each tablet has a fixed size (target_tablet_size).
+* `storage_allocated_load` - Disk space allocated for tablets.
 * `storage_allocated_utilization` - Fraction of node's disk capacity taken for `storage_allocated_load`, where 1.0 means full utilization.
 * `storage_capacity` - Total disk capacity in bytes. Used to compute `storage_allocated_utilization`. By default equal to file system's capacity.
 * `tablets_allocated` - Number of tablet replicas on the node. Migrating tablets are accounted as if migration already finished.

--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -24,14 +24,27 @@ struct table_load_stats final {
     int64_t split_ready_seq_number;
 };
 
+struct range_based_tablet_id final {
+    ::table_id table;
+    dht::token_range range;
+};
+
 struct load_stats_v1 final {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
+};
+
+struct tablet_load_stats final {
+    // Sum of all tablet sizes on a node and available disk space.
+    uint64_t effective_capacity;
+
+    std::unordered_map<locator::range_based_tablet_id, uint64_t> tablet_sizes;
 };
 
 struct load_stats {
     std::unordered_map<::table_id, locator::table_load_stats> tables;
     std::unordered_map<locator::host_id, uint64_t> capacity;
     std::unordered_map<locator::host_id, bool> critical_disk_utilization [[version 2025.3]];
+    std::unordered_map<locator::host_id, locator::tablet_load_stats> tablet_stats [[version 2025.4]];
 };
 
 }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#include "service/tablet_allocator_fwd.hh"
 #include "locator/topology.hh"
 #include "locator/token_metadata.hh"
 #include "locator/tablets.hh"
 #include "utils/stall_free.hh"
 #include "utils/extremum_tracking.hh"
 #include "utils/div_ceil.hh"
+#include "utils/pretty_printers.hh"
 
 #include <absl/container/btree_set.h>
 
@@ -22,62 +24,119 @@
 
 namespace locator {
 
+struct disk_usage {
+    using load_type = double; // Disk usage factor (0.0 to 1.0)
+
+    uint64_t capacity = 0;
+    uint64_t used = 0;
+
+    load_type get_load() const {
+        if (capacity == 0) {
+            return 0;
+        }
+        return load_type(used) / capacity;
+    }
+};
+
 /// A data structure which keeps track of load associated with data ownership
 /// on shards of the whole cluster.
 class load_sketch {
     using shard_id = seastar::shard_id;
-    using load_type = ssize_t; // In tablets.
+    using load_type = disk_usage::load_type;
 
     struct shard_load {
         shard_id id;
-        load_type load;
+        disk_usage du;
+        size_t tablet_count = 0;
+
+        load_type get_load() const {
+            return du.get_load();
+        }
     };
 
     // Less-comparator which orders by load first (ascending), and then by shard id (ascending).
     struct shard_load_cmp {
-        bool operator()(const shard_load& a, const shard_load& b) const {
-            return a.load == b.load ? a.id < b.id : a.load < b.load;
+        const std::vector<shard_load>& shards;
+        shard_load_cmp(const std::vector<shard_load>& sl)
+            : shards(sl) {
+        }
+
+        bool operator()(shard_id aid, shard_id bid) const {
+            auto load_a = shards[aid].get_load();
+            auto load_b = shards[bid].get_load();
+            return load_a == load_b ? aid < bid : load_a < load_b;
         }
     };
 
     struct node_load {
-        absl::btree_set<shard_load, shard_load_cmp> _shards_by_load;
-        std::vector<load_type> _shards;
-        load_type _load = 0;
+        std::vector<shard_load> _shards;
+        absl::btree_set<shard_id, shard_load_cmp> _shards_by_load;
+        disk_usage _du;
+        size_t _tablet_count = 0;
 
-        node_load(size_t shard_count) : _shards(shard_count) {
+        node_load(const node_load& c)
+                : _shards(c._shards)
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du(c._du) {
+        }
+
+        node_load(node_load&& m)
+                : _shards(std::move(m._shards))
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du(std::move(m._du)) {
+        }
+
+        node_load(size_t shard_count, uint64_t capacity)
+                : _shards(shard_count)
+                , _shards_by_load(shard_load_cmp(_shards))
+                , _du({capacity, 0}) {
+            uint64_t shard_capacity = capacity / shard_count;
             for (shard_id i = 0; i < shard_count; ++i) {
-                _shards[i] = 0;
+                _shards[i].du.capacity = shard_capacity;
             }
         }
 
-        void update_shard_load(shard_id shard, load_type load_delta) {
-            _load += load_delta;
+        node_load& operator=(node_load&& m) {
+            _shards = std::move(m._shards);
+            _du = std::move(m._du);
+            return *this;
+        }
 
-            auto old_load = _shards[shard];
-            auto new_load = old_load + load_delta;
-            _shards_by_load.erase(shard_load{shard, old_load});
-            _shards[shard] = new_load;
-            _shards_by_load.insert(shard_load{shard, new_load});
+        node_load& operator=(const node_load& m) {
+            _shards = m._shards;
+            _du = m._du;
+            return *this;
+        }
+
+        void update_shard_load(shard_id shard, int count_delta, uint64_t tablet_size_delta) {
+            _shards_by_load.erase(shard);
+            _shards[shard].tablet_count += count_delta;
+            if (count_delta > 0) {
+                _shards[shard].du.used += tablet_size_delta;
+            } else {
+                _shards[shard].du.used -= tablet_size_delta;
+            }
+            _shards_by_load.insert(shard);
+            _du.used += tablet_size_delta;
+            _tablet_count += count_delta;
         }
 
         void populate_shards_by_load() {
             _shards_by_load.clear();
             for (shard_id i = 0; i < _shards.size(); ++i) {
-                _shards_by_load.insert(shard_load{i, _shards[i]});
+                _shards_by_load.insert(i);
             }
         }
 
-        load_type& load() noexcept {
-            return _load;
-        }
-
-        const load_type& load() const noexcept {
-            return _load;
+        load_type get_load() const noexcept {
+            return _du.get_load();
         }
     };
     std::unordered_map<host_id, node_load> _nodes;
     token_metadata_ptr _tm;
+    load_stats_ptr _load_stats;
+    uint64_t _default_tablet_size = service::default_target_tablet_size;
+
 private:
     tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
         // We reflect migrations in the load as if they already happened,
@@ -85,7 +144,26 @@ private:
         return trinfo ? trinfo->next : ti.replicas;
     }
 
-    future<> populate_table(const tablet_map& tmap, std::optional<host_id> host, std::optional<sstring> only_dc) {
+    uint64_t get_disk_capacity_for_node(host_id node) {
+        if (_load_stats) {
+            if (_load_stats->tablet_stats.contains(node)) {
+                return _load_stats->tablet_stats.at(node).effective_capacity;
+            } else if (_load_stats->capacity.contains(node)) {
+                return _load_stats->capacity.at(node);
+            }
+        }
+        return service::default_target_tablet_size;
+    }
+
+    uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid) const {
+        uint64_t tablet_size = _default_tablet_size;
+        if (_load_stats) {
+            tablet_size = _load_stats->get_tablet_size(host, rb_tid, _default_tablet_size);
+        }
+        return std::max(tablet_size, uint64_t(1));
+    }
+
+    future<> populate_table(table_id table, const tablet_map& tmap, std::optional<host_id> host, std::optional<sstring> only_dc) {
         const topology& topo = _tm->get_topology();
         co_await tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& ti) -> future<> {
             for (auto&& replica : get_replicas_for_tablet_load(ti, tmap.get_tablet_transition_info(tid))) {
@@ -97,12 +175,16 @@ private:
                     if (only_dc && node->dc_rack().dc != *only_dc) {
                         continue;
                     }
-                    _nodes.emplace(replica.host, node_load{node->get_shard_count()});
+                    _nodes.emplace(replica.host, node_load{node->get_shard_count(), get_disk_capacity_for_node(replica.host)});
                 }
                 node_load& n = _nodes.at(replica.host);
                 if (replica.shard < n._shards.size()) {
-                    n.load() += 1;
-                    n._shards[replica.shard] += 1;
+                    const range_based_tablet_id rb_tid {table, tmap.get_token_range(tid)};
+                    auto tablet_size = get_tablet_size(replica.host, rb_tid);
+                    n._du.used += tablet_size;
+                    n._tablet_count++;
+                    n._shards[replica.shard].du.used += tablet_size;
+                    n._shards[replica.shard].tablet_count++;
                     // Note: as an optimization, _shards_by_load is populated later in populate_shards_by_load()
                 }
             }
@@ -110,8 +192,10 @@ private:
         });
     }
 public:
-    load_sketch(token_metadata_ptr tm)
-        : _tm(std::move(tm)) {
+    load_sketch(token_metadata_ptr tm, load_stats_ptr load_stats = {}, uint64_t default_tablet_size = service::default_target_tablet_size)
+        : _tm(std::move(tm))
+        , _load_stats(std::move(load_stats))
+        , _default_tablet_size(default_tablet_size) {
     }
 
     future<> populate(std::optional<host_id> host = std::nullopt,
@@ -132,11 +216,11 @@ public:
         if (only_table) {
             if (_tm->tablets().has_tablet_map(*only_table)) {
                 auto& tmap = _tm->tablets().get_tablet_map(*only_table);
-                co_await populate_table(tmap, host, only_dc);
+                co_await populate_table(*only_table, tmap, host, only_dc);
             }
         } else {
             for (const auto& [table, tmap] : _tm->tablets().all_tables_ungrouped()) {
-                co_await populate_table(*tmap, host, only_dc);
+                co_await populate_table(table, *tmap, host, only_dc);
             }
         }
 
@@ -162,7 +246,7 @@ public:
             if (shard_count == 0) {
                 throw std::runtime_error(format("Shard count not known for node {}", node));
             }
-            auto [i, _] = _nodes.emplace(node, node_load{shard_count});
+            auto [i, _] = _nodes.emplace(node, node_load{shard_count, get_disk_capacity_for_node(node)});
             i->second.populate_shards_by_load();
         }
         return _nodes.at(node);
@@ -170,55 +254,61 @@ public:
 
     shard_id get_least_loaded_shard(host_id node) {
         auto& n = ensure_node(node);
-        const shard_load& s = *n._shards_by_load.begin();
-        return s.id;
+        return *n._shards_by_load.begin();
     }
 
     shard_id get_most_loaded_shard(host_id node) {
         auto& n = ensure_node(node);
-        const shard_load& s = *std::prev(n._shards_by_load.end());
-        return s.id;
+        return *std::prev(n._shards_by_load.end());
     }
 
-    void unload(host_id node, shard_id shard) {
+    void unload(host_id node, shard_id shard, std::optional<size_t> tablet_count = std::nullopt, std::optional<uint64_t> tablet_sizes = std::nullopt) {
         auto& n = _nodes.at(node);
-        n.update_shard_load(shard, -1);
+        int count_delta = -int(tablet_count.value_or(1));
+        n.update_shard_load(shard, count_delta, tablet_sizes.value_or(_default_tablet_size));
     }
 
-    void pick(host_id node, shard_id shard) {
+    void pick(host_id node, shard_id shard, std::optional<size_t> tablet_count = std::nullopt, std::optional<uint64_t> tablet_sizes = std::nullopt) {
         auto& n = _nodes.at(node);
-        n.update_shard_load(shard, 1);
+        int count_delta = int(tablet_count.value_or(1));
+        n.update_shard_load(shard, count_delta, tablet_sizes.value_or(_default_tablet_size));
     }
 
     load_type get_load(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
-        return _nodes.at(node).load();
+        return _nodes.at(node).get_load();
     }
 
-    load_type total_load() const {
-        load_type total = 0;
-        for (auto&& n : _nodes) {
-            total += n.second.load();
+    uint64_t get_tablet_count(host_id node) const {
+        if (!_nodes.contains(node)) {
+            return 0;
         }
-        return total;
+        return _nodes.at(node)._tablet_count;
     }
 
-    load_type get_avg_shard_load(host_id node) const {
+    uint64_t get_avg_tablet_count(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
         auto& n = _nodes.at(node);
-        return div_ceil(n.load(), n._shards.size());
+        return div_ceil(n._tablet_count, n._shards.size());
     }
 
-    double get_real_avg_shard_load(host_id node) const {
+    double get_real_avg_tablet_count(host_id node) const {
         if (!_nodes.contains(node)) {
             return 0;
         }
         auto& n = _nodes.at(node);
-        return double(n.load()) / n._shards.size();
+        return double(n._tablet_count) / n._shards.size();
+    }
+
+    uint64_t get_disk_used(host_id node) {
+        if (!_nodes.contains(node)) {
+            return 0;
+        }
+        return _nodes.at(node)._du.used;
     }
 
     shard_id get_shard_count(host_id node) const {
@@ -240,8 +330,8 @@ public:
         min_max_tracker<load_type> minmax;
         if (_nodes.contains(node)) {
             auto& n = _nodes.at(node);
-            for (auto&& load: n._shards) {
-                minmax.update(load);
+            for (auto&& shard: n._shards) {
+                minmax.update(shard.get_load());
             }
         } else {
             minmax.update(0);
@@ -249,18 +339,22 @@ public:
         return minmax;
     }
 
-    // Returns nullopt if capacity is not known.
-    std::optional<double> get_allocated_utilization(host_id node, const locator::load_stats& stats, uint64_t target_tablet_size) const {
+    // Returns nullopt if node is not known.
+    std::optional<load_type> get_allocated_utilization(host_id node) const {
         if (!_nodes.contains(node)) {
             return std::nullopt;
         }
-        auto& n = _nodes.at(node);
-        if (!stats.capacity.contains(node)) {
-            return std::nullopt;
-        }
-        auto capacity = stats.capacity.at(node);
-        return capacity > 0 ? double(n.load() * target_tablet_size) / capacity : 0;
+        return _nodes.at(node).get_load();
     }
 };
 
 } // namespace locator
+
+template<>
+struct fmt::formatter<locator::disk_usage> : fmt::formatter<string_view> {
+    template <typename FormatContext>
+    auto format(const locator::disk_usage& du, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "cap: {:i} used: {:i} load: {}",
+                              utils::pretty_printed_data_size(du.capacity), utils::pretty_printed_data_size(du.used), du.get_load());
+    }
+};

--- a/locator/network_topology_strategy.cc
+++ b/locator/network_topology_strategy.cc
@@ -401,7 +401,7 @@ future<tablet_replica_set> network_topology_strategy::add_tablets_in_dc(schema_p
             }
             const auto& host_id = node.get().host_id();
             if (!existing.contains(host_id)) {
-                candidate.nodes.emplace_back(host_id, load.get_avg_shard_load(host_id));
+                candidate.nodes.emplace_back(host_id, load.get_avg_tablet_count(host_id));
             }
         }
         if (candidate.nodes.empty()) {

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -838,6 +838,12 @@ table_load_stats& table_load_stats::operator+=(const table_load_stats& s) noexce
     return *this;
 }
 
+void tablet_load_stats::add_tablet_sizes(const tablet_load_stats& tls) {
+    for (auto& [rb_tid, tablet_size] : tls.tablet_sizes) {
+        tablet_sizes[rb_tid] = tablet_size;
+    }
+}
+
 load_stats load_stats::from_v1(load_stats_v1&& stats) {
     return { .tables = std::move(stats.tables) };
 }
@@ -852,8 +858,22 @@ load_stats& load_stats::operator+=(const load_stats& s) {
     for (auto& [host, cdu] : s.critical_disk_utilization) {
         critical_disk_utilization[host] = cdu;
     }
-
+    for (auto& [host, tablet_ls] : s.tablet_stats) {
+        tablet_stats[host].effective_capacity = tablet_ls.effective_capacity;
+        tablet_stats[host].add_tablet_sizes(tablet_ls);
+    }
     return *this;
+}
+
+uint64_t load_stats::get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const {
+    if (auto node_i = tablet_stats.find(host); node_i != tablet_stats.end()) {
+        const tablet_load_stats& tls = node_i->second;
+        if (auto ts_i = tls.tablet_sizes.find(rb_tid); ts_i != tls.tablet_sizes.end()) {
+            return ts_i->second;
+        }
+    }
+    tablet_logger.debug("Unable to find tablet size on host: {} for tablet: {}", host, rb_tid);
+    return default_tablet_size;
 }
 
 tablet_range_splitter::tablet_range_splitter(schema_ptr schema, const tablet_map& tablets, host_id host, const dht::partition_range_vector& ranges)

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -468,6 +468,7 @@ struct load_stats {
     }
 
     uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const;
+    void reconcile_tablets_resize(token_metadata_ptr tmptr);
 };
 
 using load_stats_v2 = load_stats;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -63,6 +63,13 @@ struct global_tablet_id {
     auto operator<=>(const global_tablet_id&) const = default;
 };
 
+struct range_based_tablet_id {
+    table_id table;
+    dht::token_range range;
+
+    bool operator==(const range_based_tablet_id&) const = default;
+};
+
 struct tablet_replica {
     host_id host;
     shard_id shard;
@@ -98,6 +105,15 @@ struct hash<locator::global_tablet_id> {
         return utils::hash_combine(
                 std::hash<table_id>()(id.table),
                 std::hash<locator::tablet_id>()(id.tablet));
+    }
+};
+
+template<>
+struct hash<locator::range_based_tablet_id> {
+    size_t operator()(const locator::range_based_tablet_id& id) const {
+        return utils::hash_combine(
+                std::hash<table_id>()(id.table),
+                std::hash<dht::token_range>()(id.range));
     }
 };
 
@@ -420,6 +436,18 @@ struct load_stats_v1 {
     std::unordered_map<table_id, table_load_stats> tables;
 };
 
+// This is defined as final in the idl layer to limit the amount of encoded data sent via the RPC
+struct tablet_load_stats {
+    // Sum of all tablet sizes on a node and available disk space.
+    uint64_t effective_capacity = 0;
+
+    std::unordered_map<range_based_tablet_id, uint64_t> tablet_sizes;
+
+    void add_tablet_sizes(const tablet_load_stats& tls);
+};
+
+using tablet_load_stats_map = std::unordered_map<host_id, tablet_load_stats>;
+
 struct load_stats {
     std::unordered_map<table_id, table_load_stats> tables;
 
@@ -429,12 +457,17 @@ struct load_stats {
     // Critical disk utilization check for each host.
     std::unordered_map<locator::host_id, bool> critical_disk_utilization;
 
+    // Size-based load balancing data
+    tablet_load_stats_map tablet_stats;
+
     static load_stats from_v1(load_stats_v1&&);
 
     load_stats& operator+=(const load_stats& s);
     friend load_stats operator+(load_stats a, const load_stats& b) {
         return a += b;
     }
+
+    uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const;
 };
 
 using load_stats_v2 = load_stats;
@@ -845,6 +878,13 @@ template <>
 struct fmt::formatter<locator::tablet_replica> : fmt::formatter<string_view> {
     auto format(const locator::tablet_replica& r, fmt::format_context& ctx) const {
         return fmt::format_to(ctx.out(), "{}:{}", r.host, r.shard);
+    }
+};
+
+template <>
+struct fmt::formatter<locator::range_based_tablet_id> : fmt::formatter<string_view> {
+    auto format(const locator::range_based_tablet_id& rb_tid, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "{}:{}", rb_tid.table, rb_tid.range);
     }
 };
 

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -426,7 +426,7 @@ public:
     virtual storage_group& storage_group_for_token(dht::token) const = 0;
     virtual utils::chunked_vector<storage_group_ptr> storage_groups_for_token_range(dht::token_range tr) const = 0;
 
-    virtual locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
+    virtual std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept = 0;
     virtual bool all_storage_groups_split() = 0;
     virtual future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) = 0;
     virtual future<> maybe_split_compaction_group_of(size_t idx) = 0;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1127,7 +1127,7 @@ public:
 
     // The tablet filter is used to not double account migrating tablets, so it's important that
     // only one of pending or leaving replica is accounted based on current migration stage.
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept;
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept;
 
     const db::view::stats& get_view_stats() const {
         return _view_stats;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -739,12 +739,14 @@ public:
         return *_single_sg;
     }
 
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)>) const noexcept override {
-        return locator::table_load_stats{
-            .size_in_bytes = _single_sg->live_disk_space_used(),
-            .split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min()
-        };
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)>) const noexcept override {
+        return std::make_pair(locator::table_load_stats{
+                .size_in_bytes = _single_sg->live_disk_space_used(),
+                .split_ready_seq_number = std::numeric_limits<locator::resize_decision::seq_number_t>::min()},
+            locator::tablet_load_stats{}
+        );
     }
+
     bool all_storage_groups_split() override { return true; }
     future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) override { return make_ready_future(); }
     future<> maybe_split_compaction_group_of(size_t idx) override { return make_ready_future(); }
@@ -902,7 +904,7 @@ public:
         return storage_group_for_id(storage_group_of(token).first);
     }
 
-    locator::table_load_stats table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept override;
+    std::pair<locator::table_load_stats, locator::tablet_load_stats> table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept override;
     bool all_storage_groups_split() override;
     future<> split_all_storage_groups(tasks::task_info tablet_split_task_info) override;
     future<> maybe_split_compaction_group_of(size_t idx) override;
@@ -2831,20 +2833,25 @@ void table::on_flush_timer() {
     });
 }
 
-locator::table_load_stats tablet_storage_group_manager::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
-    locator::table_load_stats stats;
-    stats.split_ready_seq_number = _split_ready_seq_number;
+std::pair<locator::table_load_stats, locator::tablet_load_stats> tablet_storage_group_manager::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
+    locator::table_load_stats table_stats;
+    table_stats.split_ready_seq_number = _split_ready_seq_number;
+
+    locator::tablet_load_stats tablet_stats;
 
     for_each_storage_group([&] (size_t id, storage_group& sg) {
         locator::global_tablet_id gid { _t.schema()->id(), locator::tablet_id(id) };
         if (tablet_filter(*_tablet_map, gid)) {
-            stats.size_in_bytes += sg.live_disk_space_used();
+            const uint64_t tablet_size = sg.live_disk_space_used();
+            table_stats.size_in_bytes += tablet_size;
+            const locator::range_based_tablet_id rb_tid {gid.table, _tablet_map->get_token_range(gid.tablet)};
+            tablet_stats.tablet_sizes[rb_tid] = tablet_size;
         }
     });
-    return stats;
+    return std::make_pair(std::move(table_stats), std::move(tablet_stats));
 }
 
-locator::table_load_stats table::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
+std::pair<locator::table_load_stats, locator::tablet_load_stats> table::table_load_stats(std::function<bool(const locator::tablet_map&, locator::global_tablet_id)> tablet_filter) const noexcept {
     return _sg_manager->table_load_stats(std::move(tablet_filter));
 }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -199,6 +199,7 @@ struct colocated_tablets {
 // to same destination.
 struct migration_tablet_set {
     std::variant<global_tablet_id, colocated_tablets> tablet_s;
+    uint64_t tablet_set_disk_size = 0;
 
     table_id table() const {
         return std::visit(
@@ -227,7 +228,9 @@ struct migration_tablet_set {
         return std::holds_alternative<colocated_tablets>(tablet_s);
     }
 
-    auto operator<=>(const migration_tablet_set&) const = default;
+    bool operator==(const migration_tablet_set& rhs) const {
+        return tablet_s == rhs.tablet_s;
+    }
 };
 
 struct migration_candidate {
@@ -380,16 +383,20 @@ class load_balancer {
 
     // Represents metric for load which we want to equalize between shards or nodes.
     // Load balancer equalizes storage utilization.
-    // It is assumed that each tablet has equal size and that shards and nodes can have different capacity.
-    // So we equalize: tablet_count * target_tablet_size / capacity_in_bytes.
+    // In case force_capacity_based_balancing is true, it is assumed that each tablet has equal size and that
+    // shards and nodes can have different capacity. If force_capacity_based_balancing is false,
+    // tablet sizes are fetched from load_stats.
+    // So we equalize: sum of tablet_sizes / capacity_in_bytes.
     using load_type = double;
 
     using table_candidates_map = std::unordered_map<table_id, std::unordered_set<migration_tablet_set>>;
 
     struct shard_load {
         size_t tablet_count = 0;
+        std::optional<disk_usage> dusage;
 
         absl::flat_hash_map<table_id, size_t> tablet_count_per_table;
+        absl::flat_hash_map<table_id, uint64_t> tablet_sizes_per_table;
 
         // Number of tablets which are streamed from this shard.
         size_t streaming_read_load = 0;
@@ -437,15 +444,16 @@ class load_balancer {
         host_id id;
         uint64_t shard_count = 0;
         uint64_t tablet_count = 0;
-        std::optional<uint64_t> capacity; // Invariant: bool(capacity) || drained.
+        std::optional<disk_usage> dusage; // Invariant: bool(dusage) || drained.
         bool drained = false;
         const locator::node* node; // never nullptr
 
         // The average shard load on this node.
-        // Valid only when "capacity" is set.
+        // Valid only when "dusage" is set.
         load_type avg_load = 0;
 
         absl::flat_hash_map<table_id, size_t> tablet_count_per_table;
+        absl::flat_hash_map<table_id, uint64_t> tablet_sizes_per_table;
 
         // heap which tracks most-loaded shards using shards_by_load_cmp().
         // Valid during intra-node plan-making for nodes which are in the source node set.
@@ -456,8 +464,8 @@ class load_balancer {
         utils::chunked_vector<skipped_candidate> skipped_candidates;
 
         std::optional<double> capacity_per_shard() const {
-            return capacity.transform([&] (auto cap) {
-                return double(cap) / shard_count;
+            return dusage.transform([&] (auto du) {
+                return load_type(du.capacity) / shard_count;
             });
         }
 
@@ -474,16 +482,17 @@ class load_balancer {
         }
 
         // Call when tablet_count or capacity changes.
-        void update(uint64_t target_tablet_size) {
-            if (auto load = get_avg_load(tablet_count, target_tablet_size)) {
+        void update() {
+            if (auto load = get_avg_load()) {
                 avg_load = *load;
             }
         }
 
         // Result engaged when !drained.
-        std::optional<load_type> get_avg_load(uint64_t tablets, uint64_t target_tablet_size) const {
-            return capacity.transform([&] (auto capacity) {
-                return load_type(tablets * target_tablet_size) / capacity;
+        std::optional<load_type> get_avg_load(uint64_t used_size_delta = 0) const {
+            return dusage.transform([&] (auto du) {
+                du.used += used_size_delta;
+                return du.get_load();
             });
         }
 
@@ -496,20 +505,20 @@ class load_balancer {
         }
 
         // Result engaged for !drained nodes.
-        std::optional<load_type> shard_load(shard_id shard, uint64_t target_tablet_size) const {
-            return shard_load(shard, shards[shard].tablet_count, target_tablet_size);
-        }
-
-        // Result engaged for !drained nodes.
-        std::optional<load_type> shard_load(shard_id shard, uint64_t shard_tablet_count, uint64_t target_tablet_size) const {
-            return capacity_per_shard().transform([&] (auto cap_per_shard) {
-                return load_type(shard_tablet_count * target_tablet_size) / cap_per_shard;
+        std::optional<load_type> shard_load(shard_id shard, int64_t used_size_delta = 0) const {
+            return shards[shard].dusage.transform([&] (auto du) {
+                du.used += used_size_delta;
+                return du.get_load();
             });
         }
 
         auto shards_by_load_cmp() {
             return [this] (const auto& a, const auto& b) {
-                return shards[a].tablet_count < shards[b].tablet_count;
+                if (dusage) {
+                    return shards[a].dusage->get_load() < shards[b].dusage->get_load();
+                } else {
+                    return shards[a].tablet_count < shards[b].tablet_count;
+                }
             };
         }
 
@@ -663,6 +672,8 @@ class load_balancer {
     std::unordered_set<global_tablet_id> _scheduled_tablets;
     // Holds tablet replica count per table in the balanced node set (within a single DC).
     absl::flat_hash_map<table_id, size_t> _tablet_count_per_table;
+    // Holds total used storage per table in the DC
+    absl::flat_hash_map<table_id, uint64_t> _disk_used_per_table;
     dc_name _dc;
     std::optional<sstring> _rack; // Set when plan making is limited to a single rack.
     size_t _total_capacity_shards; // Total number of non-drained shards in the balanced node set.
@@ -816,6 +827,13 @@ public:
         }
         auto it = _table_load_stats->tables.find(id);
         return (it != _table_load_stats->tables.end()) ? &it->second : nullptr;
+    }
+
+    uint64_t get_tablet_size(host_id host, const range_based_tablet_id& rb_tid, uint64_t default_tablet_size) const {
+        if (_table_load_stats) {
+            return _table_load_stats->get_tablet_size(host, rb_tid, default_tablet_size);
+        }
+        return default_tablet_size;
     }
 
     future<bool> needs_auto_repair(const locator::global_tablet_id& gid, const locator::tablet_info& info,
@@ -1676,6 +1694,15 @@ public:
         return utils::get_local_injector().enter("tablet_allocator_shuffle");
     }
 
+    bool is_balanced(load_type min_load, load_type max_load) const {
+        if (_force_capacity_based_balancing) {
+            return min_load == max_load;
+        }
+
+        const load_type load_delta = max_load - min_load;
+        return (load_delta / max_load) < _size_based_balance_threshold;
+    }
+
     // If cluster cannot agree on tablet merge feature, then merge will not be finalized since
     // not all nodes in the cluster can handle the finalization step.
     bool bypass_merge_completion() const {
@@ -1719,14 +1746,14 @@ public:
         return *shard_info.candidates_all_tables.begin();
     }
 
-    // Evaluates impact on load balance of migrating a single tablet of a given table to dst.
-    migration_badness evaluate_dst_badness(node_load_map& nodes, table_id table, tablet_replica dst) {
+    // Evaluates impact on load balance of migrating a tablet set of a given table to dst.
+    migration_badness evaluate_dst_badness(node_load_map& nodes, table_id table, tablet_replica dst, uint64_t tablet_set_disk_size) {
         _stats.for_dc(_dc).candidates_evaluated++;
 
         auto& node_info = nodes[dst.host];
 
         // Size of all tablet replicas of the table in bytes.
-        uint64_t table_size = _tablet_count_per_table[table] * _target_tablet_size;
+        uint64_t table_size = _disk_used_per_table[table];
 
         if (node_info.drained) {
             // Moving a tablet to a drained node is always bad.
@@ -1736,33 +1763,36 @@ public:
 
         double ideal_table_load = double(table_size) / _total_capacity_storage;
 
-        // max number of tablets per shard to keep perfect distribution.
-        double shard_balance_threshold = ideal_table_load;
-        auto new_tablet_count_per_shard = node_info.shards[dst.shard].tablet_count_per_table[table] + 1;
-        auto new_shard_load = *node_info.shard_load(dst.shard, new_tablet_count_per_shard, _target_tablet_size);
-        auto dst_shard_badness = (new_shard_load - shard_balance_threshold) / table_size;
-        lblogger.trace("Table {} @{} shard balance threshold: {}, dst: {} ({:.4f})", table, dst,
-                       shard_balance_threshold, new_shard_load, dst_shard_badness);
+        auto compute_load_and_dst_badness = [&] (uint64_t capacity, uint64_t new_used) {
+            double new_load = double(new_used) / capacity;
+            // Divide badness by table_size to take into account that moving a tablet of a small table has
+            // greater impact on balance of that table than moving a tablet of the same size of a larger table
+            return std::make_pair(new_load, (new_load - ideal_table_load) / table_size);
+        };
 
-        // max number of tablets per node to keep perfect distribution.
-        double node_balance_threshold = ideal_table_load;
-        size_t new_tablet_count_per_node = node_info.tablet_count_per_table[table] + 1;
-        load_type new_node_load = *node_info.get_avg_load(new_tablet_count_per_node, _target_tablet_size);
-        auto dst_node_badness = (new_node_load - node_balance_threshold) / table_size;
+        uint64_t capacity = node_info.shards[dst.shard].dusage->capacity;
+        uint64_t new_used = node_info.shards[dst.shard].tablet_sizes_per_table[table] + tablet_set_disk_size;
+        auto [new_shard_load, dst_shard_badness] = compute_load_and_dst_badness(capacity, new_used);
+        lblogger.trace("Table {} @{} shard balance threshold: {}, dst: {} ({:.4f})", table, dst,
+                       ideal_table_load, new_shard_load, dst_shard_badness);
+
+        capacity = node_info.dusage->capacity;
+        new_used = node_info.tablet_sizes_per_table[table] + tablet_set_disk_size;
+        auto [new_node_load, dst_node_badness] = compute_load_and_dst_badness(capacity, new_used);
         lblogger.trace("Table {} @{} node balance threshold: {}, dst: {} ({:.4f})", table, dst,
-                       node_balance_threshold, new_node_load, dst_node_badness);
+                       ideal_table_load, new_node_load, dst_node_badness);
 
         return migration_badness{0, 0, dst_shard_badness, dst_node_badness};
     }
 
-    // Evaluates impact on load balance of migrating a single tablet of a given table from src.
-    migration_badness evaluate_src_badness(node_load_map& nodes, table_id table, tablet_replica src) {
+    // Evaluates impact on load balance of migrating a tablet set of a given table from src.
+    migration_badness evaluate_src_badness(node_load_map& nodes, table_id table, tablet_replica src, uint64_t tablet_set_disk_size) {
         _stats.for_dc(_dc).candidates_evaluated++;
 
         auto& node_info = nodes[src.host];
 
         // Size of all tablet replicas of the table in bytes.
-        uint64_t table_size = _tablet_count_per_table[table] * _target_tablet_size;
+        uint64_t table_size = _disk_used_per_table[table];
 
         if (node_info.drained) {
             // Moving a tablet away from a drained node is always good.
@@ -1771,28 +1801,32 @@ public:
 
         double ideal_table_load = double(table_size) / _total_capacity_storage;
 
-        double leaving_shard_balance_threshold = ideal_table_load;
-        auto new_tablet_count_per_shard = node_info.shards[src.shard].tablet_count_per_table[table] - 1;
-        auto new_shard_load = *node_info.shard_load(src.shard, new_tablet_count_per_shard, _target_tablet_size);
-        auto src_shard_badness = (leaving_shard_balance_threshold - new_shard_load) / table_size;
-        lblogger.trace("Table {} @{} shard balance threshold: {}, src: {} ({:.4f})", table, src,
-                       leaving_shard_balance_threshold, new_shard_load, src_shard_badness);
+        auto compute_load_and_src_badness = [&] (uint64_t capacity, uint64_t new_used) {
+            // Divide badness by table_size to take into account that moving a tablet of a small table has
+            // greater impact on balance of that table than moving a tablet of the same size of a larger table
+            double new_load = double(new_used) / capacity;
+            return std::make_pair(new_load, (ideal_table_load - new_load) / table_size);
+        };
 
-        // max number of tablets per node to keep perfect distribution.
-        double leaving_node_balance_threshold = ideal_table_load;
-        size_t new_tablet_count_per_node = node_info.tablet_count_per_table[table] - 1;
-        auto new_node_load = *node_info.get_avg_load(new_tablet_count_per_node, _target_tablet_size);
-        auto src_node_badness = (leaving_node_balance_threshold - new_node_load) / table_size;
+        uint64_t capacity = node_info.shards[src.shard].dusage->capacity;
+        uint64_t new_used = node_info.shards[src.shard].tablet_sizes_per_table[table] + tablet_set_disk_size;
+        auto [new_shard_load, src_shard_badness] = compute_load_and_src_badness(capacity, new_used);
+        lblogger.trace("Table {} @{} shard balance threshold: {}, src: {} ({:.4f})", table, src,
+                       ideal_table_load, new_shard_load, src_shard_badness);
+
+        capacity = node_info.dusage->capacity;
+        new_used = node_info.tablet_sizes_per_table[table] + tablet_set_disk_size;
+        auto [new_node_load, src_node_badness] = compute_load_and_src_badness(capacity, new_used);
         lblogger.trace("Table {} @{} node balance threshold: {}, src: {} ({:.4f})", table, src,
-                       leaving_node_balance_threshold, new_node_load, src_node_badness);
+                       ideal_table_load, new_node_load, src_node_badness);
 
         return migration_badness{src_shard_badness, src_node_badness, 0, 0};
     }
 
     // Evaluates impact on load balance of migrating a single tablet of a given table from src to dst.
-    migration_badness evaluate_candidate(node_load_map& nodes, table_id table, tablet_replica src, tablet_replica dst) {
-        auto src_badness = evaluate_src_badness(nodes, table, src);
-        auto dst_badness = evaluate_dst_badness(nodes, table, dst);
+    migration_badness evaluate_candidate(node_load_map& nodes, table_id table, tablet_replica src, tablet_replica dst, uint64_t tablet_set_disk_size) {
+        auto src_badness = evaluate_src_badness(nodes, table, src, tablet_set_disk_size);
+        auto dst_badness = evaluate_dst_badness(nodes, table, dst, tablet_set_disk_size);
 
         if (src.host == dst.host) {
             src_badness.src_node_badness = 0;
@@ -1820,7 +1854,7 @@ public:
 
         for (auto&& [table, tablets] : shard_info.candidates) {
             if (!tablets.empty()) {
-                auto badness = evaluate_candidate(nodes, table, src, dst);
+                auto badness = evaluate_candidate(nodes, table, src, dst, tablets.begin()->tablet_set_disk_size);
                 auto candidate = migration_candidate{*tablets.begin(), src, dst, badness};
                 lblogger.trace("Candidate: {}", candidate);
                 if (!best_candidate || candidate.badness < best_candidate->badness) {
@@ -1894,9 +1928,9 @@ public:
     // where tablets are moved back and forth between nodes and convergence is never reached.
     //
     // The assumption is that the algorithm moves tablets from more loaded nodes to less loaded nodes,
-    // so convergence is reached where the node we picked as source has lower load, or will have lower
-    // load post-movement, than the node we picked as the destination.
-    bool check_convergence(node_load& src_info, node_load& dst_info, unsigned delta = 1) {
+    // so convergence is reached where the node we picked as source has lower or equal load, than the node we
+    // picked as the destination will have post-movement.
+    bool check_convergence(node_load& src_info, node_load& dst_info, uint64_t tablet_sizes) {
         if (src_info.drained) {
             return true;
         }
@@ -1912,10 +1946,9 @@ public:
         }
 
         // Prevent load inversion post-movement which can lead to oscillations.
-        if (*src_info.get_avg_load(src_info.tablet_count - delta, _target_tablet_size) <
-            *dst_info.get_avg_load(dst_info.tablet_count + delta, _target_tablet_size)) {
-            lblogger.trace("Load inversion post-movement: src={} (avg_load={}), dst={} (avg_load={})",
-                           src_info.id, src_info.avg_load, dst_info.id, dst_info.avg_load);
+        if (src_info.avg_load <= *dst_info.get_avg_load(tablet_sizes)) {
+            lblogger.trace("Load inversion post-movement: src={} (avg_load={}), dst={} (avg_load={}) tablet_sizes={}",
+                           src_info.id, src_info.avg_load, dst_info.id, dst_info.avg_load, tablet_sizes);
             return false;
         }
 
@@ -1923,76 +1956,84 @@ public:
     }
 
     bool check_convergence(node_load& src_info, node_load& dst_info, const migration_tablet_set& tablet_set) {
-        return check_convergence(src_info, dst_info, tablet_set.tablets().size());
+        return check_convergence(src_info, dst_info, tablet_set.tablet_set_disk_size);
     }
 
     // Checks whether moving a tablet from shard A to B (intra-node) would go against convergence.
     // Returns false if the tablet should not be moved, and true if it may be moved.
     // Can be called when node_info.drained.
     bool check_intranode_convergence(const node_load& node_info, shard_id src_shard, shard_id dst_shard,
-                                     unsigned delta = 1) {
-        return node_info.shards[src_shard].tablet_count > node_info.shards[dst_shard].tablet_count + delta;
+                                     uint64_t used_size_delta) {
+        return node_info.shard_load(src_shard) > node_info.shard_load(dst_shard, int64_t(used_size_delta));
     }
 
     // Can be called when node_info.drained.
     bool check_intranode_convergence(const node_load& node_info, shard_id src_shard, shard_id dst_shard,
                                     const migration_tablet_set& tablet_set) {
-        return check_intranode_convergence(node_info, src_shard, dst_shard, tablet_set.tablets().size());
+        return check_intranode_convergence(node_info, src_shard, dst_shard, tablet_set.tablet_set_disk_size);
     }
 
     // Adjusts the load of the source and destination shards in the host where intra-node migration happens.
-    void update_node_load_on_migration(node_load& node_load, host_id host, shard_id src, shard_id dst, global_tablet_id tablet) {
-        auto& src_info = node_load.shards[src];
-        auto& dst_info = node_load.shards[dst];
-        dst_info.tablet_count++;
-        src_info.tablet_count--;
-        dst_info.tablet_count_per_table[tablet.table]++;
-        src_info.tablet_count_per_table[tablet.table]--;
+    void update_node_load_on_migration(node_load& node_load, host_id host, shard_id src, shard_id dst, const migration_tablet_set& tablet_set) {
+        auto tablet_count = tablet_set.tablets().size();
+        auto tablet_sizes = tablet_set.tablet_set_disk_size;
+        auto table = tablet_set.tablets().front().table;
+
+        auto& dst_shard = node_load.shards[dst];
+        dst_shard.tablet_count += tablet_count;
+        dst_shard.tablet_count_per_table[table] += tablet_count;
+        dst_shard.tablet_sizes_per_table[table] += tablet_sizes;
+        dst_shard.dusage->used += tablet_sizes;
+
+        auto& src_shard = node_load.shards[src];
+        src_shard.tablet_count -= tablet_count;
+        src_shard.tablet_count_per_table[table] -= tablet_count;
+        src_shard.tablet_sizes_per_table[table] -= tablet_sizes;
+        src_shard.dusage->used -= tablet_sizes;
     }
 
     // Adjusts the load of the source and destination (host:shard) that were picked for the migration.
-    void update_node_load_on_migration(node_load_map& nodes, tablet_replica src, tablet_replica dst, global_tablet_id source_tablet) {
-        {
-            auto& target_info = nodes[dst.host];
-            target_info.shards[dst.shard].tablet_count++;
-            target_info.shards[dst.shard].tablet_count_per_table[source_tablet.table]++;
-            target_info.tablet_count_per_table[source_tablet.table]++;
-            target_info.tablet_count += 1;
-            target_info.update(_target_tablet_size);
-        }
-
-        auto& src_node_info = nodes[src.host];
-        auto& src_shard_info = src_node_info.shards[src.shard];
-        src_shard_info.tablet_count -= 1;
-        src_shard_info.tablet_count_per_table[source_tablet.table]--;
-        src_node_info.tablet_count_per_table[source_tablet.table]--;
-
-        src_node_info.tablet_count -= 1;
-        src_node_info.update(_target_tablet_size);
-    }
-
-    void update_node_load_on_migration(node_load& node_load, host_id host, shard_id src, shard_id dst, const migration_tablet_set& tablet_set) {
-        for (auto tablet : tablet_set.tablets()) {
-            update_node_load_on_migration(node_load, host, src, dst, tablet);
-        }
-    }
-
     void update_node_load_on_migration(node_load_map& nodes, tablet_replica src, tablet_replica dst, const migration_tablet_set& tablet_set) {
-        for (auto tablet : tablet_set.tablets()) {
-            update_node_load_on_migration(nodes, src, dst, tablet);
+        auto tablet_count = tablet_set.tablets().size();
+        auto tablet_sizes = tablet_set.tablet_set_disk_size;
+        auto table = tablet_set.tablets().front().table;
+
+        auto& dst_node = nodes[dst.host];
+        auto& dst_shard = dst_node.shards[dst.shard];
+        dst_shard.tablet_count += tablet_count;
+        dst_shard.tablet_count_per_table[table] += tablet_count;
+        dst_shard.tablet_sizes_per_table[table] += tablet_sizes;
+        dst_shard.dusage->used += tablet_sizes;
+        dst_node.tablet_count_per_table[table] += tablet_count;
+        dst_node.tablet_sizes_per_table[table] += tablet_sizes;
+        dst_node.tablet_count += tablet_count;
+        dst_node.dusage->used += tablet_sizes;
+        dst_node.update();
+
+        auto& src_node = nodes[src.host];
+        auto& src_shard = src_node.shards[src.shard];
+        src_shard.tablet_count -= tablet_count;
+        src_shard.tablet_count_per_table[table] -= tablet_count;
+        src_shard.tablet_sizes_per_table[table] -= tablet_sizes;
+        if (src_shard.dusage) {
+            src_shard.dusage->used -= tablet_sizes;
         }
+        src_node.tablet_count_per_table[table] -= tablet_count;
+        src_node.tablet_sizes_per_table[table] -= tablet_sizes;
+        src_node.tablet_count -= tablet_count;
+        if (src_node.dusage) {
+            src_node.dusage->used -= tablet_sizes;
+        }
+        src_node.update();
     }
 
     static void unload(locator::load_sketch& sketch, host_id host, shard_id shard, const migration_tablet_set& tablet_set) {
-        for (auto _ : tablet_set.tablets()) {
-            sketch.unload(host, shard);
-        }
+        sketch.unload(host, shard, tablet_set.tablets().size(), tablet_set.tablet_set_disk_size);
     }
 
     static void pick(locator::load_sketch& sketch, host_id host, shard_id shard, const migration_tablet_set& tablet_set) {
-        for (auto _ : tablet_set.tablets()) {
-            sketch.pick(host, shard);
-        }
+        sketch.ensure_node(host);
+        sketch.pick(host, shard, tablet_set.tablets().size(), tablet_set.tablet_set_disk_size);
     }
 
     void mark_as_scheduled(const tablet_migration_info& mig) {
@@ -2025,7 +2066,7 @@ public:
         }
         std::make_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
 
-        size_t max_load = 0; // Tracks max load among shards which ran out of candidates.
+        load_type max_load = 0; // Tracks max load among shards which ran out of candidates.
 
         while (true) {
             co_await coroutine::maybe_yield();
@@ -2065,14 +2106,16 @@ public:
             // Convergence check
 
             // When in shuffle mode, exit condition is guaranteed by running out of candidates or by load limit.
-            if (!shuffle && (src == dst || !check_intranode_convergence(node_load, src, dst))) {
+            if (!shuffle && src == dst) {
                 lblogger.debug("Node {} is balanced", host);
                 break;
             }
 
             if (!src_info.has_candidates()) {
                 lblogger.debug("No more candidates on shard {} of {}", src, host);
-                max_load = std::max(max_load, src_info.tablet_count);
+                if (src_info.dusage) {
+                    max_load = std::max(max_load, src_info.dusage->get_load());
+                }
                 src_shards.pop_back();
                 push_back.cancel();
                 continue;
@@ -2081,7 +2124,6 @@ public:
             auto candidate = co_await peek_candidate(nodes, src_info, tablet_replica{host, src}, tablet_replica{host, dst});
             auto tablets = candidate.tablets;
 
-            // Recheck convergence to avoid oscillations if co-located tablets are being migrated together.
             if (!shuffle && (src == dst || !check_intranode_convergence(node_load, src, dst, tablets))) {
                 lblogger.debug("Node {} is balanced", host);
                 break;
@@ -2110,8 +2152,8 @@ public:
             erase_candidates(nodes, tmap, tablets);
 
             update_node_load_on_migration(node_load, host, src, dst, tablets);
-            sketch.pick(host, dst);
-            sketch.unload(host, src);
+            pick(sketch, host, dst, tablets);
+            unload(sketch, host, src, tablets);
         }
 
         co_return plan;
@@ -2328,7 +2370,7 @@ public:
                 -> future<migration_candidate> {
             if (drain_skipped) {
                 auto source_tablets = src_node_info.skipped_candidates.back().tablets;
-                auto badness = evaluate_candidate(nodes, source_tablets.table(), src, dst);
+                auto badness = evaluate_candidate(nodes, source_tablets.table(), src, dst, source_tablets.tablet_set_disk_size);
                 co_return migration_candidate{source_tablets, src, dst, badness};
             } else {
                 auto&& src_shard_info = src_node_info.shards[src.shard];
@@ -2355,7 +2397,7 @@ public:
                     continue;
                 }
 
-                auto badness = evaluate_dst_badness(nodes, tablets.table(), tablet_replica{new_target, 0});
+                auto badness = evaluate_dst_badness(nodes, tablets.table(), tablet_replica{new_target, 0}, tablets.tablet_set_disk_size);
                 if (!min_dst_host || badness.dst_node_badness < min_dst_badness.dst_node_badness) {
                     min_dst_badness = badness;
                     min_dst_host = new_target;
@@ -2380,7 +2422,7 @@ public:
                     co_await coroutine::maybe_yield();
                     auto new_dst = tablet_replica{host, new_dst_shard};
 
-                    auto badness = evaluate_dst_badness(nodes, tablets.table(), new_dst);
+                    auto badness = evaluate_dst_badness(nodes, tablets.table(), new_dst, tablets.tablet_set_disk_size);
                     if (!min_dst || badness < min_dst_badness) {
                         min_dst_badness = badness;
                         min_dst = new_dst;
@@ -2416,31 +2458,41 @@ public:
             // Consider better alternatives.
             if (drain_skipped) {
                 auto tablets = src_node_info.skipped_candidates.back().tablets;
-                auto badness = evaluate_src_badness(nodes, tablets.table(), src);
+                auto badness = evaluate_src_badness(nodes, tablets.table(), src, tablets.tablet_set_disk_size);
                 co_await evaluate_targets(tablets, src, badness);
             } else {
                 // Find a better candidate.
                 // Consider different tables. For each table, first find the best source shard.
                 // Then find the best target node. Then find the best shard on the target node.
-                for (auto [table, load] : src_node_info.tablet_count_per_table) {
-                    migration_badness min_src_badness;
-                    std::optional<tablet_replica> min_src;
-
-                    if (load == 0) {
+                for (auto [table, tablet_count] : src_node_info.tablet_count_per_table) {
+                    if (tablet_count == 0) {
                         lblogger.trace("No src candidates for table {} on node {}", table, src.host);
                         continue;
                     }
 
+                    migration_badness min_src_badness;
+                    std::optional<tablet_replica> min_src;
+                    std::optional<migration_tablet_set> min_tablet_set;
+                    auto check_candidate = [&] (const tablet_replica& new_src, const migration_tablet_set& tablet_set) {
+                        auto badness = evaluate_src_badness(nodes, table, new_src, tablet_set.tablet_set_disk_size);
+                        if (!min_src || badness < min_src_badness) {
+                            min_src_badness = badness;
+                            min_src = new_src;
+                            min_tablet_set = tablet_set;
+                        }
+                    };
                     for (auto new_src_shard: src_node_info.shards_by_load) {
                         auto new_src = tablet_replica{src.host, new_src_shard};
                         if (src_node_info.shards[new_src_shard].candidates[table].empty()) {
                             lblogger.trace("No src candidates for table {} on shard {}", table, new_src);
                             continue;
                         }
-                        auto badness = evaluate_src_badness(nodes, table, new_src);
-                        if (!min_src || badness < min_src_badness) {
-                            min_src_badness = badness;
-                            min_src = new_src;
+                        if (_force_capacity_based_balancing) {
+                            check_candidate(new_src, *src_node_info.shards[new_src_shard].candidates[table].begin());
+                        } else {
+                            for (const auto& tablet_set: src_node_info.shards[new_src_shard].candidates[table]) {
+                                check_candidate(new_src, tablet_set);
+                            }
                         }
                     }
 
@@ -2449,8 +2501,7 @@ public:
                         continue;
                     }
 
-                    auto tablet = *src_node_info.shards[min_src->shard].candidates[table].begin();
-                    co_await evaluate_targets(tablet, *min_src, min_src_badness);
+                    co_await evaluate_targets(*min_tablet_set, *min_src, min_src_badness);
                     if (!min_candidate.badness.is_bad()) {
                         break;
                     }
@@ -2552,7 +2603,7 @@ public:
                 shard_id shard = 0;
                 for (auto&& shard_load : node_load.shards) {
                     lblogger.debug("shard {}: load: {}, tablets: {}, candidates: {}, tables: {}", tablet_replica {host, shard},
-                                   node_load.shard_load(shard, _target_tablet_size), shard_load.tablet_count,
+                                   node_load.shard_load(shard), shard_load.tablet_count,
                                    shard_load.candidate_count(), shard_load.tablet_count_per_table);
                     shard++;
                 }
@@ -2670,7 +2721,7 @@ public:
 
             // When draining nodes, disable convergence checks so that all tablets are migrated away.
             bool can_check_convergence = !shuffle && nodes_to_drain.empty();
-            if (!shuffle && nodes_to_drain.empty()) {
+            if (can_check_convergence) {
                 // Check if all nodes reached the same avg_load. There are three sets of nodes: target, candidates (nodes_by_load)
                 // and off-candidates (removed from nodes_by_load). At any time, the avg_load for target is not greater than
                 // that of any candidate, and avg_load of any candidate is not greater than that of any in the off-candidates set.
@@ -2680,15 +2731,10 @@ public:
                 // is tracked in max_off_candidate_load. If max_off_candidate_load is equal to target's avg_load,
                 // it means that all nodes have equal avg_load. We take the maximum with the current candidate in src_node_info
                 // to handle the case of off-candidates being empty. In that case, max_off_candidate_load is 0.
-                if (std::max(max_off_candidate_load, src_node_info.avg_load) == target_info.avg_load) {
+                const load_type max_load = std::max(max_off_candidate_load, src_node_info.avg_load);
+                if (is_balanced(target_info.avg_load, max_load)) {
                     lblogger.debug("Balance achieved.");
                     _stats.for_dc(dc).stop_balance++;
-                    break;
-                }
-
-                if (!check_convergence(src_node_info, target_info)) {
-                    lblogger.debug("No more candidates. Load would be inverted.");
-                    _stats.for_dc(dc).stop_load_inversion++;
                     break;
                 }
             }
@@ -2698,13 +2744,13 @@ public:
             auto dst = global_shard_id {target, _load_sketch->get_least_loaded_shard(target)};
             lblogger.trace("target shard: {}, tablets={}, load={}", dst.shard,
                            target_info.shards[dst.shard].tablet_count,
-                           target_info.shard_load(dst.shard, _target_tablet_size));
+                           target_info.shard_load(dst.shard));
 
             if (lblogger.is_enabled(seastar::log_level::trace)) {
                 shard_id shard = 0;
                 for (auto&& shard_load : target_info.shards) {
                     lblogger.trace("shard {}: load: {}, tablets: {}, candidates: {}, tables: {}", tablet_replica{dst.host, shard},
-                                   target_info.shard_load(shard, _target_tablet_size), shard_load.tablet_count,
+                                   target_info.shard_load(shard), shard_load.tablet_count,
                                    shard_load.candidate_count(), shard_load.tablet_count_per_table);
                     shard++;
                 }
@@ -2720,11 +2766,17 @@ public:
             dst = candidate.dst;
 
             auto& tmap = tmeta.get_tablet_map(source_tablets.table());
-            // If best candidate is co-located sibling tablets, then convergence is re-checked to avoid oscillations.
             if (can_check_convergence && !check_convergence(src_node_info, target_info, source_tablets)) {
-                lblogger.debug("No more candidates. Load would be inverted.");
-                _stats.for_dc(dc).stop_load_inversion++;
-                break;
+                if (_force_capacity_based_balancing) {
+                    lblogger.debug("No more candidates. Load would be inverted.");
+                    _stats.for_dc(dc).stop_load_inversion++;
+                    break;
+                }
+                // If we are performing size-based balancing, the candidate could have been a very large tablet
+                // which would result in load inversion on the target node. Since not all tablets have the same size
+                // and there could be smaller tablets among the remaining candidates, we will continue evaluating
+                // candidates until we drain them all, or achieve balance.
+                continue;
             }
 
             // Check replication strategy constraints.
@@ -2890,8 +2942,8 @@ public:
         auto shuffle = in_shuffle_mode();
 
         _stats.for_dc(dc).calls++;
-        lblogger.debug("Examining DC {} rack {} (shuffle={}, balancing={}, tablets_per_shard_goal={})",
-                dc, rack, shuffle, _tm->tablets().balancing_enabled(), _tablets_per_shard_goal);
+        lblogger.debug("Examining DC {} rack {} (shuffle={}, balancing={}, tablets_per_shard_goal={}, force_capacity_based_balancing={})",
+                dc, rack, shuffle, _tm->tablets().balancing_enabled(), _tablets_per_shard_goal, _force_capacity_based_balancing);
 
         const locator::topology& topo = _tm->get_topology();
 
@@ -2912,15 +2964,25 @@ public:
             load.id = host;
             load.node = node;
             load.shard_count = node->get_shard_count();
-            load.shards.resize(load.shard_count);
             if (!load.shard_count) {
                 throw std::runtime_error(format("Shard count of {} not found in topology", host));
             }
             if (!_db.features().tablet_load_stats_v2) {
                 // This way load calculation will hold tablet count.
-                load.capacity = _target_tablet_size * load.shard_count;
-            } else if (_table_load_stats && _table_load_stats->capacity.contains(host)) {
-                load.capacity = _table_load_stats->capacity.at(host);
+                load.dusage = disk_usage{_target_tablet_size * load.shard_count, 0};
+            } else if (_table_load_stats) {
+                if (_table_load_stats->tablet_stats.contains(host) && !_force_capacity_based_balancing) {
+                    load.dusage = disk_usage{_table_load_stats->tablet_stats.at(host).effective_capacity, 0};
+                } else if (_table_load_stats->capacity.contains(host)) {
+                    load.dusage = disk_usage{_table_load_stats->capacity.at(host), 0};
+                }
+            }
+
+            load.shards.resize(load.shard_count);
+            if (load.dusage) {
+                for (auto& sload : load.shards) {
+                    sload.dusage = disk_usage{ load.dusage->capacity / load.shard_count, 0 };
+                }
             }
         };
 
@@ -3021,53 +3083,15 @@ public:
             if (node.drained) {
                 continue;
             }
-            if (!node.capacity) {
+            if (!node.dusage) {
                 lblogger.info("Cannot balance because capacity of node {} (or more) is unknown", host);
                 co_return plan;
             }
         }
 
-        // Compute load imbalance.
-
-        _total_capacity_shards = 0;
-        _total_capacity_nodes = 0;
-        _total_capacity_storage = 0;
-        load_type max_load = 0;
-        load_type min_load = 0;
-        std::optional<host_id> min_load_node = std::nullopt;
-        for (auto&& [host, load] : nodes) {
-            load.update(_target_tablet_size);
-            _stats.for_node(dc, host).load = load.avg_load;
-
-            if (!load.drained) {
-                if (!min_load_node || load.avg_load < min_load) {
-                    min_load = load.avg_load;
-                    min_load_node = host;
-                }
-                if (load.avg_load > max_load) {
-                    max_load = load.avg_load;
-                }
-                _total_capacity_shards += load.shard_count;
-                _total_capacity_nodes++;
-                _total_capacity_storage += *load.capacity;
-            }
-        }
-
-        for (auto&& [host, load] : nodes) {
-            size_t read = 0;
-            size_t write = 0;
-            for (auto& shard_load : load.shards) {
-                read += shard_load.streaming_read_load;
-                write += shard_load.streaming_write_load;
-            }
-            auto level = (read + write) > 0 ? seastar::log_level::info : seastar::log_level::debug;
-            lblogger.log(level, "Node {}: dc={} rack={} load={} tablets={} shards={} tablets/shard={} state={} cap={}"
-                                " stream_read={} stream_write={}",
-                         host, dc, load.rack(), load.avg_load, load.tablet_count, load.shard_count,
-                         load.tablets_per_shard(), load.state(), load.capacity, read, write);
-        }
-
-        if (!min_load_node) {
+        // Check if we have destination nodes
+        const bool has_dest_nodes = std::ranges::any_of(std::views::values(nodes), [] (const auto& load) { return !load.drained; });
+        if (!has_dest_nodes) {
             if (!nodes_to_drain.empty()) {
                 throw std::runtime_error(format("There are nodes with tablets to drain but no candidate nodes in DC {}."
                                                 " Consider adding new nodes or reducing replication factor.", dc));
@@ -3089,13 +3113,15 @@ public:
 
         // Compute per-shard load and candidate tablets.
 
-        _load_sketch = locator::load_sketch(_tm);
+        _load_sketch = locator::load_sketch(_tm, _table_load_stats, _force_capacity_based_balancing ? _target_tablet_size : 0);
         co_await _load_sketch->populate_dc(dc);
         _tablet_count_per_table.clear();
+        _disk_used_per_table.clear();
 
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
             const auto& tmap = _tm->tablets().get_tablet_map(table);
-            uint64_t total_load = 0;
+            uint64_t total_tablet_count = 0;
+            uint64_t total_tablet_sizes = 0;
 
             auto get_replicas = [this] (std::optional<tablet_desc> t) -> tablet_replica_set {
                 return t ? sorted_replicas_for_tablet_load(*t->info, t->transition) : tablet_replica_set{};
@@ -3127,11 +3153,43 @@ public:
                 auto get_table_desc = [&] (tablet_id tid) {
                     return tid == t1.tid ? t1 : t2;
                 };
+                // If the tablet is migrating, it will return the leaving replica given a pending replica
+                auto get_leaving_replica = [] (const tablet_desc& td, const tablet_replica& replica) {
+                    if (td.transition) {
+                        for (size_t i = 0; i < td.transition->next.size(); i++) {
+                            if (td.transition->next[i] == replica) {
+                                return td.info->replicas[i];
+                            }
+                        }
+                    }
+                    return replica;
+                };
 
                 while (auto next = processor.next_replica()) {
                     auto& [replica, tids] = *next;
                     if (!nodes.contains(replica.host)) {
                         continue;
+                    }
+                    utils::small_vector<uint64_t, 2> tablet_sizes;
+                    uint64_t tablet_sizes_sum = 0;
+                    for (auto tid : tids) {
+                        if (_force_capacity_based_balancing) {
+                            tablet_sizes_sum += _target_tablet_size;
+                            tablet_sizes.push_back(_target_tablet_size);
+                        } else {
+                            // If the replica is in migration, search for the tablet size in the leaving replica
+                            auto maybe_leaving_replica = (tid == t1.tid ? get_leaving_replica(t1, replica) : get_leaving_replica(*t2, replica));
+                            uint64_t tablet_group_size = 0;
+                            auto token_range = tmap.get_token_range(tid);
+                            for (auto group_member : tables) {
+                                const range_based_tablet_id rb_tid {group_member, token_range};
+                                uint64_t tablet_size = get_tablet_size(maybe_leaving_replica.host, rb_tid, 0);
+                                tablet_size = std::max(tablet_size, uint64_t(1));
+                                tablet_group_size += tablet_size;
+                                tablet_sizes_sum += tablet_size;
+                            }
+                            tablet_sizes.push_back(tablet_group_size);
+                        }
                     }
                     auto& node_load_info = nodes[replica.host];
                     shard_load& shard_load_info = node_load_info.shards[replica.shard];
@@ -3139,20 +3197,32 @@ public:
                         node_load_info.shards_by_load.push_back(replica.shard);
                     }
                     shard_load_info.tablet_count += tids.size();
+                    if (shard_load_info.dusage) {
+                        shard_load_info.dusage->used += tablet_sizes_sum;
+                    }
                     shard_load_info.tablet_count_per_table[table] += tids.size();
+                    shard_load_info.tablet_sizes_per_table[table] += tablet_sizes_sum;
                     node_load_info.tablet_count_per_table[table] += tids.size();
-                    total_load += tids.size();
+                    node_load_info.tablet_sizes_per_table[table] += tablet_sizes_sum;
+                    if (node_load_info.dusage) {
+                        node_load_info.dusage->used += tablet_sizes_sum;
+                    }
+                    total_tablet_count += tids.size();
+                    total_tablet_sizes += tablet_sizes_sum;
                     if (tmap.needs_merge() && tids.size() == 2) {
                         // Exclude both sibling tablets if either haven't finished migration yet. That's to prevent balancer from
                         // un-doing the colocation.
                         if (!migrating(t1) && !migrating(t2)) {
                             auto candidate = colocated_tablets{global_tablet_id{table, t1.tid}, global_tablet_id{table, t2->tid}};
-                            add_candidate(shard_load_info, migration_tablet_set{std::move(candidate)});
+                            add_candidate(shard_load_info, migration_tablet_set{std::move(candidate), tablet_sizes_sum});
                         }
                     } else {
-                        for (auto tid : tids) {
-                            if (!migrating(get_table_desc(tid))) { // migrating tablets are not candidates
-                                add_candidate(shard_load_info, migration_tablet_set{global_tablet_id{table, tid}});
+                        if (tids.size() != tablet_sizes.size()) {
+                            on_internal_error(lblogger, "Number of co-located tablets and their sizes don't match.");
+                        }
+                        for (size_t i = 0; i < tids.size(); i++) {
+                            if (!migrating(get_table_desc(tids[i]))) { // migrating tablets are not candidates
+                                add_candidate(shard_load_info, migration_tablet_set{global_tablet_id{table, tids[i]}, tablet_sizes[i]});
                             }
                         }
                     }
@@ -3160,10 +3230,51 @@ public:
 
                 return make_ready_future<>();
             });
-            _tablet_count_per_table[table] = total_load;
+            _disk_used_per_table[table] = total_tablet_sizes;
+            _tablet_count_per_table[table] = total_tablet_count;
         }
 
-        if (!nodes_to_drain.empty() || (_tm->tablets().balancing_enabled() && (shuffle || max_load != min_load))) {
+        // Compute load imbalance.
+
+        _total_capacity_shards = 0;
+        _total_capacity_nodes = 0;
+        _total_capacity_storage = 0;
+        load_type max_load = 0;
+        load_type min_load = 0;
+        std::optional<host_id> min_load_node = std::nullopt;
+        for (auto&& [host, load] : nodes) {
+            load.update();
+            _stats.for_node(dc, host).load = load.avg_load;
+
+            if (!load.drained) {
+                if (!min_load_node || load.avg_load < min_load) {
+                    min_load = load.avg_load;
+                    min_load_node = host;
+                }
+                if (load.avg_load > max_load) {
+                    max_load = load.avg_load;
+                }
+                _total_capacity_shards += load.shard_count;
+                _total_capacity_nodes++;
+                _total_capacity_storage += load.dusage->capacity;
+            }
+        }
+
+        for (auto&& [host, load] : nodes) {
+            size_t read = 0;
+            size_t write = 0;
+            for (auto& shard_load : load.shards) {
+                read += shard_load.streaming_read_load;
+                write += shard_load.streaming_write_load;
+            }
+            auto level = (read + write) > 0 ? seastar::log_level::info : seastar::log_level::debug;
+            lblogger.log(level, "Node {}: dc={} rack={} load={} tablets={} shards={} tablets/shard={} state={} cap={}"
+                                " stream_read={} stream_write={}",
+                         host, dc, load.rack(), load.avg_load, load.tablet_count, load.shard_count,
+                         load.tablets_per_shard(), load.state(), load.dusage->capacity, read, write);
+        }
+
+        if (!nodes_to_drain.empty() || (_tm->tablets().balancing_enabled() && (shuffle || !is_balanced(min_load, max_load)))) {
             host_id target = *min_load_node;
             lblogger.info("target node: {}, avg_load: {}, max: {}", target, min_load, max_load);
             plan.merge(co_await make_internode_plan(dc, nodes, nodes_to_drain, target));

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -673,6 +673,14 @@ class load_balancer {
     std::unordered_set<host_id> _skiplist;
     bool _use_table_aware_balancing = true;
     double _initial_scale = 1;
+
+    // This is the maximum load delta between the most and least loaded nodes,
+    // below which the balancer considers the DC balanced
+    double _size_based_balance_threshold = 0.05;
+
+    // When this is set to true, the balancer assumes all tablets
+    // have the same size: _target_tablet_size
+    bool _force_capacity_based_balancing = false;
 private:
     tablet_replica_set get_replicas_for_tablet_load(const tablet_info& ti, const tablet_transition_info* trinfo) const {
         // We reflect migrations in the load as if they already happened,
@@ -754,6 +762,8 @@ public:
         , _table_load_stats(std::move(table_load_stats))
         , _stats(stats)
         , _skiplist(std::move(skiplist))
+        , _size_based_balance_threshold(db.get_config().size_based_balance_threshold_percentage() / 100.0)
+        , _force_capacity_based_balancing(db.get_config().force_capacity_based_balancing())
     { }
 
     future<migration_plan> make_plan() {

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -3763,6 +3763,37 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_resize_requests) {
     }).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_drain_node_without_capacity) {
+    do_with_cql_env_thread([] (auto& e) {
+        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+
+        topology_builder topo(e);
+
+        auto host1 = topo.add_node(node_state::normal, 2);
+        auto host2 = topo.add_node(node_state::normal, 2);
+
+        const uint64_t node_capacity = 100UL * 1024UL * 1024UL * 1024UL;
+        topo.get_shared_load_stats().set_capacity(host1, node_capacity);
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 16);
+        auto table = add_table(e, ks_name).get();
+
+        topo.set_node_state(host2, node_state::removing);
+
+        rebalance_tablets(e, &topo.get_shared_load_stats());
+
+        // check that all tablets have been migrated from host2 to host1
+        auto& stm = e.shared_token_metadata().local();
+        auto& tmap = stm.get()->tablets().get_tablet_map(table);
+        tmap.for_each_tablet([&](auto tid, auto& tinfo) {
+            for (auto& replica : tinfo.replicas) {
+                BOOST_REQUIRE_EQUAL(replica.host, host1);
+            }
+            return make_ready_future<>();
+        }).get();
+  }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_tablet_range_splitter) {
     simple_schema ss;
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1701,11 +1701,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host1), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host2), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
 
     rebalance_tablets(e);
@@ -1718,8 +1718,8 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_empty_node) {
             testlog.debug("Checking host {}", h);
             BOOST_REQUIRE_LE(load.get_load(h), 3);
             BOOST_REQUIRE_GT(load.get_load(h), 1);
-            BOOST_REQUIRE_LE(load.get_avg_shard_load(h), 2);
-            BOOST_REQUIRE_GT(load.get_avg_shard_load(h), 0);
+            BOOST_REQUIRE_LE(load.get_avg_tablet_count(h), 2);
+            BOOST_REQUIRE_GT(load.get_avg_tablet_count(h), 0);
         }
     }
   }).get();
@@ -1914,11 +1914,11 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host1), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host2), 4);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
 
     rebalance_tablets(e, &topo.get_shared_load_stats(), {host3});
@@ -1927,7 +1927,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_skiplist) {
         load_sketch load(stm.get());
         load.populate().get();
         BOOST_REQUIRE_EQUAL(load.get_load(host3), 0);
-        BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+        BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
     }
   }).get();
 }
@@ -2058,9 +2058,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
         }
 
         topo.set_node_state(host3, node_state::left);
@@ -2070,9 +2070,9 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_rf_met) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host3), 0);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host3), 0);
         }
     }).get();
 }
@@ -2200,10 +2200,10 @@ SEASTAR_THREAD_TEST_CASE(test_decommission_two_racks) {
         {
             load_sketch load(stm.get());
             load.populate().get();
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host1), 2);
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host2), 2);
-            BOOST_REQUIRE_GE(load.get_avg_shard_load(host3), 2);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(host4), 0);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host1), 2);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host2), 2);
+            BOOST_REQUIRE_GE(load.get_avg_tablet_count(host3), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(host4), 0);
         }
 
         // Verify replicas are not collocated on racks
@@ -2362,7 +2362,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_works_with_in_progress_transitions)
 
         for (auto h : {host1, host2, host3}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 2);
         }
     }
 
@@ -2455,7 +2455,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
 
         for (auto h : {host1, host2, host3, host4}) {
             testlog.debug("Checking host {}", h);
-            BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 4);
+            BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 4);
             BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
         }
     }
@@ -2500,7 +2500,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_asymmetric_node_capacity) {
 
           for (auto h: {host2, host3}) {
               testlog.debug("Checking host {}", h);
-              BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 2); // 16 tablets / 8 shards = 2 tablets / shard
+              BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 2); // 16 tablets / 8 shards = 2 tablets / shard
               BOOST_REQUIRE_EQUAL(load.get_shard_imbalance(h), 0);
           }
         }
@@ -2686,7 +2686,7 @@ SEASTAR_THREAD_TEST_CASE(test_skiplist_is_ignored_when_draining) {
 
             for (auto h : {host2, host3}) {
                 testlog.debug("Checking host {}", h);
-                BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 1);
+                BOOST_REQUIRE_EQUAL(load.get_avg_tablet_count(h), 1);
             }
         }
     }).get();
@@ -2806,7 +2806,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
 
             min_max_tracker<unsigned> min_max_load;
             for (auto h: hosts) {
-                auto l = load.get_avg_shard_load(h);
+                auto l = load.get_avg_tablet_count(h);
                 testlog.info("Load on host {}: {}", h, l);
                 min_max_load.update(l);
                 BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
@@ -2865,10 +2865,10 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         std::unordered_map<host_id, double> initial_utilization;
         auto& hosts = topo.hosts();
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 initial_utilization[h] = *u;
             }
@@ -2879,16 +2879,14 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack1");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            auto u0 = *load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size);
+            auto u0 = *load.get_allocated_utilization(hosts[0]);
             BOOST_REQUIRE_LT(u0, initial_utilization[hosts[0]]);
             initial_utilization[hosts[0]] = u0;
             // rack2 and rack3 are not changed, to keep racks not overloaded (RF=rack_count)
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[1]]);
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[2]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1]), initial_utilization[hosts[1]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2]), initial_utilization[hosts[2]]);
         }
 
         topo.add_i4i_large(rack2);
@@ -2896,15 +2894,13 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack2");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[0]]);
-            auto u1 = *load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0]), initial_utilization[hosts[0]]);
+            auto u1 = *load.get_allocated_utilization(hosts[1]);
             BOOST_REQUIRE_LT(u1, initial_utilization[hosts[1]]);
             initial_utilization[hosts[1]] = u1;
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[2]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[2]), initial_utilization[hosts[2]]);
         }
 
         topo.add_i4i_large(rack3);
@@ -2912,20 +2908,18 @@ SEASTAR_THREAD_TEST_CASE(test_balancing_heterogeneous_cluster) {
         testlog.info("Expanded capacity in rack3");
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[0]]);
-            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1], *topo.get_load_stats(), default_target_tablet_size),
-                             initial_utilization[hosts[1]]);
-            auto u2 = *load.get_allocated_utilization(hosts[2], *topo.get_load_stats(), default_target_tablet_size);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[0]), initial_utilization[hosts[0]]);
+            BOOST_REQUIRE_EQUAL(*load.get_allocated_utilization(hosts[1]), initial_utilization[hosts[1]]);
+            auto u2 = *load.get_allocated_utilization(hosts[2]);
             BOOST_REQUIRE_LT(u2, initial_utilization[hosts[2]]);
             initial_utilization[hosts[2]] = u2;
 
             // Check that utilization difference is < 1%
             min_max_tracker<double> node_utilization;
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 node_utilization.update(*u);
             }
@@ -2966,13 +2960,13 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables) {
         auto& hosts = topo.hosts();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate(std::nullopt, table2).get();
 
             // Check that utilization difference is < 4%
             min_max_tracker<double> node_utilization;
             for (auto h: hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 BOOST_REQUIRE(u);
                 testlog.info("table2: {}: {}", h, u);
                 node_utilization.update(*u);
@@ -3016,12 +3010,12 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbala
         auto& hosts = topo.hosts();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate(std::nullopt, table2).get();
 
             min_max_tracker<double> node_utilization;
             for (auto h : hosts) {
-                auto u = load.get_allocated_utilization(h, *topo.get_load_stats(), default_target_tablet_size);
+                auto u = load.get_allocated_utilization(h);
                 testlog.info("table2: {}: {}", h, u);
                 node_utilization.update(u.value_or(0));
             }
@@ -3042,6 +3036,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
         auto per_shard_goal = e.local_db().get_config().tablets_per_shard_goal();
 
         topology_builder topo(e);
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
 
         std::vector<endpoint_dc_rack> racks = {
             topo.rack(),
@@ -3080,7 +3075,7 @@ SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table1).tablet_count(), 256);
             BOOST_REQUIRE_EQUAL(tm->tablets().get_tablet_map(table2).tablet_count(), 64);
 
-            load_sketch load(tm);
+            load_sketch load(tm, load_stats.get());
             load.populate().get();
 
             for (auto h: hosts) {
@@ -3260,7 +3255,7 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
         auto& stm = e.shared_token_metadata().local();
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             testlog.info("max load: {}", load.get_shard_minmax(host1).max());
             // The value 415 was determined empirically. If there was lack of scaling, it would be 1'600.
@@ -3270,7 +3265,7 @@ SEASTAR_THREAD_TEST_CASE(test_creating_lots_of_tables_doesnt_overflow_metadata) 
         rebalance_tablets(e, &load_stats);
 
         {
-            load_sketch load(stm.get());
+            load_sketch load(stm.get(), load_stats.get());
             load.populate().get();
             testlog.info("max load: {}", load.get_shard_minmax(host1).max());
             BOOST_REQUIRE(load.get_shard_minmax(host1).max() <= 200);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1563,6 +1563,17 @@ void do_rebalance_tablets(cql_test_env& e,
             return apply_plan(tm, plan);
         }).get();
 
+        if (load_stats) {
+            auto& tm = stm.get()->tablets();
+            for (auto&& mig : plan.migrations()) {
+                if (mig.src != mig.dst) {
+                    auto& tmap = tm.get_tablet_map(mig.tablet.table);
+                    locator::range_based_tablet_id rb_tid {mig.tablet.table, tmap.get_token_range(mig.tablet.tablet)};
+                    load_stats->migrate_tablet_size(mig.src.host, mig.dst.host, rb_tid);
+                }
+            }
+        }
+
         if (auto_split && load_stats) {
             auto& tm = *stm.get();
             for (const auto& [table, tmap]: tm.tablets().all_tables_ungrouped()) {
@@ -3022,6 +3033,135 @@ SEASTAR_THREAD_TEST_CASE(test_imbalance_in_hetero_cluster_with_two_tables_imbala
             BOOST_REQUIRE_LT(node_utilization.max() - node_utilization.min(), 0.13);
         }
     }).get();
+}
+
+static table_id create_table_and_set_tablet_sizes(cql_test_env& e, topology_builder& topo, sstring ks_name, size_t tablet_count, uint64_t table_size_bytes) {
+    const uint64_t tablet_size = table_size_bytes / tablet_count;
+
+    std::map<sstring, sstring> tablet_options = {{"min_tablet_count", to_sstring(tablet_count)}};
+    auto table = add_table(e, ks_name, tablet_options).get();
+
+    auto& load_stats = topo.get_shared_load_stats();
+    load_stats.set_size(table, table_size_bytes);
+
+    auto& stm = e.shared_token_metadata().local();
+    auto& tmap = stm.get()->tablets().get_tablet_map(table);
+    tmap.for_each_tablet([&] (tablet_id tid, const tablet_info& tinfo) {
+        auto replicas = tinfo.replicas;
+        for (auto& r : tinfo.replicas) {
+            locator::range_based_tablet_id rb_tid {table, tmap.get_token_range(tid)};
+            load_stats.set_tablet_size(r.host, rb_tid, tablet_size);
+        }
+        return make_ready_future<>();
+    }).get();
+
+    testlog.info("Created table {} of size {:i} with {} tablets and tablet size of {:i}",
+                table, utils::pretty_printed_data_size(table_size_bytes), tablet_count, utils::pretty_printed_data_size(tablet_size));
+
+    return table;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_size_based_load_balancing_table_load) {
+    // This test validates the table balance in size based load balancing.
+    // The initial tablet allocation during table creation is non-deterministic because of
+    // shuffle in network_topology_strategy.cc. This means that the tablet balancer will work on a different
+    // initial setup on every run, and that the final tablet distribution will also be different.
+    // With max_imbalance_threshold set to 1.4 and running the test 10000 times there were no failures.
+    // 1.5 was selected as a safety buffer to avoid flakyness.
+    //
+    // The following is a table of max_imbalance_threshold and failure rates for 10000 runs:
+    //
+    // threshold | # runs | # failures
+    // ----------+--------+------------
+    //     1.4   |  10000 |          0
+    //     1.3   |  10000 |          57
+    //     1.2   |  10000 |          539
+    auto cfg = tablet_cql_test_config();
+    do_with_cql_env_thread([&] (auto& e) {
+        logging::logger_registry().set_logger_level("load_balancer", logging::log_level::debug);
+
+        topology_builder topo(e);
+
+        endpoint_dc_rack dc_rack;
+        const uint64_t shard_capacity = 250UL * 1024UL * 1024UL * 1024UL;
+        const size_t tablet_count = 512;
+        const double max_imbalance_threshold = 1.5;
+        const double min_imbalance_threshold = 1 / max_imbalance_threshold;
+        uint64_t total_capacity = 0;
+
+        std::vector<host_id> hosts;
+
+        // Add disk capacity for the default node. Add all subsequent nodes to the same DC/rack
+        e.shared_token_metadata().local().get()->get_topology().for_each_node([&] (const auto& node) {
+            dc_rack = node.dc_rack();
+            auto host = node.host_id();
+            auto num_shards = node.get_shard_count();
+            auto node_capacity = shard_capacity * num_shards;
+            topo.get_shared_load_stats().set_capacity(host, node_capacity);
+            total_capacity += node_capacity;
+            testlog.info("Default node {} has {} shards and {:i} disk capacity", host, num_shards, utils::pretty_printed_data_size(node_capacity));
+            hosts.push_back(host);
+        });
+
+        auto create_node = [&] (size_t num_shards) {
+            auto host = topo.add_node(node_state::normal, num_shards, dc_rack);
+            auto node_capacity = shard_capacity * num_shards;
+            topo.get_shared_load_stats().set_capacity(host, node_capacity);
+            total_capacity += node_capacity;
+            testlog.info("Added node {} with {} shards and {:i} disk capacity", host, num_shards, utils::pretty_printed_data_size(node_capacity));
+            hosts.push_back(host);
+        };
+
+        create_node(10);
+        create_node(8);
+
+        auto ks_name = add_keyspace(e, {{dc_rack.dc, 1}});
+
+        // Add 3 tables: 0.5 the current total storage, 0.25 the total storage and 0.125 the total storage
+        std::map<table_id, uint64_t> table_sizes;
+        uint64_t table_size = total_capacity / 2;
+        for (int c = 0; c < 3; c++) {
+            auto table_id = create_table_and_set_tablet_sizes(e, topo, ks_name, tablet_count, table_size);
+            table_sizes[table_id] = table_size;
+            table_size /= 2;
+        }
+        // Add another table with 1 byte per tablet
+        table_size = tablet_count;
+        auto table_id = create_table_and_set_tablet_sizes(e, topo, ks_name, tablet_count, table_size);
+        table_sizes[table_id] = table_size;
+
+        auto& stm = e.shared_token_metadata().local();
+
+        auto check_balance = [&] {
+            for (auto& [table, table_size] : table_sizes) {
+                load_sketch load(stm.get(), topo.get_shared_load_stats().get());
+                load.populate(std::nullopt, table).get();
+
+                const double ideal_table_load = double(table_size) / total_capacity;
+                min_max_tracker<double> table_load;
+                for (auto h : hosts) {
+                    auto shard_minmax_load = load.get_shard_minmax(h);
+                    table_load.update(shard_minmax_load);
+                    testlog.info("Table: {} ideal_load: {} host: {} load: {} min_shard_load: {} max_shard_load: {}",
+                                    table, ideal_table_load, h, load.get_load(h), shard_minmax_load.min(), shard_minmax_load.max());
+
+                    BOOST_REQUIRE_LT(min_imbalance_threshold, shard_minmax_load.min() / ideal_table_load);
+                    BOOST_REQUIRE_GT(max_imbalance_threshold, shard_minmax_load.max() / ideal_table_load);
+                }
+            }
+        };
+
+        rebalance_tablets(e, &topo.get_shared_load_stats());
+
+        check_balance();
+
+        create_node(8);
+
+        rebalance_tablets(e, &topo.get_shared_load_stats());
+
+        check_balance();
+
+    }, std::move(cfg)).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_per_shard_goal_mixed_dc_rf) {

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -1,0 +1,100 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from test.pylib.manager_client import ManagerClient
+from test.cluster.conftest import skip_mode
+from test.cluster.util import get_topology_coordinator, new_test_keyspace
+from test.pylib.tablets import get_all_tablet_replicas
+from test.pylib.util import wait_for_cql_and_get_hosts
+from collections import defaultdict
+import time
+import pytest
+import logging
+import asyncio
+
+logger = logging.getLogger(__name__)
+
+GB = 1024 * 1024 * 1024
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_balance_empty_tablets(manager: ManagerClient):
+
+    # This test checks that size-based load balancing migrates empty tablets of a newly created
+    # table after a scale-out. The number of tablets on a node must be proportional to the disk
+    # capacity of that node.
+
+    logger.info('Bootstrapping cluster')
+
+    cfg = { 'error_injections_at_startup': ['short_tablet_stats_refresh_interval'] }
+
+    cfg_small = cfg | { 'data_file_capacity': 50 * GB }
+    cfg_large = cfg | { 'data_file_capacity': 100 * GB }
+
+    cmdline = [
+        '--smp', '2',
+        '--logger-log-level', 'load_balancer=debug',
+        '--logger-log-level', 'raft_topology=debug',
+    ]
+
+    servers = [await manager.server_add(config=cfg_large, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'r1'})]
+    large_host_id = await manager.get_host_id(servers[0].server_id)
+
+    cql = manager.get_cql()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
+        for table in ('t1', 't2', 't3'):
+            await cql.run_async(f'CREATE TABLE {ks}.{table} (pk int PRIMARY KEY, val text);')
+
+        servers.append(await manager.server_add(config=cfg_small, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'r1'}))
+        small_host_id = await manager.get_host_id(servers[1].server_id)
+        logger.debug(f'Large node: {large_host_id}')
+        logger.debug(f'Small node: {small_host_id}')
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+        await s0_log.wait_for('Refreshed table load stats for all DC', from_mark=s0_mark)
+
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+
+        replicas_per_node = defaultdict(int)
+        tablets_per_shard = {}
+        for row in await cql.run_async('SELECT * FROM system.tablets'):
+            if row.keyspace_name == ks:
+                table_id = row.table_id
+                for r in row.replicas:
+                    host_id = str(r[0])
+                    shard = r[1]
+                    replicas_per_node[host_id] += 1
+                    if host_id not in tablets_per_shard:
+                        tablets_per_shard[host_id] = {}
+                    if shard not in tablets_per_shard[host_id]:
+                        tablets_per_shard[host_id][shard] = defaultdict(int)
+
+                    tablets_per_shard[host_id][shard][table_id] += 1
+
+        # check replica distribution per node
+        for host_id, tablets in replicas_per_node.items():
+            logger.debug(f'Node: {host_id} tablet count: {tablets}')
+            if host_id == large_host_id:
+                assert tablets == 32, f'Larger node {host_id} must have 32 replicas'
+            else:
+                assert tablets == 16, f'Smaller node {host_id} must have 16 replicas'
+
+        # check replica distribution per shard
+        for host_id, shard_dist in tablets_per_shard.items():
+            for shard, table_dist in shard_dist.items():
+                shard_sum = sum(table_dist.values())
+                if host_id == large_host_id:
+                    assert shard_sum == 16, f'A shard of the larger host {host_id} must have either 16 tablets'
+                else:
+                    assert shard_sum == 8, f'A shard of the smaller host {host_id} must have either 8 tablets'
+
+                for table_id, count in table_dist.items():
+                    logger.debug(f'replica: {host_id}:{shard} of table_id: {table_id} tablet count: {count}')
+                    if host_id == large_host_id:
+                        assert count == 5 or count == 6, f'A shard of the larger host {host_id} must have either 5 or 6 tablets for table {table_id}'
+                    else:
+                        assert count == 2 or count == 3, f'A shard of the smaller host {host_id} must have either 2 or 3 tablets for table {table_id}'

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -318,6 +318,11 @@ async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode
     if build_mode != "release":
         cfg['error_injections_at_startup'] = [{'name': 'querier-cache-ttl-seconds', 'value': 999999999}]
 
+    # Force capacity based balancing, so that the tablet moved by the move_tablet API
+    # is still on the host we attempt to move it from. Without this, the load balancer might migrate
+    # the tablet after we query the tablet location and before this test attempts to move it.
+    cfg['force_capacity_based_balancing'] = True
+
     servers = await manager.servers_add(2, config=cfg)
 
     cql = manager.get_cql()

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -544,7 +544,14 @@ async def test_tablet_cleanup(manager: ManagerClient):
 async def test_tablet_cleanup_failure(manager: ManagerClient):
     cmdline = ['--smp=1']
 
-    servers = [await manager.server_add(cmdline=cmdline)]
+    # For capacity based balancing, so that after the move_tablet API the load balancer does
+    # not attempt to migrate the tablet back to the first node.
+    # Without this, the second node might have a slightly lower transient effective disk
+    # capacity, the size based load balancer will compute a higher load, and move the tablet
+    # back to the first node.
+    config = { 'force_capacity_based_balancing': True }
+
+    servers = [await manager.server_add(cmdline=cmdline, config=config)]
 
     cql = manager.get_cql()
     n_tablets = 1
@@ -560,7 +567,7 @@ async def test_tablet_cleanup_failure(manager: ManagerClient):
         s0_log = await manager.server_open_log(servers[0].server_id)
         s0_mark = await s0_log.mark()
 
-        servers.append(await manager.server_add())
+        servers.append(await manager.server_add(config=config))
 
         tablet_token = 0
         replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
@@ -1356,7 +1363,13 @@ async def test_decommission_rack_basic(manager: ManagerClient):
     # We need to disable this option to be able to create a keyspace. This can be ditched
     # once we've implemented scylladb/scylladb#23426 and we can add new racks with the option enabled.
     # Then we can create `rf` nodes, create the keyspace, and add another node.
-    config = {"rf_rack_valid_keyspaces": False}
+    rf_rack_valid_cfg = {"rf_rack_valid_keyspaces": False}
+
+    # Tablet size-based balancing will attempt to balance the DC based on tablet sizes, leading
+    # to imbalance on tablet count per shard, which fails the test during verify_replicas_per_server()
+    force_capacity_lb_cfg = {'force_capacity_based_balancing': True}
+
+    config = rf_rack_valid_cfg | force_capacity_lb_cfg
 
     all_servers = await create_cluster(manager, 1, num_racks, nodes_per_rack, config)
     async with create_and_populate_table(manager, rf=rf) as ctx:
@@ -1396,7 +1409,13 @@ async def test_decommission_rack_after_adding_new_rack(manager: ManagerClient):
 
     # We can't add a new rack if we create a keyspace.
     # Once scylladb/scylladb#23426 has been implemented, this can be ditched.
-    config = {"rf_rack_valid_keyspaces": False}
+    rf_rack_valid_cfg = {"rf_rack_valid_keyspaces": False}
+
+    # Tablet size-based balancing will attempt to balance the DC based on tablet sizes, leading
+    # to imbalance on tablet count per shard, which fails the test during verify_replicas_per_server()
+    force_capacity_lb_cfg = {'force_capacity_based_balancing': True}
+
+    config = rf_rack_valid_cfg | force_capacity_lb_cfg
 
     initial_servers = await create_cluster(manager, 1, initial_num_racks, nodes_per_rack, config)
     async with create_and_populate_table(manager, rf=rf) as ctx:

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import time
 import random
+from collections import defaultdict
 
 logger = logging.getLogger(__name__)
 
@@ -323,6 +324,33 @@ async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: 
                 await manager.api.keyspace_compaction(server.ip_addr, ks)
             await check()
 
+# This function returns the total number of sibling tablet pairs that can be colocated,
+# and the number of sibling tablet pairs that are currenty colocated.
+async def get_colocated_siblings_count(cql, table_id, rf):
+    res = await cql.run_async(f"SELECT last_token, replicas, new_replicas FROM system.tablets WHERE table_id = {table_id}")
+    tablets_on_shard = defaultdict(list)
+    tablet_id = 0
+    # make a map of replicas to a list of tablet ids located on those replicas
+    for row in res:
+        replicas = row.new_replicas if row.new_replicas is not None else row.replicas
+        for replica in replicas:
+            tablets_on_shard[replica].append(tablet_id)
+        tablet_id += 1
+
+    # count the colocated sibling pairs
+    colocated_count = 0
+    for replica, table_ids in tablets_on_shard.items():
+        ndx = 0
+        while ndx < len(table_ids) - 1:
+            # check sibling colocation
+            if table_ids[ndx] % 2 == 0 and table_ids[ndx + 1] == table_ids[ndx] + 1:
+                colocated_count += 1
+                ndx += 2
+            else:
+                ndx += 1
+
+    return (len(res) * rf // 2, colocated_count)
+
 @pytest.mark.parametrize("racks", [2, 3])
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
@@ -370,15 +398,32 @@ async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks)
         await manager.api.flush_keyspace(server.ip_addr, ks)
         await manager.api.keyspace_compaction(server.ip_addr, ks)
 
+    table_id = await manager.get_table_or_view_id(ks, "test")
+
+    async def colocation_progress():
+        nonlocal colocation
+        new_colocation = await get_colocated_siblings_count(cql, table_id, rf)
+        logger.debug(f"previous colocation: {colocation} new_colocation: {new_colocation}")
+        (new_coloc_target, new_coloc_current) = new_colocation
+        (prev_coloc_target, prev_coloc_current) = colocation
+        colocation = new_colocation
+        return new_coloc_target < prev_coloc_target or new_coloc_current > prev_coloc_current or None
+
+    # wait for colocation of all tablet siblings
+    colocation = await get_colocated_siblings_count(cql, table_id, rf)
+    while colocation[0] != colocation[1]:
+        await wait_for(colocation_progress, time.time() + 60)
+
+    # wait for merge to complete
     async def finished_merging():
         tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
         return tablet_count < old_tablet_count or None
-    await wait_for(finished_merging, time.time() + 120)
+    await wait_for(finished_merging, time.time() + 60)
 
 # Reproduces #23284
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-async def test_tablet_split_merge_with_many_tables(manager: ManagerClient, racks = 2):
+async def test_tablet_split_merge_with_many_tables(manager: ManagerClient, build_mode, racks = 2):
     cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200',]
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
 
@@ -388,10 +433,15 @@ async def test_tablet_split_merge_with_many_tables(manager: ManagerClient, racks
         rack = f'rack{rack_id+1}'
         servers.extend(await manager.servers_add(3, config=config, cmdline=cmdline, property_file={'dc': 'mydc', 'rack': rack}))
 
+    if build_mode == "debug":
+        number_of_tables = 20
+    else:
+        number_of_tables = 200
+
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': 1}}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH compression = {{'sstable_compression': ''}};")
-    await asyncio.gather(*[cql.run_async(f"CREATE TABLE {ks}.test{i} (pk int PRIMARY KEY, c blob);") for i in range(1, 200)])
+    await asyncio.gather(*[cql.run_async(f"CREATE TABLE {ks}.test{i} (pk int PRIMARY KEY, c blob);") for i in range(1, number_of_tables)])
 
     async def check_logs(when):
         for server in servers:
@@ -433,10 +483,27 @@ async def test_tablet_split_merge_with_many_tables(manager: ManagerClient, racks
         await manager.api.flush_keyspace(server.ip_addr, ks)
         await manager.api.keyspace_compaction(server.ip_addr, ks)
 
+    table_id = await manager.get_table_or_view_id(ks, "test")
+
+    async def colocation_progress():
+        nonlocal colocation
+        new_colocation = await get_colocated_siblings_count(cql, table_id, rf)
+        logger.debug(f"previous colocation: {colocation} new_colocation: {new_colocation}")
+        (new_coloc_target, new_coloc_current) = new_colocation
+        (prev_coloc_target, prev_coloc_current) = colocation
+        colocation = new_colocation
+        return new_coloc_target < prev_coloc_target or new_coloc_current > prev_coloc_current or None
+
+    # wait for colocation of all tablet siblings
+    colocation = await get_colocated_siblings_count(cql, table_id, rf)
+    while colocation[0] != colocation[1]:
+        await wait_for(colocation_progress, time.time() + 60)
+
+    # wait for merge to complete
     async def finished_merging():
         tablet_count = await get_tablet_count(manager, servers[0], ks, 'test')
         return tablet_count < old_tablet_count or None
-    await wait_for(finished_merging, time.time() + 120)
+    await wait_for(finished_merging, time.time() + 60)
 
     await check_logs("after merge completion")
 
@@ -447,7 +514,13 @@ async def test_tablet_split_merge_with_many_tables(manager: ManagerClient, racks
 @skip_mode('release', 'error injections are not supported in release mode')
 async def test_migration_running_concurrently_to_merge_completion_handling(manager: ManagerClient):
     cmdline = []
-    cfg = {}
+    # We force capacity based balancing, otherwise size-based load balancing will attempt to
+    # migrate the tablet from the smaller to the larger node. In cases where the second node sees
+    # a larger transient available capacity than the first one, the balancer will migrate the tablet
+    # to the larger node, and the move_tablet API will result in a no-op migration. This means we will
+    # not enter take_storage_snapshot injection, the wait for "take_storage_snapshot: waiting" will
+    # time out, and the test will fail.
+    cfg = { 'force_capacity_based_balancing': True }
     servers = [await manager.server_add(cmdline=cmdline, config=cfg)]
 
     await manager.api.disable_tablet_balancing(servers[0].ip_addr)

--- a/test/perf/tablet_load_balancing.cc
+++ b/test/perf/tablet_load_balancing.cc
@@ -359,7 +359,7 @@ future<results> test_load_balancing_with_many_tables(params p, bool tablet_aware
                 for (auto [h, _] : hosts) {
                     auto minmax = load.get_shard_minmax(h);
                     auto node_load = load.get_load(h);
-                    auto avg_shard_load = load.get_real_avg_shard_load(h);
+                    auto avg_shard_load = load.get_real_avg_tablet_count(h);
                     auto overcommit = double(minmax.max()) / avg_shard_load;
                     shard_load_minmax.update(minmax.max());
                     shard_count += load.get_shard_count(h);


### PR DESCRIPTION
Currently, the tablet load balancer performs capacity based balancing by collecting the gross disk capacity of the nodes, and computes balance assuming that all tablet sizes are the same.

This change introduces size-based load balancing. The load balancer does not assume identical tablet sizes any more, and computes load based on actual tablet sizes.

The size-based load balancer computes the difference between the most and least loaded nodes in the DC and stops further balancing if this difference is bellow the config option `size_based_balance_threshold_percentage`.
    
This config option does not apply to the absolute load, but instead to the percentage of how much the most loaded node is more loaded than the least loaded node:
    
`delta = (most_loaded - least_loaded) / most_loaded`
    
If this delta is smaller then the config threshold, the balancer will consider the nodes balanced.

This PR is a part of a series of PRs which are based on top of eachother. Previous parts:

- First part for tablet size collection via load_stats: #26035
- Second part reconcile load_stats: #26152
- The third part for load_sketch changes: https://github.com/scylladb/scylladb/pull/26153

This is a new feature, backport is not needed.