### PR TITLE
db/view/view_building: replace system keyspace functions with mutation builder

### DIFF
--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -9,6 +9,7 @@
 
 #include "db/schema_tables.hh"
 
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "service/migration_manager.hh"
 #include "service/storage_proxy.hh"
 #include "gms/feature_service.hh"
@@ -1799,7 +1800,8 @@ static void make_update_indices_mutations(
         utils::chunked_vector<mutation>& mutations)
 {
     mutation indices_mutation(indexes(), partition_key::from_singular(*indexes(), old_table->ks_name()));
-    std::vector<mutation> view_building_muts;
+    view::view_building_task_mutation_builder vb_mut_builder(timestamp);
+    std::vector<mutation> view_status_muts;
 
     auto diff = difference(old_table->all_indices(), new_table->all_indices());
     auto& db = sp.local_db();
@@ -1834,8 +1836,7 @@ static void make_update_indices_mutations(
                     }
 
                     for (auto& [id, _]: replica_tasks.view_tasks.at(view->id())) {
-                        auto mut = sys_ks.make_remove_view_building_task_mutation(timestamp, id).get();
-                        view_building_muts.push_back(std::move(mut));
+                        vb_mut_builder.del_task(id);
                         slogger.trace("Aborting view building task with ID: {} because the index is being dropped", id);
                     }
                 }
@@ -1843,7 +1844,7 @@ static void make_update_indices_mutations(
 
             // Remove entries from `system.view_build_status_v2`
             auto build_status_mut = sys_ks.make_remove_view_build_status_mutation(timestamp, {view->ks_name(), view->cf_name()}).get();
-            view_building_muts.push_back(std::move(build_status_mut));
+            view_status_muts.push_back(std::move(build_status_mut));
         }
     }
 
@@ -1862,7 +1863,8 @@ static void make_update_indices_mutations(
     }
 
     mutations.emplace_back(std::move(indices_mutation));
-    mutations.insert(mutations.end(), std::make_move_iterator(view_building_muts.begin()), std::make_move_iterator(view_building_muts.end()));
+    mutations.emplace_back(vb_mut_builder.build());
+    mutations.insert(mutations.end(), std::make_move_iterator(view_status_muts.begin()), std::make_move_iterator(view_status_muts.end()));
 }
 
 static void add_drop_column_to_mutations(schema_ptr table, const sstring& name, const schema::dropped_column& dc, api::timestamp_type timestamp, utils::chunked_vector<mutation>& mutations) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2819,16 +2819,6 @@ future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> system_k
     co_return std::pair{std::move(tasks), std::move(min_task_id)};
 }
 
-future<mutation> system_keyspace::make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id) {
-    static const sstring stmt = format("DELETE FROM {}.{} WHERE key = '{}' AND id = ?", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
-
-    auto muts = co_await _qp.get_mutations_internal(stmt, internal_system_query_state(), ts, {id});
-    if (muts.size() != 1) {
-        on_internal_error(slogger, fmt::format("expected 1 mutation got {}", muts.size()));
-    }
-    co_return std::move(muts[0]);
-}
-
 static constexpr auto VIEW_BUILDING_PROCESSING_BASE_ID_KEY = "view_building_processing_base_id";
 
 future<std::optional<table_id>> system_keyspace::get_view_building_processing_base_id() {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2819,28 +2819,6 @@ future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> system_k
     co_return std::pair{std::move(tasks), std::move(min_task_id)};
 }
 
-future<mutation> system_keyspace::make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task) {
-    static const sstring stmt = format("INSERT INTO {}.{}(key, id, type, aborted, base_id, view_id, last_token, host_id, shard) VALUES ('{}', ?, ?, ?, ?, ?, ?, ?, ?)", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
-    using namespace db::view;
-
-    data_value_or_unset view_id = unset_value{};
-    if (task.type == db::view::view_building_task::task_type::build_range) {
-        if (!task.view_id) {
-            on_internal_error(slogger, fmt::format("view_id is not set for build_range task with id: {}", task.id));
-        }
-        view_id = data_value(task.view_id->uuid());
-    }
-    auto muts = co_await _qp.get_mutations_internal(stmt, internal_system_query_state(), ts, {
-            task.id, task_type_to_sstring(task.type), task.aborted,
-            task.base_id.uuid(), view_id, dht::token::to_int64(task.last_token),
-            task.replica.host.uuid(), int32_t(task.replica.shard)
-    });
-    if (muts.size() != 1) {
-        on_internal_error(slogger, fmt::format("expected 1 mutation got {}", muts.size()));
-    }
-    co_return std::move(muts[0]);
-}
-
 future<mutation> system_keyspace::make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id) {
     static const sstring stmt = format("DELETE FROM {}.{} WHERE key = '{}' AND id = ?", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -573,7 +573,6 @@ public:
 
     // system.view_building_tasks
     future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> get_view_building_tasks();
-    future<mutation> make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task);
     future<mutation> make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id);
 
     // system.scylla_local, view_building_processing_base key

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -573,7 +573,6 @@ public:
 
     // system.view_building_tasks
     future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> get_view_building_tasks();
