### PR TITLE
test: fix 'invalid' seed hostname

### DIFF
--- a/init.cc
+++ b/init.cc
@@ -29,7 +29,9 @@ std::set<gms::inet_address> get_seeds_from_db_config(const db::config& cfg,
 
     std::set<gms::inet_address> seeds;
     if (seed_provider.parameters.contains("seeds")) {
-        for (const auto& seed : utils::split_comma_separated_list(seed_provider.parameters.at("seeds"))) {
+        const sstring seeds_str = seed_provider.parameters.at("seeds");
+        startlog.info("Configured seeds: {}", seeds_str);
+        for (const auto& seed : utils::split_comma_separated_list(seeds_str)) {
             try {
                 seeds.emplace(gms::inet_address::lookup(seed, family, preferred).get());
             } catch (...) {

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -16,7 +16,6 @@ pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Test is disabled due to scylladb/scylladb#28153")
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -32,10 +32,11 @@ async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
      3. Make sure the node started successfully since it's already bootstrapped (i.e. is a cluster member).
     """
 
+    non_existent = IPAddress("non_existent.invalid")
     s1 = await manager.server_add(start=False)
 
     # Start the node with an invalid seed and make sure it fails with an error message.
-    await manager.server_start(s1.server_id, seeds=[IPAddress("no_address")],
+    await manager.server_start(s1.server_id, seeds=[non_existent],
                                expected_error="Bad configuration: invalid value in 'seeds'", wait_interval=20)
 
     # Start the node with default seeds, to make it join the cluster.
@@ -45,4 +46,4 @@ async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     await manager.server_stop_gracefully(s1.server_id)
 
     # Start the node with an invalid seed. and make sure it starts successfully.
-    await manager.server_start(s1.server_id, seeds=[IPAddress("no_address")], wait_interval=20)
+    await manager.server_start(s1.server_id, seeds=[non_existent], wait_interval=20)


### PR DESCRIPTION
The previously used `no_address` hostname is sometimes resolved, causing the `test_start_bootstrapped_with_invalid_seed` test to fail. Replace it with a guaranteed non-existent hostname per RFC#2606, using the `.invalid` domain.

This PR can be safely backported since the change affects only tests.

Fixes: SCYLLADB-760