### PR TITLE
vector_search: adjust filter JSON to allow caching bind markers 

### DIFF
--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2135,7 +2135,7 @@ future<shared_ptr<cql_transport::messages::result_message>> vector_indexed_table
         auto filter_json = _prepared_filter.to_json(options);
         uint64_t fetch = static_cast<uint64_t>(std::ceil(limit * secondary_index::vector_index::get_oversampling(_index.metadata().options())));
         auto pkeys = co_await qp.vector_store_client().ann(
-                _schema->ks_name(), _index.metadata().name(), _schema, get_ann_ordering_vector(options), fetch, filter_json, aoe.abort_source());
+                _schema->ks_name(), _index.metadata().name(), _schema, get_ann_ordering_vector(options), fetch, std::move(filter_json), aoe.abort_source());
         if (!pkeys.has_value()) {
             co_await coroutine::return_exception(
                     exceptions::invalid_request_exception(std::visit(vector_search::vector_store_client::ann_error_visitor{}, pkeys.error())));

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -39,8 +39,7 @@ restrictions::statement_restrictions make_restrictions(
     }
 
     return restrictions::analyze_statement_restrictions(env.data_dictionary(), env.local_db().find_schema(keyspace_name, table_name),
-            statements::statement_type::SELECT, where_expr,
-            ctx,
+            statements::statement_type::SELECT, where_expr, ctx,
             /*selects_only_static_columns=*/false,
             /*for_view=*/false,
             /*allow_filtering=*/true, restrictions::check_indexes::yes);
@@ -60,7 +59,8 @@ sstring to_sstring(const bytes_ostream& out) {
 }
 
 /// Helper to get JSON string from restrictions
-sstring get_restrictions_json(const restrictions::statement_restrictions& restr, bool allow_filtering = false, const query_options& options = query_options({})) {
+sstring get_restrictions_json(
+        const restrictions::statement_restrictions& restr, bool allow_filtering = false, const query_options& options = query_options({})) {
     return to_sstring(vector_search::prepare_filter(restr, allow_filtering).to_json(options));
 }
 
@@ -181,7 +181,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_eq) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()==()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()==()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -193,7 +194,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_lt) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)<(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -205,7 +207,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_gt) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)>(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -217,7 +220,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_lte) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)<=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -229,7 +233,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_gte) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)>=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -241,7 +246,8 @@ SEASTAR_TEST_CASE(to_json_multi_column_in) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2) in ((1, 2), (3, 4))", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()IN()","lhs":["ck1","ck2"],"rhs":[[1, 2], [3, 4]]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()IN()","lhs":["ck1","ck2"],"rhs":[[1, 2], [3, 4]]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -253,7 +259,8 @@ SEASTAR_TEST_CASE(to_json_multiple_restrictions) {
         auto restr = make_restrictions("pk=1 and ck>=10 and ck<100", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":">=","lhs":"ck","rhs":10},{"type":"<","lhs":"ck","rhs":100}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":">=","lhs":"ck","rhs":10},{"type":"<","lhs":"ck","rhs":100}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -289,9 +296,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_clustering_key) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=? and ck>?", e);
-        std::vector<raw_value> bind_values = {
-            raw_value::make_value(int32_type->decompose(1)),
-            raw_value::make_value(int32_type->decompose(50))};
+        std::vector<raw_value> bind_values = {raw_value::make_value(int32_type->decompose(1)), raw_value::make_value(int32_type->decompose(50))};
         auto options = make_query_options(std::move(bind_values));
         auto json = get_restrictions_json(restr, true, options);
 
