### PR TITLE
config: reader_concurrency_semaphore: enable 50% shared pool for reader

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1519,7 +1519,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Admit new reads while their remaining time is more than this factor times their timeout times when arrived to a semaphore. Its vale means\n"
             "* <= 0.0 means new reads will never get rejected during admission\n"
             "* >= 1.0 means new reads will always get rejected during admission\n")
-    , reader_concurrency_semaphore_shared_pool_fraction(this, "reader_concurrency_semaphore_shared_pool_fraction", liveness::MustRestart, value_status::Used, 0.5,
+    , reader_concurrency_semaphore_shared_pool_fraction(this, "reader_concurrency_semaphore_shared_pool_fraction", liveness::LiveUpdate, value_status::Used, 0.5,
             "Fraction of memory to allocate to the shared pool for reader concurrency semaphores. Clamped to the [0, 1] range. A setting of 0 effectively disables the shared pool.")
     , view_update_reader_concurrency_semaphore_serialize_limit_multiplier(this, "view_update_reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
             "Start serializing view update reads after their collective memory consumption goes above $normal_limit * $multiplier.")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1519,6 +1519,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Admit new reads while their remaining time is more than this factor times their timeout times when arrived to a semaphore. Its vale means\n"
             "* <= 0.0 means new reads will never get rejected during admission\n"
             "* >= 1.0 means new reads will always get rejected during admission\n")
