### PR TITLE
mv: limit concurrency of view updates generated from staging sstables

### DIFF
--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -452,7 +452,8 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         mutation_reader_opt existings,
         tracing::trace_state_ptr tr_state,
         gc_clock::time_point now,
-        db::timeout_clock::time_point timeout) {
+        db::timeout_clock::time_point timeout,
+        wait_for_all_updates synchronous) {
     auto base_token = m.token();
     auto m_schema = m.schema();
     view_update_builder builder = make_view_update_builder(
@@ -512,7 +513,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
 
         try {
             co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
-                std::move(memory_units), service::allow_hints::yes, wait_for_all_updates::no);
+                std::move(memory_units), service::allow_hints::yes, synchronous);
         } catch (...) {
             // Ignore exceptions: any individual failure to propagate a view update will be reported
             // by a separate mechanism in mutate_MV() function. Moreover, we should continue trying

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -457,7 +457,8 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
         mutation_reader_opt existings,
         tracing::trace_state_ptr tr_state,
         gc_clock::time_point now,
-        db::timeout_clock::time_point timeout) {
+        db::timeout_clock::time_point timeout,
+        wait_for_all_updates synchronous) {
     auto base_token = m.token();
     auto m_schema = m.schema();
     view_update_builder builder = make_view_update_builder(
@@ -517,7 +518,7 @@ future<> view_update_generator::generate_and_propagate_view_updates(const replic
 
         try {
             co_await mutate_MV(base, base_token, std::move(*updates), table.view_stats(), *table.cf_stats(), tr_state,
-                std::move(memory_units), service::allow_hints::yes, wait_for_all_updates::no);
+                std::move(memory_units), service::allow_hints::yes, synchronous);
         } catch (...) {
             // Ignore exceptions: any individual failure to propagate a view update will be reported
             // by a separate mechanism in mutate_MV() function. Moreover, we should continue trying

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -121,7 +121,8 @@ public:
             mutation_reader_opt existings,
             tracing::trace_state_ptr tr_state,
             gc_clock::time_point now,
-            db::timeout_clock::time_point timeout);
+            db::timeout_clock::time_point timeout,
+            wait_for_all_updates synchronous);
 
 private:
     bool should_throttle() const;

--- a/db/view/view_update_generator.hh
+++ b/db/view/view_update_generator.hh
@@ -123,7 +123,8 @@ public:
             mutation_reader_opt existings,
             tracing::trace_state_ptr tr_state,
             gc_clock::time_point now,
-            db::timeout_clock::time_point timeout);
+            db::timeout_clock::time_point timeout,
+            wait_for_all_updates synchronous);
 
 private:
     bool should_throttle() const;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -153,6 +153,8 @@ class system_keyspace;
 
 namespace view {
 class view_update_generator;
+struct wait_for_all_updates_tag;
+using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 }
 
 }
@@ -1282,7 +1284,7 @@ public:
 
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
-            tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts) const;
+            tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts, db::view::wait_for_all_updates synchronous) const;
     std::vector<view_ptr> affected_views(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base, const mutation& update) const;
 
     mutable row_locker _row_locker;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -157,6 +157,8 @@ class system_keyspace;
 
 namespace view {
 class view_update_generator;
+struct wait_for_all_updates_tag;
+using wait_for_all_updates = bool_class<wait_for_all_updates_tag>;
 }
 
 }
@@ -1338,7 +1340,7 @@ public:
 
 private:
     future<row_locker::lock_holder> do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
-            tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts) const;
+            tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts, db::view::wait_for_all_updates synchronous) const;
     std::vector<view_ptr> affected_views(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& base, const mutation& update) const;
 
     mutable row_locker _row_locker;

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5335,7 +5335,7 @@ future<row_locker::lock_holder> table::push_view_replica_updates(shared_ptr<db::
 }
 
 future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, schema_ptr s, mutation m, db::timeout_clock::time_point timeout, mutation_source source,
