### PR TITLE
docs: Update upgrade policy documentation

### DIFF
--- a/db/schema_applier.cc
+++ b/db/schema_applier.cc
@@ -674,7 +674,7 @@ future<> schema_applier::merge_tables_and_views()
         view_ptr vp = create_view_from_mutations(_proxy, std::move(sm), user_types, base_schema);
 
         // Now when we have a referenced base - sanity check that we're not registering an old view
-        // (this could happen when we skip multiple major versions in upgrade, which is unsupported.)
+        // (this could happen when skipping major versions during an upgrade, which may be unsupported.)
         check_no_legacy_secondary_index_mv_schema(_proxy.local().get_db().local(), vp, base_schema);
 
         return vp;

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -2834,7 +2834,7 @@ void check_no_legacy_secondary_index_mv_schema(replica::database& db, const view
             "Materialized view {}.{}: first clustering key column ({}) is not computed and does not have a corresponding"
             " column in the base table. This materialized view must therefore be a secondary index created"
             " using legacy method (without computed columns) that wasn't migrated properly to new method."
-            " Make sure that you perform rolling upgrade according to documented procedure without skipping"
+            " Make sure that you perform rolling upgrade according to the documented procedure; do not skip"
             " major Scylla versions.", v->ks_name(), v->cf_name(), first_view_ck.name_as_text()));
     }
 }

--- a/docs/upgrade/about-upgrade.rst
+++ b/docs/upgrade/about-upgrade.rst
@@ -9,9 +9,12 @@ To ensure a successful upgrade, follow
 the :doc:`documented upgrade procedures <upgrade-guides/index>` tested by
 ScyllaDB. This means that:
 
-* You should perform the upgrades consecutively - to each successive X.Y
-  version, **without skipping any major or minor version**, unless there is
-  a documented upgrade procedure to bypass a version.
+* You should perform the upgrades consecutively across major versions - to each
+  successive X.Y version. Within the same major version you may upgrade from
+  any earlier minor release to a later minor release of that same major.
+  For example, you can upgrade to 2025.4 from 2025.1, 2025.2, or 2025.3.
+  Do not skip major Scylla versions unless there is a documented upgrade
+  procedure that explicitly allows it.
 * Before you upgrade to the next version, the whole cluster (each node) must
   be upgraded to the previous version.
 * You cannot perform an upgrade by replacing the nodes in the cluster with new

--- a/docs/upgrade/about-upgrade.rst
+++ b/docs/upgrade/about-upgrade.rst
@@ -9,12 +9,9 @@ To ensure a successful upgrade, follow
 the :doc:`documented upgrade procedures <upgrade-guides/index>` tested by
 ScyllaDB. This means that:
 
-* You should perform the upgrades consecutively across major versions - to each
-  successive X.Y version. Within the same major version you may upgrade from
-  any earlier minor release to a later minor release of that same major.
-  For example, you can upgrade to 2025.4 from 2025.1, 2025.2, or 2025.3.
-  Do not skip major Scylla versions unless there is a documented upgrade
-  procedure that explicitly allows it.
+* You should perform the upgrades consecutively - to each successive X.Y
+  version, **without skipping any major or minor version**, unless there is
+  a documented upgrade procedure to bypass a version.
 * Before you upgrade to the next version, the whole cluster (each node) must
   be upgraded to the previous version.
 * You cannot perform an upgrade by replacing the nodes in the cluster with new


### PR DESCRIPTION
This PR updates documentation 
policy introduced for release 2025.4, which allows skipping intermediate
minor versions (e.g., 2025.1 → 2025.4). Skipping major versions remains unsupported.