+    , reader_concurrency_semaphore_shared_pool_fraction(this, "reader_concurrency_semaphore_shared_pool_fraction", liveness::MustRestart, value_status::Used, 0.5,
+            "Fraction of memory to allocate to the shared pool for reader concurrency semaphores. Clamped to the [0, 1] range. A setting of 0 effectively disables the shared pool.")
     , view_update_reader_concurrency_semaphore_serialize_limit_multiplier(this, "view_update_reader_concurrency_semaphore_serialize_limit_multiplier", liveness::LiveUpdate, value_status::Used, 2,
             "Start serializing view update reads after their collective memory consumption goes above $normal_limit * $multiplier.")
     , view_update_reader_concurrency_semaphore_kill_limit_multiplier(this, "view_update_reader_concurrency_semaphore_kill_limit_multiplier", liveness::LiveUpdate, value_status::Used, 4,

--- a/db/config.hh
+++ b/db/config.hh
@@ -474,6 +474,7 @@ public:
     named_value<uint32_t> reader_concurrency_semaphore_kill_limit_multiplier;
     named_value<uint32_t> reader_concurrency_semaphore_cpu_concurrency;
     named_value<float> reader_concurrency_semaphore_preemptive_abort_factor;
+    named_value<double> reader_concurrency_semaphore_shared_pool_fraction;
     named_value<uint32_t> view_update_reader_concurrency_semaphore_serialize_limit_multiplier;
     named_value<uint32_t> view_update_reader_concurrency_semaphore_kill_limit_multiplier;
     named_value<uint32_t> view_update_reader_concurrency_semaphore_cpu_concurrency;

--- a/docs/dev/reader-concurrency-semaphore.md
+++ b/docs/dev/reader-concurrency-semaphore.md
@@ -67,6 +67,12 @@ Note that participation in this is opt-in for reads, in that there is a separate
 
 When reaching the kill limit, the semaphore will start throwing `std::bad_alloc` from all memory consumption registering API calls. This is a drastic measure which will result in reads being killed. This is meant to provide a hard upper limit on the memory consumption of all reads.
 
+## Shared Memory Pool
+
+Semaphores can be configured to borrow memory from a shared pool (`reader_concurrency_semaphore_shared_pool`) managed by the `reader_concurrency_semaphore_group` when their dedicated memory is exhausted. This feature is optional, allowing some semaphores to use the shared pool while others remain restricted to their dedicated limits.
+
+Borrowing also raises the anti-OOM thresholds. The serialize and kill limits are evaluated against the consumption a semaphore must cover from its own dedicated memory, i.e. its total consumption minus the pool memory still available to it (its current borrow plus the still-free pool). Equivalently, the effective serialize and kill limits are raised additively by that available pool memory (the multiplier is not applied to the raised amount). This keeps the pool useful for concurrency rather than just eviction-avoidance: serialization only engages once consumption exceeds the serialize limit even after the pool has been fully drawn down. Because the available pool memory fluctuates as other semaphores borrow and repay, the point at which a semaphore starts serializing fluctuates too.
+
 ## Permit States
 
 Permits are in one of the following states:

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1049,11 +1049,14 @@ void reader_concurrency_semaphore::consume(reader_permit::impl& permit, resource
     // This is a cheap check and should be false most of the time, providing a
     // cheap short-circuit.
     if (_resources.memory <= 0 && std::cmp_greater_equal(oom_protection_consumed_memory() + r.memory, get_kill_limit())) [[unlikely]] {
-        if (permit.on_oom_kill()) {
-            ++_stats.total_reads_killed_due_to_kill_limit;
+        // Don't kill unless kill limit is reached also when shared pool is out from the calculations
+        if (std::cmp_greater_equal(consumed_resources().memory + r.memory, _unreduced_memory * _kill_limit_multiplier())) {
+            if (permit.on_oom_kill()) {
+                ++_stats.total_reads_killed_due_to_kill_limit;
+            }
+            maybe_dump_reader_permit_diagnostics(*this, "kill limit triggered", &permit);
+            throw utils::memory_limit_reached(format("kill limit triggered on semaphore {} by permit {}", _name, permit.description()));
         }
-        maybe_dump_reader_permit_diagnostics(*this, "kill limit triggered", &permit);
-        throw utils::memory_limit_reached(format("kill limit triggered on semaphore {} by permit {}", _name, permit.description()));
     }
 
     if (_resources.memory < r.memory && _shared_pool.available_memory() > 0) {
@@ -1809,7 +1812,8 @@ future<> reader_concurrency_semaphore::with_ready_permit(reader_permit permit, r
     return with_ready_permit(*permit);
 }
 
-void reader_concurrency_semaphore::set_resources(resources r) {
+void reader_concurrency_semaphore::set_resources(resources r, size_t unreduced_memory) {
+    _unreduced_memory = unreduced_memory;
     auto delta = r - _initial_resources;
     _initial_resources = r;
     _resources += delta;

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -875,7 +875,8 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             "need_cpu_permits: {}\n"
             "awaits_permits: {}\n"
             "disk_reads: {}\n"
-            "sstables_read: {}",
+            "sstables_read: {}\n"
+            "reads_memory_borrowed_from_shared_pool: {}",
             stats.permit_based_evictions,
             stats.time_based_evictions,
             stats.inactive_reads,
@@ -897,7 +898,8 @@ static void do_dump_reader_permit_diagnostics(std::ostream& os, const reader_con
             stats.need_cpu_permits,
             stats.awaits_permits,
             stats.disk_reads,
-            stats.sstables_read);
+            stats.sstables_read,
+            stats.reads_memory_borrowed_from_shared_pool);
 }
 
 void maybe_dump_reader_permit_diagnostics(const reader_concurrency_semaphore& semaphore, std::string_view problem, reader_permit::impl* permit) noexcept {
@@ -1036,14 +1038,6 @@ ssize_t reader_concurrency_semaphore::oom_protection_consumed_memory() const noe
     return consumed_resources().memory - _shared_pool.available_memory();
 }
 
-void reader_concurrency_semaphore::borrow_from_shared_pool(resources r) noexcept {
-    const ssize_t needed_from_shared = r.memory - _resources.memory;
-    const ssize_t from_pool = std::min(needed_from_shared, _shared_pool.available_memory());
-    _shared_pool.borrow(from_pool);
-    _borrowed_from_shared += from_pool;
-    _resources.memory += from_pool;
-}
-
 void reader_concurrency_semaphore::consume(reader_permit::impl& permit, resources r) {
     // We check whether we even reached the memory limit first.
     // This is a cheap check and should be false most of the time, providing a
@@ -1060,7 +1054,11 @@ void reader_concurrency_semaphore::consume(reader_permit::impl& permit, resource
     }
 
     if (_resources.memory < r.memory && _shared_pool.available_memory() > 0) {
-        borrow_from_shared_pool(r);
+        const ssize_t needed_from_shared = r.memory - _resources.memory;
+        const ssize_t from_pool = std::min(needed_from_shared, _shared_pool.available_memory());
+        _shared_pool.borrow(from_pool);
+        _stats.reads_memory_borrowed_from_shared_pool += from_pool;
+        _resources.memory += from_pool;
     }
 
     _resources -= r;
@@ -1076,10 +1074,10 @@ reader_concurrency_semaphore::resources reader_concurrency_semaphore::repay_shar
     const ssize_t remaining = r.memory - deficit_recovery;
 
     // Then repay the shared pool from the remaining freed memory.
-    const ssize_t memory_return = std::min(remaining, _borrowed_from_shared);
+    const ssize_t memory_return = std::min(remaining, _stats.reads_memory_borrowed_from_shared_pool);
     if (memory_return > 0) {
         _shared_pool.repay(memory_return);
-        _borrowed_from_shared -= memory_return;
+        _stats.reads_memory_borrowed_from_shared_pool -= memory_return;
     }
 
     return {r.count, r.memory - memory_return};
@@ -1087,7 +1085,7 @@ reader_concurrency_semaphore::resources reader_concurrency_semaphore::repay_shar
 
 void reader_concurrency_semaphore::signal(const resources& r) noexcept {
     resources returned = r;
-    if (_borrowed_from_shared > 0) {
+    if (_stats.reads_memory_borrowed_from_shared_pool > 0) {
         returned = repay_shared_pool(r);
     }
 
@@ -1179,6 +1177,10 @@ reader_concurrency_semaphore::reader_concurrency_semaphore(
                 sm::make_counter("total_reads_failed", _stats.total_failed_reads,
                                sm::description("Counts the total number of failed user read operations. "
                                                "Add the total_reads to this value to get the total amount of reads issued on this shard."),
+                               {class_label(_name)}),
+
+                sm::make_gauge("reads_memory_borrowed_from_shared_pool", [this] { return _stats.reads_memory_borrowed_from_shared_pool; },
+                               sm::description("Holds the current amount of memory borrowed from the shared pool."),
                                {class_label(_name)}),
                 });
     }
@@ -1584,7 +1586,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit::impl& pe
 }
 
 void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
-    const auto borrowed_before = _borrowed_from_shared;
+    const auto borrowed_before = _stats.reads_memory_borrowed_from_shared_pool;
     auto admit = can_admit::no;
     while (!_wait_list.empty() && (admit = can_admit_read(_wait_list.front()).decision) == can_admit::yes) {
         auto& permit = _wait_list.front();
@@ -1644,7 +1646,7 @@ void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
         // Evicting readers will trigger another call to `maybe_admit_waiters()` from `signal()`.
         evict_readers_in_background();
     }
-    if (_borrowed_from_shared > borrowed_before) {
+    if (_stats.reads_memory_borrowed_from_shared_pool > borrowed_before) {
         // We took some memory from the shared pool while admitting. If memory
         // still remains in the pool, hand the wakeup off to the next waiting
         // semaphore so a single large return can satisfy several waiters in

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1032,22 +1032,63 @@ uint64_t reader_concurrency_semaphore::get_kill_limit() const {
     return _initial_resources.memory * _kill_limit_multiplier();
 }
 
+ssize_t reader_concurrency_semaphore::oom_protection_consumed_memory() const noexcept {
+    return consumed_resources().memory - _shared_pool.available_memory();
+}
+
+void reader_concurrency_semaphore::borrow_from_shared_pool(resources r) noexcept {
+    const ssize_t needed_from_shared = r.memory - _resources.memory;
+    const ssize_t from_pool = std::min(needed_from_shared, _shared_pool.available_memory());
+    _shared_pool.borrow(from_pool);
+    _borrowed_from_shared += from_pool;
+    _resources.memory += from_pool;
+}
+
 void reader_concurrency_semaphore::consume(reader_permit::impl& permit, resources r) {
     // We check whether we even reached the memory limit first.
     // This is a cheap check and should be false most of the time, providing a
     // cheap short-circuit.
-    if (_resources.memory <= 0 && std::cmp_greater_equal(consumed_resources().memory + r.memory, get_kill_limit())) [[unlikely]] {
+    if (_resources.memory <= 0 && std::cmp_greater_equal(oom_protection_consumed_memory() + r.memory, get_kill_limit())) [[unlikely]] {
         if (permit.on_oom_kill()) {
             ++_stats.total_reads_killed_due_to_kill_limit;
         }
         maybe_dump_reader_permit_diagnostics(*this, "kill limit triggered", &permit);
         throw utils::memory_limit_reached(format("kill limit triggered on semaphore {} by permit {}", _name, permit.description()));
     }
+
+    if (_resources.memory < r.memory && _shared_pool.available_memory() > 0) {
+        borrow_from_shared_pool(r);
+    }
+
     _resources -= r;
 }
 
+reader_concurrency_semaphore::resources reader_concurrency_semaphore::repay_shared_pool(const resources& r) noexcept {
+    // First, recover the deficit: add just enough of r.memory to bring
+    // _resources.memory up to 0 (it may be negative when consumption
+    // exceeded borrowed amount). Negative _resources.memory speed ups
+    // eviction of inactive reads, and avoiding eviction with use of
+    // shared pool is desired.
+    const ssize_t deficit_recovery = std::clamp(-_resources.memory, ssize_t(0), r.memory);
+    const ssize_t remaining = r.memory - deficit_recovery;
+
+    // Then repay the shared pool from the remaining freed memory.
+    const ssize_t memory_return = std::min(remaining, _borrowed_from_shared);
+    if (memory_return > 0) {
+        _shared_pool.repay(memory_return);
+        _borrowed_from_shared -= memory_return;
+    }
+
+    return {r.count, r.memory - memory_return};
+}
+
 void reader_concurrency_semaphore::signal(const resources& r) noexcept {
-    _resources += r;
+    resources returned = r;
+    if (_borrowed_from_shared > 0) {
+        returned = repay_shared_pool(r);
+    }
+
+    _resources += returned;
     if (_resources.count > _initial_resources.count || _resources.memory > _initial_resources.memory) [[unlikely]] {
         on_internal_error_noexcept(rcslog,
                 format("reader_concurrency_semaphore::signal(): semaphore {} detected resource leak, available {} exceeds initial {}", _name,
@@ -1070,9 +1111,11 @@ reader_concurrency_semaphore::reader_concurrency_semaphore(
         utils::updateable_value<uint32_t> kill_limit_multiplier,
         utils::updateable_value<uint32_t> cpu_concurrency,
         utils::updateable_value<float> preemptive_abort_factor,
-        register_metrics metrics)
+        register_metrics metrics,
+        reader_concurrency_semaphore_shared_pool& shared_pool)
     : _initial_resources(count, memory)
     , _resources(count, memory)
+    , _shared_pool(shared_pool)
     , _count_observer(count.observe([this] (const int& new_count) { set_resources({new_count, _initial_resources.memory}); }))
     , _name(std::move(name))
     , _max_queue_length(max_queue_length)
@@ -1148,9 +1191,13 @@ reader_concurrency_semaphore::reader_concurrency_semaphore(no_limits, sstring na
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(uint32_t(1)),
             utils::updateable_value(float(0.0)),
-            metrics) {}
+            metrics,
+            reader_concurrency_semaphore_shared_pool::empty_pool()) {}
 
 reader_concurrency_semaphore::~reader_concurrency_semaphore() {
+    if (_on_shared_pool_notify_list) {
+        _shared_pool.unregister_wakeup(*this);
+    }
     SCYLLA_ASSERT(!_stats.waiters);
     if (!_stats.total_permits) {
         // We allow destroy without stop() when the semaphore wasn't used at all yet.
@@ -1365,6 +1412,12 @@ reader_concurrency_semaphore::reason reader_concurrency_semaphore::has_available
         return reason::count_resources;
     }
 
+    {
+        const ssize_t needed_from_shared = r.memory - _resources.memory;
+        if (_shared_pool.available_memory() >= needed_from_shared) {
+            return reason::all_ok;
+        }
+    }
     return reason::memory_resources;
 }
 
@@ -1426,7 +1479,7 @@ void reader_concurrency_semaphore::evict_readers_in_background() {
 reader_concurrency_semaphore::admit_result
 reader_concurrency_semaphore::can_admit_read(const reader_permit::impl& permit) const noexcept {
     if (_resources.memory < 0) [[unlikely]] {
-        const auto consumed_memory = consumed_resources().memory;
+        const auto consumed_memory = oom_protection_consumed_memory();
         if (std::cmp_greater_equal(consumed_memory, get_kill_limit())) {
             return {can_admit::no, reason::memory_resources};
         }
@@ -1528,6 +1581,7 @@ future<> reader_concurrency_semaphore::do_wait_admission(reader_permit::impl& pe
 }
 
 void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
+    const auto borrowed_before = _borrowed_from_shared;
     auto admit = can_admit::no;
     while (!_wait_list.empty() && (admit = can_admit_read(_wait_list.front()).decision) == can_admit::yes) {
         auto& permit = _wait_list.front();
@@ -1587,6 +1641,21 @@ void reader_concurrency_semaphore::maybe_admit_waiters() noexcept {
         // Evicting readers will trigger another call to `maybe_admit_waiters()` from `signal()`.
         evict_readers_in_background();
     }
+    if (_borrowed_from_shared > borrowed_before) {
+        // We took some memory from the shared pool while admitting. If memory
+        // still remains in the pool, hand the wakeup off to the next waiting
+        // semaphore so a single large return can satisfy several waiters in
+        // order, instead of stalling them until the next return to the pool.
+        // Done before re-registering ourselves below so we offer the memory to
+        // a different semaphore rather than waking ourselves again.
+        _shared_pool.maybe_wake_next_waiter();
+    }
+    if (admit != can_admit::yes && !_wait_list.empty()) {
+        // We have waiters that could not be admitted.  If the shared pool
+        // has memory returned by another semaphore, we want to be woken up
+        // to re-evaluate admission.
+        _shared_pool.request_wakeup(*this);
+    }
 }
 
 void reader_concurrency_semaphore::maybe_wake_execution_loop() noexcept {
@@ -1601,7 +1670,7 @@ future<> reader_concurrency_semaphore::request_memory(reader_permit::impl& permi
         return permit.aux_data().fut->get_future();
     }
 
-    if (_resources.memory > 0 || (consumed_resources().memory + memory) < get_serialize_limit()) {
+    if (_resources.memory > 0 || std::cmp_less(oom_protection_consumed_memory() + ssize_t(memory), get_serialize_limit())) {
         permit.on_granted_memory();
         return make_ready_future<>();
     }

--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1350,10 +1350,22 @@ void reader_concurrency_semaphore::close_reader(mutation_reader reader) {
     });
 }
 
-bool reader_concurrency_semaphore::has_available_units(const resources& r) const {
+reader_concurrency_semaphore::reason reader_concurrency_semaphore::has_available_units(const resources& r) const {
+    if (_resources.non_zero() && _resources.count >= r.count && _resources.memory >= r.memory) {
+        return reason::all_ok;
+    }
+
     // Special case: when there is no active reader (based on count) admit one
     // regardless of availability of memory.
-    return (_resources.non_zero() && _resources.count >= r.count && _resources.memory >= r.memory) || _resources.count == _initial_resources.count;
+    if (_resources.count == _initial_resources.count) {
+        return reason::all_ok;
+    }
+
+    if (_resources.count < r.count) {
+        return reason::count_resources;
+    }
+
+    return reason::memory_resources;
 }
 
 bool reader_concurrency_semaphore::cpu_concurrency_limit_reached() const {
@@ -1444,8 +1456,8 @@ reader_concurrency_semaphore::can_admit_read(const reader_permit::impl& permit) 
         return {can_admit::no, reason::need_cpu_permits};
     }
 
-    if (!has_available_units(permit.base_resources())) {
-        auto reason = _resources.memory >= permit.base_resources().memory ? reason::count_resources : reason::memory_resources;
+    const auto reason = has_available_units(permit.base_resources());
+    if (reason != reason::all_ok) {
         if (_inactive_reads.empty()) {
             return {can_admit::no, reason};
         } else {

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <deque>
+#include <functional>
 #include <boost/intrusive/list.hpp>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
@@ -27,15 +29,42 @@ using mutation_reader_opt = optimized_optional<mutation_reader>;
 
 extern logger rcslog;
 
+class reader_concurrency_semaphore;
+
 // A shared pool of memory that can be used by multiple reader_concurrency_semaphores.
 // When a semaphore exhausts its dedicated memory, it can borrow from this pool.
+// A pool with total_memory=0 is inert: available_memory() returns 0, so no
+// borrowing occurs.
+//
+// Semaphores that have waiters blocked on memory can register themselves via
+// request_wakeup().  When memory is returned to the pool, a single registered
+// semaphore is woken up (FIFO order) so it can re-evaluate admission.  If it
+// still has blocked waiters, it re-registers at the back, giving round-robin
+// fairness across all waiting semaphores.
+//
+// The wakeup is handed off strictly in registration order: the next semaphore
+// is only offered the memory once the current head has had its turn and
+// actually borrowed some of it (via maybe_wake_next_waiter()).  A head whose
+// waiter is too big to fund declines without borrowing, leaving the memory
+// parked for its next turn rather than letting a smaller waiter in another
+// semaphore skim it.  This keeps a single large return from waking only one of
+// several waiters it could satisfy, while still preventing cross-semaphore
+// starvation.
 class reader_concurrency_semaphore_shared_pool {
     ssize_t _available_memory;
     ssize_t _total_memory;
+    std::deque<std::reference_wrapper<reader_concurrency_semaphore>> _notify_list;
 public:
     explicit reader_concurrency_semaphore_shared_pool(ssize_t memory) noexcept
         : _available_memory(memory)
         , _total_memory(memory) {}
+
+    /// Return a per-shard empty pool (total_memory=0) for semaphores that
+    /// do not participate in any shared pool.
+    static reader_concurrency_semaphore_shared_pool& empty_pool() noexcept {
+        static thread_local reader_concurrency_semaphore_shared_pool instance{0};
+        return instance;
+    }
 
     // Take memory from the pool. The caller must not borrow more than
     // available_memory(); overdrawing is a bug, so it is logged and clamped
@@ -51,10 +80,23 @@ public:
         }
     }
 
-    // Return previously borrowed memory to the pool. Repaying more than was
-    // borrowed is a bug, so it is logged and clamped to total_memory rather
-    // than inflating the pool.
+    // Return previously borrowed memory to the pool and wake a waiting
+    // semaphore if any. Repaying more than was borrowed is a bug, so it is
+    // logged and clamped to total_memory rather than inflating the pool.
     void repay(ssize_t amount) noexcept;
+
+    // Register a semaphore to be woken up the next time memory is returned
+    // to the pool.  Duplicate registrations are suppressed.
+    void request_wakeup(reader_concurrency_semaphore& sem) noexcept;
+
+    // Remove a semaphore from the notify list.  Must be called before
+    // the semaphore is destroyed to avoid dangling references.
+    void unregister_wakeup(reader_concurrency_semaphore& sem) noexcept;
+
+    // Wake the next registered semaphore if the pool still has memory to lend.
+    // Called by a semaphore that just borrowed pool memory while admitting
+    // waiters, to hand the remaining memory off to the next waiter in line.
+    void maybe_wake_next_waiter() noexcept;
 
     ssize_t available_memory() const noexcept {
         if (_available_memory < 0) {
@@ -77,6 +119,11 @@ public:
         _total_memory = memory;
         _available_memory += diff;
     }
+
+private:
+    // Pop the semaphore at the front of the notify list and wake its execution
+    // loop so it re-evaluates admission.  Caller must ensure the list isn't empty.
+    void wake_front_waiter() noexcept;
 };
 
 /// Specific semaphore for controlling reader concurrency
@@ -124,6 +171,7 @@ public:
 
     friend class reader_permit;
     friend struct reader_concurrency_semaphore_tester;
+    friend class reader_concurrency_semaphore_shared_pool;
 
     enum class evict_reason {
         permit, // evicted due to permit shortage
@@ -220,6 +268,9 @@ public:
 private:
     resources _initial_resources;
     resources _resources;
+    reader_concurrency_semaphore_shared_pool& _shared_pool;
+    bool _on_shared_pool_notify_list = false;
+    ssize_t _borrowed_from_shared = 0;
     utils::observer<int> _count_observer;
 
     struct wait_queue {
@@ -327,9 +378,21 @@ private:
     uint64_t get_serialize_limit() const;
     uint64_t get_kill_limit() const;
 
+    // Memory consumption counted against the anti-OOM (serialize/kill) limits.
+    // It excludes the memory the shared pool could still fund (this semaphore's
+    // current borrow plus the still-free pool), so while the pool can lend
+    // memory the effective serialize/kill limits are raised by that amount.
+    // Throttling thus engages only on consumption the semaphore must cover from
+    // its own dedicated memory. May be negative when the pool can fully fund the
+    // current consumption.
+    ssize_t oom_protection_consumed_memory() const noexcept;
+
     // Throws std::bad_alloc if memory consumed is oom_kill_limit_multiply_threshold more than the memory limit.
     void consume(reader_permit::impl& permit, resources r);
     void signal(const resources& r) noexcept;
+
+    void borrow_from_shared_pool(resources r) noexcept;
+    resources repay_shared_pool(const resources& r) noexcept;
 
     future<> with_ready_permit(reader_permit::impl& permit);
 
@@ -349,7 +412,8 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multiplier,
             utils::updateable_value<uint32_t> cpu_concurrency,
             utils::updateable_value<float> preemptive_abort_factor,
-            register_metrics metrics);
+            register_metrics metrics,
+            reader_concurrency_semaphore_shared_pool& shared_pool);
 
     reader_concurrency_semaphore(
             int count,
@@ -360,10 +424,11 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multiplier,
             utils::updateable_value<uint32_t> cpu_concurrency,
             utils::updateable_value<float> preemptive_abort_factor,
-            register_metrics metrics)
+            register_metrics metrics,
+            reader_concurrency_semaphore_shared_pool& shared_pool)
         : reader_concurrency_semaphore(utils::updateable_value(count), memory, std::move(name), max_queue_length,
                 std::move(serialize_limit_multiplier), std::move(kill_limit_multiplier), std::move(cpu_concurrency),
-                std::move(preemptive_abort_factor), metrics)
+                std::move(preemptive_abort_factor), metrics, shared_pool)
     { }
 
     /// Create a semaphore with practically unlimited count and memory.
@@ -384,9 +449,10 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multipler = utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value<uint32_t> cpu_concurrency = utils::updateable_value<uint32_t>(1),
             utils::updateable_value<float> preemptive_abort_factor = utils::updateable_value<float>(0.0f),
-            register_metrics metrics = register_metrics::no)
+            register_metrics metrics = register_metrics::no,
+            reader_concurrency_semaphore_shared_pool& shared_pool = reader_concurrency_semaphore_shared_pool::empty_pool())
         : reader_concurrency_semaphore(utils::updateable_value(count), memory, std::move(name), max_queue_length, std::move(serialize_limit_multipler),
-                std::move(kill_limit_multipler), std::move(cpu_concurrency), std::move(preemptive_abort_factor), metrics)
+                std::move(kill_limit_multipler), std::move(cpu_concurrency), std::move(preemptive_abort_factor), metrics, shared_pool)
     {}
 
     ~reader_concurrency_semaphore();

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -297,6 +297,7 @@ private:
 
     sstring _name;
     size_t _max_queue_length = std::numeric_limits<size_t>::max();
+    size_t _unreduced_memory = 0;
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
     utils::updateable_value<uint32_t> _cpu_concurrency;
@@ -598,7 +599,11 @@ public:
     ///
     /// After this call, \ref initial_resources() will reflect the new value.
     /// Available resources will be adjusted by the delta.
-    void set_resources(resources r);
+    void set_resources(resources r, size_t unreduced_memory = 0);
+
+    size_t unreduced_memory() const noexcept {
+        return _unreduced_memory;
+    }
 
     const resources initial_resources() const {
         return _initial_resources;

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -53,6 +53,7 @@ class reader_concurrency_semaphore;
 class reader_concurrency_semaphore_shared_pool {
     ssize_t _available_memory;
     ssize_t _total_memory;
+    seastar::metrics::metric_groups _metrics;
     std::deque<std::reference_wrapper<reader_concurrency_semaphore>> _notify_list;
 public:
     explicit reader_concurrency_semaphore_shared_pool(ssize_t memory) noexcept
@@ -108,6 +109,8 @@ public:
     ssize_t total_memory() const noexcept {
         return _total_memory;
     }
+
+    void register_metrics(const seastar::sstring& name);
 
     // Resize the pool, applying the change to the available memory too. If the
     // pool shrinks below the amount currently borrowed, _available_memory goes
@@ -229,6 +232,8 @@ public:
         uint64_t sstables_read = 0;
         // Permits waiting on something: admission, memory or execution
         uint64_t waiters = 0;
+        // Current amount of memory borrowed from the shared pool.
+        ssize_t reads_memory_borrowed_from_shared_pool = 0;
 
         friend auto operator<=>(const stats&, const stats&) = default;
     };
@@ -270,7 +275,6 @@ private:
     resources _resources;
     reader_concurrency_semaphore_shared_pool& _shared_pool;
     bool _on_shared_pool_notify_list = false;
-    ssize_t _borrowed_from_shared = 0;
     utils::observer<int> _count_observer;
 
     struct wait_queue {
@@ -392,7 +396,6 @@ private:
     void consume(reader_permit::impl& permit, resources r);
     void signal(const resources& r) noexcept;
 
-    void borrow_from_shared_pool(resources r) noexcept;
     resources repay_shared_pool(const resources& r) noexcept;
 
     future<> with_ready_permit(reader_permit::impl& permit);

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -265,7 +265,8 @@ private:
     [[nodiscard]] mutation_reader detach_inactive_reader(reader_permit::impl&, evict_reason reason) noexcept;
     void evict(reader_permit::impl&, evict_reason reason) noexcept;
 
-    bool has_available_units(const resources& r) const;
+    enum class reason { all_ok = 0, ready_list, need_cpu_permits, memory_resources, count_resources };
+    reason has_available_units(const resources& r) const;
 
     bool cpu_concurrency_limit_reached() const;
 
@@ -284,7 +285,6 @@ private:
     // A return value of can_admit::maybe means admission might be possible if
     // some of the inactive readers are evicted.
     enum class can_admit { no, maybe, yes };
-    enum class reason { all_ok = 0, ready_list, need_cpu_permits, memory_resources, count_resources };
     struct admit_result { can_admit decision; reason why; };
     admit_result can_admit_read(const reader_permit::impl& permit) const noexcept;
 

--- a/reader_concurrency_semaphore.hh
+++ b/reader_concurrency_semaphore.hh
@@ -13,6 +13,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/metrics_registration.hh>
+#include <seastar/util/log.hh>
 #include "reader_permit.hh"
 #include "utils/updateable_value.hh"
 #include "dht/i_partitioner_fwd.hh"
@@ -23,6 +24,60 @@ using namespace seastar;
 
 class mutation_reader;
 using mutation_reader_opt = optimized_optional<mutation_reader>;
+
+extern logger rcslog;
+
+// A shared pool of memory that can be used by multiple reader_concurrency_semaphores.
+// When a semaphore exhausts its dedicated memory, it can borrow from this pool.
+class reader_concurrency_semaphore_shared_pool {
+    ssize_t _available_memory;
+    ssize_t _total_memory;
+public:
+    explicit reader_concurrency_semaphore_shared_pool(ssize_t memory) noexcept
+        : _available_memory(memory)
+        , _total_memory(memory) {}
+
+    // Take memory from the pool. The caller must not borrow more than
+    // available_memory(); overdrawing is a bug, so it is logged and clamped
+    // rather than silently producing negative availability.
+    void borrow(ssize_t amount) noexcept {
+        _available_memory -= amount;
+        if (_available_memory < 0)  [[unlikely]] {
+            static thread_local logger::rate_limit rate_limit(std::chrono::seconds(30));
+            rcslog.log(log_level::warn, rate_limit,
+                    "shared reader concurrency semaphore pool over-borrowed memory: available={}, total={}, borrowed={}; clamping available memory to 0",
+                    _available_memory, _total_memory, amount);
+            _available_memory = 0;
+        }
+    }
+
+    // Return previously borrowed memory to the pool. Repaying more than was
+    // borrowed is a bug, so it is logged and clamped to total_memory rather
+    // than inflating the pool.
+    void repay(ssize_t amount) noexcept;
+
+    ssize_t available_memory() const noexcept {
+        if (_available_memory < 0) {
+            return 0;
+        }
+        return _available_memory;
+    }
+
+    ssize_t total_memory() const noexcept {
+        return _total_memory;
+    }
+
+    // Resize the pool, applying the change to the available memory too. If the
+    // pool shrinks below the amount currently borrowed, _available_memory goes
+    // negative; available_memory() clamps that to 0 on read, and the borrowed
+    // memory is reconciled as borrowers repay. Callers must serialize resizes
+    // (the group does so via adjust()) so the accounting stays consistent.
+    void set_total_memory(ssize_t memory) noexcept {
+        const auto diff = memory - _total_memory;
+        _total_memory = memory;
+        _available_memory += diff;
+    }
+};
 
 /// Specific semaphore for controlling reader concurrency
 ///

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -82,9 +82,15 @@ void reader_concurrency_semaphore_shared_pool::unregister_wakeup(reader_concurre
 // if they did the behaviour would be undefined.
 future<> reader_concurrency_semaphore_group::adjust() {
     return with_semaphore(_operations_serializer, 1, [this] () {
+        if (_semaphores.empty()) {
+            // Nothing to distribute memory to yet. This can happen when the
+            // shared pool fraction is updated before any semaphore is added.
+            return;
+        }
+
         // Clamp out-of-range values rather than rejecting them, so an invalid
         // configured value degrades gracefully instead of failing.
-        const double shared_pool_fraction = std::clamp(_shared_pool_fraction, 0.0, 1.0);
+        const double shared_pool_fraction = std::clamp(_shared_pool_fraction(), 0.0, 1.0);
         const ssize_t shared_memory = _total_memory * shared_pool_fraction;
         const ssize_t dedicated_memory = _total_memory - shared_memory;
         _shared_pool.set_total_memory(shared_memory);
@@ -115,14 +121,24 @@ future<> reader_concurrency_semaphore_group::change_weight(weighted_reader_concu
 }
 
 future<> reader_concurrency_semaphore_group::wait_adjust_complete() {
-    return with_semaphore(_operations_serializer, 1, [] {
+    // Observer-driven adjustments (e.g. a live shared_pool_fraction update) are
+    // dispatched asynchronously through the serialized action, so its adjust()
+    // hasn't necessarily acquired _operations_serializer yet by the time we get
+    // here. Wait for any in-flight action first, then drain the serializer to
+    // also cover adjustments issued directly via change_weight().
+    co_await _shared_pool_fraction_action.trigger();
+    co_await with_semaphore(_operations_serializer, 1, [] {
         return make_ready_future<>();
     });
 }
 
 future<> reader_concurrency_semaphore_group::stop() noexcept {
-    return parallel_for_each(_semaphores, [] (auto&& item) {
-        return item.second.sem.stop();
+    // Stop reacting to shared pool fraction updates and wait for any
+    // in-flight adjust() to complete before tearing down the semaphores.
+    return _shared_pool_fraction_action.join().then([this] {
+        return parallel_for_each(_semaphores, [] (auto&& item) {
+            return item.second.sem.stop();
+        });
     }).then([this] {
         _semaphores.clear();
     });

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -73,13 +73,14 @@ future<> reader_concurrency_semaphore_group::adjust() {
         ssize_t distributed_memory = 0;
         for (auto& [sg, wsem] : _semaphores) {
             const ssize_t memory_share = std::floor((double(wsem.weight) / double(_total_weight)) * dedicated_memory);
-            wsem.sem.set_resources({_max_concurrent_reads, memory_share});
+            const ssize_t unreduced_memory_share = std::floor((double(wsem.weight) / double(_total_weight)) * _total_memory);
+            wsem.sem.set_resources({_max_concurrent_reads, memory_share}, unreduced_memory_share);
             distributed_memory += memory_share;
         }
         // Slap the remainder on one of the semaphores.
         // This will be a few bytes, doesn't matter where we add it.
         auto& sem = _semaphores.begin()->second.sem;
-        sem.set_resources(sem.initial_resources() + reader_resources{0, dedicated_memory - distributed_memory});
+        sem.set_resources(sem.initial_resources() + reader_resources{0, dedicated_memory - distributed_memory}, sem.unreduced_memory());
     });
 }
 

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -8,6 +8,17 @@
 
 #include "reader_concurrency_semaphore_group.hh"
 
+void reader_concurrency_semaphore_shared_pool::repay(ssize_t amount) noexcept {
+    _available_memory += amount;
+    if (_available_memory > _total_memory)  [[unlikely]] {
+        static thread_local logger::rate_limit rate_limit(std::chrono::seconds(30));
+        rcslog.log(log_level::warn, rate_limit,
+                "shared reader concurrency semaphore pool over-repaid memory: available={}, total={}, repaid={}; clamping available memory to total",
+                _available_memory, _total_memory, amount);
+        _available_memory = _total_memory;
+    }
+}
+
 // Calling adjust is serialized since 2 adjustments can't happen simultaneously,
 // if they did the behaviour would be undefined.
 future<> reader_concurrency_semaphore_group::adjust() {

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -7,7 +7,26 @@
  */
 
 #include "reader_concurrency_semaphore_group.hh"
+#include "reader_concurrency_semaphore_group.hh"
+#include <seastar/core/metrics.hh>
 #include <algorithm>
+
+namespace sm = seastar::metrics;
+
+static const sm::label class_label("class");
+
+void reader_concurrency_semaphore_shared_pool::register_metrics(const sstring& name) {
+    _metrics.add_group("database", {
+        sm::make_gauge("reads_shared_pool_available_memory",
+                       [this] { return _available_memory; },
+                       sm::description("Holds the current amount of available memory in the shared reader concurrency semaphore pool."),
+                       {class_label(name)}),
+        sm::make_gauge("reads_shared_pool_total_memory",
+                       [this] { return _total_memory; },
+                       sm::description("Holds the total memory of the shared reader concurrency semaphore pool."),
+                       {class_label(name)}),
+    });
+}
 
 void reader_concurrency_semaphore_shared_pool::wake_front_waiter() noexcept {
     auto& sem = _notify_list.front().get();

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -8,6 +8,13 @@
 
 #include "reader_concurrency_semaphore_group.hh"
 
+void reader_concurrency_semaphore_shared_pool::wake_front_waiter() noexcept {
+    auto& sem = _notify_list.front().get();
+    _notify_list.pop_front();
+    sem._on_shared_pool_notify_list = false;
+    sem.maybe_wake_execution_loop();
+}
+
 void reader_concurrency_semaphore_shared_pool::repay(ssize_t amount) noexcept {
     _available_memory += amount;
     if (_available_memory > _total_memory)  [[unlikely]] {
@@ -16,6 +23,38 @@ void reader_concurrency_semaphore_shared_pool::repay(ssize_t amount) noexcept {
                 "shared reader concurrency semaphore pool over-repaid memory: available={}, total={}, repaid={}; clamping available memory to total",
                 _available_memory, _total_memory, amount);
         _available_memory = _total_memory;
+    }
+    // Wake a single semaphore rather than all of them.  We pop from the front
+    // (FIFO) so that every registered semaphore gets a turn: each woken
+    // semaphore re-registers at the back if it still has blocked waiters,
+    // giving round-robin fairness.  If the woken semaphore borrows some of the
+    // returned memory it hands the rest off to the next waiter via
+    // maybe_wake_next_waiter(), so a single large return can satisfy several
+    // waiters in order without skipping the head of the line.
+    if (!_notify_list.empty()) {
+        wake_front_waiter();
+    }
+}
+
+void reader_concurrency_semaphore_shared_pool::maybe_wake_next_waiter() noexcept {
+    if (available_memory() > 0 && !_notify_list.empty()) {
+        wake_front_waiter();
+    }
+}
+
+void reader_concurrency_semaphore_shared_pool::request_wakeup(reader_concurrency_semaphore& sem) noexcept {
+    if (!sem._on_shared_pool_notify_list) {
+        sem._on_shared_pool_notify_list = true;
+        _notify_list.emplace_back(sem);
+    }
+}
+
+void reader_concurrency_semaphore_shared_pool::unregister_wakeup(reader_concurrency_semaphore& sem) noexcept {
+    if (sem._on_shared_pool_notify_list) {
+        sem._on_shared_pool_notify_list = false;
+        std::erase_if(_notify_list, [&sem](std::reference_wrapper<reader_concurrency_semaphore> ref) {
+            return &ref.get() == &sem;
+        });
     }
 }
 

--- a/reader_concurrency_semaphore_group.cc
+++ b/reader_concurrency_semaphore_group.cc
@@ -7,6 +7,7 @@
  */
 
 #include "reader_concurrency_semaphore_group.hh"
+#include <algorithm>
 
 void reader_concurrency_semaphore_shared_pool::wake_front_waiter() noexcept {
     auto& sem = _notify_list.front().get();
@@ -62,16 +63,23 @@ void reader_concurrency_semaphore_shared_pool::unregister_wakeup(reader_concurre
 // if they did the behaviour would be undefined.
 future<> reader_concurrency_semaphore_group::adjust() {
     return with_semaphore(_operations_serializer, 1, [this] () {
+        // Clamp out-of-range values rather than rejecting them, so an invalid
+        // configured value degrades gracefully instead of failing.
+        const double shared_pool_fraction = std::clamp(_shared_pool_fraction, 0.0, 1.0);
+        const ssize_t shared_memory = _total_memory * shared_pool_fraction;
+        const ssize_t dedicated_memory = _total_memory - shared_memory;
+        _shared_pool.set_total_memory(shared_memory);
+
         ssize_t distributed_memory = 0;
         for (auto& [sg, wsem] : _semaphores) {
-            const ssize_t memory_share = std::floor((double(wsem.weight) / double(_total_weight)) * _total_memory);
+            const ssize_t memory_share = std::floor((double(wsem.weight) / double(_total_weight)) * dedicated_memory);
             wsem.sem.set_resources({_max_concurrent_reads, memory_share});
             distributed_memory += memory_share;
         }
         // Slap the remainder on one of the semaphores.
         // This will be a few bytes, doesn't matter where we add it.
         auto& sem = _semaphores.begin()->second.sem;
-        sem.set_resources(sem.initial_resources() + reader_resources{0, _total_memory - distributed_memory});
+        sem.set_resources(sem.initial_resources() + reader_resources{0, dedicated_memory - distributed_memory});
     });
 }
 
@@ -111,6 +119,7 @@ reader_concurrency_semaphore* reader_concurrency_semaphore_group::get_or_null(sc
         return &(it->second.sem);
     }
 }
+
 reader_concurrency_semaphore& reader_concurrency_semaphore_group::add_or_update(scheduling_group sg, size_t shares) {
     auto result = _semaphores.try_emplace(
             sg,
@@ -121,7 +130,8 @@ reader_concurrency_semaphore& reader_concurrency_semaphore_group::add_or_update(
             _serialize_limit_multiplier,
             _kill_limit_multiplier,
             _cpu_concurrency,
-            _preemptive_abort_factor
+            _preemptive_abort_factor,
+            _shared_pool
         );
     auto&& it = result.first;
     // since we serialize all group changes this change wait will be queues and no further operations

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -61,7 +61,7 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multiplier,
             utils::updateable_value<uint32_t> cpu_concurrency,
             utils::updateable_value<float> preemptive_abort_factor,
-            double shared_pool_fraction = 0.0,
+            double shared_pool_fraction,
             std::optional<sstring> name_prefix = std::nullopt)
             : _total_memory(memory)
             , _total_weight(0)

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <optional>
 #include "reader_concurrency_semaphore.hh"
+#include "utils/serialized_action.hh"
 
 // The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory.
 // The total memory is divided based on the shared_pool_fraction parameter:
@@ -24,7 +25,7 @@ class reader_concurrency_semaphore_group {
     size_t _total_weight;
     size_t _max_concurrent_reads;
     size_t _max_queue_length;
-    double _shared_pool_fraction;
+    utils::updateable_value<double> _shared_pool_fraction;
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
     utils::updateable_value<uint32_t> _cpu_concurrency;
@@ -52,6 +53,11 @@ class reader_concurrency_semaphore_group {
     reader_concurrency_semaphore_shared_pool _shared_pool;
     seastar::semaphore _operations_serializer;
     std::optional<sstring> _name_prefix;
+    // Re-splits the memory between the dedicated and shared portions whenever
+    // the shared pool fraction changes at runtime. Must be declared before
+    // its observer so the observer is destroyed first.
+    serialized_action _shared_pool_fraction_action;
+    utils::observer<double> _shared_pool_fraction_observer;
 
     future<> change_weight(weighted_reader_concurrency_semaphore& sem, size_t new_weight);
 
@@ -61,13 +67,13 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multiplier,
             utils::updateable_value<uint32_t> cpu_concurrency,
             utils::updateable_value<float> preemptive_abort_factor,
-            double shared_pool_fraction,
+            utils::updateable_value<double> shared_pool_fraction,
             std::optional<sstring> name_prefix = std::nullopt)
             : _total_memory(memory)
             , _total_weight(0)
             , _max_concurrent_reads(max_concurrent_reads)
             ,  _max_queue_length(max_queue_length)
-            , _shared_pool_fraction(shared_pool_fraction)
+            , _shared_pool_fraction(std::move(shared_pool_fraction))
             , _serialize_limit_multiplier(std::move(serialize_limit_multiplier))
             , _kill_limit_multiplier(std::move(kill_limit_multiplier))
             , _cpu_concurrency(std::move(cpu_concurrency))
@@ -75,10 +81,15 @@ public:
             , _shared_pool(0)
             , _operations_serializer(1)
             , _name_prefix(std::move(name_prefix))
+            , _shared_pool_fraction_action([this] { return adjust(); })
+            // adjust() clamps out-of-range values, so the action can't fail on
+            // a bad update.
+            , _shared_pool_fraction_observer(_shared_pool_fraction.observe(_shared_pool_fraction_action.make_observer()))
     {
-        if (shared_pool_fraction > 0) {
-            _shared_pool.register_metrics(_name_prefix.value_or("unnamed"));
-        }
+        // Register metrics unconditionally so they remain valid when the shared
+        // pool is enabled at runtime via a live config update (the gauges report
+        // 0 while the pool is disabled).
+        _shared_pool.register_metrics(_name_prefix.value_or("unnamed"));
     }
 
     ~reader_concurrency_semaphore_group() {

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -12,9 +12,10 @@
 #include <optional>
 #include "reader_concurrency_semaphore.hh"
 
-// The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory,
-// the memory is dynamically divided between them according to a relative slice of shares each semaphore
-// is given.
+// The reader_concurrency_semaphore_group is a group of semaphores that shares a common pool of memory.
+// The total memory is divided based on the shared_pool_fraction parameter:
+// - Dedicated portion (1 - shared_pool_fraction): divided between scheduling groups according to their relative weight/shares
+// - Shared portion (shared_pool_fraction): a pool accessible by all scheduling groups when their dedicated memory is exhausted
 // All of the mutating operations on the group are asynchronic and serialized. The semaphores are created
 // and managed by the group.
 
@@ -23,6 +24,7 @@ class reader_concurrency_semaphore_group {
     size_t _total_weight;
     size_t _max_concurrent_reads;
     size_t _max_queue_length;
+    double _shared_pool_fraction;
     utils::updateable_value<uint32_t> _serialize_limit_multiplier;
     utils::updateable_value<uint32_t> _kill_limit_multiplier;
     utils::updateable_value<uint32_t> _cpu_concurrency;
@@ -38,14 +40,16 @@ class reader_concurrency_semaphore_group {
                 utils::updateable_value<uint32_t> serialize_limit_multiplier,
                 utils::updateable_value<uint32_t> kill_limit_multiplier,
                 utils::updateable_value<uint32_t> cpu_concurrency,
-                utils::updateable_value<float> preemptive_abort_factor)
+                utils::updateable_value<float> preemptive_abort_factor,
+                reader_concurrency_semaphore_shared_pool& shared_pool)
                 : weight(shares)
                 , memory_share(0)
                 , sem(utils::updateable_value(count), 0, name, max_queue_length, std::move(serialize_limit_multiplier), std::move(kill_limit_multiplier),
-                      std::move(cpu_concurrency), std::move(preemptive_abort_factor), reader_concurrency_semaphore::register_metrics::yes) {}
+                      std::move(cpu_concurrency), std::move(preemptive_abort_factor), reader_concurrency_semaphore::register_metrics::yes, shared_pool) {}
     };
 
     std::unordered_map<scheduling_group, weighted_reader_concurrency_semaphore> _semaphores;
+    reader_concurrency_semaphore_shared_pool _shared_pool;
     seastar::semaphore _operations_serializer;
     std::optional<sstring> _name_prefix;
 
@@ -57,15 +61,18 @@ public:
             utils::updateable_value<uint32_t> kill_limit_multiplier,
             utils::updateable_value<uint32_t> cpu_concurrency,
             utils::updateable_value<float> preemptive_abort_factor,
+            double shared_pool_fraction = 0.0,
             std::optional<sstring> name_prefix = std::nullopt)
             : _total_memory(memory)
             , _total_weight(0)
             , _max_concurrent_reads(max_concurrent_reads)
             ,  _max_queue_length(max_queue_length)
+            , _shared_pool_fraction(shared_pool_fraction)
             , _serialize_limit_multiplier(std::move(serialize_limit_multiplier))
             , _kill_limit_multiplier(std::move(kill_limit_multiplier))
             , _cpu_concurrency(std::move(cpu_concurrency))
             , _preemptive_abort_factor(std::move(preemptive_abort_factor))
+            , _shared_pool(0)
             , _operations_serializer(1)
             , _name_prefix(std::move(name_prefix)) { }
 

--- a/reader_concurrency_semaphore_group.hh
+++ b/reader_concurrency_semaphore_group.hh
@@ -74,7 +74,12 @@ public:
             , _preemptive_abort_factor(std::move(preemptive_abort_factor))
             , _shared_pool(0)
             , _operations_serializer(1)
-            , _name_prefix(std::move(name_prefix)) { }
+            , _name_prefix(std::move(name_prefix))
+    {
+        if (shared_pool_fraction > 0) {
+            _shared_pool.register_metrics(_name_prefix.value_or("unnamed"));
+        }
+    }
 
     ~reader_concurrency_semaphore_group() {
         assert(_semaphores.empty());
@@ -86,6 +91,7 @@ public:
     reader_concurrency_semaphore& get(scheduling_group sg);
     reader_concurrency_semaphore* get_or_null(scheduling_group sg);
     reader_concurrency_semaphore& add_or_update(scheduling_group sg, size_t shares);
+    reader_concurrency_semaphore_shared_pool& get_shared_pool() noexcept { return _shared_pool; }
     future<> remove(scheduling_group sg);
     size_t size();
     void foreach_semaphore(std::function<void(scheduling_group, reader_concurrency_semaphore&)> func);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -448,6 +448,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             _cfg.view_update_reader_concurrency_semaphore_kill_limit_multiplier,
             _cfg.view_update_reader_concurrency_semaphore_cpu_concurrency,
             utils::updateable_value(0.0f),
+            _cfg.reader_concurrency_semaphore_shared_pool_fraction(),
             "view_update")
     , _row_cache_tracker(_cfg.index_cache_fraction.operator utils::updateable_value<double>(), cache_tracker::register_metrics::yes)
     , _apply_stage("db_apply", &database::do_apply)
@@ -478,7 +479,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
         _cfg.reader_concurrency_semaphore_serialize_limit_multiplier,
         _cfg.reader_concurrency_semaphore_kill_limit_multiplier,
         _cfg.reader_concurrency_semaphore_cpu_concurrency,
-        _cfg.reader_concurrency_semaphore_preemptive_abort_factor)
+        _cfg.reader_concurrency_semaphore_preemptive_abort_factor,
+        _cfg.reader_concurrency_semaphore_shared_pool_fraction())
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })
     , _memtable_flush_static_shares_observer(cfg.memtable_flush_static_shares.observe(_update_memtable_flush_static_shares_action.make_observer()))

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -424,7 +424,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(uint32_t(1)),
             utils::updateable_value(0.0f),
-            reader_concurrency_semaphore::register_metrics::yes)
+            reader_concurrency_semaphore::register_metrics::yes,
+            reader_concurrency_semaphore_shared_pool::empty_pool())
     // No limits, just for accounting.
     , _compaction_concurrency_sem(reader_concurrency_semaphore::no_limits{}, "compaction", reader_concurrency_semaphore::register_metrics::no)
     , _system_read_concurrency_sem(
@@ -437,7 +438,8 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             utils::updateable_value(std::numeric_limits<uint32_t>::max()),
             utils::updateable_value(uint32_t(1)),
             utils::updateable_value(0.0f),
-            reader_concurrency_semaphore::register_metrics::yes)
+            reader_concurrency_semaphore::register_metrics::yes,
+            reader_concurrency_semaphore_shared_pool::empty_pool())
     , _view_update_read_concurrency_semaphores_group(
             max_memory_concurrent_view_update_reads(),
             utils::updateable_value<int>(max_count_concurrent_view_update_reads),

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -448,7 +448,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
             _cfg.view_update_reader_concurrency_semaphore_kill_limit_multiplier,
             _cfg.view_update_reader_concurrency_semaphore_cpu_concurrency,
             utils::updateable_value(0.0f),
-            _cfg.reader_concurrency_semaphore_shared_pool_fraction(),
+            _cfg.reader_concurrency_semaphore_shared_pool_fraction,
             "view_update")
     , _row_cache_tracker(_cfg.index_cache_fraction.operator utils::updateable_value<double>(), cache_tracker::register_metrics::yes)
     , _apply_stage("db_apply", &database::do_apply)
@@ -480,7 +480,7 @@ database::database(const db::config& cfg, database_config dbcfg, service::migrat
         _cfg.reader_concurrency_semaphore_kill_limit_multiplier,
         _cfg.reader_concurrency_semaphore_cpu_concurrency,
         _cfg.reader_concurrency_semaphore_preemptive_abort_factor,
-        _cfg.reader_concurrency_semaphore_shared_pool_fraction())
+        _cfg.reader_concurrency_semaphore_shared_pool_fraction)
     , _stop_barrier(std::move(barrier))
     , _update_memtable_flush_static_shares_action([this, &cfg] { return _memtable_controller.update_static_shares(cfg.memtable_flush_static_shares()); })
     , _memtable_flush_static_shares_observer(cfg.memtable_flush_static_shares.observe(_update_memtable_flush_static_shares_action.make_observer()))

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -48,7 +48,8 @@ sstables_manager::sstables_manager(
         utils::updateable_value(std::numeric_limits<uint32_t>::max()),
         utils::updateable_value(uint32_t(1)),
         utils::updateable_value(0.0f),
-        reader_concurrency_semaphore::register_metrics::no)
+        reader_concurrency_semaphore::register_metrics::no,
+        reader_concurrency_semaphore_shared_pool::empty_pool())
     , _dir_semaphore(dir_sem)
     , _resolve_host_id(std::move(resolve_host_id))
     , _maintenance_sg(std::move(maintenance_sg))

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -1368,6 +1368,11 @@ SEASTAR_TEST_CASE(upgrade_sstables) {
 
 SEASTAR_THREAD_TEST_CASE(per_service_level_reader_concurrency_semaphore_test) {
     cql_test_config cfg;
+    // This test distributes the whole semaphore-group memory between service
+    // levels by weight and verifies the exact split. The shared pool would
+    // reserve part of that memory, so disable it to keep the full budget
+    // weight-distributed.
+    cfg.db_config->reader_concurrency_semaphore_shared_pool_fraction.set(0);
     do_with_cql_env_thread([] (cql_test_env& e) {
         const size_t num_service_levels = 3;
         const size_t num_keys_to_insert = 10;

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1281,7 +1281,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group) {
             utils::updateable_value(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
             utils::updateable_value(preemptive_abort_factor),
-            0);
+            utils::updateable_value<double>(0));
 
     auto stop_sem = deferred_stop(sem_group);
 
@@ -1396,7 +1396,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool) {
             utils::updateable_value(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
             utils::updateable_value(preemptive_abort_factor),
-            shared_pool_fraction);
+            utils::updateable_value<double>(shared_pool_fraction));
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg1 = create_scheduling_group("test_sg1", 1000).get();
@@ -1458,7 +1458,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_multiple_borrow
             utils::updateable_value(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
             utils::updateable_value(preemptive_abort_factor),
-            shared_pool_fraction);
+            utils::updateable_value<double>(shared_pool_fraction));
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg1 = create_scheduling_group("test_sg1", 1000).get();
@@ -1790,7 +1790,7 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_zero_shared_poo
             utils::updateable_value(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
             utils::updateable_value(preemptive_abort_factor),
-            shared_pool_fraction);
+            utils::updateable_value<double>(shared_pool_fraction));
     auto stop_sem = deferred_stop(sem_group);
 
     auto sg = create_scheduling_group("test_sg", 1000).get();
@@ -1801,6 +1801,72 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_zero_shared_poo
 
     BOOST_CHECK_EQUAL(sem_group.get_shared_pool().total_memory(), 0);
     BOOST_CHECK_EQUAL(sem_group.get(sg).initial_resources().memory, total_memory);
+}
+
+// Test that updating shared_pool_fraction at runtime re-splits the memory
+// between the shared pool and the per-scheduling-group dedicated portions.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool_live_update) {
+    const ssize_t total_memory = 100 * 1024;
+    const int max_count = 100;
+
+    auto serialize_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto kill_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto cpu_concurrency = utils::updateable_value_source<uint32_t>(100);
+    auto preemptive_abort_factor = utils::updateable_value_source<float>(0.0f);
+    auto shared_pool_fraction = utils::updateable_value_source<double>(0.5);
+
+    reader_concurrency_semaphore_group sem_group(total_memory, max_count, 1000,
+            utils::updateable_value(serialize_multiplier),
+            utils::updateable_value(kill_multiplier),
+            utils::updateable_value(cpu_concurrency),
+            utils::updateable_value(preemptive_abort_factor),
+            utils::updateable_value(shared_pool_fraction));
+    auto stop_sem = deferred_stop(sem_group);
+
+    auto sg1 = create_scheduling_group("test_sg1", 1000).get();
+    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto sg2 = create_scheduling_group("test_sg2", 1000).get();
+    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+
+    sem_group.add_or_update(sg1, 1000);
+    sem_group.add_or_update(sg2, 1000);
+    sem_group.wait_adjust_complete().get();
+
+    auto& sem1 = sem_group.get(sg1);
+    auto& shared_pool = sem_group.get_shared_pool();
+
+    auto check_split = [&] (double fraction) {
+        const ssize_t expected_shared_pool = total_memory * fraction;
+        const ssize_t expected_ded_per_sg = (total_memory - expected_shared_pool) / 2;
+        BOOST_CHECK_EQUAL(shared_pool.total_memory(), expected_shared_pool);
+        BOOST_CHECK_LE(std::abs(sem1.initial_resources().memory - expected_ded_per_sg), 2);
+    };
+
+    check_split(0.5);
+
+    // Shrinking the shared pool gives the freed memory back to the dedicated portions.
+    testlog.info("updating shared_pool_fraction 0.5 -> 0.2");
+    shared_pool_fraction.set(0.2);
+    sem_group.wait_adjust_complete().get();
+    check_split(0.2);
+
+    // Disabling the shared pool moves all memory into the dedicated portions.
+    testlog.info("updating shared_pool_fraction 0.2 -> 0");
+    shared_pool_fraction.set(0.0);
+    sem_group.wait_adjust_complete().get();
+    check_split(0.0);
+
+    // Growing the shared pool again takes memory from the dedicated portions.
+    testlog.info("updating shared_pool_fraction 0 -> 0.9");
+    shared_pool_fraction.set(0.9);
+    sem_group.wait_adjust_complete().get();
+    check_split(0.9);
+
+    // Out-of-range values are clamped to 1 rather than throwing.
+    testlog.info("updating shared_pool_fraction 0.9 -> 1.5 (clamped to 1)");
+    shared_pool_fraction.set(1.5);
+    sem_group.wait_adjust_complete().get();
+    check_split(1.0);
 }
 
 namespace {

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1276,7 +1276,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group) {
             utils::updateable_value(serialize_multiplier),
             utils::updateable_value(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
-            utils::updateable_value(preemptive_abort_factor));
+            utils::updateable_value(preemptive_abort_factor),
+            0);
 
     auto stop_sem = deferred_stop(sem_group);
 
@@ -1709,6 +1710,7 @@ SEASTAR_TEST_CASE(test_reader_concurrency_semaphore_memory_limit_engages) {
     db_cfg.enable_commitlog(false);
     db_cfg.reader_concurrency_semaphore_serialize_limit_multiplier.set(2, utils::config_file::config_source::CommandLine);
     db_cfg.reader_concurrency_semaphore_kill_limit_multiplier.set(4, utils::config_file::config_source::CommandLine);
+    db_cfg.reader_concurrency_semaphore_shared_pool_fraction.set(0); // Disable shared pool
 
     return do_with_cql_env_thread([] (cql_test_env& env) {
         auto tbl = create_memory_limit_table(env, 54);

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -2230,7 +2230,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_live_update_count) {
             utils::updateable_value<uint32_t>(kill_multiplier),
             utils::updateable_value<uint32_t>(cpu_concurrency),
             utils::updateable_value<float>(preemptive_abort_factor),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(count(), initial_memory));
@@ -2260,7 +2261,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_live_update_cpu_concu
             utils::updateable_value<uint32_t>(kill_multiplier),
             utils::updateable_value(cpu_concurrency),
             utils::updateable_value<float>(preemptive_abort_factor),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     auto require_can_admit = [&] (bool expected_can_admit, const char* description,
@@ -2313,7 +2315,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_wait_queue_overload_c
             utils::updateable_value<uint32_t>(4),
             utils::updateable_value<uint32_t>(1),
             utils::updateable_value<float>(0.0f),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
@@ -2367,7 +2370,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_double_permit_abort) 
             utils::updateable_value<uint32_t>(400),
             utils::updateable_value<uint32_t>(2),
             utils::updateable_value<float>(0.0f),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     reader_permit_opt permit1 = semaphore.obtain_permit(schema, test_name, 1024, db::no_timeout, {}).get();
@@ -2469,7 +2473,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_always_admit_one_perm
             utils::updateable_value<uint32_t>(400),
             utils::updateable_value<uint32_t>(1),
             utils::updateable_value<float>(0.0f),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     // Scenario1: all memory use used by tracking permit (not consuming count resources)
@@ -2511,7 +2516,8 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_release_base_resource
             utils::updateable_value<uint32_t>(400),
             utils::updateable_value<uint32_t>(1),
             utils::updateable_value<float>(0.0f),
-            reader_concurrency_semaphore::register_metrics::no);
+            reader_concurrency_semaphore::register_metrics::no,
+            reader_concurrency_semaphore_shared_pool::empty_pool());
     auto stop_sem = deferred_stop(semaphore);
 
     const auto expected_base_resources = reader_resources{1, 1024};

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -1228,14 +1228,17 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_set_resources) {
     reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(), initial_resources.count, initial_resources.memory);
     auto stop_sem = deferred_stop(semaphore);
 
+    BOOST_REQUIRE_EQUAL(semaphore.unreduced_memory(), 0);
+
     auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
     auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 1024, db::no_timeout, {}).get();
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(2, 2 * 1024));
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(4, 4 * 1024));
 
-    semaphore.set_resources({8, 8 * 1024});
+    semaphore.set_resources({8, 8 * 1024}, 42);
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(6, 6 * 1024));
     BOOST_REQUIRE_EQUAL(semaphore.initial_resources(), reader_resources(8, 8 * 1024));
+    BOOST_REQUIRE_EQUAL(semaphore.unreduced_memory(), 42);
 
     semaphore.set_resources({2, 2 * 1024});
     BOOST_REQUIRE_EQUAL(semaphore.available_resources(), reader_resources(0, 0));

--- a/test/boost/reader_concurrency_semaphore_test.cc
+++ b/test/boost/reader_concurrency_semaphore_test.cc
@@ -41,6 +41,10 @@ struct reader_concurrency_semaphore_tester {
     static void signal(reader_concurrency_semaphore& sem, reader_resources r) {
         sem.signal(r);
     }
+
+    static void maybe_admit_waiters(reader_concurrency_semaphore& sem) {
+        sem.maybe_admit_waiters();
+    }
 };
 
 BOOST_AUTO_TEST_SUITE(reader_concurrency_semaphore_test)
@@ -1374,6 +1378,429 @@ SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group) {
         }
         check_sem_group();
     }
+}
+
+// Test shared pool memory split, borrowing, and returning
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_shared_pool) {
+    const ssize_t total_memory = 100 * 1024;
+    const int max_count = 100;
+    const double shared_pool_fraction = 0.5;
+
+    auto serialize_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto kill_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto cpu_concurrency = utils::updateable_value_source<uint32_t>(100);
+    auto preemptive_abort_factor = utils::updateable_value_source<float>(0.0f);
+
+    reader_concurrency_semaphore_group sem_group(total_memory, max_count, 1000,
+            utils::updateable_value(serialize_multiplier),
+            utils::updateable_value(kill_multiplier),
+            utils::updateable_value(cpu_concurrency),
+            utils::updateable_value(preemptive_abort_factor),
+            shared_pool_fraction);
+    auto stop_sem = deferred_stop(sem_group);
+
+    auto sg1 = create_scheduling_group("test_sg1", 1000).get();
+    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto sg2 = create_scheduling_group("test_sg2", 1000).get();
+    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+
+    sem_group.add_or_update(sg1, 1000);
+    sem_group.add_or_update(sg2, 1000);
+    sem_group.wait_adjust_complete().get();
+
+    auto& sem1 = sem_group.get(sg1);
+    auto& shared_pool = sem_group.get_shared_pool();
+    const ssize_t expected_ded_per_sg = (total_memory * (1 - shared_pool_fraction)) / 2;
+    const ssize_t expected_shared_pool = total_memory * shared_pool_fraction;
+
+    // 1. Verify split
+    BOOST_CHECK_EQUAL(shared_pool.total_memory(), expected_shared_pool);
+    // Allow small rounding differences (due to integer division and remainder distribution)
+    BOOST_CHECK_LE(std::abs(sem1.available_resources().memory - expected_ded_per_sg), 2);
+
+    // 2. Verify borrowing and returning
+    auto permit = sem1.obtain_permit(nullptr, "test", 0, db::no_timeout, {}).get();
+    const ssize_t dedicated_mem = sem1.initial_resources().memory;
+
+    {
+        // Consume dedicated memory
+        auto units_dedicated = permit.consume_memory(dedicated_mem);
+        BOOST_CHECK_EQUAL(sem1.available_resources().memory, 0);
+        BOOST_CHECK_EQUAL(shared_pool.available_memory(), expected_shared_pool);
+
+        // Borrow from shared pool
+        const ssize_t borrow_amt = 1024;
+        auto units_borrowed = permit.consume_memory(borrow_amt);
+        BOOST_CHECK_LT(shared_pool.available_memory(), expected_shared_pool);
+        BOOST_CHECK_GE(shared_pool.available_memory(), expected_shared_pool - borrow_amt);
+
+        // Units go out of scope here, returning memory
+    }
+
+    // 3. Verify memory restored
+    BOOST_CHECK_EQUAL(shared_pool.available_memory(), expected_shared_pool);
+    BOOST_CHECK_EQUAL(sem1.available_resources().memory, dedicated_mem);
+}
+
+// Test that multiple semaphores can borrow from the same shared pool
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_multiple_borrowers) {
+    const ssize_t total_memory = 20 * 1024;
+    const int max_count = 100;
+    const double shared_pool_fraction = 0.5;
+
+    auto serialize_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto kill_multiplier = utils::updateable_value_source<uint32_t>(100);
+    auto cpu_concurrency = utils::updateable_value_source<uint32_t>(100);
+    auto preemptive_abort_factor = utils::updateable_value_source<float>(0.0f);
+
+    reader_concurrency_semaphore_group sem_group(total_memory, max_count, 1000,
+            utils::updateable_value(serialize_multiplier),
+            utils::updateable_value(kill_multiplier),
+            utils::updateable_value(cpu_concurrency),
+            utils::updateable_value(preemptive_abort_factor),
+            shared_pool_fraction);
+    auto stop_sem = deferred_stop(sem_group);
+
+    auto sg1 = create_scheduling_group("test_sg1", 1000).get();
+    auto destroy_sg1 = defer([&] { destroy_scheduling_group(sg1).get(); });
+    auto sg2 = create_scheduling_group("test_sg2", 1000).get();
+    auto destroy_sg2 = defer([&] { destroy_scheduling_group(sg2).get(); });
+
+    sem_group.add_or_update(sg1, 1000);
+    sem_group.add_or_update(sg2, 1000);
+    sem_group.wait_adjust_complete().get();
+
+    auto& sem1 = sem_group.get(sg1);
+    auto& sem2 = sem_group.get(sg2);
+    auto& shared_pool = sem_group.get_shared_pool();
+
+    const ssize_t dedicated1 = sem1.initial_resources().memory;
+    const ssize_t dedicated2 = sem2.initial_resources().memory;
+    const ssize_t shared_memory = shared_pool.total_memory();
+
+    auto permit1 = sem1.obtain_permit(nullptr, "test1", 0, db::no_timeout, {}).get();
+    auto permit2 = sem2.obtain_permit(nullptr, "test2", 0, db::no_timeout, {}).get();
+
+    {
+        // Both semaphores exhaust their dedicated memory
+        auto units1_dedicated = permit1.consume_memory(dedicated1);
+        auto units2_dedicated = permit2.consume_memory(dedicated2);
+        BOOST_CHECK_EQUAL(shared_pool.available_memory(), shared_memory);
+
+        // Both borrow from shared pool
+        const ssize_t borrow1 = 1024;
+        const ssize_t borrow2 = 2048;
+        auto units1_borrowed = permit1.consume_memory(borrow1);
+        auto units2_borrowed = permit2.consume_memory(borrow2);
+
+        BOOST_CHECK_LE(shared_pool.available_memory(), shared_memory - borrow1 - borrow2);
+    }
+
+    BOOST_CHECK_EQUAL(shared_pool.available_memory(), shared_memory);
+    BOOST_CHECK_EQUAL(sem1.available_resources().memory, dedicated1);
+    BOOST_CHECK_EQUAL(sem2.available_resources().memory, dedicated2);
+
+    // Randomly borrow and return memory
+    std::vector<std::pair<reader_permit::resource_units, size_t>> active1;
+    std::vector<std::pair<reader_permit::resource_units, size_t>> active2;
+    ssize_t allocated1 = 0;
+    ssize_t allocated2 = 0;
+
+    for (int i = 0; i < 500; ++i) {
+        bool do_alloc = true;
+        if (!active1.empty() || !active2.empty()) {
+            do_alloc = tests::random::get_bool();
+        }
+
+        if (do_alloc) {
+            // Determine which semaphore to allocate from
+            bool choose_sem1 = tests::random::get_bool();
+            if (choose_sem1) {
+                const ssize_t max_alloc1 = std::min({
+                    dedicated1 + shared_memory - allocated1,
+                    total_memory - (allocated1 + allocated2)
+                });
+                if (max_alloc1 > 0) {
+                    const ssize_t amt = tests::random::get_int<ssize_t>(1, std::min<ssize_t>(max_alloc1, 2048));
+                    active1.emplace_back(permit1.consume_memory(amt), amt);
+                    allocated1 += amt;
+                }
+            } else {
+                const ssize_t max_alloc2 = std::min({
+                    dedicated2 + shared_memory - allocated2,
+                    total_memory - (allocated1 + allocated2)
+                });
+                if (max_alloc2 > 0) {
+                    const ssize_t amt = tests::random::get_int<ssize_t>(1, std::min<ssize_t>(max_alloc2, 2048));
+                    active2.emplace_back(permit2.consume_memory(amt), amt);
+                    allocated2 += amt;
+                }
+            }
+        } else {
+            // Determine which semaphore to deallocate from
+            bool choose_sem1 = false;
+            if (!active1.empty() && !active2.empty()) {
+                choose_sem1 = tests::random::get_bool();
+            } else if (!active1.empty()) {
+                choose_sem1 = true;
+            }
+
+            if (choose_sem1) {
+                const size_t idx = tests::random::get_int<size_t>(0, active1.size() - 1);
+                allocated1 -= active1[idx].second;
+                active1.erase(active1.begin() + idx);
+            } else {
+                const size_t idx = tests::random::get_int<size_t>(0, active2.size() - 1);
+                allocated2 -= active2[idx].second;
+                active2.erase(active2.begin() + idx);
+            }
+        }
+
+        // Sanity checks
+        const ssize_t expected_borrowed1 = std::max<ssize_t>(0, allocated1 - dedicated1);
+        const ssize_t expected_borrowed2 = std::max<ssize_t>(0, allocated2 - dedicated2);
+        BOOST_CHECK_EQUAL(shared_pool.available_memory(), shared_memory - expected_borrowed1 - expected_borrowed2);
+
+        const ssize_t expected_sem1_mem = (allocated1 > dedicated1) ? 0 : dedicated1 - allocated1;
+        BOOST_CHECK_EQUAL(sem1.available_resources().memory, expected_sem1_mem);
+
+        const ssize_t expected_sem2_mem = (allocated2 > dedicated2) ? 0 : dedicated2 - allocated2;
+        BOOST_CHECK_EQUAL(sem2.available_resources().memory, expected_sem2_mem);
+    }
+
+    // Release all resources in the end
+    active1.clear();
+    active2.clear();
+    allocated1 = 0;
+    allocated2 = 0;
+
+    // Sanity checks again
+    BOOST_CHECK_EQUAL(shared_pool.available_memory(), shared_memory);
+    BOOST_CHECK_EQUAL(sem1.available_resources().memory, dedicated1);
+    BOOST_CHECK_EQUAL(sem2.available_resources().memory, dedicated2);
+}
+
+// Verify that memory borrowable from the shared pool raises the effective
+// serialize limit. While the pool can fund a request, request_memory() is
+// granted in parallel instead of serializing reads down to a single blessed
+// permit. Once the pool is exhausted, growth beyond the serialize limit
+// serializes as usual.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_raises_serialize_limit) {
+    const ssize_t dedicated = 1024;
+    const uint32_t serialize_multiplier = 2; // serialize_limit = 2 * dedicated
+    reader_concurrency_semaphore_shared_pool shared_pool(dedicated);
+
+    reader_concurrency_semaphore semaphore(reader_concurrency_semaphore::for_tests{}, get_name(),
+            10, // count
+            dedicated,
+            100, // max queue length
+            utils::updateable_value<uint32_t>(serialize_multiplier),
+            utils::updateable_value<uint32_t>(std::numeric_limits<uint32_t>::max()), // kill limit disabled
+            utils::updateable_value<uint32_t>(10), // cpu concurrency
+            utils::updateable_value<float>(0.0f),
+            reader_concurrency_semaphore::register_metrics::no,
+            shared_pool);
+    auto stop_sem = deferred_stop(semaphore);
+
+    auto permit1 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}).get();
+    auto permit2 = semaphore.obtain_permit(nullptr, get_name(), 0, db::no_timeout, {}).get();
+
+    std::vector<reader_permit::resource_units> res;
+
+    // Exhaust dedicated memory.
+    res.emplace_back(permit1.consume_memory(dedicated));
+    BOOST_REQUIRE_EQUAL(semaphore.available_resources().memory, 0);
+
+    // Consumption is now at the serialize limit on dedicated memory alone, but
+    // the pool can still fund this request, so it is granted in parallel rather
+    // than serialized (no blessed permit, nothing enqueued).
+    res.emplace_back(permit1.request_memory(dedicated).get());
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_memory, 0);
+    BOOST_REQUIRE_EQUAL(semaphore.get_blessed_permit(), 0);
+    BOOST_REQUIRE_EQUAL(shared_pool.available_memory(), 0);
+
+    // The pool is exhausted now. Growth beyond the serialize limit must
+    // serialize down to a single blessed permit.
+    auto blessed_units = permit1.request_memory(2 * dedicated).get();
+    BOOST_REQUIRE_EQUAL(semaphore.get_blessed_permit(), permit1.id());
+
+    auto enqueued_fut = permit2.request_memory(dedicated);
+    BOOST_REQUIRE(!enqueued_fut.available());
+    BOOST_REQUIRE_EQUAL(semaphore.get_stats().reads_enqueued_for_memory, 1);
+
+    // Evicting permit2 kills its outstanding memory request with std::bad_alloc.
+    simple_schema ss;
+    auto s = ss.schema();
+    auto handle = semaphore.register_inactive_read(make_empty_mutation_reader(s, permit2));
+    BOOST_REQUIRE_THROW(enqueued_fut.get(), std::bad_alloc);
+}
+
+// A semaphore woken because memory was returned to the shared pool re-evaluates
+// only its own head-of-line waiter. If that waiter is too big for the available
+// memory, the wakeup is not handed off to other semaphores: a smaller waiter in
+// another semaphore must not jump ahead and skim the returned memory, otherwise
+// a stream of small reads could starve a big cross-semaphore waiter.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_no_starvation) {
+    const ssize_t dedicated = 100;
+    const ssize_t shared = 50;
+    reader_concurrency_semaphore_shared_pool shared_pool(shared);
+    shared_pool.borrow(shared);
+
+    reader_concurrency_semaphore sem1(reader_concurrency_semaphore::for_tests{}, get_name() + "_sem1",
+            2, dedicated, 100,
+            utils::updateable_value<uint32_t>(100),
+            utils::updateable_value<uint32_t>(std::numeric_limits<uint32_t>::max()),
+            utils::updateable_value<uint32_t>(10),
+            utils::updateable_value<float>(0.0f),
+            reader_concurrency_semaphore::register_metrics::no,
+            shared_pool);
+    auto stop_sem1 = deferred_stop(sem1);
+
+    reader_concurrency_semaphore sem2(reader_concurrency_semaphore::for_tests{}, get_name() + "_sem2",
+            2, dedicated, 100,
+            utils::updateable_value<uint32_t>(100),
+            utils::updateable_value<uint32_t>(std::numeric_limits<uint32_t>::max()),
+            utils::updateable_value<uint32_t>(10),
+            utils::updateable_value<float>(0.0f),
+            reader_concurrency_semaphore::register_metrics::no,
+            shared_pool);
+    auto stop_sem2 = deferred_stop(sem2);
+
+    auto sem1_active = reader_permit_opt(sem1.obtain_permit(nullptr, "sem1_active", dedicated, db::no_timeout, {}).get());
+    auto sem2_active = reader_permit_opt(sem2.obtain_permit(nullptr, "sem2_active", dedicated, db::no_timeout, {}).get());
+
+    // sem1's head waiter needs more than the whole shared pool can hold; sem2's
+    // head waiter would fit in what gets returned. sem1 registers first.
+    auto sem1_waiter = sem1.obtain_permit(nullptr, "sem1_waiter", dedicated, db::no_timeout, {});
+    auto sem2_waiter = sem2.obtain_permit(nullptr, "sem2_waiter", shared, db::no_timeout, {});
+    BOOST_REQUIRE(!sem1_waiter.available());
+    BOOST_REQUIRE(!sem2_waiter.available());
+
+    reader_concurrency_semaphore_tester::maybe_admit_waiters(sem1);
+    reader_concurrency_semaphore_tester::maybe_admit_waiters(sem2);
+
+    // Return memory to the pool. sem1 is at the front of the notify list, so it
+    // is the one woken, but it cannot use the memory (its waiter is too big).
+    shared_pool.repay(shared);
+
+    // sem2's smaller waiter must not be served off the back of sem1's wakeup,
+    // and the returned memory stays in the pool for the big waiter's turn.
+    for (int i = 0; i < 10; ++i) {
+        seastar::thread::yield();
+    }
+    BOOST_REQUIRE(!sem1_waiter.available());
+    BOOST_REQUIRE(!sem2_waiter.available());
+    BOOST_REQUIRE_EQUAL(shared_pool.available_memory(), shared);
+
+    // Releasing the dedicated memory lets both waiters proceed on their own
+    // budgets, confirming nothing is permanently stuck.
+    sem1_active = {};
+    sem2_active = {};
+    BOOST_REQUIRE(eventually_true([&] { return sem1_waiter.available(); }));
+    BOOST_REQUIRE(eventually_true([&] { return sem2_waiter.available(); }));
+    auto sem1_admitted = sem1_waiter.get();
+    auto sem2_admitted = sem2_waiter.get();
+    BOOST_REQUIRE_EQUAL(shared_pool.available_memory(), shared);
+}
+
+// A single return to the shared pool that is large enough to fund the
+// head-of-line waiters of several semaphores must wake all of them, not just
+// the one at the front of the notify list. Each woken semaphore consumes its
+// share and hands the remaining memory off to the next, so one return drains
+// to all waiters in registration order rather than stalling the rest until the
+// next return to the pool.
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_shared_pool_wakes_multiple_waiters) {
+    const ssize_t dedicated = 10;
+    const ssize_t shared = 60;
+    const ssize_t waiter_memory = dedicated; // each waiter is fully funded by the pool
+    constexpr int num_sems = 3;
+    reader_concurrency_semaphore_shared_pool shared_pool(shared);
+    // Drain the pool so the waiters below have to wait for memory to be returned.
+    shared_pool.borrow(shared);
+
+    auto make_sem = [&] (sstring name) {
+        return std::make_unique<reader_concurrency_semaphore>(reader_concurrency_semaphore::for_tests{}, std::move(name),
+                2, dedicated, 100,
+                utils::updateable_value<uint32_t>(100),
+                utils::updateable_value<uint32_t>(std::numeric_limits<uint32_t>::max()),
+                utils::updateable_value<uint32_t>(10),
+                utils::updateable_value<float>(0.0f),
+                reader_concurrency_semaphore::register_metrics::no,
+                shared_pool);
+    };
+
+    std::vector<std::unique_ptr<reader_concurrency_semaphore>> sems;
+    for (int i = 0; i < num_sems; ++i) {
+        sems.push_back(make_sem(format("{}_sem{}", get_name(), i)));
+    }
+
+    // Permits must be released before the semaphores are stopped. A single
+    // teardown does both in order, regardless of how the test exits.
+    std::vector<reader_permit_opt> actives;
+    std::vector<reader_permit_opt> admitted;
+    auto teardown = defer([&] {
+        actives.clear();
+        admitted.clear();
+        for (auto& sem : sems) {
+            sem->stop().get();
+        }
+    });
+
+    std::vector<future<reader_permit>> waiters;
+    for (int i = 0; i < num_sems; ++i) {
+        auto& sem = *sems[i];
+        // Active permit consumes all dedicated memory, so the waiter below has
+        // to borrow from the shared pool to be admitted.
+        actives.emplace_back(sem.obtain_permit(nullptr, "active", dedicated, db::no_timeout, {}).get());
+        waiters.push_back(sem.obtain_permit(nullptr, "waiter", waiter_memory, db::no_timeout, {}));
+    }
+
+    for (int i = 0; i < num_sems; ++i) {
+        BOOST_REQUIRE(!waiters[i].available());
+        reader_concurrency_semaphore_tester::maybe_admit_waiters(*sems[i]);
+    }
+
+    // A single return funds all the waiters. They must all be admitted off this
+    // one return, in order, without further activity on the pool.
+    shared_pool.repay(shared);
+
+    for (int i = 0; i < num_sems; ++i) {
+        BOOST_REQUIRE(eventually_true([&] { return waiters[i].available(); }));
+        admitted.emplace_back(waiters[i].get());
+    }
+
+    // Each admitted waiter borrowed waiter_memory from the pool.
+    BOOST_REQUIRE_EQUAL(shared_pool.available_memory(), shared - num_sems * waiter_memory);
+}
+
+// Test that shared_pool_fraction of 0 means no shared pool is used
+SEASTAR_THREAD_TEST_CASE(test_reader_concurrency_semaphore_group_zero_shared_pool) {
+    const ssize_t total_memory = 10 * 1024;
+    const int max_count = 100;
+    const double shared_pool_fraction = 0.0;
+
+    auto serialize_multiplier = utils::updateable_value_source<uint32_t>(2);
+    auto kill_multiplier = utils::updateable_value_source<uint32_t>(3);
+    auto cpu_concurrency = utils::updateable_value_source<uint32_t>(1);
+    auto preemptive_abort_factor = utils::updateable_value_source<float>(0.0f);
+
+
+    reader_concurrency_semaphore_group sem_group(total_memory, max_count, 1000,
+            utils::updateable_value(serialize_multiplier),
+            utils::updateable_value(kill_multiplier),
+            utils::updateable_value(cpu_concurrency),
+            utils::updateable_value(preemptive_abort_factor),
+            shared_pool_fraction);
+    auto stop_sem = deferred_stop(sem_group);
+
+    auto sg = create_scheduling_group("test_sg", 1000).get();
+    auto destroy_sg = defer([&] { destroy_scheduling_group(sg).get(); });
+
+    sem_group.add_or_update(sg, 1000);
+    sem_group.wait_adjust_complete().get();
+
+    BOOST_CHECK_EQUAL(sem_group.get_shared_pool().total_memory(), 0);
+    BOOST_CHECK_EQUAL(sem_group.get(sg).initial_resources().memory, total_memory);
 }
 
 namespace {

--- a/test/cluster/test_reader_concurrency_semaphore_shared_pool.py
+++ b/test/cluster/test_reader_concurrency_semaphore_shared_pool.py
@@ -1,0 +1,149 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import time
+
+from cassandra.query import SimpleStatement
+from cassandra import ConsistencyLevel
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for
+
+from .util import new_test_keyspace, new_test_table
+
+
+logger = logging.getLogger(__name__)
+
+SHARED_POOL_FRACTION = "reader_concurrency_semaphore_shared_pool_fraction"
+
+TOTAL_MEMORY_METRIC = "scylla_database_reads_shared_pool_total_memory"
+AVAILABLE_MEMORY_METRIC = "scylla_database_reads_shared_pool_available_memory"
+BORROWED_MEMORY_METRIC = "scylla_database_reads_memory_borrowed_from_shared_pool"
+MAIN_POOL_LABELS = {"class": "unnamed"}
+
+
+async def _pool_metric(manager: ManagerClient, ip_addr: str, name: str) -> int:
+    metrics = await manager.metrics.query(ip_addr)
+    return int(metrics.get(name, MAIN_POOL_LABELS) or 0)
+
+
+async def test_shared_pool_live_resize_under_reads(manager: ManagerClient):
+    """
+    Change reader_concurrency_semaphore_shared_pool_fraction live (0.2 -> 0 -> 0.5)
+    while a continuous stream of reads is in flight, verifying via metrics that
+    the shared pool is resized correctly and reads keep succeeding. Finally drive
+    the pool to 0.99 so the tiny dedicated budget is exhausted and confirm reads
+    borrow from the shared pool.
+
+    The node runs with a small memory budget so the reader semaphore's dedicated
+    memory (a fixed 2% fraction of node memory) is small enough to exercise the
+    shared pool with ordinary reads.
+    """
+    server = await manager.server_add(cmdline=["--smp", "1"])
+    cql, hosts = await manager.get_ready_cql([server])
+    ip = server.ip_addr
+    host = hosts[0]
+
+    rows = 10
+    blob_size = 100 * 1024
+    concurrency = 50
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = {'replication_factor': 1}", host) as ks:
+        async with new_test_table(manager, ks, "pk int, ck int, v blob, PRIMARY KEY (pk, ck)", host=host) as tbl:
+            await manager.server_update_config(server.server_id, SHARED_POOL_FRACTION, 0.2)
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (0, ?, ?)")
+            blob = bytes(blob_size)
+            await asyncio.gather(*(cql.run_async(insert, [i, blob]) for i in range(rows)))
+            await manager.api.flush_keyspace(ip, ks)
+            logger.info(f"Inserted {rows} rows of {blob_size} bytes into a single partition")
+
+            stop_event = asyncio.Event()
+            # Unpaged reverse-order full-partition scan, kept running in the
+            # background for the whole test so the semaphore is always under load
+            # while the shared pool fraction is changed.
+            select = SimpleStatement(f"SELECT * FROM {tbl} WHERE pk = 0 ORDER BY ck DESC",
+                                     consistency_level=ConsistencyLevel.ONE,
+                                     fetch_size=None)
+            read_state = {"count": 0, "max_borrowed": 0}
+
+            async def do_reads():
+                while not stop_event.is_set():
+                    await cql.run_async(select, host=host)
+                    read_state["count"] += 1
+
+            # The borrow gauge is a gauge that drops back to 0 once a read repays
+            # the pool, so it must be sampled continuously while reads are in
+            # flight. Sum across all per-semaphore (per-scheduling-group) series.
+            async def sample_borrowed():
+                while not stop_event.is_set():
+                    metrics = await manager.metrics.query(ip)
+                    borrowed = int(metrics.get(BORROWED_MEMORY_METRIC) or 0)
+                    read_state["max_borrowed"] = max(read_state["max_borrowed"], borrowed)
+
+            async def reads_advanced(baseline: int):
+                # Truthy once enough new reads have completed since the baseline.
+                done = read_state["count"] - baseline
+                return done if done > 50 else None
+
+            read_tasks = [asyncio.create_task(do_reads()) for _ in range(concurrency)]
+            sampler_task = asyncio.create_task(sample_borrowed())
+
+            try:
+                # Make sure reads are actively running so the live config changes
+                # below happen while the semaphore is under load.
+                await wait_for(lambda: reads_advanced(0), time.time() + 60, label="reads start")
+
+                # The shared pool holds ~0.2 of the group.
+                total_20 = await _pool_metric(manager, ip, TOTAL_MEMORY_METRIC)
+                available_20 = await _pool_metric(manager, ip, AVAILABLE_MEMORY_METRIC)
+                logger.info(f"fraction=0.2: total={total_20} available={available_20}")
+                assert total_20 > 0
+                assert 0 <= available_20 <= total_20
+
+                # Live update to 0: the shared pool is emptied.
+                await manager.server_update_config(server.server_id, SHARED_POOL_FRACTION, 0)
+
+                async def pool_emptied():
+                    return (await _pool_metric(manager, ip, TOTAL_MEMORY_METRIC)) == 0 or None
+                await wait_for(pool_emptied, time.time() + 60, label="pool total drops to 0")
+                assert (await _pool_metric(manager, ip, AVAILABLE_MEMORY_METRIC)) == 0
+                logger.info("fraction=0: shared pool emptied")
+
+                # Reads must keep succeeding with the pool disabled.
+                reads_at_zero = read_state["count"]
+                await wait_for(lambda: reads_advanced(reads_at_zero), time.time() + 60,
+                               label="reads progress with pool disabled")
+
+                # Live update to 0.5: the shared pool grows to ~half the group.
+                await manager.server_update_config(server.server_id, SHARED_POOL_FRACTION, 0.5)
+
+                async def pool_grew():
+                    total = await _pool_metric(manager, ip, TOTAL_MEMORY_METRIC)
+                    # 0.5 must be clearly larger than the 0.2 total.
+                    return total if total > total_20 * 2 else None
+                total_50 = await wait_for(pool_grew, time.time() + 60, label="pool total grows")
+                available_50 = await _pool_metric(manager, ip, AVAILABLE_MEMORY_METRIC)
+                logger.info(f"fraction=0.5: total={total_50} available={available_50}")
+                assert 0 <= available_50 <= total_50
+
+                # Drive the dedicated budget almost to zero (0.99 shared) so the
+                # in-flight reads immediately exhaust it and borrow from the
+                # shared pool. Sample until a non-zero borrow is observed.
+                await manager.server_update_config(server.server_id, SHARED_POOL_FRACTION, 0.99)
+
+                async def borrowed_seen():
+                    return read_state["max_borrowed"] or None
+                await wait_for(borrowed_seen, time.time() + 60, label="reads borrow from shared pool")
+                logger.info(f"fraction=0.99: peak memory borrowed from shared pool = {read_state['max_borrowed']}")
+            finally:
+                stop_event.set()
+                sampler_task.cancel()
+                await asyncio.gather(*read_tasks, sampler_task, return_exceptions=True)
+
+            logger.info(f"Total successful reads during test: {read_state['count']}")
+            assert read_state["count"] > 0


### PR DESCRIPTION
Before this patch series, the following phenomena occurred:
 - Service levels with a small number of shares received a very small
   fraction of memory, which could lead to problems like query cache
   thrashing.
 - Merely adding (without using) new service levels decreased memory
   limits, possibly significantly.

This patch series implements and enabled the `shared_memory_pool`.
With the shared pool, the memory is divided as follows:
 - 50% is a dedicated portion divided between scheduling groups
   according to their relative weight/shares
 - 50% is a shared portion accessible by all scheduling groups when
   their dedicated memory is exhausted
 
The intention is that the dedicated pool protects important workloads
and the shared pool protects low-share workloads from complete resource
starvation.

There is some overhead (median ~100 insns/op) introduced with
the new code:

Before this patch series:
```
386834.79 tps ( 58.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   36357 insns/op,   14673 cycles/op,        0 errors)
throughput:
        mean=   386098.65 standard-deviation=5222.68
        median= 387763.56 median-absolute-deviation=2160.04
        maximum=388900.65 minimum=365498.19
instructions_per_op:
        mean=   36330.26 standard-deviation=23.06
        median= 36326.54 median-absolute-deviation=19.85
        maximum=36398.05 minimum=36300.82
cpu_cycles_per_op:
        mean=   14671.44 standard-deviation=111.26
        median= 14643.20 median-absolute-deviation=44.47
        maximum=15146.67 minimum=14600.69
```

This commit:
```
390527.45 tps ( 58.1 allocs/op,   0.0 logallocs/op,  14.1 tasks/op,   36418 insns/op,   14532 cycles/op,        0 errors)
throughput:
        mean=   390795.39 standard-deviation=5050.17
        median= 392699.20 median-absolute-deviation=2067.07
        maximum=394192.92 minimum=369615.50
instructions_per_op:
        mean=   36423.83 standard-deviation=23.41
        median= 36420.97 median-absolute-deviation=17.54
        maximum=36468.23 minimum=36364.91
cpu_cycles_per_op:
        mean=   14481.18 standard-deviation=59.98
        median= 14460.10 median-absolute-deviation=37.62
        maximum=14671.55 minimum=14406.30
```

The implementation was evaluated in two experiments: 
 1) a small number of high-priority service levels (with rate-limited bandwidth) run alongside resource-heavy, low-priority workloads
 2)  a high-share service level receives the protection it is entitled to by its shares when a large number (5) of low-share (40) high-demand clients compete against a single high-share (1000) high-demand client with bounded bandwidth

