### PR TITLE
Coroutinize gossipring property file snitch

### DIFF
--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -64,15 +64,11 @@ future<> gossiping_property_file_snitch::start() {
             periodic_reader_callback();
         });
 
-        return read_property_file().then([this] {
+        co_await read_property_file();
             start_io();
-            set_snitch_ready();
-            return make_ready_future<>();
-        });
     }
 
     set_snitch_ready();
-    return make_ready_future<>();
 }
 
 void gossiping_property_file_snitch::periodic_reader_callback() {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -18,20 +18,20 @@
 
 namespace locator {
 future<bool> gossiping_property_file_snitch::property_file_was_modified() {
-        try {
-            auto f = co_await open_file_dma(_prop_file_name, open_flags::ro);
-            auto st = co_await f.stat();
-            if (!_last_file_mod ||
-                _last_file_mod->tv_sec != st.st_mtim.tv_sec) {
-                _last_file_mod = st.st_mtim;
-                co_return true;
-            } else {
-                co_return false;
-            }
-        } catch (...) {
-            logger().error("Failed to open {} for read or to get stats", _prop_file_name);
-            throw;
+    try {
+        auto f = co_await open_file_dma(_prop_file_name, open_flags::ro);
+        auto st = co_await f.stat();
+        if (!_last_file_mod ||
+            _last_file_mod->tv_sec != st.st_mtim.tv_sec) {
+            _last_file_mod = st.st_mtim;
+            co_return true;
+        } else {
+            co_return false;
         }
+    } catch (...) {
+        logger().error("Failed to open {} for read or to get stats", _prop_file_name);
+        throw;
+    }
 }
 
 gossiping_property_file_snitch::gossiping_property_file_snitch(const snitch_config& cfg)
@@ -65,7 +65,7 @@ future<> gossiping_property_file_snitch::start() {
         });
 
         co_await read_property_file();
-            start_io();
+        start_io();
     }
 
     set_snitch_ready();
@@ -78,17 +78,17 @@ future<> gossiping_property_file_snitch::periodic_reader_callback() {
         if (was_modified) {
             co_await read_property_file();
         }
-        } catch (...) {
-            logger().error("Exception has been thrown when parsing the property file.");
-        }
+    } catch (...) {
+        logger().error("Exception has been thrown when parsing the property file.");
+    }
 
-        if (_state == snitch_state::stopping || _state == snitch_state::io_pausing) {
-            this->set_stopped();
-        } else if (_state != snitch_state::stopped) {
-            _file_reader.arm(reload_property_file_period());
-        }
+    if (_state == snitch_state::stopping || _state == snitch_state::io_pausing) {
+        this->set_stopped();
+    } else if (_state != snitch_state::stopped) {
+        _file_reader.arm(reload_property_file_period());
+    }
 
-        _file_reader_runs = false;
+    _file_reader_runs = false;
 }
 
 gms::application_state_map gossiping_property_file_snitch::get_app_states() const {
@@ -112,17 +112,17 @@ future<> gossiping_property_file_snitch::read_property_file() {
         ex = std::current_exception();
     }
     if (ex) {
-            //
-            // In case of an error:
-            //    - Halt if in the constructor.
-            //    - Print an error when reloading.
-            //
-            if (_state == snitch_state::initializing) {
-                logger().error("Failed to parse a properties file ({}). Halting...", _prop_file_name);
-                co_await coroutine::return_exception_ptr(std::move(ex));
-            } else {
-                logger().warn("Failed to reload a properties file ({}). Using previous values.", _prop_file_name);
-            }
+        //
+        // In case of an error:
+        //    - Halt if in the constructor.
+        //    - Print an error when reloading.
+        //
+        if (_state == snitch_state::initializing) {
+            logger().error("Failed to parse a properties file ({}). Halting...", _prop_file_name);
+            co_await coroutine::return_exception_ptr(std::move(ex));
+        } else {
+            logger().warn("Failed to reload a properties file ({}). Using previous values.", _prop_file_name);
+        }
     }
 }
 
@@ -155,9 +155,9 @@ future<> gossiping_property_file_snitch::reload_configuration() {
             local_s->set_my_dc_and_rack(new_dc, new_rack);
             local_s->set_prefer_local(new_prefer_local);
         });
-            co_await seastar::async([this] {
-                _reconfigured();
-            });
+        co_await seastar::async([this] {
+            _reconfigured();
+        });
     }
 }
 

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -208,12 +208,12 @@ void gossiping_property_file_snitch::start_io() {
 
 future<> gossiping_property_file_snitch::stop() {
     if (_state == snitch_state::stopped || _state == snitch_state::io_paused) {
-        return make_ready_future<>();
+        co_return;
     }
 
     _state = snitch_state::stopping;
 
-    return stop_io();
+    co_await stop_io();
 }
 
 future<> gossiping_property_file_snitch::pause_io() {

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -218,12 +218,12 @@ future<> gossiping_property_file_snitch::stop() {
 
 future<> gossiping_property_file_snitch::pause_io() {
     if (_state == snitch_state::stopped || _state == snitch_state::io_paused) {
-        return make_ready_future<>();
+        co_return;
     }
 
     _state = snitch_state::io_pausing;
 
-    return stop_io();
+    co_await stop_io();
 }
 
 using registry_default = class_registrator<i_endpoint_snitch, gossiping_property_file_snitch, const snitch_config&>;

--- a/locator/gossiping_property_file_snitch.cc
+++ b/locator/gossiping_property_file_snitch.cc
@@ -158,17 +158,14 @@ future<> gossiping_property_file_snitch::reload_configuration() {
     }
 
     if (_state == snitch_state::initializing || _my_dc != new_dc || _my_rack != new_rack || _prefer_local != new_prefer_local) {
-        return container().invoke_on_all([new_dc, new_rack, new_prefer_local] (snitch_ptr& local_s) {
+        co_await container().invoke_on_all([new_dc, new_rack, new_prefer_local] (snitch_ptr& local_s) {
             local_s->set_my_dc_and_rack(new_dc, new_rack);
             local_s->set_prefer_local(new_prefer_local);
-        }).then([this] {
-            return seastar::async([this] {
+        });
+            co_await seastar::async([this] {
                 _reconfigured();
             });
-        });
     }
-
-    return make_ready_future<>();
 }
 
 void gossiping_property_file_snitch::set_stopped() {

--- a/locator/gossiping_property_file_snitch.hh
+++ b/locator/gossiping_property_file_snitch.hh
@@ -50,7 +50,7 @@ public:
     }
 
 private:
-    void periodic_reader_callback();
+    future<> periodic_reader_callback();
 
     /**
      * Parse the property file and indicate the StorageService and a Gossiper if


### PR DESCRIPTION
Most of it's then-chains are quire hairy and look much nicer as coroutines.
Last patch restores indentation.

Code cleanup, no backport required.