### PR TITLE
types/vector: avoid unnecessary copies during vector reserialization

### DIFF
--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -1441,17 +1441,17 @@ static managed_bytes reserialize_value(View value_bytes,
 
     if (type.is_vector()) {
         const vector_type_impl& vtype = dynamic_cast<const vector_type_impl&>(type);
-        std::vector<managed_bytes> elements = vtype.split_fragmented(value_bytes);
-
         const auto& elements_type = vtype.get_elements_type()->without_reversed();
 
-        if (elements_type.bound_value_needs_to_be_reserialized()) {
-            for (size_t i = 0; i < elements.size(); i++) {
-                elements[i] = reserialize_value(managed_bytes_view(elements[i]), elements_type);
+        return with_simplified(value_bytes, [&] (FragmentedView auto view) -> managed_bytes {
+            auto element_views = vtype.split_fragmented_view(view);
+            std::vector<managed_bytes> elements;
+            elements.reserve(element_views.size());
+            for (auto& ev : element_views) {
+                elements.push_back(reserialize_value(ev, elements_type));
             }
-        }
-
-        return vector_type_impl::build_value_fragmented(std::move(elements), elements_type.value_length_if_fixed());
+            return vector_type_impl::build_value_fragmented(std::move(elements), elements_type.value_length_if_fixed());
+        });
     }
     on_internal_error(expr_logger,
         fmt::format("Reserializing type that shouldn't need reserialization: {}", type.name()));

--- a/types/types.cc
+++ b/types/types.cc
@@ -1427,6 +1427,7 @@ utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(View in)
 }
 template utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(managed_bytes_view in);
 template utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(fragmented_temporary_buffer::view in);
+template utils::chunked_vector<managed_bytes_opt> partially_deserialize_listlike(single_fragmented_view in);
 
 template <FragmentedView View>
 std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(View in) {
@@ -1445,6 +1446,7 @@ std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(V
 }
 template std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(managed_bytes_view in);
 template std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(fragmented_temporary_buffer::view in);
+template std::vector<std::pair<managed_bytes, managed_bytes>> partially_deserialize_map(single_fragmented_view in);
 
 list_type
 list_type_impl::get_instance(data_type elements, bool is_multi_cell) {

--- a/types/vector.hh
+++ b/types/vector.hh
@@ -29,7 +29,18 @@ public:
     }
     static std::strong_ordering compare_vectors(data_type elements_comparator, vector_dimension_t dimension,
                         managed_bytes_view o1, managed_bytes_view o2);
-                        
+
+    template <FragmentedView View>
+    std::vector<View> split_fragmented_view(View v) const {
+        std::vector<View> elements;
+        elements.reserve(_dimension);
+        auto fixed_len = _elements_type->value_length_if_fixed();
+        for (size_t i = 0; i < _dimension; ++i) {
+            elements.push_back(read_vector_element(v, fixed_len));
+        }
+        return elements;
+    }
+
     std::vector<managed_bytes> split_fragmented(FragmentedView auto v) const {
         std::vector<managed_bytes> elements;
         elements.reserve(_dimension);
@@ -46,16 +57,24 @@ public:
         return elements;
     }
 
-    template <typename Range> // range of managed_bytes or managed_bytes_view
-    requires requires (Range it) { {*std::begin(it)} -> std::convertible_to<managed_bytes_view>; }
+    template <std::ranges::forward_range Range>
     static managed_bytes build_value_fragmented(Range&& range, std::optional<size_t> value_length_if_fixed) {
         bool is_fixed_length = value_length_if_fixed.has_value();
         size_t size = 0;
 
+        auto get_view = [](auto&& v) {
+            if constexpr (std::convertible_to<decltype(v), managed_bytes_view>) {
+                return managed_bytes_view(v);
+            } else {
+                return v;
+            }
+        };
+
         for (auto&& v : range) {
-            size += v.size();
+            auto view = get_view(v);
+            size += view.size_bytes();
             if (!is_fixed_length) {
-                size += (size_t)unsigned_vint::serialized_size(v.size());
+                size += (size_t)unsigned_vint::serialized_size(view.size_bytes());
             }
         }
 
@@ -63,12 +82,13 @@ public:
         auto out = ret.begin();
 
         for (auto&& v : range) {
+            auto view = get_view(v);
             if (!is_fixed_length) {
-                out += unsigned_vint::serialize(v.size(), out);
+                out += unsigned_vint::serialize(view.size_bytes(), out);
             }
-            auto read_bytes = [v] (bytes_view element_bytes) {return read_simple_bytes(element_bytes, v.size());};
-            auto element = with_linearized(managed_bytes_view(v), read_bytes);
-            out = std::copy_n(element.begin(), element.size(), out);
+            with_linearized(view, [&out](bytes_view element_bytes) {
+                out = std::copy_n(element_bytes.begin(), element_bytes.size(), out);
+            });
         }
 
         return managed_bytes(ret);


### PR DESCRIPTION
When a bound value contains a set or map, ScyllaDB reserializes it to normalize element ordering. Vectors nested inside such types go through `reserialize_value()` when their element type itself contains sets/maps (e.g., `vector<frozen<map<int,int>>, N>`).

The old code unconditionally called `split_fragmented()`, which copies every element into `managed_bytes`, only to immediately pass each copy to `reserialize_value()` and discard it. Additionally, `build_value_fragmented()` went through a redundant `read_simple_bytes` intermediate copy when writing elements to the output buffer.

This patch:

1. **`split_fragmented_view()`** — splits the vector into zero-copy element views, avoiding per-element `managed_bytes` allocations before reserialization.

2. **`with_simplified()` dispatch** — wraps the call so that when the input is a single contiguous fragment (common case), the compiler receives a `single_fragmented_view` and eliminates fragment-boundary branching at compile time.

3. **Generalized `build_value_fragmented()`** — accepts any `forward_range` of `FragmentedView` elements, writing directly into the output buffer via `with_linearized` instead of going through `read_simple_bytes`. This benefits **all** callers, including the INSERT path for `vector<float, N>`.

4. **Explicit template instantiations** — `with_simplified()` causes `reserialize_value` to be instantiated with `single_fragmented_view`, which pulls in `partially_deserialize_listlike` and `partially_deserialize_map` for that type. These are added in types.cc alongside the existing `managed_bytes_view` and `fragmented_temporary_buffer::view` instantiations.

### Performance impact

The reserialization path optimization applies only to vectors with set/map-containing elements. However, the `build_value_fragmented()` improvement applies to **every vector INSERT** via `evaluate_vector()`, including `vector<float, N>`.

Microbenchmark results (50,000 × 1536-dim float vectors):

| Path | Time/vector | vs old |
|------|-------------|--------|
| Old: `split_fragmented` + old `build_value_fragmented` | 27.13 µs | baseline |
| New: `split_fragmented_view` + new `build_value_fragmented` | 13.21 µs | 2.1x |
| New: `with_simplified` + `split_fragmented_view` + new `build_value_fragmented` | 4.81 µs | 5.6x |

Isolated `build_value_fragmented` cost: ~2.3 µs (new) vs ~2.8 µs (old) — **18% faster rebuild**, directly benefiting `vector<float, N>` INSERTs.

References: [SCYLLADB-471](https://scylladb.atlassian.net/browse/SCYLLADB-471)
Fixes: [SCYLLADB-1799](https://scylladb.atlassian.net/browse/SCYLLADB-1799)

[SCYLLADB-471]: https://scylladb.atlassian.net/browse/SCYLLADB-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