### PR TITLE
tools/toolchain/optimized_clang.sh: fix variable quoting and profile …

### DIFF
--- a/tools/toolchain/optimized_clang.sh
+++ b/tools/toolchain/optimized_clang.sh
@@ -123,7 +123,7 @@ _get_distribution_components() {
                 continue
                 ;;
         esac
-        echo $target
+        echo "$target"
     done
 }
 
@@ -164,7 +164,7 @@ if [[ "${CLANG_BUILD}" = "INSTALL" ]]; then
 
     echo "[clang-stage3] build the compiler applied CSPGO profile"
     cd "${CLANG_BUILD_DIR}"
-    llvm-profdata merge build/csprofiles/default_*.profraw -output=csir.prof
+    llvm-profdata merge build/profiles/csir-*.profraw -output=csir.prof
     llvm-profdata merge ir.prof csir.prof -output=combined.prof
     rm -rf build
     # linker flags are needed for BOLT


### PR DESCRIPTION
…path in optimized_clang.sh

This PR fixes two unrelated issues found by CodeQL in the script:

- Unquoted variable expansion (line 126): echo $target → echo "$target" to prevent word splitting
- Incorrect profile path (line 167): build/csprofiles/default_*.profraw → build/profiles/csir-*.profraw to match the actual CSPGO profile location set on line 163 The second fix ensures the CSPGO profile merging step references the correct directory and file pattern.


Backport: unsure what the impact is on clang performance when compiling Scylla. Probably not worth it.


Completely untested. Just the compilation will kill my laptop!