### PR TITLE
Store sstable token ranges in scylla metadata and use to improve cleanup predicate

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -589,7 +589,7 @@ protected:
     std::optional<sstables::sstable_set::incremental_selector> _selector;
     std::unordered_set<sstables::shared_sstable> _compacting_for_max_purgeable_func;
     // optional owned_ranges vector for cleanup;
-    const owned_ranges_ptr _owned_ranges = {};
+    const replica::owned_ranges_ptr _owned_ranges = {};
     // required for reshard compaction.
     const dht::sharder* _sharder = nullptr;
     const std::optional<dht::incremental_owned_ranges_checker> _owned_ranges_checker;

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -14,7 +14,7 @@
 #include <variant>
 #include "sstables/types_fwd.hh"
 #include "sstables/sstable_set.hh"
-#include "compaction_fwd.hh"
+#include "replica/database_fwd.hh"
 #include "mutation_writer/token_group_based_splitting_writer.hh"
 
 namespace compaction {
@@ -173,7 +173,7 @@ struct compaction_descriptor {
     // This also selects the kind of compaction to do.
     compaction_type_options options = compaction_type_options::make_regular();
     // If engaged, compaction will cleanup the input sstables by skipping non-owned ranges.
-    compaction::owned_ranges_ptr owned_ranges;
+    replica::owned_ranges_ptr owned_ranges;
     // Required for reshard compaction.
     const dht::sharder* sharder;
 
@@ -203,7 +203,7 @@ struct compaction_descriptor {
                                    uint64_t max_sstable_bytes = default_max_sstable_bytes,
                                    sstables::run_id run_identifier = sstables::run_id::create_random_id(),
                                    compaction_type_options options = compaction_type_options::make_regular(),
-                                   compaction::owned_ranges_ptr owned_ranges_ = {})
+                                   replica::owned_ranges_ptr owned_ranges_ = {})
         : sstables(std::move(sstables))
         , level(level)
         , max_sstable_bytes(max_sstable_bytes)

--- a/compaction/compaction_fwd.hh
+++ b/compaction/compaction_fwd.hh
@@ -11,14 +11,10 @@
 
 #include <seastar/core/shared_ptr.hh>
 
-#include "dht/i_partitioner_fwd.hh"
-
 namespace compaction {
 
 class compaction_group_view;
 class strategy_control;
 struct compaction_state;
-
-using owned_ranges_ptr = seastar::lw_shared_ptr<const dht::token_range_vector>;
 
 } // namespace compaction

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -36,6 +36,7 @@
 #include "utils/pluggable.hh"
 #include "compaction/compaction_reenabler.hh"
 #include "utils/disk_space_monitor.hh"
+#include "replica/database_fwd.hh"
 
 namespace db {
 class compaction_history_entry;
@@ -58,10 +59,6 @@ class rewrite_sstables_compaction_task_executor;
 class split_compaction_task_executor;
 class cleanup_sstables_compaction_task_executor;
 class validate_sstables_compaction_task_executor;
-
-inline owned_ranges_ptr make_owned_ranges_ptr(dht::token_range_vector&& ranges) {
-    return make_lw_shared<const dht::token_range_vector>(std::move(ranges));
-}
 
 // Compaction manager provides facilities to submit and track compaction jobs on
 // behalf of existing tables.
@@ -248,10 +245,10 @@ private:
     requires std::derived_from<TaskType, compaction_task_executor> &&
             std::derived_from<TaskType, compaction_task_impl>
 
-    future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(sstring reason, tasks::task_info info, compaction_group_view& t, compaction_type_options options, owned_ranges_ptr owned_ranges_ptr,
+    future<compaction_manager::compaction_stats_opt> perform_task_on_all_files(sstring reason, tasks::task_info info, compaction_group_view& t, compaction_type_options options, replica::owned_ranges_ptr owned_ranges_ptr,
                                                                                get_candidates_func get_func, throw_if_stopping do_throw_if_stopping, Args... args);
 
-    future<compaction_stats_opt> rewrite_sstables(compaction::compaction_group_view& t, compaction_type_options options, owned_ranges_ptr, get_candidates_func, tasks::task_info info,
+    future<compaction_stats_opt> rewrite_sstables(compaction::compaction_group_view& t, compaction_type_options options, replica::owned_ranges_ptr, get_candidates_func, tasks::task_info info,
                                                   can_purge_tombstones can_purge = can_purge_tombstones::yes, sstring options_desc = "");
 
     // Stop all fibers, without waiting. Safe to be called multiple times.
@@ -343,9 +340,9 @@ public:
     // Cleanup is about discarding keys that are no longer relevant for a
     // given sstable, e.g. after node loses part of its token range because
     // of a newly added node.
-    future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
+    future<> perform_cleanup(replica::owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
 private:
-    future<> try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
+    future<> try_perform_cleanup(replica::owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
 
     // Add sst to or remove it from the respective compaction_state.sstables_requiring_cleanup set.
     bool update_sstable_cleanup_state(compaction_group_view& t, const sstables::shared_sstable& sst, const dht::token_range_vector& sorted_owned_ranges);
@@ -353,7 +350,7 @@ private:
     future<> on_compaction_completion(compaction_group_view& t, compaction_completion_desc desc, sstables::offstrategy offstrategy);
 public:
     // Submit a table to be upgraded and wait for its termination.
-    future<> perform_sstable_upgrade(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, bool exclude_current_version, tasks::task_info info);
+    future<> perform_sstable_upgrade(replica::owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, bool exclude_current_version, tasks::task_info info);
 
     // Submit a table to be scrubbed and wait for its termination.
     future<compaction_stats_opt> perform_sstable_scrub(compaction::compaction_group_view& t, compaction_type_options::scrub opts, tasks::task_info info);

--- a/compaction/compaction_state.hh
+++ b/compaction/compaction_state.hh
@@ -16,6 +16,7 @@
 #include "compaction/compaction_fwd.hh"
 #include "compaction/compaction_backlog_manager.hh"
 #include "gc_clock.hh"
+#include "replica/database_fwd.hh"
 
 namespace compaction {
 
@@ -49,7 +50,7 @@ struct compaction_state {
 
     // Used only with vnodes, will not work with tablets. Can be removed once vnodes are gone.
     std::unordered_set<sstables::shared_sstable> sstables_requiring_cleanup;
-    compaction::owned_ranges_ptr owned_ranges_ptr;
+    replica::owned_ranges_ptr owned_ranges_ptr;
 
     gc_clock::time_point last_regular_compaction;
 

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -692,7 +692,7 @@ private:
     sharded<sstables::sstable_directory>& _dir;
     sharded<replica::database>& _db;
     compaction_sstable_creator_fn _creator;
-    compaction::owned_ranges_ptr _owned_ranges_ptr;
+    replica::owned_ranges_ptr _owned_ranges_ptr;
 public:
     table_resharding_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
@@ -700,7 +700,7 @@ public:
             sharded<sstables::sstable_directory>& dir,
             sharded<replica::database>& db,
             compaction_sstable_creator_fn creator,
-            compaction::owned_ranges_ptr owned_ranges_ptr) noexcept
+            replica::owned_ranges_ptr owned_ranges_ptr) noexcept
         : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "table", std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
         , _dir(dir)
         , _db(db)
@@ -717,7 +717,7 @@ private:
     sharded<sstables::sstable_directory>& _dir;
     replica::database& _db;
     compaction_sstable_creator_fn _creator;
-    compaction::owned_ranges_ptr _local_owned_ranges_ptr;
+    replica::owned_ranges_ptr _local_owned_ranges_ptr;
     std::vector<replica::reshard_shard_descriptor>& _destinations;
 public:
     shard_resharding_compaction_task_impl(tasks::task_manager::module_ptr module,
@@ -727,7 +727,7 @@ public:
             sharded<sstables::sstable_directory>& dir,
             replica::database& db,
             compaction_sstable_creator_fn creator,
-            compaction::owned_ranges_ptr local_owned_ranges_ptr,
+            replica::owned_ranges_ptr local_owned_ranges_ptr,
             std::vector<replica::reshard_shard_descriptor>& destinations) noexcept;
 protected:
     virtual future<> run() override;

--- a/db/schema_applier.hh
+++ b/db/schema_applier.hh
@@ -228,9 +228,9 @@ private:
     future<> merge_functions();
     future<> merge_aggregates();
 
-    void commit_tables_and_views();
+    future<> commit_tables_and_views();
     future<> finalize_tables_and_views();
-    void commit_on_shard(replica::database& db);
+    future<> commit_on_shard(replica::database& db);
 };
 
 }

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -3771,4 +3771,8 @@ future<utils::chunked_vector<temporary_buffer<char>>> database::sample_data_file
     co_return result;
 }
 
+owned_ranges_ptr make_owned_ranges_ptr(dht::token_range_vector&& ranges) {
+    return make_lw_shared<const dht::token_range_vector>(std::move(ranges));
+}
+
 } // namespace replica

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -12,6 +12,7 @@
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 #include <seastar/core/rwlock.hh>
+#include "compaction/compaction_fwd.hh"
 #include "db/view/view.hh"
 #include "locator/network_topology_strategy.hh"
 #include "locator/tablets.hh"
@@ -1056,7 +1057,7 @@ future<> database::create_local_system_table(
     auto lock = get_tables_metadata().hold_write_lock();
     std::exception_ptr ex;
     try {
-        add_column_family(ks, table, std::move(cfg), replica::database::is_new_cf::no);
+        co_await add_column_family(ks, table, std::move(cfg), replica::database::is_new_cf::no);
     } catch (...) {
         ex = std::current_exception();
     }
@@ -1073,10 +1074,22 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
         : _commitlog.get();
 }
 
-void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata) {
+future<owned_ranges_ptr> maybe_make_owned_ranges_ptr(locator::effective_replication_map_ptr erm, locator::host_id host_id) {
+    if (!erm) {
+        co_return nullptr;
+    }
+    if (erm->get_token_metadata().sorted_tokens().empty()) {
+        co_return nullptr;
+    }
+    co_return make_owned_ranges_ptr(co_await erm->get_ranges(host_id));
+}
+
+future<> database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata) {
     schema = local_schema_registry().learn(schema);
     auto&& rs = ks.get_replication_strategy();
+    auto my_host_id = get_token_metadata().get_topology().my_host_id();
     locator::effective_replication_map_ptr erm;
+    owned_ranges_ptr owned_ranges_ptr;  // For vnode-based replication
     if (auto pt_rs = rs.maybe_as_per_table()) {
         auto metadata_ptr = not_commited_new_metadata;
         if (!metadata_ptr) {
@@ -1086,10 +1099,11 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
         erm = pt_rs->make_replication_map(schema->id(), metadata_ptr);
     } else {
         erm = ks.get_static_effective_replication_map();
+        owned_ranges_ptr = co_await maybe_make_owned_ranges_ptr(erm, my_host_id);
     }
     // avoid self-reporting
     auto& sst_manager = get_sstables_manager(*schema);
-    auto cf = make_lw_shared<column_family>(schema, std::move(cfg), ks.metadata()->get_storage_options_ptr(), _compaction_manager, sst_manager, *_cl_stats, _row_cache_tracker, erm);
+    auto cf = make_lw_shared<column_family>(schema, std::move(cfg), ks.metadata()->get_storage_options_ptr(), _compaction_manager, sst_manager, *_cl_stats, _row_cache_tracker, erm, owned_ranges_ptr);
     cf->set_durable_writes(ks.metadata()->durable_writes());
 
     if (is_new) {
@@ -1122,7 +1136,7 @@ future<> database::add_column_family_and_make_directory(schema_ptr schema, is_ne
     auto& ks = find_keyspace(schema->ks_name());
     std::exception_ptr ex;
     try {
-        add_column_family(ks, schema, ks.make_column_family_config(*schema, *this), is_new);
+        co_await add_column_family(ks, schema, ks.make_column_family_config(*schema, *this), is_new);
     } catch (...) {
         ex = std::current_exception();
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -489,6 +489,7 @@ private:
     schema_ptr _schema;
     config _config;
     locator::effective_replication_map_ptr _erm;
+    owned_ranges_ptr _owned_ranges;
     lw_shared_ptr<const storage_options> _storage_opts;
     memtable_table_shared_data _memtable_shared_data;
     mutable table_stats _stats;
@@ -932,8 +933,14 @@ public:
     future<std::vector<locked_cell>> lock_counter_cells(const mutation& m, db::timeout_clock::time_point timeout);
 
     logalloc::occupancy_stats occupancy() const;
+
+    const owned_ranges_ptr& get_owned_ranges() const noexcept {
+        return _owned_ranges;
+    }
+
+    sstables::sstable_writer_config configure_writer(sstring origin) const;
 public:
-    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options> sopts, compaction::compaction_manager& cm, sstables::sstables_manager& sm, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm);
+    table(schema_ptr schema, config cfg, lw_shared_ptr<const storage_options> sopts, compaction::compaction_manager& cm, sstables::sstables_manager& sm, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker, locator::effective_replication_map_ptr erm, owned_ranges_ptr owned_ranges = nullptr);
 
     table(column_family&&) = delete; // 'this' is being captured during construction
     ~table();
@@ -1831,7 +1838,7 @@ public:
     void init_schema_commitlog();
 
     using is_new_cf = bool_class<struct is_new_cf_tag>;
-    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr);
+    future<> add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr);
     future<> make_column_family_directory(schema_ptr schema);
     future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new);
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1104,7 +1104,7 @@ public:
     // a future<bool> that is resolved when offstrategy_compaction completes.
     // The future value is true iff offstrategy compaction was required.
     future<bool> perform_offstrategy_compaction(tasks::task_info info);
-    future<> perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges,
+    future<> perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges,
                                         tasks::task_info info,
                                         do_flush = do_flush::yes);
     future<unsigned> estimate_pending_compactions() const;

--- a/replica/database_fwd.hh
+++ b/replica/database_fwd.hh
@@ -12,6 +12,8 @@
 #include <vector>
 #include <seastar/core/sharded.hh>
 
+#include "dht/i_partitioner_fwd.hh"
+
 namespace replica {
 
 // replica/database.hh
@@ -48,4 +50,7 @@ using clustering_key_view = clustering_key_prefix_view;
 // memtable.hh
 namespace replica {
 class memtable;
+
+using owned_ranges_ptr = seastar::lw_shared_ptr<const dht::token_range_vector>;
+owned_ranges_ptr make_owned_ranges_ptr(dht::token_range_vector&& ranges);
 }

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -99,7 +99,7 @@ distributed_loader::lock_table(global_table_ptr& table, sharded<sstables::sstabl
 //  - The second part calls each shard's distributed object to reshard the SSTables they were
 //    assigned.
 future<>
-distributed_loader::reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr) {
+distributed_loader::reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, owned_ranges_ptr owned_ranges_ptr) {
     auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
     auto task = co_await compaction_module.make_and_start_task<compaction::table_resharding_compaction_task_impl>({}, std::move(ks_name), std::move(table_name), dir, db, std::move(creator), std::move(owned_ranges_ptr));
     co_await task->done();
@@ -206,7 +206,7 @@ distributed_loader::process_upload_dir(sharded<replica::database>& db, sharded<d
         // - split the keyspace local ranges per compaction_group as done in table::perform_cleanup_compaction
         //   so that cleanup can be considered per compaction group
         const auto& erm = db.local().find_keyspace(ks).get_static_effective_replication_map();
-        auto owned_ranges_ptr = skip_cleanup ? lw_shared_ptr<dht::token_range_vector>(nullptr) : compaction::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(erm).get());
+        auto owned_ranges_ptr = skip_cleanup ? lw_shared_ptr<dht::token_range_vector>(nullptr) : replica::make_owned_ranges_ptr(db.local().get_keyspace_local_ranges(erm).get());
         reshard(directory, db, ks, cf, make_sstable, owned_ranges_ptr).get();
         if (!skip_reshape) {
             reshape(directory, db, compaction::reshape_mode::strict, ks, cf, make_sstable,

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -70,7 +70,7 @@ class distributed_loader {
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, compaction::reshape_mode mode,
             sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter);
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator,
-            compaction::owned_ranges_ptr owned_ranges_ptr = nullptr);
+            owned_ranges_ptr owned_ranges_ptr = nullptr);
     static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags);
     static future<> lock_table(global_table_ptr&, sharded<sstables::sstable_directory>& dir);
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -2253,7 +2253,7 @@ future<bool> table::perform_offstrategy_compaction(tasks::task_info info) {
     co_return performed;
 }
 
-future<> table::perform_cleanup_compaction(compaction::owned_ranges_ptr sorted_owned_ranges,
+future<> table::perform_cleanup_compaction(owned_ranges_ptr sorted_owned_ranges,
                                            tasks::task_info info,
                                            do_flush do_flush) {
     auto* cg = try_get_compaction_group_with_static_sharding();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1665,7 +1665,7 @@ table::try_flush_memtable_to_sstable(compaction_group& cg, lw_shared_ptr<memtabl
         auto consumer = _compaction_strategy.make_interposer_consumer(metadata, [this, old, permit, &newtabs, estimated_partitions, &cg] (mutation_reader reader) mutable -> future<> {
           std::exception_ptr ex;
           try {
-            sstables::sstable_writer_config cfg = get_sstables_manager().configure_writer("memtable");
+            sstables::sstable_writer_config cfg = configure_writer("memtable");
             cfg.backup = incremental_backups_enabled();
 
             auto newtab = make_sstable();
@@ -2602,8 +2602,7 @@ public:
         return _t.make_sstable();
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
-        auto cfg = _t.get_sstables_manager().configure_writer(std::move(origin));
-        return cfg;
+        return _t.configure_writer(std::move(origin));
     }
     api::timestamp_type min_memtable_timestamp() const override {
         return _cg.min_memtable_timestamp();
@@ -2750,10 +2749,11 @@ void storage_group::clear_sstables() {
 
 table::table(schema_ptr schema, config config, lw_shared_ptr<const storage_options> sopts, compaction::compaction_manager& compaction_manager,
         sstables::sstables_manager& sst_manager, cell_locker_stats& cl_stats, cache_tracker& row_cache_tracker,
-        locator::effective_replication_map_ptr erm)
+        locator::effective_replication_map_ptr erm, owned_ranges_ptr owned_ranges)
     : _schema(std::move(schema))
     , _config(std::move(config))
     , _erm(std::move(erm))
+    , _owned_ranges(std::move(owned_ranges))
     , _storage_opts(std::move(sopts))
     , _view_stats(format("{}_{}_view_replica_update", _schema->ks_name(), _schema->cf_name()),
                          keyspace_label(_schema->ks_name()),
@@ -4556,6 +4556,12 @@ future<uint64_t> table::estimated_partitions_in_range(dht::token_range tr) const
         partition_count += co_await sst->estimated_keys_for_range(tr);
     });
     co_return partition_count;
+}
+
+sstables::sstable_writer_config table::configure_writer(sstring origin) const {
+    auto cfg = get_sstables_manager().configure_writer(origin);
+    cfg.owned_ranges = get_owned_ranges();
+    return cfg;
 }
 
 } // namespace replica

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -564,11 +564,16 @@ private:
     uint64_t _partition_header_length = 0;
     uint64_t _prev_row_start = 0;
     std::optional<key> _partition_key;
+    dht::token _current_token;
     utils::hashed_key _current_murmur_hash{{0, 0}};
     std::optional<key> _first_key, _last_key;
     index_sampling_state _index_sampling_state;
     bytes_ostream _tmp_bufs;
     uint64_t _num_partitions_consumed = 0;
+    std::optional<dht::token_range_vector::const_iterator> _owned_ranges_cur_it = std::nullopt;
+    std::optional<dht::token_range_vector::const_iterator> _owned_ranges_next_it = std::nullopt;
+    dht::token_range_vector::const_iterator _owned_ranges_end;
+    utils::chunked_vector<std::pair<dht::token, dht::token>> _token_ranges;
 
     const sstable_schema _sst_schema;
 
@@ -843,6 +848,11 @@ public:
       if (_index_writer) {
         prepare_summary(_sst._components->summary, estimated_partitions, _schema.min_index_interval());
       }
+
+        if (_cfg.owned_ranges && !_cfg.owned_ranges->empty()) {
+            _owned_ranges_next_it = _cfg.owned_ranges->begin();
+            _owned_ranges_end = _cfg.owned_ranges->end();
+        }
     }
 
     ~writer();
@@ -987,6 +997,7 @@ void writer::consume_new_partition(const dht::decorated_key& dk) {
     _prev_row_start = _data_writer->offset();
 
     _partition_key = key::from_partition_key(_schema, dk.key());
+    _current_token = dk.token();
     maybe_add_summary_entry(dk.token(), bytes_view(*_partition_key));
 
     _current_murmur_hash = utils::make_hashed_key(bytes_view(*_partition_key));
@@ -1611,11 +1622,37 @@ stop_iteration writer::consume_end_of_partition() {
     _collector.update(std::move(_c_stats));
     _c_stats.reset();
 
+    // Do we need to advance to the next token range?
+    auto cmp = dht::token_comparator();
+    if (_token_ranges.empty() ||
+            (_owned_ranges_cur_it && (*_owned_ranges_cur_it)->after(_current_token, cmp)) ||
+            (!_owned_ranges_cur_it && _owned_ranges_next_it && !(*_owned_ranges_next_it)->before(_current_token, cmp))) {
+        _token_ranges.emplace_back(_current_token, _current_token);
+        // Locate next token range
+        while (_owned_ranges_next_it && (*_owned_ranges_next_it)->after(_current_token, cmp)) {
+            if (++*_owned_ranges_next_it == _owned_ranges_end) {
+                _owned_ranges_next_it.reset();
+                break;
+            }
+        }
+        if (_owned_ranges_next_it && (*_owned_ranges_next_it)->contains(_current_token, cmp)) {
+            _owned_ranges_cur_it = _owned_ranges_next_it;
+            if (++*_owned_ranges_next_it == _owned_ranges_end) {
+                _owned_ranges_next_it.reset();
+            }
+        } else {
+            // Assume we're writing into a pending range
+            _owned_ranges_cur_it.reset();
+        }
+    } else {
+        _token_ranges.back().second = _current_token;
+    }
     if (!_first_key) {
         _first_key = *_partition_key;
     }
     _last_key = std::move(*_partition_key);
     _partition_key = std::nullopt;
+    _current_token = dht::token();
     return get_data_offset() < _cfg.max_sstable_size ? stop_iteration::no : stop_iteration::yes;
 }
 
@@ -1658,6 +1695,17 @@ void writer::consume_end_of_stream() {
 
     _sst.set_first_and_last_keys();
 
+    std::optional<scylla_metadata::token_ranges> disk_token_ranges;
+    if (!_token_ranges.empty()) {
+        disk_token_ranges.emplace();
+        disk_token_ranges->token_ranges.elements.reserve(_token_ranges.size());
+        for (const auto& tr : _token_ranges) {
+            disk_token_ranges->token_ranges.elements.emplace_back(disk_token_range{
+                {false /* exclusive */, {tr.first.data()}},
+                {false /* exclusive */, {tr.second.data()}}});
+        }
+    }
+
     _sst._components->statistics.contents[metadata_type::Serialization] = std::make_unique<serialization_header>(std::move(_sst_schema.header));
     seal_statistics(_sst.get_version(), _sst._components->statistics, _collector,
         _sst._schema->get_partitioner().name(), _sst._schema->bloom_filter_fp_chance(),
@@ -1695,7 +1743,7 @@ void writer::consume_end_of_stream() {
     std::optional<scylla_metadata::ext_timestamp_stats> ts_stats(scylla_metadata::ext_timestamp_stats{
         .map = _collector.get_ext_timestamp_stats()
     });
-    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(ld_stats), std::move(ts_stats));
+    _sst.write_scylla_metadata(_shard, std::move(identifier), std::move(ld_stats), std::move(ts_stats), std::move(disk_token_ranges));
     _sst.seal_sstable(_cfg.backup).get();
 }
 

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -81,6 +81,8 @@ struct sstable_open_config {
     // Mimics behavior when a SSTable is streamed to a given shard, where SSTable
     // writer considers the shard that created the SSTable as its owner.
     bool current_shard_as_sstable_owner = false;
+    // Do not move the sharding metadata to the sharder, keeping it in the scylla metadata..
+    bool keep_sharding_metadata = false;
 };
 
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1404,7 +1404,7 @@ future<> sstable::open_data(sstable_open_config cfg) noexcept {
     co_await update_info_for_opened_data(cfg);
     parse_assert(!_shards.empty(), get_filename());
     auto* sm = _components->scylla_metadata->data.get<scylla_metadata_type::Sharding, sharding_metadata>();
-    if (sm) {
+    if (sm && !cfg.keep_sharding_metadata) {
         // Sharding information uses a lot of memory and once we're doing with this computation we will no longer use it.
         co_await utils::clear_gently(sm->token_ranges.elements);
         sm->token_ranges.elements = {};

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2016,7 +2016,8 @@ static sstable_column_kind to_sstable_column_kind(column_kind k) {
 
 void
 sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
-        std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats) {
+        std::optional<scylla_metadata::large_data_stats> ld_stats, std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
+        std::optional<scylla_metadata::token_ranges> token_ranges) {
     auto&& first_key = get_first_decorated_key();
     auto&& last_key = get_last_decorated_key();
 
@@ -2089,6 +2090,10 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         sstable_schema.columns.elements.push_back(sstable_column_description{to_sstable_column_kind(col.kind), {col.name()}, {to_bytes(col.type->name())}});
     }
     _components->scylla_metadata->data.set<scylla_metadata_type::Schema>(std::move(sstable_schema));
+
+    if (token_ranges) {
+        _components->scylla_metadata->data.set<scylla_metadata_type::TokenRanges>(std::move(*token_ranges));
+    }
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata);
 }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -673,7 +673,8 @@ private:
     void write_scylla_metadata(shard_id shard,
                                run_identifier identifier,
                                std::optional<scylla_metadata::large_data_stats> ld_stats,
-                               std::optional<scylla_metadata::ext_timestamp_stats> ts_stats);
+                               std::optional<scylla_metadata::ext_timestamp_stats> ts_stats,
+                               std::optional<scylla_metadata::token_ranges> token_ranges);
 
     future<> read_filter(sstable_open_config cfg = {});
 

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -256,6 +256,8 @@ public:
     // from disk to achieve that.
     future<> load_owner_shards(const dht::sharder& sharder);
 
+    dht::token_range_vector load_token_ranges() const;
+
     // Call as the last method before the object is destroyed.
     // No other uses of the object can happen at this point.
     future<> destroy();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -46,6 +46,7 @@
 #include "dht/decorated_key.hh"
 #include "service/session.hh"
 #include "sstables/trie/bti_index.hh"
+#include "compaction/compaction_fwd.hh"
 
 #include <seastar/util/optimized_optional.hh>
 
@@ -116,6 +117,7 @@ struct sstable_writer_config {
     size_t summary_byte_cost;
     sstring origin;
     bool correct_pi_block_width = true;
+    replica::owned_ranges_ptr owned_ranges = nullptr;
 
 private:
     explicit sstable_writer_config() {}

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -180,6 +180,8 @@ public:
         return _storage->is_known_endpoint(std::move(endpoint));
     }
 
+    // Consider calling the table's configure_writer() instead
+    // as it sets cfg.owned_ranges appropriately.
     virtual sstable_writer_config configure_writer(sstring origin) const;
     const db::config& config() const { return _db_config; }
     cache_tracker& get_cache_tracker() { return _cache_tracker; }

--- a/streaming/consumer.cc
+++ b/streaming/consumer.cc
@@ -63,7 +63,7 @@ mutation_reader_consumer make_streaming_consumer(sstring origin,
                 }
                 schema_ptr s = reader.schema();
 
-                auto cfg = cf->get_sstables_manager().configure_writer(origin);
+                auto cfg = cf->configure_writer(origin);
                 return sst->write_components(std::move(reader), adjusted_estimated_partitions, s,
                                              cfg, encoding_stats{}).then([sst] {
                     return sst->open_data();

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1265,7 +1265,7 @@ SEASTAR_TEST_CASE(upgrade_sstables) {
             auto& cm = db.get_compaction_manager();
             for (auto& [ks_name, ks] : db.get_keyspaces()) {
                 const auto& erm = ks.get_static_effective_replication_map();
-                auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(co_await db.get_keyspace_local_ranges(erm));
+                auto owned_ranges_ptr = replica::make_owned_ranges_ptr(co_await db.get_keyspace_local_ranges(erm));
                 for (auto& [cf_name, schema] : ks.metadata()->cf_meta_data()) {
                     auto& t = db.find_column_family(schema->id());
                     constexpr bool exclude_current_version = false;

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -41,7 +41,7 @@ public:
         auto gtable = co_await replica::get_table_on_all_shards(db, ks_name, cf_name);
         co_await replica::distributed_loader::lock_table(gtable, dir);
     }
-    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr = nullptr) {
+    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, replica::owned_ranges_ptr owned_ranges_ptr = nullptr) {
         return replica::distributed_loader::reshard(dir, db, std::move(ks_name), std::move(table_name), std::move(creator), std::move(owned_ranges_ptr));
     }
 };
@@ -584,7 +584,7 @@ SEASTAR_TEST_CASE(sstable_directory_shared_sstables_reshard_correctly_with_owned
             return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
         };
         const auto& erm = e.db().local().find_keyspace("ks").get_static_effective_replication_map();
-        auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm).get());
+        auto owned_ranges_ptr = replica::make_owned_ranges_ptr(e.db().local().get_keyspace_local_ranges(erm).get());
         distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable), std::move(owned_ranges_ptr)).get();
         verify_that_all_sstables_are_local(sstdir, smp::count * smp::count).get();
       });

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -1357,6 +1357,7 @@ const char* to_string(sstables::scylla_metadata_type t) {
         case sstables::scylla_metadata_type::ExtTimestampStats: return "ext_timestamp_stats";
         case sstables::scylla_metadata_type::SSTableIdentifier: return "sstable_identifier";
         case sstables::scylla_metadata_type::Schema: return "schema";
+        case sstables::scylla_metadata_type::TokenRanges: return "token_ranges";
     }
     std::abort();
 }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -381,7 +381,11 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         auto sst = sst_man.make_sstable(schema, options, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);
 
         try {
-            co_await sst->load(schema->get_sharder(), sstables::sstable_open_config{.load_first_and_last_position_metadata = false});
+            auto open_cfg = sstables::sstable_open_config{
+                .load_first_and_last_position_metadata = false,
+                .keep_sharding_metadata = true,
+            };
+            co_await sst->load(schema->get_sharder(), open_cfg);
         } catch (...) {
             // Print each individual error here since parallel_for_each
             // will propagate only one of them up the stack.
@@ -1379,6 +1383,9 @@ const char* to_string(sstables::ext_timestamp_stats_type t) {
 class scylla_metadata_visitor {
     json_writer& _writer;
 
+    dht::token as_token(const sstables::disk_string<uint16_t>& ds) const {
+        return dht::token(dht::token::kind::key, bytes_view(ds));
+    }
 public:
     scylla_metadata_visitor(json_writer& writer) : _writer(writer) { }
 
@@ -1392,7 +1399,7 @@ public:
             _writer.Key("exclusive");
             _writer.Bool(e.left.exclusive);
             _writer.Key("token");
-            _writer.String(disk_string_to_string(e.left.token));
+            _writer.AsString(as_token(e.left.token));
             _writer.EndObject();
 
             _writer.Key("right");
@@ -1400,7 +1407,7 @@ public:
             _writer.Key("exclusive");
             _writer.Bool(e.right.exclusive);
             _writer.Key("token");
-            _writer.String(disk_string_to_string(e.right.token));
+            _writer.AsString(as_token(e.right.token));
             _writer.EndObject();
 
             _writer.EndObject();


### PR DESCRIPTION
If the sstable has token_ranges in scylla_metadata
use them to see if the sstable needs cleanup, or wheather
the sstable token ranges are all contained in the
sorted_owned_ranges.

This is much more accurate than just relying on the
"default" sstable token range which is using only the
first and last keys.

Performance comparison:
```
$ ./build/release/scylla perf-sstable --mode=write --testdir=testlog/release --partitions=10000 --iterations=10
Before (6f6ee5581e): 613809.81 +- 7916.01 partitions / sec (10 runs, 1 concurrent ops)
After  (ffcea7787f): 601031.85 +- 9221.37 partitions / sec (10 runs, 1 concurrent ops)
```
This translates to 2% regression

Fixes #12215