### PR TITLE
test.py: rewrite gather metrics

### DIFF
--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -19,6 +19,7 @@ from multiprocessing import Event
 from pathlib import Path
 from typing import TYPE_CHECKING
 from test import TOP_SRC_DIR, MODES_TIMEOUT_FACTOR, path_to
+from test.pylib.runner import PHASE_REPORT_KEY
 from test.pylib.random_tables import RandomTables
 from test.pylib.skip_types import skip_env
 from test.pylib.util import unique_name
@@ -83,26 +84,6 @@ def pytest_addoption(parser):
     parser.addoption('--artifacts_dir_url', action='store', type=str, default=None, dest='artifacts_dir_url',
                      help='Provide the URL to artifacts directory to generate the link to failed tests directory '
                           'with logs')
-
-
-# This is a constant used in `pytest_runtest_makereport` below to store the full report for the test case
-# in a stash which can then be accessed from fixtures to print the stacktrace for the failed test
-PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
-
-
-@pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
-    """This is a post-test hook executed by the pytest library.
-    Use it to access the test result and store a flag indicating failure
-    so we can later retrieve it in our fixtures like `manager`.
-
-    `item.stash` is the same stash as `request.node.stash` (in the `request`
-    fixture provided by pytest).
-    """
-    outcome = yield
-    report = outcome.get_result()
-
-    item.stash[PHASE_REPORT_KEY] = report
 
 
 conn_logger = logging.getLogger("conn_messages")
@@ -255,15 +236,16 @@ async def manager(request: pytest.FixtureRequest,
     manager_client = manager_internal()  # set up client object in fixture with scope function
     await manager_client.before_test(test_case_name, test_log)
     yield manager_client
-    # `request.node.stash` contains a report stored in `pytest_runtest_makereport` from where we can retrieve
-    # test failure.
+    # `request.node.stash` contains reports stored per phase in `pytest_runtest_makereport`
+    # from where we can retrieve test failure.
     cluster_status = None
     found_errors = {}
     failed = False
     failed_test_dir_path = None
     try:
-        report = request.node.stash[PHASE_REPORT_KEY]
-        failed = report.when == "call" and report.failed
+        reports = request.node.stash[PHASE_REPORT_KEY]
+        call_report = reports.get("call")
+        failed = call_report is not None and call_report.failed
 
         # Check if the test has the check_nodes_for_errors marker
         found_errors = await manager_client.check_all_errors(check_all_errors=(request.node.get_closest_marker("check_nodes_for_errors") is not None))
@@ -282,7 +264,7 @@ async def manager(request: pytest.FixtureRequest,
                 {'pytest.log': test_log, 'test_py.log': test_py_log_test}
             )
             with open(failed_test_dir_path / "stacktrace.txt", "w") as f:
-                f.write(report.longreprtext)
+                f.write(call_report.longreprtext)
             if request.config.getoption('artifacts_dir_url') is not None:
                 # get the relative path to the tmpdir for the failed directory
                 dir_path_relative = f"{failed_test_dir_path.as_posix()[failed_test_dir_path.as_posix().find('testlog'):]}"
@@ -362,8 +344,9 @@ async def random_tables(request, manager):
     # The cluster will be marked as dirty if the test failed, but that happens
     # at the end of `manager` fixture which we depend on (so these steps will be
     # executed after us) - so at this point, we need to check for failure ourselves too.
-    report = request.node.stash[PHASE_REPORT_KEY]
-    failed = report.when == "call" and report.failed
+    reports = request.node.stash[PHASE_REPORT_KEY]
+    call_report = reports.get("call")
+    failed = call_report is not None and call_report.failed
     if not failed and not await manager.is_dirty():
         tables.drop_all()
 

--- a/test/cluster/storage/conftest.py
+++ b/test/cluster/storage/conftest.py
@@ -59,8 +59,9 @@ def volumes_factory(pytestconfig, build_mode, request):
     # Unmount volumes and optionally preserve data. Copying cannot be done in the finally
     # clause of the wrapper above as at that point test is not yet marked as failed. So the
     # copy and consequently volumes cleanup have to be done here.
-    report = request.node.stash[PHASE_REPORT_KEY]
-    test_failed = report.when == "call" and report.failed
+    reports = request.node.stash[PHASE_REPORT_KEY]
+    call_report = reports.get("call")
+    test_failed = call_report is not None and call_report.failed
     preserve_data = test_failed or request.config.getoption("save_log_on_success")
 
     for id, volume in enumerate(volumes):

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -13,7 +13,6 @@ import subprocess
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
-from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
@@ -21,7 +20,6 @@ from _pytest._code.code import ReprFileLocation
 
 from scripts import coverage as coverage_script
 from test import DEBUG_MODES, TEST_DIR, TOP_SRC_DIR, path_to
-from test.pylib.resource_gather import get_resource_gather
 from test.pylib.runner import BUILD_MODE, RUN_ID, TEST_SUITE
 from test.pylib.scylla_cluster import merge_cmdline_options
 
@@ -171,43 +169,31 @@ class CppTestCase(pytest.Item):
             (self.path.relative_to(TEST_DIR).with_suffix("") / f"{self.name}{extra}.{self.run_id}{suffix}").parts
         )
 
-    def make_testpy_test_object_mock(self) -> SimpleNamespace:
-        """Returns object that used in resource gathering.
-
-        It needed to not change the logic of writing metrics to DB that used in test types from test.py.
-        """
-        return SimpleNamespace(
-            time_end=0,
-            time_start=0,
-            id=self.run_id,
-            mode=self.parent.build_mode,
-            success=False,
-            shortname=self.name,
-            suite=SimpleNamespace(
-                log_dir=self.parent.log_dir,
-                name=self.parent.test_name,
-            ),
-        )
-
     def run_exe(self, test_args: list[str], output_file: pathlib.Path) -> subprocess.Popen[str]:
