### PR TITLE
test: pylib: Convict the node on server_stop()

### DIFF
--- a/api/api-doc/failure_detector.json
+++ b/api/api-doc/failure_detector.json
@@ -8,6 +8,30 @@
    ],
    "apis":[
       {
+         "path":"/failure_detector/convict/{host}",
+         "operations":[
+            {
+               "method":"POST",
+               "summary":"Forces failure detection of a given host locally, marks the node as DOWN, drops connections",
+               "type":"string",
+               "nickname":"convict",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+                  {
+                     "name":"host",
+                     "description":"Host ID of the node to convict",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                  }
+               ]
+            }
+         ]
+      },
+      {
          "path":"/failure_detector/phi",
          "operations":[
             {

--- a/api/column_family.cc
+++ b/api/column_family.cc
@@ -9,6 +9,7 @@
 #include <fmt/ranges.h>
 #include "column_family.hh"
 #include "api/api.hh"
+#include "api/validate.hh"
 #include "api/api-doc/column_family.json.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include <vector>

--- a/api/failure_detector.cc
+++ b/api/failure_detector.cc
@@ -9,8 +9,11 @@
 #include "failure_detector.hh"
 #include "api/api.hh"
 #include "api/api-doc/failure_detector.json.hh"
+#include "api/validate.hh"
 #include "gms/application_state.hh"
 #include "gms/gossiper.hh"
+
+extern logging::logger apilog;
 
 namespace api {
 using namespace seastar::httpd;
@@ -64,6 +67,15 @@ void set_failure_detector(http_context& ctx, routes& r, gms::gossiper& g) {
         return make_ready_future<json::json_return_type>(8);
     });
 
+    fd::convict.set(r, [&g] (std::unique_ptr<request> req) -> future<json::json_return_type> {
+        return g.container().invoke_on(0, [req = std::move(req)] (gms::gossiper& g) -> future<json::json_return_type> {
+            auto host_id = validate_host_id(req->get_path_param("host"));
+            apilog.info("Convict {}", host_id);
+            co_await g.convict(host_id);
+            co_return seastar::json::json_void();
+        });
+    });
+
     fd::get_simple_states.set(r, [&g] (std::unique_ptr<request> req) {
         return g.container().invoke_on(0, [] (gms::gossiper& g) {
             std::vector<fd::mapper> nodes_status;
@@ -114,6 +126,7 @@ void unset_failure_detector(http_context& ctx, routes& r) {
     fd::set_phi_convict_threshold.unset(r);
     fd::get_endpoint_state.unset(r);
     fd::get_endpoint_phi_values.unset(r);
+    fd::convict.unset(r);
 }
 
 }

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -61,6 +61,7 @@
 #include "utils/rjson.hh"
 #include "utils/user_provided_param.hh"
 #include "sstable_dict_autotrainer.hh"
+#include "api/validate.hh"
 
 using namespace seastar::httpd;
 using namespace std::chrono_literals;
@@ -111,41 +112,6 @@ static bool any_of_keyspaces_use_tablets(const http_context& ctx) {
 
     auto keyspaces = db.get_all_keyspaces();
     return std::any_of(std::begin(keyspaces), std::end(keyspaces), uses_tablets);
-}
-
-locator::host_id validate_host_id(const sstring& param) {
-    auto hoep = locator::host_id_or_endpoint(param, locator::host_id_or_endpoint::param_type::host_id);
-    return hoep.id();
-}
-
-bool validate_bool(const sstring& param) {
-    if (param == "true") {
-        return true;
-    } else if (param == "false") {
-        return false;
-    } else {
-        throw std::runtime_error("Parameter must be either 'true' or 'false'");
-    }
-}
-
-bool validate_bool_x(const sstring& param, bool default_value) {
-    if (param.empty()) {
-        return default_value;
-    }
-
-    if (strcasecmp(param.c_str(), "true") == 0 || strcasecmp(param.c_str(), "yes") == 0 || param == "1") {
-        return true;
-    }
-    if (strcasecmp(param.c_str(), "false") == 0 || strcasecmp(param.c_str(), "no") == 0 || param == "0") {
-        return false;
-    }
-
-    throw std::runtime_error("Invalid boolean parameter value");
-}
-
-static
-int64_t validate_int(const sstring& param) {
-    return std::atoll(param.c_str());
 }
 
 std::vector<table_info> parse_table_infos(const sstring& ks_name, const http_context& ctx, sstring value) {

--- a/api/storage_service.hh
+++ b/api/storage_service.hh
@@ -84,11 +84,4 @@ void set_load_meter(http_context& ctx, httpd::routes& r, service::load_meter& lm
 void unset_load_meter(http_context& ctx, httpd::routes& r);
 seastar::future<json::json_return_type> run_toppartitions_query(db::toppartitions_query& q, bool legacy_request = false);
 
-// converts string value of boolean parameter into bool
-// maps (case insensitively)
-//     "true", "yes" and "1" into true
-//     "false", "no" and "0" into false
-// otherwise throws runtime_error
-bool validate_bool_x(const sstring& param, bool default_value);
-
 } // namespace api

--- a/api/tasks.cc
+++ b/api/tasks.cc
@@ -11,6 +11,7 @@
 
 #include "api/api.hh"
 #include "api/storage_service.hh"
+#include "api/validate.hh"
 #include "api/api-doc/tasks.json.hh"
 #include "api/api-doc/storage_service.json.hh"
 #include "compaction/compaction_manager.hh"

--- a/api/validate.hh
+++ b/api/validate.hh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2015-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include "locator/host_id.hh"
+#include "locator/token_metadata.hh"
+#include <seastar/core/sstring.hh>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <strings.h>
+
+inline locator::host_id validate_host_id(const sstring& param) {
+    auto hoep = locator::host_id_or_endpoint(param, locator::host_id_or_endpoint::param_type::host_id);
+    return hoep.id();
+}
+
+inline bool validate_bool(const sstring& param) {
+    if (param == "true") {
+        return true;
+    } else if (param == "false") {
+        return false;
+    } else {
+        throw std::runtime_error("Parameter must be either 'true' or 'false'");
+    }
+}
+
+// converts string value of boolean parameter into bool
+// maps (case insensitively)
+//     "true", "yes" and "1" into true
+//     "false", "no" and "0" into false
+// otherwise throws runtime_error
+inline bool validate_bool_x(const sstring& param, bool default_value) {
+    if (param.empty()) {
+        return default_value;
+    }
+
+    if (strcasecmp(param.c_str(), "true") == 0 || strcasecmp(param.c_str(), "yes") == 0 || param == "1") {
+        return true;
+    }
+    if (strcasecmp(param.c_str(), "false") == 0 || strcasecmp(param.c_str(), "no") == 0 || param == "0") {
+        return false;
+    }
+
+    throw std::runtime_error("Invalid boolean parameter value");
+}
+
+inline int64_t validate_int(const sstring& param) {
+    return std::atoll(param.c_str());
+}

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -1208,6 +1208,7 @@ int64_t gossiper::get_endpoint_downtime(locator::host_id ep) const noexcept {
 // - on_dead callbacks
 // It is called from failure_detector
 future<> gossiper::convict(locator::host_id endpoint) {
+    co_await coroutine::switch_to(_gcfg.gossip_scheduling_group);
     auto permit = co_await lock_endpoint(endpoint, null_permit_id);
     auto state = get_endpoint_state_ptr(endpoint);
     if (!state || !is_alive(state->get_host_id())) {

--- a/gms/gossiper.hh
+++ b/gms/gossiper.hh
@@ -300,11 +300,6 @@ public:
 
 private:
     /**
-     * @param endpoint end point that is convicted.
-     */
-    future<> convict(locator::host_id endpoint);
-
-    /**
      * Removes the endpoint from gossip completely
      *
      * @param endpoint endpoint to be removed from the current membership.
@@ -319,6 +314,11 @@ public:
     future<> remove_endpoint(locator::host_id endpoint, permit_id);
     // Returns true if an endpoint was removed
     future<> force_remove_endpoint(locator::host_id id, permit_id);
+
+    /**
+     * @param endpoint endpoint that is convicted.
+     */
+    future<> convict(locator::host_id endpoint);
 private:
     /**
      * The gossip digest is built based on randomization

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -503,7 +503,7 @@ class ScyllaNode:
         if gently:
             self.cluster.manager.server_stop_gracefully(server_id=self.server_id)
         else:
-            self.cluster.manager.server_stop(server_id=self.server_id)
+            self.cluster.manager.server_stop(server_id=self.server_id, convict=False)
 
         if wait or wait_other_notice:
             self.wait_until_stopped(wait_seconds=wait_seconds, marks=marks, dump_core=gently)

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -64,7 +64,8 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         server_to_down = await find_server_by_host_id(manager, servers, HostID(str(base_replicas[0][0])))
 
         logger.info('Downing a node to be replaced')
-        await manager.server_stop(server_to_replace.server_id)
+        # convict=False to avoid triggering SCYLLADB-1996
+        await manager.server_stop(server_to_replace.server_id, convict=False)
 
         logger.info('Blocking tablet rebuild')
         coord = await get_topology_coordinator(manager)
@@ -83,7 +84,8 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         await coord_log.wait_for('tablet_transition_updates: waiting', from_mark=coord_mark)
 
         if server_to_down.server_id != server_to_replace.server_id:
-            await manager.server_stop(server_to_down.server_id)
+            # convict=False to avoid triggering SCYLLADB-1996
+            await manager.server_stop(server_to_down.server_id, convict=False)
 
         # The update is supposed to go to the second replica only, since the other one is downed.
         # If pairing would shift, the update to the view would be lost because the first replica

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -259,7 +259,7 @@ async def test_backoff_when_node_fails_task_rpc(manager: ManagerClient):
     # will be retrying to send a request to it.
     ignore_gossiper_err = "view_building_coordinator_ignore_gossiper"
     await manager.api.enable_injection(s1.ip_addr, ignore_gossiper_err, one_shot=False)
-    await manager.server_stop(s2.server_id)
+    await manager.server_stop(s2.server_id, convict=False)
 
     start = time.time()
 

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -352,8 +352,8 @@ async def test_do_not_finish_view_builder_with_nodes_down(manager: ManagerClient
         # Stop two nodes. Use non-graceful stop to avoid waiting for the
         # view_builder_consume_end_of_partition_delay injection to time out.
         logger.info("Stopping nodes 2 and 3")
-        await manager.server_stop(servers[1].server_id)
-        await manager.server_stop(servers[2].server_id)
+        await manager.server_stop(servers[1].server_id, convict=True)
+        await manager.server_stop(servers[2].server_id, convict=True)
 
         # Unpause the view builder on the remaining node - it should not finish
         # because it cannot replicate view updates to the down nodes.

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -884,15 +884,15 @@ async def test_restore_tablets_node_loss_resiliency(build_mode: str, manager: Ma
         await log.wait_for("pause_tablet_restore: waiting for message", from_mark=mark)
 
         if target == 'api':
-            await manager.server_stop(servers[1].server_id)
+            await manager.server_stop(servers[1].server_id, convict=True)
             with pytest.raises(aiohttp.client_exceptions.ClientConnectorError):
                 await manager.api.wait_task(servers[1].ip_addr, tid)
         else:
             if target == 'coordinator':
-                await manager.server_stop(servers[0].server_id)
+                await manager.server_stop(servers[0].server_id, convict=True)
                 await manager.api.message_injection(servers[2].ip_addr, "pause_tablet_restore")
             elif target == 'replica':
-                await manager.server_stop(servers[2].server_id)
+                await manager.server_stop(servers[2].server_id, convict=True)
 
             # Sometimes killing nodes manage to restore tablets before being killed
             # So the best thing to do is to make sure restore task finishes at all

--- a/test/cluster/random_failures/cluster_events.py
+++ b/test/cluster/random_failures/cluster_events.py
@@ -475,7 +475,7 @@ async def remove_data_dir_of_dead_node(manager: ManagerClient,
     data_dir = os.path.join(await manager.server_get_workdir(running_servers[1].server_id), "data")
 
     LOGGER.info("Kill a node")
-    await manager.server_stop(server_id=running_servers[1].server_id)
+    await manager.server_stop(server_id=running_servers[1].server_id, convict=True)
     await manager.server_not_sees_other_server(
         server_ip=running_servers[0].ip_addr,
         other_ip=running_servers[1].ip_addr,
@@ -601,7 +601,7 @@ async def remove_node(manager: ManagerClient,
 
     LOGGER.info(f"Kill a node: target={target.server_id} (rack={target.rack})")
 
-    await manager.server_stop(server_id=target.server_id)
+    await manager.server_stop(server_id=target.server_id, convict=True)
     await manager.server_not_sees_other_server(
         server_ip=coordinator.ip_addr,
         other_ip=target.ip_addr,
@@ -686,7 +686,7 @@ async def kill_coordinator_node(manager: ManagerClient,
     yield
 
     LOGGER.info("Kill the coordinator node")
-    await manager.server_stop(server_id=(await get_coordinator_host(manager=manager)).server_id)
+    await manager.server_stop(server_id=(await get_coordinator_host(manager=manager)).server_id, convict=True)
     await wait_new_coordinator_elected(manager=manager, expected_num_of_elections=2, deadline=time.time() + 60)
 
     yield

--- a/test/cluster/random_failures/cluster_events.py
+++ b/test/cluster/random_failures/cluster_events.py
@@ -672,7 +672,7 @@ async def kill_non_coordinator_node(manager: ManagerClient,
     yield
 
     LOGGER.info("Kill a non-coordinator node")
-    await manager.server_stop(server_id=(await get_non_coordinator_host(manager=manager)).server_id)
+    await manager.server_stop(server_id=(await get_non_coordinator_host(manager=manager)).server_id, convict=False)
 
     LOGGER.info("Sleep for 2 seconds")
     await asyncio.sleep(2)

--- a/test/cluster/random_failures/test_random_failures.py
+++ b/test/cluster/random_failures/test_random_failures.py
@@ -177,7 +177,7 @@ async def test_random_failures(manager: ManagerClient,
             )
         if matches := await coordinator_log.grep(coordinator_log_pattern):
             LOGGER.info("Found following message in the coordinator's log:\n\t%s", matches[-1][0])
-            await manager.server_stop(server_id=s_info.server_id)
+            await manager.server_stop(server_id=s_info.server_id, convict=True)
 
     BANNED_NOTIFICATION = "received notification of being banned from the cluster from"
     STARTUP_FAILED_PATTERN = f"init - Startup failed:|{BANNED_NOTIFICATION}"
@@ -218,7 +218,7 @@ async def test_random_failures(manager: ManagerClient,
         if s_info in await manager.running_servers():
             LOGGER.info("The new node is dead.  Check if it failed to startup.")
             assert await server_log.grep(STARTUP_FAILED_PATTERN)
-            await manager.server_stop(server_id=s_info.server_id)  # remove the node from the list of running servers
+            await manager.server_stop(server_id=s_info.server_id, convict=True)  # remove the node from the list of running servers
 
         LOGGER.info("Try to remove the dead new node from the cluster.")
         with suppress(Exception):

--- a/test/cluster/storage/conftest.py
+++ b/test/cluster/storage/conftest.py
@@ -95,4 +95,4 @@ async def space_limited_servers(manager: ManagerClient, volumes_factory: Callabl
             yield servers
         finally:
             # Stop servers to be able to unmount volumes
-            await gather_safely(*(manager.server_stop(server.server_id) for server in servers))
+            await gather_safely(*(manager.server_stop(server.server_id, convict=False) for server in servers))

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -420,7 +420,7 @@ async def test_localnodes_joining_nodes(manager: ManagerClient):
     # server" error).
     # Without this trick, this test will take 2 minutes of wait to finish.
     for server in await manager.starting_servers():
-        await manager.server_stop(server.server_id)
+        await manager.server_stop(server.server_id, convict=False)
     try:
         await task
     except Exception as e:

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -355,7 +355,7 @@ async def test_localnodes_down_normal_node(manager: ManagerClient):
     # be down, the gossiper on the first node will soon realize it is down,
     # but still consider it in a "normal" state - "DN" (down and normal).
     # We then want to check that "/localnodes" handles this state correctly.
-    await manager.server_stop(servers[1].server_id)
+    await manager.server_stop(servers[1].server_id, convict=True)
     # After that, "/localnodes" should no longer return the second node.
     # It might take a short while until the first node learns what happened
     # to the second, so we may need to retry for a while.

--- a/test/cluster/test_batchlog_manager.py
+++ b/test/cluster/test_batchlog_manager.py
@@ -52,7 +52,7 @@ async def test_batchlog_replay_while_a_node_is_down(manager: ManagerClient) -> N
 
         await asyncio.gather(*[manager.api.disable_injection(s.ip_addr, "storage_proxy_fail_remove_from_batchlog") for s in servers])
 
-        await manager.server_stop(servers[1].server_id)
+        await manager.server_stop(servers[1].server_id, convict=True)
 
         batchlog_row_count = (await cql.run_async("SELECT COUNT(*) FROM system.batchlog_v2", host=hosts[0]))[0].count
         assert batchlog_row_count > 0
@@ -113,7 +113,7 @@ async def test_batchlog_replay_aborted_on_shutdown(manager: ManagerClient) -> No
 
         await asyncio.gather(*[manager.api.disable_injection(s.ip_addr, "storage_proxy_fail_remove_from_batchlog") for s in servers])
 
-        await manager.server_stop(servers[1].server_id)
+        await manager.server_stop(servers[1].server_id, convict=True)
 
         await asyncio.gather(*[manager.api.disable_injection(s.ip_addr, "skip_batch_replay") for s in servers if s != servers[1]])
 

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -345,7 +345,7 @@ async def test_cdc_colocation(manager: ManagerClient):
         s1_host_id = await manager.get_host_id(servers[1].server_id)
 
         # Stop first node and test partitions available on second node
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=True)
 
         accessible_partitions = set([pk for pk, host_id in pk_to_host.items() if host_id == s1_host_id])
         inaccessible_partitions = set([pk for pk, host_id in pk_to_host.items() if host_id == s0_host_id])

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -124,7 +124,7 @@ async def test_change_two(manager, random_tables, build_mode):
     if build_mode != 'release':
         s0_logs = await manager.server_open_log(servers[0].server_id)
         await s0_logs.wait_for('crash-before-prev-ip-removed hit, killing the node')
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=False)
         await manager.server_start(servers[0].server_id)
         await manager.api.enable_injection(servers[0].ip_addr, 'ip-change-raft-sync-delay', one_shot=False)
     await reconnect_driver(manager)

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -80,7 +80,7 @@ async def test_client_routes_node_restart(request, manager: ManagerClient):
     cql, hosts = await manager.get_ready_cql(servers)
     server_to_restart = servers[2]
 
-    await manager.server_stop(server_to_restart.server_id)
+    await manager.server_stop(server_to_restart.server_id, convict=False)
     await manager.api.client.post("/v2/client-routes", host=servers[0].ip_addr, json=[generate_client_routes_entry(1)])
     await wait_for_expected_client_routes_size(cql, 1)
 
@@ -147,7 +147,7 @@ async def test_client_routes_lost_quorum(request, manager: ManagerClient):
     await wait_for_expected_client_routes_size(cql, 1)
 
     for server in servers[1:]:
-        await manager.server_stop(server.server_id)
+        await manager.server_stop(server.server_id, convict=False)
 
     async def fail_req(f):
         with pytest.raises(HTTPError) as exc:
@@ -246,7 +246,7 @@ async def test_client_routes_snapshot_transfer(request, manager: ManagerClient, 
     error_to_inject = "block_group0_transfer_snapshot"
 
     await manager.server_update_config(server_to_restart.server_id, "error_injections_at_startup", [error_to_inject])
-    await manager.server_stop(server_to_restart.server_id)
+    await manager.server_stop(server_to_restart.server_id, convict=False)
 
     await manager.api.client.post("/v2/client-routes", host=servers[0].ip_addr, json=[generate_client_routes_entry(1)])
     await wait_for_expected_client_routes_size(cql, 1)

--- a/test/cluster/test_client_routes.py
+++ b/test/cluster/test_client_routes.py
@@ -61,7 +61,7 @@ async def test_client_routes(request, manager: ManagerClient):
     running_servers = await manager.running_servers()
     server_to_stop = running_servers[0]
     running_server = running_servers[1]
-    await manager.server_stop(server_to_stop.server_id)
+    await manager.server_stop(server_to_stop.server_id, convict=True)
     await manager.remove_node(running_server.server_id, server_to_stop.server_id)
     await wait_for_expected_client_routes_size(cql, num_servers)
 

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -56,7 +56,7 @@ async def change_support_for_test_feature_and_restart(manager: ManagerClient, sr
             injections.remove(TEST_FEATURE_ENABLE_ERROR_INJECTION)
         await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, list(injections))
 
-    await asyncio.gather(*(manager.server_stop(srv.server_id) for srv in srvs))
+    await asyncio.gather(*(manager.server_stop(srv.server_id, convict=False) for srv in srvs))
     await asyncio.gather(*(adjust_feature_in_config(manager, srv, enable) for srv in srvs))
     await asyncio.gather(*(manager.server_start(srv.server_id, expected_error) for srv in srvs))
 

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -198,7 +198,7 @@ async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerC
         assert TEST_FEATURE_NAME not in await get_enabled_features(cql, host)
 
     # Remove the last node
-    await manager.server_stop(servers[-1].server_id)
+    await manager.server_stop(servers[-1].server_id, convict=True)
     await manager.remove_node(servers[0].server_id, servers[-1].server_id)
 
     # The feature should eventually become enabled

--- a/test/cluster/test_commitlog.py
+++ b/test/cluster/test_commitlog.py
@@ -78,7 +78,7 @@ async def test_reboot(request, manager: ManagerClient):
     logger.info("Some new data is written into test table")
 
     table_content_before_crash = await load_table()
-    await manager.server_stop(server_info.server_id)
+    await manager.server_stop(server_info.server_id, convict=False)
     await manager.server_start(server_info.server_id)
     cql = await reconnect_driver(manager)
     await wait_for_cql_and_get_hosts(cql, [server_info], time.time() + 60)

--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -121,7 +121,7 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ManagerClient):
         logger.debug(f"The following segments were removed: {removed_segments}")
 
         logger.debug("Kill + restart the node")
-        await manager.server_stop(server.server_id)
+        await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
 
         manager.driver_close()

--- a/test/cluster/test_different_group0_ids.py
+++ b/test/cluster/test_different_group0_ids.py
@@ -27,7 +27,7 @@ async def test_different_group0_ids(manager: ManagerClient):
 
     id_b = await manager.get_host_id(scylla_b.server_id)
 
-    await manager.server_stop(scylla_b.server_id)
+    await manager.server_stop(scylla_b.server_id, convict=False)
     await manager.server_start(scylla_b.server_id, seeds=[scylla_a.ip_addr])
 
     # Since scylla_a and scylla_b have different group0 IDs and didn't join each other,

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -275,7 +275,7 @@ async def test_reboot(manager, key_provider):
     async def restart(manager: ManagerClient, servers: list[ServerInfo], table_names: list[str]):
         # pylint: disable=unused-argument
         for s in servers:
-            await manager.server_stop(s.server_id)
+            await manager.server_stop(s.server_id, convict=False)
             await manager.server_start(s.server_id)
 
     num_servers = 3
@@ -535,7 +535,7 @@ async def test_system_encryption_reboot(manager: ManagerClient, tmpdir):
     async def restart(manager: ManagerClient, servers: list[ServerInfo], table_names: list[str]):
         # pylint: disable=unused-argument
         for s in servers:
-            await manager.server_stop(s.server_id)
+            await manager.server_stop(s.server_id, convict=False)
             await manager.server_start(s.server_id)
 
     options = {"commitlog_sync": "batch",

--- a/test/cluster/test_gossiper.py
+++ b/test/cluster/test_gossiper.py
@@ -23,7 +23,7 @@ async def test_gossiper_endpoints(manager: ManagerClient) -> None:
 
     down_server_index = 1
     down_server_ip = servers_ips[down_server_index]
-    await manager.server_stop(servers[down_server_index].server_id)
+    await manager.server_stop(servers[down_server_index].server_id, convict=True)
     for ip in servers_ips:
         if ip != down_server_ip:
             await manager.server_not_sees_other_server(ip, down_server_ip)

--- a/test/cluster/test_gossiper.py
+++ b/test/cluster/test_gossiper.py
@@ -4,12 +4,14 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
+import logging
+
 from test.pylib.manager_client import ManagerClient
 import pytest
 
-pytestmark = pytest.mark.prepare_3_racks_cluster
+logger = logging.getLogger(__name__)
 
-
+@pytest.mark.prepare_3_racks_cluster
 async def test_gossiper_endpoints(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     servers_ips = [await manager.get_host_ip(server.server_id) for server in servers]
@@ -35,3 +37,24 @@ async def test_gossiper_endpoints(manager: ManagerClient) -> None:
             down_endpoints = await manager.api.get_down_endpoints(ip)
             assert len(down_endpoints) == 1, "Incorrect number of down endpoints"
             assert down_server_ip in down_endpoints, "Stopped server isn't marked as dead"
+
+
+@pytest.mark.asyncio
+async def test_natural_failure_detection(manager: ManagerClient, failure_detector_timeout) -> None:
+    """Verify that the failure detector detects a killed node as DOWN
+    without using the convict mechanism, relying on natural detection."""
+    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
+    down_server = servers[0]
+    down_server_ip = down_server.ip_addr
+
+    logger.info(f"Stopping {down_server} without conviction")
+    await manager.server_stop(down_server.server_id, convict=False)
+
+    logger.info(f"Waiting for other nodes to detect {down_server} as DOWN via natural failure detection")
+    await manager.others_not_see_server(down_server_ip)
+
+    for srv in servers:
+        if srv.server_id == down_server.server_id:
+            continue
+        down_endpoints = await manager.api.get_down_endpoints(srv.ip_addr)
+        assert down_server_ip in down_endpoints, f"Server {srv} did not detect {down_server} as down"

--- a/test/cluster/test_group0_recovers_after_partial_command_application.py
+++ b/test/cluster/test_group0_recovers_after_partial_command_application.py
@@ -76,7 +76,7 @@ async def test_group0_recovers_after_partial_command_application(manager: Manage
 
         # The error injection enters an infinite loop, so kill the process.
         logger.info("Kill the first node")
-        await manager.server_stop(srv1.server_id)
+        await manager.server_stop(srv1.server_id, convict=False)
 
         # Before restarting, enable an error injection which causes the state
         # machine to load the group0 state before (re)applying any group0

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -569,7 +569,7 @@ async def do_test_tablet_incremental_repair_merge_error(manager, error):
     await inject_error_on(manager, "tablet_force_tablet_count_decrease_once", servers)
     await coord_log.wait_for(f'Got {error}', from_mark=mark)
     await inject_error_off(manager, "tablet_force_tablet_count_decrease", servers)
-    await manager.server_stop(coord_serv.server_id)
+    await manager.server_stop(coord_serv.server_id, convict=False)
     await manager.server_start(coord_serv.server_id)
 
     for server in servers:
@@ -784,7 +784,7 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_
 
         logger.info("Adding data only on first node")
         await manager.api.flush_keyspace(servers[1].ip_addr, ks)
-        await manager.server_stop(servers[1].server_id)
+        await manager.server_stop(servers[1].server_id, convict=False)
         manager.driver_close()
         cql = await reconnect_driver(manager)
         await write_with_cl_one(0, 10)
@@ -793,7 +793,7 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_
         logger.info("Adding data only on second node")
         await manager.server_start(servers[1].server_id)
         await manager.api.flush_keyspace(servers[0].ip_addr, ks)
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=False)
         manager.driver_close()
         cql = await reconnect_driver(manager)
         await write_with_cl_one(10, 20)

--- a/test/cluster/test_internode_compression.py
+++ b/test/cluster/test_internode_compression.py
@@ -159,7 +159,7 @@ async def do_test_internode_compression_between_datacenters(manager: ManagerClie
 
             verifier(msg_size, node1_proxy, node2_proxy, node3_proxy)
 
-    await asyncio.gather(*[manager.server_stop(s.server_id) for s,_ in servers])
+    await asyncio.gather(*[manager.server_stop(s.server_id, convict=False) for s,_ in servers])
     await asyncio.gather(*[p.stop() for p in proxies])
     # these will all except, because we just stopped them above
     for coro in proxy_futs:

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -37,7 +37,7 @@ async def test_broken_bootstrap(manager: ManagerClient):
         except Exception:
             pass
 
-        await gather_safely(*(manager.server_stop(srv.server_id) for srv in [server_a, server_b]))
+        await gather_safely(*(manager.server_stop(srv.server_id, convict=False) for srv in [server_a, server_b]))
 
         await manager.server_start(server_a.server_id)
         await manager.driver_connect()
@@ -95,7 +95,7 @@ async def test_full_shutdown_during_replace(manager: ManagerClient, reuse_ip: bo
             replacing_host_id = await manager.get_host_id(replacing_server.server_id)
 
             logger.info(f'Stopping {live_servers + [replacing_server]}')
-            await gather_safely(*(manager.server_stop(srv.server_id) for srv in live_servers + [replacing_server]))
+            await gather_safely(*(manager.server_stop(srv.server_id, convict=False) for srv in live_servers + [replacing_server]))
             replacing_task.cancel()
 
             for srv in live_servers:

--- a/test/cluster/test_long_query_timeout_erm.py
+++ b/test/cluster/test_long_query_timeout_erm.py
@@ -106,7 +106,7 @@ async def test_long_query_timeout_erm(request, manager: ManagerClient, query_typ
         server_to_kill = done.pop().result()
 
     logger.info(f"Kill a node: {server_to_kill.ip_addr}")
-    await manager.server_stop(server_to_kill.server_id)
+    await manager.server_stop(server_to_kill.server_id, convict=True)
 
     logger.info("Unblock reads")
     for server in servers:

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -60,7 +60,7 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
 
     # Try to downgrade one node
     await manager.server_update_config(servers[0].server_id, 'error_injections_at_startup', [])
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=False)
     await manager.server_start(servers[0].server_id,
                                expected_error="Feature 'TEST_ONLY_FEATURE' was previously supported by all nodes in the cluster")
     

--- a/test/cluster/test_raft_ignore_nodes.py
+++ b/test/cluster/test_raft_ignore_nodes.py
@@ -59,20 +59,20 @@ async def make_servers(manager: ManagerClient, servers_num: int,
     return servers_ordered
 
 
-async def test_raft_replace_ignore_nodes(manager: ManagerClient, failure_detector_timeout) -> None:
+async def test_raft_replace_ignore_nodes(manager: ManagerClient) -> None:
     """Replace 3 dead nodes.
 
        This is a slow test with a 7 node cluster and 3 replace operations,
        we want to run it only in dev mode.
     """
     logger.info("Booting initial cluster")
-    servers = await make_servers(manager, 7, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
+    servers = await make_servers(manager, 7)
 
     s1_id = await manager.get_host_id(servers[1].server_id)
     s2_id = await manager.get_host_id(servers[2].server_id)
     logger.info(f"Stopping servers {servers[:3]}")
-    await manager.server_stop(servers[0].server_id)
-    await manager.server_stop(servers[1].server_id)
+    await manager.server_stop(servers[0].server_id, convict=True)
+    await manager.server_stop(servers[1].server_id, convict=True)
     await manager.server_stop_gracefully(servers[2].server_id)
 
     ignore_dead: list[IPAddress | HostID] = [s1_id, servers[2].ip_addr]

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -247,7 +247,7 @@ async def test_can_restart(manager: ManagerClient, raft_op_timeout: int) -> None
     servers = await manager.servers_add(5)
 
     logger.info(f"Stopping {servers}")
-    await asyncio.gather(*(manager.server_stop(srv.server_id) for srv in servers))
+    await asyncio.gather(*(manager.server_stop(srv.server_id, convict=False) for srv in servers))
 
     # This ensures the read barriers below fail quickly without group 0 quorum.
     await asyncio.gather(*(update_group0_raft_op_timeout(srv.server_id, manager, raft_op_timeout) for srv in servers))

--- a/test/cluster/test_raft_recovery_during_join.py
+++ b/test/cluster/test_raft_recovery_during_join.py
@@ -87,7 +87,7 @@ async def test_raft_recovery_during_join(manager: ManagerClient):
     dead_hosts.append(failed_server_host)
 
     logging.info(f'Killing {dead_servers}')
-    await asyncio.gather(*(manager.server_stop(server_id=srv.server_id) for srv in dead_servers))
+    await asyncio.gather(*(manager.server_stop(server_id=srv.server_id, convict=False) for srv in dead_servers))
 
     logging.info('Checking that group 0 has no majority')
     with pytest.raises(Exception, match="raft operation \\[read_barrier\\] timed out"):

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -66,7 +66,7 @@ async def test_raft_recovery_entry_loss(manager: ManagerClient):
             "SELECT value FROM system.scylla_local WHERE key = 'raft_group0_id'"))[0].value
 
     logging.info(f'Stopping {live_servers[0].server_id} to keep its group 0 state in v1')
-    await manager.server_stop(live_servers[0].server_id)
+    await manager.server_stop(live_servers[0].server_id, convict=False)
 
     logging.info('Creating keyspace ks1, moving the group 0 state to v2')
     await cql.run_async(
@@ -77,7 +77,7 @@ async def test_raft_recovery_entry_loss(manager: ManagerClient):
     await read_barrier(manager.api, get_host_api_address(host))
 
     logging.info(f'Stopping {live_servers[1].server_id} to keep its group 0 state in v2')
-    await manager.server_stop(live_servers[1].server_id)
+    await manager.server_stop(live_servers[1].server_id, convict=False)
 
     logging.info('Creating keyspace ks2, moving the group 0 state to v3')
     await cql.run_async(

--- a/test/cluster/test_raft_recovery_entry_loss.py
+++ b/test/cluster/test_raft_recovery_entry_loss.py
@@ -93,7 +93,7 @@ async def test_raft_recovery_entry_loss(manager: ManagerClient):
     logging.info(f'Found group 0 schema version {v_group0}')
 
     logging.info(f'Killing {dead_servers}')
-    await asyncio.gather(*(manager.server_stop(server_id=srv.server_id) for srv in dead_servers))
+    await asyncio.gather(*(manager.server_stop(server_id=srv.server_id, convict=False) for srv in dead_servers))
 
     logging.info(f'Starting {live_servers}')
     await asyncio.gather(*(manager.server_start(server_id=srv.server_id) for srv in live_servers))

--- a/test/cluster/test_raft_recovery_user_data.py
+++ b/test/cluster/test_raft_recovery_user_data.py
@@ -97,7 +97,7 @@ async def test_raft_recovery_user_data(manager: ManagerClient, remove_dead_nodes
     await asyncio.sleep(1)
 
     logging.info(f'Killing {dead_servers}')
-    await gather_safely(*(manager.server_stop(server_id=srv.server_id) for srv in dead_servers))
+    await gather_safely(*(manager.server_stop(server_id=srv.server_id, convict=False) for srv in dead_servers))
 
     logging.info('Checking that group 0 has no majority')
     with pytest.raises(Exception, match="raft operation \\[read_barrier\\] timed out"):

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -97,7 +97,7 @@ async def test_raft_voters_multidc_kill_dc(
     if stop_gracefully:
         await asyncio.gather(*(manager.server_stop_gracefully(srv.server_id) for srv in dc_servers[0]))
     else:
-        await asyncio.gather(*(manager.server_stop(srv.server_id) for srv in dc_servers[0]))
+        await asyncio.gather(*(manager.server_stop(srv.server_id, convict=False) for srv in dc_servers[0]))
 
     # Assert: Verify that the majority has not been lost (we can change the topology)
 

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -20,13 +20,13 @@ from test.pylib.random_tables import RandomTables, Column, TextType
 logger = logging.getLogger(__name__)
 
 
-async def test_replace_different_ip(manager: ManagerClient, failure_detector_timeout) -> None:
+async def test_replace_different_ip(manager: ManagerClient) -> None:
     """Replace an existing node with new node using a different IP address"""
-    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
+    servers = await manager.servers_add(3)
     logger.info(f"cluster started, servers {servers}")
 
     logger.info(f"replacing server {servers[0]}")
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=True)
     replaced_server = servers[0]
     replace_cfg = ReplaceConfig(replaced_id = replaced_server.server_id, reuse_ip_addr = False, use_host_id = False)
     new_server = await manager.server_add(replace_cfg)
@@ -65,17 +65,17 @@ async def test_replace_different_ip(manager: ManagerClient, failure_detector_tim
         await wait_for(check_peers_and_gossiper, time.time() + 60)
         logger.info(f"server {s} system.peers and gossiper state is valid")
 
-async def test_replace_different_ip_using_host_id(manager: ManagerClient, failure_detector_timeout) -> None:
+async def test_replace_different_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node reusing the replaced node host id"""
-    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
-    await manager.server_stop(servers[0].server_id)
+    servers = await manager.servers_add(3)
+    await manager.server_stop(servers[0].server_id, convict=True)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = False, use_host_id = True)
     await manager.server_add(replace_cfg)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
-async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detector_timeout) -> None:
+async def test_replace_reuse_ip(request, manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address"""
-    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout}, auto_rack_dc="dc1")
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
     host2 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[2]], time.time() + 60))[0]
 
     logger.info(f"creating test table")
@@ -126,10 +126,10 @@ async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detecto
     await manager.server_sees_other_server(servers[1].ip_addr, servers[0].ip_addr)
     await manager.server_sees_other_server(servers[2].ip_addr, servers[0].ip_addr)
 
-async def test_replace_reuse_ip_using_host_id(manager: ManagerClient, failure_detector_timeout) -> None:
+async def test_replace_reuse_ip_using_host_id(manager: ManagerClient) -> None:
     """Replace an existing node with new node using the same IP address and same host id"""
-    servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout})
-    await manager.server_stop(servers[0].server_id)
+    servers = await manager.servers_add(3)
+    await manager.server_stop(servers[0].server_id, convict=True)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = True)
     await manager.server_add(replace_cfg)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)

--- a/test/cluster/test_shutdown_hang.py
+++ b/test/cluster/test_shutdown_hang.py
@@ -36,7 +36,7 @@ async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
         await cql.run_async(f"create table {ks}.t (pk int primary key)")
 
         logger.info(f"Stop {s2}")
-        await manager.server_stop(s2.server_id)
+        await manager.server_stop(s2.server_id, convict=True)
 
         logger.info("Write data with small timeout")
         # We're using a small timeout for the insert so it's not unexpected that it would fail on slow

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -500,7 +500,7 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
             # Collect raft state and log entry counts before crash
             state_before_crash = await collect_all_raft_state(cql, hosts[0])
 
-            await manager.server_stop(server.server_id)
+            await manager.server_stop(server.server_id, convict=False)
 
             await manager.server_start(server.server_id)
             await reconnect_driver(manager)

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1711,7 +1711,7 @@ async def test_excludenode(manager: ManagerClient):
         with pytest.raises(Exception, match=".* does not belong to this cluster"):
             await manager.api.exclude_node(live_node.ip_addr, hosts=[str(uuid.uuid4())])
 
-        await manager.server_stop(node_to_remove.server_id)
+        await manager.server_stop(node_to_remove.server_id, convict=True)
         await manager.others_not_see_server(node_to_remove.ip_addr)
         await manager.api.exclude_node(live_node.ip_addr, hosts=[await manager.get_host_id(node_to_remove.server_id)])
 
@@ -1750,7 +1750,7 @@ async def test_excludenode_shrink_rf(manager: ManagerClient):
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
         # Stop the only node in dc2
-        await manager.server_stop(dc2_server.server_id)
+        await manager.server_stop(dc2_server.server_id, convict=True)
         await manager.others_not_see_server(dc2_server.ip_addr)
 
         # Mark the dc2 node as excluded
@@ -2366,7 +2366,7 @@ async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.Fixtur
             assert t.replicas[0][0] == dc1_host_id
 
         # Stop dc2/rack1 node and mark it as excluded
-        await manager.server_stop(dc2_rack1_server.server_id)
+        await manager.server_stop(dc2_rack1_server.server_id, convict=True)
         await manager.others_not_see_server(dc2_rack1_server.ip_addr)
         await manager.api.exclude_node(dc1_server.ip_addr, hosts=[await manager.get_host_id(dc2_rack1_server.server_id)])
 
@@ -2419,7 +2419,7 @@ async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, ma
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({k}, {k});", host=dc1_host) for k in range(10)])
 
         # Stop dc2/rack1 node but do NOT exclude it
-        await manager.server_stop(dc2_rack1_server.server_id)
+        await manager.server_stop(dc2_rack1_server.server_id, convict=True)
         await manager.others_not_see_server(dc2_rack1_server.ip_addr)
 
         # ALTER KEYSPACE to add replicas in dc2 (rack1 and rack2).

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1630,7 +1630,7 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     logger.info("Migration done")
 
     logger.info("Stop node1 and copy the sstables from node2")
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=False)
     for src_path in glob.glob(os.path.join(node1_table_dir, sstable_filename_glob)):
         dst_path = os.path.join(node0_table_dir, os.path.basename(src_path))
         shutil.copy(src_path, dst_path)

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -540,7 +540,7 @@ async def test_tablet_cleanup(manager: ManagerClient):
         # Kill and restart first node.
         # Check that this doesn't resurrect cleaned data.
         logger.info("Brutally restart first node")
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=False)
         await manager.server_start(servers[0].server_id)
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
         await manager.servers_see_each_other(servers)
@@ -2180,7 +2180,7 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
         # Give enough time for split to happen in debug mode
         await wait_for(finished_splitting, time.time() + 120)
 
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=False)
         await manager.server_start(servers[0].server_id)
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
         await manager.servers_see_each_other(servers)

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -147,7 +147,7 @@ async def test_move_tablet(manager: ManagerClient, move_table: str):
 
         # Now the dst node should hold both tablets. Stop the other node and
         # verify we can read from both tables.
-        await manager.server_stop(servers[src_server].server_id)
+        await manager.server_stop(servers[src_server].server_id, convict=False)
 
         rows = await cql.run_async(f"SELECT * FROM {ks}.test")
         assert len(rows) == row_count
@@ -403,7 +403,7 @@ async def test_repair_colocated_base_and_view(manager: ManagerClient):
         await manager.api.flush_keyspace(servers[1].ip_addr, ks)
 
         # Stop node 2 and write data while it is down
-        await manager.server_stop(servers[1].server_id)
+        await manager.server_stop(servers[1].server_id, convict=False)
 
         cql.execute(SimpleStatement(f"INSERT INTO {ks}.test(pk, c) VALUES(2, 20)", consistency_level=ConsistencyLevel.ONE))
         await manager.api.flush_keyspace(servers[0].ip_addr, ks)

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -89,7 +89,7 @@ async def test_crash_during_intranode_migration(manager: ManagerClient):
 
         s0_logs = await manager.server_open_log(servers[0].server_id)
         await s0_logs.wait_for('crash-in-tablet-write-both-read-new hit')
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=False)
         await manager.server_start(servers[0].server_id)
         await wait_for_cql_and_get_hosts(manager.cql, servers, time.time() + 60)
 

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -375,7 +375,7 @@ async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ManagerClient):
 
         # Step3: Node n1 is lost permanently
         logger.info("Stop n1")
-        await manager.server_stop(servers[0].server_id)
+        await manager.server_stop(servers[0].server_id, convict=True)
         stopped_servers.add(servers[0])
         cql = await reconnect_driver(manager)
 

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -642,4 +642,4 @@ async def test_background_merge_deadlock(manager: ManagerClient):
 
     await wait_for(finished_merge, time.time() + 120)
 
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=False)

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -117,14 +117,14 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 @pytest.mark.parametrize("fail_replica", ["source", "destination"])
 @pytest.mark.parametrize("fail_stage", ["streaming", "allow_write_both_read_old", "write_both_read_old", "write_both_read_new", "use_new", "cleanup", "cleanup_target", "end_migration", "revert_migration"])
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
-async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage, failure_detector_timeout):
+async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail_replica, fail_stage):
     if fail_stage == 'cleanup' and fail_replica == 'destination':
         skip_env('Failing destination during cleanup is pointless')
     if fail_stage == 'cleanup_target' and fail_replica == 'source':
         skip_env('Failing source during target cleanup is pointless')
 
     logger.info("Bootstrapping cluster")
-    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled', 'failure_detector_timeout_in_ms': failure_detector_timeout}
+    cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
     host_ids = []
     servers = []
 
@@ -243,7 +243,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
                     return
 
                 logger.info(f"Stop {self.replica} {host_ids[self.fail_idx]}")
-                await manager.server_stop(servers[self.fail_idx].server_id)
+                await manager.server_stop(servers[self.fail_idx].server_id, convict=True)
                 logger.info(f"Remove {self.replica} {host_ids[self.fail_idx]} via {host_ids[via]}")
                 await manager.remove_node(servers[via].server_id, servers[self.fail_idx].server_id)
                 logger.info(f"Done with {self.replica} {host_ids[self.fail_idx]}")

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -541,7 +541,7 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
         await log.wait_for("Waiting after tablet cleanup", from_mark=mark, timeout=60)
 
         # Restart the leaving replica (src_server)
-        await manager.server_stop(src_server.server_id)
+        await manager.server_stop(src_server.server_id, convict=False)
         await manager.server_start(src_server.server_id)
         await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 30)
 

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -498,7 +498,7 @@ async def test_node_lost_during_decommission_drain(manager: ManagerClient):
 
         await coord_log.wait_for('topology_coordinator_pause_before_processing_backlog: waiting', from_mark=mark)
 
-        await manager.server_stop(srv_to_remove.server_id)
+        await manager.server_stop(srv_to_remove.server_id, convict=True)
         await manager.server_not_sees_other_server(coord_serv.ip_addr, srv_to_remove.ip_addr)
         await manager.api.exclude_node(coord_serv.ip_addr, [await manager.get_host_id(srv_to_remove.server_id)])
 

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -47,7 +47,7 @@ async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
 
     logger.info('Stopping a node to be removed')
-    await manager.server_stop(servers[2].server_id)
+    await manager.server_stop(servers[2].server_id, convict=True)
 
     logger.info('Restarting leader')
     raft_leader_host_id = await get_topology_coordinator(manager)
@@ -195,7 +195,7 @@ async def test_removenode(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info('Removing a node')
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=True)
     await manager.remove_node(servers[1].server_id, servers[0].server_id)
     servers = servers[1:]
 
@@ -243,8 +243,8 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info('Removing a node with another node down')
-    await manager.server_stop(servers[0].server_id) # removed
-    await manager.server_stop(servers[1].server_id) # ignored
+    await manager.server_stop(servers[0].server_id, convict=True) # removed
+    await manager.server_stop(servers[1].server_id, convict=True) # ignored
     await manager.remove_node(servers[2].server_id, servers[0].server_id, [servers[1].ip_addr])
 
     await manager.others_not_see_server(servers[1].ip_addr)

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -215,7 +215,7 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
                 "SELECT value FROM system.scylla_local WHERE key = 'raft_group0_id'"))[0].value
 
             # Kill one server.
-            await manager.server_stop(down_server.server_id)
+            await manager.server_stop(down_server.server_id, convict=True)
             servers.pop()
 
             await alter_system_schema(keyspace)

--- a/test/cluster/test_topology_rejoin.py
+++ b/test/cluster/test_topology_rejoin.py
@@ -16,7 +16,7 @@ async def test_start_after_sudden_stop(manager: ManagerClient, random_tables) ->
     """Tests a server can rejoin the cluster after being stopped suddenly"""
     servers = await manager.running_servers()
     table = await random_tables.add_table(ncolumns=5)
-    await manager.server_stop(servers[0].server_id)
+    await manager.server_stop(servers[0].server_id, convict=True)
     await table.add_column()
     await manager.server_start(servers[0].server_id)
     await random_tables.verify_schema()

--- a/test/cluster/test_topology_schema.py
+++ b/test/cluster/test_topology_schema.py
@@ -31,6 +31,6 @@ async def test_topology_schema_changes(manager, random_tables):
     await random_tables.verify_schema()
 
     # Test add column after hard stop of a server (1/3)
-    await manager.server_stop(servers[1].server_id)
+    await manager.server_stop(servers[1].server_id, convict=True)
     await table.add_column()
     await random_tables.verify_schema()

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -43,7 +43,7 @@ async def test_truncation_records_pruned_on_dirty_restart(manager: ManagerClient
     cql = manager.get_cql()
 
     async def restart():
-        await manager.server_stop(server.server_id)
+        await manager.server_stop(server.server_id, convict=False)
         await manager.server_start(server.server_id)
         manager.driver_close()
         await manager.driver_connect()

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -200,7 +200,7 @@ async def test_truncate_with_coordinator_crash(manager: ManagerClient):
         trunc_future = cql.run_async(f'TRUNCATE TABLE {ks}.test', host=trunc_host)
         # Wait for the topology coordinator to crash
         await raft_leader_log.wait_for('truncate_crash_after_session_clear hit, killing the node')
-        await manager.server_stop(raft_leader.server_id)
+        await manager.server_stop(raft_leader.server_id, convict=False)
         # Restart the crashed node
         await manager.server_start(raft_leader.server_id)
         # Wait for truncate to complete

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -347,7 +347,7 @@ class ManagerClient:
            To be used when a current cluster wants to be reused."""
         await self.client.put_json("/cluster/mark-clean")
 
-    async def server_stop(self, server_id: ServerNum, convict=False) -> None:
+    async def server_stop(self, server_id: ServerNum, convict: bool) -> None:
         """Stop specified server.
 
         convict: If True, immediately marks the node as DOWN on all live nodes,

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -19,7 +19,7 @@ from time import time
 import logging
 from test.pylib.log_browsing import ScyllaLogFile
 from test.pylib.rest_client import UnixRESTClient, ScyllaRESTAPIClient, ScyllaMetricsClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host
+from test.pylib.util import wait_for, wait_for_cql_and_get_hosts, universalasync_typed_wrap, Host, gather_safely
 from test.pylib.internal_types import ServerNum, IPAddress, HostID, ServerInfo, ServerUpState
 from test.pylib.scylla_cluster import ReplaceConfig, ScyllaServer, ScyllaVersionDescription
 from test.pylib.driver_utils import safe_driver_shutdown
@@ -347,10 +347,34 @@ class ManagerClient:
            To be used when a current cluster wants to be reused."""
         await self.client.put_json("/cluster/mark-clean")
 
-    async def server_stop(self, server_id: ServerNum) -> None:
-        """Stop specified server"""
+    async def server_stop(self, server_id: ServerNum, convict=False) -> None:
+        """Stop specified server.
+
+        convict: If True, immediately marks the node as DOWN on all live nodes,
+                 bypassing the natural failure detection delay (~20s).
+                 Set to True when the test waits for other nodes to notice the down node
+                 to speed up the test (e.g. before
+                 remove_node, replace, or waiting for failure detection).
+                 Set to False when conviction is pointless (single node, all stopped, immediate restart)
+                 or the test wants to exercise natural failure detection.
+        """
+        host_id = None
+        if convict:
+            try:
+                host_id = await self.get_host_id(server_id)
+            except Exception:
+                # Server may have never completed bootstrap, so host_id is unknown.
+                # Skip conviction in this case.
+                pass
         logger.debug("ManagerClient stopping %s", server_id)
         await self.client.put_json(f"/cluster/server/{server_id}/stop")
+        if host_id is not None:
+            try:
+                await self.convict_on_all(host_id)
+            except Exception:
+                # It's a best-effort attempt, ignore errors
+                # In some scenarios errors are expected, e.g. when server_stop() is called concurrently on many servers.
+                pass
 
     async def server_stop_gracefully(self, server_id: ServerNum, timeout: float = 180) -> None:
         """Stop specified server gracefully"""
@@ -379,6 +403,19 @@ class ManagerClient:
             raise Exception("No running servers")
         # Any server will do, it's a group0 operation
         await self.api.enable_tablet_balancing(servers[0].ip_addr)
+
+    async def convict(self, convict_on: ServerInfo, host: HostID):
+        """Convicts a given host on a live server.
+        convict_on will mark "host" as DOWN and drop connections to it.
+        """
+        logger.debug(f"Convicting {host} on {convict_on.ip_addr}")
+        await self.api.convict(convict_on.ip_addr, host)
+
+    async def convict_on_all(self, host: HostID):
+        """Convicts a given host on all live servers.
+        Each live server will mark "host" as DOWN and drop connections to it.
+        """
+        await gather_safely(*(self.api.convict(server.ip_addr, host) for server in await self.running_servers()))
 
     async def server_start(self,
                            server_id: ServerNum,

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -320,6 +320,9 @@ class ScyllaRESTAPIClient:
         res = await self.client.post_json(f"/storage_service/tablets/repair", host=node_ip, timeout=timeout, params=params)
         return res
 
+    async def convict(self, node_ip: str, host: HostID) -> None:
+        await self.client.post(f"/failure_detector/convict/{host}", host=node_ip)
+
     async def enable_tablet_balancing(self, node_ip: str) -> None:
         await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "true"})
 


### PR DESCRIPTION
This is about ungraceful stop, where the node is killed.

Test cases typically need to wait for other nodes to notice that the
node is down before proceeding. By default, that takes about 20s. Can
be reduced via config by reducing failure detector threshold, but it's
not the best solution:

 - cannot set the threshold too low, or we'll introduce falkiness due to false
   positives
 - so it's still slow (a couple of seconds)
 - developers forget about it and the test still works

This patch speeds this up by adding a way to convict the node immediately after stopping the node, controlled by the "convict" parameter.

At the end of the series the "convict" parameter is required, and each test decides what it wants. Commits are split into steps:

- the series starts with defaulting to convict=False
- each test case sets "convict" explicitly, and changes are split into 3 commits depending on whether convict=True is: useless, beneficial, undesirable
- finally, the "convict" parameter is made mandatory

There is also a dedicated test for natural failure detection (test_natural_failure_detection in test_gossiper.py) to ensure FD coverage is not lost.

Tested on dev-mode
cluster/test_tablets_parallel_decommission.py::test_node_lost_during_decommission_drain:
Wall clock time reduced from 41s to 16s

No backport: enhancement