-    future<mutation> make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id);
 
     // system.scylla_local, view_building_processing_base key
     future<std::optional<table_id>> get_view_building_processing_base_id();

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -76,6 +76,19 @@ view_building_task_mutation_builder& view_building_task_mutation_builder::set_mi
     return *this;
 }
 
+view_building_task_mutation_builder& view_building_task_mutation_builder::set_task(db::view::view_building_task& task) {
+    auto id = task.id;
+    set_type(id, task.type);
+    set_aborted(id, task.aborted);
+    set_base_id(id, task.base_id);
+    if (task.view_id) {
+        set_view_id(id, *task.view_id);
+    }
+    set_last_token(id, task.last_token);
+    set_replica(id, task.replica);
+    return *this;
+}
+
 }
 
 }

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -14,7 +14,11 @@ namespace db {
 namespace view {
 
 utils::UUID view_building_task_mutation_builder::new_id() {
-    return _uuid_gen();
+    if (_uuid_gen) {
+        return (*_uuid_gen)();
+    } else {
+        utils::on_internal_error("view_building_task_mutation_builder: cannot generate new id without uuid generator");
+    }
 }
 
 clustering_key view_building_task_mutation_builder::get_ck(utils::UUID id) {

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -47,6 +47,7 @@ public:
     view_building_task_mutation_builder& del_all_tasks();
     // Sets the static column min_task_id to `id`.
     view_building_task_mutation_builder& set_min_task_id(utils::UUID id);
+    view_building_task_mutation_builder& set_task(db::view::view_building_task& task);
 
     mutation build() {
         return std::move(_m);

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -20,12 +20,12 @@ namespace view {
 // Factory for mutations to `system.view_building_tasks` table.
 class view_building_task_mutation_builder {
     api::timestamp_type _ts;
-    task_uuid_generator _uuid_gen;
+    std::optional<task_uuid_generator> _uuid_gen;
     schema_ptr _s;
     mutation _m;
 
 public:
-    view_building_task_mutation_builder(api::timestamp_type ts, task_uuid_generator uuid_gen)
+    view_building_task_mutation_builder(api::timestamp_type ts, std::optional<task_uuid_generator> uuid_gen = std::nullopt)
             : _ts(ts)
             , _uuid_gen(std::move(uuid_gen))
             , _s(db::system_keyspace::view_building_tasks())

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "db/view/view_building_worker.hh"
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "db/view/view_consumer.hh"
 #include "dht/token.hh"
 #include "replica/database.hh"
@@ -273,22 +274,23 @@ future<> view_building_worker::create_staging_sstable_tasks() {
     shards.erase(0); // We're already holding shard0 lock
     auto locks = co_await lock_staging_mutex_on_multiple_shards(std::move(shards));
 
-    utils::chunked_vector<canonical_mutation> cmuts;
     auto guard = co_await _group0.client().start_operation(_as);
     auto uuid_gen = _vb_state_machine.building_state.make_task_uuid_generator(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), std::move(uuid_gen));
     auto my_host_id = _db.get_token_metadata().get_topology().my_host_id();
     for (auto& [table_id, sst_infos]: _sstables_to_register) {
         for (auto& sst_info: sst_infos) {
             view_building_task task {
-                uuid_gen(), view_building_task::task_type::process_staging, false,
+                builder.new_id(), view_building_task::task_type::process_staging, false,
                 table_id, ::table_id{}, {my_host_id, sst_info.shard}, sst_info.last_token
             };
-            auto mut = co_await _sys_ks.make_view_building_task_mutation(guard.write_timestamp(), task);
-            cmuts.emplace_back(std::move(mut));
+            builder.set_task(task);
+            vbw_logger.trace("Creating process staging task: {} with ID: {} for replica: {}", task, task.id, task.replica);
         }
     }
 
-    vbw_logger.debug("Creating {} process_staging view_building_tasks", cmuts.size());
+    utils::chunked_vector<canonical_mutation> cmuts;
+    cmuts.emplace_back(builder.build());
     auto cmd = _group0.client().prepare_command(service::write_mutations{std::move(cmuts)}, guard, "create view building tasks");
     co_await _group0.client().add_entry(std::move(cmd), std::move(guard), _as);
 

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -15,6 +15,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include "auth/resource.hh"
+#include "db/view/view_building_task_mutation_builder.hh"
 #include "locator/host_id.hh"
 #include "schema/schema_registry.hh"
 #include "service/migration_manager.hh"
@@ -792,7 +793,6 @@ static future<> add_view_building_tasks_mutations(storage_proxy& sp, view_ptr vi
     using namespace db::view;
 
     auto& db = sp.local_db();
-    auto& sys_ks = sp.system_keyspace();
     auto& vb_sm = sp.view_building_state_machine();
 
     auto base_id = view->view_info()->base_id();
@@ -800,21 +800,23 @@ static future<> add_view_building_tasks_mutations(storage_proxy& sp, view_ptr vi
     auto erm = base_cf.get_effective_replication_map();
     auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(base_id);
     auto uuid_gen = vb_sm.building_state.make_task_uuid_generator(ts);
+    db::view::view_building_task_mutation_builder builder(ts, std::move(uuid_gen));
 
     co_await tablet_map.for_each_tablet([&] (auto tid, const auto& tablet_info) -> future<> {
         auto last_token = tablet_map.get_last_token(tid);
         for (auto& replica: tablet_info.replicas) {
-            auto id = uuid_gen();
+            auto id = builder.new_id();
             view_building_task task {
                 id, view_building_task::task_type::build_range, false,
                 base_id, view->id(), replica, last_token
             };
 
-            auto mut = co_await sys_ks.make_view_building_task_mutation(ts, task);
-            out.push_back(std::move(mut));
+            builder.set_task(task);
             mlogger.trace("Creating view building task: {} with ID: {} for replica: {}", task, id, replica);
         }
+        co_return;
     });
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_new_view_announcement(storage_proxy& sp, view_ptr view, api::timestamp_type ts) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -674,13 +674,13 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
     using namespace db::view;
     mlogger.info("Cleaning view building state for all views in keyspace {} ", ks_meta->name());
 
+    db::view::view_building_task_mutation_builder builder(ts);
     auto& sys_ks = sp.system_keyspace();
     auto& vb_state_machine = sp.view_building_state_machine();
 
-    auto drop_all_tasks_in_task_map = [&] (const task_map& task_map) -> future<> {
+    auto drop_all_tasks_in_task_map = [&] (const task_map& task_map) {
         for (auto& [id, _]: task_map) {
-            auto mut = co_await sys_ks.make_remove_view_building_task_mutation(ts, id);
-            out.push_back(std::move(mut));
+            builder.del_task(id);
             mlogger.trace("Aborting view building task with ID: {} because the keyspace is being dropped", id);
         }
     };
@@ -694,9 +694,9 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
 
         for (auto [_, replica_tasks]: vb_state_machine.building_state.tasks_state.at(tid)) {
             for (auto& [_, views_tasks]: replica_tasks.view_tasks) {
-                co_await drop_all_tasks_in_task_map(views_tasks);
+                drop_all_tasks_in_task_map(views_tasks);
             }
-            co_await drop_all_tasks_in_task_map(replica_tasks.staging_tasks);
+            drop_all_tasks_in_task_map(replica_tasks.staging_tasks);
         }
     }
 
@@ -705,6 +705,7 @@ static future<> add_cleanup_view_building_state_drop_keyspace_mutations(storage_
         auto build_status_mut = co_await sys_ks.make_remove_view_build_status_mutation(ts, {view->ks_name(), view->cf_name()});
         out.push_back(std::move(build_status_mut));
     }
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_keyspace_drop_announcement(storage_proxy& sp, const sstring& ks_name, api::timestamp_type ts) {
@@ -871,6 +872,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
     using namespace db::view;
     mlogger.info("Cleaning view building state for view {} ({}.{})", view->id(), view->ks_name(), view->cf_name());
 
+    db::view::view_building_task_mutation_builder builder(ts);
     auto& sys_ks = sp.system_keyspace();
     auto& vb_state_machine = sp.view_building_state_machine();
 
@@ -884,8 +886,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
 
             // Abort all view building tasks for this view
             for (auto& [id, _]: replica_tasks.view_tasks.at(view->id())) {
-                auto mut = co_await sys_ks.make_remove_view_building_task_mutation(ts, id);
-                out.push_back(std::move(mut));
+                builder.del_task(id);
                 mlogger.trace("Aborting view building task with ID: {} because the view is being dropped", id);
             }
         }
@@ -894,6 +895,7 @@ static future<> add_cleanup_view_building_state_drop_view_mutations(storage_prox
     // Remove entries from `system.view_build_status_v2`
     auto build_status_mut = co_await sys_ks.make_remove_view_build_status_mutation(ts, {view->ks_name(), view->cf_name()});
     out.push_back(std::move(build_status_mut));
+    out.emplace_back(builder.build());
 }
 
 future<utils::chunked_vector<mutation>> prepare_view_drop_announcement(storage_proxy& sp, const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts) {


### PR DESCRIPTION
`system.view_building_tasks` is a single partition table, so it makes more sense to use a mutation builder and generate 1 mutation per group0 command instead of generating multiple mutations.

This PR removes all `make_..._mutation()` system keyspace functions related to view building tasks and replaces them with mutation builder.

Refs https://github.com/scylladb/scylladb/issues/25929

This patch doesn't fix any bug, it only reduces number of generated mutations, no need to backport it.