### PR TITLE
sstables/trie: translate all key cells in one go, not lazily

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -618,6 +618,7 @@ perf_tests = set([
     'test/perf/perf_idl',
     'test/perf/perf_vint',
     'test/perf/perf_big_decimal',
+    'test/perf/perf_bti_key_translation',
     'test/perf/perf_sort_by_proximity',
 ])
 

--- a/sstables/trie/bti_key_translation.cc
+++ b/sstables/trie/bti_key_translation.cc
@@ -11,95 +11,56 @@
 
 namespace sstables::trie {
 
-static bytes_view bytespan_to_bytesview(std::span<const std::byte> s) {
-    return {reinterpret_cast<const bytes::value_type*>(s.data()), s.size()};
-}
-
 lazy_comparable_bytes_from_ring_position::lazy_comparable_bytes_from_ring_position(const schema& s, dht::ring_position_view rpv)
-    : _token(rpv.token())
-    , _pk(rpv.key() ? std::optional<partition_key>(*rpv.key()) : std::optional<partition_key>())
-    // Weight <1 for maximum_token is semantically equivalent to weight 1,
-    // and `init_first_fragment` assumes that it's 1.
-    , _weight(_token.is_maximum() ? 1 : rpv.weight())
-    , _s(s)
+    : _s(s)
+    // Note about `dht::maximum_token()`: this isn't a real token.
+    // It's just a fake element greater than any real token.
+    // It is never written used during writes, but might appear as a search key during reads.
+    // So we need to encode it in a way that preserves the ordering, doesn't matter to what exactly.
+    // Here we arbitrarily encode identically to the greatest real token, with weight 1.
+    // (Weight was handled in the constructor).
+    //
+    // dht::minimum_token() also isn't a real token, but it doesn't need special handling,
+    // because its `unbias()` returns something smaller than any real token's `unbias()`.
+    , _weight(rpv.token().is_maximum() ? bound_weight::after_all_prefixed : bound_weight(rpv.weight()))
+    // If there's no key, we just eagerly translate the "key part" to the terminator byte.
+    , _pk(rpv.key()
+        ? decltype(_pk)(*rpv.key())
+        : decltype(_pk)(comparable_bytes(managed_bytes{bytes::value_type(bound_weight_to_terminator(_weight))})))
 {
-    init_first_fragment();
+    if (std::holds_alternative<comparable_bytes>(_pk)) {
+        // If we initialized `_pk` to a `comparable_bytes`, we must initialize `_size` accordingly.
+        // (operator++ expects it).
+        // This branch is only entered if there's no partition key, only a token.
+        // So the entire encoding is the nine bytes in _token_buf (leading 0x40, token), and the one terminator byte in `comparable_bytes`.
+        _size = _token_buf.size() + 1;
+    }
+    init_first_fragment(rpv.token().is_maximum() ? dht::token::last() : rpv.token());
 }
 
 lazy_comparable_bytes_from_ring_position::lazy_comparable_bytes_from_ring_position(const schema& s, dht::decorated_key dk)
-    : _token(std::move(dk._token))
+    : _s(s)
+    , _weight(bound_weight::equal)
     , _pk(std::move(dk._key))
-    , _weight(0)
-    , _s(s)
 {
-    init_first_fragment();
+    init_first_fragment(dk._token);
 }
 
-void lazy_comparable_bytes_from_ring_position::init_first_fragment() {
-    _frags.emplace_back(bytes::initialized_later(), 9);
-    auto p = _frags[0].data();
+void lazy_comparable_bytes_from_ring_position::init_first_fragment(dht::token dht_token) {
+    auto p = _token_buf.data();
     // 0x40 is the key field separator as defined by the BTI byte-comparable encoding.
     // See also https://github.com/apache/cassandra/blob/fad1f7457032544ab6a7b40c5d38ecb8b25899bb/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.md#multi-component-sequences-partition-or-clustering-keys-tuples-bounds-and-nulls
-    p[0] = 0x40;
-    auto token = _token.is_maximum() ? std::numeric_limits<uint64_t>::max() : _token.unbias();
-    seastar::write_be<uint64_t>(reinterpret_cast<char*>(&p[1]), token);
-}
-
-void lazy_comparable_bytes_from_ring_position::advance() {
-    if (_finished) {
-        return;
-    }
-    if (_pk) {
-        if (!_gen_it.has_value()) {
-            _gen.emplace(lazy_comparable_bytes_from_compound(*_s.partition_key_type(), _pk->representation()));
-            _gen_it = _gen->begin();
-        }
-        if (*_gen_it != std::default_sentinel) {
-            _frags.emplace_back(bytespan_to_bytesview(**_gen_it));
-            ++*_gen_it;
-            return;
-        }
-    }
-    std::byte terminator;
-    // 0x20, 0x38, 0x60 are terminators defined by the BTI byte-comparable encoding.
-    // See also https://github.com/apache/cassandra/blob/fad1f7457032544ab6a7b40c5d38ecb8b25899bb/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.md#multi-component-sequences-partition-or-clustering-keys-tuples-bounds-and-nulls
-    if (_weight < 0) {
-        terminator = std::byte(0x20);
-    } else if (_weight == 0) {
-        terminator = std::byte(0x38);
-    } else {
-        terminator = std::byte(0x60);
-    }
-    _frags.push_back(bytes{bytes::value_type(terminator)});
-    _finished = true;
-}
-
-auto lazy_comparable_bytes_from_ring_position::iterator::operator++() -> iterator& {
-    ++_i;
-    if (_i == _owner._frags.size()) {
-        if (_owner._finished) {
-            return *this;
-        }
-        _owner.advance();
-    }
-    _frag = std::as_writable_bytes(std::span(_owner._frags[_i]));
-    return *this;
+    *p++ = std::byte(0x40);
+    uint64_t token = dht_token.unbias();
+    seastar::write_be<uint64_t>(reinterpret_cast<char*>(p), token);
 }
 
 void lazy_comparable_bytes_from_ring_position::trim(const size_t n) {
-    size_t remaining = n;
-    for (size_t i = 0; i < _frags.size(); ++i) {
-        if (_frags[i].size() >= remaining) {
-            _frags[i].resize(remaining);
-            _frags.resize(i + 1);
-            break;
-        }
-        remaining -= _frags[i].size();
-    }
-    _finished = true;
+    SCYLLA_ASSERT(n <= _size);
+    _size = n;
 }
 
-static std::byte bound_weight_to_terminator(bound_weight b) {
+std::byte bound_weight_to_terminator(bound_weight b) {
     // 0x20, 0x38, 0x60 are terminators defined by the BTI byte-comparable encoding.
     // See also https://github.com/apache/cassandra/blob/fad1f7457032544ab6a7b40c5d38ecb8b25899bb/src/java/org/apache/cassandra/utils/bytecomparable/ByteComparable.md#multi-component-sequences-partition-or-clustering-keys-tuples-bounds-and-nulls
     switch (b) {

--- a/test/boost/bti_key_translation_test.cc
+++ b/test/boost/bti_key_translation_test.cc
@@ -15,6 +15,7 @@
 #include "test/lib/key_utils.hh"
 #include "test/lib/log.hh"
 #include "test/lib/nondeterministic_choice_stack.hh"
+#include <generator>
  
 static std::vector<std::byte> linearize(comparable_bytes_iterator auto&& it) {
     auto result = std::vector<std::byte>(); 

--- a/test/perf/CMakeLists.txt
+++ b/test/perf/CMakeLists.txt
@@ -94,3 +94,7 @@ add_perf_test(perf_row_cache_reads)
 add_perf_test(perf_generic_server)
 add_perf_test(perf_s3_client)
 add_perf_test(perf_sort_by_proximity)
+add_perf_test(perf_bti_key_translation
+  LIBRARIES
+    dht
+    sstables)

--- a/test/perf/perf_bti_key_translation.cc
+++ b/test/perf/perf_bti_key_translation.cc
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2020-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/testing/test_runner.hh>
+
+#include "schema/schema.hh"
+#include "schema/schema_builder.hh"
+#include "sstables/mx/types.hh"
+#include "sstables/trie/bti_key_translation.hh"
+
+struct lcb_mismatch_test {
+    schema_ptr _s;
+    std::vector<sstables::clustering_info> keys;
+    lcb_mismatch_test() {
+        int n_columns = 16;
+        auto builder = schema_builder("ks", "t")
+            .with_column("pk", int32_type, column_kind::partition_key);
+        for (int i = 0; i <= n_columns; ++i) {
+            builder.with_column(bytes(fmt::format("c{}", i).c_str()), int32_type, column_kind::clustering_key);
+        }
+        _s = builder.build();
+        std::vector<data_value> components;
+        for (int i = 0; i < n_columns - 1; ++i) {
+            components.push_back(data_value(int32_t(0)));
+        }
+        for (int i = 0; i < 100; ++i) {
+            components.push_back(data_value(int32_t(i)));
+            keys.push_back({
+                sstables::clustering_info{
+                    clustering_key_prefix::from_deeply_exploded(*_s, components),
+                    sstables::bound_kind_m::clustering
+                }
+            });
+            components.pop_back();
+        }
+    }
+};
+
+PERF_TEST_F(lcb_mismatch_test, lcb_mismatch) {
+    for (size_t i = 1; i < keys.size(); ++i) {
+        auto a = sstables::trie::lazy_comparable_bytes_from_clustering_position(*_s, keys[i - 1]);
+        auto b = sstables::trie::lazy_comparable_bytes_from_clustering_position(*_s, keys[i]);
+        auto [offset, ptr] = sstables::trie::lcb_mismatch(a.begin(), b.begin());
+        perf_tests::do_not_optimize(offset);
+        perf_tests::do_not_optimize(ptr);
+    }
+}
+

--- a/types/comparable_bytes.hh
+++ b/types/comparable_bytes.hh
@@ -48,6 +48,7 @@ public:
     bool empty() const { return _encoded_bytes.empty(); }
 
     managed_bytes_view as_managed_bytes_view() const { return managed_bytes_view(_encoded_bytes); }
+    managed_bytes_mutable_view as_managed_bytes_mutable_view() { return managed_bytes_mutable_view(_encoded_bytes); }
 
     auto operator<=>(const comparable_bytes& other) const {
         return compare_unsigned(managed_bytes_view(_encoded_bytes), managed_bytes_view(other._encoded_bytes));

--- a/types/comparable_bytes.hh
+++ b/types/comparable_bytes.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "keys/compound.hh"
+#include "mutation/position_in_partition.hh"
 #include "utils/managed_bytes.hh"
 
 class data_value;
@@ -76,3 +78,6 @@ struct fmt::formatter<comparable_bytes_opt> : fmt::formatter<managed_bytes_view>
         return fmt::format_to(ctx.out(), "null");
     }
 };
+
+template <allow_prefixes AllowPrefixes>
+comparable_bytes comparable_bytes_from_compound(const compound_type<AllowPrefixes>& p, managed_bytes_view representation, std::byte terminator);

--- a/utils/mutable_view.hh
+++ b/utils/mutable_view.hh
@@ -61,4 +61,8 @@ public:
         size_t n = std::min(count, (_end - _begin) - pos);
         return basic_mutable_view{_begin + pos, n};
     }
+
+    explicit operator std::span<CharT>() const noexcept {
+        return std::span<CharT>(_begin, _end);
+    }
 };


### PR DESCRIPTION
Applying lazy evaluation to the BTI encoding of clustering keys
was probably a bad default.
The possible benefits are dubious (because it's quite likely that the laziness
won't allow us to avoid that much work), but the overhead needed to
implement the laziness is large and immediate.

In this patch we get rid of the laziness.
We rewrite lazy_comparable_bytes_from_clustering_position
and lazy_comparable_bytes_from_ring_position
so that they performs the key translation eagerly,
all components to a single bytes_ostream in one synchronous call.


perf_bti_key_translation (microbenchmark added in this series, 1 iteration is 100 translations of a clustering key with 8 cells of int32_type):
```
Before:
test                            iterations      median         mad         min         max      allocs       tasks        inst      cycles
lcb_mismatch_test.lcb_mismatch        9233   109.930us     0.000ns   109.930us   109.930us    4356.000       0.000   2615394.3    614709.6

After:
test                            iterations      median         mad         min         max      allocs       tasks        inst      cycles
lcb_mismatch_test.lcb_mismatch       50952    19.487us     0.000ns    19.487us    19.487us     198.000       0.000    603120.1    109042.9
```

Enhancement, backport not required.