### PR TITLE
Add digests for all sstable components in scylla metadata

### DIFF
--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -161,6 +161,7 @@ std::string_view to_string(compaction_type type) {
     case compaction_type::Reshape: return "Reshape";
     case compaction_type::Split: return "Split";
     case compaction_type::Major: return "Major";
+    case compaction_type::RewriteComponent: return "RewriteComponent";
     }
     on_internal_error_noexcept(clogger, format("Invalid compaction type {}", int(type)));
     return "(invalid)";
@@ -2048,6 +2049,7 @@ compaction_type compaction_type_options::type() const {
         compaction_type::Reshape,
         compaction_type::Split,
         compaction_type::Major,
+        compaction_type::RewriteComponent,
     };
     static_assert(std::variant_size_v<compaction_type_options::options_variant> == std::size(index_to_type));
     return index_to_type[_options.index()];
@@ -2083,6 +2085,9 @@ static std::unique_ptr<compaction> make_compaction(compaction_group_view& table_
         }
         std::unique_ptr<compaction> operator()(compaction_type_options::split split_options) {
             return std::make_unique<split_compaction>(table_s, std::move(descriptor), cdata, std::move(split_options), progress_monitor);
+        }
+        std::unique_ptr<compaction> operator()(compaction_type_options::component_rewrite) {
+            throw std::runtime_error("component_rewrite compaction should be handled separately");
         }
     } visitor_factory{table_s, std::move(descriptor), cdata, progress_monitor};
 
@@ -2138,6 +2143,34 @@ future<compaction_result> scrub_sstables_validate_mode(compaction_descriptor des
     co_return res;
 }
 
+future<compaction_result> rewrite_sstables_component(compaction_descriptor descriptor, compaction_group_view& table_s) {
+    return seastar::async([descriptor = std::move(descriptor), &table_s] () mutable {
+        compaction_result result {
+            .stats = {
+                .started_at = db_clock::now(),
+            },
+        };
+
+        const auto& options = descriptor.options.as<compaction_type_options::component_rewrite>();
+        bool update_id = static_cast<bool>(options.update_id);
+        // When rewriting a component, we cannot use the standard descriptor creator
+        // because we must preserve the sstable version.
+        auto creator = [&table_s] (sstables::shared_sstable sst) {
+            return table_s.make_sstable(sst->state(), sst->get_version());
+        };
+        result.new_sstables.reserve(descriptor.sstables.size());
+        for (auto& sst : descriptor.sstables) {
+            auto rewritten = sst->link_with_rewritten_component(creator, options.component_to_rewrite, options.modifier, update_id).get();
+            result.new_sstables.push_back(rewritten);
+        }
+
+        descriptor.replacer({std::move(descriptor.sstables), result.new_sstables});
+
+        result.stats.ended_at = db_clock::now();
+        return result;
+    });
+}
+
 future<compaction_result>
 compact_sstables(compaction_descriptor descriptor, compaction_data& cdata, compaction_group_view& table_s, compaction_progress_monitor& progress_monitor) {
     if (descriptor.sstables.empty()) {
@@ -2148,6 +2181,9 @@ compact_sstables(compaction_descriptor descriptor, compaction_data& cdata, compa
             && std::get<compaction_type_options::scrub>(descriptor.options.options()).operation_mode == compaction_type_options::scrub::mode::validate) {
         // Bypass the usual compaction machinery for dry-mode scrub
         return scrub_sstables_validate_mode(std::move(descriptor), cdata, table_s, progress_monitor);
+    }
+    if (descriptor.options.type() == compaction_type::RewriteComponent) {
+        return rewrite_sstables_component(std::move(descriptor), table_s);
     }
     return compaction::run(make_compaction(table_s, std::move(descriptor), cdata, progress_monitor));
 }

--- a/compaction/compaction_group_view.hh
+++ b/compaction/compaction_group_view.hh
@@ -46,6 +46,7 @@ public:
     virtual reader_permit make_compaction_reader_permit() const = 0;
     virtual sstables::sstables_manager& get_sstables_manager() noexcept = 0;
     virtual sstables::shared_sstable make_sstable(sstables::sstable_state) const = 0;
+    virtual sstables::shared_sstable make_sstable(sstables::sstable_state, sstables::sstable_version_types) const = 0;
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const = 0;
     virtual api::timestamp_type min_memtable_timestamp() const = 0;
     virtual api::timestamp_type min_memtable_live_timestamp() const = 0;

--- a/docs/dev/sstable-scylla-format.md
+++ b/docs/dev/sstable-scylla-format.md
@@ -31,6 +31,7 @@ in individual sections
         | scylla_build_id
         | scylla_version
         | ext_timestamp_stats
+        | components_digests
 
 `sharding_metadata` (tag 1): describes what token sub-ranges are included in this
 sstable. This is used, when loading the sstable, to determine which shard(s)
@@ -65,8 +66,20 @@ if the sstable has numerical generation).  Yet, unlike the sstable that may
 change if the sstable is migrated to a different shard or node, the sstable
 identifier is stable and copied with the rest of the scylla metadata.
 
