### PR TITLE
compaction: cleanup: Don't time out when waiting for staging sstables

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -117,6 +117,10 @@ bool is_eligible_for_compaction(const sstables::shared_sstable& sst) noexcept {
     return !sst->requires_view_building() && !sst->is_quarantined();
 }
 
+bool is_eventually_eligible_for_compaction(const sstables::shared_sstable& sst) noexcept {
+    return sst->requires_view_building();
+}
+
 logging::logger clogger("compaction");
 
 static const std::unordered_map<compaction_type, sstring> compaction_types = {

--- a/compaction/compaction.hh
+++ b/compaction/compaction.hh
@@ -23,6 +23,9 @@
 namespace compaction {
 
 bool is_eligible_for_compaction(const sstables::shared_sstable& sst) noexcept;
+// Return whether sstable will be eventually eligible for compaction. Those can be sstables
+// being processed externally (e.g. view building) and will become available later.
+bool is_eventually_eligible_for_compaction(const sstables::shared_sstable& sst) noexcept;
 
 // Return the name of the compaction type
 // as used over the REST api, e.g. "COMPACTION" or "CLEANUP".

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -207,6 +207,7 @@ private:
     future<std::vector<sstables::shared_sstable>> get_candidates(compaction::compaction_group_view& t) const;
 
     bool eligible_for_compaction(const sstables::shared_sstable& sstable) const;
+    bool eventually_eligible_for_compaction(const sstables::shared_sstable& sstable) const;
     bool eligible_for_compaction(const sstables::frozen_sstable_run& sstable_run) const;
 
     template <std::ranges::range Range>


### PR DESCRIPTION
Cleanup will time out if it didn't process any sstable for 300s (the max_idle_time). Staging sstables can only be processed once they move into regular state. If view update generator takes more than max_idle_time to process a sstable, the cleanup happening concurrently will likely time out. The generator can take time, due to many factors, like sstable size, or whether the system is stressed, which can result in thrashing due to usage of evictable reader when processing the sstables.
The solution will consist of not timing out cleanup if we realize the "idleness" is due to staging sstables that will eventually become eligible once the generator is done with them.

Fixes #27957.

It can be backported in order to avoid cleanup failures while staging sstables are being processed.