-        resource_gather = get_resource_gather(
-            is_switched_on=self.config.getoption("--gather-metrics"),
-            test=self.make_testpy_test_object_mock(),
-        )
-        resource_gather.make_cgroup()
-        process = resource_gather.run_process(
-            args=[self.parent.exe_path, *test_args, *self.test_custom_args],
-            timeout=TIMEOUT_DEBUG if self.parent.build_mode in DEBUG_MODES else TIMEOUT,
-            output_file=output_file,
-            cwd=TOP_SRC_DIR,
-            env=self.parent.test_env,
-        )
-        resource_gather.write_metrics_to_db(
-            metrics=resource_gather.get_test_metrics(),
-            success=process.returncode == 0,
-        )
-        resource_gather.remove_cgroup()
-        return process
+        args = [str(self.parent.exe_path), *test_args, *self.test_custom_args]
+        timeout = TIMEOUT_DEBUG if self.parent.build_mode in DEBUG_MODES else TIMEOUT
+        env = {**os.environ, **self.parent.test_env}
+
+        with output_file.open(mode="w", encoding="utf-8") as output_handle:
+            p = subprocess.Popen(
+                args=args,
+                bufsize=1,
+                stdout=output_handle,
+                stderr=subprocess.STDOUT,
+                close_fds=True,
+                cwd=TOP_SRC_DIR,
+                env=env,
+                text=True,
+            )
+            try:
+                p.communicate(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                p.kill()
+                p.communicate()
+            except KeyboardInterrupt:
+                p.kill()
+                raise
+        return p
 
     def runtest(self) -> None:
         failures, output = self.parent.run_test_case(test_case=self)

--- a/test/pylib/cpp/boost.py
+++ b/test/pylib/cpp/boost.py
@@ -72,7 +72,7 @@ class BoostTestFile(CppFile):
             "--color_output=false",
         ]
         if not self.no_parallel:
-            args.append(f"--{run_test=}")
+            args.append(f"--run_test={run_test}")
 
         args.append("--")
 

--- a/test/pylib/db/model.py
+++ b/test/pylib/db/model.py
@@ -22,19 +22,26 @@ class Metric:
     host_id: str
     memory_peak: int = None
     success: bool = None
+    status: str = None
     system_sec: float = None
     time_end: datetime = None
     time_start: datetime = None
     time_taken: float = None
     usage_sec: float = None
     user_sec: float = None
+    worker_id: str = None
 
 
 @define
 class SystemResourceMetric:
     host_id: str
     cpu: float
-    memory: float
+    memory_free: int
+    memory_available: int
+    memory_used: int
+    memory_active: int
+    memory_inactive: int
+    memory_buffers: int
     timestamp: datetime
 
 
@@ -42,7 +49,8 @@ class SystemResourceMetric:
 class Test:
     host_id: str
     architecture: str
-    directory: str
+    path: str
+    file: str
     mode: str
     run_id: int
     test_name: str

--- a/test/pylib/db/model.py
+++ b/test/pylib/db/model.py
@@ -9,6 +9,14 @@ from attr import define
 
 
 @define
+class HostInfo:
+    host_id: str
+    cpu_model: str
+    cpu_cores: int
+    ram_bytes: int
+
+
+@define
 class CgroupMetric:
     memory: int
     test_id: int

--- a/test/pylib/db/writer.py
+++ b/test/pylib/db/writer.py
@@ -29,7 +29,8 @@ create_table = [
         id INTEGER PRIMARY KEY,
         host_id VARCHAR(5) NOT NULL,
         architecture VARCHAR(15) NOT NULL,
-        directory VARCHAR(255),
+        path TEXT NOT NULL,
+        file VARCHAR(255) NOT NULL,
         mode VARCHAR(15) NOT NULL,
         run_id INTEGER,
         test_name VARCHAR(255) NOT NULL
@@ -49,6 +50,8 @@ create_table = [
         time_start DATETIME,
         time_end DATETIME,
         success BOOLEAN,
+        status VARCHAR(15),
+        worker_id VARCHAR(15),
         FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id)
     );
     ''',
@@ -57,8 +60,13 @@ create_table = [
     CREATE TABLE IF NOT EXISTS {SYSTEM_RESOURCE_METRICS_TABLE} (
         id INTEGER PRIMARY KEY,
         host_id VARCHAR(5) NOT NULL,
-        memory REAL,
         cpu REAL,
+        memory_free INTEGER,
+        memory_available INTEGER,
+        memory_used INTEGER,
+        memory_active INTEGER,
+        memory_inactive INTEGER,
+        memory_buffers INTEGER,
         timestamp DATETIME
     );
     ''',
@@ -177,6 +185,12 @@ class SQLiteWriter:
         """
         for model in data_list:
             self.write_row(model, table_name)
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection and release the file descriptor."""
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
 
     def write_row_if_not_exist(self, model, table_name: str) -> int:
         """

--- a/test/pylib/db/writer.py
+++ b/test/pylib/db/writer.py
@@ -20,10 +20,21 @@ TESTS_TABLE = 'tests'
 METRICS_TABLE = 'test_metrics'
 SYSTEM_RESOURCE_METRICS_TABLE = 'system_resource_metrics'
 CGROUP_MEMORY_METRICS_TABLE = 'cgroup_memory_metrics'
+HOST_INFO_TABLE = 'host_info'
 DEFAULT_DB_NAME = f'sqlite_{HOST_ID}.db'
 DATE_TIME_TEMPLATE = '%Y-%m-%d %H:%M:%S.%f'
 
 create_table = [
+    # host_info must be created first — all other tables reference it via host_id FK
+    f'''
+    CREATE TABLE IF NOT EXISTS {HOST_INFO_TABLE} (
+        host_id VARCHAR(5) PRIMARY KEY,
+        cpu_model TEXT NOT NULL,
+        cpu_cores INTEGER NOT NULL,
+        ram_bytes INTEGER NOT NULL
+    );
+    ''',
+
     f'''
     CREATE TABLE IF NOT EXISTS {TESTS_TABLE} (
         id INTEGER PRIMARY KEY,
@@ -33,7 +44,8 @@ create_table = [
         file VARCHAR(255) NOT NULL,
         mode VARCHAR(15) NOT NULL,
         run_id INTEGER,
-        test_name VARCHAR(255) NOT NULL
+        test_name VARCHAR(255) NOT NULL,
+        FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
     );
     ''',
 
@@ -52,7 +64,8 @@ create_table = [
         success BOOLEAN,
         status VARCHAR(15),
         worker_id VARCHAR(15),
-        FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id)
+        FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id),
+        FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
     );
     ''',
 
@@ -67,7 +80,8 @@ create_table = [
         memory_active INTEGER,
         memory_inactive INTEGER,
         memory_buffers INTEGER,
-        timestamp DATETIME
+        timestamp DATETIME,
+        FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
     );
     ''',
 
@@ -78,7 +92,8 @@ create_table = [
         host_id VARCHAR(5) NOT NULL,
         memory REAL,
         timestamp DATETIME,
-        FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id)
+        FOREIGN KEY(test_id) REFERENCES {TESTS_TABLE}(id),
+        FOREIGN KEY(host_id) REFERENCES {HOST_INFO_TABLE}(host_id)
     );
     '''
 ]
@@ -192,13 +207,14 @@ class SQLiteWriter:
             self._connection.close()
             self._connection = None
 
-    def write_row_if_not_exist(self, model, table_name: str) -> int:
+    def write_row_if_not_exist(self, model, table_name: str, id_column: str = "id") -> int:
         """
         Writes a row to the table if it doesn't exist, otherwise returns the existing row's ID.
 
         Args:
             model: A AttrsInstance object with a data to insert.
             table_name: Name of the table where data is being written.
