### PR TITLE
cmake: link `vector_search` to `test-lib` instead of `cql3`

### DIFF
--- a/cql3/CMakeLists.txt
+++ b/cql3/CMakeLists.txt
@@ -137,8 +137,7 @@ target_link_libraries(cql3
     ANTLR3::antlr3
   PRIVATE
     lang
-    transport
-    vector_search)
+    transport)
 
 check_headers(check-headers cql3
   GLOB_RECURSE ${CMAKE_CURRENT_SOURCE_DIR}/*.hh)

--- a/test/lib/CMakeLists.txt
+++ b/test/lib/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(test-lib
     scylla_version
     service
     sstables
+    vector_search # used by cql3
     utils
     Boost::regex
     Boost::unit_test_framework)


### PR DESCRIPTION
PR #26237 fixed linker errors by linking `cql3` to `vector_search` but this introduced a circular dependency between these two static libraries, sometimes causing failures during compilation :

```
ninja: error: dependency cycle:
/home/user/Development/scylladb/build/debug/cql3/CqlParser.hpp ->
data_dictionary/libdata_dictionary.a ->
data_dictionary/CMakeFiles/data_dictionary.dir/data_dictionary.cc.o ->
/home/user/Development/scylladb/build/debug/cql3/CqlParser.hpp
```

So, instead of linking the `vector_search` library to the `cql3` library, link it directly to the executable where the `cql3` library is also to be linked. For the test cases, this means linking `vector_search` to the `test-lib` library. Since both `vector_search` and `cql3` are static libraries, the linker will resolve them correctly regardless of the order in which they are linked.

Refs #26235
Refs #26237

cmake fix. Backport not required.