### PR TITLE
scylla-gdb.py: small-objects: don't cass free_object to void*

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5075,7 +5075,6 @@ class scylla_small_objects(gdb.Command):
             self._resolve_symbols = resolve_symbols
 
             self._text_ranges = get_text_ranges()
-            self._free_object_ptr = gdb.lookup_type('void').pointer().pointer()
             self._page_size = int(gdb.parse_and_eval('\'seastar::memory::page_size\''))
             self._free_in_pool = set()
             self._free_in_span = set()
@@ -5084,7 +5083,7 @@ class scylla_small_objects(gdb.Command):
               pool_next_free = small_pool['_free']
               while pool_next_free:
                 self._free_in_pool.add(int(pool_next_free))
-                pool_next_free = pool_next_free.reinterpret_cast(self._free_object_ptr).dereference()
+                pool_next_free = pool_next_free['next']
 
             self._span_it = iter(spans())
             self._obj_it = iter([]) # initialize to exhausted iterator
@@ -5104,7 +5103,7 @@ class scylla_small_objects(gdb.Command):
             span_next_free = span.page['freelist']
             while span_next_free:
                 self._free_in_span.add(int(span_next_free))
-                span_next_free = span_next_free.reinterpret_cast(self._free_object_ptr).dereference()
+                span_next_free = span_next_free['next']
 
             return span_start, span_end
 


### PR DESCRIPTION
When walking the free-list of a pool or a span, the small-object code casts the dereferenced `free_object*` to `void*`. This is unnecessary, just use the `next` field of the `free_object` to look up the next free object. I think this monkey business with `void*` was done to speed up walking the free-list, but recently we've seen small-object --summarize fail in CI, and it could be related.

Fixes: #25733

scylla-gdb.py improvement, no backport required