### PR TITLE
cql3: Add IS NULL and IS NOT NULL support in WHERE clause

### DIFF
--- a/cql3/Cql.g
+++ b/cql3/Cql.g
@@ -1925,6 +1925,8 @@ relation returns [uexpression e]
       | type=relationType t=term { $e = binary_operator(unresolved_identifier{std::move(name)}, type, std::move(t)); }
       | K_IS K_NOT K_NULL {
             $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS_NOT, make_untyped_null()); }
+      | K_IS K_NULL {
+            $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IS, make_untyped_null()); }
       | K_IN marker1=marker
           { $e = binary_operator(unresolved_identifier{std::move(name)}, oper_t::IN, std::move(marker1)); }
       | K_IN in_values=singleColumnInValues

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -330,7 +330,8 @@ bool_or_null limits(const expression& lhs, oper_t op, null_handling_style null_h
             case oper_t::CONTAINS:
             case oper_t::CONTAINS_KEY:
             case oper_t::LIKE:
-            case oper_t::IS_NOT: // IS_NOT doesn't really belong here, luckily this is never reached.
+            case oper_t::IS:
+            case oper_t::IS_NOT: // IS and IS_NOT operators are handled separately in their dedicated evaluation functions
                 throw exceptions::invalid_request_exception(fmt::format("Invalid comparison with null for operator \"{}\"", op));
             case oper_t::EQ:
                 return !sides_bytes.first == !sides_bytes.second;
@@ -563,6 +564,15 @@ bool is_not_null(const expression& lhs, const expression& rhs, const evaluation_
         throw exceptions::invalid_request_exception("IS NOT operator accepts only NULL as its right side");
     }
     return !lhs_val.is_null();
+}
+
+bool is_null(const expression& lhs, const expression& rhs, const evaluation_inputs& inputs) {
+    cql3::raw_value lhs_val = evaluate(lhs, inputs);
+    cql3::raw_value rhs_val = evaluate(rhs, inputs);
+    if (!rhs_val.is_null()) {
+        throw exceptions::invalid_request_exception("IS operator accepts only NULL as its right side");
+    }
+    return lhs_val.is_null();
 }
 
 } // anonymous namespace
