### PR TITLE
alternator: remove internal Paxos tables from ListTables output

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -72,6 +72,7 @@
 #include "alternator/ttl_tag.hh"
 #include "vector_search/vector_store_client.hh"
 #include "utils/simple_value_with_expiry.hh"
+#include "service/paxos/paxos_state.hh"
 
 using namespace std::chrono_literals;
 
@@ -4452,7 +4453,8 @@ future<executor::request_return_type> executor::list_tables(client_state& client
             | std::views::filter([this] (data_dictionary::table t) {
                         return t.schema()->ks_name().find(KEYSPACE_NAME_PREFIX) == 0 &&
                             !t.schema()->is_view() &&
-                            !cdc::is_log_for_some_table(_proxy.local_db(), t.schema()->ks_name(), t.schema()->cf_name());
+                            !cdc::is_log_for_some_table(_proxy.local_db(), t.schema()->ks_name(), t.schema()->cf_name()) &&
+                            !service::paxos::paxos_store::try_get_base_table(t.schema()->cf_name());
                     })
             | std::views::transform([] (data_dictionary::table t) {
                         return t.schema()->cf_name();


### PR DESCRIPTION
Alternator's "ListTables" operation already filters out CDC log tables from the list of tables it shows, but recently we added another type of internal table - the "...$paxos" table for LWT state - but forgot to filter it out and it began showing in ListTables.

This patch filters the paxos tables from ListTables, and also adds a reproducing test: The new test does a read-modify-write operation which requires LWT (our default test write isolation mode is NOT unsafe_rmw), so it creates the extra paxos table. Before this patch the new test failed because the Paxos table was listed, and after the patch it passes.

The new test is not sensitive to the choice of suffix "$paxos", and actually will fail if any table suddenly appear which includes our long random-named table's name as a part of its name, so if in the future we'll rename this internal table or add more of them, the test will continue to be useful.

Fixes #28145

This is an annoying (though not much more than annoying)  user-visible problem, and the patch is tiny and looks harmless, so let's backport it to any vulnerable branch . I.e., a branch that uses tablets (and the new "$paxos" internal tables) for Alternator. I verified with `test/alternator/run --release 2025.4 test_table.py::test_list_tables_no_paxos` that the test fails on 2025.4 and passes on 2025.3, so let's backport it to 2025.4 and later.