@@ -379,7 +384,8 @@ SEASTAR_TEST_CASE(to_json_bind_marker_multi_column) {
         auto options = make_query_options(std::move(bind_values));
         auto json = get_restrictions_json(restr, true, options);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
+        auto expected =
+                R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -395,7 +401,8 @@ SEASTAR_TEST_CASE(to_json_no_bind_markers_uses_cache) {
         auto json1 = to_sstring(filter.to_json(options1));
 
         std::vector<raw_value> bind_values = {raw_value::make_value(int32_type->decompose(999))};
-        auto options2 = query_options(db::consistency_level::ONE, raw_value_vector_with_unset(std::move(bind_values)), query_options::specific_options::DEFAULT);
+        auto options2 =
+                query_options(db::consistency_level::ONE, raw_value_vector_with_unset(std::move(bind_values)), query_options::specific_options::DEFAULT);
         auto json2 = to_sstring(filter.to_json(options2));
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":42}],"allow_filtering":false})json";

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -13,7 +13,6 @@
 #include "cql3/util.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
-#include "utils/rjson.hh"
 #include "vector_search/filter.hh"
 
 BOOST_AUTO_TEST_SUITE(filter_test)
@@ -51,9 +50,18 @@ query_options make_query_options(std::vector<raw_value> values) {
     return query_options(raw_value_vector_with_unset(std::move(values)));
 }
 
+sstring to_sstring(const bytes_ostream& out) {
+    sstring result;
+    for (bytes_view fragment : out) {
+        auto sv = to_string_view(fragment);
+        result.append(sv.data(), sv.size());
+    }
+    return result;
+}
+
 /// Helper to get JSON string from restrictions
-sstring get_restrictions_json(const restrictions::statement_restrictions& restr, bool allow_filtering = false) {
-    return rjson::print(vector_search::prepare_filter(restr, allow_filtering).to_json(query_options({})));
+sstring get_restrictions_json(const restrictions::statement_restrictions& restr, bool allow_filtering = false, const query_options& options = query_options({})) {
+    return to_sstring(vector_search::prepare_filter(restr, allow_filtering).to_json(options));
 }
 
 } // anonymous namespace
@@ -64,9 +72,9 @@ SEASTAR_TEST_CASE(to_json_empty_restrictions) {
 
         auto schema = e.local_db().find_schema("ks", "t");
         restrictions::statement_restrictions restr(schema, false);
-        auto json = rjson::print(vector_search::prepare_filter(restr, false).to_json(query_options({})));
+        auto json = to_sstring(vector_search::prepare_filter(restr, false).to_json(query_options({})));
 
-        BOOST_CHECK_EQUAL(json, "{}");
+        BOOST_CHECK_EQUAL(json, "");
     });
 }
 
@@ -149,7 +157,7 @@ SEASTAR_TEST_CASE(to_json_single_column_in) {
         auto restr = make_restrictions("pk=1 and ck in (1, 2, 3)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"IN","lhs":"ck","rhs":[1,2,3]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"IN","lhs":"ck","rhs":[1, 2, 3]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -173,7 +181,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_eq) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()==()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()==()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -185,7 +193,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_lt) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)<(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -197,7 +205,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_gt) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)>(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -209,7 +217,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_lte) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)<=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<=()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()<=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -221,7 +229,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_gte) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2)>=(10, 20)", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>=()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>=()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -233,7 +241,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_in) {
         auto restr = make_restrictions("pk=1 and (ck1, ck2) in ((1, 2), (3, 4))", e);
         auto json = get_restrictions_json(restr, true);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()IN()","lhs":["ck1","ck2"],"rhs":[[1,2],[3,4]]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()IN()","lhs":["ck1","ck2"],"rhs":[[1, 2], [3, 4]]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -267,11 +275,9 @@ SEASTAR_TEST_CASE(to_json_bind_marker_partition_key) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=?", e);
-        auto filter = vector_search::prepare_filter(restr, false);
-
         std::vector<raw_value> bind_values = {raw_value::make_value(int32_type->decompose(42))};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, false, options);
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":42}],"allow_filtering":false})json";
         BOOST_CHECK_EQUAL(json, expected);
@@ -283,13 +289,11 @@ SEASTAR_TEST_CASE(to_json_bind_marker_clustering_key) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=? and ck>?", e);
-        auto filter = vector_search::prepare_filter(restr, true);
-
         std::vector<raw_value> bind_values = {
             raw_value::make_value(int32_type->decompose(1)),
             raw_value::make_value(int32_type->decompose(50))};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, true, options);
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":">","lhs":"ck","rhs":50}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
@@ -305,13 +309,13 @@ SEASTAR_TEST_CASE(to_json_bind_marker_different_values) {
 
         std::vector<raw_value> bind_values1 = {raw_value::make_value(int32_type->decompose(100))};
         auto options1 = make_query_options(std::move(bind_values1));
-        auto json1 = rjson::print(filter.to_json(options1));
+        auto json1 = to_sstring(filter.to_json(options1));
         auto expected1 = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":100}],"allow_filtering":false})json";
         BOOST_CHECK_EQUAL(json1, expected1);
 
         std::vector<raw_value> bind_values2 = {raw_value::make_value(int32_type->decompose(200))};
         auto options2 = make_query_options(std::move(bind_values2));
-        auto json2 = rjson::print(filter.to_json(options2));
+        auto json2 = to_sstring(filter.to_json(options2));
         auto expected2 = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":200}],"allow_filtering":false})json";
         BOOST_CHECK_EQUAL(json2, expected2);
     });
@@ -322,11 +326,9 @@ SEASTAR_TEST_CASE(to_json_bind_marker_string_value) {
         cquery_nofail(e, "create table ks.t(pk text, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=?", e);
-        auto filter = vector_search::prepare_filter(restr, false);
-
         std::vector<raw_value> bind_values = {raw_value::make_value(utf8_type->decompose("hello_world"))};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, false, options);
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"hello_world"}],"allow_filtering":false})json";
         BOOST_CHECK_EQUAL(json, expected);
