### PR TITLE
Optimize row_cache and memtables for schema without clustering columns

### DIFF
--- a/db/cache_mutation_reader.hh
+++ b/db/cache_mutation_reader.hh
@@ -228,6 +228,7 @@ public:
                                dht::decorated_key dk,
                                query::clustering_key_filter_ranges&& crr,
                                read_context& ctx,
+                               std::unique_ptr<read_context> unique_ctx,
                                partition_snapshot_ptr snp,
                                row_cache& cache)
         : mutation_reader::impl(std::move(s), ctx.permit())
@@ -239,7 +240,7 @@ public:
         , _lsa_manager(cache)
         , _lower_bound(position_in_partition::before_all_clustered_rows())
         , _upper_bound(position_in_partition_view::before_all_clustered_rows())
-        , _read_context_holder()
+        , _read_context_holder(std::move(unique_ctx))
         , _read_context(ctx)    // ctx is owned by the caller, who's responsible for closing it.
         , _next_row(*_schema, *_snp, false, _read_context.is_reversed())
         , _read_time(get_read_time())
@@ -252,18 +253,6 @@ public:
                 _read_context.is_reversed(),
                 fmt::ptr(&*_snp));
         push_mutation_fragment(*_schema, _permit, partition_start(_dk, _snp->partition_tombstone()));
-    }
-    cache_mutation_reader(schema_ptr s,
-                               dht::decorated_key dk,
-                               query::clustering_key_filter_ranges&& crr,
-                               std::unique_ptr<read_context> unique_ctx,
-                               partition_snapshot_ptr snp,
-                               row_cache& cache)
-        : cache_mutation_reader(s, std::move(dk), std::move(crr), *unique_ctx, std::move(snp), cache)
-    {
-        // Assume ownership of the read_context.
-        // It is our responsibility to close it now.
-        _read_context_holder = std::move(unique_ctx);
     }
     cache_mutation_reader(const cache_mutation_reader&) = delete;
     cache_mutation_reader(cache_mutation_reader&&) = delete;
@@ -1127,20 +1116,9 @@ inline mutation_reader make_cache_mutation_reader(schema_ptr s,
                                                             query::clustering_key_filter_ranges crr,
                                                             row_cache& cache,
                                                             cache::read_context& ctx,
-                                                            partition_snapshot_ptr snp)
-{
-    return make_mutation_reader<cache::cache_mutation_reader>(
-        std::move(s), std::move(dk), std::move(crr), ctx, std::move(snp), cache);
-}
-
-// transfer ownership of ctx to cache_mutation_reader
-inline mutation_reader make_cache_mutation_reader(schema_ptr s,
-                                                            dht::decorated_key dk,
-                                                            query::clustering_key_filter_ranges crr,
-                                                            row_cache& cache,
                                                             std::unique_ptr<cache::read_context> unique_ctx,
                                                             partition_snapshot_ptr snp)
 {
     return make_mutation_reader<cache::cache_mutation_reader>(
-        std::move(s), std::move(dk), std::move(crr), std::move(unique_ctx), std::move(snp), cache);
+        std::move(s), std::move(dk), std::move(crr), ctx, std::move(unique_ctx), std::move(snp), cache);
 }

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -73,29 +73,12 @@ public:
     struct dummy_entry_tag{};
     struct evictable_tag{};
 
-    cache_entry(dummy_entry_tag)
-        : _key{dht::token(), partition_key::make_empty()}
-    {
-        _flags._dummy_entry = true;
-    }
-
-    cache_entry(schema_ptr s, const dht::decorated_key& key, const mutation_partition& p)
-        : _key(key)
-        , _pe(partition_entry::make_evictable(*s, mutation_partition(*s, p)))
-    { }
-
-    cache_entry(schema_ptr s, dht::decorated_key&& key, mutation_partition&& p)
-        : cache_entry(evictable_tag(), s, std::move(key),
-            partition_entry::make_evictable(*s, std::move(p)))
-    { }
-
+    cache_entry(dummy_entry_tag);
+    cache_entry(schema_ptr s, const dht::decorated_key& key, const mutation_partition& p);
+    cache_entry(schema_ptr s, dht::decorated_key&& key, mutation_partition&& p);
     // It is assumed that pe is fully continuous
     // pe must be evictable.
-    cache_entry(evictable_tag, schema_ptr s, dht::decorated_key&& key, partition_entry&& pe) noexcept
-        : _key(std::move(key))
-        , _pe(std::move(pe))
-    { }
-
+    cache_entry(evictable_tag, schema_ptr s, dht::decorated_key&& key, partition_entry&& pe) noexcept;
     cache_entry(cache_entry&&) noexcept;
     ~cache_entry();
 

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -57,7 +57,7 @@ class cache_entry {
     } _flags{};
     friend class size_calculator;
 
-    mutation_reader do_read(row_cache&, cache::read_context& ctx);
+    mutation_reader do_read(row_cache&, cache::read_context& ctx, std::unique_ptr<cache::read_context> ctx_holder);
     mutation_reader do_read(row_cache&, std::unique_ptr<cache::read_context> unique_ctx);
 public:
     friend class row_cache;

--- a/db/row_cache.hh
+++ b/db/row_cache.hh
@@ -16,6 +16,7 @@
 #include "utils/phased_barrier.hh"
 #include "utils/histogram.hh"
 #include "mutation/partition_version.hh"
+#include "mutation/single_row_partition.hh"
 #include "utils/double-decker.hh"
 #include "db/cache_tracker.hh"
 #include "readers/empty.hh"
@@ -44,9 +45,15 @@ class lsa_manager;
 // Intrusive set entry which holds partition data.
 //
 // TODO: Make memtables use this format too.
