### PR TITLE
replica: Fail timed-out single-key read on cleaned up tablet replica

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3924,6 +3924,14 @@ table::query(schema_ptr query_schema,
         querier_opt = std::move(*saved_querier);
     }
 
+    co_await utils::get_local_injector().inject("replica_query_wait", [&] (auto& handler) -> future<> {
+        auto table_name = handler.template get<std::string_view>("table");
+        if (table_name && *table_name == _schema->cf_name()) {
+            tlogger.info("replica_query_wait: waiting");
+            co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::minutes(5));
+        }
+    });
+
     while (!qs.done()) {
         auto&& range = *qs.current_partition_range++;
 
@@ -4518,6 +4526,7 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
     co_await stop_compaction_groups(sg);
     co_await utils::get_local_injector().inject("delay_tablet_compaction_groups_cleanup", std::chrono::seconds(5));
     co_await cleanup_compaction_groups(db, sys_ks, tid, sg);
+    co_await utils::get_local_injector().inject("tablet_cleanup_completion_wait", utils::wait_for_message(std::chrono::seconds(5)));
 }
 
 future<> table::cleanup_tablet_without_deallocation(database& db, db::system_keyspace& sys_ks, locator::tablet_id tid) {

--- a/replica/tablets.cc
+++ b/replica/tablets.cc
@@ -941,7 +941,7 @@ public:
     const lw_shared_ptr<const sstables::sstable_set>& find_sstable_set(size_t i) const {
         auto it = _sstable_sets.find(i);
         if (it == _sstable_sets.end() || !it->second) [[unlikely]] {
-            on_internal_error(tablet_logger, format("SSTable set wasn't found for tablet {} of table {}.{}", i, schema()->ks_name(), schema()->cf_name()));
+            throw std::runtime_error(format("SSTable set wasn't found for tablet {} of table {}.{}", i, schema()->ks_name(), schema()->cf_name()));
         }
         return it->second;
     }

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1808,3 +1808,71 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
         await load_and_stream_task
 
         await check(ks)
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_timed_out_reader_after_cleanup(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=debug',
+        '--logger-log-level', 'raft_topology=debug',
+        '--range-request-timeout-in-ms', '1000', # shorten time coordinator abandon the request, releasing erm
+        '--read-request-timeout-in-ms', '1000',
+        '--abort-on-internal-error', 'true',
+    ]
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
+
+        servers.append(await manager.server_add(cmdline=cmdline))
+
+        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        key = 7 # Whatever
+        tablet_token = 0 # Doesn't matter since there is one tablet
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({key}, 0)")
+        rows = await cql.run_async(f"SELECT pk from {ks}.test")
+        assert len(list(rows)) == 1
+
+        replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
+
+        s0_host_id = await manager.get_host_id(servers[0].server_id)
+        s1_host_id = await manager.get_host_id(servers[1].server_id)
+        dst_shard = 0
+
+        s0_log = await manager.server_open_log(servers[0].server_id)
+        s0_mark = await s0_log.mark()
+
+        await manager.api.enable_injection(servers[0].ip_addr, "replica_query_wait", one_shot=False, parameters={"table": "test"})
+
+        replica_query = cql.run_async(f"SELECT * from {ks}.test where pk={key} BYPASS CACHE", host=hosts[1])
+        await s0_log.wait_for('replica_query_wait: waiting', from_mark=s0_mark)
+
+        await manager.api.enable_injection(servers[0].ip_addr, "tablet_cleanup_completion_wait", one_shot=False)
+
+        migration_task = asyncio.create_task(
+            manager.api.move_tablet(servers[0].ip_addr, ks, "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
+
+        # migration should proceed once replica query times out on coordinator, causing it to be abandoned
+        await s0_log.wait_for('tablet_cleanup_completion_wait: waiting', from_mark=s0_mark)
+
+        await manager.api.message_injection(servers[0].ip_addr, "replica_query_wait")
+        await manager.api.disable_injection(servers[0].ip_addr, "replica_query_wait")
+
+        # swallow exception of timed out read.
+        try:
+            await replica_query
+        except:
+            pass
+
+        await manager.api.message_injection(servers[0].ip_addr, "tablet_cleanup_completion_wait")
+        logger.info("Waiting for migration to finish")
+        await migration_task
+        logger.info("Migration done")
+
+        rows = await cql.run_async(f"SELECT pk from {ks}.test")
+        assert len(list(rows)) == 1


### PR DESCRIPTION
Consider the following:
1) single-key read starts, blocks on replica e.g. waiting for memory.
2) the same replica is migrated away
3) single-key read expires, coordinator abandons it, releases erm.
4) migration advances to cleanup stage, barrier doesn't wait on
   timed-out read
5) compaction group of the replica is deallocated on cleanup
6) that single-key resumes, but doesn't find sstable set (post cleanup)
7) with abort-on-internal-error turned on, node crashes

It's fine for abandoned (= timed out) reads to fail, since the coordinator is gone.
For active reads (non timed out), the barrier will wait for them since their coordinator holds erm.
This solution consists of failing reads which underlying tablet replica has been cleaned up, by just converting internal error to plain exception.

Fixes #26229.

Yes, must be backported since it can affect all versions with tablets.