### PR TITLE
topology coordinator: restrict node join/remove to preserve RF-rack v…

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -1254,6 +1254,59 @@ const effective_replication_map_ptr& token_metadata_guard::get_erm() const {
 }
 
 void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars) {
+    assert_rf_rack_valid_keyspace(ks, tmptr, ars,
+        tmptr->get_topology().get_datacenter_racks(),
+        [&tmptr] (host_id host) {
+            return tmptr->is_normal_token_owner(host);
+        }
+    );
+}
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars, locator::node_added new_node) {
+    auto dc_rack_map = tmptr->get_topology().get_datacenter_racks();
+
+    if (dc_rack_map.contains(new_node.dc)) {
+        // include the new node only if it's added to an existing DC. ?
+        dc_rack_map[new_node.dc][new_node.rack].insert(new_node.id);
+        tablet_logger.debug("[assert_rf_rack_valid_keyspace]: Including new node {} in DC '{}' and rack '{}'", new_node.id, new_node.dc, new_node.rack);
+    }
+
+    assert_rf_rack_valid_keyspace(ks, tmptr, ars,
+        dc_rack_map,
+        [&tmptr, new_node] (host_id host) {
+            if (host == new_node.id) {
+                return true;
+            }
+            return tmptr->is_normal_token_owner(host);
+        }
+    );
+}
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars, locator::node_removed removed_node) {
+    auto dc_rack_map = tmptr->get_topology().get_datacenter_racks();
+    // remove the node from the map, if it exists
+    if (dc_rack_map.contains(removed_node.dc) && dc_rack_map[removed_node.dc].contains(removed_node.rack)) {
+        dc_rack_map[removed_node.dc][removed_node.rack].erase(removed_node.id);
+        if (dc_rack_map[removed_node.dc][removed_node.rack].empty()) {
+            dc_rack_map[removed_node.dc].erase(removed_node.rack);
+            if (dc_rack_map[removed_node.dc].empty()) {
+                dc_rack_map.erase(removed_node.dc);
+            }
+        }
+    }
+    tablet_logger.debug("[assert_rf_rack_valid_keyspace]: Excluding removed node {} from DC '{}' and rack '{}'", removed_node.id, removed_node.dc, removed_node.rack);
+
+    assert_rf_rack_valid_keyspace(ks, tmptr, ars,
+        dc_rack_map,
+        [&tmptr] (host_id host) {
+            return tmptr->is_normal_token_owner(host);
+        }
+    );
+}
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars,
+    const std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<host_id>>>& dc_rack_map,
+    std::function<bool(host_id)> is_normal_token_owner) {
     tablet_logger.debug("[assert_rf_rack_valid_keyspace]: Starting verifying that keyspace '{}' is RF-rack-valid", ks);
 
     // Any keyspace that does NOT use tablets is RF-rack-valid.
@@ -1265,8 +1318,6 @@ void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr
     // Tablets can only be used with NetworkTopologyStrategy.
     SCYLLA_ASSERT(ars.get_type() == replication_strategy_type::network_topology);
     const auto& nts = *static_cast<const network_topology_strategy*>(std::addressof(ars));
-
-    const auto& dc_rack_map = tmptr->get_topology().get_datacenter_racks();
 
     for (const auto& dc : nts.get_datacenters()) {
         if (!dc_rack_map.contains(dc)) {
@@ -1283,8 +1334,8 @@ void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr
         for (const auto& [_, rack_nodes] : rack_map) {
             // We must ignore zero-token nodes because they don't take part in replication.
             // Verify that this rack has at least one normal node.
-            const bool normal_rack = std::ranges::any_of(rack_nodes, [tmptr] (host_id host_id) {
-                return tmptr->is_normal_token_owner(host_id);
+            const bool normal_rack = std::ranges::any_of(rack_nodes, [tmptr, is_normal_token_owner] (host_id host_id) {
+                return is_normal_token_owner(host_id);
             });
             if (normal_rack) {
                 ++normal_rack_count;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -812,6 +812,26 @@ class abstract_replication_strategy;
 /// * The keyspace need not exist. We use its name purely for informational reasons (in error messages).
 void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr, const abstract_replication_strategy&);
 
+struct node_added {
+    host_id id;
+    sstring dc;
+    sstring rack;
+};
+
+struct node_removed {
+    host_id id;
+    sstring dc;
+    sstring rack;
+};
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars, node_added);
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars, node_removed);
+
+void assert_rf_rack_valid_keyspace(std::string_view ks, const token_metadata_ptr tmptr, const abstract_replication_strategy& ars,
+    const std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<host_id>>>& dc_rack_map,
+    std::function<bool(host_id)> is_normal_token_owner);
+
 }
 
 template <>

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3483,6 +3483,70 @@ void database::check_rf_rack_validity(const bool enforce_rf_rack_valid_keyspaces
     }
 }
 
+bool database::validate_joining_node_rf_rack(locator::token_metadata_ptr tmptr, locator::host_id new_node, sstring_view datacenter, sstring_view rack) const {
+    const auto& keyspaces = get_keyspaces();
+    std::vector<std::string_view> invalid_keyspaces{};
+    bool enforce = _cfg.rf_rack_valid_keyspaces();
+
+    for (const auto& [name, info] : keyspaces) {
+        try {
+            locator::assert_rf_rack_valid_keyspace(name, tmptr, info.get_replication_strategy(),
+                    locator::node_added{new_node, sstring(datacenter), sstring(rack)});
+        } catch (...) {
+            if (enforce) {
+                return false;
+            }
+            invalid_keyspaces.push_back(std::string_view(name));
+        }
+    }
+
+    if (invalid_keyspaces.size() != 0) {
+        const auto ks_list = invalid_keyspaces
+                | std::views::join_with(std::string_view(", "))
+                | std::ranges::to<std::string>();
+
+        dblog.warn("The joining node {} with DC='{}' and rack='{}' makes some existing keyspaces not RF-rack-valid, i.e. the replication factor "
+                "does not match the number of racks in one of the datacenters. That may reduce "
+                "availability in case of a failure (cf. "
+                "https://docs.scylladb.com/manual/stable/reference/glossary.html#term-RF-rack-valid-keyspace). "
+                "Those keyspaces are: {}", new_node, datacenter, rack, ks_list);
+    }
+
+    return true;
+}
+
+bool database::validate_removing_node_rf_rack(locator::token_metadata_ptr tmptr, locator::host_id removed_node, sstring_view datacenter, sstring_view rack) const {
+    const auto& keyspaces = get_keyspaces();
+    std::vector<std::string_view> invalid_keyspaces{};
+    bool enforce = _cfg.rf_rack_valid_keyspaces();
+
+    for (const auto& [name, info] : keyspaces) {
+        try {
+            locator::assert_rf_rack_valid_keyspace(name, tmptr, info.get_replication_strategy(),
+                    locator::node_removed{removed_node, sstring(datacenter), sstring(rack)});
+        } catch (...) {
+            if (enforce) {
+                return false;
+            }
+            invalid_keyspaces.push_back(std::string_view(name));
+        }
+    }
+
+    if (invalid_keyspaces.size() != 0) {
+        const auto ks_list = invalid_keyspaces
+                | std::views::join_with(std::string_view(", "))
+                | std::ranges::to<std::string>();
+
+        dblog.warn("The removed node {} with DC='{}' and rack='{}' makes some existing keyspaces not RF-rack-valid, i.e. the replication factor "
+                "does not match the number of racks in one of the datacenters. That may reduce "
+                "availability in case of a failure (cf. "
+                "https://docs.scylladb.com/manual/stable/reference/glossary.html#term-RF-rack-valid-keyspace). "
+                "Those keyspaces are: {}", removed_node, datacenter, rack, ks_list);
+    }
+
+    return true;
+}
+
 utils::chunked_vector<uint64_t> compute_random_sorted_ints(uint64_t max_value, uint64_t n_values) {
     static thread_local std::minstd_rand rng{std::random_device{}()};
     std::uniform_int_distribution<uint64_t> dist(0, max_value);

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -2091,6 +2091,9 @@ public:
     // * the `locator::topology` instance corresponding to the passed `locator::token_metadata_ptr`
     //   must contain a complete list of racks and data centers in the cluster.
     void check_rf_rack_validity(const bool enforce_rf_rack_valid_keyspaces, const locator::token_metadata_ptr) const;
+
+    bool validate_joining_node_rf_rack(locator::token_metadata_ptr, locator::host_id new_node, sstring_view datacenter, sstring_view rack) const;
+    bool validate_removing_node_rf_rack(locator::token_metadata_ptr, locator::host_id removed_node, sstring_view datacenter, sstring_view rack) const;
 private:
     // SSTable sampling might require considerable amounts of memory,
     // so we want to limit the number of concurrent sampling operations.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2885,8 +2885,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         co_await update_topology_state(std::move(node.guard), {builder.build(), rtbuilder.build()}, reason);
                         break;
                         }
-                    case topology_request::leave:
+                    case topology_request::leave: {
                         SCYLLA_ASSERT(node.rs->ring);
+
+                        auto validation_result = validate_removing_node(node);
+                        if (!validation_result) {
+                            builder.with_node(node.id)
+                                .del("topology_request");
+                            rtbuilder.done("removenode rejected");
+                            co_await update_topology_state(take_guard(std::move(node)), {builder.build(), rtbuilder.build()},
+                                                        "removenode rejected");
+                            break;
+                        }
+
                         // start decommission and put tokens of decommissioning nodes into write_both_read_old state
                         // meaning that reads will go to the replica being decommissioned
                         // but writes will go to new owner as well
@@ -2898,8 +2909,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                         co_await update_topology_state(take_guard(std::move(node)), {builder.build(), rtbuilder.build()},
                                                        "start decommission");
                         break;
+                        }
                     case topology_request::remove: {
                         SCYLLA_ASSERT(node.rs->ring);
+
+                        auto validation_result = validate_removing_node(node);
+                        if (!validation_result) {
+                            builder.with_node(node.id)
+                                .del("topology_request");
+                            rtbuilder.done("removenode rejected");
+                            co_await update_topology_state(take_guard(std::move(node)), {builder.build(), rtbuilder.build()},
+                                                        "removenode rejected");
+                            break;
+                        }
 
                         builder.set_transition_state(topology::transition_state::tablet_draining)
                                .set_version(_topo_sm._topology.version + 1)
@@ -2987,6 +3009,22 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
             }
         }
 
+        if (*node.request == topology_request::join) {
+            bool is_zero_token_node = false;
+            if (node.req_param.has_value()) {
+                // TODO seems not to work since req_param is not set here ?
+                auto num_tokens = std::get<join_param>(node.req_param.value()).num_tokens;
+                auto tokens_string = std::get<join_param>(node.req_param.value()).tokens_string;
+                is_zero_token_node = (num_tokens == 0 && tokens_string.empty());
+            }
+
+            if (!is_zero_token_node && !_db.validate_joining_node_rf_rack(get_token_metadata_ptr(), to_host_id(node.id), node.rs->datacenter, node.rs->rack)) {
+                return join_node_response_params::rejected {
+                    .reason = "Cannot join the node because its addition would make some existing keyspace not RF-rack-valid",
+                };
+            }
+        }
+
         std::vector<sstring> unsupported_features;
         const auto& supported_features = node.rs->supported_features;
         std::ranges::set_difference(node.topology->enabled_features, supported_features, std::back_inserter(unsupported_features));
@@ -2999,6 +3037,13 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
         }
 
         return join_node_response_params::accepted {};
