### PR TITLE
storage_service: Return num_tablets in add_repair_tablet_request

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3569,6 +3569,10 @@
         "properties":{
             "tablet_task_id":{
                 "type":"string"
+            },
+            "num_tablets":{
+                "type":"string",
+                "description":"Number of tablets are requested to be repaired"
             }
         }
       },

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6813,6 +6813,8 @@ future<std::unordered_map<sstring, sstring>> storage_service::add_repair_tablet_
         }
     }
 
+    res["num_tablets"] = std::to_string(tokens.size());
+
     if (!await_completion) {
         auto duration = std::chrono::duration<float>(std::chrono::steady_clock::now() - start);
         slogger.info("Issued tablet repair by API request table_id={} tokens={} all_tokens={} tablet_task_id={} duration={}",


### PR DESCRIPTION
Currently, it returns only the task id of the requests. The exact number of tablets are requested to be repaired are not known. This info is useful for the management tool.

Add num_tablets to the tablet_repair_result, so that the user could know how many tablets will be repaired by the tablet scheduler.

Fxies #26875

Improvment. Low risk. Nice to have in 2025.4. 