### PR TITLE
Add system_distributed_tablets keyspace

### DIFF
--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -65,7 +65,9 @@ bool query_processor::topology_global_queue_empty() {
 }
 
 future<bool> query_processor::ongoing_rf_change(const service::group0_guard& guard, sstring ks) {
-    return remote().first.get().ss.ongoing_rf_change(guard, std::move(ks));
+    return remote().first.get().ss.ongoing_rf_change(guard, std::move(ks)).then([](std::optional<utils::UUID> rf_change_id) {
+        return rf_change_id.has_value();
+    });
 }
 
 static service::query_state query_state_for_internal_call() {

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -894,6 +894,8 @@ future<> system_distributed_tablets_keyspace::create_tables() {
         on_internal_error(dlogger, "DDL for system_distributed_tablets keyspace must be executed on shard 0");
     }
 
+    co_await utils::get_local_injector().inject("block-system-distributed-tablets-create-tables", utils::wait_for_message(std::chrono::seconds(30)));
+
     const auto& tmptr = _sp.local_db().get_token_metadata();
     auto& topology = tmptr.get_topology();
     if (!tmptr.is_normal_token_owner(topology.my_host_id())) {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -132,6 +132,7 @@ private:
 class system_distributed_tablets_keyspace {
 public:
     static constexpr auto NAME = "system_distributed_tablets";
+    static constexpr auto RF_PER_DC = 1;
 
 private:
     service::migration_manager& _mm;
@@ -145,6 +146,11 @@ public:
 private:
     static std::vector<schema_ptr> ensured_tables();
 
+    struct status {
+        bool keyspace_exists;
+        bool tables_exist;
+    };
+    status get_status() const;
     // Must be called only on shard 0.
     future<> create_tables();
 };

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -123,4 +123,30 @@ private:
     future<> create_tables(std::vector<schema_ptr> tables);
 };
 
+/**
+ * Service for bootstrapping the `system_distributed_tablets` keyspace and its tables.
+ *
+ * This keyspace holds system tables that need to be replicated with tablets.
+ * It is the successor of the older vnode-based `system_distributed` keyspace.
+ */
+class system_distributed_tablets_keyspace {
+public:
+    static constexpr auto NAME = "system_distributed_tablets";
+
+private:
+    service::migration_manager& _mm;
+    service::storage_proxy& _sp;
+
+public:
+    system_distributed_tablets_keyspace(service::migration_manager&, service::storage_proxy&);
+
+    future<> start();
+
+private:
+    static std::vector<schema_ptr> ensured_tables();
+
+    // Must be called only on shard 0.
+    future<> create_tables();
+};
+
 }

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -32,6 +32,7 @@ namespace cdc {
 namespace service {
     class storage_proxy;
     class migration_manager;
+    class storage_service;
 }
 
 namespace db {
@@ -132,14 +133,15 @@ private:
 class system_distributed_tablets_keyspace {
 public:
     static constexpr auto NAME = "system_distributed_tablets";
-    static constexpr auto RF_PER_DC = 1;
+    static constexpr auto RF_GOAL_PER_DC = 3;
 
 private:
     service::migration_manager& _mm;
     service::storage_proxy& _sp;
+    service::storage_service& _ss;
 
 public:
-    system_distributed_tablets_keyspace(service::migration_manager&, service::storage_proxy&);
+    system_distributed_tablets_keyspace(service::migration_manager&, service::storage_proxy&, service::storage_service&);
 
     future<> start();
 
@@ -148,6 +150,7 @@ private:
 
     struct status {
         bool keyspace_exists;
+        bool rf_ok;
         bool tables_exist;
     };
     status get_status() const;

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -139,6 +139,8 @@ public:
     static constexpr auto NAME = "system_distributed_tablets";
     static constexpr auto RF_GOAL_PER_DC = 3;
 
+    static constexpr auto SNAPSHOTS = "snapshots";
+
 private:
     service::migration_manager& _mm;
     service::storage_proxy& _sp;
@@ -156,6 +158,7 @@ public:
     future<> wait_until_started();
 
 private:
+    static schema_ptr snapshots();
     static std::vector<schema_ptr> ensured_tables();
 
     struct status {

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -13,9 +13,13 @@
 #include "utils/UUID.hh"
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
+#include "gms/feature.hh"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/shared_future.hh>
 
 #include <unordered_map>
 
@@ -130,7 +134,7 @@ private:
  * This keyspace holds system tables that need to be replicated with tablets.
  * It is the successor of the older vnode-based `system_distributed` keyspace.
  */
-class system_distributed_tablets_keyspace {
+class system_distributed_tablets_keyspace : public peering_sharded_service<system_distributed_tablets_keyspace> {
 public:
     static constexpr auto NAME = "system_distributed_tablets";
     static constexpr auto RF_GOAL_PER_DC = 3;
@@ -139,11 +143,17 @@ private:
     service::migration_manager& _mm;
     service::storage_proxy& _sp;
     service::storage_service& _ss;
+    gms::feature::listener_registration _listener;
+    seastar::named_gate _startup_gate;
+    promise<> _started_promise;
+    shared_future<> _started_future = make_ready_future<>();
 
 public:
     system_distributed_tablets_keyspace(service::migration_manager&, service::storage_proxy&, service::storage_service&);
 
     future<> start();
+    future<> stop();
+    future<> wait_until_started();
 
 private:
     static std::vector<schema_ptr> ensured_tables();

--- a/main.cc
+++ b/main.cc
@@ -1368,6 +1368,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             static sharded<db::system_distributed_keyspace> sys_dist_ks;
+            static sharded<db::system_distributed_tablets_keyspace> sys_dist_tablets_ks;
             static sharded<db::system_keyspace> sys_ks;
             static sharded<db::view::view_update_generator> view_update_generator;
             static sharded<db::view::view_builder> view_builder;
@@ -2505,6 +2506,14 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                     return es.invoke_on_all(&alternator::expiration_service::start);
                 }).get();
             }
+
+            checkpoint(stop_signal, "starting system distributed tablets keyspace");
+            sys_dist_tablets_ks.start(std::ref(mm), std::ref(proxy), std::ref(ss)).get();
+            auto stop_sys_dist_tablets_ks = defer_verbose_shutdown("system distributed tablets keyspace", [] {
+                sys_dist_tablets_ks.stop().get();
+            });
+
+            sys_dist_tablets_ks.local().start().get();
 
             db.invoke_on_all(&replica::database::revert_initial_system_read_concurrency_boost).get();
             notify_set.notify_all(configurable::system_state::started).get();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -50,7 +50,8 @@ static const std::unordered_set<std::string_view> internal_keyspaces = {
         db::system_keyspace::NAME,
         db::schema_tables::NAME,
         auth::meta::legacy::AUTH_KS,
-        tracing::trace_keyspace_helper::KEYSPACE_NAME
+        tracing::trace_keyspace_helper::KEYSPACE_NAME,
+        db::system_distributed_tablets_keyspace::NAME,
 };
 
 bool is_internal_keyspace(std::string_view name) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -1180,11 +1180,15 @@ template
 future<> migration_manager::announce_with_raft<schema_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout);
 template
 future<> migration_manager::announce_with_raft<topology_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout);
+template
+future<> migration_manager::announce_with_raft<mixed_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout);
 
 template
 future<> migration_manager::announce<schema_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout = std::nullopt);
 template
 future<> migration_manager::announce<topology_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout = std::nullopt);