+    }
+
+    bool validate_removing_node(const node_to_work_on& node) {
+        if (!_db.validate_removing_node_rf_rack(get_token_metadata_ptr(), to_host_id(node.id), node.rs->datacenter, node.rs->rack)) {
+            return false;
+        }
+        return true;
     }
 
     // Tries to finish accepting the joining node by updating the cluster

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -1,0 +1,112 @@
+#
+# Copyright (C) 2025-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+from test.pylib.manager_client import ManagerClient
+
+
+import pytest
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize("enforce", [True, False])
+@pytest.mark.asyncio
+async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, enforce: bool):
+    """
+    Test adding a node to a new rack when it would violate RF-rack constraints.
+
+    Creates a cluster with 3 racks and a keyspace with RF=3, then attempts to add a 4th node
+    in a new rack which would make the keyspace not RF-rack-valid.
+
+    When enforce=True: Node addition should be rejected with an error
+    When enforce=False: Node addition should succeed but with a warning log
+    """
+    cfg = {'rf_rack_valid_keyspaces': enforce}
+    cmdline = ['--logger-log-level', 'tablets=debug', '--logger-log-level', 'raft_topology=debug']
+
+    servers = await manager.servers_add(3, config=cfg, cmdline=cmdline, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"},
+    ])
+    cql = manager.get_cql()
+
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
+
+    if enforce:
+        # Node should be rejected
+        await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r4"}, expected_error="would make some existing keyspace not RF-rack-valid")
+
+        # add a node in an existing rack - should succeed
+        await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
+    else:
+        logs = [await manager.server_open_log(s.server_id) for s in servers]
+
+        # Node should be accepted but with a warning
+        await manager.server_add(config=cfg, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r4"})
+
+        matches = [log.grep('makes some existing keyspaces not RF-rack-valid') for log in logs]
+        assert any(matches)
+
+
+@pytest.mark.parametrize("enforce", [True, False])
+@pytest.mark.parametrize("op", ["remove", "decommission"])
+@pytest.mark.asyncio
+async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bool, op: str):
+    """
+    Test removing a node when it would violate RF-rack constraints.
+
+    Creates a cluster with 3 racks (2 nodes per rack) and a keyspace with RF=3.
+    First removes one node from the last rack (should succeed).
+    Then attempts to remove the other node from the same rack, which would eliminate
+    that rack entirely and make the keyspace not RF-rack-valid (fewer racks than RF).
+
+    When enforce=True: Second node removal should be rejected with an error
+    When enforce=False: Second node removal should succeed but with a warning log
+    """
+    cfg = {'rf_rack_valid_keyspaces': enforce}
+    cmdline = ['--logger-log-level', 'tablets=debug', '--logger-log-level', 'raft_topology=debug']
+
+    async def remove_node(server_id: str, expected_error: str = None):
+        if op == "remove":
+            await manager.server_stop_gracefully(server_id)
+            await manager.remove_node(servers[0].server_id, server_id, expected_error=expected_error)
+        elif op == "decommission":
+            await manager.decommission_node(server_id, expected_error=expected_error)
+
+    # Create 6 servers: 2 in each of 3 racks
+    servers = await manager.servers_add(6, config=cfg, cmdline=cmdline, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"},
+        {"dc": "dc1", "rack": "r3"},
+    ])
+    cql = manager.get_cql()
+
+    await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
+
+    # First removal: Remove one node from rack r3 (should always succeed)
+    await remove_node(servers[5].server_id)
+
+    # Second removal: Try to remove the other node from rack r3
+    # This would eliminate rack r3 entirely, violating RF-rack constraints
+    if enforce:
+        # Node removal should be rejected
+        await remove_node(servers[4].server_id, expected_error="removenode rejected")
+
+        # Remove a node from rack r1 - should succeed since r1 will still have one node left
+        await remove_node(servers[1].server_id)
+    else:
+        logs = [await manager.server_open_log(s.server_id) for s in servers]
+
+        # Node removal should succceed but with a warning
+        await remove_node(servers[4].server_id)
+
+        matches = [log.grep('makes some existing keyspaces not RF-rack-valid') for log in logs]
+        assert any(matches)


### PR DESCRIPTION
…alidity

when a new node joins or an existing node is removed / decommissioned, check if the operation would violate the RF-rack-validity of some keyspace. if so - reject the operation in order to preserve RF-rack-validity.

Fixes scylladb/scylladb#23345

no backport