### PR TITLE
test/cluster/test_view_building_coordinator: skip reproducer instead of xfail

### DIFF
--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -770,7 +770,7 @@ async def test_file_streaming(manager: ManagerClient):
 #   because last token after tablet merge = last token of tablet2 before merge
 @pytest.mark.asyncio
 @skip_mode('release', 'error injections are not supported in release mode')
-@pytest.mark.xfail(reason="#26244")
+@pytest.mark.skip(reason="#26244")
 async def test_staging_sstables_with_tablet_merge(manager: ManagerClient):
     node_count = 2
     servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[


### PR DESCRIPTION
The reproducer for issue scylladb/scylladb#26244 takes some time and since the test is failing, there is no point in wasting resources on it.
We can change the xfail mark to skip.

Refs scylladb/scylladb#26244

The reproducer was merged before branching 2025.4, so we should backport this to improve CI.