### PR TITLE
Remove table::for_all_partitions_slow()

### DIFF
--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1307,9 +1307,6 @@ private:
     void recalculate_tablet_count_stats();
     int64_t calculate_tablet_count() const;
 public:
-    // Iterate over all partitions.  Protocol is the same as std::all_of(),
-    // so that iteration can be stopped by returning false.
-    future<bool> for_all_partitions_slow(schema_ptr, reader_permit permit, std::function<bool (const dht::decorated_key&, const mutation_partition&)> func) const;
 
     friend std::ostream& operator<<(std::ostream& out, const column_family& cf);
     // Testing purposes.

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -649,40 +649,6 @@ SEASTAR_TEST_CASE(test_flush_in_the_middle_of_a_scan) {
   });
 }
 
-// Iterate over all partitions.  Protocol is the same as std::all_of(),
-// so that iteration can be stopped by returning false.
-static future<bool> for_all_partitions_slow(const replica::column_family& cf, schema_ptr s, reader_permit permit, std::function<bool (const dht::decorated_key&, const mutation_partition&)> func) {
-    struct iteration_state {
-        mutation_reader reader;
-        std::function<bool (const dht::decorated_key&, const mutation_partition&)> func;
-        bool ok = true;
-        bool empty = false;
-    public:
-        bool done() const { return !ok || empty; }
-        iteration_state(schema_ptr s, reader_permit permit, const replica::column_family& cf,
-                std::function<bool (const dht::decorated_key&, const mutation_partition&)>&& func)
-            : reader(cf.make_mutation_reader(std::move(s), std::move(permit)))
-            , func(std::move(func))
-        { }
-    };
-
-    return do_with(iteration_state(std::move(s), std::move(permit), cf, std::move(func)), [] (iteration_state& is) {
-        return do_until([&is] { return is.done(); }, [&is] {
-            return read_mutation_from_mutation_reader(is.reader).then([&is](mutation_opt&& mo) {
-                if (!mo) {
-                    is.empty = true;
-                } else {
-                    is.ok = is.func(mo->decorated_key(), mo->partition());
-                }
-            });
-        }).then([&is] {
-            return is.ok;
-        }).finally([&is] {
-            return is.reader.close();
-        });
-    });
-}
-
 SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
     return sstables::test_env::do_with_async([] (sstables::test_env& env) {
     auto s = schema_builder(some_keyspace, some_column_family)
@@ -725,7 +691,15 @@ SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
             (void)cf.flush();
         }
 
-            co_await for_all_partitions_slow(cf, s, env.make_reader_permit(), [&, s] (const dht::decorated_key& pk, const mutation_partition& mp) {
+            auto reader = cf.make_mutation_reader(s, env.make_reader_permit());
+            while (true) {
+                mutation_opt mo = co_await read_mutation_from_mutation_reader(reader);
+                if (!mo) {
+                    break;
+                }
+
+                const dht::decorated_key& pk = mo->decorated_key();
+                const mutation_partition& mp = mo->partition();
                 auto p1 = value_cast<int32_t>(int32_type->deserialize(pk._key.explode(*s)[0]));
                 for (const rows_entry& re : mp.range(*s, interval<clustering_key_prefix>())) {
                     auto c1 = value_cast<int32_t>(int32_type->deserialize(re.key().explode(*s)[0]));
@@ -734,8 +708,8 @@ SEASTAR_TEST_CASE(test_multiple_memtables_multiple_partitions) {
                         result[p1][c1] = value_cast<int32_t>(int32_type->deserialize(cell->as_atomic_cell(r1_col).value().linearize()));
                     }
                 }
-                return true;
-            });
+            }
+            co_await reader.close();
             BOOST_REQUIRE(shadow == result);
     }).then([cf_stats] {}).get();
     });


### PR DESCRIPTION
This method was once implemented by calling table::for_all_partitions(), which was supposed to be non-slow version. Then callers of "non-slow" method were updated and the method itself was renamed into "_slow()" one. Nowadays only one test still uses it.

At the same time the method itself mostly consists of a boilerplate code that moves bits around to call lambda on the partitions read from reader. Open-coding the method into the calling test results in much shorter and simpler to follow code.

Code cleanup, no backport needed