### PR TITLE
locator: use get_primary_replica for get_primary_endpoints

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -240,15 +240,18 @@ tablet_replica_set get_new_replicas(const tablet_info& tinfo, const tablet_migra
     return replace_replica(tinfo.replicas, mig.src, mig.dst);
 }
 
-tablet_replica_set get_primary_replicas(const tablet_info& info, const tablet_transition_info* transition) {
+tablet_replica_set get_primary_replicas(const locator::tablet_map& tablet_map, tablet_id tid, std::function<bool(const tablet_replica&)> filter) {
+    const auto& info = tablet_map.get_tablet_info(tid);
+    const auto* transition = tablet_map.get_tablet_transition_info(tid);
+
     auto write_selector = [&] {
         if (!transition) {
             return write_replica_set_selector::previous;
         }
         return transition->writes;
     };
-    auto primary = [] (tablet_replica_set set) -> tablet_replica {
-        return set.front();
+    auto primary = [tid, filter = std::move(filter)] (tablet_replica_set set) -> tablet_replica {
+        return maybe_get_primary_replica(tid, set, filter).value();
     };
     auto add = [] (tablet_replica r1, tablet_replica r2) -> tablet_replica_set {
         // if primary replica is not the one leaving, then only primary will be streamed to.

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -330,9 +330,11 @@ struct tablet_migration_info {
     locator::tablet_replica dst;
 };
 
+class tablet_map;
+
 /// Returns the replica set which will become the replica set of the tablet after executing a given tablet transition.
 tablet_replica_set get_new_replicas(const tablet_info&, const tablet_migration_info&);
-tablet_replica_set get_primary_replicas(const tablet_info&, const tablet_transition_info*);
+tablet_replica_set get_primary_replicas(const locator::tablet_map&, tablet_id, std::function<bool(const tablet_replica&)> filter);
 tablet_transition_info migration_to_transition_info(const tablet_info&, const tablet_migration_info&);
 
 /// Describes streaming required for a given tablet transition.

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -172,7 +172,7 @@ public:
     host_id_vector_replica_set get_endpoints(const dht::token& token) const;
     future<> stream_sstable_mutations(streaming::plan_id, const dht::partition_range&, std::vector<sstables::shared_sstable>);
 protected:
-    virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token) const;
+    virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const;
     future<> stream_sstables(const dht::partition_range&, std::vector<sstables::shared_sstable>, shared_ptr<stream_progress> progress);
 private:
     host_id_vector_replica_set get_all_endpoints(const dht::token& token) const;
@@ -187,7 +187,7 @@ public:
     }
 
     virtual future<> stream(shared_ptr<stream_progress> on_streamed) override;
-    virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token) const override;
+    virtual host_id_vector_replica_set get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const override;
 
 private:
     host_id_vector_replica_set to_replica_set(const locator::tablet_replica_set& replicas) const {
@@ -208,7 +208,7 @@ private:
 };
 
 host_id_vector_replica_set sstable_streamer::get_endpoints(const dht::token& token) const {
-    return get_all_endpoints(token) | std::views::filter([&topo = _erm->get_topology(), scope = _stream_scope] (const auto& ep) {
+    auto host_filter = [&topo = _erm->get_topology(), scope = _stream_scope] (const locator::host_id& ep) {
         switch (scope) {
         case stream_scope::all:
             return true;
@@ -219,28 +219,35 @@ host_id_vector_replica_set sstable_streamer::get_endpoints(const dht::token& tok
         case stream_scope::node:
             return topo.is_me(ep);
         }
-    }) | std::ranges::to<host_id_vector_replica_set>();
+    };
+
+    if (_primary_replica_only) {
+        if (_stream_scope == stream_scope::node) {
+            throw std::runtime_error("Cannot set both primary_replica_only and stream_scope::node");
+        }
+        return get_primary_endpoints(token, std::move(host_filter));
+    }
+    return get_all_endpoints(token) | std::views::filter(std::move(host_filter)) | std::ranges::to<host_id_vector_replica_set>();
 }
 
 host_id_vector_replica_set sstable_streamer::get_all_endpoints(const dht::token& token) const {
-    if (_primary_replica_only) {
-        return get_primary_endpoints(token);
-    }
     auto current_targets = _erm->get_natural_replicas(token);
     auto pending = _erm->get_pending_replicas(token);
     std::move(pending.begin(), pending.end(), std::back_inserter(current_targets));
     return current_targets;
 }
 
-host_id_vector_replica_set sstable_streamer::get_primary_endpoints(const dht::token& token) const {
+host_id_vector_replica_set sstable_streamer::get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const {
     auto current_targets = _erm->get_natural_replicas(token);
     current_targets.resize(1);
-    return current_targets;
+    return current_targets | std::views::filter(std::move(filter)) | std::ranges::to<host_id_vector_replica_set>();
 }
 
-host_id_vector_replica_set tablet_sstable_streamer::get_primary_endpoints(const dht::token& token) const {
+host_id_vector_replica_set tablet_sstable_streamer::get_primary_endpoints(const dht::token& token, std::function<bool(const locator::host_id&)> filter) const {
     auto tid = _tablet_map.get_tablet_id(token);
-    auto replicas = locator::get_primary_replicas(_tablet_map.get_tablet_info(tid), _tablet_map.get_tablet_transition_info(tid));
+    auto replicas = locator::get_primary_replicas(_tablet_map, tid, [filter = std::move(filter)] (const locator::tablet_replica& replica) {
+        return filter(replica.host);
+    });
     return to_replica_set(replicas);
 }
 


### PR DESCRIPTION
Currently, tablet_sstable_streamer::get_primary_endpoints is out of sync with tablet_map::get_primary_replica. The get_primary_replica optimizes the choice of the replica so that the work is fairly distributes among nodes. Meanwhile, get_primary_endpoints always chooses the first replica.

Use get_primary_replica for get_primary_endpoints.

Fixes: https://github.com/scylladb/scylladb/issues/21883.

Optimization; no need to backport