### PR TITLE
db/view/view_building_coordinator: rate-limit iterations triggered by finished RPCs

### DIFF
--- a/db/view/view_building_coordinator.hh
+++ b/db/view/view_building_coordinator.hh
@@ -86,6 +86,7 @@ private:
 
     using remote_work_results = std::vector<std::pair<utils::UUID, db::view::view_task_result>>;
     std::unordered_map<locator::tablet_replica, shared_future<std::optional<remote_work_results>>> _remote_work;
+    rpc_callback_manager _rcm;
 
 public:
     view_building_coordinator(replica::database& db, raft::server& raft, service::raft_group0& group0,


### PR DESCRIPTION
Especially in large clusters, where there are lots of shards,
building empty view may temporarily overload group0, making other
changes (like schema) impossible.

This patch adds `rpc_callback_manager`, a middleware responsible for
rate-limiting iterations of view building coordinator triggered by
finished RPC calls.

The manager ensures that at least 1s elapsed since last successful
group0 commit by the coordinator, when a RPC call was finished.
Only if all of the remote work is done, then the manager notifies the
coordinator immediately.

Fixes https://github.com/scylladb/scylladb/issues/26311

The PR should be backported to 2025.4.