### PR TITLE
test/cqlpy: comment out Cassandra check that is no longer relevant

### DIFF
--- a/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/alter_test.py
@@ -163,11 +163,13 @@ def testAlterIndexInterval(cql, test_keyspace):
         assert options['max_index_interval'] == 512
 
 # Migrated from cql_tests.py:TestCQL.create_alter_options_test()
-# Reproduces #9929
+# Reproduces #9935
 @pytest.mark.xfail(reason="Issue #9935")
 def testCreateAlterKeyspaces(cql, test_keyspace, this_dc):
-    assert_invalid_throw(cql, test_keyspace, SyntaxException, "CREATE KEYSPACE ks1")
-    assert_invalid_throw(cql, test_keyspace, ConfigurationException, "CREATE KEYSPACE ks1 WITH replication= { 'replication_factor' : 1 }")
+    # ScyllaDB allows default parameters on CREATE KEYSPACE, so these checks
+    # are no longer valid:
+    #assert_invalid_throw(cql, test_keyspace, SyntaxException, "CREATE KEYSPACE ks1")
+    #assert_invalid_throw(cql, test_keyspace, ConfigurationException, "CREATE KEYSPACE ks1 WITH replication= { 'replication_factor' : 1 }")
 
     with create_keyspace(cql, "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 }") as ks1:
         with create_keyspace(cql, "replication={ 'class' : 'SimpleStrategy', 'replication_factor' : 1 } AND durable_writes=false") as ks2:


### PR DESCRIPTION
In the test translated from Cassandra validation/operations/alter_test.py we had two lines in the beginning of an unrelated test that verified that CREATE KEYSPACE is not allowed without replication parameters. But starting recently, ScyllaDB does have defaults and does allow these CREATE KEYSPACE. So comment out these two test lines.

We didn't notice that this test started to fail, because it was already marked xfail, because in the main part of this test, it reproduces a different issue!

The annoying side-affect of these no-longer-passing checks was that because the test expected a CREATE KEYSPACE to fail, it didn't bother to delete this keyspace when it finished, which causes test.py to report that there's a problem because some keyspaces still exist at the end of the test.

Fixes #26292 

No need to backport, test cleanup only.