### PR TITLE
alternator: a couple of small cleanups suggested by copilot

### DIFF
--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -485,7 +485,7 @@ std::optional<bytes> unwrap_bytes(const rjson::value& value, bool from_query) {
         return rjson::base64_decode(value);
     } catch (...) {
         if (from_query) {
-            throw api_error::serialization(format("Invalid base64 data"));
+            throw api_error::serialization("Invalid base64 data");
         }
         return std::nullopt;
     }


### PR DESCRIPTION
The first patch improves the input validation of  the CONTAINS operator. I believe this is not a critical fix, because RapidJSON already has exception-throwing RAPIDJSON_ASSERT() that check for unexpected JSON structure (like something we expect to be a list isn't actually a list), but it's cleaner to do these checks explicitly.

The second patch just removes an unnecessary call to format() on a constant string.