### PR TITLE
tools: fix documentation links after change to source-available

### DIFF
--- a/release.cc
+++ b/release.cc
@@ -15,7 +15,6 @@
 
 #include <seastar/core/format.hh>
 
-static const char scylla_product_str[] = SCYLLA_PRODUCT;
 static const char scylla_version_str[] = SCYLLA_VERSION;
 static const char scylla_release_str[] = SCYLLA_RELEASE;
 static const char scylla_build_mode_str[] = SCYLLA_BUILD_MODE_STR;
@@ -31,12 +30,9 @@ std::string scylla_build_mode()
 }
 
 std::string doc_link(std::string_view url_tail) {
-    const std::string_view product = scylla_product_str;
     const std::string_view version = scylla_version_str;
 
-    const auto prefix = product == "scylla-enterprise" ? "enterprise" : "opensource";
-
-    std::string branch = product == "scylla-enterprise" ? "enterprise" : "master";
+    std::string branch = "master";
     if (!version.ends_with("~dev")) {
         std::vector<std::string> components;
         boost::split(components, version, boost::algorithm::is_any_of("."));
@@ -45,7 +41,7 @@ std::string doc_link(std::string_view url_tail) {
         branch = fmt::format("branch-{}.{}", components[0], components[1]);
     }
 
-    return fmt::format("https://{}.docs.scylladb.com/{}/{}", prefix, branch, url_tail);
+    return fmt::format("https://docs.scylladb.com/manual/{}/{}", branch, url_tail);
 }
 
 // get the version number into writeable memory, so we can grep for it if we get a core dump

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -3624,7 +3624,7 @@ const std::map<operation, operation_action>& get_operations_with_func() {
                 "backup",
                 "copy SSTables from a specified keyspace's snapshot to a designated bucket in object storage",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/backup.html")),
                 {
                     typed_option<sstring>("keyspace", "Name of a keyspace to copy SSTables from"),
@@ -3723,7 +3723,7 @@ nodetool cluster repair on one node only.
 Note that nodetool cluster repair repairs only tablet keyspaces.
 To repair vnode keyspaces use nodetool repair.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/cluster/repair.html")),
                         {
                             typed_option<std::vector<sstring>>("in-dc", "Constrain repair to specific datacenter(s)"),
@@ -3887,7 +3887,7 @@ For more information, see: {}
                 "disablebinary",
                 "Disable the CQL native protocol",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/disablebinary.html")),
             },
             {
@@ -3899,7 +3899,7 @@ For more information, see: {}"
                 "disablegossip",
                 "Disable the gossip protocol",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/disablegossip.html")),
             },
             {
@@ -3918,7 +3918,7 @@ before upgrading a node to a new version or before any maintenance action is
 performed. When you want to simply flush memtables to disk, use the nodetool
 flush command.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/drain.html")),
             },
             {
@@ -3930,7 +3930,7 @@ For more information, see: {}"
                 "enableautocompaction",
                 "Enables automatic compaction for the given keyspace and table(s)",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/enableautocompaction.html")),
                 { },
                 {
@@ -3947,7 +3947,7 @@ For more information, see: {}"
                 "enablebackup",
                 "Enables incremental backup",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/enablebackup.html")),
             },
             {
@@ -3961,7 +3961,7 @@ For more information, see: {}"
 fmt::format(R"(
 The native protocol is enabled by default.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/enablebinary.html")),
             },
             {
@@ -3975,7 +3975,7 @@ For more information, see: {}"
 fmt::format(R"(
 The gossip protocol is enabled by default.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/enablegossip.html")),
             },
             {
@@ -3991,7 +3991,7 @@ Flush memtables to on-disk SSTables in the specified keyspace and table(s).
 If no keyspace is specified, all keyspaces are flushed.
 If no table(s) are specified, all tables in the specified keyspace are flushed.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/flush.html")),
                 { },
                 {
@@ -4008,7 +4008,7 @@ For more information, see: {}"
                 "getendpoints",
                 "Print the end points that owns the key",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/getendpoints.html")),
                 { },
                 {
@@ -4038,7 +4038,7 @@ Prints a table with the name and current logging level for each logger in Scylla
                 "getsstables",
                 "Get the sstables that contain the given key",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/getsstables.html")),
                 {
                     typed_option<>("hex-format", "The key is given in hex dump format"),
@@ -4060,7 +4060,7 @@ For more information, see: {}"
 fmt::format(R"(
 This value is the probability for tracing a request. To change this value see settraceprobability.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/gettraceprobability.html")),
             },
             {
@@ -4072,7 +4072,7 @@ For more information, see: {}"
                 "gossipinfo",
                 "Shows the gossip information for the cluster",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/gossipinfo.html")),
             },
             {
@@ -4098,7 +4098,7 @@ For more information, see: {}"
                 "info",
                 "Print node information (uptime, load, ...)",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/info.html")),
                 {
                     typed_option<>("tokens,T", "Display all tokens"),
@@ -4115,7 +4115,7 @@ For more information, see: {}"
 fmt::format(R"(
 Dropped tables (column family) will not be part of the listsnapshots.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/listsnapshots.html")),
                 { },
                 { },
@@ -4145,7 +4145,7 @@ This operation is not supported.
                 "netstats",
                 "Print network information on provided host (connecting node by default)",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/netstats.html")),
                 {
                     typed_option<>("human-readable,H", "Display bytes in human readable form, i.e. KiB, MiB, GiB, TiB"),
@@ -4164,7 +4164,7 @@ fmt::format(R"(
 Provide the latency request that is recorded by the coordinator.
 This command is helpful if you encounter slow node operations.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/proxyhistograms.html")),
                 { },
                 {
@@ -4186,7 +4186,7 @@ Scylla first figures out which ranges the local node (the one we want to rebuild
 is responsible for. Then which node in the cluster contains the same ranges.
 Finally, Scylla streams the data to the local node.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/rebuild.html")),
                 {
                     typed_option<>("force", "Enforce the source_dc option, even if it unsafe to use for rebuild"),
@@ -4210,7 +4210,7 @@ Materialized Views (MV) and Secondary Indexes (SI) of the upload table, and if
 they exist, they are automatically updated. Uploading MV or SI SSTables is not
 required and will fail.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/refresh.html")),
                 {
                     typed_option<>("load-and-stream", "Allows loading sstables that do not belong to this node, in which case they are automatically streamed to the owning nodes"),
@@ -4238,7 +4238,7 @@ Provide the Host ID of the node to specify which node you want to remove.
 Important: use this command *only* on nodes that are not reachable by other nodes
 by any means!
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/removenode.html")),
                 {
                     typed_option<sstring>("ignore-dead-nodes", "Comma-separated list of dead node host IDs to ignore during removenode"),
@@ -4268,7 +4268,7 @@ all of the nodes in the cluster, or let ScyllaDB Manager do it for you.
 Note that nodetool repair repairs only vnode keyspaces. To repair tablet
 keyspaces use nodetool cluster repair.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/repair.html")),
                 {
                     typed_option<>("dc-parallel", "Repair datacenters in parallel"),
@@ -4313,7 +4313,7 @@ For more information, see: https://opensource.docs.scylladb.com/stable/operating
                 "restore",
                 "Copy SSTables from a designated bucket in object store to a specified keyspace or table",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/restore.html")),
                 {
                     typed_option<sstring>("endpoint", "ID of the configured object storage endpoint to copy SSTables from"),
@@ -4336,7 +4336,7 @@ For more information, see: {}"
                 "ring",
                 "Print information about the token ring",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/ring.html")),
                 {
                     typed_option<>("resolve-ip,r", "Show node domain names instead of IPs")
@@ -4355,7 +4355,7 @@ For more information, see: {}"
                 "scrub",
                 "Scrub the SSTable files in the specified keyspace or table(s)",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/scrub.html")),
                 {
                     typed_option<>("no-snapshot", "Do not take a snapshot of scrubbed tables before starting scrub (default false)"),
@@ -4382,7 +4382,7 @@ For more information, see: {}"
 fmt::format(R"(
 Resetting the log level of one or all loggers is not supported yet.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/setlogginglevel.html")),
                 { },
                 {
@@ -4403,7 +4403,7 @@ Value is trace probability between 0 and 1. 0 the trace will never happen and 1
 the trace will always happen. Anything in between is a percentage of the time,
 converted into a decimal. For example, 60% would be 0.6.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/settraceprobability.html")),
                 { },
                 {
@@ -4419,7 +4419,7 @@ For more information, see: {}"
                 "snapshot",
                 "Take a snapshot of specified keyspaces or a snapshot of the specified table",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/snapshot.html")),
                 {
                     typed_option<sstring>("table", "The table(s) to snapshot, multiple ones can be joined with ','"),
@@ -4440,7 +4440,7 @@ For more information, see: {}"
                 "sstableinfo",
                 "Information about sstables per keyspace/table",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/sstableinfo.html")),
                 { },
                 {
@@ -4457,7 +4457,7 @@ For more information, see: {}"
                 "status",
                 "Displays cluster information for a table in a keyspace, a single keyspace or all keyspaces",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/status.html")),
                 {
                     typed_option<>("resolve-ip,r", "Show node domain names instead of IPs"),
@@ -4480,7 +4480,7 @@ Results can be one of the following: `running` or `not running`.
 
 By default, the incremental backup status is `not running`.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/statusbackup.html")),
             },
             {
@@ -4499,7 +4499,7 @@ Results can be one of the following: `running` or `not running`.
 
 By default, the native transport is `running`.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/statusbinary.html")),
             },
             {
@@ -4516,7 +4516,7 @@ Results can be one of the following: `running` or `not running`.
 
 By default, the gossip protocol is `running`.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/statusgossip.html")),
             },
             {
@@ -4530,7 +4530,7 @@ For more information, see: {}"
 fmt::format(R"(
 This command is usually used to stop compaction that has a negative impact on the performance of a node.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/stop.html")),
                 {
                     typed_option<int>("id", "The id of the compaction operation to stop (not implemented)"),
@@ -4555,7 +4555,7 @@ since the last time you ran the nodetool cfhistograms command.
 
 Also invokable as "cfhistograms".
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/cfhistograms.html")),
                 { },
                 {
@@ -4572,7 +4572,7 @@ For more information, see: {}"
                 {"cfstats"},
                 "Print statistics on tables",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tablestats.html")),
                 {
                     typed_option<bool>("ignore,i", false, "Ignore the list of tables and display the remaining tables"),
@@ -4604,7 +4604,7 @@ fmt::format(R"(
 Aborts a task with given id. If the task is not abortable, appropriate message
 will be printed, depending on why the abort failed.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/abort.html")),
                             { },
                             {
@@ -4618,7 +4618,7 @@ fmt::format(R"(
 Unregisters all finished local tasks from the specified module. If a module is not specified,
 all modules are drained.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/drain.html")),
                             {
                                 typed_option<sstring>("module", "The module name; if specified, only the tasks from this module are unregistered"),
@@ -4632,7 +4632,7 @@ fmt::format(R"(
 Gets or sets the time in seconds for which tasks started by user will be kept in task manager after
 they are finished.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/user-ttl.html")),
                             {
                                 typed_option<uint32_t>("set", "New user_task_ttl value", -1),
@@ -4648,7 +4648,7 @@ keyspace, table, entity, shard, start_time, and end_time) of tasks in a specifie
 
 Allows to monitor tasks for extended time.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/list.html")),
                             {
                                 typed_option<>("internal", "Show internal tasks"),
@@ -4665,7 +4665,7 @@ For more information, see: {}"
                             "modules",
                             "Gets a list of modules supported by task manager",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/modules.html")),
                             { },
                             { },
@@ -4674,7 +4674,7 @@ For more information, see: {}"
                             "status",
                             "Gets a status of the task",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/status.html")),
                             { },
                             {
@@ -4688,7 +4688,7 @@ fmt::format(R"(
 Lists statuses of a specified task and all its descendants in BFS order.
 If id param isn't specified, trees of all non-internal tasks are listed.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/tree.html")),
                             { },
                             {
@@ -4702,7 +4702,7 @@ fmt::format(R"(
 Gets or sets the time in seconds for which tasks will be kept in task manager after
 they are finished.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/ttl.html")),
                             {
                                 typed_option<uint32_t>("set", "New task_ttl value", -1),
@@ -4722,7 +4722,7 @@ If quiet flag is set, nothing is printed. Instead the right exit code is returne
 - 124, if the operation timed out;
 - 125, if there was an error.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/tasks/wait.html")),
                             {
                                 typed_option<>("quiet,q", "If set, status isn't printed"),
@@ -4771,7 +4771,7 @@ For more information, see: {}"
                 "toppartitions",
                 "Sample and print the most active partitions for a given column family",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/toppartitions.html")),
                 {
                     typed_option<int>("duration,d", 5000, "Duration in milliseconds"),
@@ -4802,7 +4802,7 @@ Can also be used to upgrade all sstables to the latest sstable version.
 Note that this command is not needed for changes described above to take effect. They take effect gradually as new sstables are written and old ones are compacted.
 This command should be used when it is desired that such changes take effect right away.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/upgradesstables.html")),
                 {
                     typed_option<>("include-all-sstables,a", "Include all sstables, even those already on the current version"),
@@ -4822,7 +4822,7 @@ For more information, see: {}"
                 "viewbuildstatus",
                 "Show progress of a materialized view build",
 fmt::format(R"(
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/viewbuildstatus.html")),
                 {},
                 {
@@ -4842,7 +4842,7 @@ Displays the Apache Cassandra version which your version of Scylla is most
 compatible with, not your current Scylla version. To display the Scylla version,
 run `scylla --version`.
 
-For more information, see: {}"
+For more information, see: {}
 )", doc_link("operating-scylla/nodetool-commands/version.html")),
             },
             {

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -36,6 +36,7 @@
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/open_info.hh"
+#include "release.hh"
 #include "replica/schema_describe_helper.hh"
 #include "test/lib/cql_test_env.hh"
 #include "tools/json_writer.hh"
@@ -2106,7 +2107,7 @@ const std::map<operation, operation_func> operations_with_func{
 /* dump-data */
     {{"dump-data",
             "Dump content of sstable(s)",
-R"(
+fmt::format(R"(
 Dump the content of the data component. This component contains the data-proper
 of the sstable. This might produce a huge amount of output. In general the
 human-readable output will be larger than the binary file.
@@ -2118,9 +2119,8 @@ format.
 Supports both a text and JSON output. The text output uses the built-in scylla
 printers, which are also used when logging mutation-related data structures.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-data
-for more information on this operation, including the schema of the JSON output.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-data")),
             {
                     typed_option<std::vector<sstring>>("partition", "partition(s) to filter for, partitions are expected to be in the hex format"),
                     typed_option<sstring>("partitions-file", "file containing partition(s) to filter for, partitions are expected to be in the hex format"),
@@ -2132,7 +2132,7 @@ for more information on this operation, including the schema of the JSON output.
 /* dump-index */
     {{"dump-index",
             "Dump content of sstable index(es)",
-R"(
+fmt::format(R"(
 Dump the content of the index component. Contains the partition-index of the data
 component. This is effectively a list of all the partitions in the sstable, with
 their starting position in the data component and optionally a promoted index,
@@ -2140,80 +2140,73 @@ which contains a sampled index of the clustering rows in the partition.
 Positions (both that of partition and that of rows) is valid for uncompressed
 data.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-index
-for more information on this operation, including the schema of the JSON output.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-index"))},
             dump_index_operation},
 /* dump-compression-info */
     {{"dump-compression-info",
             "Dump content of sstable compression info(s)",
-R"(
+fmt::format(R"(
 Dump the content of the compression-info component. Contains compression
 parameters and maps positions into the uncompressed data to that into compressed
 data. Note that compression happens over chunks with configurable size, so to
 get data at a position in the middle of a compressed chunk, the entire chunk has
 to be decompressed.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-compression-info
-for more information on this operation, including the schema of the JSON output.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-compression-info"))},
             dump_compression_info_operation},
 /* dump-summary */
     {{"dump-summary",
             "Dump content of sstable summary(es)",
-R"(
+fmt::format(R"(
 Dump the content of the summary component. The summary is a sampled index of the
 content of the index-component. An index of the index. Sampling rate is chosen
 such that this file is small enough to be kept in memory even for very large
 sstables.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-summary
-for more information on this operation, including the schema of the JSON output.
-
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-summary"))},
             dump_summary_operation},
 /* dump-statistics */
     {{"dump-statistics",
             "Dump content of sstable statistics(s)",
-R"(
+fmt::format(R"(
 Dump the content of the statistics component. Contains various metadata about the
 data component. In the sstable 3 format, this component is critical for parsing
 the data component.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-statistics
-for more information on this operation, including the schema of the JSON output.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-statistics"))},
             dump_statistics_operation},
 /* dump-scylla-metadata */
     {{"dump-scylla-metadata",
             "Dump content of sstable scylla metadata(s)",
-R"(
+fmt::format(R"(
 Dump the content of the scylla-metadata component. Contains scylla-specific
 metadata about the data component. This component won't be present in sstables
 produced by Apache Cassandra.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#dump-scylla-metadata
-for more information on this operation, including the schema of the JSON output.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#dump-scylla-metadata"))},
             dump_scylla_metadata_operation},
 /* validate */
     {{"validate",
             "Validate the sstable(s), same as scrub in validate mode",
-R"(
+fmt::format(R"(
 Validates the content of the sstable on the mutation-fragment level, see
 https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#sstable-content
 for more details.
 Any parsing errors will also be detected, but after successful parsing the
 validation will happen on the fragment level.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#validate
-for more information on this operation.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#validate"))},
             validate_operation},
 /* scrub */
     {{"scrub",
             "Scrub the sstable(s), in the specified mode",
-R"(
+fmt::format(R"(
 Read and re-write the sstable, getting rid of or fixing broken parts, depending
 on the selected mode.
 Output sstables are written to the directory specified via `--output-directory`.
@@ -2226,9 +2219,8 @@ abort the scrub. This can be overridden by the
 be aborted if an sstable cannot be written because its generation clashes with
 pre-existing sstables in the directory.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#scrub
-for more information on this operation, including what the different modes do.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#scrub")),
             {
                     typed_option<std::string>("scrub-mode", "scrub mode to use, one of (abort, skip, segregate, validate)"),
                     typed_option<std::string>("output-dir", ".", "directory to place the scrubbed sstables to"),
@@ -2238,12 +2230,11 @@ for more information on this operation, including what the different modes do.
 /* validate-checksums */
     {{"validate-checksums",
             "Validate the checksums of the sstable(s)",
-R"(
+fmt::format(R"(
 Validate both the whole-file and the per-chunk checksums of the data component.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#validate-checksums
-for more information on this operation.
-)"},
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#validate-checksums"))},
             validate_checksums_operation},
 /* decompress */
     {{"decompress",
@@ -2262,7 +2253,7 @@ the output will be:
 /* write */
     {{"write",
             "Write an sstable",
-R"(
+fmt::format(R"(
 Write an sstable based on a JSON representation of the content. The JSON
 representation has to have the same schema as that of a single sstable
 from the output of the dump-data operation (corresponding to the $SSTABLE
@@ -2282,9 +2273,8 @@ format and random UUID generation (printed to stdout). By default it is
 placed in the local directory, can be changed with --output-dir. If the
 output sstable clashes with an existing sstable, the write will fail.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#write
-for more information on this operation, including the schema of the JSON input.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#write")),
             {
                     typed_option<std::string>("input-file", "the file containing the input"),
                     typed_option<std::string>("output-dir", ".", "directory to place the output sstable(s) to"),
@@ -2294,13 +2284,12 @@ for more information on this operation, including the schema of the JSON input.
 /* script */
     {{"script",
             "Run a script on content of an sstable",
-R"(
+fmt::format(R"(
 Read the sstable(s) and pass the resulting fragment stream to the script
 specified by `--script-file`. Currently only Lua scripts are supported.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#script
-for more information on this operation, including the API documentation.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#script")),
             {
                 typed_option<>("merge", "merge all sstables into a single mutation fragment stream (use a combining reader over all sstable readers)"),
                 typed_option<std::string>("script-file", "script file to load and execute"),
@@ -2321,7 +2310,7 @@ for more information on this operation, including the API documentation.
 /* query */
     {{"query",
             "Run a query on the content of the sstable(s)",
-R"(
+fmt::format(R"(
 The query is run on the combined content of all input sstables.
 
 By default, the following query is run: SELECT * FROM $table.
@@ -2345,9 +2334,8 @@ cql_test_env. This temporary directory will have a size of a couple of megabytes
 By default it will create this in /tmp, this can be changed with the `TEMPDIR`
 environment variable. This temporary directory is removed on exit.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#query
-for more information on this operation, including usage examples.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#query")),
             {
                 typed_option<std::string>("query,q", "execute the query provided on the command-line"),
                 typed_option<std::string>("query-file", "execute the query from the file, the file is expected to contain a single query"),
@@ -2357,7 +2345,7 @@ for more information on this operation, including usage examples.
 /* upgrade */
     {{"upgrade",
             "Upgrade sstable(s) to the highest supported version and apply the latest schema",
-R"(
+fmt::format(R"(
 This command is an offline version of nodetool upgradesstables.
 Applies the latest sstable version and the latest schema to the sstables.
 
@@ -2374,9 +2362,8 @@ versions which are supported for writing: mc, md and me.
 
 Mapping of input sstables to output sstables is printed to stdout.
 
-See https://docs.scylladb.com/operating-scylla/admin-tools/scylla-sstable#upgrade
-for more information on this operation, including usage examples.
-)",
+For more information, see: {}
+)", doc_link("operating-scylla/admin-tools/scylla-sstable#upgrade")),
             {
                 typed_option<std::string>("output-dir", ".", "directory to place the output sstable(s) to"),
                 typed_option<std::string>("sstable-version", fmt::to_string(sstables::get_highest_sstable_version()), "sstable version to use, defaults to the latest supported version"),


### PR DESCRIPTION
Some tools commands have links to online documentation in their help output. These links were left behind in the source-available change, they still point to the old opensource docs. Furthermore, the links in the scylla-sstable help output always point to the latest stable release's documentation, instead of the appropriate one for the branch the tool was built from. Fix both of these.

Fixes: scylladb/scylladb#26320

Broken documentation link fix for the  tool help output, needs backport to all live source-available versions.