+template
+future<> migration_manager::announce<mixed_change>(utils::chunked_vector<mutation> schema, group0_guard, std::string_view description, std::optional<raft_timeout> timeout = std::nullopt);
 
 future<group0_guard> migration_manager::start_group0_operation(std::optional<raft_timeout> timeout) {
     SCYLLA_ASSERT(this_shard_id() == 0);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1386,32 +1386,35 @@ public:
     }
 };
 
-future<bool> storage_service::ongoing_rf_change(const group0_guard& guard, sstring ks) const {
-    auto ongoing_ks_rf_change = [&] (utils::UUID request_id) -> future<bool> {
+future<std::optional<utils::UUID>> storage_service::ongoing_rf_change(const group0_guard& guard, sstring ks) const {
+    auto ongoing_ks_rf_change = [&] (utils::UUID request_id) -> future<std::optional<utils::UUID>> {
         auto req_entry = co_await _sys_ks.local().get_topology_request_entry(request_id);
-        co_return std::holds_alternative<global_topology_request>(req_entry.request_type) &&
-            std::get<global_topology_request>(req_entry.request_type) == global_topology_request::keyspace_rf_change &&
-            req_entry.new_keyspace_rf_change_ks_name.has_value() && req_entry.new_keyspace_rf_change_ks_name.value() == ks;
+        if (std::holds_alternative<global_topology_request>(req_entry.request_type) &&
+                std::get<global_topology_request>(req_entry.request_type) == global_topology_request::keyspace_rf_change &&
+                req_entry.new_keyspace_rf_change_ks_name.has_value() && req_entry.new_keyspace_rf_change_ks_name.value() == ks) {
+            co_return request_id;
+        }
+        co_return std::nullopt;
     };
     if (_topology_state_machine._topology.global_request_id.has_value()) {
         auto req_id = _topology_state_machine._topology.global_request_id.value();
         if (co_await ongoing_ks_rf_change(req_id)) {
-            co_return true;
+            co_return req_id;
         }
     }
     for (auto request_id : _topology_state_machine._topology.paused_rf_change_requests) {
         if (co_await ongoing_ks_rf_change(request_id)) {
-            co_return true;
+            co_return request_id;
         }
         co_await coroutine::maybe_yield();
     }
     for (auto request_id : _topology_state_machine._topology.global_requests_queue) {
         if (co_await ongoing_ks_rf_change(request_id)) {
-            co_return true;
+            co_return request_id;
         }
         co_await coroutine::maybe_yield();
     }
-    co_return false;
+    co_return std::nullopt;
 }
 
 future<> storage_service::raft_initialize_discovery_leader(const join_node_request_params& params) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -937,7 +937,7 @@ public:
     bool topology_global_queue_empty() const {
         return !_topology_state_machine._topology.global_request.has_value();
     }
-    future<bool> ongoing_rf_change(const group0_guard& guard, sstring ks) const;
+    future<std::optional<utils::UUID>> ongoing_rf_change(const group0_guard& guard, sstring ks) const;
     future<> raft_initialize_discovery_leader(const join_node_request_params& params);
     future<> initialize_done_topology_upgrade_state();
 private:

--- a/test/cluster/test_system_distributed_tablets.py
+++ b/test/cluster/test_system_distributed_tablets.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 KS = "system_distributed_tablets"
 TABLES = {
+    "snapshots",
 }
 
 

--- a/test/cluster/test_system_distributed_tablets.py
+++ b/test/cluster/test_system_distributed_tablets.py
@@ -1,0 +1,232 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+import time
+import asyncio
+import logging
+
+import pytest
+
+from test.pylib.internal_types import ServerUpState
+from test.pylib.rest_client import HTTPError, inject_error_one_shot
+from test.pylib.manager_client import ManagerClient
+from test.cluster.util import parse_replication_options, wait_for_cql_and_get_hosts
+from test.cluster.conftest import skip_mode
+
+
+logger = logging.getLogger(__name__)
+
+KS = "system_distributed_tablets"
+TABLES = {
+}
+
+
+async def verify_schema(cql, expected_replication: dict[str, list[str]], timeout: int = 10, retry_interval: int = 1) -> None:
+    async def _check():
+        # Verify keyspace exists
+        rows = await cql.run_async(f"SELECT replication_v2 FROM system_schema.keyspaces WHERE keyspace_name='{KS}'")
+        assert len(rows) == 1, f"Keyspace {KS} not found"
+
+        # Verify replication options
+        replication = parse_replication_options(rows[0].replication_v2)
+        expected_repl_strategy = 'org.apache.cassandra.locator.NetworkTopologyStrategy'
+        assert replication.get('class') == expected_repl_strategy, f"Invalid replication class for keyspace {KS}: expected = {expected_repl_strategy}, actual = {replication.get('class')}"
+        replication.pop('class')
+        assert replication == expected_replication, f"Invalid replication options for keyspace {KS}: expected = {expected_replication}, actual = {replication}"
+
+        # Verify tablets are enabled
+        rows = await cql.run_async(f"SELECT initial_tablets FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{KS}'")
+        assert len(rows) == 1 and rows[0].initial_tablets is not None, f"Tablets not enabled for keyspace {KS}"
+
+        # Verify tables exist
+        rows = await cql.run_async(f"SELECT table_name FROM system_schema.tables WHERE keyspace_name = '{KS}'")
+        found_tables = {row.table_name for row in rows}
+        assert found_tables == TABLES
+
+    start = time.time()
+    last_error = None
+    while True:
+        try:
+            await _check()
+            return
+        except AssertionError as exc:
+            last_error = exc
+
+        if timeout is None or time.time() >= start + timeout:
+            raise last_error
+        await asyncio.sleep(retry_interval)
+
+
+@pytest.mark.asyncio
+async def test_auto_rf(manager: ManagerClient):
+    """
+    Verify that system_distributed_tablets keyspace and tables are created automatically
+    and that its replication options are automatically expanded as nodes in new racks join the cluster.
+    """
+
+    logger.info("Create first node and verify that schema is created")
+    servers = [await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})]
+    cql = manager.get_cql()
+    await verify_schema(cql, {'dc1': ['r1']})
+
+    logger.info("Check schema after restart")
+    await asyncio.gather(*[manager.server_stop(s.server_id) for s in servers])
+    await asyncio.gather(*[manager.server_start(s.server_id) for s in servers])
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await verify_schema(cql, {'dc1': ['r1']})
+
+    logger.info("Add a node in an existing rack")
+    servers.append(await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}))
+    await verify_schema(cql, {'dc1': ['r1']}, timeout=0)
+
+    logger.info("Add a second rack with two nodes and verify it is added to the RF")
+    r2_servers = await manager.servers_add(2, property_file=[{"dc": "dc1", "rack": "r2"}, {"dc": "dc1", "rack": "r2"}])
+    servers.extend(r2_servers)
+    await verify_schema(cql, {'dc1': ['r1', 'r2']})
+
+    logger.info("Add a third rack and verify it is added to the RF")
+    servers.append(await manager.server_add(property_file={"dc": "dc1", "rack": "r3"}))
+    await verify_schema(cql, {'dc1': ['r1', 'r2', 'r3']})
+
+    logger.info("Add a fourth rack and verify it is not added to the RF (RF goal 3 has been reached)")
+    servers.append(await manager.server_add(property_file={"dc": "dc1", "rack": "r4"}))
+    await verify_schema(cql, {'dc1': ['r1', 'r2', 'r3']}, timeout=0)
+    rows = await cql.run_async(f"SELECT * FROM system.topology_requests WHERE request_type='keyspace_rf_change' AND new_keyspace_rf_change_ks_name='{KS}' AND done=False ALLOW FILTERING")
+    assert len(rows) == 0, f"Unexpected pending RF change requests for keyspace {KS}"
+
+    logger.info("Add a node in a new dc and verify it is added to the RF of the new DC")
+    servers.append(await manager.server_add(property_file={"dc": "dc2", "rack": "r1"}))
+    await verify_schema(cql, {'dc1': ['r1', 'r2', 'r3'], 'dc2': ['r1']})
+
+    logger.info("Add a zero-token node in a new dc and verify the RF is not changed")
+    cfg_zero_token = {"join_ring": "false"}
+    servers.append(await manager.server_add(property_file={"dc": "zero-token-dc", "rack": "zero-token-rack"}, config=cfg_zero_token))
+    await verify_schema(cql, {'dc1': ['r1', 'r2', 'r3'], 'dc2': ['r1']})
+
+    logger.info("Decommission a node from a rack with multiple nodes")
+    await manager.decommission_node(r2_servers[0].server_id)
+
+    logger.info("Decommission the last node from a rack (expected to fail because inter-rack tablet migrations are not supported)")
+    with pytest.raises(HTTPError, match="Decommission failed"):
+        logger.info("Decommission another node")
+        await manager.decommission_node(r2_servers[1].server_id)
+
+    logger.info("Remove the rack from the replication options and retry decommission (expected to succeed)")
+    await cql.run_async(f"ALTER KEYSPACE {KS} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r3'], 'dc2': ['r1']}}")
+    await verify_schema(cql, {'dc1': ['r1', 'r3'], 'dc2': ['r1']})
+    await manager.decommission_node(r2_servers[1].server_id)
+
+    logger.info("Drop the tables and verify they are recreated when some node (re)starts")
+    for table in TABLES:
+        await cql.run_async(f"DROP TABLE {KS}.{table}")
+    rows = await cql.run_async(f"SELECT table_name FROM system_schema.tables WHERE keyspace_name = '{KS}'")
+    assert len(rows) == 0, f"Tables not dropped in keyspace {KS}"
+    await manager.server_restart(servers[0].server_id)
+    await verify_schema(cql, {'dc1': ['r1', 'r3'], 'dc2': ['r1']})
+
+
+@pytest.mark.asyncio
+@skip_mode("release", "error injections are not supported in release mode")
+async def test_upgrades(manager: ManagerClient):
+    """
+    Test that the system_distributed_tablets keyspace and tables are created
+    when the cluster is upgraded to a version that supports the RACK_LIST_RF feature.
+
+    - Start a 2-node cluster where one node has the RACK_LIST_RF feature
+      suppressed (thus simulating a node running an older version).
+    - Decommission the node with the suppressed feature to let the remaining
+      node enable the feature.
+    - Confirm that the remaining node automatically creates the keyspace and
+      tables without requiring a restart.
+    """
+
+    logger.info("Create first node with the RACK_LIST_RF feature disabled")
+    cfg = {
+        "error_injections_at_startup": [
+            {"name": "suppress_features", "value": "RACK_LIST_RF"}
+        ]
+    }
+    server_with_suppressed_feature = await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}, config=cfg)
+
+    logger.info("Add a second node")
+    await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})
+
+    logger.info(f"Verify that the {KS} keyspace is not created")
+    cql = manager.get_cql()
+    rows = await cql.run_async(f"SELECT replication_v2 FROM system_schema.keyspaces WHERE keyspace_name='{KS}'")
+    assert len(rows) == 0, f"Keyspace {KS} found"
+
+    logger.info("Remove the first node to enable the RACK_LIST_RF feature")
+    await manager.decommission_node(server_with_suppressed_feature.server_id)
+
+    logger.info(f"Verify that the {KS} keyspace and its tables are now created")
+    await verify_schema(cql, {'dc1': ['r1']})
+
+
+@pytest.mark.asyncio
+@skip_mode("release", "error injections are not supported in release mode")
+async def test_concurrent_rack_additions(manager: ManagerClient):
+    """
+    Test that if we add multiple racks in parallel, the new nodes will
+    serialize their RF change requests for the system_distributed_tablets
+    keyspace. Specifically, each node should wait for any ongoing RF change on
+    that keyspace to finish before issuing a new RF change for adding its
+    own rack to the rack-list RF.
+
+    This limitation stems from the numeric-to-rack-list conversion feature
+    (https://github.com/scylladb/scylladb/commit/c077283352). Before this feature,
+    there was no such limitation; RF changes were just queued and executed, so
+    multiple RF changes for one keyspace could safely sit in the global
+    topology requests queue. With the numeric-to-rack-list conversion feature,
+    the topology coordinator can "pause" an RF change to run tablet colocations
+    and later "resume" it by re-queuing it, so the queue now mixes new and
+    resumed RF changes without prioritization. To avoid interleaving resumed and
+    new RF changes for the same keyspace, the nodes must ensure not to enqueue
+    an RF change if another one is ongoing for the same keyspace. By "ongoing"
+    we mean queued, paused, or under execution.
+    """
+    logger.info("Create first node")
+    servers = [await manager.server_add(property_file={"dc": "dc1", "rack": "r1"})]
+    cql = manager.get_cql()
+    await verify_schema(cql, {'dc1': ['r1']})
+
+    logger.info(f"Injecting wait-before-committing-rf-change-event into the leader node {servers[0]}")
+    injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
+                                                    'wait-before-committing-rf-change-event')
+
+    leader_log_file = await manager.server_open_log(servers[0].server_id)
+
+    cmdline=['--logger-log-level', 'topology_state_machine=debug:raft_topology=trace:load_balancer=trace']
+    block_cfg = {"error_injections_at_startup": ["block-system-distributed-tablets-create-tables"]}
+
+    logger.info("Add second rack with create_tables blocked")
+    server2 = await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}, config=block_cfg, cmdline=cmdline, connect_driver=False, expected_server_up_state=ServerUpState.HOST_ID_QUERIED)
+
+    logger.info("Waiting until second rack pauses on the injected error")
+    server2_log = await manager.server_open_log(server2.server_id)
+    await server2_log.wait_for("block-system-distributed-tablets-create-tables: waiting for message")
+
+    logger.info("Add third rack with create_tables blocked")
+    server3 = await manager.server_add(property_file={"dc": "dc1", "rack": "r3"}, config=block_cfg, cmdline=cmdline, connect_driver=False, expected_server_up_state=ServerUpState.HOST_ID_QUERIED)
+
+    logger.info("Waiting until third rack pauses on the injected error")
+    server3_log = await manager.server_open_log(server3.server_id)
+    await server3_log.wait_for("block-system-distributed-tablets-create-tables: waiting for message")
+
+    logger.info("Unblock create_tables on second node to kick off the first RF change")
+    await manager.api.message_injection(server2.ip_addr, "block-system-distributed-tablets-create-tables")
+
+    logger.info(f"Waiting for the leader node {servers[0]} to reach the RF-change commit barrier")
+    await leader_log_file.wait_for("wait-before-committing-rf-change-event: waiting", timeout=20)
+
+    logger.info("Unblock create_tables on third node; it should observe the ongoing RF change and wait")
+    await manager.api.message_injection(server3.ip_addr, "block-system-distributed-tablets-create-tables")
+    await server3_log.wait_for("Detected ongoing RF change for system_distributed_tablets", timeout=20)
+
+    logger.info("Release the topology coordinator injection and verify RF includes both racks")
+    await injection_handler.message()
+    await verify_schema(cql, {'dc1': ['r1', 'r2', 'r3']})

