### PR TITLE
raft: auth: add semaphore to auth_cache::load_all

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1791,7 +1791,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             checkpoint(stop_signal, "starting auth cache");
-            auth_cache.start(std::ref(qp)).get();
+            auth_cache.start(std::ref(qp), std::ref(stop_signal.as_sharded_abort_source())).get();
             auto stop_auth_cache = defer_verbose_shutdown("auth cache", [&] {
                 auth_cache.stop().get();
             });

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -943,7 +943,7 @@ private:
             _stream_manager.start(std::ref(*cfg), std::ref(_db), std::ref(_view_builder), std::ref(_view_building_worker), std::ref(_ms), std::ref(_mm), std::ref(_gossiper), scheduling_groups.streaming_scheduling_group).get();
             auto stop_streaming = defer_verbose_shutdown("stream manager", [this] { _stream_manager.stop().get(); });
 
-            _auth_cache.start(std::ref(_qp)).get();
+            _auth_cache.start(std::ref(_qp), std::ref(abort_sources)).get();
             auto stop_auth_cache = defer_verbose_shutdown("auth cache", [this] { _auth_cache.stop().get(); });
 
             _ss.start(std::ref(abort_sources), std::ref(_db),


### PR DESCRIPTION
Auth cache loading at startup is racing between
auth service and raft code and it doesn't support
concurrency causing it to crash.

We can't easily remove any of the places as during
raft recovery snapshot is not loaded and it relies
on loading cache via auth service. Therefore we add
semaphore.


Fixes https://github.com/scylladb/scylladb/issues/27540
Backport: no, auth cache was not released yet