@@ -338,11 +340,9 @@ SEASTAR_TEST_CASE(to_json_mixed_literals_and_bind_markers) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=1 and ck>?", e);
-        auto filter = vector_search::prepare_filter(restr, true);
-
         std::vector<raw_value> bind_values = {raw_value::make_value(int32_type->decompose(25))};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, true, options);
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":">","lhs":"ck","rhs":25}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
@@ -354,16 +354,14 @@ SEASTAR_TEST_CASE(to_json_bind_marker_in_list) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
         auto restr = make_restrictions("pk=1 and ck in ?", e);
-        auto filter = vector_search::prepare_filter(restr, true);
-
         auto list_type = list_type_impl::get_instance(int32_type, true);
         auto list_val = make_list_value(list_type, {data_value(10), data_value(20), data_value(30)});
 
         std::vector<raw_value> bind_values = {raw_value::make_value(list_val.serialize_nonnull())};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, true, options);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"IN","lhs":"ck","rhs":[10,20,30]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"IN","lhs":"ck","rhs":[10, 20, 30]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -373,16 +371,15 @@ SEASTAR_TEST_CASE(to_json_bind_marker_multi_column) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
         auto restr = make_restrictions("pk=1 and (ck1, ck2)>?", e);
-        auto filter = vector_search::prepare_filter(restr, true);
 
         auto tuple_type = tuple_type_impl::get_instance({int32_type, int32_type});
         auto tuple_val = make_tuple_value(tuple_type, {data_value(10), data_value(20)});
 
         std::vector<raw_value> bind_values = {raw_value::make_value(tuple_val.serialize_nonnull())};
         auto options = make_query_options(std::move(bind_values));
-        auto json = rjson::print(filter.to_json(options));
+        auto json = get_restrictions_json(restr, true, options);
 
-        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10,20]}],"allow_filtering":true})json";
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"()>()","lhs":["ck1","ck2"],"rhs":[10, 20]}],"allow_filtering":true})json";
         BOOST_CHECK_EQUAL(json, expected);
     });
 }
@@ -395,11 +392,11 @@ SEASTAR_TEST_CASE(to_json_no_bind_markers_uses_cache) {
         auto filter = vector_search::prepare_filter(restr, false);
 
         auto options1 = query_options({});
-        auto json1 = rjson::print(filter.to_json(options1));
+        auto json1 = to_sstring(filter.to_json(options1));
 
         std::vector<raw_value> bind_values = {raw_value::make_value(int32_type->decompose(999))};
         auto options2 = query_options(db::consistency_level::ONE, raw_value_vector_with_unset(std::move(bind_values)), query_options::specific_options::DEFAULT);
-        auto json2 = rjson::print(filter.to_json(options2));
+        auto json2 = to_sstring(filter.to_json(options2));
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":42}],"allow_filtering":false})json";
         BOOST_CHECK_EQUAL(json1, expected);

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -7,7 +7,6 @@
  */
 
 #include "cql3/expr/expression.hh"
-#include "types/types.hh"
 #include "vector_search/vector_store_client.hh"
 #include "utils.hh"
 #include "vs_mock_server.hh"
@@ -21,8 +20,6 @@
 #include "cql3/statements/select_statement.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
-#include "test/lib/log.hh"
-#include <cstdio>
 #include <functional>
 #include <chrono>
 #include <memory>
@@ -39,7 +36,6 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/net/tcp.hh>
-#include <tuple>
 #include <variant>
 #include <vector>
 #include <filesystem>

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -8,7 +8,6 @@
 
 #include "cql3/expr/expression.hh"
 #include "types/types.hh"
-#include "utils/rjson.hh"
 #include "vector_search/vector_store_client.hh"
 #include "utils.hh"
 #include "vs_mock_server.hh"
@@ -81,6 +80,12 @@ timeout_config make_query_timeout(std::chrono::seconds timeout) {
     cfg.cas_timeout = timeout;
     cfg.other_timeout = timeout;
     return cfg;
+}
+
+bytes_ostream make_filter(std::string_view s = {}) {
+    bytes_ostream out;
+    out.write(s.data(), s.size());
+    return out;
 }
 
 } // namespace
@@ -269,7 +274,7 @@ SEASTAR_TEST_CASE(vector_store_client_ann_test_disabled) {
         auto schema = co_await create_test_table(env, "ks", "vs");
         auto& vs = env.local_qp().vector_store_client();
 
-        auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+        auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
         BOOST_REQUIRE(!keys);
         BOOST_CHECK(std::holds_alternative<vector_store_client::disabled>(keys.error()));
     });
@@ -287,7 +292,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
 
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::addr_unavailable>(keys.error()));
             },
@@ -307,7 +312,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
 
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
             },
@@ -334,7 +339,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
 
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset(milliseconds(10)));
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset(milliseconds(10)));
 
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::aborted>(keys.error()));
@@ -360,7 +365,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
 
                 // server responds with 404 - client should return service_error
                 server->next_ann_response({status_type::not_found, "idx2 not found"});