--- a/test/lib/cql_test_env.hh
+++ b/test/lib/cql_test_env.hh
@@ -18,6 +18,7 @@
 
 #include "db/view/view_building_worker.hh"
 #include "db/view/view_update_generator.hh"
+#include "db/system_distributed_keyspace.hh"
 #include "service/qos/service_level_controller.hh"
 #include "replica/database.hh"
 #include "transport/messages/result_message_base.hh"
@@ -188,6 +189,8 @@ public:
     virtual sharded<service::raft_group_registry>& get_raft_group_registry() = 0;
 
     virtual sharded<db::system_keyspace>& get_system_keyspace() = 0;
+
+    virtual sharded<db::system_distributed_tablets_keyspace>& get_system_distributed_tablets_keyspace() = 0;
 
     virtual sharded<service::tablet_allocator>& get_tablet_allocator() = 0;
 


### PR DESCRIPTION
This PR introduces a new system keyspace called `system_distributed_tablets`. The keyspace is replicated with tablets and will act as a replacement for the old vnode-based `system_distributed` keyspace.

Since tablets enforce more strict policies regarding the replication factor (the RF cannot exceed the number of nodes or racks), the keyspace ships with an ad-hoc auto-RF mechanism:
* The keyspace has an RF goal of 3, meaning that the system will be attempting to increase the per-DC RF up to 3 replicas, depending on the availability of racks.
* Every token-owning node that joins the cluster will be checking if the RF goal has been reached in its DC. If not, it will be checking if its rack appears in the keyspace's rack-list RF. If not, it will be issuing an RF change request to add it.

