### PR TITLE
reader_concurrency_semaphore: move state switch to active_await to tracked_file_impl

### DIFF
--- a/reader_concurrency_semaphore.cc
+++ b/reader_concurrency_semaphore.cc
@@ -1770,6 +1770,9 @@ private:
         auto res = co_await func(*get_file_impl(_tracked_file));
 
         if constexpr (std::is_same_v<std::remove_cvref_t<decltype(res)>, temporary_buffer<uint8_t>>) {
+            // Read could have returned less data than requested, reduce memory usage accordingly.
+            units.reset_to(reader_resources::with_memory(res.size()));
+
             co_return make_tracked_temporary_buffer(std::move(res), std::move(units));
         } else {
             // We currently have two return types: temporary_buffer<uint8_t> (above) and size_t.

--- a/sstables/consumer.hh
+++ b/sstables/consumer.hh
@@ -513,7 +513,6 @@ protected:
     sstables::reader_position_tracker _stream_position;
     // remaining length of input to read (if <0, continue until end of file).
     uint64_t _remain;
-    std::optional<reader_permit::awaits_guard> _awaits_guard;
     bool _first_invoke = true;
 public:
     using read_status = data_consumer::read_status;
@@ -525,29 +524,11 @@ public:
             , _remain(maxlen) {}
 
     future<> consume_input() {
-        // On first invoke we are guaranteed to go to the disk, so mark as
-        // blocked unconditionally. On succeeding invokes, we determine whether
-        // we need to block inside operator().
-        // One corner case this misses is when the last operator() consumed all
-        // data but didn't want more so the next invocation will block, we bet
-        // on this being rare.
-        if (_first_invoke) {
-            _first_invoke = false;
-            mark_blocked();
-        }
         return _input.consume(state_processor());
     }
 
     void verify_end_state() {
         state_processor().verify_end_state();
-    }
-
-    void mark_blocked() {
-        _awaits_guard.emplace(_permit);
-    }
-
-    void mark_unblocked() {
-        _awaits_guard.reset();
     }
 
     data_consumer::processing_result skip(temporary_buffer<char>& data, uint32_t len) {
@@ -590,7 +571,6 @@ public:
     // called by input_stream::consume():
     future<consumption_result_type>
     operator()(temporary_buffer<char> data) {
-        mark_unblocked();
         if (data.size() >= _remain) {
             // We received more data than we actually care about, so process
             // the beginning of the buffer, and return the rest to the stream
@@ -618,7 +598,6 @@ public:
                 _remain -= orig_data_size - data.size();
                 _stream_position.position -= data.size();
                 if (value == proceed::yes) {
-                    mark_blocked();
                     return make_ready_future<consumption_result_type>(continue_consuming{});
                 } else {
                     return make_ready_future<consumption_result_type>(stop_consuming<char>{std::move(data)});
@@ -637,7 +616,6 @@ public:
                 }
                 _stream_position.position += skip.get_value();
                 _remain -= skip.get_value();
-                mark_blocked();
                 return make_ready_future<consumption_result_type>(std::move(skip));
             });
         }


### PR DESCRIPTION
Reader permits have specific states, which represent the resource they are using at the moment:
* `active_need_cpu` - the read is active and needs CPU resource to make progress
* `active_await` - the read is active and waits for an IO (or remote request) to complete

The permit will often switch between these two states as the as needed. Being in the correct state for the current circumstance is crucial. The semaphore decides whether a new permit can be allowed, depending on resource availability. A permit in the `active_need_cpu` will consume a CPU resource which might block a new permit from being admitted. Permits should switch to `active_await` state when doing IO. Doing so releases the CPU resource they held on, allowing other reads which need CPU to make progress while they wait for the IO to complete. This is the same idea which underpins asynchronous programming.

The state switch from `active_need_cpu` to `active_await` currently happens in `sstables::continuous_data_consumer`. This component is a higher level one, determining when IO will happen is not trivial. Sure enough, a bug managed to sneak in, in fact it may be a bug the original author (yours truly) was aware of but thought will be rare enough to be insignificant, as evidenced by https://github.com/scylladb/scylladb/blob/f49c9e896a7b2eb32f7b9eb9284b2ae81fe30c56/sstables/consumer.hh#L528-L533

The fix is to move the state switch from this higher level component, to a much lower level one, where all different IO paths will eventually converge: the `tracked_file_impl`.

Fixes: SCYLLADB-458

Bug was introduced in 434f2efde54, backport is needed to all releases.