### PR TITLE
sstables/sstable_directory: don't forget to delete other components when deleting TemporaryHashes.db

### DIFF
--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -184,7 +184,7 @@ void sstable_directory::filesystem_components_lister::handle(sstables::entry_des
     }
 
     dirlog.trace("for SSTable directory, scanning {}", filename);
-    _state->generations_found.emplace(desc.generation, filename);
+    auto generations_found_it = _state->generations_found.emplace(desc.generation, filename);
 
     switch (desc.component) {
     case component_type::TemporaryStatistics:
@@ -202,7 +202,7 @@ void sstable_directory::filesystem_components_lister::handle(sstables::entry_des
         // This file isn't included in the TOC, so we can't remove on the "usual"
         // mechanism for partially-written components, and instead we have to explicitly
         // mark it for removal here.
-        _state->generations_found.erase(desc.generation);
+        _state->generations_found.erase(generations_found_it);
         _state->files_for_removal.insert(filename.native());
         break;
     case component_type::TOC:

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -442,6 +442,9 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
 
     temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC);
     touch_file(temp_file_name);
+    // Reproducer for #scylladb/scylladb#26393
+    temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryHashes);
+    touch_file(temp_file_name);
     temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
@@ -452,6 +455,7 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
         require_exist(temp_sst_dir_3, false);
 
         require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
+        require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryHashes), false);
         require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data), false);
     }, test_config).get();
 }

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -94,7 +94,7 @@ static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id 
 
 future<> do_with_cql_env_and_compaction_groups_cgs(unsigned cgs, std::function<void(cql_test_env&)> func, cql_test_config cfg = {}, thread_attributes thread_attr = {}) {
     // clean the dir before running
-    if (cfg.db_config->data_file_directories.is_set()) {
+    if (cfg.db_config->data_file_directories.is_set() && cfg.clean_data_dir_before_test) {
         co_await recursive_remove_directory(fs::path(cfg.db_config->data_file_directories()[0]));
         co_await recursive_touch_directory(cfg.db_config->data_file_directories()[0]);
     }
@@ -445,13 +445,15 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_incomplete_sstables) {
     temp_file_name = sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data);
     touch_file(temp_file_name);
 
+    auto test_config = cql_test_config(db_cfg_ptr);
+    test_config.clean_data_dir_before_test = false;
     do_with_cql_env_and_compaction_groups([&sst_dir, &ks, &cf, &temp_sst_dir_2, &temp_sst_dir_3] (cql_test_env& e) {
         require_exist(temp_sst_dir_2, false);
         require_exist(temp_sst_dir_3, false);
 
         require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::TemporaryTOC), false);
         require_exist(sst::filename(sst_dir, ks, cf, sstables::get_highest_sstable_version(), generation_from_value(4), sst::format_types::big, component_type::Data), false);
-    }, db_cfg_ptr).get();
+    }, test_config).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
@@ -531,6 +533,8 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
                component_basename(gen[7], component_type::TOC) + "\n" +
                component_basename(gen[8], component_type::TOC) + "\n");
 
+    auto test_config = cql_test_config(db_cfg_ptr);
+    test_config.clean_data_dir_before_test = false;
     do_with_cql_env_and_compaction_groups([&] (cql_test_env& e) {
         // Empty log filesst_dir
         // Empty temporary log file
@@ -556,7 +560,7 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
         require_exist(gen_filename(gen[6], component_type::Data), false);
         require_exist(gen_filename(gen[7], component_type::TemporaryTOC), false);
         require_exist(pending_delete_dir + "/sstables-6-8.log", false);
-    }, db_cfg_ptr).get();
+    }, test_config).get();
 }
 
 // Snapshot tests and their helpers

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -103,6 +103,7 @@ public:
     gms::inet_address broadcast_address = gms::inet_address("localhost");
     bool ms_listen = false;
     bool run_with_raft_recovery = false;
+    bool clean_data_dir_before_test = true;
 
     std::optional<timeout_config> query_timeout;
 


### PR DESCRIPTION
TemporaryHashes.db is a temporary sstable component used during ms
sstable writes. It's different from other sstable components in that
it's not included in the TOC. Because of this, it has a special case in
the logic that deletes unfinished sstables on boot.
(After Scylla dies in the middle of a sstable write).

But there's a bug in that special case,
which causes Scylla to forget to delete other components from the same unfinished sstable.

The code intends only to delete the TemporaryHashes.db file from the
`_state->generations_found` multimap, but it accidentally also deletes
the file's sibling components from the multimap. Fix that.

Also, extend a related test so that it would catch the problem before the fix. 

Fixes scylladb/scylladb#26393

Bugfix, needs backport to 2025.4.