### PR TITLE
cdc: garbage collect CDC streams for tablets

### DIFF
--- a/cdc/generation.hh
+++ b/cdc/generation.hh
@@ -220,8 +220,11 @@ future<utils::chunked_vector<mutation>> get_cdc_generation_mutations_v3(
     size_t mutation_size_threshold, api::timestamp_type mutation_timestamp);
 
 future<mutation> create_table_streams_mutation(table_id, db_clock::time_point, const locator::tablet_map&, api::timestamp_type);
+future<mutation> create_table_streams_mutation(table_id, db_clock::time_point, const std::vector<cdc::stream_id>&, api::timestamp_type);
 utils::chunked_vector<mutation> make_drop_table_streams_mutations(table_id, api::timestamp_type ts);
 
 future<mutation> get_switch_streams_mutation(table_id table, db_clock::time_point stream_ts, cdc_stream_diff diff, api::timestamp_type ts);
+future<utils::chunked_vector<mutation>> get_cdc_stream_gc_mutations(table_id table, db_clock::time_point base_ts, const std::vector<cdc::stream_id>& base_stream_set, api::timestamp_type ts);
+table_streams::const_iterator get_new_base_for_gc(const table_streams&, std::chrono::seconds ttl);
 
 } // namespace cdc

--- a/cdc/generation_service.hh
+++ b/cdc/generation_service.hh
@@ -153,6 +153,9 @@ public:
 
     future<> generate_tablet_resize_update(utils::chunked_vector<canonical_mutation>& muts, table_id table, const locator::tablet_map& new_tablet_map, api::timestamp_type ts);
 
