### PR TITLE
Switch REST API server to use content-streaming

### DIFF
--- a/api/error_injection.cc
+++ b/api/error_injection.cc
@@ -24,7 +24,7 @@ void set_error_injection(http_context& ctx, routes& r) {
     hf::enable_injection.set(r, [](std::unique_ptr<request> req) -> future<json::json_return_type> {
         sstring injection = req->get_path_param("injection");
         bool one_shot = req->get_query_param("one_shot") == "True";
-        auto params = req->content;
+        auto params = co_await util::read_entire_stream_contiguous(*req->content_stream);
 
         const size_t max_params_size = 1024 * 1024;
         if (params.size() > max_params_size) {

--- a/api/system.cc
+++ b/api/system.cc
@@ -54,7 +54,8 @@ void set_system(http_context& ctx, routes& r) {
 
     hm::set_metrics_config.set(r, [](std::unique_ptr<http::request> req) -> future<json::json_return_type> {
         rapidjson::Document doc;
-        doc.Parse(req->content.c_str());
+        auto content = co_await util::read_entire_stream_contiguous(*req->content_stream);
+        doc.Parse(content.c_str());
         if (!doc.IsArray()) {
             throw bad_param_exception("Expected a json array");
         }

--- a/api/system.cc
+++ b/api/system.cc
@@ -87,21 +87,23 @@ void set_system(http_context& ctx, routes& r) {
                 relabels[i].expr = element["regex"].GetString();
             }
         }
-        return do_with(std::move(relabels), false, [](const std::vector<seastar::metrics::relabel_config>& relabels, bool& failed) {
-            return smp::invoke_on_all([&relabels, &failed] {
+        {
+            bool failed = false;
+            co_await smp::invoke_on_all([&relabels, &failed] {
                 return metrics::set_relabel_configs(relabels).then([&failed](const metrics::metric_relabeling_result& result) {
                     if (result.metrics_relabeled_due_to_collision > 0) {
                         failed = true;
                     }
                     return;
                 });
-            }).then([&failed](){
+            });
+            {
                 if (failed) {
                     throw bad_param_exception("conflicts found during relabeling");
                 }
-                return make_ready_future<json::json_return_type>(seastar::json::json_void());
-            });
-        });
+                co_return seastar::json::json_void();
+            }
+        }
     });
 
     hs::get_system_uptime.set(r, [](const_req req) {

--- a/main.cc
+++ b/main.cc
@@ -1371,6 +1371,7 @@ sharded<locator::shared_token_metadata> token_metadata;
             }).get();
 
             stop_signal.check();
+            ctx.http_server.server().invoke_on_all([] (auto& server) { server.set_content_streaming(true); }).get();
             with_scheduling_group(maintenance_scheduling_group, [&] {
                 return ctx.http_server.listen(socket_address{api_addr, cfg->api_port()});
             }).get();


### PR DESCRIPTION
Seastar httpd recommended users to stop using contiguous requet.content string and read body they need from request's input_stream instead. However, "official" deprecation of request content had been only made recently.

This PR patches REST API server to turn this feature on and patches few handlers that mess with request bodies to read them from request stream.

Using newer seastar API, no need to backport