### PR TITLE
tablets global barrier: acknowledge barrier_and_drain from all nodes

### DIFF
--- a/locator/token_metadata.hh
+++ b/locator/token_metadata.hh
@@ -112,6 +112,7 @@ public:
 private:
     utils::phased_barrier::operation _op;
     service::topology::version_t _version;
+    const token_metadata* _tm = nullptr;
     link_type _link;
 
     // When engaged it means the version is no longer latest and should be released soon as to
@@ -120,8 +121,7 @@ private:
     std::chrono::steady_clock::duration _log_threshold;
 public:
     version_tracker() = default;
-    version_tracker(utils::phased_barrier::operation op, service::topology::version_t version)
-        : _op(std::move(op)), _version(version) {}
+    version_tracker(utils::phased_barrier::operation op, const token_metadata& tm);
     version_tracker(version_tracker&&) noexcept = default;
     version_tracker& operator=(version_tracker&& o) noexcept {
         if (this != &o) {
@@ -136,6 +136,8 @@ public:
     service::topology::version_t version() const {
         return _version;
     }
+
+    long version_use_count() const;
 
     void mark_expired(std::chrono::steady_clock::duration log_threshold) {
         if (!_expired_at) {
@@ -172,7 +174,7 @@ private:
     friend class token_metadata_impl;
 };
 
-class token_metadata final {
+class token_metadata final: public enable_lw_shared_from_this<token_metadata> {
     shared_token_metadata* _shared_token_metadata = nullptr;
     std::unique_ptr<token_metadata_impl> _impl;
 private:
@@ -410,7 +412,7 @@ class shared_token_metadata : public peering_sharded_service<shared_token_metada
             boost::intrusive::constant_time_size<false>>;
     version_tracker_list_type _trackers;
 private:
-    version_tracker new_tracker(token_metadata::version_t);
+    version_tracker new_tracker(const token_metadata& tm);
 public:
     // used to construct the shared object as a sharded<> instance
     // lock_func returns semaphore_units<>
@@ -419,7 +421,7 @@ public:
         , _lock_func(std::move(lock_func))
         , _versions_barrier("shared_token_metadata::versions_barrier")
     {
-        _shared->set_version_tracker(new_tracker(_shared->get_version()));
+        _shared->set_version_tracker(new_tracker(*_shared));
     }
 
     shared_token_metadata(const shared_token_metadata& x) = delete;
@@ -445,6 +447,9 @@ public:
     void set_stall_detector_threshold(std::chrono::steady_clock::duration threshold) {
         _stall_detector_threshold = threshold;
     }
+
+    // Returns a map version -> use_count
+    std::unordered_map<service::topology::version_t, int> describe_stale_versions();
 
     future<> stale_versions_in_use() const {
         return _stale_versions_in_use.get_future();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -4964,7 +4964,6 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
     co_await stop_compaction_groups(sg);
     co_await utils::get_local_injector().inject("delay_tablet_compaction_groups_cleanup", std::chrono::seconds(5));
     co_await cleanup_compaction_groups(db, sys_ks, tid, sg);
-    co_await utils::get_local_injector().inject("tablet_cleanup_completion_wait", utils::wait_for_message(std::chrono::seconds(5)));
 }
 
 future<> table::cleanup_tablet_without_deallocation(database& db, db::system_keyspace& sys_ks, locator::tablet_id tid) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -612,8 +612,13 @@ private:
                     try {
                         // FIXME: get_schema_for_write() doesn't timeout
                         schema_ptr s = co_await get_schema_for_write(schema_version, reply_to_host_id, shard, timeout);
+
+                        // This erm ensures that tablet migrations wait for replica requests,
+                        // even if the coordinator is no longer available.
+                        const auto erm = s->table().get_effective_replication_map();
+
                         // Note: blocks due to execution_stage in replica::database::apply()
-                        co_await p->run_fenceable_write(s->table().get_effective_replication_map()->get_replication_strategy(),
+                        co_await p->run_fenceable_write(erm->get_replication_strategy(),
                             fence, src_addr,
                             [&] { return apply_fn(p, trace_state_ptr, std::move(s), m, timeout); });
                         // We wait for send_mutation_done to complete, otherwise, if reply_to is busy, we will accumulate
@@ -863,6 +868,10 @@ private:
             slogger.info("storage_proxy::handle_read injection done");
         });
 
+        // This erm ensures that tablet migrations wait for replica requests,
+        // even if the coordinator is no longer available.
+        auto erm = s->table().get_effective_replication_map();
+
         auto pr2 = ::compat::unwrap(std::move(pr), *s);
         auto do_query = [&]() {
             if constexpr (verb == read_verb::read_data) {
@@ -870,7 +879,6 @@ private:
                     // this function assumes singular queries but doesn't validate
                     throw std::runtime_error("READ_DATA called with wrapping range");
                 }
-                auto erm = s->table().get_effective_replication_map();
                 p->get_stats().replica_data_reads++;
                 if (!oda) {
                     throw std::runtime_error("READ_DATA called without digest algorithm");
@@ -987,6 +995,12 @@ private:
 
         auto schema = co_await get_schema_for_read(cmd.schema_version, src_addr, src_shard, *timeout);
         dht::token token = dht::get_token(*schema, key);
+
+        // This guard ensures that tablet migrations wait for replica requests,
+        // even if the LWT coordinator is no longer available.
+        locator::token_metadata_guard guard(schema->table(), token);
+        co_await _sp.apply_fence(fence_opt, src_addr);
+
         unsigned shard = schema->table().shard_for_reads(token);
         bool local = shard == this_shard_id();
         _sp.get_stats().replica_cross_shard_ops += !local;
@@ -1027,6 +1041,12 @@ private:
         });
         auto schema = co_await get_schema_for_read(proposal.update.schema_version(), src_addr, src_shard, *timeout);
         dht::token token = proposal.update.decorated_key(*schema).token();
+
+        // This guard ensures that tablet migrations wait for replica requests,
+        // even if the LWT coordinator is no longer available.
+        locator::token_metadata_guard guard(schema->table(), token);
+        co_await _sp.apply_fence(fence_opt, src_addr);
+
         unsigned shard = schema->table().shard_for_reads(token);
         bool local = shard == this_shard_id();
         _sp.get_stats().replica_cross_shard_ops += !local;
@@ -1068,6 +1088,12 @@ private:
         auto d = defer([] { pruning--; });
         auto schema = co_await get_schema_for_read(schema_id, src_addr, src_shard, *timeout);
         dht::token token = dht::get_token(*schema, key);
+
+        // This guard ensures that tablet migrations wait for replica requests,
+        // even if the LWT coordinator is no longer available.
+        locator::token_metadata_guard guard(schema->table(), token);
+        co_await _sp.apply_fence(fence_opt, src_addr);
+
         unsigned shard = schema->table().shard_for_reads(token);
         bool local = shard == this_shard_id();
         _sp.get_stats().replica_cross_shard_ops += !local;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6225,8 +6225,9 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
                 }
                 co_await container().invoke_on_all([version] (storage_service& ss) -> future<> {
                     const auto current_version = ss._shared_token_metadata.get()->get_version();
-                    rtlogger.info("Got raft_topology_cmd::barrier_and_drain, version {}, current version {}",
-                        version, current_version);
+                    rtlogger.info("Got raft_topology_cmd::barrier_and_drain, version {}, "
+                        "current version {}, stale versions (version: use_count): {}",
+                        version, current_version, ss._shared_token_metadata.describe_stale_versions());
 
                     // This shouldn't happen under normal operation, it's only plausible
                     // if the topology change coordinator has

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6140,7 +6140,7 @@ future<> storage_service::snitch_reconfigured() {
     }
 }
 
-future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd) {
+future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd) {
     raft_topology_cmd_result result;
     rtlogger.info("topology cmd rpc {} is called index={}", cmd.cmd, cmd_index);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -974,7 +974,7 @@ private:
 
     std::unordered_set<raft::server_id> find_raft_nodes_from_hoeps(const locator::host_id_or_endpoint_list& hoeps) const;
 
-    future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, const raft_topology_cmd& cmd);
+    future<raft_topology_cmd_result> raft_topology_cmd_handler(raft::term_t term, uint64_t cmd_index, raft_topology_cmd cmd);
 
     future<> raft_decommission();
     future<> raft_removenode(locator::host_id host_id, locator::host_id_or_endpoint_list ignore_nodes_params);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -410,7 +410,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         return service::topology::parse_replaced_node(req_param);
     }
 
-    future<> exec_direct_command_helper(raft::server_id id, uint64_t cmd_index, const raft_topology_cmd& cmd) {
+    future<> exec_direct_command_helper(raft::server_id id, uint64_t cmd_index, raft_topology_cmd cmd) {
         rtlogger.debug("send {} command with term {} and index {} to {}",
             cmd.cmd, _term, cmd_index, id);
         _topology_cmd_rpc_tracker.active_dst.emplace(id);
@@ -426,7 +426,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         }
     };
 
-    future<node_to_work_on> exec_direct_command(node_to_work_on&& node, const raft_topology_cmd& cmd) {
+    future<node_to_work_on> exec_direct_command(node_to_work_on&& node, raft_topology_cmd cmd) {
         auto id = node.id;
         release_node(std::move(node));
         const auto cmd_index = ++_last_cmd_index;
@@ -436,7 +436,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         co_return retake_node(co_await start_operation(), id);
     };
 
-    future<> exec_global_command_helper(auto nodes, const raft_topology_cmd& cmd) {
+    future<> exec_global_command_helper(auto nodes, raft_topology_cmd cmd) {
         const auto cmd_index = ++_last_cmd_index;
         _topology_cmd_rpc_tracker.current = cmd.cmd;
         _topology_cmd_rpc_tracker.index = cmd_index;
@@ -453,7 +453,7 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     };
 
     future<group0_guard> exec_global_command(
-            group0_guard guard, const raft_topology_cmd& cmd,
+            group0_guard guard, raft_topology_cmd cmd,
             const std::unordered_set<raft::server_id>& exclude_nodes,
             drop_guard_and_retake drop_and_retake = drop_guard_and_retake::yes) {
         rtlogger.info("executing global topology command {}, excluded nodes: {}", cmd.cmd, exclude_nodes);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1208,13 +1208,16 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
         rtlogger.info("enabled features: {}", features_to_enable);
     }
 
-    future<group0_guard> global_token_metadata_barrier(group0_guard&& guard, std::unordered_set<raft::server_id> exclude_nodes = {}, bool* fenced = nullptr) {
+    future<group0_guard> global_token_metadata_barrier(group0_guard&& guard, std::unordered_set<raft::server_id> exclude_nodes = {}, bool* fenced = nullptr, bool drain_all_nodes = false) {
         auto version = _topo_sm._topology.version;
         bool drain_failed = false;
         try {
             guard = co_await exec_global_command(std::move(guard), raft_topology_cmd::command::barrier_and_drain, exclude_nodes, drop_guard_and_retake::yes);
         } catch (...) {
             rtlogger.warn("drain rpc failed, proceed to fence old writes: {}", std::current_exception());
+            if (drain_all_nodes) {
+                throw;
+            }
             drain_failed = true;
         }
         if (drain_failed) {
@@ -1240,7 +1243,30 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
     future<group0_guard> global_tablet_token_metadata_barrier(group0_guard guard) {
         // FIXME: Don't require all nodes to be up, only tablet replicas.
-        return global_token_metadata_barrier(std::move(guard), _topo_sm._topology.ignored_nodes);
+
+        // Let x be the current topology version, post-conditions of this barrier:
+        // * there are no coordinators with versions < x and no such coordinators
+        //   are possible in the future
+        // * no replicas are currently executing requests with versions < x - 1
+        //   and no new such requests are possible in the future
+        //     Why? The barrier_and_drain handler runs group0.read_barrier() first,
+        //     which guarantees that the new version and the previous fence_version are
+        //     published on all shards before we drain them. After that we drain all
+        //     requests with versions < x ==> no current and future requests are possible
+        //     with versions < x - 1 since the fence for x - 1 is set. Future stale
+        //     requests with version x - 1 are sill possible until the next
+        //     global barrier.
+        // * a quorum of replicas doesn't allow new requests with versions < x,
+        //   but there could be arbitrary number of already running read or mutation
+        //   requests with version x - 1 on those replicas
+        // * some replicas could still be accepting new requests with versions == x - 1
+
+        bool* const fenced = nullptr;
+        const auto drain_all_nodes = true;        
+        return global_token_metadata_barrier(std::move(guard), 
+            _topo_sm._topology.ignored_nodes,
+            fenced,
+            drain_all_nodes);
     }
 
     // Represents a two-state state machine which changes monotonically

--- a/service/topology_coordinator.hh
+++ b/service/topology_coordinator.hh
@@ -80,7 +80,7 @@ struct term_changed_error : public std::runtime_error {
 future<> wait_for_gossiper(raft::server_id id, const gms::gossiper& g, seastar::abort_source& as);
 
 using raft_topology_cmd_handler_type = noncopyable_function<future<raft_topology_cmd_result>(
-        raft::term_t, uint64_t, const raft_topology_cmd&)>;
+        raft::term_t, uint64_t, raft_topology_cmd)>;
 
 struct topology_coordinator_cmd_rpc_tracker {
     raft_topology_cmd::command current;

--- a/test/cluster/test_automatic_cleanup.py
+++ b/test/cluster/test_automatic_cleanup.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
 #
 from test.pylib.manager_client import ManagerClient
-from test.cluster.util import new_test_keyspace
+from test.cluster.util import new_test_keyspace, get_topology_version
 from cassandra import WriteFailure
 import pytest
 import logging
@@ -132,10 +132,7 @@ async def test_cleanup_waits_for_stale_writes(manager: ManagerClient):
         logger.info("Trigger topology_coordinator/write_both_read_new/after_barrier")
         await manager.api.message_injection(servers[0].ip_addr, "topology_coordinator/write_both_read_new/after_barrier")
         await bootstrap_task
-        rows = await cql.run_async(
-            "select version from system.topology where key = 'topology'",
-            host=hosts[0])
-        version_after_node2_bootstrap = rows[0].version
+        version_after_node2_bootstrap = await get_topology_version(cql, hosts[0])
         host1_id = await manager.get_host_id(servers[1].server_id)
 
         # Have a cleanup started by decommission and failed on global barrier wait for the stale write

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -9,7 +9,6 @@ from test.pylib.util import unique_name, wait_for_cql_and_get_hosts, wait_for
 from cassandra import WriteFailure, ConsistencyLevel
 from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import ScyllaMetrics
-from test.pylib.tablets import get_all_tablet_replicas
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement
 from test.cluster.util import new_test_keyspace, reconnect_driver
@@ -360,113 +359,6 @@ async def test_fence_lwt_during_bootstap(manager: ManagerClient):
         row = rows[0]
         assert row.pk == 1
         assert row.c == 2
-
-
-@pytest.mark.asyncio
-@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_fenced_out_on_tablet_migration_while_handling_paxos_verb(manager: ManagerClient):
-    """
-    This test verifies that the fencing token is checked on replicas
-    after the local Paxos state is updated. This ensures that if we failed
-    to drain an LWT request during topology changes the replicas
-    where paxos verbs got stuck won't contributed to the target CLs.
-    
-    Scenario:
-    1. Set up a three-node cluster:
-       - n1 (rack1) is the topology coordinator.
-       - The table has a single tablet with RF=2, and replicas on n2 (rack2) and n3 (rack1).
-       - n3 will act as an LWT coordinator that fails `barrier_and_drain`.
-       - A test tablet migration will proceed, incrementing both `version` and `fence_version`
-         on all nodes, including n2. This will cause accept on n2 to be fenced out when
-         it eventually gets unstuck.
-    2. Inject `paxos_accept_proposal_wait` on n2 — we need to suspend the accept on n2.
-    3. Run an LWT on n3 and wait until it hits the injection on n2.
-    4. Inject `raft_topology_barrier_and_drain_fail_before` on n2 to simulate
-       an intermittent network failure. This causes `barrier_and_drain` to fail,
-       but `global_token_metadata_barrier` still succeeds because
-       `raft_topology_cmd::command::barrier` delivers the new `fence_version`
-       to all replicas, including n2.
-       Note: `global_token_metadata_barrier` is called multiple times during tablet migration.
-       Since `stale_versions_in_use` on replicas waits for *all* previous versions of
-       `token_metadata` to be dropped, we must use `enable_injection(one_shot=False)` so that
-       all `barrier_and_drain` calls on n2 fail.
-    5. Migrate the tablet replica from n3 to n1. The migration must succeed
-       even with an unfinished LWT holding an old `erm` version, because the
-       LWT coordinator on n3 was fenced out.
-    6. Release the `paxos_accept_proposal_wait` injection. The LWT must fail
-       with a "stale topology exception" because the topology version from the
-       request is older than the current `fence_version`.
-    """
-    cmdline = [
-        '--logger-log-level', 'paxos=trace',
-        '--smp', '1'
-    ]
-
-    logger.info("Bootstrapping the cluster")
-    servers = await manager.servers_add(3,
-                                        cmdline=cmdline,
-                                        property_file=[
-                                            {'dc': 'my_dc', 'rack': 'rack1'},
-                                            {'dc': 'my_dc', 'rack': 'rack2'},
-                                            {'dc': 'my_dc', 'rack': 'rack1'}
-                                        ])
-
-    (cql, hosts) = await manager.get_ready_cql(servers)
-    host_ids = await asyncio.gather(*[manager.get_host_id(s.server_id) for s in servers])
-
-    logger.info("Disable tablet balancing")
-    await manager.disable_tablet_balancing()
-
-    logger.info("Create a test keyspace")
-    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
-        logger.info("Create test table")
-        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
-
-        logger.info("Ensure that the tablet replicas are located on n2,n3")
-        [tablet] = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
-        [r1, r2] = tablet.replicas
-        if host_ids[0] in {r1[0], r2[0]}:
-            # the only possibility is r1=n1 && r2=n2, because otherwise two
-            # replicas would be on the same rack
-            await manager.api.move_tablet(servers[0].ip_addr, ks, "test",
-                                          host_ids[0], 0,
-                                          host_ids[2], 0,
-                                          tablet.last_token)
-
-        logger.info(f"Injecting 'paxos_accept_proposal_wait' into {servers[1]}")
-        await manager.api.enable_injection(servers[1].ip_addr, 'paxos_accept_proposal_wait', one_shot=True)
-
-        logger.info(f"Start an LWT on {servers[2]}")
-        insert_lwt = cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 1) IF NOT EXISTS", host=hosts[2])
-
-        logger.info(f"Open log on {servers[1]}")
-        s2_log = await manager.server_open_log(servers[1].server_id)
-        logger.info("Wait for 'paxos_accept_proposal_wait: waiting for message'")
-        await s2_log.wait_for('paxos_accept_proposal_wait: waiting for message')
-
-        logger.info(f"Injecting 'raft_topology_barrier_and_drain_fail_before' into {servers[2]}")
-        await manager.api.enable_injection(servers[2].ip_addr,
-                                           'raft_topology_barrier_and_drain_fail_before',
-                                           one_shot=False)
-
-        logger.info(f"Migrate the tablet replica from {servers[2]} to {servers[1]}")
-        await manager.api.move_tablet(servers[0].ip_addr, ks, "test", host_ids[2], 0,
-                                      host_ids[0], 0, tablet.last_token)
-
-        async def fenced_out_requests():
-            metrics = await manager.metrics.query(servers[1].ip_addr)
-            metric_name = 'scylla_storage_proxy_replica_fenced_out_requests'
-            return metrics.get(metric_name) or 0
-
-        assert await fenced_out_requests() == 0
-
-        logger.info(f"Release 'paxos_accept_proposal_wait' on {servers[1]}")
-        await manager.api.message_injection(servers[1].ip_addr, "paxos_accept_proposal_wait")
-
-        with pytest.raises(WriteFailure, match="stale topology exception"):
-            await insert_lwt
-
-        assert await fenced_out_requests() == 1
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -11,7 +11,7 @@ from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import ScyllaMetrics
 from cassandra.pool import Host # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement
-from test.cluster.util import new_test_keyspace, reconnect_driver
+from test.cluster.util import new_test_keyspace, get_topology_version
 from test.pylib.scylla_cluster import ScyllaVersionDescription
 import pytest
 import logging
@@ -41,13 +41,6 @@ async def set_fence_version(manager: ManagerClient, host: Host, new_version: int
     await manager.cql.run_async("update system.topology set fence_version=%s where key = 'topology'",
                                 parameters=[new_version],
                                 host=host)
-
-
-async def get_version(manager: ManagerClient, host: Host):
-    rows = await manager.cql.run_async(
-        "select version from system.topology where key = 'topology'",
-        host=host)
-    return rows[0].version
 
 
 def send_errors_metric(metrics: ScyllaMetrics):
@@ -106,7 +99,7 @@ async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bo
     # causing topology_state_load on it to see the decremented version and report broken invariants.
     await manager.api.cleanup_all(servers[2].ip_addr)
 
-    version = await get_version(manager, host2)
+    version = await get_topology_version(cql, host2)
     logger.info(f"version on host2 {version}")
 
     await set_version(manager, host2, version - 1)
@@ -164,7 +157,7 @@ async def test_fence_hints(request, manager: ManagerClient):
     hosts = await wait_for_cql_and_get_hosts(cql, [s0, s2], time.time() + 60)
 
     host2 = host_by_server(hosts, s2)
-    new_version = (await get_version(manager, host2)) + 1
+    new_version = (await get_topology_version(cql, host2)) + 1
     logger.info(f"Set version and fence_version to {new_version} on node {host2}")
     await set_version(manager, host2, new_version)
     await set_fence_version(manager, host2, new_version)

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from contextlib import asynccontextmanager
 import itertools
+import re
 
 logger = logging.getLogger(__name__)
 
@@ -1977,9 +1978,19 @@ async def test_crash_on_missing_table_from_load_stats(manager: ManagerClient):
         s0_mark = await s0_log.mark()
         await s0_log.wait_for('raft topology: Refreshed table load stats for all DC', from_mark=s0_mark)
 
+
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_timed_out_reader_after_cleanup(manager: ManagerClient):
+async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
+    """
+    The test verifies that tablet replicas hold ERMS while processing requests,
+    and that the tablet's global barrier waits for all replicas to acknowledge it.
+    To do this, the test starts a read request and makes it hang on the
+    `replica_query_wait` injection, then initiates tablet migration. Finally, it
+    checks that the tablet's global barrier waits for the replica handling that
+    request to complete.
+    """
+
     logger.info("Bootstrapping cluster")
     cmdline = [
         '--logger-log-level', 'storage_service=debug',
@@ -2008,7 +2019,6 @@ async def test_timed_out_reader_after_cleanup(manager: ManagerClient):
 
         replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)
 
-        s0_host_id = await manager.get_host_id(servers[0].server_id)
         s1_host_id = await manager.get_host_id(servers[1].server_id)
         dst_shard = 0
 
@@ -2020,13 +2030,21 @@ async def test_timed_out_reader_after_cleanup(manager: ManagerClient):
         replica_query = cql.run_async(f"SELECT * from {ks}.test where pk={key} BYPASS CACHE", host=hosts[1])
         await s0_log.wait_for('replica_query_wait: waiting', from_mark=s0_mark)
 
-        await manager.api.enable_injection(servers[0].ip_addr, "tablet_cleanup_completion_wait", one_shot=False)
+        version_before_move = (await cql.run_async(
+            "select version from system.topology where key = 'topology'", 
+            host=hosts[0]))[0].version
 
+        s0_mark = await s0_log.mark()
         migration_task = asyncio.create_task(
             manager.api.move_tablet(servers[0].ip_addr, ks, "test", replica[0], replica[1], s1_host_id, dst_shard, tablet_token))
 
         # migration should proceed once replica query times out on coordinator, causing it to be abandoned
-        await s0_log.wait_for('tablet_cleanup_completion_wait: waiting', from_mark=s0_mark)
+        new_version = version_before_move + 1
+        await s0_log.wait_for(re.escape(
+            f"Got raft_topology_cmd::barrier_and_drain, version {new_version}, "
+            f"current version {new_version}, "
+            f"stale versions (version: use_count): {{{version_before_move}: 1}}"),
+            from_mark=s0_mark)
 
         await manager.api.message_injection(servers[0].ip_addr, "replica_query_wait")
         await manager.api.disable_injection(servers[0].ip_addr, "replica_query_wait")
@@ -2037,7 +2055,6 @@ async def test_timed_out_reader_after_cleanup(manager: ManagerClient):
         except:
             pass
 
-        await manager.api.message_injection(servers[0].ip_addr, "tablet_cleanup_completion_wait")
         logger.info("Waiting for migration to finish")
         await migration_task
         logger.info("Migration done")

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -12,7 +12,7 @@ from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error_one_shot, HTTPError, read_barrier
 from test.pylib.util import wait_for_cql_and_get_hosts, unique_name, wait_for
 from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas, get_tablet_count, TabletReplicas
-from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace
+from test.cluster.util import reconnect_driver, create_new_test_keyspace, new_test_keyspace, get_topology_version
 from test.cqlpy.cassandra_tests.validation.entities.secondary_index_test import dotestCreateAndDropIndex
 
 import pytest
@@ -2030,9 +2030,7 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
         replica_query = cql.run_async(f"SELECT * from {ks}.test where pk={key} BYPASS CACHE", host=hosts[1])
         await s0_log.wait_for('replica_query_wait: waiting', from_mark=s0_mark)
 
-        version_before_move = (await cql.run_async(
-            "select version from system.topology where key = 'topology'", 
-            host=hosts[0]))[0].version
+        version_before_move = await get_topology_version(cql, hosts[0])
 
         s0_mark = await s0_log.mark()
         migration_task = asyncio.create_task(

--- a/test/cluster/util.py
+++ b/test/cluster/util.py
@@ -92,6 +92,13 @@ async def get_topology_coordinator(manager: ManagerClient) -> HostID:
     return await manager.api.get_raft_leader(host_address)
 
 
+async def get_topology_version(cql: Session, host: Host) -> int:
+    rows = await cql.run_async(
+        "select version from system.topology where key = 'topology'",
+        host=host)
+    return rows[0].version
+
+
 async def find_server_by_host_id(manager: ManagerClient, servers: List[ServerInfo], host_id: HostID) -> ServerInfo:
     for s in servers:
         if await manager.get_host_id(s.server_id) == host_id:


### PR DESCRIPTION
Before this series, the `global_barrier` used during tablet migration did not guarantee that `barrier_and_drain` was acknowledged by tablet replicas. As a result, if a request coordinator was fenced out, stale requests from previous topology versions could still execute on replicas in parallel with new requests from incompatible topology versions. For example, stale requests from `tablet_transition_stage::streaming` could run concurrently with new requests from `tablet_transition_stage::use_new`. This caused several issues, including [#26864](https://github.com/scylladb/scylladb/issues/26864) and [#26375](https://github.com/scylladb/scylladb/issues/26375).

This PR fixes the problem in two steps:
* Replicas now hold an erm strong pointer while handling RPCs from coordinators.
* The tablet barrier is updated to require `barrier_and_drain` acknowledgments from all nodes.

A description of alternative solutions and various tradeoffs can be found in [this document](https://docs.google.com/document/d/1tpDtPOsrGaZGBYkdwOKApQv4eMzrBydMM1GaYYmaPgg/edit?pli=1&tab=t.0#heading=h.vidfy0hrz5j7).

[A previous attempt on this changes](https://github.com/scylladb/scylladb/pull/27185).

Fixes: https://github.com/scylladb/scylladb/issues/26864
Fixes: https://github.com/scylladb/scylladb/issues/26375

backport: needs backport to 2025.4 (fixes #26864 for tablets LWT)