### PR TITLE
db/view/view_building_worker: hold read apply mutex when finishing batch

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -674,9 +674,11 @@ void view_building_worker::batch::start() {
     state = batch_state::in_progress;
     work = smp::submit_to(replica.shard, [this] () -> future<> {
         return do_work();
-    }).finally([this] () {
+    }).finally([this] () -> future<> {
+        auto& local_vbw = _vbw.local();
+        auto lock = co_await local_vbw._group0_client.hold_read_apply_mutex(local_vbw._as);
         state = batch_state::finished;
-        _vbw.local()._vb_state_machine.event.broadcast();
+        local_vbw._vb_state_machine.event.broadcast();
     });
 }
 


### PR DESCRIPTION
There was a race between loop in `view_building_worker::run_view_building_state_observer()` and a moment when a batch was finishing its work (`.finally()` callback in `view_building_worker::batch::start()`).

State observer waits on `_vb_state_machine.event` CV and when it's awoken, it takes group0 read apply mutex and updates its state. While updating the state, the observer looks at `batch::state` field and reacts to it accordingly.
On the other hand, when a batch finishes its work, it sets `state` field to `batch_state::finished` and does a broadcast on `_vb_state_machine.event` CV.
So if the batch will execute the callback in `.finally()` while the observer is updating its state, the observer may miss the event on the CV and it will never notice that the batch was finished.

This patch fixes this by obtaining the group0 read apply mutex in the `.finally()` callback.

Fixes scylladb/scylladb#26204

View building coordinator wasn't released yet, no backport needed.