-                auto keys = co_await vs.ann("ks", "idx2", schema, std::vector<float>{0.3, 0.2, 0.1}, 1, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx2", schema, std::vector<float>{0.3, 0.2, 0.1}, 1, make_filter(), as.reset());
                 BOOST_REQUIRE(!server->ann_requests().empty());
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().body, R"({"vector":[0.3,0.2,0.1],"limit":1})");
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().path, "/api/v1/indexes/ks/idx2/ann");
@@ -371,7 +376,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
 
                 // missing primary_keys in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!server->ann_requests().empty());
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().body, R"({"vector":[0.1,0.2,0.3],"limit":2})");
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().path, "/api/v1/indexes/ks/idx/ann");
@@ -380,37 +385,37 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
 
                 // missing distances in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances1":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // missing pk1 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk11":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // missing ck1 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck11":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of pk2 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of ck2 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2]},"distances":[0.1,0.2]})"});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // correct reply - service should return keys
                 server->next_ann_response({status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE});
-                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 BOOST_REQUIRE(keys);
                 BOOST_REQUIRE_EQUAL(keys->size(), 2);
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).partition.key().explode()), "[05, 07]");
@@ -439,8 +444,8 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_request) {
 
                 // correct reply - service should return keys
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5],"pk2":[7],"ck1":[9],"ck2":[2]},"distances":[0.1]})"});
-                auto filter = rjson::parse(R"({"restrictions":[{"type":"==","lhs":"pk1","rhs":5}],"allow_filtering":false})");
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, filter, as.reset());
+                auto filter = R"({"restrictions":[{"type":"==","lhs":"pk1","rhs":5}],"allow_filtering":false})";
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(filter), as.reset());
                 BOOST_REQUIRE(keys);
                 BOOST_REQUIRE_EQUAL(keys->size(), 1);
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).partition.key().explode()), "[05, 07]");
@@ -579,7 +584,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update) {
                 // Wait until requests are handled by s2
                 // To avoid race condition we wait twice long as DNS refresh interval before checking the result.
                 BOOST_CHECK(co_await repeat_until(DNS_REFRESH_INTERVAL * 2, [&]() -> future<bool> {
-                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return s2->ann_requests().size() > 0;
                 }));
             },
@@ -609,7 +614,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_high_availability) {
                 // Because requests are distributed in random order due to load balancing,
                 // repeat the ANN query until the unavailable server is queried.
                 BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                    keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return unavail_s->connections().size() > 1;
                 }));
 
@@ -643,7 +648,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_load_balancing) {
                 // The load balancing algorithm is random, so we send requests in a loop
                 // until both servers have received at least one, verifying that load is distributed.
                 BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return !s1->ann_requests().empty() && !s2->ann_requests().empty();
                 }));
             },
@@ -673,7 +678,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_high_availability) {
                 // Because requests are distributed in random order due to load balancing,
                 // repeat the ANN query until the unavailable server is queried.
                 BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                    keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return unavail_s->connections().size() > 1;
                 }));
 
@@ -707,7 +712,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
                 // The load balancing algorithm is random, so we send requests in a loop
                 // until both servers have received at least one, verifying that load is distributed.
                 BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return !s1->ann_requests().empty() && !s2->ann_requests().empty();
                 }));
             },
@@ -832,7 +837,7 @@ SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
                 vs.start_background_tasks();
 
                 // Send request to unavailable node - this will put the node to backoff.
-                auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_CHECK(!result);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(result.error()));
@@ -843,7 +848,7 @@ SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
 
                 // Wait until node is taken out of the backoff state and used for requests again.
                 BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                    auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     co_return result.has_value();
                 }));
             },
@@ -874,7 +879,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
                 vs.start_background_tasks();
 
                 for (int i = 0; i < NUM_OF_PARALLEL_REQUESTS; ++i) {
-                    requests.push_back(vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset()));
+                    requests.push_back(vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset()));
                 }
                 // Wait for all requests to establish a connection with the server.
                 co_await repeat_until([&unavail_s]() -> future<bool> {
@@ -916,7 +921,7 @@ SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_request
                 // Set request timeout to 100ms, hence max backoff time is 2x100ms = 200ms.
                 cfg.db_config->read_request_timeout_in_ms.set(100);
                 // Trigger status checking by making ANN request to unavailable server.
-                co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                 co_await repeat_until([&unavail_s]() -> future<bool> {
                     // Wait for 1 ANN request + 4 status check connections (5 total)
                     co_return unavail_s->connections().size() > 4;
@@ -959,7 +964,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
                         {{"primary.node", std::vector<std::string>{primary->host()}}, {"secondary.node", std::vector<std::string>{secondary->host()}}});
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_CHECK(keys);
             },
@@ -982,7 +987,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
                 configure(vs).with_dns({{"secondary.node", std::vector<std::string>{secondary->host()}}});
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_CHECK(keys);
             },
@@ -1006,7 +1011,7 @@ SEASTAR_TEST_CASE(vector_store_client_https) {
                 configure(vs).with_dns({{certs.server_cert_cn(), std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_CHECK(keys);
                 co_return;
@@ -1036,7 +1041,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
                 co_await env.vector_store_client().invoke_on_all([&](this auto, vector_store_client& vs) -> future<> {
                     auto schema = env.local_db().find_schema("ks", "idx");
                     auto as = abort_source_timeout();
-                    auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                    auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                     BOOST_REQUIRE(!keys);
                 });
 
@@ -1049,7 +1054,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
                     auto schema = env.local_db().find_schema("ks", "idx");
                     auto as = abort_source_timeout();
                     BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
-                        auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                        auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
                         co_return keys.has_value();
                     }));
                 });
