### PR TITLE
build: lock cxxbridge-cmd version to the rest of the cxx packages

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -426,7 +426,7 @@ elif [ "$ID" == "arch" ]; then
     echo -e "Configure example:\n\t./configure.py\n\tninja release"
 fi
 
-cargo --config net.git-fetch-with-cli=true install cxxbridge-cmd --root /usr/local
+cargo --config net.git-fetch-with-cli=true install cxxbridge-cmd --version 1.0.83 --root /usr/local
 
 CURL_ARGS=$(minio_download_jobs)
 if [ ! -z "${CURL_ARGS}" ]; then

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-42-20251109
+docker.io/scylladb/scylla-toolchain:fedora-42-20251122


### PR DESCRIPTION
rust/Cargo.toml locks the cxx packages to version 1.0.83, but install-dependencies.sh does not lock cxxbridge-cmd, part of that ecosystem. Since cxx 1.0.189 broke compatibility with 1.0.83 (understandable, as these are all sub-packages of a single repository), builds with newer cxxbridge-cmd are broken.

Fix by locking cxxbridge-cmd to the same version as the other cxx subpackages.

Regenerated frozen toolchain with optimized clang from
    https://devpkg.scylladb.com/clang/clang-20.1.8-Fedora-42-aarch64.tar.gz
    https://devpkg.scylladb.com/clang/clang-20.1.8-Fedora-42-x86_64.tar.gz

Probably better done by building cxxbridge-cmd during the build itself, but that is a deeper change.

Fixes #27176

Toolchains cannot be updated without this, so we need to backport this to all live versions.