+            id_column: Name of the primary key column to return (default: "id").
 
         Return:
             int: Returns the ID of the existing or newly inserted record
@@ -210,7 +226,7 @@ class SQLiteWriter:
 
                 # Construct the SQL query to retrieve the ID if the record exists
                 select_query = f"""
-                    SELECT id FROM {table_name} WHERE {
+                    SELECT {id_column} FROM {table_name} WHERE {
                     ' AND '.join([f"{col} = ?" for col in data.keys()])
                     }
                 """

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -6,7 +6,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import getpass
 import logging
 import os
@@ -15,15 +14,18 @@ import shlex
 import subprocess
 import time
 from abc import ABC
+from concurrent.futures.thread import ThreadPoolExecutor
 from datetime import datetime
 from functools import lru_cache
 from pathlib import Path
+from time import sleep
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import psutil
 
-from test import HOST_ID
+from threading import Event
+from test import HOST_ID, TOP_SRC_DIR
 from test.pylib.db.model import Metric, SystemResourceMetric, CgroupMetric, Test
 from test.pylib.db.writer import (
     CGROUP_MEMORY_METRICS_TABLE,
@@ -35,25 +37,32 @@ from test.pylib.db.writer import (
 )
 
 if TYPE_CHECKING:
-    from asyncio import Task, Event
-    from typing import TextIO
+    from typing import IO, TextIO
 
     from test.pylib.suite.base import Test as TestPyTest
 
 logger = logging.getLogger(__name__)
 
+
+def get_current_cgroup() -> Path:
+    """Get the current cgroup path for this process."""
+    with open("/proc/self/cgroup", 'r') as f:
+        cgroup_info = f.readlines()
+    return Path(f"/sys/fs/cgroup/{cgroup_info[0].strip().split(':')[-1]}")
+
+SCYLLA_TEST_CGROUP_BASE_ENV = 'SCYLLA_TEST_CGROUP_BASE'
+
+
 @lru_cache(maxsize=None)
 def get_cgroup() -> Path:
-    cgroup_path = f"/proc/{os.getpid()}/cgroup"
-    with open(cgroup_path, 'r') as f:
-        cgroup_info = f.readlines()
-    # Extract the relative cgroup for the process and make it absolute and add where the test.py process should be
-    # placed in.
-    # This can be used to manipulate the cgroup's controllers
-    cgroup_name = Path(f"/sys/fs/cgroup/{cgroup_info[0].strip().split(':')[-1]}")
-    if cgroup_name.stem != 'resource_gather':
-        cgroup_name = cgroup_name / 'resource_gather'
-    return cgroup_name
+    # Use the env var when set so that xdist worker subprocesses (which are spawned
+    # after the master has moved itself to tests/master/default) still compute the
+    # correct top-level cgroup path rather than one nested inside the master's cgroup.
+    env_val = os.environ.get(SCYLLA_TEST_CGROUP_BASE_ENV)
+    base = Path(env_val) if env_val else get_current_cgroup()
+    if base.stem != 'resource_gather':
+        base = base / 'resource_gather'
+    return base
 
 
 CGROUP_INITIAL = get_cgroup()
@@ -61,62 +70,8 @@ CGROUP_TESTS = CGROUP_INITIAL.parent / 'tests'
 
 
 class ResourceGather(ABC):
-    def __init__(self, test: TestPyTest):
-        # get the event loop for the current thread or create a new one if there's none
-        try:
-            self.loop = asyncio.get_running_loop()
-            self.own_loop = False
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            self.own_loop = True
-        self.test = test
-        self.db_path = self.test.suite.log_dir.parent / DEFAULT_DB_NAME
-        standardized_name = self.test.shortname.replace("/", "_")
-        self.cgroup_path = Path(
-            f"{CGROUP_TESTS}/{self.test.suite.name}.{standardized_name}.{self.test.mode}.{self.test.id}"
-        )
-        self.logger = logging.getLogger(__name__)
 
-    def __del__(self):
-        if self.own_loop:
-            self.loop.close()
-
-    def run_process(self,
-                    args: list[str],
-                    timeout: float,
-                    output_file: Path,
-                    cwd: Path | None = None,
-                    env: dict | None = None) -> subprocess.Popen[str]:
-
-        args = shlex.split(subprocess.list2cmdline(args))
-        if env:
-            env.update(os.environ)
-        else:
-            env = os.environ.copy()
-        with output_file.open(mode="w", encoding="utf-8") as output_handle:
-            p = subprocess.Popen(
-                args=args,
-                bufsize=1,
-                stdout=output_handle,
-                stderr=subprocess.STDOUT,
-                preexec_fn=self.put_process_to_cgroup,
-                close_fds=True,
-                cwd=cwd,
-                env=env,
-                text=True,
-            )
-            try:
-                p.communicate(timeout=timeout)
-            except subprocess.TimeoutExpired:
-                logger.critical(f"Process {args} timed out")
-                p.kill()
-                p.communicate()
-            except KeyboardInterrupt:
-                p.kill()
-                raise
-        return p
-
-    def make_cgroup(self) -> None:
+    def setup_test_tracking(self) -> None:
         pass
 
     def put_process_to_cgroup(self) -> None:
@@ -128,141 +83,201 @@ class ResourceGather(ABC):
     def write_metrics_to_db(self, metrics: Metric, success: bool = False) -> None:
         pass
 
-    def cgroup_monitor(self, test_event: Event) -> Task:
+    def teardown_test_tracking(self) -> None:
         pass
 
-    def remove_cgroup(self) -> None:
+    def stop_monitoring(self) -> None:
+        pass
+
+    def cgroup_monitor(self) -> None:
         pass
 
 
-class ResourceGatherOff(ResourceGather):
-    def cgroup_monitor(self, test_event: Event) -> Task:
-        return self.loop.create_task(no_monitor())
+class ResourceGatherRecord(ResourceGather):
+    """Writes test records and timing metrics to the DB, but performs no cgroup operations.
 
+    Used when --gather-metrics is OFF so all tests still appear in the tests table.
+    """
 
-class ResourceGatherOn(ResourceGather):
-    def __init__(self, test: TestPyTest):
-        super().__init__(test)
+    def __init__(self, temp_dir: Path, test: TestPyTest | SimpleNamespace, worker_id: str | None = None):
+        self.test = test
+        self.worker_id = worker_id or "master"
+        self.db_path = temp_dir / DEFAULT_DB_NAME
         self.sqlite_writer = SQLiteWriter(self.db_path)
+        self.logger = logging.getLogger(__name__)
+
+        directory_path = str(test.suite.suite_path.relative_to(TOP_SRC_DIR))
+
         self.test_id: int = self.sqlite_writer.write_row_if_not_exist(
             Test(
                 host_id=HOST_ID,
                 architecture=platform.machine(),
-                directory=test.suite.name,
+                path=directory_path,
+                file=test.suite.test_file_name,
                 mode=test.mode,
                 run_id=test.id,
                 test_name=test.shortname,
             ),
             TESTS_TABLE)
 
-    def make_cgroup(self) -> None:
-        os.makedirs(self.cgroup_path, exist_ok=True)
-
     def get_test_metrics(self) -> Metric:
-        test_metrics: Metric = Metric(test_id=self.test_id, host_id=HOST_ID)
+        test_metrics = Metric(test_id=self.test_id, host_id=HOST_ID, worker_id=self.worker_id)
         test_metrics.time_taken = self.test.time_end - self.test.time_start
         test_metrics.time_start = datetime.fromtimestamp(self.test.time_start)
         test_metrics.time_end = datetime.fromtimestamp(self.test.time_end)
         test_metrics.success = self.test.success
-        memory_peak = self.cgroup_path / 'memory.peak'
-        if memory_peak.exists():
-            with open(memory_peak, 'r') as file:
-                test_metrics.memory_peak = file.read()
-
-        cpu_stat = self.cgroup_path / 'cpu.stat'
-        if cpu_stat.exists():
-            with open(cpu_stat, 'r', ) as file:
-                self._parse_cpu_stat(file, test_metrics)
         return test_metrics
-
-    def run_process(self,
-                    args: list[str],
-                    timeout: float,
-                    output_file: Path,
-                    cwd: Path | None = None,
-                    env: dict | None = None) -> subprocess.Popen[str]:
-        stop_monitoring = asyncio.Event()
-
-        self.test.time_start = time.time()
-        test_resource_watcher = self.cgroup_monitor(test_event=stop_monitoring)
-        try:
-            p = super().run_process(args=args, timeout=timeout, output_file=output_file, cwd=cwd, env=env)
-        finally:
-            stop_monitoring.set()
-            self.test.time_end = time.time()
-            self.loop.run_until_complete(asyncio.gather(test_resource_watcher))
-        return p
 
     def write_metrics_to_db(self, metrics: Metric, success: bool = False) -> None:
         metrics.success = success
         self.sqlite_writer.write_row(metrics, METRICS_TABLE)
 
-    def put_process_to_cgroup(self) -> None:
-        try:
-            pid = os.getpid()
-            with open(self.cgroup_path / 'cgroup.procs', "a") as cgroup:
-                cgroup.write(str(pid))
-        except Exception as e:
-            logger.warning('Test %s is not moved to cgroup: %s', self.test, e)
+    def teardown_test_tracking(self) -> None:
+        self.sqlite_writer.close()
 
-    def remove_cgroup(self) -> None:
-        try:
-            os.rmdir(self.cgroup_path)
-        except OSError as e:
-            logger.warning(f'Can\'t delete cgroup directory: {e.strerror}' )
 
-    def cgroup_monitor(self, test_event: Event) -> Task:
-        return self.loop.create_task(self._monitor_cgroup(test_event))
+class ResourceGatherOn(ResourceGatherRecord):
+    """Resource gatherer that tracks worker-level cgroup memory and CPU metrics.
 
-    async def _monitor_cgroup(self, test_event: Event) -> None:
-        """Continuously monitors CPU and memory utilization."""
+    Uses the worker's cgroup (CGROUP_TESTS/{worker_id}) which hierarchically includes
+    all Scylla node processes running under that worker, giving accurate memory readings.
+    """
+
+    def __init__(self, temp_dir: Path, test: TestPyTest | SimpleNamespace, worker_id: str | None = None):
+        super().__init__(temp_dir, test, worker_id)
+        self.pool = ThreadPoolExecutor(max_workers=1)
+        self.future = None
+        self.stop_event = Event()
+        self.cgroup_path = CGROUP_TESTS / self.worker_id
+        self._memory_peak_fd: IO | None = None
+        self._cpu_stat_start: dict[str, float] | None = None
+
+    def stop_monitoring(self) -> None:
+        self.stop_event.set()
+        if self.future is not None:
+            self.future.result()
+            self.pool.shutdown(wait=True)
+
+    def cgroup_monitor(self) -> None:
+        self.future = self.pool.submit(self._monitor_cgroup)
+
+    def _monitor_cgroup(self) -> None:
+        """Continuously monitors cgroup memory utilization every second."""
+        memory_current = self.cgroup_path / 'memory.current'
+        sqlite_writer = SQLiteWriter(self.db_path)
         try:
-            while not test_event.is_set():
-                with  open(self.cgroup_path / 'memory.current', 'r') as memory_current:
+            while not self.stop_event.is_set():
+                try:
                     timeline_record = CgroupMetric(
                         test_id=self.test_id,
                         host_id=HOST_ID,
-                        memory=int(memory_current.read()),
+                        memory=int(memory_current.read_text().strip()),
                         timestamp=datetime.now()
                     )
+                    sqlite_writer.write_row(timeline_record, CGROUP_MEMORY_METRICS_TABLE)
+                except Exception as e:
+                    self.logger.debug(f"Could not read cgroup memory for {self.cgroup_path}: {e}")
+                self.stop_event.wait(1)
+        finally:
+            sqlite_writer.close()
 
-                    self.sqlite_writer.write_row(timeline_record, CGROUP_MEMORY_METRICS_TABLE)
+    def setup_test_tracking(self) -> None:
+        # Open a fresh FD on memory.peak so the kernel resets its per-FD peak tracker
+        # to the current memory. Reading this FD later returns the peak memory since it
+        # was opened, i.e., the peak during this test only.
+        memory_peak_path = self.cgroup_path / 'memory.peak'
+        if memory_peak_path.exists():
+            self._memory_peak_fd = open(memory_peak_path, 'r')
 
-                # Control the frequency of updates, for example, every 2 seconds
-                await asyncio.sleep(1)
-        except asyncio.CancelledError:
-            self.logger.info(f'cgroup monitoring job was cancelled')
+        # Snapshot cpu.stat at the start of the test. Unlike memory.peak, cpu.stat
+        # has no per-FD reset mechanism — values are cumulative for the cgroup's
+        # lifetime. We subtract this snapshot from the end-of-test reading to get
+        # per-test CPU usage.
+        cpu_stat_path = self.cgroup_path / 'cpu.stat'
+        if cpu_stat_path.exists():
+            with open(cpu_stat_path, 'r') as f:
+                self._cpu_stat_start = self._read_cpu_stat(f)
+
+    def get_test_metrics(self) -> Metric:
+        test_metrics = super().get_test_metrics()
+        if self._memory_peak_fd is not None:
+            try:
+                self._memory_peak_fd.seek(0)
+                test_metrics.memory_peak = int(self._memory_peak_fd.read().strip())
+            except Exception as e:
+                self.logger.warning(f"Could not read memory.peak for {self.cgroup_path}: {e}")
+
+        cpu_stat_path = self.cgroup_path / 'cpu.stat'
+        if cpu_stat_path.exists() and self._cpu_stat_start is not None:
+            with open(cpu_stat_path, 'r') as f:
+                cpu_stat_end = self._read_cpu_stat(f)
+            for stat, attr in self._CPU_STAT_FIELDS.items():
+                start_val = self._cpu_stat_start.get(stat, 0.0)
+                end_val = cpu_stat_end.get(stat, 0.0)
+                setattr(test_metrics, attr, end_val - start_val)
+
+        return test_metrics
+
+    def teardown_test_tracking(self) -> None:
+        if self._memory_peak_fd is not None:
+            self._memory_peak_fd.close()
+            self._memory_peak_fd = None
+        self._cpu_stat_start = None
+        super().teardown_test_tracking()
+
+    # Maps cpu.stat keys to Metric attribute names. Values in cpu.stat are in
+    # microseconds; we convert to seconds when assigning to the Metric.
+    _CPU_STAT_FIELDS = {
+        'user_usec': 'user_sec',
+        'system_usec': 'system_sec',
+        'usage_usec': 'usage_sec',
+    }
 
     @staticmethod
-    def _parse_cpu_stat(file: TextIO, metrics: Metric) -> None:
-        # Map the values from cpu.state to the model. Keys are values from cpu.stat
-        stats = {'user_usec': 'user_sec', 'system_usec': 'system_sec', 'usage_usec': 'usage_sec'}
+    def _read_cpu_stat(file: TextIO) -> dict[str, float]:
+        """Read cpu.stat and return the relevant counters converted to seconds."""
+        result: dict[str, float] = {}
         for line in file.readlines():
-            stat, value = line.split(' ')
-            if stat in stats.keys():
-                setattr(metrics, stats[stat], float(value) / 1_000_000)
+            parts = line.split(' ', 1)
+            if len(parts) == 2 and parts[0] in ResourceGatherOn._CPU_STAT_FIELDS:
+                result[parts[0]] = float(parts[1]) / 1_000_000
+        return result
 
 
-def get_resource_gather(is_switched_on: bool, test: TestPyTest | SimpleNamespace) -> ResourceGather:
+def get_resource_gather(temp_dir: Path, is_switched_on: bool, test: TestPyTest | SimpleNamespace, worker_id: str | None = None) -> ResourceGather:
+    """Return a resource gatherer for the given test. Always creates a test record in the DB."""
     if is_switched_on:
-        return ResourceGatherOn(test)
+        return ResourceGatherOn(temp_dir, test, worker_id)
     else:
-        return ResourceGatherOff(test)
+        return ResourceGatherRecord(temp_dir, test, worker_id)
 
 
 def _is_cgroup_rw() -> bool:
     with open('/proc/mounts', 'r') as f:
         for line in f.readlines():
-            if 'cgroup2' in line :
+            if 'cgroup2' in line:
                 options = line.split(' ')[3].split(',')
-                if 'rw' in options:
-                    return True
-                else:
-                    return False
+                return 'rw' in options
+    return False
+
+def propagate_subtree_controls(group: Path):
+    with open(group / 'cgroup.controllers', 'r') as f:
+        controllers = f.readline().strip()
+    if not controllers:
+        return
+    controllers = " ".join(map(lambda x: f"+{x}", controllers.split(" ")))
+    with open(group / 'cgroup.subtree_control', 'w') as f:
+        f.write(controllers)
 
 
 def setup_cgroup(is_required: bool) -> None:
     if is_required:
+        # Export the cgroup base path as an env var so that xdist worker subprocesses
+        # inherit it. Workers are spawned after the master has already moved itself into
+        # tests/master/default, so without this env var they would compute CGROUP_INITIAL
+        # relative to that nested cgroup instead of the original top-level scope.
+        os.environ[SCYLLA_TEST_CGROUP_BASE_ENV] = str(CGROUP_INITIAL.parent)
+
         # check where the process is executed in podman or in docker
         is_podman = os.access("/run/.containerenv", os.F_OK)
         is_docker = os.access("/.dockerenv", os.F_OK)
@@ -290,7 +305,6 @@ def setup_cgroup(is_required: bool) -> None:
             else:
                 configured = True
 
-
         if not configured:
             with open(CGROUP_INITIAL.parent / 'cgroup.procs') as f:
                 processes = [line.strip() for line in f.readlines()]
@@ -299,39 +313,72 @@ def setup_cgroup(is_required: bool) -> None:
                 with open(CGROUP_INITIAL / 'cgroup.procs', "w") as f:
                     f.write(str(process))
 
-            with open(CGROUP_INITIAL.parent / 'cgroup.controllers', "r") as f:
-                controllers = f.readline()
-            controllers = " ".join(map(lambda x: f"+{x}", controllers.split(" ")))
+            propagate_subtree_controls(CGROUP_INITIAL.parent)
 
-            with open(CGROUP_INITIAL.parent / 'cgroup.subtree_control', "w") as f:
-                f.write(controllers)
-
-            with open(CGROUP_TESTS / 'cgroup.subtree_control', "w") as f:
-                f.write(controllers)
+        # Always ensure CGROUP_TESTS has subtree controls enabled so that worker
+        # sub-cgroups and per-test cgroups can use memory tracking.
+        propagate_subtree_controls(CGROUP_TESTS)
 
 
-async def monitor_resources(cancel_event: Event, stop_event: Event, tmpdir: Path) -> None:
+def setup_worker_cgroup() -> None:
+    from test.pylib.util import get_xdist_worker_id
+    worker_id = get_xdist_worker_id() or "master"
+    # this method is creating the worker cgroup, but the main cgroup is created in the master thread, so this is just to
+    # avoid race conditions
+    for i in range(10):
+        if CGROUP_TESTS.exists():
+            break
+        time.sleep(0.5)
+    worker_cgroup_path = CGROUP_TESTS / worker_id
+    worker_cgroup_path_default = worker_cgroup_path / 'default'
+    for group in [worker_cgroup_path, worker_cgroup_path_default]:
+        if not group.exists():
+            group.mkdir()
+    propagate_subtree_controls(worker_cgroup_path)
+    # Move the current worker process into the worker's default leaf cgroup.
+    # Scylla processes spawned by the test (via ScyllaClusterManager) will inherit
+    # this cgroup. The worker-level cgroup (CGROUP_TESTS/{worker_id}) is used for
+    # hierarchical memory monitoring and captures all descendant processes.
+    try:
+        with open(worker_cgroup_path_default / 'cgroup.procs', 'w') as f:
+            f.write(str(os.getpid()))
+    except Exception as e:
+        logger.warning(f"Could not move worker process to cgroup {worker_cgroup_path_default}: {e}")
+
+
+class SystemResourceMonitor:
     """Continuously monitors CPU and memory utilization."""
-    sqlite_writer = SQLiteWriter(tmpdir / DEFAULT_DB_NAME)
-    while not cancel_event.is_set() and not stop_event.is_set():
-        timeline_record = SystemResourceMetric(
-            host_id=HOST_ID,
-            cpu=psutil.cpu_percent(interval=0.1),
-            memory=psutil.virtual_memory().percent,
-            timestamp=datetime.now(),
-        )
+    def __init__(self, tmpdir: Path):
+        self.tmpdir = tmpdir
+        self.stop_event = Event()
+        self.thread = ThreadPoolExecutor(max_workers=1)
 
-        sqlite_writer.write_row(timeline_record, SYSTEM_RESOURCE_METRICS_TABLE)
+    def start(self) -> None:
+        self.thread.submit(self._monitor_resources, self.tmpdir)
 
-        # Control the frequency of updates, for example, every 2 seconds
-        await asyncio.sleep(2)
+    def stop(self) -> None:
+        self.stop_event.set()
+        self.thread.shutdown(wait=True)
 
+    def _monitor_resources(self, tmpdir: Path) -> None:
+        sqlite_writer = SQLiteWriter(tmpdir / DEFAULT_DB_NAME)
+        try:
+            while not self.stop_event.is_set():
+                vm = psutil.virtual_memory()
+                timeline_record = SystemResourceMetric(
+                    host_id=HOST_ID,
+                    cpu=psutil.cpu_percent(interval=0.1),
+                    memory_free=vm.free,
+                    memory_available=vm.available,
+                    memory_used=vm.used,
+                    memory_active=vm.active,
+                    memory_inactive=vm.inactive,
+                    memory_buffers=vm.buffers,
+                    timestamp=datetime.now(),
+                )
+                sqlite_writer.write_row(timeline_record, SYSTEM_RESOURCE_METRICS_TABLE)
 
-async def no_monitor() -> None:
-    pass
-
-
-def run_resource_watcher(is_required: bool, cancel_event: Event, stop_event:Event, tmpdir: str) -> Task:
-    if is_required:
-        return asyncio.create_task(monitor_resources(cancel_event, stop_event, Path(tmpdir)))
-    return asyncio.create_task(no_monitor())
+                # Control the frequency of updates, for example, every 2 seconds
+                sleep(2)
+        finally:
+            sqlite_writer.close()

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -26,10 +26,11 @@ import psutil
 
 from threading import Event
 from test import HOST_ID, TOP_SRC_DIR
-from test.pylib.db.model import Metric, SystemResourceMetric, CgroupMetric, Test
+from test.pylib.db.model import HostInfo, Metric, SystemResourceMetric, CgroupMetric, Test
 from test.pylib.db.writer import (
     CGROUP_MEMORY_METRICS_TABLE,
     DEFAULT_DB_NAME,
+    HOST_INFO_TABLE,
     METRICS_TABLE,
     SYSTEM_RESOURCE_METRICS_TABLE,
     TESTS_TABLE,
@@ -242,6 +243,23 @@ class ResourceGatherOn(ResourceGatherRecord):
             if len(parts) == 2 and parts[0] in ResourceGatherOn._CPU_STAT_FIELDS:
                 result[parts[0]] = float(parts[1]) / 1_000_000
         return result
+
+
+def gather_host_info() -> HostInfo:
+    """Collect static hardware information about the current host."""
+    try:
+        cpu_model = "unknown"
+        with open("/proc/cpuinfo") as f:
+            for line in f:
+                if line.startswith("model name"):
+                    cpu_model = line.split(":", 1)[1].strip()
+                    break
+    except OSError:
+        cpu_model = platform.processor() or "unknown"
+
+    cpu_cores = psutil.cpu_count(logical=False) or os.cpu_count() or 0
+    ram_bytes = psutil.virtual_memory().total
+    return HostInfo(host_id=HOST_ID, cpu_model=cpu_model, cpu_cores=cpu_cores, ram_bytes=ram_bytes)
 
 
 def get_resource_gather(temp_dir: Path, is_switched_on: bool, test: TestPyTest | SimpleNamespace, worker_id: str | None = None) -> ResourceGather:

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -31,7 +31,8 @@ from _pytest.junitxml import xml_key
 
 from test import ALL_MODES, DEBUG_MODES, TEST_RUNNER, TOP_SRC_DIR, HOST_ID
 from test.pylib.resource_gather import setup_cgroup, setup_worker_cgroup, get_resource_gather, SystemResourceMonitor, \
-    SCYLLA_TEST_CGROUP_BASE_ENV
+    SCYLLA_TEST_CGROUP_BASE_ENV, gather_host_info
+from test.pylib.db.writer import SQLiteWriter, DEFAULT_DB_NAME, HOST_INFO_TABLE
 from test.pylib.scylla_cluster import merge_cmdline_options
 from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.suite.base import (
@@ -431,6 +432,19 @@ def pytest_configure(config: pytest.Config) -> None:
     if testpy_run_id := config.getoption("--run_id"):
         if config.getoption("--repeat") != 1:
             raise RuntimeError("Can't use --run_id and --repeat simultaneously.")
+    # Write host hardware info once, at the very start, before any test preparation.
+    # Done unconditionally (not gated on --gather-metrics) so that the host_info FK
+    # referenced by every other table is always populated, regardless of whether
+    # full metrics collection is enabled.
+    # Only in the main process — xdist workers share the same DB and the same host_id,
+    # so there is nothing new to record.
+    if os.environ.get("PYTEST_XDIST_WORKER") is None and not config.getoption("--collect-only"):
+        temp_dir = pathlib.Path(config.getoption("--tmpdir")).absolute()
+        writer = SQLiteWriter(temp_dir / DEFAULT_DB_NAME)
+        try:
+            writer.write_row_if_not_exist(gather_host_info(), HOST_INFO_TABLE, id_column="host_id")
+        finally:
+            writer.close()
 
 
 class DisabledFile(pytest.File):

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -13,6 +13,7 @@ import pathlib
 import platform
 import random
 import sys
+import time
 from argparse import BooleanOptionalAction
 from collections import defaultdict
 from itertools import chain, count
@@ -20,6 +21,7 @@ from functools import cache, cached_property
 from pathlib import Path
 from random import randint
 from typing import TYPE_CHECKING, Callable
+from types import SimpleNamespace
 
 import pytest
 import xdist
@@ -28,6 +30,8 @@ from _pytest.junitxml import xml_key
 
 
 from test import ALL_MODES, DEBUG_MODES, TEST_RUNNER, TOP_SRC_DIR, HOST_ID
+from test.pylib.resource_gather import setup_cgroup, setup_worker_cgroup, get_resource_gather, SystemResourceMonitor, \
+    SCYLLA_TEST_CGROUP_BASE_ENV
 from test.pylib.scylla_cluster import merge_cmdline_options
 from test.pylib.skip_reason_plugin import skip_marker
 from test.pylib.suite.base import (
@@ -63,6 +67,7 @@ logger = logging.getLogger(__name__)
 # Store pytest config globally so we can access it in hooks that only receive report
 _pytest_config: pytest.Config | None = None
 
+_system_resource_monitor: SystemResourceMonitor | None = None
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption('--mode', choices=ALL_MODES, action="append", dest="modes",
@@ -115,6 +120,111 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                      dest="exe_url", action="store",
                      help="URL to download the relocatable executable. Not working with `mode`")
 
+# Stores the per-phase test reports so that fixtures and hooks can inspect the
+# outcome of each phase (setup / call / teardown) independently.
+PHASE_REPORT_KEY = pytest.StashKey[dict[str, pytest.CollectReport]]()
+
+
+def _build_test_mock(item: pytest.Item) -> SimpleNamespace:
+    """Build a SimpleNamespace test object for resource gathering from any pytest item.
+
+    Works for both Python test items and C++ CppTestCase items, providing a
+    unified interface for the resource-gather subsystem.
+    """
+    from test.pylib.cpp.base import CppTestCase
+
+    params_stash = get_params_stash(node=item)
+    build_mode = params_stash[BUILD_MODE] if params_stash else item.config.build_modes[0]
+    run_id = item.stash.get(RUN_ID, None) or item.config.getoption("--run_id")
+    temp_dir = pathlib.Path(item.config.getoption("--tmpdir")).absolute()
+
+    # Strip the ".mode.run_id" suffix appended by modify_pytest_item()
+    test_name = item.name
+    suffix = f".{build_mode}.{run_id}"
+    original_test_name = test_name[:-len(suffix)] if test_name.endswith(suffix) else test_name
+
+    file_path = item.path
+    suite_path = file_path.parent
+
+    if isinstance(item, CppTestCase):
+        file_name = f"{item.parent.test_name}.cc"
+        shortname = item.test_case_name
+    else:
+        file_name = file_path.name
+        shortname = original_test_name
+
+    return SimpleNamespace(
+        time_end=0,
+        time_start=0,
+        id=run_id,
+        mode=build_mode,
+        success=False,
+        status=None,
+        path=file_path,
+        shortname=shortname,
+        suite=SimpleNamespace(
+            log_dir=temp_dir / build_mode,
+            name=suite_path.name,
+            suite_path=suite_path,
+            test_file_name=file_name,
+        ),
+    )
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    test_mock = _build_test_mock(item)
+    test_mock.time_start = time.time()
+
+    resource_gather = get_resource_gather(
+        temp_dir=pathlib.Path(item.config.getoption("--tmpdir")),
+        is_switched_on=item.config.getoption("--gather-metrics"),
+        test=test_mock,
+        worker_id=os.environ.get("PYTEST_XDIST_WORKER"),
+    )
+    try:
+        resource_gather.setup_test_tracking()
+        resource_gather.cgroup_monitor()
+    except Exception:
+        resource_gather.stop_monitoring()
+        resource_gather.teardown_test_tracking()
+        raise
+    try:
+        return (yield)
+    finally:
+        if resource_gather is not None:
+            test_mock.time_end = time.time()
+            resource_gather.stop_monitoring()
+
+            try:
+                reports = item.stash.get(PHASE_REPORT_KEY, {})
+                # skipped test have no call report so need to get setup report instead
+                call_report = reports.get("call") if reports.get("call") is not None else reports.get("setup")
+                success = call_report is not None and not call_report.failed
+                test_metrics = resource_gather.get_test_metrics()
+                if call_report is not None:
+                    status = "skipped" if call_report.skipped else call_report.outcome
+                    if hasattr(call_report, "wasxfail"):
+                        if call_report.skipped:
+                            status = "xfailed"
+                        elif call_report.passed:
+                            status = "xpassed"
+                    else:
+                        # with xfail_strict = true wasxfail is not present when test is xpassed, so need to check report
+                        if 'XPASS' in call_report.longreprtext:
+                            status = "xpassed"
+                else:
+                    status = "unknown"
+                test_metrics.status = status
+
+                resource_gather.write_metrics_to_db(
+                    metrics=test_metrics,
+                    success=success
+                )
+            finally:
+                resource_gather.teardown_test_tracking()
+
+
 @pytest.fixture(scope="module", autouse=True)
 def build_mode(request: pytest.FixtureRequest) -> str:
     params_stash = get_params_stash(node=request.node)
@@ -161,7 +271,13 @@ def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Confi
 def pytest_sessionstart(session: pytest.Session) -> None:
     # test.py starts S3 mock and create/cleanup testlog by itself. Also, if we run with --collect-only option,
     # we don't need this stuff.
-    if TEST_RUNNER != "pytest" or session.config.getoption("--collect-only"):
+    global _system_resource_monitor
+    gather_metrics = session.config.getoption("--gather-metrics")
+    temp_dir = pathlib.Path(session.config.getoption("--tmpdir")).absolute()
+    save_log_on_success = session.config.getoption("--save-log-on-success")
+    toxiproxy_byte_limit = session.config.getoption("--byte-limit")
+    collect_only = session.config.getoption("--collect-only")
+    if TEST_RUNNER != "pytest" or collect_only:
         return
 
     # Check if this is an xdist worker
@@ -177,10 +293,19 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         prepare_environment(
             tempdir_base=temp_dir,
             modes=get_modes_to_run(session.config),
-            gather_metrics=session.config.getoption("--gather-metrics"),
-            save_log_on_success=session.config.getoption("--save-log-on-success"),
-            toxiproxy_byte_limit=session.config.getoption("--byte-limit"),
+            gather_metrics=gather_metrics,
+            save_log_on_success=save_log_on_success,
+            toxiproxy_byte_limit=toxiproxy_byte_limit,
         )
+    if gather_metrics:
+        # In the master process, set up the cgroup hierarchy if test.py hasn't done it already.
+        # Workers inherit SCYLLA_TEST_CGROUP_BASE_ENV from the master via environment inheritance.
+        if not is_xdist_worker and SCYLLA_TEST_CGROUP_BASE_ENV not in os.environ:
+            setup_cgroup(is_required=True)
+        setup_worker_cgroup()
+        _system_resource_monitor = SystemResourceMonitor(temp_dir)
+        _system_resource_monitor.start()
+
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -227,6 +352,9 @@ def pytest_runtest_logreport(report):
 
 
 def pytest_sessionfinish(session: pytest.Session) -> None:
+    global _system_resource_monitor
+    if _system_resource_monitor:
+        _system_resource_monitor.stop()
 
     is_xdist_worker = xdist.is_xdist_worker(request_or_session=session)
     # If all tests passed, remove the log file to save space and avoid confusion with logs from failed runs.
@@ -339,23 +467,32 @@ def pytest_collect_file(file_path: pathlib.Path,
 
     return collectors
 
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    # This hook is used to capture test failures and save their details to a file in the pytest_tests_logs directory.
-    # We use tryfirst=True to ensure that this hook runs before any other hooks that might modify the report,
-    # and we use hookwrapper=True to allow us to access the report after it has been generated by other hooks.
-    outcome = yield
+    """Post-test hook to store test result in stash and optionally save logs.
 
-    rep = outcome.get_result()
-    # we only look at actual failing test calls, not setup/teardown
-    pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
-    if rep.failed or (_pytest_config.getoption("--save-log-on-success") and rep.when == "teardown"):
-        mode = "a" if os.path.exists(pytest_tests_logs) else "w"
-        with open(pytest_tests_logs/ f"{item._nodeid.replace("::", "-").replace("/", "-")}-{rep.when}-{HOST_ID}.log",mode) as f:
-            f.write(rep.longreprtext + "\n")
-            for section in rep.sections:
-                f.write(section[0] + "\n")
-                f.write(section[1] + "\n")
+    Stores each phase's report in item.stash[PHASE_REPORT_KEY][phase] so
+    fixtures and hooks can access the test outcome per phase.  `item.stash`
+    is the same stash as `request.node.stash` in pytest fixtures.
+
+    When --test-py-init is set, also saves failed test details to log files.
+    """
+    outcome = yield
+    report = outcome.get_result()
+
+    # Store report per phase for use by fixtures and hooks
+    item.stash.setdefault(PHASE_REPORT_KEY, {})[report.when] = report
+
+    # Optionally save test failure logs to files
+    if _pytest_config:
+        pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
+        if report.failed or _pytest_config.getoption("--save-log-on-success"):
+            with open(pytest_tests_logs / f"{item._nodeid.replace('::', '-').replace('/', '-')}-{report.when}-{HOST_ID}.log", 'a') as f:
+                f.write(report.longreprtext + "\n")
+                for section in report.sections:
+                    f.write(section[0] + "\n")
+                    f.write(section[1] + "\n")
 
 class TestSuiteConfig:
     def __init__(self, config_file: pathlib.Path):


### PR DESCRIPTION
Rewrite gather metrics to be able to gather metrics for python tests correctly. 
Python tests require different handling of metrics gathering from cgroup than C++ tests. pytest do not execute each python tests in a separate process, so we can't put it there and get the metrics.
The idea is to put the whole pytest process to the cgroup and get the metrics. This will work because pytest runs the threads as a completely separate processes and inside the thread it will run tests consequently.
Additionally, to simplify system resource monitor moved to pytest main thread.
Change the behavior of the gathering metrics. From this PR some data will be collected even with `--no-gather-metrics`. This data do not need any configuration and just metadata of the tests: test name, time of execution, status of the test. When `--gather-metrics` provided additionally will be written the data gathered from the cgroups about the memory for each specific test and system CPU/RAM utilization.

Backport is not needed, because it's a framework change only.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-575

~Blocked by: https://github.com/scylladb/scylladb/pull/27618~

Now python tests have metrics gathered from the cgroups as well with their own Scylla instances.
```bash
$ sqlite3 --header testlog/sqlite_af8cb.db 'select tst.path, tst.file, tst.test_name, user_sec,system_sec,usage_sec,memory_peak /1024/1024 as memory_peak_mb from test_metrics join tests as tst where tst.id = test_metrics.test_id order by memory_peak_mb desc limit 10;'
path|file|test_name|user_sec|system_sec|usage_sec|memory_peak_mb
test/cluster/dtest|limits_test.py|test_max_cells|489.468174|27.6638949999999|517.132069|4241
test/cluster/dtest|rebuild_test.py|test_rebuild_stream_abort_repro|93.6400869999998|28.9843249999999|122.624412|4241
test/cluster/dtest|schema_management_test.py|test_prepared_statements_work_after_node_restart_after_altering_schema_without_changing_columns|6.8933219999999|3.63569899999993|10.5290209999994|4241
test/cluster/dtest|schema_management_test.py|test_dropping_keyspace_with_many_columns|1.31770999999981|0.754742999999962|2.07245299999977|4241
test/cluster/dtest|schema_management_test.py|test_multiple_create_table_in_parallel|5.48435300000028|2.72915200000011|8.21350499999971|4241
test/cluster/dtest|schema_management_test.py|test_alter_table_in_parallel_to_read_and_write[write]|80.687293|18.5562|99.2434920000005|4241
test/cluster/dtest|schema_management_test.py|test_alter_table_in_parallel_to_read_and_write[read]|79.1984790000001|18.0969829999999|97.2954609999997|4241
test/cluster/dtest|schema_management_test.py|test_alter_table_in_parallel_to_read_and_write[mixed]|85.332915|18.9321070000001|104.265022|4241
test/cluster/dtest|schema_management_test.py|test_update_schema_while_node_is_killed[create_table]|10.5875369999999|5.67954400000008|16.267081|4241
test/cluster/dtest|schema_management_test.py|test_update_schema_while_node_is_killed[alter_table]|11.3801709999998|6.54689099999996|17.9270630000001|4241
```
