### PR TITLE
sstables: fix some typos in comments

### DIFF
--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -548,7 +548,7 @@ private:
     // If true, we don't build the bloom filter during the main pass
     // (when Data.db is written), but we instead write the murmur hashes
     // of keys to a temporary file, and later (after Data.db is written,
-    // but before the sstable is sealed) we build the bloom fitler from that.
+    // but before the sstable is sealed) we build the bloom filter from that.
     //
     // (Ideally this mechanism should only be used if the optimal size of the
     // filter can't be well estimated in advance. As of this writing we use

--- a/sstables/trie/bti_key_translation.hh
+++ b/sstables/trie/bti_key_translation.hh
@@ -73,7 +73,7 @@ public:
         lazy_comparable_bytes_from_ring_position& _owner;
         // Note: the reason we keep `_current` in a separate member
         // is because `operator*` returns a reference to the span.
-        // (Becauase the caller mutates it while it's reading the iterator,
+        // (Because the caller mutates it while it's reading the iterator,
         // for convenience.)
         std::span<std::byte> _current;
         // When `_remaining` is nullopt, it means that we haven't considered
@@ -144,7 +144,7 @@ struct lazy_comparable_bytes_from_clustering_position {
         lazy_comparable_bytes_from_clustering_position& _owner;
         // Note: the reason we keep `_current` in a separate member
         // is because `operator*` returns a reference to the span.
-        // (Becauase the caller mutates it while it's reading the iterator,
+        // (Because the caller mutates it while it's reading the iterator,
         // for convenience.)
         managed_bytes_mutable_view _remaining;
         std::span<std::byte> _current;


### PR DESCRIPTION
I added those typos recently, and spellcheckers complain.

Cosmetic change, backports not needed.