@@ -1078,7 +1083,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_hostname) {
                 configure(vs).with_dns({{hostname, std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
@@ -1104,7 +1109,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_different_ca_cert_verification_error
                 configure(vs).with_dns({{certs.server_cert_cn(), std::vector<std::string>{server->host()}}});
                 vs.start_background_tasks();
 
-                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
+                auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, make_filter(), as.reset());
 
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));

--- a/vector_search/filter.cc
+++ b/vector_search/filter.cc
@@ -62,157 +62,150 @@ sstring value_to_json(const data_type& type, const cql3::raw_value& val) {
     return to_json_string(*type, to_bytes(val.view()));
 }
 
-void write_to_json(bytes_ostream& out, std::string_view s) {
-    out.write(s.data(), s.size());
+void append(prepared_filter::cache& c, std::string_view s) {
+    if (!c.empty() && std::holds_alternative<sstring>(c.back())) {
+        std::get<sstring>(c.back()).append(s.data(), s.size());
+    } else {
+        c.emplace_back(sstring(s));
+    }
 }
 
-rjson::value lhs_to_json(const cql3::expr::column_value& col) {
-    return rjson::from_string(col.col->name_as_text());
+void append_lhs(prepared_filter::cache& c, const cql3::expr::column_value& col) {
+    append(c, "\"");
+    append(c, col.col->name_as_text());
+    append(c, "\"");
 }
 
-rjson::value lhs_to_json(const cql3::expr::tuple_constructor& lhs_tuple) {
-    auto arr = rjson::empty_array();
+void append_lhs(prepared_filter::cache& c, const cql3::expr::tuple_constructor& lhs_tuple) {
+    append(c, "[");
+    bool first = true;
     for (const auto& elem : lhs_tuple.elements) {
         if (auto* cv = cql3::expr::as_if<cql3::expr::column_value>(&elem)) {
-            rjson::push_back(arr, rjson::from_string(cv->col->name_as_text()));
+            if (!first) {
+                append(c, ",");
+            }
+            first = false;
+            append_lhs(c, *cv);
         }
     }
-    return arr;
+    append(c, "]");
 }
 
-prepared_restriction make_prepared_restriction(const sstring& op_str, rjson::value lhs_json, const cql3::expr::expression& rhs_expr) {
+void append_rhs(prepared_filter::cache& c, const cql3::expr::expression& rhs_expr) {
     auto rhs_type = cql3::expr::type_of(rhs_expr);
     if (cql3::expr::contains_bind_marker(rhs_expr)) {
-        return prepared_restriction{
-                .type_json = rjson::from_string(op_str), .lhs_json = std::move(lhs_json), .rhs = prepared_rhs{std::move(rhs_type), rhs_expr}};
+        c.emplace_back(bind_marker_metadata{std::move(rhs_type), rhs_expr});
     } else {
         auto rhs_val = cql3::expr::evaluate(rhs_expr, cql3::query_options({}));
-        auto rhs_json = rjson::parse(value_to_json(rhs_type, rhs_val));
-        return prepared_restriction{.type_json = rjson::from_string(op_str), .lhs_json = std::move(lhs_json), .rhs = std::move(rhs_json)};
+        append(c, value_to_json(rhs_type, rhs_val));
     }
 }
 
-void single_column_restriction_to_prepared(
-        const cql3::expr::binary_operator& binop, const cql3::expr::column_value& col, std::vector<prepared_restriction>& restrictions) {
+void append_separator(prepared_filter::cache& c, bool& needs_comma) {
+    if (needs_comma) {
+        append(c, ",");
+    }
+    needs_comma = true;
+}
+
+void append_restriction(prepared_filter::cache& c, const sstring& op_str, const cql3::expr::column_value& col, const cql3::expr::expression& rhs_expr) {
+    append(c, "{\"type\":\"");
+    append(c, op_str);
+    append(c, "\",\"lhs\":");
+    append_lhs(c, col);
+    append(c, ",\"rhs\":");
+    append_rhs(c, rhs_expr);
+    append(c, "}");
+}
+
+void append_restriction(prepared_filter::cache& c, const sstring& op_str, const cql3::expr::tuple_constructor& lhs_tuple, const cql3::expr::expression& rhs_expr) {
+    append(c, "{\"type\":\"");
+    append(c, op_str);
+    append(c, "\",\"lhs\":");
+    append_lhs(c, lhs_tuple);
+    append(c, ",\"rhs\":");
+    append_rhs(c, rhs_expr);
+    append(c, "}");
+}
+
+void single_column_restriction_to_json(const cql3::expr::binary_operator& binop, const cql3::expr::column_value& col, prepared_filter::cache& c, bool& needs_comma) {
     auto op_str = to_single_column_op_string(binop.op);
     if (!op_str) {
         throw exceptions::unsupported_operation_exception(sstring("Unsupported operator in restriction on column ") + col.col->name_as_text());
     }
 
-    restrictions.push_back(make_prepared_restriction(*op_str, lhs_to_json(col), binop.rhs));
+    append_separator(c, needs_comma);
+    append_restriction(c, *op_str, col, binop.rhs);
 }
 
-void multi_column_restriction_to_prepared(
-        const cql3::expr::binary_operator& binop, const cql3::expr::tuple_constructor& lhs_tuple, std::vector<prepared_restriction>& restrictions) {
+void multi_column_restriction_to_json(const cql3::expr::binary_operator& binop, const cql3::expr::tuple_constructor& lhs_tuple, prepared_filter::cache& c, bool& needs_comma) {
     auto op_str = to_multi_column_op_string(binop.op);
     if (!op_str) {
         throw exceptions::unsupported_operation_exception(sstring("Unsupported operator in restriction on columns ") + to_string(lhs_tuple));
     }
 
-    restrictions.push_back(make_prepared_restriction(*op_str, lhs_to_json(lhs_tuple), binop.rhs));
+    append_separator(c, needs_comma);
+    append_restriction(c, *op_str, lhs_tuple, binop.rhs);
 }
 
-void binary_operator_to_prepared(const cql3::expr::binary_operator& binop, std::vector<prepared_restriction>& restrictions) {
+void binary_operator_to_json(const cql3::expr::binary_operator& binop, prepared_filter::cache& c, bool& needs_comma) {
     if (auto* cv = cql3::expr::as_if<cql3::expr::column_value>(&binop.lhs)) {
-        single_column_restriction_to_prepared(binop, *cv, restrictions);
+        single_column_restriction_to_json(binop, *cv, c, needs_comma);
         return;
     }
 
     if (auto* tuple = cql3::expr::as_if<cql3::expr::tuple_constructor>(&binop.lhs)) {
-        multi_column_restriction_to_prepared(binop, *tuple, restrictions);
+        multi_column_restriction_to_json(binop, *tuple, c, needs_comma);
         return;
     }
 }
 
-void expression_to_prepared(const cql3::expr::expression& expr, std::vector<prepared_restriction>& restrictions) {
+void expression_to_json(const cql3::expr::expression& expr, prepared_filter::cache& c, bool& needs_comma) {
     cql3::expr::for_each_expression<cql3::expr::binary_operator>(expr, [&](const cql3::expr::binary_operator& binop) {
-        binary_operator_to_prepared(binop, restrictions);
+        binary_operator_to_json(binop, c, needs_comma);
     });
-}
-
-void restriction_to_json(bytes_ostream& out, const prepared_restriction& r, const cql3::query_options& options) {
-    write_to_json(out, "{\"type\":");
-    write_to_json(out, rjson::print(r.type_json));
-    write_to_json(out, ",\"lhs\":");
-    write_to_json(out, rjson::print(r.lhs_json));
-    write_to_json(out, ",\"rhs\":");
-    write_to_json(out, rjson::print(r.rhs_to_json(options)));
-    write_to_json(out, "}");
-}
-
-void restrictions_to_json(bytes_ostream& out, const std::vector<prepared_restriction>& restrictions, bool allow_filtering, const cql3::query_options& options) {
-    if (restrictions.empty() && !allow_filtering) {
-        return;
-    }
-
-    write_to_json(out, "{\"restrictions\":[");
-
-    bool first = true;
-    for (const auto& r : restrictions) {
-        if (!first) {
-            write_to_json(out, ",");
-        }
-        first = false;
-        restriction_to_json(out, r, options);
-    }
-
-    write_to_json(out, "],\"allow_filtering\":");
-    write_to_json(out, allow_filtering ? "true" : "false");
-    write_to_json(out, "}");
 }
 
 } // anonymous namespace
 
-rjson::value prepared_restriction::rhs_to_json(const cql3::query_options& options) const {
-    return std::visit(
-            [&](const auto& v) -> rjson::value {
-                using T = std::decay_t<decltype(v)>;
-                if constexpr (std::is_same_v<T, rjson::value>) {
-                    return rjson::copy(v);
-                } else {
-                    const auto& [type, expr] = v;
-                    auto val = cql3::expr::evaluate(expr, options);
-                    return rjson::parse(value_to_json(type, val));
-                }
-            },
-            rhs);
-}
-
 bytes_ostream prepared_filter::to_json(const cql3::query_options& options) const {
-    bytes_ostream out;
-
-    if (_cached_json) {
-        write_to_json(out, rjson::print(_cached_json.value()));
-        return out;
+    bytes_ostream result;
+    for (const auto& entry : _cache) {
+        std::visit(overloaded_functor{
+            [&](const sstring& s) {
+                result.write(s.data(), s.size());
+            },
+            [&](const bind_marker_metadata& marker) {
+                auto val = cql3::expr::evaluate(marker.expr, options);
+                auto json_str = value_to_json(marker.type, val);
+                result.write(json_str.data(), json_str.size());
+            }
+        }, entry);
     }
-
-    restrictions_to_json(out, _restrictions, _allow_filtering, options);
-    return out;
+    return result;
 }
 
 prepared_filter prepare_filter(const cql3::restrictions::statement_restrictions& restrictions, bool allow_filtering) {
-    if (restrictions.is_empty()) {
-        return prepared_filter({}, allow_filtering);
-    }
+    prepared_filter::cache c;
 
-    std::vector<prepared_restriction> prepared_restrictions;
+    if (restrictions.is_empty() && !allow_filtering) {
+        return prepared_filter(std::move(c));
+    }
 
     auto& partition_key_restrictions = restrictions.get_partition_key_restrictions();
     auto& clustering_columns_restrictions = restrictions.get_clustering_columns_restrictions();
 
-    expression_to_prepared(partition_key_restrictions, prepared_restrictions);
-    expression_to_prepared(clustering_columns_restrictions, prepared_restrictions);
+    append(c, "{\"restrictions\":[");
 
-    bool has_bind_markers = cql3::expr::contains_bind_marker(partition_key_restrictions) || cql3::expr::contains_bind_marker(clustering_columns_restrictions);
+    bool needs_comma = false;
+    expression_to_json(partition_key_restrictions, c, needs_comma);
+    expression_to_json(clustering_columns_restrictions, c, needs_comma);
 
-    if (!has_bind_markers) {
-        bytes_ostream cached_out;
-        restrictions_to_json(cached_out, prepared_restrictions, allow_filtering, cql3::query_options({}));
-        auto cached_json = rjson::parse(sstring(to_string_view(cached_out.linearize())));
-        return prepared_filter(std::move(prepared_restrictions), allow_filtering, std::move(cached_json));
-    }
+    append(c, "],\"allow_filtering\":");
+    append(c, allow_filtering ? "true" : "false");
+    append(c, "}");
 
-    return prepared_filter(std::move(prepared_restrictions), allow_filtering);
+    return prepared_filter(std::move(c));
 }
 
 } // namespace vector_search

--- a/vector_search/filter.hh
+++ b/vector_search/filter.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "bytes_ostream.hh"
-#include "utils/rjson.hh"
 #include "cql3/expr/expression.hh"
 
 namespace cql3 {
@@ -25,35 +24,31 @@ class statement_restrictions;
 
 namespace vector_search {
 
-struct prepared_rhs {
+/// Metadata for a bind marker in the cached JSON template.
+/// Contains the type and expression needed to evaluate the bind marker at execution time.
+struct bind_marker_metadata {
     data_type type;
     cql3::expr::expression expr;
 };
 
-struct prepared_restriction {
-    rjson::value type_json;
-    rjson::value lhs_json;
-    std::variant<rjson::value, prepared_rhs> rhs;
-
-    rjson::value rhs_to_json(const cql3::query_options& options) const;
-};
+/// A cache entry is either a literal JSON string or a bind marker to be substituted.
+using filter_cache_entry = std::variant<sstring, bind_marker_metadata>;
 
 class prepared_filter {
-    std::vector<prepared_restriction> _restrictions;
-    bool _allow_filtering;
-    // Cached JSON representation for filters without bind markers.
-    std::optional<rjson::value> _cached_json;
-
 public:
-    prepared_filter(std::vector<prepared_restriction> restrictions, bool allow_filtering, std::optional<rjson::value> cached_json = std::nullopt)
-        : _restrictions(std::move(restrictions))
-        , _allow_filtering(allow_filtering)
-        , _cached_json(std::move(cached_json)) {
+    using cache = std::vector<filter_cache_entry>;
+
+    explicit prepared_filter(cache cache)
+        : _cache(std::move(cache)) {
     }
 
     /// Serializes the prepared filter to a JSON buffer compatible with the Vector Store service filtering API.
+    /// Bind marker placeholders in the cached template are substituted with actual values from `query_options`.
     /// Returns a bytes_ostream that can be efficiently consumed without materialization.
     bytes_ostream to_json(const cql3::query_options& options) const;
+
+private:
+    cache _cache;
 };
 
 /// Prepares a filter from CQL statement restrictions for use in Vector Store service.

--- a/vector_search/filter.hh
+++ b/vector_search/filter.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "bytes_ostream.hh"
 #include "utils/rjson.hh"
 #include "cql3/expr/expression.hh"
 
@@ -50,8 +51,9 @@ public:
         , _cached_json(std::move(cached_json)) {
     }
 
-    /// Serializes the prepared filter to JSON compatible with the Vector Store service filtering API.
-    rjson::value to_json(const cql3::query_options& options) const;
+    /// Serializes the prepared filter to a JSON buffer compatible with the Vector Store service filtering API.
+    /// Returns a bytes_ostream that can be efficiently consumed without materialization.
+    bytes_ostream to_json(const cql3::query_options& options) const;
 };
 
 /// Prepares a filter from CQL statement restrictions for use in Vector Store service.

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -20,7 +20,6 @@
 #include "types/json_utils.hh"
 #include "schema/schema.hh"
 #include <charconv>
-#include <exception>
 #include <fmt/ranges.h>
 #include <regex>
 #include <random>

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -137,11 +137,12 @@ auto ck_from_json(rjson::value const& item, std::size_t idx, schema_ptr const& s
     return clustering_key_prefix::from_exploded(raw_ck);
 }
 
-auto write_ann_json(vs_vector vs_vector, limit limit, const rjson::value& filter) -> json_content {
-    if (filter.ObjectEmpty()) {
+auto write_ann_json(vs_vector vs_vector, limit limit, bytes_ostream&& filter) -> json_content {
+    if (filter.empty()) {
         return seastar::format(R"({{"vector":[{}],"limit":{}}})", fmt::join(vs_vector, ","), limit);
     }
-    return seastar::format(R"({{"vector":[{}],"limit":{},"filter":{}}})", fmt::join(vs_vector, ","), limit, rjson::print(filter));
+    return seastar::format(R"({{"vector":[{}],"limit":{},"filter":{}}})", fmt::join(vs_vector, ","), limit,
+            fmt::join(filter.fragments() | std::views::transform(to_string_view), ""));
 }
 
 auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::expected<primary_keys, ann_error> {
@@ -300,7 +301,7 @@ struct vector_store_client::impl {
         return _primary_uris.empty() && _secondary_uris.empty();
     }
 
-    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
+    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, bytes_ostream&& filter, abort_source& as)
             -> future<std::expected<primary_keys, ann_error>> {
         if (is_disabled()) {
             vslogger.error("Disabled Vector Store while calling ann");
@@ -308,7 +309,7 @@ struct vector_store_client::impl {
         }
 
         auto path = format("/api/v1/indexes/{}/{}/ann", keyspace, name);
-        auto content = write_ann_json(std::move(vs_vector), limit, filter);
+        auto content = write_ann_json(std::move(vs_vector), limit, std::move(filter));
 
         auto resp = co_await request(operation_type::POST, std::move(path), std::move(content), as);
         if (!resp) {
@@ -380,9 +381,9 @@ auto vector_store_client::is_disabled() const -> bool {
     return _impl->is_disabled();
 }
 
-auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
-        -> future<std::expected<primary_keys, ann_error>> {
-    return _impl->ann(keyspace, name, schema, vs_vector, limit, filter, as);
+auto vector_store_client::ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, bytes_ostream&& filter,
+        abort_source& as) -> future<std::expected<primary_keys, ann_error>> {
+    return _impl->ann(keyspace, name, schema, vs_vector, limit, std::move(filter), as);
 }
 
 void vector_store_client_tester::set_dns_refresh_interval(vector_store_client& vsc, std::chrono::milliseconds interval) {

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -10,7 +10,6 @@
 
 #include "dht/decorated_key.hh"
 #include "keys/keys.hh"
-#include "seastarx.hh"
 #include "error.hh"
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -12,7 +12,6 @@
 #include "keys/keys.hh"
 #include "seastarx.hh"
 #include "error.hh"
-#include "utils/rjson.hh"
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/http/reply.hh>
@@ -75,7 +74,7 @@ public:
     auto is_disabled() const -> bool;
 
     /// Request the vector store service for the primary keys of the nearest neighbors
-    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
+    auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, bytes_ostream&& filter, abort_source& as)
             -> future<std::expected<primary_keys, ann_error>>;
 
 private:


### PR DESCRIPTION
Change the cached filter from `rjson::value` to `bytes_ostream`.
This allows us to create the stream during prepare with bind markers, which would be substituted with real values during execution.

It may be also used to consume the result and send it via HTTP without materializing with prior changes to `vector_store_client`.

The change improves the performance by expanding the caching mechanism with support for bind markers inside WHERE clauses.

Follow-up to: https://github.com/scylladb/scylladb/pull/28276
Fixes: SCYLLADB-372