### PR TITLE
test: wait for cql in test_two_tablets_concurrent_repair_and_migratio…

### DIFF
--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1190,6 +1190,8 @@ async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(m
 
     cql = await safe_rolling_restart(manager, [servers[0]], with_down=insert_with_down)
 
+    await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 30)
+
     all_replicas = await get_all_tablet_replicas(manager, servers[1], ks, "test")
     migration_replicas = all_replicas[0]
 


### PR DESCRIPTION
…n_repair_writer_level

In test_two_tablets_concurrent_repair_and_migration_repair_writer_level safe_rolling_restart returns ready cql. However, get_all_tablet_replicas uses the cql reference from manager that isn't ready. Wait for cql.

Fixes: #26328

The test was modified in a recent change, bug was fixed in backports of that change. Needs backport to 2025.4.