### PR TITLE
lwt: prohibit for tablet-based views and cdc logs

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -370,6 +370,10 @@ future<> tablet_metadata::set_colocated_table(table_id id, table_id base_id) {
         _table_groups.erase(it);
     }
 
+    if (!_table_groups.contains(base_id)) {
+        on_internal_error(tablet_logger, format("Trying to set co-located table {} with base table {} but it's not a base table.", id, base_id));
+    }
+
     if (auto it = _base_table.find(id); it == _base_table.end()) {
         _base_table[id] = base_id;
         _table_groups[base_id].push_back(id);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -985,6 +985,13 @@ std::optional<table_id> database::get_base_table_for_tablet_colocation(const sch
         return find_schema(table_id);
     };
 
+    auto table_id_by_name = [this, &new_cfms, &s] (std::string_view cf_name) {
+        const auto it = std::ranges::find_if(new_cfms, [&s, cf_name] (const auto& p) {
+            return p.second->ks_name() == s.ks_name() && p.second->cf_name() == cf_name;
+        });
+        return it == new_cfms.end() ? find_uuid(s.ks_name(), cf_name) : it->second->id();
+    };
+
     // Co-locate a view table with its base table when it has exactly the same partition key - the same columns
     // in the same order. In this case the tokens of corresponding partitions are equal and we can benefit from
     // locality of view updates.
@@ -1013,20 +1020,12 @@ std::optional<table_id> database::get_base_table_for_tablet_colocation(const sch
         return s.view_info()->base_id();
     }
 
-    if (const auto t = service::paxos::paxos_store::try_get_base_table(s.cf_name()); t) {
-        return find_uuid(s.ks_name(), *t);
+    if (const auto t = service::paxos::paxos_store::try_get_base_table(s.cf_name())) {
+        return table_id_by_name(*t);
     }
 
     if (cdc::is_log_schema(s)) {
-        auto base_cf_name = cdc::base_name(s.cf_name());
-
-        for (auto new_cfm : new_cfms) {
-            if (new_cfm.second->ks_name() == s.ks_name() && new_cfm.second->cf_name() == base_cf_name) {
-                return new_cfm.second->id();
-            }
-        }
-
-        return find_schema(s.ks_name(), base_cf_name)->id();
+        return table_id_by_name(cdc::base_name(s.cf_name()));
     }
 
     return std::nullopt;


### PR DESCRIPTION
`SELECT` commands with SERIAL consistency level are historically allowed for vnode-based views, even though they don't provide linearizability guarantees and in general don't make much sense. In this PR we prohibit LWTs for tablet-based views, but preserve old behavior for vnode-based views for compatibility. Similar logic is applied to CDC log tables.

We also add a general check that disallows colocating a table with another colocated table, since this is not needed for now.

Fixes https://github.com/scylladb/scylladb/issues/26258

backports: not needed (a new feature)