Setup & Configuration of Experiment 1
*   Environment: Single-shard ScyllaDB (--smp 1, --memory 4G).
*   Dataset: 55 GB of data spread across 1M partitions (up to 5,000 clustering rows per partition, mean ~500, 100 bytes/row).
*   Workload: Multi-partition range scans (WHERE token(pk) >= ?) of size 5,000, paged at 1,000 rows.
*   Service Levels:
    *   Low-Priority: sl100 (100 shares).
    *   High-Priority: sl1 and sl2 (1,000 shares each).
*   Parameters Tested: reader_concurrency_semaphore_shared_pool_fraction of 0, 0.2, 0.5, and 0.99.

Phases of Experiment 1
 * Phase 1: Read data using 25 workers assigned to the low-priority service level (sl100).
 * Phase 2: Keep the sl100 workers running, and add workers for high-priority service levels sl1 and sl2 with a client-side bandwidth cap of 3 MB/s per service level.
 
Results of Experiment 1
1.  Overall Throughput Boost: Enabling the shared memory pool significantly improves overall throughput, showing an increase of 35% to 50% compared to having no shared pool (shared_pool_percent=0).
2.  Improved Cache Efficiency: Increasing the shared pool percentage directly correlates with a reduction in querier cache misses, preventing query cache thrashing for the low-share workload.
3.  Strict Isolation for High-Priority Workloads: The throughput and rate-limited bandwidth of the high-priority service levels (sl1 and sl2) remain completely unaffected when the shared pool is enabled and low-priority workloads scale up.

Setup & Configuration of Experiment 2
*   Environment: Single-shard ScyllaDB (--smp 1, --memory 3G).
*   Dataset: 55 GB of data spread across 1M partitions (up to 5,000 clustering rows per partition, mean ~500, 100 bytes/row).
*   Workload: Multi-partition range scans (WHERE token(pk) >= ?) of size 5,000, paged at 1,000 rows.
*   Service Levels:
    *   High-Priority: sl1000 (1000 shares).
    *   High-Priority: sl1-sl5 (40 shares each).
*   Parameters Tested: reader_concurrency_semaphore_shared_pool_fraction of 0, 0.2, 0.5, and 0.99.

Phases of Experiment 2
 * Phase 1: Read data using 5 workers with sl1000, with client-side cap at 30MB/s
 * Phase 2: Keep sl1000 workers and add sl1-sl5 workers

Results of Experiment 2
1. With `shared_pool_fraction=0.2` and `shared_pool_fraction=0.5` the high demand client is protected (there is some bandwidth reduction but smaller than 10%)
2. With `shared_pool_fraction=0.99` the bandwidth of the high demand client drops by 20-30%

Fixes: SCYLLADB-455
No backport, it's new feature.