### PR TITLE
incremental_compaction_strategy: enable DEFAULT_SPACE_AMPLIFICATION_GOAL

### DIFF
--- a/compaction/incremental_compaction_strategy.cc
+++ b/compaction/incremental_compaction_strategy.cc
@@ -91,11 +91,11 @@ static int validate_fragment_size(const std::map<sstring, sstring>& options, std
 static std::optional<double> validate_space_amplification_goal(const std::map<sstring, sstring>& options) {
     auto tmp_value = compaction_strategy_impl::get_value(options,
         incremental_compaction_strategy::SPACE_AMPLIFICATION_GOAL_OPTION);
-    if (tmp_value) {
-        auto space_amplification_goal = cql3::statements::property_definitions::to_double(incremental_compaction_strategy::SPACE_AMPLIFICATION_GOAL_OPTION,
-            tmp_value, 0.0);
+    auto space_amplification_goal = cql3::statements::property_definitions::to_double(incremental_compaction_strategy::SPACE_AMPLIFICATION_GOAL_OPTION,
+        tmp_value, incremental_compaction_strategy::DEFAULT_SPACE_AMPLIFICATION_GOAL);
+    if (space_amplification_goal) {
         if (space_amplification_goal <= 1.0 || space_amplification_goal > 2.0) {
-            throw exceptions::configuration_exception(fmt::format("{} value ({}) must be greater than 1.0 and less than or equal to 2.0",
+            throw exceptions::configuration_exception(fmt::format("{} value ({}) must be greater than 1.0 and less than or equal to 2.0; or 0 to disable",
                 incremental_compaction_strategy::SPACE_AMPLIFICATION_GOAL_OPTION, space_amplification_goal));
         }
         return space_amplification_goal;

--- a/compaction/incremental_compaction_strategy.hh
+++ b/compaction/incremental_compaction_strategy.hh
@@ -48,11 +48,12 @@ class incremental_compaction_strategy : public compaction_strategy_impl {
     using size_bucket_t = std::vector<sstables::frozen_sstable_run>;
 public:
     static constexpr int32_t DEFAULT_MAX_FRAGMENT_SIZE_IN_MB = 1000;
+    static constexpr double DEFAULT_SPACE_AMPLIFICATION_GOAL = 1.5;
     static constexpr auto FRAGMENT_SIZE_OPTION = "sstable_size_in_mb";
     static constexpr auto SPACE_AMPLIFICATION_GOAL_OPTION = "space_amplification_goal";
 private:
     size_t _fragment_size = DEFAULT_MAX_FRAGMENT_SIZE_IN_MB*1024*1024;
-    std::optional<double> _space_amplification_goal;
+    std::optional<double> _space_amplification_goal = DEFAULT_SPACE_AMPLIFICATION_GOAL;
     static std::vector<sstable_run_and_length> create_run_and_length_pairs(const std::vector<sstables::frozen_sstable_run>& runs);
 
     static std::vector<std::vector<sstables::frozen_sstable_run>> get_buckets(const std::vector<sstables::frozen_sstable_run>& runs, const incremental_compaction_strategy_options& options);

--- a/docs/cql/compaction.rst
+++ b/docs/cql/compaction.rst
@@ -253,13 +253,13 @@ The following options only apply to IncrementalCompactionStrategy:
 
 =====
 
-``space_amplification_goal`` (default: null)
+``space_amplification_goal`` (default: 1.5)
 
    .. versionadded:: 2020.1.6
 
    This is a threshold of the ratio of the sum of the sizes of the two largest tiers to the size of the largest tier,
    above which ICS will automatically compact the second largest and largest tiers together to eliminate stale data that may have been overwritten, expired, or deleted.
-   The space_amplification_goal is given as a double-precision floating point number that must be greater than 1.0.
+   The space_amplification_goal is given as a double-precision floating point number that must be greater than 1.0 and less than or equal to 2.0; or 0 to disable.
 
    For example, if **'space_amplification_goal = 1.25'** and the largest tier holds **1000GB**,
    when the second-largest tier accumulates SSTables with the total size of 250GB or more,


### PR DESCRIPTION
As we gained ample experience with ICS in the field, we saw great benefits from the Space Amplification Goal feature, while running into issues when it wasn't enabled.

This change enabled SAG by default using the value of 1.5

Fixes #26245

* Although this is an enhancement, we do have long experience with SAG in the field and would like to change the default in released versions (after thoroughly testing this change in master and 2026.1)