### PR TITLE
test:cluster:mv: await on create features in test_mv_build_during_shutdown

### DIFF
--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -84,3 +84,4 @@ async def test_mv_build_during_shutdown(manager: ManagerClient):
         except NoHostAvailable as e:
             if not any(s in str(e).lower() for s in ("abort requested", "semaphore aborted")):
                 raise
+        

--- a/test/pylib/util.py
+++ b/test/pylib/util.py
@@ -20,7 +20,7 @@ from functools import cache
 import random
 import string
 
-from typing import Optional, TypeVar, Any, cast
+from typing import List, Optional, TypeVar, Any, cast
 
 from cassandra.cluster import NoHostAvailable, Session, Cluster # type: ignore # pylint: disable=no-name-in-module
 from cassandra.protocol import InvalidRequest # type: ignore # pylint: disable=no-name-in-module
@@ -375,6 +375,26 @@ async def gather_safely(*awaitables: Awaitable):
     for result in results:
         if isinstance(result, BaseException):
             raise result from None
+    return results
+
+
+async def gather_safely_and_ignore_specific_exceptions(awaitables: List[Awaitable], ignore_exceptions: List[str] | str):
+    """
+    Same as gather_safely but this can ignore specific exceptions happening during the gathering 
+    This will help in specific situations where some exceptions are expected
+    also i will make the test code look cleaner (let the infra do the heavy lifting). 
+    """
+    if isinstance(ignore_exceptions, str): 
+        ignore_exceptions = [ignore_exceptions]
+    elif not isinstance(ignore_exceptions, list): 
+        raise TypeError(f"ignore_exceptions should be a string or a list of strings but got {type(ignore_exceptions)}")
+    elif any(not isinstance(s, str) for s in ignore_exceptions):
+        raise TypeError("ignore_exceptions should be a list of strings but got list of different types")         
+    results = await asyncio.gather(*awaitables, return_exceptions=True)
+    for result in results:
+        if isinstance(result, BaseException):
+            if not any(s in str(result).lower() for s in ignore_exceptions):
+                raise result from None
     return results
 
 


### PR DESCRIPTION
  test_mv_build_during_shutdown started two async CREATE MATERIALIZED VIEW
  operations and never awaited them (asyncio.gather(...) without await).

  This leaves schema futures running past the test body and into teardown.
  At that point new_test_keyspace drops the keyspace, which can race with
  still-running/aborting view build work during node drain/shutdown.
  That race explains a rare shutdown-time crash/core in stress loops.

  Fix:

  - Make the test explicitly wait for both create futures before teardown.
  - Use await asyncio.gather(..., return_exceptions=True) so both futures are drained even if one fails during shutdown.

  - Test teardown must not proceed while those operations are unresolved.
  - Awaiting both futures removes dangling background work and makes shutdown + keyspace drop ordering deterministic.

backport none: test enhancement 