+    future<utils::chunked_vector<mutation>> garbage_collect_cdc_streams_for_table(table_id table, std::optional<std::chrono::seconds> ttl, api::timestamp_type ts);
+    future<> garbage_collect_cdc_streams(utils::chunked_vector<canonical_mutation>& muts, api::timestamp_type ts);
+
 private:
     /* Retrieve the CDC generation which starts at the given timestamp (from a distributed table created for this purpose)
      * and start using it for CDC log writes if it's not obsolete.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -145,6 +145,8 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
     std::unordered_map<locator::host_id, locator::load_stats> _load_stats_per_node;
     serialized_action _tablet_load_stats_refresh;
 
+    static constexpr std::chrono::seconds cdc_streams_gc_refresh_interval = std::chrono::seconds(60);
+
     std::chrono::milliseconds _ring_delay;
 
     gate::holder _group0_holder;
@@ -762,6 +764,42 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                 }
             }
             co_await coroutine::maybe_yield();
+        }
+    }
+
+    future<> cdc_streams_gc_fiber() {
+        auto can_proceed = [this] { return !_async_gate.is_closed() && !_as.abort_requested(); };
+        while (can_proceed()) {
+            bool sleep = true;
+            try {
+                auto guard = co_await start_operation();
+                utils::chunked_vector<canonical_mutation> updates;
+
+                co_await _cdc_gens.garbage_collect_cdc_streams(updates, guard.write_timestamp());
+
+                if (!updates.empty()) {
+                    co_await update_topology_state(std::move(guard), std::move(updates), "CDC streams GC");
+                } else {
+                    release_guard(std::move(guard));
+                }
+            } catch (raft::request_aborted&) {
+                rtlogger.debug("CDC streams GC fiber aborted");
+                sleep = false;
+            } catch (seastar::abort_requested_exception&) {
+                rtlogger.debug("CDC streams GC fiber aborted");
+                sleep = false;
+            } catch (...) {
+                rtlogger.warn("CDC streams GC fiber got error {}", std::current_exception());
+            }
+            auto refresh_interval = utils::get_local_injector().is_enabled("short_cdc_streams_gc_refresh_interval") ?
+                    std::chrono::seconds(1) : cdc_streams_gc_refresh_interval;
+            if (sleep && can_proceed()) {
+                try {
+                    co_await seastar::sleep_abortable(refresh_interval, _as);
+                } catch (...) {
+                    rtlogger.debug("CDC streams GC: sleep failed: {}", std::current_exception());
+                }
+            }
         }
     }
 
@@ -3711,6 +3749,7 @@ future<> topology_coordinator::run() {
 
     co_await fence_previous_coordinator();
     auto cdc_generation_publisher = cdc_generation_publisher_fiber();
+    auto cdc_streams_gc = cdc_streams_gc_fiber();
     auto tablet_load_stats_refresher = start_tablet_load_stats_refresher();
     auto gossiper_orphan_remover = gossiper_orphan_remover_fiber();
     auto group0_voter_refresher = group0_voter_refresher_fiber();
@@ -3754,6 +3793,7 @@ future<> topology_coordinator::run() {
     co_await std::move(tablet_load_stats_refresher);
     co_await _tablet_load_stats_refresh.join();
     co_await std::move(cdc_generation_publisher);
+    co_await std::move(cdc_streams_gc);
     co_await std::move(gossiper_orphan_remover);
     co_await std::move(group0_voter_refresher);
     co_await std::move(vb_coordinator_fiber);

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -18,6 +18,7 @@
 #include "cdc/log.hh"
 #include "cdc/cdc_options.hh"
 #include "cdc/metadata.hh"
+#include "db/system_keyspace.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
@@ -2341,6 +2342,257 @@ SEASTAR_THREAD_TEST_CASE(test_cdc_generate_stream_diff) {
         testlog.info("test_construct_next_stream_set: expected_opened={}", expected_opened);
 
         do_test_diff(a, b, expected_closed, expected_opened);
+    }
+}
+
+struct cdc_gc_test_config {
+    table_id table;
+    std::vector<std::vector<cdc::stream_id>> streams;
+    size_t new_base_stream;
+};
+
+void do_cdc_gc_test(cql_test_env& e, const cdc_gc_test_config& cfg) {
+    auto do_group0_write = [&] (std::function<future<utils::chunked_vector<mutation>>(api::timestamp_type ts)> fn) -> future<> {
+        while (true) {
+            auto& group0_client = e.get_raft_group0_client();
+            abort_source as;
+            auto guard = group0_client.start_operation(as).get();
+            auto ts = guard.write_timestamp();
+
+            auto muts = fn(ts).get();
+            utils::chunked_vector<canonical_mutation> cmuts = {muts.begin(), muts.end()};
+
+            auto group0_cmd = group0_client.prepare_command(
+                ::service::write_mutations{
+                    .mutations{std::move(cmuts)},
+                },
+                guard,
+                "test_cdc_gc_mutations");
+            try {
+                group0_client.add_entry(std::move(group0_cmd), std::move(guard), as, ::service::raft_timeout{}).get();
+            } catch (::service::group0_concurrent_modification&) {
+                continue;
+            }
+            break;
+        }
+        return make_ready_future<>();
+    };
+
+    std::vector<db_clock::time_point> stream_ts;
+    {
+        auto db_now = db_clock::now();
+        auto next_stream_ts = db_now;
+        for (size_t i = 0; i < cfg.streams.size(); i++) {
+            stream_ts.emplace_back(next_stream_ts);
+            next_stream_ts += std::chrono::seconds(5);
+        }
+    }
+
+    // write base stream to cdc_streams_state
+    do_group0_write([&] (api::timestamp_type ts) -> future<utils::chunked_vector<mutation>> {
+        auto m = co_await cdc::create_table_streams_mutation(cfg.table, stream_ts[0], cfg.streams[0], ts);
+        co_return utils::chunked_vector<mutation>({ std::move(m) });
+    }).get();
+
+    // write stream diffs to cdc_streams_history
+    for (size_t i = 0; i + 1 < cfg.streams.size(); i++) {
+        do_group0_write([&] (api::timestamp_type ts) -> future<utils::chunked_vector<mutation>> {
+            auto history_schema = db::system_keyspace::cdc_streams_history();
+            auto diff = co_await cdc::metadata::generate_stream_diff(cfg.streams[i], cfg.streams[i+1]);
+            auto mut = co_await get_switch_streams_mutation(cfg.table, stream_ts[i+1], diff, ts);
+            co_return utils::chunked_vector<mutation>({ std::move(mut) });
+        }).get();
+    }
+
+    // verify the base stream (streams[0]) is written to cdc_streams_state
+    e.execute_cql(format("SELECT stream_id FROM system.cdc_streams_state WHERE table_id = {}", cfg.table.uuid())).then([&] (shared_ptr<cql_transport::messages::result_message> msg) {
+        auto row_assert = assert_that(msg).is_rows()
+                    .with_size(cfg.streams[0].size());
+        for (auto sid : cfg.streams[0]) {
+            row_assert.with_row({ {sid.to_bytes()} });
+        }
+    }).get();
+
+    // gc the cdc streams with the new base stream cfg.new_base_stream
+    testlog.info("test_cdc_gc_mutations: start gc");
+
+    do_group0_write([&] (api::timestamp_type ts) -> future<utils::chunked_vector<mutation>> {
+        return cdc::get_cdc_stream_gc_mutations(cfg.table, stream_ts[cfg.new_base_stream], cfg.streams[cfg.new_base_stream], ts);
+    }).get();
+
+    // verify the new base stream is written to cdc_streams_state
+    e.execute_cql(format("SELECT stream_id FROM system.cdc_streams_state WHERE table_id = {}", cfg.table.uuid())).then([&] (shared_ptr<cql_transport::messages::result_message> msg) {
+        auto row_assert = assert_that(msg).is_rows()
+                    .with_size(cfg.streams[cfg.new_base_stream].size());
+        for (auto sid : cfg.streams[cfg.new_base_stream]) {
+            row_assert.with_row({ {sid.to_bytes()} });
+        }
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_cdc_gc_mutations) {
+    do_with_cql_env_thread([](cql_test_env& e) {
+
+        {
+            // create stream sets:
+            // 0: 10 20 30
+            // 1: 10    30 40 (20 closed, 40 opened)
+            // then gc with 1 as the new base, so after gc we should have only stream 1
+            // as the base and the history is empty
+
+            auto table = table_id(utils::UUID_gen::get_time_UUID());
+            std::vector<cdc::stream_id> streams0;
+            for (auto t : {10, 20, 30}) {
+                streams0.emplace_back(dht::token(t), 0);
+            }
+            std::vector<cdc::stream_id> streams1 = {streams0[0], streams0[2], cdc::stream_id(dht::token(40), 0)};
+
+            cdc_gc_test_config test1 = {
+                .table = table,
+                .streams = { std::move(streams0), std::move(streams1) },
+                .new_base_stream = 1,
+            };
+
+            do_cdc_gc_test(e, test1);
+
+            e.execute_cql(format("SELECT * FROM system.cdc_streams_history WHERE table_id = {}", table.uuid())).then([] (shared_ptr<cql_transport::messages::result_message> msg) {
+                assert_that(msg).is_rows()
+                        .with_size(0);
+            }).get();
+        }
+
+        {
+            // create stream sets:
+            // 0: 10 20 30
+            // 1: 10    30 40       (20 closed, 40 opened)
+            // 2: 10    30 40 50    (50 opened)
+            // then gc with 1 as the new base, so after gc we should have stream 1
+            // as the base and one history entry for open 50
+
+            auto table = table_id(utils::UUID_gen::get_time_UUID());
+            std::vector<cdc::stream_id> streams0;
+            for (auto t : {10, 20, 30}) {
+                streams0.emplace_back(dht::token(t), 0);
+            }
+            std::vector<cdc::stream_id> streams1 = {streams0[0], streams0[2], cdc::stream_id(dht::token(40), 0)};
+            std::vector<cdc::stream_id> streams2 = {streams0[0], streams0[2], streams1[2], cdc::stream_id(dht::token(50), 0)};
+
+            cdc_gc_test_config test2 = {
+                .table = table,
+                .streams = { std::move(streams0), std::move(streams1), std::move(streams2)},
+                .new_base_stream = 1,
+            };
+
+            do_cdc_gc_test(e, test2);
+
+            e.execute_cql(format("SELECT stream_state, stream_id FROM system.cdc_streams_history WHERE table_id = {}", table.uuid())).then([&] (shared_ptr<cql_transport::messages::result_message> msg) {
+                assert_that(msg).is_rows()
+                        .with_size(1)
+                        .with_row({ {byte_type->decompose(std::to_underlying(cdc::stream_state::opened))}, { test2.streams[2][3].to_bytes() } });
+            }).get();
+        }
+    }).get();
+}
+
+SEASTAR_THREAD_TEST_CASE(test_cdc_gc_get_new_base) {
+    auto make_streams_map = [&](std::vector<std::chrono::seconds> entries) {
+        cdc::table_streams streams_map;
+        auto base_time = db_clock::now() - std::chrono::seconds(100); // Start from 100 seconds ago
+
+        for (const auto& offset : entries) {
+            auto tp = base_time + offset;
+            auto ts = std::chrono::duration_cast<api::timestamp_clock::duration>(tp.time_since_epoch()).count();
+
+            streams_map[ts] = cdc::committed_stream_set{tp, std::vector<cdc::stream_id>{}};
+        }
+        return streams_map;
+    };
+
+    // Test case 1: Single entry
+    {
+        auto streams_map = make_streams_map({
+            std::chrono::seconds(20),
+        });
+
+        // Should point to the only entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(50));
+        BOOST_REQUIRE(it == streams_map.begin());
+        }
+
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(150));
+        BOOST_REQUIRE(it == streams_map.begin());
+        }
+    }
+
+    // Test case 2: two entries
+    {
+        auto streams_map = make_streams_map({
+            std::chrono::seconds(30), // covers up to 10 seconds ago
+            std::chrono::seconds(90),
+        });
+
+        // Should point to the first entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(80));
+        BOOST_REQUIRE(it == streams_map.begin());
+        }
+
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(50));
+        BOOST_REQUIRE(it == streams_map.begin());
+        }
+
+        // Should point to the second entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(10));
+        BOOST_REQUIRE(it == std::next(streams_map.begin()));
+        }
+
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(5));
+        BOOST_REQUIRE(it == std::next(streams_map.begin()));
+        }
+    }
+
+    // Test case 3: multiple entries
+    {
+        auto streams_map = make_streams_map({
+            std::chrono::seconds(10), // covers up to 70 seconds ago
+            std::chrono::seconds(30), // covers up to 40 seconds ago
+            std::chrono::seconds(60), // covers up to 10 seconds ago
+            std::chrono::seconds(90),
+        });
+
+        // Should point to the first entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(80));
+        BOOST_REQUIRE(it == streams_map.begin());
+        }
+
+        // Should point to the second entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(70));
+        BOOST_REQUIRE(it == std::next(streams_map.begin()));
+        }
+
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(50));
+        BOOST_REQUIRE(it == std::next(streams_map.begin()));
+        }
+
+        // Should point to the third entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(15));
+        BOOST_REQUIRE(it == std::next(streams_map.begin(), 2));
+        }
+
+        // Should point to the last entry
+        {
+        auto it = cdc::get_new_base_for_gc(streams_map, std::chrono::seconds(5));
+        BOOST_REQUIRE(it == std::next(streams_map.begin(), 3));
+        }
     }
 }
 

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -292,3 +292,51 @@ async def test_cdc_colocation(manager: ManagerClient):
                     f"Stream {stream_id} partitions {partitions} are not fully contained in inaccessible partitions"
 
         await manager.server_start(servers[0].server_id)
+
+# Test garbage collection of CDC streams.
+# Create a CDC table with short TTL, then split the tablets to create a new stream set,
+# and wait until the old streams are garbage collected and we have a single stream set again.
+# Verify the remaining stream set is equal to the most recent stream set.
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cdc_stream_garbage_collection(manager: ManagerClient):
+    cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1, 'error_injections_at_startup': ['short_cdc_streams_gc_refresh_interval' ] }
+    servers = await manager.servers_add(1, config=cfg)
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true, 'ttl': 5}}")
+
+        rows = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
+        assert len(rows) == 1
+
+        await cql.run_async(f"ALTER TABLE {ks}.test_scylla_cdc_log WITH tablets = {{'min_tablet_count': 4}};")
+
+        async def new_stream_timestamp_created():
+            rows = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
+            if len(rows) > 1:
+                return True
+        await wait_for(new_stream_timestamp_created, time.time() + 60)
+
+        ts_before = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
+        streams_before = await cql.run_async(f"SELECT * FROM system.cdc_streams WHERE keyspace_name='{ks}' AND table_name='test'")
+
+        async def streams_garbage_collected():
+            rows = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
+            if len(rows) == 1:
+                return True
+        await wait_for(streams_garbage_collected, time.time() + 60)
+
+        ts_after = await cql.run_async(f"SELECT * FROM system.cdc_timestamps WHERE keyspace_name='{ks}' AND table_name='test'")
+        streams_after = await cql.run_async(f"SELECT * FROM system.cdc_streams WHERE keyspace_name='{ks}' AND table_name='test'")
+
+        # now we have a single timestamp, and it is the most recent one
+        assert len(ts_after) == 1
+        assert ts_after[0].timestamp == ts_before[0].timestamp
+
+        # now there is a single stream set, and it is the same as the stream set for the most recent timestamp
+        assert set([r.stream_id for r in streams_after if r.stream_state == CdcStreamState.CURRENT]) == \
+                set([r.stream_id for r in streams_before if r.timestamp == ts_before[0].timestamp and r.stream_state == CdcStreamState.CURRENT])
+
+        # the cdc_streams_history is empty. we have only a base stream set
+        rows = await cql.run_async("SELECT * FROM system.cdc_streams_history")
+        assert len(rows) == 0


### PR DESCRIPTION
introduce helper functions that can be used for garbage collecting old
cdc streams for tablets-based keyspaces.

add a background fiber to the topology coordinator that runs
periodically and checks for old CDC streams for tablets keyspaces that
can be garbage collected.