### PR TITLE
replica/table: do not stop major compaction when disabling auto compaction

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1203,7 +1203,7 @@ future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_
 }
 
 std::vector<shared_ptr<compaction_task_executor>>
-compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt) noexcept {
+compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt, bool skip_major_compaction) noexcept {
     auto ongoing_compactions = get_compactions(filter).size();
     auto tasks = _tasks
             | std::views::filter([&filter, type_opt] (const auto& task) {
@@ -1229,13 +1229,13 @@ compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bo
     return tasks;
 }
 
-future<> compaction_manager::stop_ongoing_compactions(sstring reason, compaction_group_view* t, std::optional<compaction_type> type_opt) noexcept {
-    return stop_ongoing_compactions(std::move(reason), [t] (const compaction_group_view* x) { return !t || x == t; }, type_opt);
+future<> compaction_manager::stop_ongoing_compactions(sstring reason, compaction_group_view* t, std::optional<compaction_type> type_opt, bool skip_major_compaction) noexcept {
+    return stop_ongoing_compactions(std::move(reason), [t] (const compaction_group_view* x) { return !t || x == t; }, type_opt, skip_major_compaction);
 }
 
-future<> compaction_manager::stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view* t)> filter, std::optional<compaction_type> type_opt) noexcept {
+future<> compaction_manager::stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view* t)> filter, std::optional<compaction_type> type_opt, bool skip_major_compaction) noexcept {
     try {
-        auto tasks = do_stop_ongoing_compactions(std::move(reason), std::move(filter), type_opt);
+        auto tasks = do_stop_ongoing_compactions(std::move(reason), std::move(filter), type_opt, skip_major_compaction);
         bool task_stopped = true;
         co_await await_tasks(std::move(tasks), task_stopped);
     } catch (...) {

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -1206,8 +1206,8 @@ std::vector<shared_ptr<compaction_task_executor>>
 compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt, bool skip_major_compaction) noexcept {
     auto ongoing_compactions = get_compactions(filter).size();
     auto tasks = _tasks
-            | std::views::filter([&filter, type_opt] (const auto& task) {
-                return filter(task.compacting_table()) && (!type_opt || task.compaction_type() == *type_opt);
+            | std::views::filter([&filter, type_opt, skip_major_compaction] (const auto& task) {
+                return filter(task.compacting_table()) && (!type_opt || task.compaction_type() == *type_opt)  && (!skip_major_compaction || !task.is_major_compaction());
             })
             | std::views::transform([] (auto& task) { return task.shared_from_this(); })
             | std::ranges::to<std::vector<shared_ptr<compaction_task_executor>>>();

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -561,6 +561,10 @@ public:
     virtual void abort() noexcept override {
         return compaction_task_executor::abort(_as);
     }
+
+    bool is_major_compaction() const noexcept override {
+        return true;
+    }
 protected:
     virtual future<> run() override {
         return perform();

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -424,12 +424,12 @@ public:
 
 private:
     std::vector<shared_ptr<compaction_task_executor>>
-    do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt) noexcept;
-    future<> stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt = {}) noexcept;
+    do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt, bool skip_major_compaction = false) noexcept;
+    future<> stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt = {}, bool skip_major_compaction = false) noexcept;
 
 public:
     // Stops ongoing compaction of a given table and/or compaction_type.
-    future<> stop_ongoing_compactions(sstring reason, compaction::compaction_group_view* t = nullptr, std::optional<compaction_type> type_opt = {}) noexcept;
+    future<> stop_ongoing_compactions(sstring reason, compaction::compaction_group_view* t = nullptr, std::optional<compaction_type> type_opt = {}, bool skip_major_compaction = false) noexcept;
 
     future<> await_ongoing_compactions(compaction_group_view* t);
 

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -625,6 +625,9 @@ public:
     void stop_compaction(sstring reason) noexcept;
 
     sstables::compaction_stopped_exception make_compaction_stopped_exception() const;
+    virtual bool is_major_compaction() const noexcept {
+        return false;
+    }
 
     template<typename TaskExecutor, typename... Args>
     requires std::is_base_of_v<compaction_task_executor, TaskExecutor> &&

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4090,7 +4090,7 @@ table::disable_auto_compaction() {
     _compaction_disabled_by_user = true;
     return with_gate(_async_gate, [this] {
         return parallel_foreach_compaction_group_view([this] (compaction::compaction_group_view& view) {
-            return _compaction_manager.stop_ongoing_compactions("disable auto-compaction", &view, compaction::compaction_type::Compaction);
+            return _compaction_manager.stop_ongoing_compactions("disable auto-compaction", &view, compaction::compaction_type::Compaction, true);
         });
     });
 }

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -199,3 +199,52 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
         # For dropping the keyspace
         await manager.server_start(server.server_id)
         await reconnect_driver(manager)
+
+# Testcase for https://github.com/scylladb/scylladb/issues/24501
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_disable_autocompaction_during_major_compaction(manager: ManagerClient):
+    """
+    Test disable autocompaction during a major compaction doesn't stop the major compaction.
+    1. Create a single node cluster.
+    2. Create a table and populate it.
+    3. Inject error to make major compaction wait
+    4. Start compaction, wait for it to reach injection point
+    5. Disable autocompaction on the table
+    6. Resume the major compaction and expect it to complete successfully
+    """
+    logger.info("Starting a single node cluster")
+    server = await manager.server_add(cmdline=["--logger-log-level", "compaction=debug"])
+    # disable autocompaction on system and system_schema keyspaces to avoid interference with testing
+    await disable_autocompaction_across_keyspaces(manager, server.ip_addr, "system", "system_schema")
+
+    cf = "cf"
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        logger.info("Creating table")
+        await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")
+
+        logger.info("Populating table")
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.{cf} (pk) VALUES ({k});") for k in range(100)])
+        await manager.api.keyspace_flush(server.ip_addr, ks, cf)
+
+        logger.info("Inject error to make major compaction wait")
+        injection = "major_compaction_wait"
+        await manager.api.enable_injection(server.ip_addr, injection, False)
+
+        logger.info("Start compaction and wait for it to pause at the injection point")
+        log = await manager.server_open_log(server.server_id)
+        mark = await log.mark()
+        compaction_task = asyncio.create_task(manager.api.keyspace_compaction(server.ip_addr, ks, cf))
+        await log.wait_for("major_compaction_wait: waiting", from_mark=mark, timeout=30)
+
+        # Now that major compaction is in progress, disable autocompaction on the table
+        logger.info("Disabling autocompaction on the table")
+        await manager.api.disable_autocompaction(server.ip_addr, ks, cf)
+
+        # now resume major compaction and it should complete successfully
+        logger.info("Resuming major compaction")
+        mark = await log.mark()
+        await manager.api.message_injection(server.ip_addr, injection)
+        await compaction_task
+        await log.wait_for(f"Compact {ks}.{cf} .* Compacted .*", from_mark=mark, timeout=30)


### PR DESCRIPTION
When auto compaction is disabled, all ongoing compactions, including
major compactions, are stopped. However, major compactions should not be
stopped, since the disable request applies only to regular auto
compactions. This PR fixes that by skipping any ongoing major
compactions when sending the stop request during auto compaction
disable.

Fixes #24501

PR improves how the compactions are stopped when a disable auto compaction request is executed. 
No need to backport
