### PR TITLE
test.py: remove 'sudo' from resource_gather.py

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -269,7 +269,6 @@ def setup_cgroup(is_required: bool) -> None:
         if _is_cgroup_rw() and is_docker:
             subprocess.run(
                 [
-                    "sudo",
                     "mount",
                     "-o",
                     "remount,rw",
@@ -279,7 +278,7 @@ def setup_cgroup(is_required: bool) -> None:
             )
 
         if is_podman or is_docker:
-            subprocess.run(['sudo', 'chown', '-R', f"{getpass.getuser()}:{getpass.getuser()}", '/sys/fs/cgroup'],
+            subprocess.run(['chown', '-R', f"{getpass.getuser()}:{getpass.getuser()}", '/sys/fs/cgroup'],
                            check=True)
 
         configured = False


### PR DESCRIPTION
The container now runs as root (https://github.com/scylladb/scylladb/commit/4c1f4c419c67136498f687f809f9fbc818fb0276), so sudo it's not needed anymore
