### PR TITLE
utils: stall_free: add dispose_gently

### DIFF
--- a/locator/abstract_replication_strategy.cc
+++ b/locator/abstract_replication_strategy.cc
@@ -509,7 +509,7 @@ static_effective_replication_map::~static_effective_replication_map() {
 vnode_effective_replication_map::~vnode_effective_replication_map() {
     if (is_registered()) {
         try {
-            _factory->submit_background_work(clear_gently(std::move(_replication_map),
+            _factory->submit_background_work(dispose_gently(std::move(_replication_map),
                 std::move(*_pending_endpoints),
                 std::move(*_read_endpoints),
                 std::move(_tmptr)));


### PR DESCRIPTION
dispose_gently consumes the object moved to it,
clearing it gently before it's destroyed.

* improvement, no backport needed