+`components_digests` (tag 12): a `map<component_type, uint32_t>` with CRC32 digests of
+all SSTable component files that are checksummed during write. Each entry maps a component
+type (e.g., Data, Index, Filter, Statistics, etc.) to its CRC32 checksum. This allows
+verifying the integrity of individual component files.
+
 The [scylla sstable dump-scylla-metadata](https://github.com/scylladb/scylladb/blob/master/docs/operating-scylla/admin-tools/scylla-sstable.rst#dump-scylla-metadata) tool
 can be used to dump the scylla metadata in JSON format.
+
+## Trailing digest
+
+When the `components_digests` subcomponent is present, the `Scylla.db` file contains
+a trailing CRC32 digest appended after the serialized subcomponents data.
+This digest covers the entire serialized `data` section (i.e., all subcomponents)
+and can be used to verify the integrity of the scylla metadata itself.
 
 ## sharding_metadata subcomponent
 

--- a/docs/dev/sstables-directory-structure.md
+++ b/docs/dev/sstables-directory-structure.md
@@ -107,7 +107,8 @@ Here are the different component types:
 
 
 * Scylla (`Scylla.db`)  
-  A file holding scylla-specific metadata about the SSTable, such as sharding information, extended features support, and sstabe-run identifier.
+  A file holding scylla-specific metadata about the SSTable, such as sharding information, extended features support, sstable-run identifier, and CRC32 digests of all SSTable component files.
+  When component digests are present, the file also contains a trailing CRC32 digest of its own serialized metadata (excluding the digest itself).
 
 
 * Partition Key Index (`Partitions.db`)  

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -597,6 +597,7 @@ private:
 
     bool _is_bootstrap_or_replace = false;
     sstables::shared_sstable make_sstable(sstables::sstable_state state);
+    sstables::shared_sstable make_sstable(sstables::sstable_state state, sstables::sstable_version_types version);
 
 public:
     void on_flush_timer();

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -484,7 +484,12 @@ static bool belongs_to_other_shard(const std::vector<shard_id>& shards) {
 
 sstables::shared_sstable table::make_sstable(sstables::sstable_state state) {
     auto& sstm = get_sstables_manager();
-    return sstm.make_sstable(_schema, *_storage_opts, calculate_generation_for_new_table(), state, sstm.get_preferred_sstable_version(), sstables::sstable::format_types::big);
+    return make_sstable(state, sstm.get_preferred_sstable_version());
+}
+
+sstables::shared_sstable table::make_sstable(sstables::sstable_state state, sstables::sstable_version_types version) {
+    auto& sstm = get_sstables_manager();
+    return sstm.make_sstable(_schema, *_storage_opts, calculate_generation_for_new_table(), state, version, sstables::sstable::format_types::big);
 }
 
 sstables::shared_sstable table::make_sstable() {
@@ -2718,6 +2723,9 @@ public:
     }
     sstables::shared_sstable make_sstable(sstables::sstable_state state) const override {
         return _t.make_sstable(state);
+    }
+    sstables::shared_sstable make_sstable(sstables::sstable_state state, sstables::sstable_version_types version) const override {
+        return _t.make_sstable(state, version);
     }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
         auto cfg = _t.get_sstables_manager().configure_writer(std::move(origin));

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -632,6 +632,10 @@ private:
     std::unique_ptr<file_writer> close_writer(std::unique_ptr<file_writer>& w);
 
     void close_data_writer();
+    void close_index_writer();
+    void close_rows_writer();
+    void close_partitions_writer();
+
     void ensure_tombstone_is_written() {
         if (!_tombstone_written) {
             consume(tombstone());
@@ -979,6 +983,35 @@ void writer::close_data_writer() {
         _sst.write_crc(chksum_wr->finalize_checksum());
     } else {
         _sst.write_digest(_sst._components->compression.get_full_checksum());
+    }
+}
+
+void writer::close_index_writer() {
+    if (_index_writer) {
+        close_writer(_index_writer);
+    }
+}
+
+void writer::close_partitions_writer() {
+    if (_partitions_writer) {
+        _sst._partitions_db_footer = std::move(*_bti_partition_index_writer).finish(
+            _sst.get_version(),
+            _first_key.value(),
+            _last_key.value());
+        close_writer(_partitions_writer);
+    }
+}
+
+void writer::close_rows_writer() {
+    if (_rows_writer) {
+        // Append some garbage padding to the file just to ensure that it's never empty.
+        // (Otherwise it would be empty if the sstable contains only small partitions).
+        // This is a hack to work around some bad interactions between zero-sized files
+        // and object storage. (It seems that e.g. minio considers a zero-sized file
+        // upload to be a no-op, which breaks some assumptions).
+        uint32_t garbage = seastar::cpu_to_be(0x13371337);
+        _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
+        close_writer(_rows_writer);
     }
 }
 
@@ -1630,27 +1663,10 @@ void writer::consume_end_of_stream() {
         _collector.add_compression_ratio(_sst._components->compression.compressed_file_length(), _sst._components->compression.uncompressed_file_length());
     }
 
-  if (_index_writer) {
-    close_writer(_index_writer);
-  }
+    close_index_writer();
 
-    if (_partitions_writer) {
-        _sst._partitions_db_footer = std::move(*_bti_partition_index_writer).finish(
-            _sst.get_version(),
-            _first_key.value(),
-            _last_key.value());
-        close_writer(_partitions_writer);
-    }
-    if (_rows_writer) {
-        // Append some garbage padding to the file just to ensure that it's never empty.
-        // (Otherwise it would be empty if the sstable contains only small partitions).
-        // This is a hack to work around some bad interactions between zero-sized files
-        // and object storage. (It seems that e.g. minio considers a zero-sized file
-        // upload to be a no-op, which breaks some assumptions).
-        uint32_t garbage = seastar::cpu_to_be(0x13371337);
-        _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
-        close_writer(_rows_writer);
-    }
+    close_partitions_writer();
+    close_rows_writer();
 
     if (_hashes_writer) {
         close_writer(_hashes_writer);

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -630,6 +630,7 @@ private:
 
     // Returns the closed writer
     std::unique_ptr<file_writer> close_writer(std::unique_ptr<file_writer>& w);
+    uint32_t close_digest_writer(std::unique_ptr<file_writer>& w);
 
     void close_data_writer();
     void close_index_writer();
@@ -951,14 +952,14 @@ void writer::init_file_writers() {
 
     if (_sst.has_component(component_type::Index)) {
         out = _sst._storage->make_data_or_index_sink(_sst, component_type::Index).get();
-        _index_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), _sst.index_filename());
+        _index_writer = std::make_unique<crc32_digest_file_writer>(std::move(out), _sst.sstable_buffer_size, _sst.index_filename());
     }
     if (_sst.has_component(component_type::Partitions) && _sst.has_component(component_type::Rows)) {
         out = _sst._storage->make_data_or_index_sink(_sst, component_type::Rows).get();
-        _rows_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), component_name(_sst, component_type::Rows));
+        _rows_writer = std::make_unique<crc32_digest_file_writer>(std::move(out), _sst.sstable_buffer_size, component_name(_sst, component_type::Rows));
         _bti_row_index_writer = trie::bti_row_index_writer(*_rows_writer);
         out = _sst._storage->make_data_or_index_sink(_sst, component_type::Partitions).get();
-        _partitions_writer = std::make_unique<file_writer>(output_stream<char>(std::move(out)), component_name(_sst, component_type::Partitions));
+        _partitions_writer = std::make_unique<crc32_digest_file_writer>(std::move(out), _sst.sstable_buffer_size, component_name(_sst, component_type::Partitions));
         _bti_partition_index_writer = trie::bti_partition_index_writer(*_partitions_writer);
     }
     if (_delayed_filter) {
@@ -975,6 +976,12 @@ std::unique_ptr<file_writer> writer::close_writer(std::unique_ptr<file_writer>& 
     return writer;
 }
 
+uint32_t writer::close_digest_writer(std::unique_ptr<file_writer>& w) {
+    auto writer = close_writer(w);
+    auto chksum_wr = static_cast<crc32_digest_file_writer*>(writer.get());
+    return chksum_wr->full_checksum();
+}
+
 void writer::close_data_writer() {
     auto writer = close_writer(_data_writer);
     if (!_compression_enabled) {
@@ -988,7 +995,7 @@ void writer::close_data_writer() {
 
 void writer::close_index_writer() {
     if (_index_writer) {
-        close_writer(_index_writer);
+        _sst.get_components_digests().map[component_type::Index] = close_digest_writer(_index_writer);
     }
 }
 
@@ -998,7 +1005,7 @@ void writer::close_partitions_writer() {
             _sst.get_version(),
             _first_key.value(),
             _last_key.value());
-        close_writer(_partitions_writer);
+        _sst.get_components_digests().map[component_type::Partitions] = close_digest_writer(_partitions_writer);
     }
 }
 
@@ -1011,7 +1018,7 @@ void writer::close_rows_writer() {
         // upload to be a no-op, which breaks some assumptions).
         uint32_t garbage = seastar::cpu_to_be(0x13371337);
         _rows_writer->write(reinterpret_cast<const char*>(&garbage), sizeof(garbage));
-        close_writer(_rows_writer);
+        _sst.get_components_digests().map[component_type::Rows] = close_digest_writer(_rows_writer);
     }
 }
 

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -965,7 +965,7 @@ void writer::init_file_writers() {
         file_output_stream_options options;
         options.buffer_size = 32 * 1024;
         _hashes_writer = std::make_unique<file_writer>(_sst.make_component_file_writer(component_type::TemporaryHashes, std::move(options),
-            open_flags::wo | open_flags::create | open_flags::exclusive).get());
+            sstable_write_open_flags).get());
     }
 }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -641,7 +641,7 @@ future<sstring> sstable_directory::create_pending_deletion_log(opened_directory&
         dirlog.trace("Writing {}", tmp_pending_delete_log);
 
             touch_directory(pending_delete_dir).get();
-            auto oflags = open_flags::wo | open_flags::create | open_flags::exclusive;
+            auto oflags = sstable_write_open_flags;
             // Create temporary pending_delete log file.
             auto f = open_file_dma(tmp_pending_delete_log, oflags).get();
             // Write all toc names into the log file.

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1516,7 +1516,7 @@ future<> sstable::update_info_for_opened_data(sstable_open_config cfg) {
 }
 
 future<> sstable::create_data() noexcept {
-    auto oflags = open_flags::wo | open_flags::create | open_flags::exclusive;
+    auto oflags = sstable_write_open_flags;
     file_open_options opt;
     opt.extent_allocation_size_hint = 32 << 20;
     opt.sloppy_size = true;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -171,6 +171,7 @@ std::unique_ptr<crc32_digest_file_writer> make_calculate_digest_writer() noexcep
     return std::make_unique<crc32_digest_file_writer>(make_null_data_sink(default_sstable_buffer_size), default_sstable_buffer_size);
 }
 
+// Must be called in a seastar thread.
 template <typename T>
 uint32_t serialized_checksum(sstable_version_types v, const T& object) {
     auto writer = make_calculate_digest_writer();
@@ -578,6 +579,16 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
     s.positions.pop_back();
 }
 
+future<> parse(const schema& s, sstable_version_types v, random_access_reader& in, scylla_metadata& metadata) {
+    co_await parse(s, v, in, metadata.data);
+    auto it = metadata.data.get<scylla_metadata_type::ComponentsDigests, scylla_metadata::components_digests>();
+    // if metadata contains component digests, also parse its own digest
+    if (it) {
+        metadata.digest.emplace();
+        co_await parse(s, v, in, metadata.digest.value());
+    }
+}
+
 inline void write(sstable_version_types v, file_writer& out, const summary_entry& entry) {
     // FIXME: summary entry is supposedly written in memory order, but that
     // would prevent portability of summary file between machines of different
@@ -600,6 +611,11 @@ inline void write(sstable_version_types v, file_writer& out, const summary& s) {
     }
     write(v, out, s.entries);
     write(v, out, s.first_key, s.last_key);
+}
+
+inline void write(sstable_version_types v, file_writer& out, const scylla_metadata& s) {
+    write(v, out, s.data);
+    write(v, out, s.digest.value());
 }
 
 future<summary_entry&> sstable::read_summary_entry(size_t i) {
@@ -983,10 +999,10 @@ void sstable::open_sstable(const sstring& origin) {
     _storage->open(*this);
 }
 
-void sstable::write_toc(file_writer w) {
+void sstable::write_toc(std::unique_ptr<crc32_digest_file_writer> w) {
     sstlog.debug("Writing TOC file {} ", toc_filename());
 
-    do_write_simple(w, [&] (version_types v, file_writer& w) {
+    do_write_simple(*w, [&] (version_types v, file_writer& w) {
         for (auto&& key : _recognized_components) {
             // new line character is appended to the end of each component name.
             auto value = sstable_version_constants::get_component_map(v).at(key) + "\n";
@@ -994,6 +1010,8 @@ void sstable::write_toc(file_writer w) {
             write(v, w, b);
         }
     });
+
+    _components_digests.map[component_type::TOC] = w->full_checksum();
 }
 
 void sstable::write_crc(const checksum& c) {
@@ -1010,6 +1028,7 @@ void sstable::write_digest(uint32_t full_checksum) {
         auto digest = to_sstring<bytes>(full_checksum);
         write(v, w, digest);
     }, buffer_size);
+    _components_digests.map[component_type::Data] = full_checksum;
 }
 
 thread_local std::array<std::vector<int>, downsampling::BASE_SAMPLING_LEVEL> downsampling::_sample_pattern_cache;
@@ -1133,7 +1152,8 @@ void sstable::write_compression() {
         return;
     }
 
-    write_simple<component_type::CompressionInfo>(_components->compression);
+    auto digest = write_simple_with_digest<component_type::CompressionInfo>(_components->compression);
+    _components_digests.map[component_type::CompressionInfo] = digest;
 }
 
 void sstable::validate_partitioner() {
@@ -1358,11 +1378,30 @@ future<> sstable::read_partitions_db_footer() {
 }
 
 void sstable::write_statistics() {
-    write_simple<component_type::Statistics>(_components->statistics);
+    auto digest = write_simple_with_digest<component_type::Statistics>(_components->statistics);
+    _components_digests.map[component_type::Statistics] = digest;
 }
 
 void sstable::mark_as_being_repaired(const service::session_id& id) {
     being_repaired = id;
+}
+
+std::optional<uint32_t> sstable::get_component_digest(component_type c) const {
+    if (!has_scylla_component()) {
+        return std::nullopt;
+    }
+    if (c == component_type::Scylla) {
+        return _components->scylla_metadata->digest;
+    }
+    const auto* cd = _components->scylla_metadata->get_components_digests();
+    if (!cd) {
+        return std::nullopt;
+    }
+    auto it = cd->map.find(c);
+    if (it == cd->map.end()) {
+        return std::nullopt;
+    }
+    return it->second;
 }
 
 int64_t sstable::update_repaired_at(int64_t repaired_at) {
@@ -1391,14 +1430,18 @@ bool sstable::should_update_repaired_at(int64_t repaired_at) const {
 // This efficiently creates a modified SSTable without copying all files.
 // 1. Create a new SSTable object with a new generation number
 //    - The creator function determines the new generation
-// 2. Hard-link all components EXCEPT the one being rewritten and optionally the Scylla component (if update_sstable_id is true)
+// 2. Hard-link all components EXCEPT the one being rewritten and Scylla metadata
 //    - The component being rewritten will be written fresh (not linked)
-// 3. Copy in-memory components from the source SSTable
+//    - Scylla metadata must be rewritten to include the new component's digest
+// 3. Copy in-memory component metadata from the source SSTable
 //    - This doesn't deep copy _components, just copies the foreign_ptr
 // 4. Apply the modifier function to the new SSTable's components
-// 5. If update_sstable_id is true, read scylla metadata and change sstable_id
-// 6. Write the component being rewritten (and optionally the Scylla component if update_sstable_id is true) to the new SSTable
-// 7. Finalize the new SSTable
+// 5. Re-read the Scylla metadata from disk
+//    - Ensures we have the latest on-disk metadata (not potentially modified in-memory state)
+// 6. If update_sstable_id is true, update the Scylla metadata's sstable identifier to a new value
+// 7. Write the component with updated Scylla metadata
+//    - Uses write_component_with_metadata() which handles digest calculation and metadata updates
+// 8. Finalize the new SSTable
 //    - Copy sharding information, seal the SSTable, and open data files
 future<shared_sstable> sstable::link_with_rewritten_component(std::function<shared_sstable(shared_sstable)> sstable_creator,
         component_type component,
@@ -1420,26 +1463,20 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
         auto new_sst = creator(shared_from_this());
         auto generation = new_sst->generation();
 
-        std::unordered_set<component_type> excluded_components = {component};
-        if (update_sstable_id) {
-            excluded_components.insert(component_type::Scylla);
-        }
-
-        _storage->link_with_excluded_components(*this, generation, excluded_components).get();
+        _storage->link_with_excluded_components(*this, generation, {component, component_type::Scylla}).get();
         new_sst->copy_components(*this).get();
 
         modifier(*new_sst);
 
+        // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
+        // If unchanged, reuse the existing _components->scylla_metadata instead.
+        scylla_metadata metadata;
+        read_simple<component_type::Scylla>(metadata).get();
         if (update_sstable_id) {
-            // FIXME: Optimize by re-reading metadata only if _components->scylla_metadata was modified after loading.
-            // If unchanged, reuse the existing _components->scylla_metadata instead.
-            scylla_metadata metadata;
-            read_simple<component_type::Scylla>(metadata).get();
             metadata.set_sstable_identifier();
-            new_sst->write_component_with_metadata(component, std::move(metadata));
-        } else {
-            new_sst->write_component(component);
         }
+
+        new_sst->write_component_with_metadata(component, std::move(metadata));
 
         new_sst->_shards = this->_shards;
         new_sst->seal_sstable(false).get();
@@ -1450,12 +1487,24 @@ future<shared_sstable> sstable::link_with_rewritten_component(std::function<shar
     });
 }
 
+// Rewrites a single SSTable component along with updated Scylla metadata.
+// This is used when modifying components (e.g., Statistics) without rewriting the entire SSTable.
+// 1. Write the component file (e.g., Statistics-*.db)
+//    - This calculates and stores the component's digest in _components_digests.map[type]
+// 2. Update the Scylla metadata's ComponentsDigests map with the new component digest
+// 3. Calculate the Scylla metadata's own digest based on its updated data
+// 4. Write the Scylla metadata component file
+// 5. Set the in-memory Scylla metadata to the new metadata
 void sstable::write_component_with_metadata(component_type type, scylla_metadata metadata) {
     if (!is_component_rewrite_supported(type)) {
         on_internal_error(sstlog, "Only Statistics component can be rewritten.");
     }
 
     write_component(type);
+
+    metadata.get_or_create_components_digests().map[type] = _components_digests.map[type];
+    metadata.digest = serialized_checksum(_version, metadata.data);
+
     write_simple<component_type::Scylla>(metadata);
 
     _components->scylla_metadata = std::move(metadata);
@@ -1650,7 +1699,8 @@ void sstable::write_filter() {
 
     auto&& bs = f->bits();
     auto filter_ref = sstables::filter_ref(f->num_hashes(), bs.get_storage());
-    write_simple<component_type::Filter>(filter_ref);
+    auto digest = write_simple_with_digest<component_type::Filter>(filter_ref);
+    _components_digests.map[component_type::Filter] = digest;
 }
 
 void sstable::maybe_rebuild_filter_from_index(uint64_t num_partitions) {
@@ -2129,6 +2179,7 @@ sstable::read_scylla_metadata() noexcept {
         }
         return read_simple<component_type::Scylla>(*_components->scylla_metadata).then([this] {
             _features = _components->scylla_metadata->get_features();
+            _components->digest = get_component_digest(component_type::Data);
         });
     });
 }
@@ -2218,6 +2269,9 @@ sstable::write_scylla_metadata(shard_id shard, struct run_identifier identifier,
         sstable_schema.columns.elements.push_back(sstable_column_description{to_sstable_column_kind(col.kind), {col.name()}, {to_bytes(col.type->name())}});
     }
     _components->scylla_metadata->data.set<scylla_metadata_type::Schema>(std::move(sstable_schema));
+    _components->scylla_metadata->data.set<scylla_metadata_type::ComponentsDigests>(scylla_metadata::components_digests{_components_digests});
+
+    _components->scylla_metadata->digest = serialized_checksum(_version, _components->scylla_metadata->data);
 
     write_simple<component_type::Scylla>(*_components->scylla_metadata);
 }
@@ -3974,6 +4028,8 @@ future<std::vector<std::unique_ptr<sstable_stream_source>>> create_stream_source
                 std::vector<temporary_buffer<char>> bufs;
 
                 co_await seastar::async([&] {
+                    tmp.get_or_create_components_digests();
+                    tmp.digest = serialized_checksum(_sst->get_version(), tmp.data);
                     using buffer_data_sink_impl = seastar::util::basic_memory_data_sink<decltype(bufs), 128*1024>;
                     file_writer fw(data_sink(std::make_unique<buffer_data_sink_impl>(bufs)));
                     write(_sst->get_version(), fw, tmp);
@@ -4062,11 +4118,15 @@ private:
         if (!_sst->get_shared_components().scylla_metadata) {
             co_return;
         }
+        auto& metadata = *_sst->get_shared_components().scylla_metadata;
+
         file_output_stream_options options;
         options.buffer_size = default_sstable_buffer_size;
         co_await seastar::async([&] {
+            metadata.get_or_create_components_digests();
+            metadata.digest = serialized_checksum(_sst->get_version(), metadata.data);
             auto w = _sst->make_component_file_writer(component_type::Scylla, std::move(options), open_flags::wo | open_flags::create).get();
-            write(_sst->get_version(), w, *_sst->get_shared_components().scylla_metadata);
+            write(_sst->get_version(), w, metadata);
             w.close();
         });
     }

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -722,9 +722,6 @@ private:
 
     future<> read_statistics();
     void write_statistics();
-    // Rewrite statistics component by creating a temporary Statistics and
-    // renaming it into place of existing one.
-    void rewrite_statistics();
     // Validate metadata that's used to optimize reads when user specifies
     // a clustering key range. If this specific metadata is incorrect, then
     // it should be cleared. Otherwise, it could lead to bad decisions.
@@ -1019,7 +1016,8 @@ public:
         return _components->compression;
     }
 
-    future<> mutate_sstable_level(uint32_t);
+    void mutate_sstable_level(uint32_t);
+    bool should_mutate_sstable_level(uint32_t) const;
 
     const summary& get_summary() const {
         return _components->summary;
@@ -1134,10 +1132,9 @@ public:
     service::session_id being_repaired;
 public:
     void mark_as_being_repaired(const service::session_id& id);
-    // This function must run inside a seastar thread since it calls
-    // rewrite_statistics which must run inside a seastar thread.
     int64_t update_repaired_at(int64_t repaired_at);
     future<> copy_components(const sstable& src);
+    bool should_update_repaired_at(int64_t repaired_at) const;
 
     // Creates a new sstable by linking all sstable components except for the specified component,
     // which is created by calling the provided sstable_creator function and then written to the disc.

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "sstables/writer.hh"
 #include "version.hh"
 #include "shared_sstable.hh"
 #include "open_info.hh"
@@ -652,9 +653,15 @@ private:
 
     template <component_type Type, typename T>
     void write_simple(const T& comp);
-    void do_write_simple(file_writer&& writer,
+    void do_write_simple(file_writer& writer,
                          noncopyable_function<void (version_types, file_writer&)> write_component);
     void do_write_simple(component_type type,
+            noncopyable_function<void (version_types version, file_writer& writer)> write_component,
+            unsigned buffer_size);
+
+    template <component_type Type, typename T>
+    uint32_t write_simple_with_digest(const T& comp);
+    uint32_t do_write_simple_with_digest(component_type type,
             noncopyable_function<void (version_types version, file_writer& writer)> write_component,
             unsigned buffer_size);
 
@@ -666,6 +673,9 @@ private:
     future<> unlink_component(component_type type) noexcept;
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
+            open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
+
+    future<std::unique_ptr<crc32_digest_file_writer>> make_digests_component_file_writer(component_type c, file_output_stream_options options,
             open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
 
     void generate_toc();

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -182,6 +182,8 @@ inline fs::path make_path(std::string_view table_dir, sstable_state state) {
 
 constexpr const char* repair_origin = "repair";
 
+const open_flags sstable_write_open_flags = open_flags::wo | open_flags::create | open_flags::exclusive;
+
 class delayed_commit_changes {
     std::unordered_set<sstring> _dirs;
     friend class filesystem_storage;
@@ -673,10 +675,10 @@ private:
     future<> unlink_component(component_type type) noexcept;
 
     future<file_writer> make_component_file_writer(component_type c, file_output_stream_options options,
-            open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
+            open_flags oflags = sstable_write_open_flags) noexcept;
 
     future<std::unique_ptr<crc32_digest_file_writer>> make_digests_component_file_writer(component_type c, file_output_stream_options options,
-            open_flags oflags = open_flags::wo | open_flags::create | open_flags::exclusive) noexcept;
+            open_flags oflags = sstable_write_open_flags) noexcept;
 
     void generate_toc();
     void open_sstable(const sstring& origin);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "sstables/writer.hh"
 #include "version.hh"
 #include "shared_sstable.hh"
 #include "open_info.hh"
@@ -66,6 +65,11 @@ class corrupt_data_handler;
 }
 
 namespace sstables {
+
+template <typename ChecksumType, bool calculate_chunk_checksums>
+requires ChecksumUtils<ChecksumType>
+class checksummed_file_writer;
+using crc32_digest_file_writer = checksummed_file_writer<crc32_utils, false>;
 
 struct abstract_index_reader;
 class sstable_directory;
@@ -636,6 +640,8 @@ private:
     // with linking or moving the sstable between directories.
     mutable named_semaphore _mutate_sem{1, named_semaphore_exception_factory{"sstable mutate"}};
     std::optional<sstring> _cloned_to_sstable_filename;
+    // Used only for writing sstable.
+    scylla_metadata::components_digests _components_digests;
 public:
     bool has_component(component_type f) const;
     sstables_manager& manager() { return _manager; }
@@ -711,7 +717,8 @@ private:
     future<> read_summary() noexcept;
 
     void write_summary() {
-        write_simple<component_type::Summary>(_components->summary);
+        auto digest = write_simple_with_digest<component_type::Summary>(_components->summary);
+        _components_digests.map[component_type::Summary] = digest;
     }
 
     // To be called when we try to load an SSTable that lacks a Summary. Could
@@ -760,6 +767,7 @@ private:
     void disable_component_memory_reload();
 
     static bool is_component_rewrite_supported(component_type type);
+    // Must be called in a seastar thread
     void write_component(component_type type);
 public:
     // Finds first position_in_partition in a given partition.
@@ -840,7 +848,7 @@ private:
 
     future<> open_or_create_data(open_flags oflags, file_open_options options = {}) noexcept;
     // runs in async context (called from storage::open)
-    void write_toc(file_writer w);
+    void write_toc(std::unique_ptr<crc32_digest_file_writer> w);
     static future<uint32_t> read_digest_from_file(file f);
     static future<lw_shared_ptr<checksum>> read_checksum_from_file(file f);
 public:
@@ -1030,6 +1038,13 @@ public:
     std::optional<uint32_t> get_digest() const {
         return _components->digest;
     }
+
+    // Used only for writing sstable.
+    scylla_metadata::components_digests& get_components_digests() {
+        return _components_digests;
+    }
+
+    std::optional<uint32_t> get_component_digest(component_type c) const;
 
     // Gets ratio of droppable tombstone. A tombstone is considered droppable here
     // for cells and tombstones expired before the time point "GC before", which

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -215,13 +215,13 @@ void filesystem_storage::open(sstable& sst) {
                                     open_flags::create |
                                     open_flags::exclusive,
                                     options).get();
-    auto w = file_writer(output_stream<char>(std::move(sink)), component_name(sst, component_type::TemporaryTOC));
+    auto w = std::make_unique<crc32_digest_file_writer>(std::move(sink), sst.sstable_buffer_size, component_name(sst, component_type::TemporaryTOC));
 
     bool toc_exists = file_exists(fmt::to_string(sst.filename(component_type::TOC))).get();
     if (toc_exists) {
         // TOC will exist at this point if write_components() was called with
         // the generation of a sstable that exists.
-        w.close();
+        w->close();
         remove_file(fmt::to_string(sst.filename(component_type::TemporaryTOC))).get();
         throw std::runtime_error(format("SSTable write failed due to existence of TOC file for generation {} of {}.{}", sst._generation, sst._schema->ks_name(), sst._schema->cf_name()));
     }
@@ -714,15 +714,10 @@ void object_storage_base::open(sstable& sst) {
     sst.manager().sstables_registry().create_entry(owner(), status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
-    sst.write_toc(
-        file_writer(
-            output_stream<char>(
-                data_sink(
-                    std::make_unique<memory_data_sink>(bufs)
-                )
-            )
-        )
-    );
+    auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
+    auto w = std::make_unique<crc32_digest_file_writer>(std::move(out), sst.sstable_buffer_size, component_name(sst, component_type::TOC));
+
+    sst.write_toc(std::move(w));
     put_object(make_object_name(sst, component_type::TOC), std::move(bufs)).get();
 }
 

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -93,6 +93,12 @@ class storage {
     }
 
 public:
+    // Clone an sstable to a new generation, hard-linking all components except those in excluded_components.
+    // The new sstable is created with a TemporaryTOC, so it will be removed on restart if not sealed.
+    virtual future<> link_with_excluded_components(const sstable& sst, generation_type new_gen,
+            const std::unordered_set<component_type>& excluded_components) const {
+        SCYLLA_ASSERT(false && "link_with_excluded_components not implemented");
+    }
     virtual ~storage() {}
 
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -691,6 +691,9 @@ struct scylla_metadata {
         auto* sid = data.get<scylla_metadata_type::SSTableIdentifier, scylla_metadata::sstable_identifier>();
         return sid ? sid->value : sstable_id::create_null_id();
     }
+    void set_sstable_identifier(sstable_id sid = sstable_id{utils::UUID_gen::get_time_UUID()}) {
+        data.set<scylla_metadata_type::SSTableIdentifier>(scylla_metadata::sstable_identifier{sid});
+    }
 
     template <typename Describer>
     auto describe_type(sstable_version_types v, Describer f) { return f(data); }

--- a/sstables/types.hh
+++ b/sstables/types.hh
@@ -547,6 +547,7 @@ enum class scylla_metadata_type : uint32_t {
     ExtTimestampStats = 9,
     SSTableIdentifier = 10,
     Schema = 11,
+    ComponentsDigests = 12,
 };
 
 // UUID is used for uniqueness across nodes, such that an imported sstable
@@ -644,6 +645,7 @@ struct scylla_metadata {
     using ext_timestamp_stats = disk_hash<uint32_t, ext_timestamp_stats_type, int64_t>;
     using sstable_identifier = sstable_identifier_type;
     using sstable_schema = sstable_schema_type;
+    using components_digests = disk_hash<uint32_t, component_type, uint32_t>;
 
     disk_set_of_tagged_union<scylla_metadata_type,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Sharding, sharding_metadata>,
@@ -656,8 +658,10 @@ struct scylla_metadata {
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ScyllaVersion, scylla_version>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ExtTimestampStats, ext_timestamp_stats>,
             disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::SSTableIdentifier, sstable_identifier>,
-            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Schema, sstable_schema>
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::Schema, sstable_schema>,
+            disk_tagged_union_member<scylla_metadata_type, scylla_metadata_type::ComponentsDigests, components_digests>
             > data;
+    std::optional<uint32_t> digest;
 
     sstable_enabled_features get_features() const {
         auto features = data.get<scylla_metadata_type::Features, sstable_enabled_features>();
@@ -694,9 +698,17 @@ struct scylla_metadata {
     void set_sstable_identifier(sstable_id sid = sstable_id{utils::UUID_gen::get_time_UUID()}) {
         data.set<scylla_metadata_type::SSTableIdentifier>(scylla_metadata::sstable_identifier{sid});
     }
-
-    template <typename Describer>
-    auto describe_type(sstable_version_types v, Describer f) { return f(data); }
+    components_digests& get_or_create_components_digests() {
+        auto* cd = data.get<scylla_metadata_type::ComponentsDigests, components_digests>();
+        if (!cd) {
+            data.set<scylla_metadata_type::ComponentsDigests>(components_digests{});
+            cd = data.get<scylla_metadata_type::ComponentsDigests, components_digests>();
+        }
+        return *cd;
+    }
+    const components_digests* get_components_digests() const {
+        return data.get<scylla_metadata_type::ComponentsDigests, components_digests>();
+    }
 };
 
 static constexpr int DEFAULT_CHUNK_SIZE = 65536;

--- a/sstables/writer.hh
+++ b/sstables/writer.hh
@@ -65,7 +65,7 @@ serialized_size(sstable_version_types v, const T& object) {
     return size;
 }
 
-template <typename ChecksumType>
+template <typename ChecksumType, bool calculate_chunk_checksums>
 requires ChecksumUtils<ChecksumType>
 class checksummed_file_data_sink_impl : public data_sink_impl {
     data_sink _out;
@@ -92,7 +92,9 @@ public:
 
                 per_chunk_checksum = ChecksumType::checksum(per_chunk_checksum, buf.begin() + offset, size);
                 _full_checksum = checksum_combine_or_feed<ChecksumType>(_full_checksum, per_chunk_checksum, buf.begin() + offset, size);
-                _c.checksums.push_back(per_chunk_checksum);
+                if constexpr (calculate_chunk_checksums) {
+                    _c.checksums.push_back(per_chunk_checksum);
+                }
             }
         }
         return _out.put(std::move(bufs));
@@ -112,29 +114,29 @@ public:
     }
 };
 
-template <typename ChecksumType>
+template <typename ChecksumType, bool calculate_chunk_checksums>
 requires ChecksumUtils<ChecksumType>
 class checksummed_file_data_sink : public data_sink {
 public:
     checksummed_file_data_sink(data_sink out, struct checksum& cinfo, uint32_t& full_file_checksum)
-        : data_sink(std::make_unique<checksummed_file_data_sink_impl<ChecksumType>>(std::move(out), cinfo, full_file_checksum)) {}
+        : data_sink(std::make_unique<checksummed_file_data_sink_impl<ChecksumType, calculate_chunk_checksums>>(std::move(out), cinfo, full_file_checksum)) {}
 };
 
-template <typename ChecksumType>
+template <typename ChecksumType, bool calculate_chunk_checksums>
 requires ChecksumUtils<ChecksumType>
 inline
 output_stream<char> make_checksummed_file_output_stream(data_sink out, struct checksum& cinfo, uint32_t& full_file_checksum) {
-    return output_stream<char>(checksummed_file_data_sink<ChecksumType>(std::move(out), cinfo, full_file_checksum));
+    return output_stream<char>(checksummed_file_data_sink<ChecksumType, calculate_chunk_checksums>(std::move(out), cinfo, full_file_checksum));
 }
 
-template <typename ChecksumType>
+template <typename ChecksumType, bool calculate_chunk_checksums>
 requires ChecksumUtils<ChecksumType>
 class checksummed_file_writer : public file_writer {
     checksum _c;
     uint32_t _full_checksum;
 public:
     checksummed_file_writer(data_sink out, size_t buffer_size, component_name c)
-            : file_writer(make_checksummed_file_output_stream<ChecksumType>(std::move(out), _c, _full_checksum), std::move(c))
+            : file_writer(make_checksummed_file_output_stream<ChecksumType, calculate_chunk_checksums>(std::move(out), _c, _full_checksum), std::move(c))
             , _c(uint32_t(std::min(size_t(DEFAULT_CHUNK_SIZE), buffer_size)), {})
             , _full_checksum(ChecksumType::init_checksum()) {}
 
@@ -152,8 +154,10 @@ public:
     }
 };
 
-using adler32_checksummed_file_writer = checksummed_file_writer<adler32_utils>;
-using crc32_checksummed_file_writer = checksummed_file_writer<crc32_utils>;
+using adler32_checksummed_file_writer = checksummed_file_writer<adler32_utils, true>;
+using crc32_checksummed_file_writer = checksummed_file_writer<crc32_utils, true>;
+
+using crc32_digest_file_writer = checksummed_file_writer<crc32_utils, false>;
 
 template <typename T, typename W>
 requires Writer<W>

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -111,6 +111,7 @@ public:
     virtual reader_permit make_compaction_reader_permit() const override { return _semaphore.make_permit(); }
     virtual sstables::sstables_manager& get_sstables_manager() noexcept override { return _sst_man; }
     virtual sstables::shared_sstable make_sstable(sstables::sstable_state) const override { return _sstable_factory(); }
+    virtual sstables::shared_sstable make_sstable(sstables::sstable_state, sstables::sstable_version_types) const override { return _sstable_factory(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return _sst_man.configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
     virtual api::timestamp_type min_memtable_live_timestamp() const override { return api::min_timestamp; }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5128,6 +5128,9 @@ struct large_row_handler : public db::large_data_handler {
     virtual future<> delete_large_data_entries(const schema& s, sstring sstable_name, std::string_view) const override {
         return make_ready_future<>();
     }
+    virtual future<> update_large_data_entries_sstable_name(const schema& s, sstring old_name, sstring new_name, std::string_view large_table_name) const override {
+        return make_ready_future<>();
+    }
 };
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6384,4 +6384,155 @@ SEASTAR_TEST_CASE(failure_when_adding_new_sstable_test) {
     });
 }
 
+static future<> test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id update_id) {
+    return test_env::do_with_async([update_id] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+        auto pk = ss.make_pkey();
+
+        auto mut1 = mutation(s, pk);
+        mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+        auto original_sst = make_sstable_containing(env.make_sstable(s), {mut1});
+
+        BOOST_REQUIRE(original_sst->get_sstable_level() == 0);
+
+        auto table = env.make_table_for_tests(s);
+        auto close_table = deferred_stop(table);
+
+        table->add_sstable_and_update_cache(original_sst).get();
+
+        auto all_sstables = table->get_sstables();
+        BOOST_REQUIRE(all_sstables->size() == 1);
+        BOOST_REQUIRE(all_sstables->contains(original_sst));
+
+        auto& cm = table->get_compaction_manager();
+
+        uint32_t new_level = 5;
+        auto modifier = [new_level] (sstable& sst) {
+            sst.mutate_sstable_level(new_level);
+        };
+
+        auto& compaction_group_view = table->compaction_group_view_for_sstable(original_sst);
+
+        std::vector<sstables::shared_sstable> sstables_to_rewrite = {original_sst};
+        auto rewritten_map = cm.perform_component_rewrite(compaction_group_view,
+                                                          tasks::task_info{},
+                                                          std::move(sstables_to_rewrite),
+                                                          component_type::Statistics,
+                                                          std::move(modifier),
+                                                          update_id).get();
+
+        BOOST_REQUIRE(rewritten_map.size() == 1);
+        auto it = rewritten_map.find(original_sst);
+        BOOST_REQUIRE(it != rewritten_map.end());
+
+        auto new_sst = it->second;
+        BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
+        BOOST_REQUIRE(new_sst->generation() != original_sst->generation());
+        if (update_id) {
+            BOOST_REQUIRE(new_sst->sstable_identifier() != original_sst->sstable_identifier());
+        } else {
+            BOOST_REQUIRE(new_sst->sstable_identifier() == original_sst->sstable_identifier());
+        }
+
+        all_sstables = table->get_sstables();
+        BOOST_REQUIRE(all_sstables->size() == 1);
+        BOOST_REQUIRE(!all_sstables->contains(original_sst));
+        BOOST_REQUIRE(all_sstables->contains(new_sst));
+    });
+}
+
+SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_with_backup) {
+    return test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id::yes);
+}
+
+SEASTAR_TEST_CASE(test_perform_component_rewrite_single_sstable_without_backup) {
+    return test_perform_component_rewrite_single_sstable(compaction::compaction_type_options::component_rewrite::update_sstable_id::no);
+}
+
+SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
+    return test_env::do_with_async([] (test_env& env) {
+        simple_schema ss;
+        auto s = ss.schema();
+
+        // Generate 10 sstables
+        std::vector<sstables::shared_sstable> all_sstables;
+        for (int i = 0; i < 10; ++i) {
+            auto pk = ss.make_pkey(i);
+            auto mut = mutation(s, pk);
+            mut.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
+            auto sst = make_sstable_containing(env.make_sstable(s), {mut});
+            all_sstables.push_back(sst);
+        }
+
+        auto table = env.make_table_for_tests(s);
+        auto close_table = deferred_stop(table);
+
+        table->disable_auto_compaction().get();
+
+        for (auto& sst : all_sstables) {
+            table->add_sstable_and_update_cache(sst).get();
+        }
+
+        auto current_sstables = table->get_sstables();
+        BOOST_REQUIRE(current_sstables->size() == 10);
+
+        std::vector<sstables::shared_sstable> sstables_to_rewrite;
+        std::vector<sstables::shared_sstable> sstables_to_keep;
+        for (int i = 0; i < 10; ++i) {
+            if (i % 2 == 0) {
+                sstables_to_rewrite.push_back(all_sstables[i]);
+            } else {
+                sstables_to_keep.push_back(all_sstables[i]);
+            }
+        }
+
+        BOOST_REQUIRE(sstables_to_rewrite.size() == 5);
+        BOOST_REQUIRE(sstables_to_keep.size() == 5);
+
+        std::map<compaction::compaction_group_view*, std::vector<sstables::shared_sstable>> groups;
+        for (auto& sst : sstables_to_rewrite) {
+            auto& cg_view = table->compaction_group_view_for_sstable(sst);
+            groups[&cg_view].push_back(sst);
+        }
+
+        auto& cm = table->get_compaction_manager();
+        uint32_t new_level = 3;
+
+        std::map<sstables::shared_sstable, sstables::shared_sstable> merged_rewritten_map;
+        for (auto& [cg_view, ssts] : groups) {
+            auto modifier = [new_level] (sstable& sst) {
+                sst.mutate_sstable_level(new_level);
+            };
+            auto rewritten_map = cm.perform_component_rewrite(*cg_view,
+                                                              tasks::task_info{},
+                                                              std::move(ssts),
+                                                              component_type::Statistics,
+                                                              std::move(modifier)).get();
+            merged_rewritten_map.insert(rewritten_map.begin(), rewritten_map.end());
+        }
+
+        BOOST_REQUIRE(merged_rewritten_map.size() == 5);
+        for (const auto& [old_sst, new_sst] : merged_rewritten_map) {
+            BOOST_REQUIRE(new_sst->get_sstable_level() == new_level);
+            BOOST_REQUIRE(new_sst->generation() != old_sst->generation());
+        }
+
+        // Verify the table now contains exactly 10 sstables
+        current_sstables = table->get_sstables();
+        BOOST_REQUIRE(current_sstables->size() == 10);
+
+        // Verify that the 5 rewritten sstables were replaced
+        for (const auto& [old_sst, new_sst] : merged_rewritten_map) {
+            BOOST_REQUIRE(current_sstables->contains(new_sst));
+            BOOST_REQUIRE(!current_sstables->contains(old_sst));
+        }
+
+        // Verify that the 5 sstables we didn't rewrite still exist
+        for (auto& sst : sstables_to_keep) {
+            BOOST_REQUIRE(current_sstables->contains(sst));
+        }
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -402,7 +402,7 @@ SEASTAR_TEST_CASE(wrong_range) {
     });
 }
 
-future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const std::string& dir_path, uint32_t new_level) {
+future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const std::string& dir_path, uint32_t new_level, bool update_sstable_id = false) {
     auto modifier = [new_level] (sstables::sstable& sst) {
         sst.mutate_sstable_level(new_level);
     };
@@ -410,7 +410,7 @@ future<sstable_ptr> mutate_sstable_level(test_env& env, sstable_ptr sstp, const 
         return env.make_sstable(sstp->get_schema(), dir_path, sstp->get_version());
     };
 
-    auto new_sst = co_await sstp->link_with_rewritten_component(std::move(creator), component_type::Statistics, modifier, false);
+    auto new_sst = co_await sstp->link_with_rewritten_component(std::move(creator), component_type::Statistics, modifier, update_sstable_id);
     co_await sstp->unlink();
     sstp = new_sst;
 
@@ -903,4 +903,113 @@ BOOST_AUTO_TEST_CASE(test_parse_path_bad) {
     for (auto path : paths) {
         BOOST_CHECK_THROW(parse_path(path), std::exception);
     }
+}
+
+using compress_sstable = tests::random_schema_specification::compress_sstable;
+static future<> test_component_digest_persistence(component_type component, sstable::version_types version, compress_sstable compress = compress_sstable::no, bool rewrite_statistics = false) {
+    return test_env::do_with_async([component, version, compress, rewrite_statistics] (test_env& env) mutable {
+        auto random_spec = tests::make_random_schema_specification(
+            "ks",
+            std::uniform_int_distribution<size_t>(1, 4),
+            std::uniform_int_distribution<size_t>(2, 4),
+            std::uniform_int_distribution<size_t>(2, 8),
+            std::uniform_int_distribution<size_t>(2, 8),
+            compress);
+        auto random_schema = tests::random_schema{tests::random::get_int<uint32_t>(), *random_spec};
+        auto schema = random_schema.schema();
+
+        const auto muts = tests::generate_random_mutations(random_schema, 2).get();
+        auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts);
+
+        auto& components = sstables::test(sst_original).get_components();
+        bool has_component = components.find(component) != components.end();
+        BOOST_REQUIRE(has_component);
+
+        auto toc_path = fmt::to_string(sst_original->toc_filename());
+        auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name());
+        auto dir_path = std::filesystem::path(toc_path).parent_path().string();
+
+        std::optional<uint32_t> original_digest;
+        if (rewrite_statistics) {
+            auto original_sstable_id = sst_original->sstable_identifier();
+            original_digest = sst_original->get_component_digest(component);
+            BOOST_REQUIRE(original_digest.has_value());
+
+            sst_original = mutate_sstable_level(env, sst_original, dir_path, 10, true).get();
+            entry_desc.generation = sst_original->generation();
+
+            auto new_digest = sst_original->get_component_digest(component);
+            BOOST_REQUIRE(new_digest.has_value());
+            BOOST_REQUIRE(original_digest.value() != new_digest.value());
+
+            BOOST_REQUIRE_NE(original_sstable_id, sst_original->sstable_identifier());
+        }
+
+        sst_original = nullptr;
+
+        auto sst_reopened = env.make_sstable(schema, dir_path, entry_desc.generation, entry_desc.version, entry_desc.format);
+        sst_reopened->load(schema->get_sharder()).get();
+
+        auto loaded_digest = sst_reopened->get_component_digest(component);
+        BOOST_REQUIRE(loaded_digest.has_value());
+
+        auto f = open_file_dma(sstables::test(sst_reopened).filename(component).native(), open_flags::ro).get();
+        auto stream = make_file_input_stream(f);
+        auto close_stream = deferred_close(stream);
+        auto component_data = util::read_entire_stream_contiguous(stream).get();
+        auto calculated_digest = crc32_utils::checksum(component_data.begin(), component_data.size());
+        BOOST_REQUIRE_EQUAL(calculated_digest, loaded_digest.value());
+
+        // calculate scylla component digest, by reading file_size - sizeof(uint32_t)
+        auto f2 = open_file_dma(sstables::test(sst_reopened).filename(sstables::component_type::Scylla).native(), open_flags::ro).get();
+        auto stream2 = make_file_input_stream(f2);
+        auto close_stream2 = deferred_close(stream2);
+        auto scylla_data = util::read_entire_stream_contiguous(stream2).get();
+        auto calc_scylla_digest = crc32_utils::checksum(scylla_data.begin(), scylla_data.size() - sizeof(uint32_t));
+        BOOST_REQUIRE_EQUAL(calc_scylla_digest, sst_reopened->get_scylla_metadata()->digest);
+    });
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_index) {
+    return test_component_digest_persistence(component_type::Index, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_partitions) {
+    return test_component_digest_persistence(component_type::Partitions, sstable::version_types::ms);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_rows) {
+    return test_component_digest_persistence(component_type::Rows, sstable::version_types::ms);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_summary) {
+    return test_component_digest_persistence(component_type::Summary, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_filter) {
+    return test_component_digest_persistence(component_type::Filter, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_compression) {
+    return test_component_digest_persistence(component_type::CompressionInfo, sstable::version_types::me, compress_sstable::yes);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_toc) {
+    return test_component_digest_persistence(component_type::TOC, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_statistics) {
+    return test_component_digest_persistence(component_type::Statistics, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_statistics_rewrite) {
+    return test_component_digest_persistence(component_type::Statistics, sstable::version_types::me, compress_sstable::no, true);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_data) {
+    return test_component_digest_persistence(component_type::Data, sstable::version_types::me);
+}
+
+SEASTAR_TEST_CASE(test_digest_persistence_data_compressed) {
+    return test_component_digest_persistence(component_type::Data, sstable::version_types::me, compress_sstable::yes);
 }

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -966,7 +966,7 @@ static future<> test_component_digest_persistence(component_type component, ssta
         auto close_stream2 = deferred_close(stream2);
         auto scylla_data = util::read_entire_stream_contiguous(stream2).get();
         auto calc_scylla_digest = crc32_utils::checksum(scylla_data.begin(), scylla_data.size() - sizeof(uint32_t));
-        BOOST_REQUIRE_EQUAL(calc_scylla_digest, sst_reopened->get_scylla_metadata()->digest);
+        BOOST_REQUIRE_EQUAL(calc_scylla_digest, sst_reopened->get_component_digest(sstables::component_type::Scylla).value());
     });
 }
 

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -541,7 +541,8 @@ async def test_tablet_incremental_repair_merge_higher_repaired_at_number(manager
     s1_mark = await logs[0].mark()
     await trigger_tablet_merge(manager, servers, logs)
     # The merge process will set the unrepaired sstable with repaired_at=3 to repaired_at=0 during merge
-    await logs[0].wait_for('Finished repaired_at update for tablet merge .* old=3 new=0 sstables_repaired_at=2', from_mark=s1_mark)
+    await logs[0].wait_for('Updating repaired_at for tablet merge .* old=3 new=0 sstables_repaired_at=2', from_mark=s1_mark)
+    await logs[0].wait_for('Completed updating repaired_at=.* for tablet merge', from_mark=s1_mark)
 
     for server in servers:
         await manager.server_stop_gracefully(server.server_id)

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -94,6 +94,9 @@ public:
     sstables::shared_sstable make_sstable(sstables::sstable_state) const override {
         return table().make_sstable();
     }
+    sstables::shared_sstable make_sstable(sstables::sstable_state, sstables::sstable_version_types version) const override {
+        return table().make_sstable(sstables::sstable_state::normal, version);
+    }
     sstables::sstable_writer_config configure_writer(sstring origin) const override {
         return _sstables_manager.configure_writer(std::move(origin));
     }

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -804,6 +804,7 @@ public:
     virtual reader_permit make_compaction_reader_permit() const override { return _permit; }
     virtual sstables::sstables_manager& get_sstables_manager() noexcept override { return _sst_man; }
     virtual sstables::shared_sstable make_sstable(sstables::sstable_state) const override { return do_make_sstable(); }
+    virtual sstables::shared_sstable make_sstable(sstables::sstable_state, sstables::sstable_version_types) const override { return do_make_sstable(); }
     virtual sstables::sstable_writer_config configure_writer(sstring origin) const override { return do_configure_writer(std::move(origin)); }
     virtual api::timestamp_type min_memtable_timestamp() const override { return api::min_timestamp; }
     virtual api::timestamp_type min_memtable_live_timestamp() const override { return api::min_timestamp; }


### PR DESCRIPTION
This pull request adds support for calculation and storing CRC32 digests for all SSTable components.
This change replaces plain file_writer with crc32_digest_file_writer for all SSTable components that should be checksummed. The resulting component digests are stored in the sstable structure
and later persisted to disk as part of the Scylla metadata component during writer::consume_end_of_stream.
Several test cases where introduced to verify expected behaviour.

Additionally, this PR adds new rewrite component mechanism for safe sstable component rewriting.
Previously, rewriting an sstable component (e.g., via rewrite_statistics) created a temporary file that was renamed to the final name after sealing. This allowed crash recovery by simply removing the temporary file on startup.
    
However, with component digests stored in scylla_metadata (#20100),
replacing a component like Statistics requires atomically updating both the component
and scylla_metadata with the new digest - impossible with POSIX rename.
    
The new mechanism creates a clone sstable with a fresh generation:
    
- Hard-links all components from the source except the component being rewritten and scylla_metadata
- Copies original sstable components pointer and recognized components from the source
- Invokes a modifier callback to adjust the new sstable before rewriting
- Writes the modified component along with updated scylla_metadata containing the new digest
- Seals the new sstable with a temporary TOC
- Replaces the old sstable atomically, the same way as it is done in compaction
    
This is built on the rewrite_sstables compaction framework to support batch operations (e.g., following incremental repair).
In case of any failure durning the whole process, sstable will be automatically deleted on the node startup due to
temporary toc persistence.

Backport is not required, it is a new feature

Fixes https://github.com/scylladb/scylladb/issues/20100, https://github.com/scylladb/scylladb/issues/27453