### PR TITLE
select_statement: add a warning about unsupported paging for vs queries

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -1182,6 +1182,9 @@ future<shared_ptr<cql_transport::messages::result_message>> indexed_table_select
         if (stats) {
             stats->add_latency(duration);
         }
+        if (_prepared_ann_ordering.has_value() && options.get_page_size() >= 0) {
+            result->add_warning("Paging is not supported for Vector Search queries. The entire result set has been returned.");
+        }
         co_return result;
 }
 


### PR DESCRIPTION
Currently we do not support paging for vector search queries. When we get such a query with paging enabled we ignore the paging and return the entire result. This behavior can be confusing for users, as there is no warning about paging not working with vector search. This patch fixes that by adding a warning to the result of ANN queries with paging enabled.

Fixes: VECTOR-191