The keyspace uses rack-list RFs, so each node will attempt to create it only after the `rack_list_rf` feature is enabled.

The implementation was based on Benny's patches, which are part of a larger feature (native backup and restore):
https://github.com/bhalevy/scylla/commits/tablets-backup-and-restore-wip-v3

The PR is marked as Draft because:
* The keyspace blocks rack decommissions. Users need to manually ALTER the keyspace to remove the rack, and then decommission its nodes. This is not a new problem; it affects user keyspaces as well. However, system keyspaces are supposedly managed by the system. We need at least to document this.
* We may end up with RF=2 despite having 3 racks available, which is not ideal. This happens in a DC with 4 racks after decommissioning one rack from the rack-list. 
* We have a few more internal keyspaces that need to be migrated to tablets (`audit` and `system_traces`, see https://github.com/scylladb/scylladb/issues/22733). If we decide to stick with this solution (instead of moving the auto-RF logic to the topology coordinator), it would be nice to make the code reusable.
* The code does not examine if the new rack has enough capacity; it will issue an RF change request, the topology coordinator will mark it as `done: True`, it will update the keyspace schema, and it will schedule tablet rebuilds, which will fail (and be rolled back) but the schema update will not be rolled back. So, the keyspace will appear as having a higher RF than it actually does (disclaimer: haven't tested it).

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-201

New feature, no backport needed.