### PR TITLE
database: Log message after critical_disk_utilization mode is set

### DIFF
--- a/replica/database.cc
+++ b/replica/database.cc
@@ -751,17 +751,13 @@ do_parse_schema_tables(sharded<service::storage_proxy>& proxy, const sstring cf_
 
 future<> database::set_in_critical_disk_utilization_mode(sharded<database>& sharded_db, bool enabled) {
     return sharded_db.invoke_on_all([enabled] (replica::database& db) {
-        dblog.info("Setting critical disk utilization mode: {}", enabled);
-        if (enabled) {
-            ++db._critical_disk_utilization_mode_count;
-            return;
-        }
-
-        --db._critical_disk_utilization_mode_count;
-        if (db._critical_disk_utilization_mode_count > 0) {
+        dblog.info("Asked to set critical disk utilization mode: {}", enabled);
+        db._critical_disk_utilization_mode_count += enabled ? 1 : -1;
+        if (!enabled && db._critical_disk_utilization_mode_count > 0) {
             dblog.debug("Database is still in critical disk utilization mode, requires {} more call(s) to disable it",
                         db._critical_disk_utilization_mode_count);
         }
+        dblog.info("Set critical disk utilization mode: {}", db._critical_disk_utilization_mode_count > 0);
     });
 }
 

--- a/test/storage/test_out_of_space_prevention.py
+++ b/test/storage/test_out_of_space_prevention.py
@@ -70,7 +70,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
                 disk_info = psutil.disk_usage(workdir)
                 with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
                     for _ in range(2):
-                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+                        mark, _ = await log.wait_for("database - Set critical disk utilization mode: true", from_mark=mark)
 
                     logger.info("Write data and verify it did not reach the target node")
                     query = next(write_generator(cf, 1))
@@ -89,10 +89,10 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
                     mark = await log.mark()
                     await manager.server_restart(servers[0].server_id)
                     for _ in range(2):
-                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+                        mark, _ = await log.wait_for("database - Set critical disk utilization mode: true", from_mark=mark)
 
                     time.sleep(1) # Let the cluster run for a sec to grep for potential errors
-                    assert await log.grep("database - Setting critical disk utilization mode: false", from_mark=mark) == []
+                    assert await log.grep("database - Set critical disk utilization mode: false", from_mark=mark) == []
 
                     try:
                         cql.execute(f"INSERT INTO {cf} (pk, t) VALUES (-1, 'x')", host=host[0], execution_profile=cl_one_profile).result()
@@ -103,7 +103,7 @@ async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Ca
 
                 logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
                 for _ in range(2):
-                    mark, _ = await log.wait_for("database - Setting critical disk utilization mode: false", from_mark=mark)
+                    mark, _ = await log.wait_for("database - Set critical disk utilization mode: false", from_mark=mark)
 
                 logger.info("Write more data and expect it to succeed")
                 cl_all_profile = cql.execution_profile_clone_update(EXEC_PROFILE_DEFAULT, consistency_level = ConsistencyLevel.ALL)
@@ -317,7 +317,7 @@ async def test_autotoogle_reject_incoming_migrations(manager: ManagerClient, vol
                 disk_info = psutil.disk_usage(workdir)
                 with random_content_file(workdir, int(disk_info.total*0.85) - disk_info.used):
                     for _ in range(2):
-                        mark, _ = await log.wait_for("database - Setting critical disk utilization mode: true", from_mark=mark)
+                        mark, _ = await log.wait_for("database - Set critical disk utilization mode: true", from_mark=mark)
 
                     logger.info("Migrate a tablet to the target node and expect a failure")
                     await manager.api.move_tablet(node_ip=servers[0].ip_addr, ks=ks, table=table, src_host=source_host,
@@ -327,7 +327,7 @@ async def test_autotoogle_reject_incoming_migrations(manager: ManagerClient, vol
 
                 logger.info("With blob file removed, wait for DB to drop below the critical disk utilization level")
                 for _ in range(2):
-                    mark, _ = await log.wait_for("database - Setting critical disk utilization mode: false", from_mark=mark)
+                    mark, _ = await log.wait_for("database - Set critical disk utilization mode: false", from_mark=mark)
 
                 logger.info("Migrate a tablet to the target node and expect a success")
                 await manager.api.move_tablet(node_ip=servers[0].ip_addr, ks=ks, table=table, src_host=source_host,


### PR DESCRIPTION
This is a follow-up of the previous fix: https://github.com/scylladb/scylladb/pull/26030

The test test_user_writes_rejection starts a 3-node cluster and creates a large file on one of the nodes, to trigger the out-of-space prevention mechanism, which should reject writes on that node.

It waits for the log message 'Setting critical disk utilization mode: true' and then executes a write expecting the node to reject it.

Currently, the message is logged before the `_critical_disk_utilization` variable is actually updated. This causes the test to fail sporadically if it runs quickly enough.

The fix splits the logging into two steps:
1. "Asked to set critical disk utilization mode" - logged before any action 2) "Set critical disk utilization mode" - logged after `_critical_disk_utilization` has been updated

The tests are updated to wait for the second message.

Fixes https://github.com/scylladb/scylladb/issues/26004

Backport to 2025.4 is required. The test and the feature were introduced then.