### PR TITLE
configure: increase SCHEDULING_GROUPS_COUNT to 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else()
     set(Seastar_EXCLUDE_APPS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_EXCLUDE_TESTS_FROM_ALL ON CACHE BOOL "" FORCE)
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
-    set(Seastar_SCHEDULING_GROUPS_COUNT 19 CACHE STRING "" FORCE)
+    set(Seastar_SCHEDULING_GROUPS_COUNT 20 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
     add_subdirectory(seastar)
     target_compile_definitions (seastar

--- a/configure.py
+++ b/configure.py
@@ -2000,7 +2000,7 @@ def configure_seastar(build_dir, mode, mode_config):
         '-DSeastar_DEPRECATED_OSTREAM_FORMATTERS=OFF',
         '-DSeastar_UNUSED_RESULT_ERROR=ON',
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
-        '-DSeastar_SCHEDULING_GROUPS_COUNT=19',
+        '-DSeastar_SCHEDULING_GROUPS_COUNT=20',
         '-DSeastar_IO_URING=ON',
     ]
 

--- a/docs/features/workload-prioritization.rst
+++ b/docs/features/workload-prioritization.rst
@@ -425,7 +425,7 @@ In order for workload prioritization to take effect, application users need to b
 
 Limits
 ======
-ScyllaDB is limited to 8 service levels, including the default one; this means you can create up to 7 service levels.
+ScyllaDB is limited to 9 service levels, including the default one; this means you can create up to 8 service levels.
 
 
 Additional References

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -433,7 +433,7 @@ async def test_service_levels_over_limit(manager: ManagerClient):
     cql = manager.get_cql()
     hosts = await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
 
-    SL_LIMIT = 7
+    SL_LIMIT = 8
     sls = []
     for i in range(SL_LIMIT + 1):
         sl = f"sl_{i}_{unique_name()}"

--- a/test/cqlpy/test_service_levels.py
+++ b/test/cqlpy/test_service_levels.py
@@ -142,10 +142,10 @@ def test_list_effective_service_level_without_attached(scylla_only, cql):
         with pytest.raises(InvalidRequest, match=f"Role {role} doesn't have assigned any service level"):
             cql.execute(f"LIST EFFECTIVE SERVICE LEVEL OF {role}")
 
-# Scylla Enterprise limits the number of service levels to a small number (8 including 1 default service level).
+# Scylla Enterprise limits the number of service levels to a small number (9 including 1 default service level).
 # This test verifies that attempting to create more service levels than that results in an InvalidRequest error
 # and doesn't silently succeed. 
-# The test also has a regression check if a user can create exactly 7 service levels.
+# The test also has a regression check if a user can create exactly 8 service levels.
 # In case you are adding a new internal scheduling group and this test failed, you should increase `SCHEDULING_GROUPS_COUNT`
 #
 # Reproduces enterprise issue #4481.
@@ -161,7 +161,7 @@ def test_scheduling_groups_limit(scylla_only, cql):
                 created_count = created_count + 1
 
     assert created_count > 0
-    assert created_count == 7 # regression check
+    assert created_count == 8 # regression check
 
 def test_default_shares_in_listings(scylla_only, cql):
     with scylla_inject_error(cql, "create_service_levels_without_default_shares", one_shot=False), \


### PR DESCRIPTION
We would like to have an additional service level
available for users of the Vector Store service,
which would allow us to de/prioritize vector
operations as needed. To allow that, we increase
the number of scheduling groups from 19 to 20
and adjust the related test accordingly.