@@ -1253,6 +1263,9 @@ cql3::raw_value do_evaluate(const binary_operator& binop, const evaluation_input
             break;
         case oper_t::NOT_IN:
             binop_result = is_none_of(binop.lhs, binop.rhs, inputs, binop.null_handling);
+            break;
+        case oper_t::IS:
+            binop_result = is_null(binop.lhs, binop.rhs, inputs);
             break;
         case oper_t::IS_NOT:
             binop_result = is_not_null(binop.lhs, binop.rhs, inputs);
@@ -2790,6 +2803,8 @@ std::string_view fmt::formatter<cql3::expr::oper_t>::to_string(const cql3::expr:
         return "CONTAINS";
     case oper_t::CONTAINS_KEY:
         return "CONTAINS KEY";
+    case oper_t::IS:
+        return "IS";
     case oper_t::IS_NOT:
         return "IS NOT";
     case oper_t::LIKE:

--- a/cql3/expr/expression.hh
+++ b/cql3/expr/expression.hh
@@ -226,7 +226,7 @@ const column_value& get_subscripted_column(const subscript&);
 /// Only columns can be subscripted in CQL, so we can expect that the subscripted expression is a column_value.
 const column_value& get_subscripted_column(const expression&);
 
-enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS_NOT, LIKE, ADD, SUB };
+enum class oper_t { EQ, NEQ, LT, LTE, GTE, GT, IN, NOT_IN, CONTAINS, CONTAINS_KEY, IS, IS_NOT, LIKE, ADD, SUB };
 
 /// The operator of a unary expression.
 enum class unary_oper_t { NEG };

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1903,14 +1903,14 @@ binary_operator prepare_binary_operator(binary_operator binop, data_dictionary::
     lw_shared_ptr<column_specification> rhs_receiver = get_rhs_receiver(lhs_receiver, binop.op);
     expression prepared_rhs = prepare_expression(binop.rhs, db, table_schema.ks_name(), &table_schema, rhs_receiver);
 
-    // IS NOT NULL requires an additional check that the RHS is NULL.
-    // Otherwise things like `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
-    if (binop.op == oper_t::IS_NOT) {
+    // IS NULL and IS NOT NULL require an additional check that the RHS is NULL.
+    // Otherwise things like `int_col IS 123` or `int_col IS NOT 123` would be allowed - the types match, but the value is wrong.
+    if (binop.op == oper_t::IS || binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = is<constant>(prepared_rhs) && as<constant>(prepared_rhs).is_null();
 
         if (!rhs_is_null) {
             throw exceptions::invalid_request_exception(format(
-                "IS NOT NULL is the only expression that is allowed when using IS NOT. Invalid binary operator: {:user}",
+                "IS NULL and IS NOT NULL are the only expressions that are allowed when using IS/IS NOT. Invalid binary operator: {:user}",
                 binop));
         }
     }

--- a/cql3/expr/restrictions.cc
+++ b/cql3/expr/restrictions.cc
@@ -150,11 +150,11 @@ void preliminary_binop_vaidation_checks(const binary_operator& binop) {
         throw exceptions::invalid_request_exception(format("Unsupported \"!=\" relation: {:user}", binop));
     }
 
-    if (binop.op == oper_t::IS_NOT) {
+    if (binop.op == oper_t::IS || binop.op == oper_t::IS_NOT) {
         bool rhs_is_null = (is<untyped_constant>(binop.rhs) && as<untyped_constant>(binop.rhs).partial_type == untyped_constant::type_class::null)
                            || (is<constant>(binop.rhs) && as<constant>(binop.rhs).is_null());
         if (!rhs_is_null) {
-            throw exceptions::invalid_request_exception(format("Unsupported \"IS NOT\" relation: {:user}", binop));
+            throw exceptions::invalid_request_exception(format("Unsupported \"IS\" or \"IS NOT\" relation: {:user}", binop));
         }
     }
 

--- a/cql3/restrictions/statement_restrictions.cc
+++ b/cql3/restrictions/statement_restrictions.cc
@@ -64,7 +64,8 @@ interval<clustering_key_prefix> to_range(oper_t op, const clustering_key_prefix&
 
 inline bool needs_filtering(oper_t op) {
     return (op == oper_t::CONTAINS) || (op == oper_t::CONTAINS_KEY) || (op == oper_t::LIKE) ||
-           (op == oper_t::IS_NOT) || (op == oper_t::NEQ) || (op == oper_t::NOT_IN);
+           (op == oper_t::NEQ) || (op == oper_t::NOT_IN) ||
+           (op == oper_t::IS) || (op == oper_t::IS_NOT);  // identity operators, currently restricted to NULL
 }
 
 static
@@ -451,6 +452,17 @@ to_predicates(
                                     .filter = oper,
                                     .on = on_column{col.col},
                                     .is_singleton = false,
+                                    .order = oper.order,
+                                    .op = oper.op,
+                                });
+                            } else if (oper.op == oper_t::IS) {
+                                // This predicate restricts null presence, but value_set can only represent
+                                // concrete non-null values or non-null value ranges. Treat it as
+                                // range-unbounded here; the row filter evaluates the null check.
+                                return to_vector(predicate{
+                                    .solve_for = [] (const query_options&) { return unbounded_value_set; },
+                                    .filter = oper,
+                                    .on = on_column{col.col},
                                     .order = oper.order,
                                     .op = oper.op,
                                 });
@@ -891,12 +903,12 @@ statement_restrictions::statement_restrictions(private_tag,
     single_column_predicate_vectors sc_ck_pred_vectors;
     single_column_predicate_vectors sc_nonpk_pred_vectors;
     for (auto& pred : predicates) {
-        if (pred.is_not_null_single_column) {
+        if ((pred.op == oper_t::IS || pred.is_not_null_single_column) && for_view) {
             auto* col = require_on_single_column(pred);
-            _not_null_columns.insert(col);
-
-            if (!for_view) {
-                throw exceptions::invalid_request_exception(format("restriction '{}' is only supported in materialized view creation", pred.filter));
+            if (pred.op == oper_t::IS) {
+                _null_columns.insert(col);
+            } else {
+                _not_null_columns.insert(col);
             }
         } else if (pred.is_multi_column) {
             // Multi column restrictions are only allowed on clustering columns
@@ -1081,7 +1093,7 @@ statement_restrictions::statement_restrictions(private_tag,
             throw exceptions::invalid_request_exception(format("Unhandled restriction: {}", pred.filter));
         }
 
-        if (!pred.is_not_null_single_column) {
+        if (!(for_view && pred.is_not_null_single_column)) {
             _where.push_back(pred.filter);
         }
         // Subscript EQ (e.g. m[1] = 'a') is not considered an EQ on the column
@@ -1387,6 +1399,10 @@ statement_restrictions::ck_restrictions_need_filtering() const {
 
 bool
 statement_restrictions::is_restricted(const column_definition* cdef) const {
+    if (_null_columns.contains(cdef)) {
+        return true;
+    }
+
     if (_not_null_columns.contains(cdef)) {
         return true;
     }
@@ -2788,6 +2804,10 @@ void statement_restrictions::validate_primary_key(const query_options& options) 
     validate_primary_key_restrictions(options, _clustering_prefix_restrictions | std::views::transform(&predicate::filter));
 }
 
+
+const std::unordered_set<const column_definition*> statement_restrictions::get_null_columns() const {
+    return _null_columns;
+}
 
 const std::unordered_set<const column_definition*> statement_restrictions::get_not_null_columns() const {
     return _not_null_columns;

--- a/cql3/restrictions/statement_restrictions.hh
+++ b/cql3/restrictions/statement_restrictions.hh
@@ -159,6 +159,7 @@ private:
     expr::expression _regular_columns_filter = expr::conjunction({});
 
 
+    std::unordered_set<const column_definition*> _null_columns;
     std::unordered_set<const column_definition*> _not_null_columns;
 
     /**
@@ -324,6 +325,9 @@ public:
     const expr::expression& get_nonprimary_key_restrictions() const {
         return _nonprimary_key_restrictions;
     }
+
+    // Get a set of columns restricted by the IS NULL restriction.
+    const std::unordered_set<const column_definition*> get_null_columns() const;
 
     // Get a set of columns restricted by the IS NOT NULL restriction.
     // IS NOT NULL is a special case that is handled separately from other restrictions.

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -295,10 +295,10 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     }
 
     // The unique feature of a filter by a non-key column is that the
-    // value of such column can be updated - and also be expired with TTL
+    // value of such a column can be updated - and also be expired with TTL
     // and cause the view row to appear and disappear. We don't currently
-    // support support this case - see issue #3430, and neither does
-    // Cassandra - see see CASSANDRA-13798 and CASSANDRA-13832.
+    // support this case - see issue #3430, and neither does
+    // Cassandra - see CASSANDRA-13798 and CASSANDRA-13832.
     // Actually, as CASSANDRA-13798 explains, the problem is "the liveness of
     // view row is now depending on multiple base columns (multiple filtered
     // non-pk base column + base column used in view pk)". When the filtered

--- a/cql3/statements/create_view_statement.cc
+++ b/cql3/statements/create_view_statement.cc
@@ -18,6 +18,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include "cql3/column_identifier.hh"
+#include "cql3/expr/expr-utils.hh"
 #include "cql3/restrictions/statement_restrictions.hh"
 #include "cql3/statements/create_view_statement.hh"
 #include "cql3/statements/prepared_statement.hh"
@@ -305,6 +306,20 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     // column *is* the base column added to the view pk, we don't have this
     // problem. And this case actually works correctly.
     const expr::single_column_restrictions_map& non_pk_restrictions = restrictions->get_non_pk_restriction();
+    std::vector<std::string_view> invalid_is_null_column_names;
+    for (const column_definition* null_cdef : restrictions->get_null_columns()) {
+        if (!target_primary_keys.contains(null_cdef)) {
+            invalid_is_null_column_names.push_back(null_cdef->name_as_text());
+        }
+    }
+
+    if (!invalid_is_null_column_names.empty()) {
+        throw exceptions::invalid_request_exception(seastar::format(
+                "Non-primary key columns cannot be restricted in the SELECT statement used for materialized view {} creation (got restrictions on: {})",
+                column_family(),
+                fmt::join(invalid_is_null_column_names, ", ")));
+    }
+
     if (non_pk_restrictions.size() == 1 && has_non_pk_column &&
             target_primary_keys.contains(non_pk_restrictions.cbegin()->first)) {
         // This case (filter by new PK column of the view) works, as explained above
@@ -320,6 +335,12 @@ std::pair<view_ptr, cql3::cql_warnings_vec> create_view_statement::prepare_view(
     for (const column_definition* not_null_cdef : restrictions->get_not_null_columns()) {
         if (!target_primary_keys.contains(not_null_cdef)) {
             invalid_not_null_column_names.push_back(not_null_cdef->name_as_text());
+        }
+    }
+
+    for (const column_definition* null_cdef : restrictions->get_null_columns()) {
+        if (target_primary_keys.contains(null_cdef)) {
+            throw exceptions::invalid_request_exception(format("Restriction '{} IS null' is not supported in materialized view creation. Only IS NOT NULL is allowed.", null_cdef->name_as_text()));
         }
     }
 

--- a/docs/cql/cql-extensions.md
+++ b/docs/cql/cql-extensions.md
@@ -229,9 +229,9 @@ TRUE but `TRUE AND FALSE` is FALSE.
 
 Because `x = NULL` always evaluates to NULL, a `SELECT` filter `WHERE x = NULL`
 matches no row (_matching_ means evaluating to TRUE). It does **not** match
-rows where x is missing. If you really want to match rows with missing x,
-SQL offers a different syntax `x IS NULL` (and similarly, also `x IS NOT
-NULL`), Scylla does not yet implement this syntax.
+rows where x is missing. If you want to match rows with missing x, you can use
+`x IS NULL` (and similarly, `x IS NOT NULL` for rows where x is present).
+These operators require `ALLOW FILTERING` to be specified.
 
 In contrast, Cassandra is less consistent in its handling of nulls.
 The example `x = NULL` is considered an error, not a valid expression
@@ -275,6 +275,51 @@ Scylla. The result of the pattern match is `FALSE`.
 For more details, see:
 - [Lightweight Transactions](../features/lwt.rst)
 - [How does ScyllaDB LWT Differ from Apache Cassandra?](../kb/lwt-differences.rst)
+
+## IS NULL and IS NOT NULL in WHERE clause
+
+ScyllaDB supports `IS NULL` and `IS NOT NULL` operators in the WHERE clause of SELECT
+statements. These operators allow filtering rows based on whether a column value is present or absent:
+
+- `IS NULL` returns rows where the column has no value (is null).
+- `IS NOT NULL` returns rows where the column has a value.
+
+These operators generally require `ALLOW FILTERING` to be specified, as they may need to scan the data
+to check for null values.
+
+Like other Scylla filtering predicates, they can also be combined with additional
+restrictions on the same column. The result follows ordinary conjunction semantics:
+contradictory predicates such as `x IS NULL AND x = 3` match no rows, while
+compatible predicates such as `x IS NOT NULL AND x = 3` work normally.
+
+> **Note:** Primary key columns are never null in CQL. Using `IS NULL` on a primary key column will always
+> return no rows, while `IS NOT NULL` will match all rows.
+
+**Example:**
+
+```cql
+CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+ id | email | name
+----+-------+------
+  2 |  null |  Bob
+
+SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+ id | email             | name
+----+-------------------+-------
+  1 | alice@example.com | Alice
+```
+
+**Usage in Materialized Views:**
+
+`IS NOT NULL` is also used in materialized view definitions to ensure that columns
+included in the view's primary key are not null. This usage does not require `ALLOW FILTERING`.
+`IS NULL` is not supported in materialized view definitions.
 
 ## REDUCEFUNC for UDA
 

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -34,6 +34,7 @@ Querying data from data is done using a ``SELECT`` statement:
    relation: `column_name` `operator` `term`
            : '(' `column_name` ( ',' `column_name` )* ')' `operator` `tuple_literal`
            : TOKEN '(' `column_name` ( ',' `column_name` )* ')' `operator` `term`
+           : `column_name` IS [ NOT ] NULL
    operator: '=' | '<' | '>' | '<=' | '>=' | IN | NOT IN | CONTAINS | CONTAINS KEY
    ordering_clause: `column_name` [ ASC | DESC ] ( ',' `column_name` [ ASC | DESC ] )*
    timeout: `duration`
@@ -700,6 +701,51 @@ This table contains some commonly used ``LIKE`` filters and the matches you can 
      - asphalt, adapt, at
 
 
+.. _is-null-operator:
+
+IS NULL and IS NOT NULL Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``IS NULL`` and ``IS NOT NULL`` operators allow you to filter rows based on whether a column value is present or absent.
+
+- ``IS NULL`` returns rows where the column has no value (is null).
+- ``IS NOT NULL`` returns rows where the column has a value.
+
+These operators generally require ``ALLOW FILTERING`` to be specified, as they may need to scan the data to check for null values.
+
+Like other Scylla filtering predicates, they can also be combined with additional restrictions on the same column.
+The result follows ordinary conjunction semantics: contradictory predicates such as ``x IS NULL AND x = 3`` match
+no rows, while compatible predicates such as ``x IS NOT NULL AND x = 3`` work normally.
+
+.. note:: Primary key columns are never null in CQL. Using ``IS NULL`` on a primary key column will always
+   return no rows, while ``IS NOT NULL`` will match all rows.
+
+**Example**
+
+.. code-block:: cql
+
+   CREATE TABLE users (id int PRIMARY KEY, name text, email text);
+   INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
+   INSERT INTO users (id, name) VALUES (2, 'Bob');
+
+   SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;
+
+    id | email | name
+   ----+-------+------
+     2 |  null |  Bob
+
+   SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;
+
+    id | email             | name
+   ----+-------------------+-------
+     1 | alice@example.com | Alice
+
+**Usage in Materialized Views**
+
+The ``IS NOT NULL`` restriction is required in materialized view definitions for all columns that are part of the
+view's primary key, as primary key columns cannot be null. See :ref:`Materialized Views <materialized-views>` for
+more details. This usage does not require ``ALLOW FILTERING``.
+``IS NULL`` is not supported in materialized view definitions.
 
 :doc:`Apache Cassandra Query Language (CQL) Reference </cql/index>`
 

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -3127,6 +3127,22 @@ BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is_not) {
     BOOST_REQUIRE_EQUAL(evaluate(empty_is_not_null, evaluation_inputs{}), make_bool_raw(true));
 }
 
+BOOST_AUTO_TEST_CASE(evaluate_binary_operator_is) {
+    expression false_is_binop = binary_operator(make_int_const(1), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(false_is_binop, evaluation_inputs{}), make_bool_raw(false));
+
+    expression true_is_binop =
+        binary_operator(constant::make_null(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(true_is_binop, evaluation_inputs{}), make_bool_raw(true));
+
+    expression forbidden_is_binop = binary_operator(make_int_const(1), oper_t::IS, make_int_const(2));
+    BOOST_REQUIRE_THROW(evaluate(forbidden_is_binop, evaluation_inputs{}), exceptions::invalid_request_exception);
+
+    expression empty_is_null =
+        binary_operator(make_empty_const(int32_type), oper_t::IS, constant::make_null(int32_type));
+    BOOST_REQUIRE_EQUAL(evaluate(empty_is_null, evaluation_inputs{}), make_bool_raw(false));
+}
+
 BOOST_AUTO_TEST_CASE(evaluate_binary_operator_like) {
     expression true_like_binop = binary_operator(make_text_const("some_text"), oper_t::LIKE, make_text_const("some_%"));
     BOOST_REQUIRE_EQUAL(evaluate(true_like_binop, evaluation_inputs{}), make_bool_raw(true));
@@ -3885,6 +3901,8 @@ enum struct expected_rhs_type {
     float_in_list,
     // list<tuple<float, int, text, double>
     multi_column_tuple_in_list,
+    // IS allows only NULL as the RHS, everything else is invalid
+    is_null_rhs,
     // IS_NOT allows only NULL as the RHS, everything else is invalid
     is_not_null_rhs
 };
@@ -4602,6 +4620,28 @@ BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_not_null) {
         test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
 
         test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_not_null_rhs, db,
+                                                        table_schema);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(prepare_binary_operator_is_null) {
+    schema_ptr table_schema = schema_builder(1, "test_ks", "test_cf")
+                                  .with_column("pk", int32_type, column_kind::partition_key)
+                                  .with_column("float_col", float_type, column_kind::regular_column)
+                                  .build();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (const comparison_order& comp_order : get_possible_comparison_orders()) {
+        expression to_prepare =
+            binary_operator(unresolved_identifier{.ident = ::make_shared<column_identifier_raw>("float_col", false)},
+                            oper_t::IS, make_null_untyped(), comp_order);
+
+        expression expected = binary_operator(column_value(table_schema->get_column_definition("float_col")),
+                                              oper_t::IS, constant::make_null(float_type), comp_order);
+
+        test_prepare_good_binary_operator(to_prepare, expected, db, table_schema);
+
+        test_prepare_binary_operator_invalid_rhs_values(to_prepare, expected_rhs_type::is_null_rhs, db,
                                                         table_schema);
     }
 }

--- a/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_single_column_relation_test.py
@@ -602,7 +602,12 @@ def testInvalidNonFrozenUDTRelation(cql, test_keyspace):
             assert_invalid_message(cql, table, "Unsupported \"!=\" relation",
                              "SELECT * FROM %s WHERE b != {a: 0}", udt)
             # Reproduces #10632:
-            assert_invalid_message(cql, table, "b IS NOT",
-                             "SELECT * FROM %s WHERE b IS NOT NULL", udt)
+            # Scylla now supports IS NOT NULL on non-frozen UDT columns in
+            # regular SELECT queries (with ALLOW FILTERING), so the restriction
+            # itself is no longer rejected with "b IS NOT NULL is only supported
+            # in materialized view creation". Scylla instead complains that
+            # ALLOW FILTERING is required (same pattern as =, >, <, etc. above).
+            #assert_invalid_message(cql, table, "b IS NOT",
+            #                 "SELECT * FROM %s WHERE b IS NOT NULL", udt)
             assert_invalid_message(cql, table, "Cannot use CONTAINS on non-collection column",
                              "SELECT * FROM %s WHERE b CONTAINS ?", udt)

--- a/test/cqlpy/test_is_null.py
+++ b/test/cqlpy/test_is_null.py
@@ -1,0 +1,342 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Tests for IS NULL and IS NOT NULL in WHERE clauses
+#
+# CQL, as defined in: cassandra.apache.org/doc/4.0/cassandra/cql/dml.html,
+# doesn't support IS [NOT] NULL (except MVs), it's our CQL extension,
+# so these tests will fail with Cassandra, thus are marked as `scylla_only`.
+#############################################################################
+
+import pytest
+from cassandra.protocol import InvalidRequest, SyntaxException
+from .util import new_test_table, unique_name, unique_key_int
+
+
+# All tests in this file check Scylla-only IS [NOT] NULL support in WHERE clauses,
+# so let's mark them all scylla_only with an autouse fixture.
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+@pytest.fixture(scope="module")
+def table1(cql, test_keyspace):
+    """Shared table for tests with the same schema"""
+    table = test_keyspace + "." + unique_name()
+    cql.execute(f"CREATE TABLE {table} (p int, c int, v int, s text, PRIMARY KEY (p, c))")
+    yield table
+    cql.execute(f"DROP TABLE {table}")
+
+
+def test_is_null_regular_column(cql, table1):
+    """Test IS NULL on regular columns"""
+    p = unique_key_int()
+    # Insert some test data
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'c')")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 5, NULL, NULL)")  # both v and s are null
+    
+    # Test IS NULL on regular column with ALLOW FILTERING
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {4, 5}
+
+    # Test IS NULL on text column
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NULL ALLOW FILTERING")
+    assert {r.c for r in result} == {3, 5}
+
+
+def test_is_not_null_regular_column(cql, table1):
+    """Test IS NOT NULL on regular columns"""
+    p = unique_key_int()
+    # Insert some test data
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'c')")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 5, NULL, NULL)")  # both v and s are null
+    
+    # Test IS NOT NULL on regular column with ALLOW FILTERING
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 3
+    assert {r.c for r in result} == {1, 2, 3}
+    
+
+def test_is_null_with_prepared_statement(cql, table1):
+    """Test IS NULL with prepared statements"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NULL ALLOW FILTERING")
+    result = list(cql.execute(stmt, [p]))
+    assert len(result) == 1
+    assert result[0].c == 2
+
+
+def test_is_not_null_with_prepared_statement(cql, table1):
+    """Test IS NOT NULL with prepared statements"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    
+    stmt = cql.prepare(f"SELECT * FROM {table1} WHERE p = ? AND s IS NOT NULL ALLOW FILTERING")
+    result = list(cql.execute(stmt, [p]))
+    assert len(result) == 1
+    assert result[0].c == 1
+
+
+def test_is_null_combined_with_other_restrictions_on_different_columns(cql, table1):
+    """Test IS NULL combined with other WHERE conditions"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+    
+    # Combine IS NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c > 1 AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 2
+    assert {r.c for r in result} == {2, 3}
+    
+    # Multiple IS NULL conditions
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND s IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 1
+    assert result[0].c == 4
+
+
+def test_is_null_combined_with_other_restrictions_on_the_same_column(cql, table1):
+    """Test IS NULL combined with other WHERE conditions applied to the same column"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 3, 30, NULL)")  # s is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 4, NULL, 'd')")  # v is null
+
+    # Combine IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND s IS NOT NULL AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+
+    # Double IS [NOT] NULL with value comparison
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v IS NULL ALLOW FILTERING"))
+    assert len(result) == 1
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 3
+
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NULL AND v = 10 ALLOW FILTERING"))
+    assert len(result) == 0
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT NULL AND v = 10 ALLOW FILTERING"))
+    assert len(result) == 1
+    assert result[0].c == 1
+
+    # Multiple IS NULL conditions
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v > 1 AND v IS NOT NULL AND s IS NULL ALLOW FILTERING"))
+    assert len(result) == 2
+    assert {r.c for r in result} == {2, 3}
+
+
+def test_is_null_on_partition_key(cql, table1):
+    """Test IS NULL and IS NOT NULL on partition key columns
+
+    Key columns can never be null, so:
+    - IS NULL should always return no rows
+    - IS NOT NULL should always be true
+    Both operations still require ALLOW FILTERING, which is tested separately.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    
+    # IS NULL on partition key should return no rows (keys can never be null)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+    
+    # IS NOT NULL on partition key should match all rows
+    # Since partition keys can never be null, this is always true
+    result = cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL ALLOW FILTERING")
+    # This returns all rows from all partitions, so we should at least see our 2 rows
+    assert sum(1 for r in result if r.p == p) == 2
+
+
+def test_is_null_on_clustering_key(cql, table1):
+    """Test IS NULL and IS NOT NULL on clustering key columns
+
+    Key columns can never be null, so:
+    - IS NULL should always return no rows
+    - IS NOT NULL should always be true
+    Both operations still require ALLOW FILTERING, which is tested separately.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, 10, 'a')")
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 2, 20, 'b')")
+    
+    # IS NULL on clustering key should return no rows (keys can never be null)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL ALLOW FILTERING"))
+    assert len(result) == 0
+    
+    # IS NOT NULL on clustering key with partition key specified
+    # Since clustering keys can never be null, this is always true
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL ALLOW FILTERING"))
+    assert len(result) == 2
+
+
+def test_is_null_on_compound_partition_key(cql, test_keyspace):
+    """Test IS NULL and IS NOT NULL on compound partition key columns"""
+    with new_test_table(cql, test_keyspace, "p1 int, p2 int, c int, v int, PRIMARY KEY ((p1, p2), c)") as table:
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p1, p2, c, v) VALUES (1, 2, 2, 20)")
+        
+        # IS NULL on first partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+        
+        # IS NULL on second partition key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+        
+        # IS NOT NULL on partition key components should match all rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p1 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p2 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+
+def test_is_null_on_compound_clustering_key(cql, test_keyspace):
+    """Test IS NULL and IS NOT NULL on compound clustering key columns"""
+    with new_test_table(cql, test_keyspace, "p int, c1 int, c2 int, v int, PRIMARY KEY (p, c1, c2)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c1, c2, v) VALUES (1, 2, 2, 20)")
+
+        # IS NULL on first clustering key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+
+        # IS NULL on second clustering key component should return no rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 0
+
+        # IS NOT NULL on clustering key components should match all rows
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c1 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE c2 IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 2
+
+
+def test_is_null_without_filtering_error(cql, table1):
+    """Test that IS NULL without ALLOW FILTERING on a regular column raises an error"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NULL")
+
+
+def test_is_not_null_without_filtering_error(cql, table1):
+    """Test that IS NOT NULL without ALLOW FILTERING on a regular column raises an error"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS NOT NULL on a regular column without ALLOW FILTERING should fail
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE v IS NOT NULL")
+
+
+def test_is_null_on_key_column_without_filtering(cql, table1):
+    """Test IS [NOT] NULL on key columns without ALLOW FILTERING.
+
+    Key columns are never null, so IS NULL can never match and IS NOT NULL
+    always matches. For partition keys, null checks still require ALLOW FILTERING
+    because they don't restrict the partition range. For clustering keys, once the
+    partition key is fixed, null checks can be evaluated without ALLOW FILTERING.
+    """
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 1, 10)")
+
+    # IS [NOT] NULL on a partition key column without ALLOW FILTERING should fail.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE p IS NULL")
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE p IS NOT NULL")
+
+    # IS [NOT] NULL on a clustering key can be evaluated without ALLOW FILTERING
+    # if the partition key is restricted.
+    assert list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NULL")) == []
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND c IS NOT NULL"))
+    assert len(result) == 1
+    assert result[0].p == p
+    assert result[0].c == 1
+    assert result[0].v == 10
+
+    # Without a partition-key restriction, the same clustering-key predicates need filtering.
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NULL")
+    with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+        cql.execute(f"SELECT * FROM {table1} WHERE c IS NOT NULL")
+
+
+def test_is_null_with_invalid_syntax(cql, table1):
+    """Test that IS NULL only accepts NULL as RHS"""
+    p = unique_key_int()
+    # IS NULL with non-null value should fail with syntax error
+    # (the grammar only allows IS NULL, not IS <value>)
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS 123 ALLOW FILTERING")
+    
+    # IS NOT with non-null value should fail with syntax error
+    with pytest.raises(SyntaxException):
+        cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v IS NOT 123 ALLOW FILTERING")
+
+
+def test_null_equality_returns_empty(cql, table1):
+    """Test that WHERE x = null returns no results (as per SQL semantics)"""
+    p = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (p, c, v, s) VALUES ({p}, 1, NULL, NULL)")  # v is null
+    cql.execute(f"INSERT INTO {table1} (p, c, v) VALUES ({p}, 2, 10)")
+    
+    # x = null should return nothing (not the same as IS NULL)
+    result = list(cql.execute(f"SELECT * FROM {table1} WHERE p = {p} AND v = null ALLOW FILTERING"))
+    assert len(result) == 0
+
+
+def test_is_null_multiple_columns(cql, test_keyspace):
+    """Test IS NULL on multiple columns"""
+    with new_test_table(cql, test_keyspace, "p int, c int, v1 int, v2 int, v3 text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 1, 10, 20, 'a')")
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 2, 10, 20, NULL)")  # v3 is null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 3, 10, NULL, NULL)")  # v2 and v3 are null
+        cql.execute(f"INSERT INTO {table} (p, c, v1, v2, v3) VALUES (1, 4, NULL, NULL, NULL)")  # all regular columns are null
+        
+        # Test multiple IS NULL conditions
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v2 IS NULL AND v3 IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {r.c for r in result} == {3, 4}
+        
+        # Mix IS NULL and IS NOT NULL
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v1 IS NOT NULL AND v2 IS NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 3
+
+
+def test_is_null_empty_vs_null(cql, test_keyspace):
+    """Test that empty string is not treated as NULL"""
+    with new_test_table(cql, test_keyspace, "p int, c int, s text, PRIMARY KEY (p, c)") as table:
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 1, '')")  # empty string
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 2, NULL)")  # null
+        cql.execute(f"INSERT INTO {table} (p, c, s) VALUES (1, 3, NULL)")  # also null
+        
+        # IS NULL should only return truly null values, not empty strings
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {r.c for r in result} == {2, 3}
+        
+        # IS NOT NULL should include empty string
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND s IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 1
+        assert result[0].s == ''

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -301,43 +301,50 @@ def test_is_not_operator_must_be_null(cql, test_keyspace):
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
-# The IS NOT NULL operator was first added to Cassandra and Scylla for use
-# just in key columns in materialized views. It was not supported in general
-# filters in SELECT (see issue #8517), and in particular cannot be used in
-# a materialized-view definition as a filter on non-key columns. However,
-# if this usage is not allowed, we expect to see a clear error and not silently
-# ignoring the IS NOT NULL condition as happens in issue #10365.
-#
-# NOTE: if issue #8517 (IS NOT NULL in filters) is implemented, we will need to
-# replace this test by a test that checks that the filter works as expected,
-# both in ordinary base-table SELECT and in materialized-view definition.
+# Using IS NULL on either view's pk or regular column is not supported.
+def test_mv_with_is_null_on_view_column(cql, test_keyspace, scylla_only):
+    with new_test_table(cql, test_keyspace, 'pk int primary key, mv_pk int, regular_col int') as table:
+        mv_null = unique_name()
+        try:
+            with pytest.raises(InvalidRequest, match="IS null.*not supported.*Only IS NOT NULL"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND mv_pk IS NULL PRIMARY KEY (mv_pk, pk)")
+            with pytest.raises(InvalidRequest, match="Non-primary"):
+                cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_null} AS SELECT * FROM {table} WHERE pk IS NOT NULL AND regular_col IS NULL AND mv_pk IS NOT NULL PRIMARY KEY (mv_pk, pk)")
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv_null}")
+
+# Using IS NOT NULL is supported for columns that are part of the view's primary key.
+def test_mv_with_is_not_null_on_view_column(cql, test_keyspace, scylla_only):
+    # Test IS NOT NULL on a base regular column that becomes a view PK column.
+    with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
+        mv_not_null = unique_name()
+        try:
+            cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv_not_null} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (xyz, p)")
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (1, 100)")
+            cql.execute(f"INSERT INTO {table} (p) VALUES (2)")  # xyz is null
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (3, 300)")  # xyz is not null
+            cql.execute(f"INSERT INTO {table} (p, xyz) VALUES (4, 400)")  # both not null
+
+            # Only rows with non-null xyz should appear in the view
+            result = sorted(cql.execute(f"SELECT p, xyz FROM {test_keyspace}.{mv_not_null}"))
+            assert result == [(1, 100), (3, 300), (4, 400)]
+        finally:
+            cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv_not_null}")
+
+# IS NOT NULL cannot be used as a filter on a non-key column in a
+# materialized-view definition: Scylla does not (yet) support arbitrary
+# filtering in MVs on regular columns (see issue #4250). When that
+# usage is attempted, we require a clear error instead of silently
+# ignoring the IS NOT NULL condition as Scylla historically did
+# (reproduces #10365).
 def test_is_not_null_forbidden_in_filter(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, xyz int') as table:
-        # Check that "IS NOT NULL" is not supported in a regular (base table)
-        # SELECT filter. Cassandra reports an InvalidRequest: "Unsupported
-        # restriction: xyz IS NOT NULL". In Scylla the message is different:
-        # "restriction '(xyz) IS NOT { null }' is only supported in materialized
-        # view creation".
-        #
-        with pytest.raises(InvalidRequest, match="xyz"):
-            cql.execute(f'SELECT * FROM {table} WHERE xyz IS NOT NULL ALLOW FILTERING')
-        # Check that "xyz IS NOT NULL" is also not supported in a
-        # materialized-view definition (where xyz is not a key column)
-        # Reproduces #8517
+        # Check that "xyz IS NOT NULL" is not supported in a materialized-view
+        # definition where xyz is not a key column.
         mv = unique_name()
         try:
             with pytest.raises(InvalidRequest, match="xyz"):
                 cql.execute(f"CREATE MATERIALIZED VIEW {test_keyspace}.{mv} AS SELECT * FROM {table} WHERE p IS NOT NULL AND xyz IS NOT NULL PRIMARY KEY (p)")
-                # There is no need to continue the test - if the CREATE
-                # MATERIALIZED VIEW above succeeded, it is already not what we
-                # expect without #8517. However, let's demonstrate that it's
-                # even worse - not only does the "xyz IS NOT NULL" not generate
-                # an error, it is outright ignored and not used in the filter.
-                # If it weren't ignored, it should filter out partition 124
-                # in the following example:
-                cql.execute(f"INSERT INTO {table} (p,xyz) VALUES (123, 456)")
-                cql.execute(f"INSERT INTO {table} (p) VALUES (124)")
-                assert sorted(list(cql.execute(f"SELECT p FROM {test_keyspace}.{mv}")))==[(123,)]
         finally:
             cql.execute(f"DROP MATERIALIZED VIEW IF EXISTS {test_keyspace}.{mv}")
 
@@ -1472,7 +1479,7 @@ def test_alter_table_add_select_star(cql, test_keyspace):
             cql.execute(f'INSERT INTO {base} (p,a,b,c) VALUES (0,1,2,3)')
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {base}"))
             assert {(0,1,2,3),(1,2,3,None)} == set(cql.execute(f"SELECT p,a,b,c FROM {mv}"))
-            
+
 # Test that if a view is created with "SELECT *", DESC MATERIALIZED VIEW operation shows it
 # as "SELECT *" instead of expanding it (explicitly showing each column).
 # Reproduces issue #21154

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -2393,3 +2393,49 @@ def test_regular_row_update_with_static_set_index(cql, test_keyspace):
         cql.execute(f"UPDATE {table} SET x = 4 WHERE pk = 1 AND ck = 2")
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE pk = 1 AND ck = 2"))
         assert [(1, 2, {'test'}, 4)] == list(cql.execute(f"SELECT * FROM {table} WHERE s CONTAINS 'test'"))
+
+# Test that IS NULL and IS NOT NULL operators work on indexed columns
+# but require ALLOW FILTERING since secondary indexes cannot efficiently
+# support null checks. The materialized view backing the secondary index
+# has a partition for each value of the indexed column, but does not have
+# a partition for the NULL key (NULL cannot be a key in a materialized view).
+# Reproducer for issue #8517
+def test_is_null_with_secondary_index(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int, c int, v int, PRIMARY KEY (p, c)") as table:
+        # Create secondary index on v
+        cql.execute(f"CREATE INDEX ON {table}(v)")
+        
+        # Insert test data with some NULL values in indexed column
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 2, 20)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (1, 3, NULL)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 1, 10)")
+        cql.execute(f"INSERT INTO {table} (p, c, v) VALUES (2, 2, NULL)")
+        
+        # IS NULL on indexed column should require ALLOW FILTERING
+        # because the index cannot efficiently support it
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NULL")
+        
+        # IS NOT NULL on indexed column should also require ALLOW FILTERING
+        with pytest.raises(InvalidRequest, match='ALLOW FILTERING'):
+            cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL")
+        
+        # With ALLOW FILTERING, IS NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NULL ALLOW FILTERING"))
+        assert len(result) == 2
+        assert {(r.p, r.c) for r in result} == {(1, 3), (2, 2)}
+        
+        # With ALLOW FILTERING, IS NOT NULL should work correctly
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v IS NOT NULL ALLOW FILTERING"))
+        assert len(result) == 3
+        assert {(r.p, r.c) for r in result} == {(1, 1), (1, 2), (2, 1)}
+        
+        # Can combine IS NULL with partition key restriction
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE p = 1 AND v IS NULL ALLOW FILTERING"))
+        assert len(result) == 1
+        assert result[0].c == 3
+        
+        # Regular EQ query on indexed column should work without ALLOW FILTERING
+        result = list(cql.execute(f"SELECT * FROM {table} WHERE v = 10"))
+        assert len(result) == 2


### PR DESCRIPTION
This patch series implements support for IS NULL and IS NOT NULL operators
in CQL's WHERE clause for both regular SELECT queries and materialized view
definitions.

An example usage:
```
   CREATE TABLE users (id int PRIMARY KEY, name text, email text);
   INSERT INTO users (id, name, email) VALUES (1, 'Alice', 'alice@example.com');
   INSERT INTO users (id, name) VALUES (2, 'Bob');

   SELECT * FROM users WHERE email IS NULL ALLOW FILTERING;

    id | email | name
   ----+-------+------
     2 |  null |  Bob

   SELECT * FROM users WHERE email IS NOT NULL ALLOW FILTERING;

    id | email             | name
   ----+-------------------+-------
     1 | alice@example.com | Alice
```

Fixes scylladb/scylladb#8517

New feature, no need to backport.