### PR TITLE
cql3/query_processor: execute statement with scheduling group if `USING SERVICE LEVEL` was used

### DIFF
--- a/cql3/attributes.cc
+++ b/cql3/attributes.cc
@@ -115,6 +115,10 @@ db::timeout_clock::duration attributes::get_timeout(const query_options& options
     return std::chrono::duration_cast<db::timeout_clock::duration>(std::chrono::nanoseconds(duration.nanoseconds));
 }
 
+std::optional<sstring> attributes::get_service_level_name() const {
+    return _service_level;
+}
+
 qos::service_level_options attributes::get_service_level(qos::service_level_controller& sl_controller) const {
     auto sl_name = *_service_level;
     if (!sl_controller.has_service_level(sl_name)) {

--- a/cql3/attributes.hh
+++ b/cql3/attributes.hh
@@ -58,6 +58,8 @@ public:
 
     db::timeout_clock::duration get_timeout(const query_options& options) const;
 
+    std::optional<sstring> get_service_level_name() const;
+
     qos::service_level_options get_service_level(qos::service_level_controller& sl_controller) const;
 
     void fill_prepare_context(prepare_context& ctx);

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "seastar/core/scheduling.hh"
 #include "timeout_config.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "audit/audit.hh"
@@ -119,6 +120,8 @@ public:
     void set_audit_info(audit::audit_info_ptr&& info) { _audit_info = std::move(info); }
 
     virtual void sanitize_audit_info() {}
+
+    virtual scheduling_group get_scheduling_group(const service::client_state& state) const { return current_scheduling_group(); }
 };
 
 class cql_statement_no_metadata : public cql_statement {

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -225,6 +225,17 @@ db::timeout_clock::duration select_statement::get_timeout(const service::client_
     return state.get_timeout_config().*get_timeout_config_selector();
 }
 
+scheduling_group select_statement::get_scheduling_group(const service::client_state& state) const {
+    if (_attrs->is_service_level_set()) {
+        auto sl_name = *_attrs->get_service_level_name();
+        if (!state.get_service_level_controller().has_service_level(sl_name)) {
+            throw exceptions::invalid_request_exception(fmt::format("Service level {} doesn't exist", sl_name));
+        }
+        return state.get_service_level_controller().get_scheduling_group(sl_name);
+    }
+    return current_scheduling_group();
+}
+
 ::shared_ptr<const cql3::metadata> select_statement::get_result_metadata() const {
     // FIXME: COUNT needs special result metadata handling.
     return _selection->get_result_metadata();

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -157,6 +157,8 @@ public:
 
     db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 
+    virtual scheduling_group get_scheduling_group(const service::client_state& state) const override;
+
 protected:
     uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;
     static uint64_t get_inner_loop_limit(uint64_t limit, bool is_aggregate);


### PR DESCRIPTION
Execute the statement in correct scheduling group.

By default user's scheduling group will be used (the same on which the user's connection is working),
but if the statement is SELECT and `USING SERVICE LEVEL` clause was used, 
the statement will be executed on scheduling group associated with the service level.

Fixes https://github.com/scylladb/scylladb/issues/24439