### PR TITLE
test/pylib/resource_gather.py: create parent directory of log files

### DIFF
--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -88,6 +88,9 @@ class ResourceGather(ABC):
                     cwd: Path | None = None,
                     env: dict | None = None) -> subprocess.Popen[str]:
 
+        # Make sure the output directory exists
+        output_file.parent.mkdir(parents=True, exist_ok=True)
+
         args = shlex.split(subprocess.list2cmdline(args))
         if env:
             env.update(os.environ)


### PR DESCRIPTION
When individual tests are run with pytest directly, the testlog/{mode} dir is not guranteed to exist. This results in failure to create the log file for stdout. A simple fix is to call mkdir on the log file's parent directory, not depending on the caller or context to have set this up.

Small improvement for development, no backport