-class cache_entry {
+class cache_entry final {
     dht::decorated_key _key;
-    partition_entry _pe;
+
+    // FIXME: Make variable-length, so that we pay only for the format which is actively used.
+    // To do that, double_decker's intrusive_array needs to support run-time size of objects.
+    // single_row_partition is 40 bytes: 24 for evictable, 8 for schema_ptr and 8 for managed_ref.
+    // partition_entry is 24 bytes.
+    partition_storage storage;
+
     // True when we know that there is nothing between this entry and the previous one in cache
     struct {
         bool _continuous : 1;
@@ -54,6 +61,7 @@ class cache_entry {
         bool _head : 1;
         bool _tail : 1;
         bool _train : 1;
+        bool _single_row_partition : 1;
     } _flags{};
     friend class size_calculator;
 
@@ -62,6 +70,10 @@ class cache_entry {
 public:
     friend class row_cache;
     friend class cache_tracker;
+
+    partition_format format() const noexcept {
+        return _flags._single_row_partition ? partition_format::single_row : partition_format::generic;
+    }
 
     bool is_head() const noexcept { return _flags._head; }
     void set_head(bool v) noexcept { _flags._head = v; }
@@ -76,6 +88,7 @@ public:
     cache_entry(dummy_entry_tag);
     cache_entry(schema_ptr s, const dht::decorated_key& key, const mutation_partition& p);
     cache_entry(schema_ptr s, dht::decorated_key&& key, mutation_partition&& p);
+    cache_entry(schema_ptr s, dht::decorated_key&& key, single_row_partition&& p);
     // It is assumed that pe is fully continuous
     // pe must be evictable.
     cache_entry(evictable_tag, schema_ptr s, dht::decorated_key&& key, partition_entry&& pe) noexcept;
@@ -83,7 +96,13 @@ public:
     ~cache_entry();
 
     static cache_entry& container_of(partition_entry& pe) {
-        return *boost::intrusive::get_parent_from_member(&pe, &cache_entry::_pe);
+        return *boost::intrusive::get_parent_from_member(
+                reinterpret_cast<decltype(cache_entry::storage)*>(&pe), &cache_entry::storage);
+    }
+
+    static cache_entry& container_of(single_row_partition& srp) {
+        return *boost::intrusive::get_parent_from_member(
+                reinterpret_cast<decltype(cache_entry::storage)*>(&srp), &cache_entry::storage);
     }
 
     // Called when all contents have been evicted.
@@ -101,11 +120,22 @@ public:
         return _key;
     }
 
+    // Call only when format() == partition_format::generic.
+    partition_entry& get_partition_entry() { return storage.pe; }
+
     friend dht::ring_position_view ring_position_view_to_compare(const cache_entry& ce) noexcept { return ce.position(); }
 
-    const partition_entry& partition() const noexcept { return _pe; }
-    partition_entry& partition() { return _pe; }
-    const schema_ptr& schema() const noexcept { return _pe.get_schema(); }
+    template <typename Visitor>
+    auto accept(this auto& self, Visitor&& v) {
+        return self.storage.accept(self.format(), std::forward<Visitor>(v));
+    }
+
+    const schema_ptr& schema() const noexcept {
+        return accept([&] (auto& p) {
+            return std::reference_wrapper<const schema_ptr>(p.get_schema());
+        }).get();
+    }
+
     mutation_reader read(row_cache&, cache::read_context&);
     mutation_reader read(row_cache&, std::unique_ptr<cache::read_context>);
     mutation_reader read(row_cache&, cache::read_context&, utils::phased_barrier::phase_type);
@@ -279,6 +309,8 @@ private:
     // The entry which is returned will have the tombstone applied to it.
     //
     // Must be run under reclaim lock
+    //
+    // Can be called only when cache is using partition_format::generic.
     cache_entry& find_or_create_incomplete(const partition_start& ps, row_cache::phase_type phase, const previous_entry_pointer* previous = nullptr);
 
     // Creates (or touches) a cache entry for missing partition so that sstables are not
@@ -344,6 +376,10 @@ public:
     row_cache(row_cache&&) = default;
     row_cache(const row_cache&) = delete;
 public:
+    partition_format get_partition_format() const {
+        return ::get_partition_format(*_schema);
+    }
+
     // Implements mutation_source for this cache, see mutation_reader.hh
     // User needs to ensure that the row_cache object stays alive
     // as long as the reader is used.
@@ -397,6 +433,11 @@ public:
     // Intended to be used only in tests.
     // Can only be called prior to any reads.
     void populate(const mutation& m, const previous_entry_pointer* previous = nullptr);
+
+    // Populate cache from given mutation, which must be fully continuous.
+    // If previous != nullptr and it is still a predecessor of the inserted key,
+    // the range between previous and the inserted entry is marked as continuous.
+    void try_populate(const mutation& m, const previous_entry_pointer* previous = nullptr);
 
     // Finds the entry in cache for a given key.
     // Intended to be used only in tests.

--- a/mutation/mutation_fragment_v2.hh
+++ b/mutation/mutation_fragment_v2.hh
@@ -183,7 +183,7 @@ public:
         }
         _data->_memory.reset_to(o._data->_memory.resources());
     }
-    mutation_fragment_v2(mutation_fragment_v2&& other) = default;
+    mutation_fragment_v2(mutation_fragment_v2&& other) noexcept = default;
     mutation_fragment_v2& operator=(mutation_fragment_v2&& other) noexcept {
         if (this != &other) {
             this->~mutation_fragment_v2();

--- a/mutation/single_row_partition.hh
+++ b/mutation/single_row_partition.hh
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "schema/schema.hh"
+#include "mutation/mutation_fragment_v2.hh"
+#include "mutation/partition_version.hh"
+#include "reader_permit.hh"
+#include "mutation_partition.hh"
+#include "utils/lru.hh"
+
+#include <seastar/util/backtrace.hh>
+
+#include <deque>
+#include <fmt/format.h>
+
+/// Determines format of partition entry in memtable and row_cache.
+/// For a given table, all partitions use the same format within a given scylla process.
+/// Different servers may use different format.
+enum class partition_format {
+    // Handles large partitions with many rows well.
+    // With MVCC.
+    // rows entries linked into LRU, partition entry evicted when the last row is evicted.
+    // Partitions may be incomplete in cache (tracks clustering range continuity).
+    generic,
+
+    // For schema without clustering columns.
+    // No MVCC.
+    // partition entry (single_row_partition) linked into LRU.
+    // Partitions always complete in cache (no continuity tracking).
+    single_row
+};
+
+inline
+partition_format get_partition_format(const schema& s) {
+    return s.clustering_key_size() ? partition_format::generic : partition_format::single_row;
+}
+
+// A simplified mutation_partition object for schemas without a clustering key.
+// LSA-managed object.
+// Mutators should run under owning allocator.
+class single_row_partition final : public evictable {
+    schema_ptr _s;
+
+    // Indirect so that cache_entry doesn't increase in size for generic storage.
+    managed_ref<deletable_row> _row;
+public:
+    using fragments_vector = utils::small_vector<mutation_fragment_v2, 3>;
+
+    single_row_partition(schema_ptr);
+    single_row_partition(schema_ptr, const mutation_partition&);
+    single_row_partition(schema_ptr, mutation_partition&&);
+    single_row_partition(single_row_partition&&) noexcept = default;
+    single_row_partition(const single_row_partition&) = delete;
+
+    // Memory usage excluding memory taken directly by this object.
+    // Run under owning allocator.
+    size_t external_memory_usage() const {
+        return _row->cells().external_memory_usage(*_s, column_kind::regular_column);
+    }
+
+    void on_evicted() noexcept override;
+    void on_evicted_shallow() noexcept override {};
+
+    // Frees elements of this entry.
+    // Returns stop_iteration::yes iff there are no more elements to free.
+    stop_iteration clear_gently(cache_tracker*) noexcept;
+
+    deletable_row& row() { return *_row; }
+    const deletable_row& row() const { return *_row; }
+    const schema_ptr& get_schema() const { return _s; }
+    fragments_vector as_fragments(const dht::decorated_key& key, reader_permit) const;
+
+    // No exception guarantees.
+    void apply(const schema& mp_schema, const mutation_partition& mp, mutation_application_stats& app_stats);
+
+    // No exception guarantees.
+    void apply(const schema& mp_schema, mutation_partition&& mp, mutation_application_stats& app_stats);
+
+    // Weak exception guarantees. After exception, p may be partially applied, but both this and p will
+    // commute to the same value as they would, should the exception not happen.
+    void apply_monotonically(single_row_partition&& p);
+
+    // Strong exception guarantees.
+    void upgrade(schema_ptr new_schema);
+};
+
+/// A run-time dependent partition storage with a layout chosen based
+/// on partition_format which is known externally.
+///
+/// Starts with uninitialized storage, must initialize manually.
+/// If initialized, must call destroy() before this instance is destroyed.
+union partition_storage final {
+    partition_entry pe;       // partition_format::generic
+    single_row_partition srp; // partition_format::single_row
+
+    partition_storage() noexcept {}
+    ~partition_storage() noexcept {}
+    partition_storage(const partition_storage&) = delete;
+    partition_storage(partition_storage&&) = delete;
+
+    static size_t size_of(partition_format f) {
+        switch (f) {
+            case partition_format::generic: return sizeof(partition_entry);
+            case partition_format::single_row: return sizeof(single_row_partition);
+        }
+        abort();
+    }
+
+    template <typename Visitor>
+    auto accept(this auto& self, partition_format f, Visitor&& v) {
+        switch (f) {
+            case partition_format::generic: return v(self.pe);
+            case partition_format::single_row: return v(self.srp);
+        }
+        throw_with_backtrace<std::invalid_argument>(fmt::format("Unsupported format: {}", static_cast<int>(f)));
+    }
+
+    partition_storage(partition_format f, partition_storage&& o) noexcept {
+        switch (f) {
+            case partition_format::single_row:
+                new (&srp) single_row_partition(std::move(o.srp));
+                break;
+            case partition_format::generic:
+                new (&pe) partition_entry(std::move(o.pe));
+                break;
+            default:
+                abort();
+        }
+    }
+
+    void destroy(partition_format f) noexcept {
+        switch (f) {
+            case partition_format::single_row:
+                srp.~single_row_partition();
+                break;
+            case partition_format::generic:
+                pe.~partition_entry();
+                break;
+            default:
+                abort();
+        }
+    }
+};

--- a/readers/from_fragments.hh
+++ b/readers/from_fragments.hh
@@ -10,6 +10,7 @@
 #include "schema/schema_fwd.hh"
 #include <deque>
 #include "dht/i_partitioner_fwd.hh"
+#include "utils/small_vector.hh"
 
 class mutation_reader;
 class reader_permit;
@@ -22,6 +23,9 @@ namespace query {
 
 mutation_reader
 make_mutation_reader_from_fragments(schema_ptr, reader_permit, std::deque<mutation_fragment_v2>);
+
+mutation_reader
+make_mutation_reader_from_fragments(schema_ptr, reader_permit, utils::small_vector<mutation_fragment_v2, 3>);
 
 mutation_reader
 make_mutation_reader_from_fragments(schema_ptr, reader_permit, std::deque<mutation_fragment_v2>, const dht::partition_range& pr);

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -14,7 +14,9 @@
 #include "partition_builder.hh"
 #include "mutation/mutation_partition_view.hh"
 #include "readers/empty.hh"
+#include "schema_upgrader.hh"
 #include "readers/forwardable.hh"
+#include "readers/from_fragments.hh"
 #include "sstables/types.hh"
 
 namespace replica {
@@ -154,7 +156,9 @@ memtable::~memtable() {
 }
 
 void memtable::evict_entry(memtable_entry& e, mutation_cleaner& cleaner) noexcept {
-    e.partition().evict(cleaner);
+    e.accept(make_visitor([&] (partition_entry& pe) {
+        pe.evict(cleaner);
+    }, [&] (single_row_partition& srp) {}));
     nr_partitions--;
 }
 
@@ -202,7 +206,7 @@ future<> memtable::clear_gently() noexcept {
     });
 }
 
-partition_entry&
+memtable_entry&
 memtable::find_or_create_partition_slow(partition_key_view key) {
     SCYLLA_ASSERT(!reclaiming_enabled());
 
@@ -212,15 +216,15 @@ memtable::find_or_create_partition_slow(partition_key_view key) {
     // partitions doesn't support heterogeneous lookup.
     // We could switch to boost::intrusive_map<> similar to what we have for row keys.
     auto& outer = current_allocator();
-    return with_allocator(standard_allocator(), [&, this] () -> partition_entry& {
+    return with_allocator(standard_allocator(), [&, this] () -> memtable_entry& {
         auto dk = dht::decorate_key(*_schema, key);
-        return with_allocator(outer, [&dk, this] () -> partition_entry& {
+        return with_allocator(outer, [&dk, this] () -> memtable_entry& {
             return find_or_create_partition(dk);
         });
     });
 }
 
-partition_entry&
+memtable_entry&
 memtable::find_or_create_partition(const dht::decorated_key& key) {
     SCYLLA_ASSERT(!reclaiming_enabled());
 
@@ -230,18 +234,18 @@ memtable::find_or_create_partition(const dht::decorated_key& key) {
     if (i == partitions.end() || !hint.match) {
         partitions_type::iterator entry = partitions.emplace_before(i,
                 key.token().raw(), hint,
-                _schema, dht::decorated_key(key), mutation_partition(*_schema));
+                _schema, dht::decorated_key(key));
         ++nr_partitions;
         ++_table_stats.memtable_partition_insertions;
         if (!hint.emplace_keeps_iterators()) {
             current_allocator().invalidate_references();
         }
-        return entry->partition();
+        return *entry;
     } else {
         ++_table_stats.memtable_partition_hits;
         upgrade_entry(*i);
     }
-    return i->partition();
+    return *i;
 }
 
 bool
@@ -410,6 +414,18 @@ public:
     void operator()(const partition_end& eop) {}
 };
 
+// Upgrades mutation_fragment_v2 collection in-place to a new schema, if necessary.
+template <typename Frags>
+void upgrade(Frags& frags, const schema_ptr& frags_s, const schema_ptr& new_schema) {
+    if (new_schema != frags_s) {
+        schema_upgrader_v2 upgrader(new_schema);
+        upgrader(frags_s);
+        for (auto&& f : frags) {
+            f = upgrader(std::move(f));
+        }
+    }
+}
+
 class scanning_reader final : public mutation_reader::impl, private iterator_reader {
     std::optional<dht::partition_range> _delegate_range;
     mutation_reader_opt _delegate;
@@ -455,6 +471,53 @@ public:
          , _fwd_mr(fwd_mr)
      { }
 
+     void read_from_single_row() {
+         read_section()(region(), [&] {
+             memtable_entry *e = fetch_entry();
+             if (!e) {
+                 _end_of_stream = true;
+                 return;
+             }
+             auto key = e->key();
+             auto& srp = e->get_single_row_partition();
+             auto frags = srp.as_fragments(key, _permit);
+             upgrade(frags, srp.get_schema(), schema());
+             for (auto&& f: frags) {
+                 push_mutation_fragment(std::move(f));
+             }
+             advance_iterator();
+             update_last(std::move(key));
+         });
+     }
+
+     void read_from_generic() {
+         auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
+             memtable_entry *e = fetch_entry();
+             if (!e) {
+                 return { };
+             } else {
+                 // FIXME: Introduce a memtable specific reader that will be returned from
+                 // memtable_entry::read and will allow filling the buffer without the overhead of
+                 // virtual calls, intermediate buffers and futures.
+                 auto key = e->key();
+                 auto snp = e->snapshot(*mtbl());
+                 advance_iterator();
+                 return std::pair(std::move(key), std::move(snp));
+             }
+         });
+         if (key_and_snp) {
+             update_last(key_and_snp->first);
+
+             auto cr = query::clustering_key_filter_ranges::get_ranges(*schema(), _slice, key_and_snp->first.key());
+             bool digest_requested = _slice.options.contains<query::partition_slice::option::with_digest>();
+             bool is_reversed = _slice.is_reversed();
+             _delegate = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, _permit, std::move(key_and_snp->first), std::move(cr), std::move(key_and_snp->second), digest_requested, region(), read_section(), mtbl(), streamed_mutation::forwarding::no, *mtbl());
+             _delegate->upgrade_schema(schema());
+         } else {
+             _end_of_stream = true;
+         }
+     }
+
     virtual future<> fill_buffer() override {
         return do_until([this] { return is_end_of_stream() || is_buffer_full(); }, [this] {
             if (!_delegate) {
@@ -462,35 +525,28 @@ public:
                 if (_delegate_range) {
                     _delegate = delegate_reader(_permit, *_delegate_range, _slice, streamed_mutation::forwarding::no, _fwd_mr);
                 } else {
-                    auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
-                        memtable_entry *e = fetch_entry();
-                        if (!e) {
-                            return { };
-                        } else {
-                            // FIXME: Introduce a memtable specific reader that will be returned from
-                            // memtable_entry::read and will allow filling the buffer without the overhead of
-                            // virtual calls, intermediate buffers and futures.
-                            auto key = e->key();
-                            auto snp = e->snapshot(*mtbl());
-                            advance_iterator();
-                            return std::pair(std::move(key), std::move(snp));
-                        }
-                    });
-                    if (key_and_snp) {
-                        update_last(key_and_snp->first);
-
-                        auto cr = query::clustering_key_filter_ranges::get_ranges(*schema(), _slice, key_and_snp->first.key());
-                        bool digest_requested = _slice.options.contains<query::partition_slice::option::with_digest>();
-                        bool is_reversed = _slice.is_reversed();
-                        _delegate = make_partition_snapshot_flat_reader_from_snp_schema(is_reversed, _permit, std::move(key_and_snp->first), std::move(cr), std::move(key_and_snp->second), digest_requested, region(), read_section(), mtbl(), streamed_mutation::forwarding::no, *mtbl());
-                        _delegate->upgrade_schema(schema());
-                    } else {
-                        _end_of_stream = true;
+                    switch (get_partition_format(*schema())) {
+                        case partition_format::single_row:
+                            read_from_single_row();
+                            break;
+                        case partition_format::generic:
+                            read_from_generic();
+                            break;
+                        default:
+                            abort();
                     }
                 }
             }
 
-            return is_end_of_stream() ? make_ready_future<>() : fill_buffer_from_delegate();
+            if (is_end_of_stream()) {
+                return make_ready_future<>();
+            }
+
+            if (_delegate) {
+                return fill_buffer_from_delegate();
+            }
+
+            return make_ready_future<>();
         });
     }
     virtual future<> next_partition() override {
@@ -565,6 +621,9 @@ public:
     uint64_t compute_size(memtable_entry& e, partition_snapshot& snp) {
         return e.size_in_allocator_without_rows(_mt.allocator())
             + _mt.allocator().object_memory_size_in_allocator(&*snp.version());
+    }
+    uint64_t compute_size(memtable_entry& e) {
+        return e.size_in_allocator(_mt.allocator());
     }
 };
 
@@ -642,7 +701,7 @@ public:
     flush_reader& operator=(flush_reader&&) = delete;
     flush_reader& operator=(const flush_reader&) = delete;
 private:
-    void get_next_partition() {
+    void get_next_partition_generic() {
         uint64_t component_size = 0;
         auto key_and_snp = read_section()(region(), [&] () -> std::optional<std::pair<dht::decorated_key, partition_snapshot_ptr>> {
             memtable_entry* e = fetch_entry();
@@ -663,6 +722,45 @@ private:
             _partition_reader = make_partition_snapshot_flat_reader<false, partition_snapshot_flush_accounter>(snp_schema, _permit, std::move(key_and_snp->first), std::move(cr),
                             std::move(key_and_snp->second), false, region(), read_section(), mtbl(), streamed_mutation::forwarding::no, *snp_schema, _flushed_memory);
             _partition_reader->upgrade_schema(schema());
+        } else {
+            _end_of_stream = true;
+        }
+    }
+    void get_next_partition_single_row() {
+        read_section()(region(), [&] {
+            memtable_entry* e = fetch_entry();
+            if (!e) {
+                _end_of_stream = true;
+                return;
+            }
+            auto key = e->key();
+            auto& srp = e->get_single_row_partition();
+            auto frags = srp.as_fragments(key, _permit);
+            upgrade(frags, srp.get_schema(), schema());
+            for (auto&& f : frags) {
+                push_mutation_fragment(std::move(f));
+            }
+
+            auto component_size = _flushed_memory.compute_size(*e);
+
+            // No exceptions after this point bcause we have side effects and don't want retries.
+            std::invoke([&] () noexcept {
+                advance_iterator();
+                _flushed_memory.update_bytes_read(component_size);
+                update_last(std::move(key));
+            });
+        });
+    }
+    void get_next_partition() {
+        switch (get_partition_format(*schema())) {
+            case partition_format::generic:
+                get_next_partition_generic();
+                break;
+            case partition_format::single_row:
+                get_next_partition_single_row();
+                break;
+            default:
+                abort();
         }
     }
     future<> close_partition_reader() noexcept {
@@ -674,7 +772,6 @@ public:
             if (!_partition_reader) {
                 get_next_partition();
                 if (!_partition_reader) {
-                    _end_of_stream = true;
                     return make_ready_future<>();
                 }
             }
@@ -708,7 +805,7 @@ public:
 };
 
 partition_snapshot_ptr memtable_entry::snapshot(memtable& mtbl) {
-    return _pe.read(mtbl.region(), mtbl.cleaner(), no_cache_tracker);
+    return storage.pe.read(mtbl.region(), mtbl.cleaner(), no_cache_tracker);
 }
 
 mutation_reader_opt
@@ -722,6 +819,20 @@ memtable::make_mutation_reader_opt(schema_ptr query_schema,
     bool is_reversed = slice.is_reversed();
     if (query::is_single_partition(range) && !fwd_mr) {
         const query::ring_position& pos = range.start()->value();
+        if (get_partition_format(*_schema) == partition_format::single_row) {
+            return _table_shared_data.read_section(*this, [&] () -> mutation_reader_opt {
+                auto i = partitions.find(pos, dht::ring_position_comparator(*_schema));
+                if (i == partitions.end()) {
+                    return {};
+                }
+                upgrade_entry(*i);
+                auto& srp = i->storage.srp;
+                auto r = make_mutation_reader_from_fragments(srp.get_schema(), permit, srp.as_fragments(i->key(), permit));
+                r.upgrade_schema(query_schema);
+                return mutation_reader_opt(std::move(r));
+            });
+        }
+
         auto snp = _table_shared_data.read_section(*this, [&] () -> partition_snapshot_ptr {
             auto i = partitions.find(pos, dht::ring_position_comparator(*_schema));
             if (i != partitions.end()) {
@@ -788,9 +899,14 @@ void
 memtable::apply(const mutation& m, db::rp_handle&& h) {
     with_allocator(allocator(), [this, &m] {
         _table_shared_data.allocating_section(*this, [&, this] {
-            auto& p = find_or_create_partition(m.decorated_key());
+            auto& e = find_or_create_partition(m.decorated_key());
             _stats_collector.update(*m.schema(), m.partition());
-            p.apply(region(), cleaner(), *_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
+            e.accept(make_visitor([&] (partition_entry& pe) {
+                pe.apply(region(), cleaner(), *_schema, m.partition(), *m.schema(), _table_stats.memtable_app_stats);
+            }, [&] (single_row_partition& srp) {
+                srp.apply(*m.schema(), m.partition(), _table_stats.memtable_app_stats);
+            }));
+
         });
     });
     update(std::move(h));
@@ -800,12 +916,16 @@ void
 memtable::apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h) {
     with_allocator(allocator(), [this, &m, &m_schema] {
         _table_shared_data.allocating_section(*this, [&, this] {
-            auto& p = find_or_create_partition_slow(m.key());
+            auto& e = find_or_create_partition_slow(m.key());
             mutation_partition mp(*m_schema);
             partition_builder pb(*m_schema, mp);
             m.partition().accept(*m_schema, pb);
             _stats_collector.update(*m_schema, mp);
-            p.apply(region(), cleaner(), *_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
+            e.accept(make_visitor([&] (partition_entry& pe) {
+                pe.apply(region(), cleaner(), *_schema, std::move(mp), *m_schema, _table_stats.memtable_app_stats);
+            }, [&] (single_row_partition& srp) {
+                srp.apply(*m_schema, std::move(mp), _table_stats.memtable_app_stats);
+            }));
         });
     });
     update(std::move(h));
@@ -827,19 +947,36 @@ mutation_source memtable::as_data_source() {
     });
 }
 
-memtable_entry::memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p)
+memtable_entry::memtable_entry(schema_ptr s, dht::decorated_key key)
     : _key(std::move(key))
-    , _pe(*s, std::move(p))
-{ }
+{
+    switch (get_partition_format(*s)) {
+        case partition_format::generic:
+            new (&storage.pe) partition_entry(*s, mutation_partition(*s));
+            break;
+        case partition_format::single_row:
+            new (&storage.srp) single_row_partition(std::move(s));
+            _flags._single_row_partition = true;
+            break;
+    }
+}
 
 memtable_entry::memtable_entry(memtable_entry&& o) noexcept
     : _key(std::move(o._key))
-    , _pe(std::move(o._pe))
+    , storage(o.format(), std::move(o.storage))
     , _flags(o._flags)
 { }
 
+memtable_entry::~memtable_entry() noexcept {
+    storage.destroy(format());
+}
+
 stop_iteration memtable_entry::clear_gently() noexcept {
-    return _pe.clear_gently(no_cache_tracker);
+    return accept(make_visitor([&] (partition_entry& pe) {
+        return pe.clear_gently(no_cache_tracker);
+    }, [&] (single_row_partition& srp) {
+        return srp.clear_gently(no_cache_tracker);
+    }));
 }
 
 void memtable::mark_flushed(mutation_source underlying) noexcept {
@@ -855,9 +992,15 @@ bool memtable::is_flushed() const noexcept {
 }
 
 void memtable_entry::upgrade_schema(logalloc::region& r, const schema_ptr& s, mutation_cleaner& cleaner) {
-    if (schema() != s) {
-        partition().upgrade(r, s, cleaner, no_cache_tracker);
-    }
+    accept(make_visitor([&] (partition_entry& pe) {
+        if (pe.get_schema() != s) {
+            pe.upgrade(r, s, cleaner, no_cache_tracker);
+        }
+    }, [&] (single_row_partition& srp) {
+        if (srp.get_schema() != s) {
+            srp.upgrade(s);
+        }
+    }));
 }
 
 void memtable::upgrade_entry(memtable_entry& e) {
@@ -879,7 +1022,8 @@ size_t memtable_entry::object_memory_size(allocation_strategy& allocator) {
 
 auto fmt::formatter<replica::memtable_entry>::format(const replica::memtable_entry& mt,
                                                      fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    return fmt::format_to(ctx.out(), "{{{}: {}}}", mt.key(), partition_entry::printer(mt.partition()));
+    // FIXME
+    return fmt::format_to(ctx.out(), "{{{}: }}", mt.key());
 }
 
 auto fmt::formatter<replica::memtable>::format(replica::memtable& mt,

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -827,6 +827,11 @@ mutation_source memtable::as_data_source() {
     });
 }
 
+memtable_entry::memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p)
+    : _key(std::move(key))
+    , _pe(*s, std::move(p))
+{ }
+
 memtable_entry::memtable_entry(memtable_entry&& o) noexcept
     : _key(std::move(o._key))
     , _pe(std::move(o._pe))

--- a/replica/memtable.hh
+++ b/replica/memtable.hh
@@ -48,11 +48,7 @@ public:
 
     friend class memtable;
 
-    memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p)
-        : _key(std::move(key))
-        , _pe(*s, std::move(p))
-    { }
-
+    memtable_entry(schema_ptr s, dht::decorated_key key, mutation_partition p);
     memtable_entry(memtable_entry&& o) noexcept;
     // Frees elements of the entry in batches.
     // Returns stop_iteration::yes iff there are no more elements to free.

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -4323,7 +4323,7 @@ SEASTAR_TEST_CASE(row_cache_is_populated_using_compacting_sstable_reader) {
         // meaning the input from sstables wasn't compacted and we put
         // unnecessary pressure on the cache.
         cache_entry& entry = t.get_row_cache().lookup(pk);
-        const utils::immutable_collection<mutation_partition::rows_type>& rt = entry.partition().version()->partition().clustered_rows();
+        const utils::immutable_collection<mutation_partition::rows_type>& rt = entry.get_partition_entry().version()->partition().clustered_rows();
         BOOST_ASSERT(rt.calculate_size() == 1);
     });
 }
@@ -4558,7 +4558,7 @@ SEASTAR_TEST_CASE(test_populating_cache_with_expired_and_nonexpired_tombstones) 
         }).get();
 
         cache_entry& entry = t.get_row_cache().lookup(dk);
-        auto& cp = entry.partition().version()->partition();
+        auto& cp = entry.get_partition_entry().version()->partition();
 
         BOOST_REQUIRE_EQUAL(cp.clustered_row(*s, ck1).deleted_at(), row_tombstone(tombstone(1, dt_noexp))); // non-expired tombstone is in cache
         BOOST_REQUIRE(cp.find_row(*s, ck2) == nullptr); // expired tombstone isn't in cache
@@ -4727,7 +4727,7 @@ SEASTAR_TEST_CASE(test_cache_compacts_expired_tombstones_on_read) {
         rd1.fill_buffer().get(); // cache_mutation_reader compacts cache on fill buffer
 
         cache_entry& entry = cache.lookup(pkey);
-        auto& cp = entry.partition().version()->partition();
+        auto& cp = entry.get_partition_entry().version()->partition();
 
         BOOST_REQUIRE(cp.find_row(*s, ck1) != nullptr); // live row is in cache
         BOOST_REQUIRE_EQUAL(cp.clustered_row(*s, ck2).deleted_at(), row_tombstone(tombstone(1, dt_noexp))); // non-expired tombstone is in cache
@@ -4776,7 +4776,7 @@ SEASTAR_TEST_CASE(test_compact_range_tombstones_on_read) {
         tombstone_gc_state gc_state(nullptr);
 
         cache_entry& entry = cache.lookup(pk);
-        auto& cp = entry.partition().version()->partition();
+        auto& cp = entry.get_partition_entry().version()->partition();
 
         // check all rows are in cache
         BOOST_REQUIRE(cp.find_row(*s.schema(), ck0) != nullptr);
@@ -5013,7 +5013,7 @@ SEASTAR_THREAD_TEST_CASE(test_reproduce_18045) {
     cache.populate(m);
 
     with_allocator(tracker.allocator(), [&] {
-        auto& e = *cache.lookup(pk).partition().version()->partition().clustered_rows().begin();
+        auto& e = *cache.lookup(pk).get_partition_entry().version()->partition().clustered_rows().begin();
         tracker.get_lru().remove(e);
         e.on_evicted(tracker);
     });

--- a/test/lib/mutation_source_test.hh
+++ b/test/lib/mutation_source_test.hh
@@ -55,14 +55,21 @@ public:
     struct generate_counters_tag { };
     using generate_counters = bool_class<generate_counters_tag>;
     using generate_uncompactable = bool_class<class generate_uncompactable_tag>;
+    using maybe_without_clustering = bool_class<class maybe_without_clustering>;
     using compress = bool_class<struct compress_tag>;
 
     // With generate_uncompactable::yes, the mutation will be uncompactable, that
     // is no higher level tombstone will cover lower level tombstones and no
     // tombstone will cover data, i.e. compacting the mutation will not result
     // in any changes.
-    explicit random_mutation_generator(generate_counters, local_shard_only lso = local_shard_only::yes, generate_uncompactable uc = generate_uncompactable::no,
-            std::optional<uint32_t> seed_opt = std::nullopt, const char* ks_name="ks", const char* cf_name="cf", compress c = compress::yes);
+    explicit random_mutation_generator(generate_counters,
+            local_shard_only lso = local_shard_only::yes,
+            generate_uncompactable uc = generate_uncompactable::no,
+            std::optional<uint32_t> seed_opt = std::nullopt,
+            const char* ks_name="ks",
+            const char* cf_name="cf",
+            compress c = compress::yes,
+            maybe_without_clustering without_clustering = maybe_without_clustering::no);
     random_mutation_generator(generate_counters gc, uint32_t seed)
             : random_mutation_generator(gc, local_shard_only::yes, generate_uncompactable::no, seed) {}
     ~random_mutation_generator();

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -206,6 +206,12 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
         cache.populate(muts.back());
     }
 
+    auto cache_stats = tracker.region().collect_stats();
+    std::cout << "Cache LSA stats (" << fmt::to_string(tracker.region().occupancy()) << "):" << "\n";
+    for (auto [ name, size ] : cache_stats) {
+        std::cout << "  " << name << ": " << size << "\n";
+    }
+
     mutation& m = muts[0];
     result.memtable = mt->occupancy().used_space();
     result.cache = tracker.region().occupancy().used_space() - cache_initial_occupancy;
@@ -276,12 +282,6 @@ int main(int argc, char** argv) {
 
             std::cout << "\n";
             size_calculator::print_cache_entry_size();
-
-            auto cache_st = tracker.region().collect_stats();
-            std::cout << "LSA stats:" << "\n";
-            for (auto [ name, size ] : cache_st) {
-                std::cout << "  " << name << ": " << size << "\n";
-            }
         });
     });
 }

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -59,6 +59,8 @@ public:
 
         std::cout << prefix() << "sizeof(rows_entry) = " << sizeof(rows_entry) << "\n";
         std::cout << prefix() << "sizeof(evictable) = " << sizeof(evictable) << "\n";
+        std::cout << prefix() << "sizeof(partition_entry) = " << sizeof(partition_entry) << "\n";
+        std::cout << prefix() << "sizeof(single_row_partition) = " << sizeof(single_row_partition) << "\n";
         std::cout << prefix() << "sizeof(deletable_row) = " << sizeof(deletable_row) << "\n";
         std::cout << prefix() << "sizeof(row) = " << sizeof(row) << "\n";
         std::cout << prefix() << "radix_tree::inner_node::node_sizes = ";

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -194,6 +194,8 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
     auto s = make_schema(settings);
     auto mt = make_lw_shared<replica::memtable>(s);
 
+    // Evict cache so that we have an empty region and object stats include only new objects
+    tracker.clear();
     auto cache_initial_occupancy = tracker.region().occupancy().used_space();
 
     row_cache cache(s, make_empty_snapshot_source(), tracker);

--- a/test/perf/memory_footprint_test.cc
+++ b/test/perf/memory_footprint_test.cc
@@ -193,9 +193,10 @@ static sizes calculate_sizes(cache_tracker& tracker, const mutation_settings& se
     sizes result;
     auto s = make_schema(settings);
     auto mt = make_lw_shared<replica::memtable>(s);
-    row_cache cache(s, make_empty_snapshot_source(), tracker);
 
     auto cache_initial_occupancy = tracker.region().occupancy().used_space();
+
+    row_cache cache(s, make_empty_snapshot_source(), tracker);
 
     SCYLLA_ASSERT(mt->occupancy().used_space() == 0);
 

--- a/utils/intrusive-array.hh
+++ b/utils/intrusive-array.hh
@@ -331,7 +331,7 @@ public:
             ptr--;
         }
 
-        static_assert(offsetof(intrusive_array, _data[0].object) == 0);
+//        static_assert(offsetof(intrusive_array, _data[0].object) == 0);
         return *reinterpret_cast<intrusive_array*>(ptr);
     }
 };

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -2206,7 +2206,8 @@ public:
         other._sanitizer = region_sanitizer(_tracker.get_impl().sanitizer_report_backtrace());
     }
 
-    std::unordered_map<std::string, uint64_t> collect_stats() const {
+    std::unordered_map<std::string, uint64_t> collect_stats() {
+        close_active();
         std::unordered_map<std::string, uint64_t> sizes;
         for (auto& desc : _segment_descs) {
             const_cast<region_impl&>(*this).for_each_live(segment_pool().segment_from(desc), [&sizes] (const object_descriptor* desc, void* obj, size_t size) {
@@ -2485,7 +2486,7 @@ uint64_t region::id() const noexcept {
     return get_impl().id();
 }
 
-std::unordered_map<std::string, uint64_t> region::collect_stats() const {
+std::unordered_map<std::string, uint64_t> region::collect_stats() {
     return get_impl().collect_stats();
 }
 

--- a/utils/logalloc.hh
+++ b/utils/logalloc.hh
@@ -407,7 +407,7 @@ public:
 
     uint64_t id() const noexcept;
 
-    std::unordered_map<std::string, uint64_t> collect_stats() const;
+    std::unordered_map<std::string, uint64_t> collect_stats();
 
     friend class allocating_section;
 };


### PR DESCRIPTION
Partitions with clustering keys need complex data structures and algorithms, which support
partial population and eviction (so continuity), range tombstones, preemptible partition reading
and cache update from memtable, MVCC. For schemas without a clustering key, partitions are single-row
and we need none of that, which can greatly simplify storage format and
algorithms.

This patch introduces single_row_partition, which is a simplified
mutation_partition. cache_entry and memtable_entry use a union which
switches partition storage based on schema.

We need to keep a flag per entry to determine storage, so that
move constructor for entries can be implemented.

This change improves both performance and memory efficiency.

perf-simple-query -c1 -m4G --duration 20 --partitions=100000

Shows 10% higher throughput.

Before:

```
104414.15 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42222 insns/op,   32637 cycles/op,        0 errors)
102393.88 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42194 insns/op,   32378 cycles/op,        0 errors)
105695.93 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42198 insns/op,   32434 cycles/op,        0 errors)
105478.88 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42214 insns/op,   32496 cycles/op,        0 errors)
102236.54 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42195 insns/op,   32629 cycles/op,        0 errors)
105563.66 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42186 insns/op,   32475 cycles/op,        0 errors)
105873.30 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42189 insns/op,   32394 cycles/op,        0 errors)
105828.58 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42208 insns/op,   32417 cycles/op,        0 errors)
105940.72 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42200 insns/op,   32395 cycles/op,        0 errors)
105929.56 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42192 insns/op,   32423 cycles/op,        0 errors)
105896.85 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42217 insns/op,   32432 cycles/op,        0 errors)
102453.55 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42212 insns/op,   32434 cycles/op,        0 errors)
105736.21 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42201 insns/op,   32451 cycles/op,        0 errors)
105641.48 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42230 insns/op,   32483 cycles/op,        0 errors)
105876.68 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42205 insns/op,   32414 cycles/op,        0 errors)
105874.01 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42229 insns/op,   32418 cycles/op,        0 errors)
105356.80 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42213 insns/op,   32557 cycles/op,        0 errors)
105534.58 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42242 insns/op,   32463 cycles/op,        0 errors)
105676.64 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42217 insns/op,   32460 cycles/op,        0 errors)
105826.56 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   42199 insns/op,   32439 cycles/op,        0 errors)
throughput:
	mean=   105161.43 standard-deviation=1252.56
	median= 105695.93 median-absolute-deviation=711.87
	maximum=105940.72 minimum=102236.54
instructions_per_op:
	mean=   42208.05 standard-deviation=15.03
	median= 42207.64 median-absolute-deviation=9.60
	maximum=42242.02 minimum=42186.17
cpu_cycles_per_op:
	mean=   32461.52 standard-deviation=71.24
	median= 32438.57 median-absolute-deviation=38.10
	maximum=32637.40 minimum=32378.25
```

After:

```
115440.62 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39367 insns/op,   29423 cycles/op,        0 errors)
113392.87 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39329 insns/op,   29304 cycles/op,        0 errors)
117156.36 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39321 insns/op,   29301 cycles/op,        0 errors)
117038.88 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39330 insns/op,   29285 cycles/op,        0 errors)
116815.73 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39364 insns/op,   29365 cycles/op,        0 errors)
116815.88 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39330 insns/op,   29378 cycles/op,        0 errors)
117262.35 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39329 insns/op,   29283 cycles/op,        0 errors)
116862.80 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39329 insns/op,   29391 cycles/op,        0 errors)
117175.67 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39325 insns/op,   29308 cycles/op,        0 errors)
116697.18 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39344 insns/op,   29426 cycles/op,        0 errors)
117466.62 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39338 insns/op,   29236 cycles/op,        0 errors)
113193.96 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39337 insns/op,   29335 cycles/op,        0 errors)
116261.25 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39330 insns/op,   29423 cycles/op,        0 errors)
114774.71 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39333 insns/op,   29523 cycles/op,        0 errors)
116781.10 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39357 insns/op,   29388 cycles/op,        0 errors)
116914.98 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39343 insns/op,   29372 cycles/op,        0 errors)
116984.75 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39332 insns/op,   29364 cycles/op,        0 errors)
117128.28 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39325 insns/op,   29307 cycles/op,        0 errors)
116795.86 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39345 insns/op,   29342 cycles/op,        0 errors)
116910.57 tps ( 64.1 allocs/op,   0.0 logallocs/op,  14.2 tasks/op,   39367 insns/op,   29358 cycles/op,        0 errors)
throughput:
	mean=   116393.52 standard-deviation=1229.33
	median= 116862.80 median-absolute-deviation=645.36
	maximum=117466.62 minimum=113193.96
instructions_per_op:
	mean=   39338.76 standard-deviation=14.33
	median= 39332.95 median-absolute-deviation=9.26
	maximum=39367.11 minimum=39321.36
cpu_cycles_per_op:
	mean=   29355.62 standard-deviation=65.25
	median= 29363.63 median-absolute-deviation=48.22
	maximum=29523.27 minimum=29235.63
```

memory_footprint_test -c1 -m1G --partition-count=1600 --clustering-key-size=0

cache is using 66% of the old space, so we can now cache 50% more data.
memtable is using 81% of the old space, so we can hold 22% more data.

Note: size in sstables is 326400, so 204 bytes / partition.
Sizes include all 1600 partitions.

Before:
 - in cache:     1637968
 - in memtable:  1335368

After:
 - in cache:     1087584
 - in memtable:  1092162

Fixes https://github.com/scylladb/scylladb/issues/27841
Fixes https://github.com/scylladb/scylladb/issues/2972

TODO:

-  This patch increases the size of cache_entry and memtable_entry for
the generic format, because sizeof(single_row_partition) = 40, due to
sizeof(evictable) = 24. While sizeof(partition_entry) = 24. To fix,
without hurting efficiency for small partitions, we could make entries
variable-length based on format. That requires adapting
intrusive_array used by double_decker, which currently assumes
fixed-size entries.