### PR TITLE
scylla-gdb.py: scylla small-objects: make freelist traversal more robust

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5104,10 +5104,15 @@ class scylla_small_objects(gdb.Command):
             span_end = int(span_start + span.size() * self._page_size)
 
             # span's free list
-            span_next_free = span.page['freelist']
-            while span_next_free:
-                self._free_in_span.add(int(span_next_free))
-                span_next_free = span_next_free['next']
+            try:
+                span_next_free = span.page['freelist']
+                while span_next_free:
+                    self._free_in_span.add(int(span_next_free))
+                    span_next_free = span_next_free['next']
+            except gdb.error:
+                # This loop sometimes steps on "Cannot access memory at address", causing CI instability.
+                # Catch the exception and break the freelist traversal loop gracefully.
+                gdb.write(f"Warning: error traversing freelist of span [0x{span_start:x}, 0x{span_end:x}), some of the listed objects in this span may be free objects.\n")
 
             return span_start, span_end
 


### PR DESCRIPTION
Traversing the span's freelist is known to generate "Cannot access memory at address ..." errors, which is especially annoying when it results in failed CI. Make this loop more robust: catch gdb.error coming from it and just log a warning that some listed objects in the span may be free ones.

Fixes: #27681

Failure was seen only on master so far, no backport needed.