### PR TITLE
sstables: adapt summary memory usage to actual disk:memory ratio

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1303,8 +1303,15 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , abort_on_lsa_bad_alloc(this, "abort_on_lsa_bad_alloc", value_status::Used, false, "Abort when allocation in LSA region fails.")
     , murmur3_partitioner_ignore_msb_bits(this, "murmur3_partitioner_ignore_msb_bits", value_status::Used, default_murmur3_partitioner_ignore_msb_bits, "Number of most significant token bits to ignore in murmur3 partitioner; increase for very large clusters.")
     , unspooled_dirty_soft_limit(this, "unspooled_dirty_soft_limit", value_status::Used, 0.6, "Soft limit of unspooled dirty memory expressed as a portion of the hard limit.")
-    , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005, "Enforces that 1 byte of summary is written for every N (2000 by default)"
-        "bytes written to data file. Value must be between 0 and 1.")
+    , sstable_summary_memory_fraction(this, "sstable_summary_memory_fraction", liveness::LiveUpdate, value_status::Used, 0.05,
+        "Fraction of shard memory willing to dedicate to SSTable summary data. "
+        "The effective summary-to-data ratio is derived from this value and the disk-to-memory ratio "
+        "(disk capacity comes from total_data_disk_capacity if set, otherwise filesystem capacity). "
+        "Ignored when sstable_summary_ratio is explicitly set. Value must be between 0 and 1.")
+    , sstable_summary_ratio(this, "sstable_summary_ratio", value_status::Used, 0.0005,
+        "Enforces that 1 byte of summary is written for every N (2000 by default) "
+        "bytes written to data file. Value must be between 0 and 1. "
+        "When explicitly set, overrides the ratio computed from sstable_summary_memory_fraction (preferred).")
     , components_memory_reclaim_threshold(this, "components_memory_reclaim_threshold", liveness::LiveUpdate, value_status::Used, .2, "Ratio of available memory for all in-memory components of SSTables in a shard beyond which the memory will be reclaimed from components until it falls back under the threshold. Currently, this limit is only enforced for bloom filters.")
     , large_memory_allocation_warning_threshold(this, "large_memory_allocation_warning_threshold", value_status::Used, (size_t(128) << 10) + 1, "Warn about memory allocations above this size; set to zero to disable.")
     , enable_deprecated_partitioners(this, "enable_deprecated_partitioners", value_status::Used, false, "Enable the byteordered and random partitioners. These partitioners are deprecated and will be removed in a future version.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -399,6 +399,7 @@ public:
     named_value<bool> abort_on_lsa_bad_alloc;
     named_value<unsigned> murmur3_partitioner_ignore_msb_bits;
     named_value<double> unspooled_dirty_soft_limit;
+    named_value<double> sstable_summary_memory_fraction;
     named_value<double> sstable_summary_ratio;
     named_value<double> components_memory_reclaim_threshold;
     named_value<size_t> large_memory_allocation_warning_threshold;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -373,9 +373,12 @@ database::view_update_read_concurrency_sem() {
 static auto configure_sstables_manager(const db::config& cfg, const database_config& db_cfg) {
     return sstables::sstables_manager::config {
         .available_memory = db_cfg.available_memory,
+        .total_disk_capacity = db_cfg.total_data_disk_capacity,
+        .sstable_summary_memory_fraction = cfg.sstable_summary_memory_fraction,
+        .sstable_summary_ratio = cfg.sstable_summary_ratio(),
+        .sstable_summary_ratio_is_set = cfg.sstable_summary_ratio.is_set(),
         .enable_sstable_key_validation = cfg.enable_sstable_key_validation(),
         .enable_data_integrity_check = cfg.enable_sstable_data_integrity_check(),
-        .sstable_summary_ratio = cfg.sstable_summary_ratio(),
         .column_index_size = cfg.column_index_size_in_kb() * 1024,
         .column_index_auto_scale_threshold_in_kb = cfg.column_index_auto_scale_threshold_in_kb,
         .memory_reclaim_threshold = cfg.components_memory_reclaim_threshold,

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1492,6 +1492,7 @@ struct database_config {
     seastar::scheduling_group commitlog_scheduling_group;
     seastar::scheduling_group schema_commitlog_scheduling_group;
     size_t available_memory;
+    uint64_t total_data_disk_capacity = 0;
 };
 
 struct string_pair_eq {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2302,7 +2302,7 @@ future<> sstable::generate_summary() {
         file_input_stream_options options;
         options.buffer_size = sstable_buffer_size;
 
-        auto s = summary_generator(_schema->get_partitioner(), _components->summary, _manager.get_config().sstable_summary_ratio);
+        auto s = summary_generator(_schema->get_partitioner(), _components->summary, _manager.effective_summary_ratio());
             auto ctx = make_lw_shared<index_consume_entry_context<summary_generator>>(
                     *this, sem.make_tracking_only_permit(_schema, "generate-summary", db::no_timeout, {}), s, trust_promoted_index::yes,
                     make_file_input_stream(index_file, 0, index_size, std::move(options)), 0, index_size,

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -107,9 +107,12 @@ class sstables_manager {
 public:
     struct config {
         size_t available_memory;
+        uint64_t total_disk_capacity = 0;
+        utils::updateable_value<double> sstable_summary_memory_fraction = utils::updateable_value<double>(0.05);
+        double sstable_summary_ratio = 0.0005;
+        bool sstable_summary_ratio_is_set = false;
         bool enable_sstable_key_validation = false;
         bool enable_data_integrity_check = false;
-        double sstable_summary_ratio = 0.0005;
         size_t column_index_size = 64 << 10;
         utils::updateable_value<uint32_t> column_index_auto_scale_threshold_in_kb = utils::updateable_value<uint32_t>(10240);
         utils::updateable_value<double> memory_reclaim_threshold = utils::updateable_value<double>(0.2);
@@ -206,6 +209,10 @@ public:
     }
 
     virtual sstable_writer_config configure_writer(sstring origin) const;
+    // Computes the effective summary-to-data ratio.
+    // If sstable_summary_ratio was explicitly set, returns that.
+    // Otherwise, derives it from sstable_summary_memory_fraction and the disk:memory ratio.
+    double effective_summary_ratio() const noexcept;
     const config& get_config() const noexcept { return _config; }
     cache_tracker& get_cache_tracker() { return _cache_tracker; }
     const std::vector<sstables::file_io_extension*>& file_io_extensions() const { return _file_io_extensions; }

--- a/test/boost/cache_algorithm_test.cc
+++ b/test/boost/cache_algorithm_test.cc
@@ -12,6 +12,8 @@
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/log.hh"
 #include "db/config.hh"
+#include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
 
 BOOST_AUTO_TEST_SUITE(cache_algorithm_test)
 
@@ -97,7 +99,8 @@ SEASTAR_TEST_CASE(test_index_doesnt_flood_cache_in_small_partition_workload) {
         //
         // The sanity check here is that the maximum total size of the touched index pages is much greater than RAM.
         // (Maximum is reached when each hot row lands on a different index page.)
-        const uint64_t data_summary_ratio = static_cast<uint64_t>(1 / e.local_db().get_config().sstable_summary_ratio());
+        const uint64_t data_summary_ratio = sstables::summary_byte_cost(
+                e.local_db().get_user_sstables_manager().effective_summary_ratio());
         BOOST_REQUIRE_GT(hot_subset_size * pk_size * data_summary_ratio, 2 * seastar::memory::stats().total_memory());
 
         auto get_misses = [&e] { return e.local_db().row_cache_tracker().get_stats().partition_misses; };

--- a/test/cluster/dtest/dtest_setup.py
+++ b/test/cluster/dtest/dtest_setup.py
@@ -497,6 +497,9 @@ class DTestSetup:
         values: dict[str, Any] = self.cluster_options | {
             "phi_convict_threshold": 5,
             "task_ttl_in_seconds": 0,
+            # Set sstable_summary_ratio explicitly so test outcomes don't
+            # depend on how much disk space the test machine actually has.
+            "sstable_summary_ratio": 0.0005,
             "read_request_timeout_in_ms": timeout,
             "range_request_timeout_in_ms": range_timeout,
             "write_request_timeout_in_ms": timeout,

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -647,6 +647,12 @@ private:
             dbcfg.memtable_to_cache_scheduling_group = scheduling_groups.memtable_to_cache_scheduling_group;
             dbcfg.gossip_scheduling_group = scheduling_groups.gossip_scheduling_group;
 
+            // Set sstable_summary_ratio explicitly for tests so the outcome
+            // doesn't depend on how much disk space the machine has.
+            if (!cfg->sstable_summary_ratio.is_set()) {
+                cfg->sstable_summary_ratio.set(0.0005);
+            }
+
             auto get_tm_cfg = sharded_parameter([&] {
                 return tasks::task_manager::config {
                     .task_ttl = cfg->task_ttl_seconds,

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -154,6 +154,10 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         'rf_rack_valid_keyspaces': True,
 
         'alternator_allow_system_table_write': True,
+
+        # Set sstable_summary_ratio explicitly so test outcomes don't
+        # depend on how much disk space the test machine actually has.
+        'sstable_summary_ratio': 0.0005,
     }
 
 # Seastar options can not be passed through scylla.yaml, use command line


### PR DESCRIPTION
The default sstable_summary_ratio, 0.0005, is a product of two design targets: 1:100 memory:disk ratio, and 5% allocation of memory to sstable summaries. But in practice most deployments have better than 1:100 memory:disk ratio, sometimes much better. In those cases, the summary memory ratio is too low and we end up with small summaries, and in turn large index pages. This causes high CPU and disk bandwidth spent on fetching large index pages.

This patch makes the summary ratio adaptive by measuring the actual disk space (instead of the 1:100 assumption in current code), and creating a new parameter sstable_summary_memory_fraction (default 0.05) for the sstable summary memory allocation. The orignal parameter (sstable_summary_ratio) is deprecated but still used if explicitly set.

Tests use explicit 100:1 disk:memory ratio.

The downside is that casual tests with low --memory setting and a large disk will see very small summaries.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-620

New featurette. No backport.