-        tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts) const {
+        tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem, query::partition_slice::option_set custom_opts, db::view::wait_for_all_updates synchronous) const {
     schema_ptr base = schema();
     m.upgrade(base);
     gc_clock::time_point now = gc_clock::now();
@@ -5357,7 +5357,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     const bool need_static = db::view::needs_static_row(m.partition(), views);
     if (!need_regular && !need_static) {
         tracing::trace(tr_state, "View updates do not require read-before-write");
-        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-no-read-before-write", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout);
+        co_await gen->generate_and_propagate_view_updates(*this, base, sem.make_tracking_only_permit(s, "push-view-updates-no-read-before-write", timeout, tr_state), std::move(views), std::move(m), { }, tr_state, now, timeout, synchronous);
         // In this case we are not doing a read-before-write, just a
         // write, so no lock is needed.
         co_return row_locker::lock_holder();
@@ -5391,7 +5391,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
     auto pk = dht::partition_range::make_singular(m.decorated_key());
     auto permit = co_await sem.obtain_permit(base, "push-view-updates-read-before-write", estimate_read_memory_cost(), timeout, tr_state);
     auto reader = source.make_mutation_reader(base, permit, pk, slice, tr_state, streamed_mutation::forwarding::no, mutation_reader::forwarding::no);
-    co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout);
+    co_await gen->generate_and_propagate_view_updates(*this, base, std::move(permit), std::move(views), std::move(m), std::move(reader), tr_state, now, timeout, synchronous);
     tracing::trace(tr_state, "View updates for {}.{} were generated and propagated", base->ks_name(), base->cf_name());
     // return the local partition/row lock we have taken so it
     // remains locked until the caller is done modifying this
@@ -5403,7 +5403,7 @@ future<row_locker::lock_holder> table::do_push_view_replica_updates(shared_ptr<d
 future<row_locker::lock_holder> table::push_view_replica_updates(shared_ptr<db::view::view_update_generator> gen, const schema_ptr& s, mutation&& m, db::timeout_clock::time_point timeout,
         tracing::trace_state_ptr tr_state, reader_concurrency_semaphore& sem) const {
     return do_push_view_replica_updates(std::move(gen), s, std::move(m), timeout, as_mutation_source(),
-            std::move(tr_state), sem, {});
+            std::move(tr_state), sem, {}, db::view::wait_for_all_updates::no);
 }
 
 future<row_locker::lock_holder>
@@ -5417,7 +5417,8 @@ table::stream_view_replica_updates(shared_ptr<db::view::view_update_generator> g
             as_mutation_source_excluding_staging(),
             tracing::trace_state_ptr(),
             *_config.streaming_read_concurrency_semaphore,
-            query::partition_slice::option_set::of<query::partition_slice::option::bypass_cache>());
+            query::partition_slice::option_set::of<query::partition_slice::option::bypass_cache>(),
+            db::view::wait_for_all_updates::yes);
 }
 
 mutation_source

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -11,8 +11,9 @@ import asyncio
 import pytest
 from test.pylib.util import wait_for_view, wait_for
 from test.cluster.mv.tablets.test_mv_tablets import pin_the_only_tablet
-from test.pylib.tablets import get_tablet_replica
+from test.pylib.tablets import get_tablet_replica, get_tablet_replicas
 from test.cluster.util import new_test_keyspace
+from test.cluster.test_view_building_coordinator import delete_table_sstables
 
 logger = logging.getLogger(__name__)
 
@@ -185,3 +186,96 @@ async def test_configurable_mv_control_flow_delay(manager: ManagerClient) -> Non
         # Additionally, check that the delay is zero for a zero value
         # of the view_flow_control_delay_limit_in_ms parameter
         assert computed_delays[0] == 0.0
