### PR TITLE
compaction_manager: perform_cleanup: calculate sstables cleanup state only once

### DIFF
--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -351,6 +351,7 @@ public:
     // of a newly added node.
     future<> perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
 private:
+    future<> calculate_sstables_cleanup_state(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t);
     future<> try_perform_cleanup(owned_ranges_ptr sorted_owned_ranges, compaction::compaction_group_view& t, tasks::task_info info);
 
     // Add sst to or remove it from the respective compaction_state.sstables_requiring_cleanup set.


### PR DESCRIPTION
While perform_cleanup waits for staging sstables to be processed new sstables may be flushed, but due to #12215, newly flushed sstables are highly likely to be detected as requiring cleanup, extending the loop indefinitely, as long as there are staging sstables.

Fixes #27935

* Issue exists since scylla 5.4 and was hit several times in the field where cleanup timed out, please backport to all live versions.