+
+# This test verifies that view update backlog doesn't grow unbounded
+# when generating view updates from staging sstables.
+# The test creates staging sstables by deleting normal sstables and repairing,
+# then checks that view updates are processed with limited concurrency, by checking
+# the view update backlog metric.
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
+async def test_view_backlog_bounded_during_staging_sstable_processing(manager: ManagerClient) -> None:
+    # Use 3 nodes: 1 in rack1 (source for repair) and 2 in rack2 (base and view tablets)
+    # With RF=2, this ensures we have a replica to repair from after deleting sstables
+    servers = [
+        await manager.server_add(config={'tablets_mode_for_new_keyspaces': 'enabled'}, property_file={'dc': 'dc1', 'rack': 'rack1'}),
+        await manager.server_add(config={'tablets_mode_for_new_keyspaces': 'enabled'}, property_file={'dc': 'dc1', 'rack': 'rack2'}),
+        await manager.server_add(config={'tablets_mode_for_new_keyspaces': 'enabled'}, property_file={'dc': 'dc1', 'rack': 'rack2'}),
+    ]
+
+    # Disable automatic tablet load balancing since we're setting the layout manually
+    await asyncio.gather(*(manager.api.disable_tablet_balancing(s.ip_addr) for s in servers))
+
+    cql = manager.get_cql()
+    # Use RF=2 so that after deleting sstables on one node, repair can restore data from the other replica
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view AS SELECT * FROM {ks}.tab "
+                        "WHERE c IS NOT NULL and key IS NOT NULL PRIMARY KEY (c, key) ")
+
+        await wait_for_view(cql, 'mv_cf_view', len(servers))
+
+        # Move base table tablet to servers[1] (rack2) and view tablet to servers[2] (rack2)
+        # This ensures remote updates between the two nodes in rack2
+        host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+        base_replicas = await get_tablet_replicas(manager, servers[0], ks, "tab", 0)
+        view_replicas = await get_tablet_replicas(manager, servers[0], ks, "mv_cf_view", 0)
+
+        for base_host_id, base_shard in base_replicas:
+            if base_host_id == host_ids[2]:
+                await manager.api.move_tablet(servers[0].ip_addr, ks, "tab", base_host_id, base_shard, host_ids[1], 0, 0)
+                break
+
+        for view_host_id, view_shard in view_replicas:
+            if view_host_id == host_ids[1]:
+                await manager.api.move_tablet(servers[0].ip_addr, ks, "mv_cf_view", view_host_id, view_shard, host_ids[2], 0, 0)
+                break
+
+        await manager.api.enable_injection(servers[1].ip_addr, "never_finish_remote_view_updates", one_shot=False)
+
+        # First, measure the overhead per row by checking backlog with exactly one view update
+        # Then use all rows of that size
+        row_value = 'a' * 100
+        await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES (0, 0, '{row_value}')")
+
+        # Wait until the backlog is non-zero (view update generated)
+        async def backlog_nonzero():
+            local_metrics = await manager.metrics.query(servers[1].ip_addr)
+            backlog = local_metrics.get('scylla_storage_proxy_replica_view_update_backlog')
+            return backlog or None
+
+        backlog_per_row = await wait_for(backlog_nonzero, deadline=time.time() + 10.0)
+        logger.info(f"Backlog per row (overhead): {backlog_per_row}")
+
+        await manager.api.disable_injection(servers[1].ip_addr, "never_finish_remote_view_updates")
+
+        # Populate the base table with enough data to exceed concurrency limit
+        # The concurrency limit is 128, so 200 rows should be sufficient
+        rows = 200
+        for i in range(rows):
+            await cql.run_async(f"INSERT INTO {ks}.tab (key, c, v) VALUES ({i}, {i}, '{row_value}')")
+
+        # Flush to create sstables on all replicas
+        await asyncio.gather(*(manager.api.keyspace_flush(s.ip_addr, ks) for s in servers))
+
+        # Prepare servers[1] for accepting staging sstables
+        await delete_table_sstables(manager, servers[1], ks, "tab")
+        await manager.server_stop_gracefully(servers[1].server_id)
+        await manager.server_start(servers[1].server_id)
+
+        log_file = await manager.server_open_log(servers[1].server_id)
+
+        await manager.api.enable_injection(servers[1].ip_addr, "never_finish_remote_view_updates", one_shot=False)
+        await manager.api.repair(servers[1].ip_addr, ks, "tab")
+
+        await log_file.wait_for(f"view_update_generator - Processing {ks}.tab", timeout=60)
+
+        # Check that view update backlog is bounded (not growing unbounded)
+        # The backlog should respect the concurrency limit of 128
+        local_metrics = await manager.metrics.query(servers[1].ip_addr)
+        view_backlog = local_metrics.get('scylla_storage_proxy_replica_view_update_backlog')
+
+        # With concurrency limit of 128, the backlog should be approximately 128 * backlog_per_row
+        assert view_backlog <= backlog_per_row * 128, f"View backlog {view_backlog} exceeds expected limit {backlog_per_row * 128}"
+
+        await manager.api.disable_injection(servers[1].ip_addr, "never_finish_remote_view_updates")


### PR DESCRIPTION
When we generate view updates from staging sstables, we reuse the common path for generating view updates from writes. On this path, we generate remote view updates asynchronously, without waiting for them. These view updates contribute to the increase in the view update backlog. However, when generating updates from staging sstables the view update backlog is not taken into account for controlling the rate of generated updates. Because of this, if we start processing a staging sstable while the write workload is already saturating our capacity for view updates, we'll get overloaded and start failing writes.
To avoid this scenario, in this patch we limit the concurrency of view updates generated from staging sstables. We do that the same way as during view building - by using synchronous view updates. By using synchronous view updates, at any point we have at most as much view updates as how many are generated in a batch (128).

The concurrency of view updates is confirmed by the added test.

Fixes: https://github.com/scylladb/scylladb/issues/21535
Fixes: https://github.com/scylladb/scylladb/issues/26407