### PR TITLE
Download backup manifests and populate system_distributed.snapshot_sstables

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -561,6 +561,7 @@ scylla_tests = set([
     'test/boost/crc_test',
     'test/boost/dict_trainer_test',
     'test/boost/dirty_memory_manager_test',
+    'test/boost/tablet_aware_restore_test',
     'test/boost/double_decker_test',
     'test/boost/duration_test',
     'test/boost/dynamic_bitset_test',

--- a/sstables_loader.cc
+++ b/sstables_loader.cc
@@ -31,6 +31,10 @@
 #include "message/messaging_service.hh"
 #include "service/storage_service.hh"
 
+#include "sstables/object_storage_client.hh"
+#include "utils/rjson.hh"
+#include "db/system_distributed_keyspace.hh"
+
 #include <cfloat>
 #include <algorithm>
 
@@ -977,4 +981,72 @@ future<tasks::task_id> sstables_loader::download_new_sstables(sstring ks_name, s
 future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_tests(const std::vector<sstables::shared_sstable>& sstables,
                                                                                   std::vector<dht::token_range>&& tablets_ranges) {
     return tablet_sstable_streamer::get_sstables_for_tablets(sstables, std::move(tablets_ranges));
+}
+
+static future<size_t> process_manifest(input_stream<char>& is, const sstring& expected_snapshot_name,
+                                 const sstring& manifest_prefix, db::system_distributed_keyspace& sys_dist_ks,
+                                 db::consistency_level cl) {
+    // Read the entire JSON content
+    rjson::chunked_content content = co_await util::read_entire_stream(is);
+
+    rjson::value parsed = rjson::parse(std::move(content));
+
+    // Basic validation that tablet_count is a power of 2, as expected by our restore process
+    size_t tablet_count = parsed["table"]["tablet_count"].GetUint64();
+    assert(std::has_single_bit(tablet_count));
+
+    // Extract the necessary fields from the manifest
+    // Expected JSON structure documented in docs/dev/object_storage.md
+    auto snapshot_name = sstring(rjson::to_string_view(parsed["snapshot"]["name"]));
+    if (snapshot_name != expected_snapshot_name) {
+        throw std::runtime_error(fmt::format("Manifest {} belongs to snapshot '{}', expected '{}'",
+            manifest_prefix, snapshot_name, expected_snapshot_name));
+    }
+    auto keyspace = sstring(rjson::to_string_view(parsed["table"]["keyspace_name"]));
+    auto table = sstring(rjson::to_string_view(parsed["table"]["table_name"]));
+    auto datacenter = sstring(rjson::to_string_view(parsed["node"]["datacenter"]));
+    auto rack = sstring(rjson::to_string_view(parsed["node"]["rack"]));
+
+    // Process each sstable entry in the manifest
+    // FIXME: cleanup of the snapshot-related rows is needed in case anything throws in here.
+    const auto& sstables_array = parsed["sstables"];
+    for (auto& sstable_entry : sstables_array.GetArray()) {
+        auto id = sstables::sstable_id(utils::UUID(rjson::to_string_view(sstable_entry["id"])));
+        auto first_token = dht::token::from_int64(sstable_entry["first_token"].GetInt64());
+        auto last_token = dht::token::from_int64(sstable_entry["last_token"].GetInt64());
+        auto toc_name = sstring(rjson::to_string_view(sstable_entry["toc_name"]));
+        auto prefix = sstring(std::filesystem::path(manifest_prefix).parent_path().string());
+        // Insert the snapshot sstable metadata into system_distributed.snapshot_sstables with a TTL of 3 days, that should be enough
+        // for any snapshot restore operation to complete, and after that the metadata will be automatically cleaned up from the table
+        co_await sys_dist_ks.insert_snapshot_sstable(snapshot_name, keyspace, table, datacenter, rack, id, first_token, last_token,
+                                                    toc_name, prefix, cl);
+    }
+
+    co_return tablet_count;
+}
+
+future<size_t> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl) {
+    // Download manifests in parallel and populate system_distributed.snapshot_sstables
+    // with the content extracted from each manifest
+    auto client = sm.get_endpoint_client(endpoint);
+
+    // tablet_count to be returned by this function, we also validate that all manifests passed contain the same tablet count
+    std::optional<size_t> tablet_count;
+
+    co_await seastar::max_concurrent_for_each(manifest_prefixes, 16, [&] (const sstring& manifest_prefix) {
+        // Download the manifest JSON file
+        sstables::object_name name(bucket, manifest_prefix);
+        auto source = client->make_download_source(name);
+        return seastar::with_closeable(input_stream<char>(std::move(source)), [&] (input_stream<char>& is) {
+            return process_manifest(is, expected_snapshot_name, manifest_prefix, sys_dist_ks, cl).then([&](size_t count) {
+                if (!tablet_count) {
+                    tablet_count = count;
+                } else if (*tablet_count != count) {
+                    throw std::runtime_error(fmt::format("Inconsistent tablet_count values in manifest {}: expected {}, got {}", manifest_prefix, *tablet_count, count));
+                }
+            });
+        });
+    });
+
+    co_return *tablet_count;
 }

--- a/sstables_loader.hh
+++ b/sstables_loader.hh
@@ -15,6 +15,8 @@
 #include "schema/schema_fwd.hh"
 #include "sstables/shared_sstable.hh"
 #include "tasks/task_manager.hh"
+#include "db/consistency_level_type.hh"
+
 
 using namespace seastar;
 
@@ -26,6 +28,7 @@ namespace sstables { class storage_manager; }
 
 namespace netw { class messaging_service; }
 namespace db {
+class system_distributed_keyspace;
 namespace view {
 class view_builder;
 class view_building_worker;
@@ -169,3 +172,5 @@ struct tablet_sstable_collection {
 // Another prerequisite is that the sstables' token ranges are sorted by its `start` in descending order.
 future<std::vector<tablet_sstable_collection>> get_sstables_for_tablets_for_tests(const std::vector<sstables::shared_sstable>& sstables,
                                                                                   std::vector<dht::token_range>&& tablets_ranges);
+
+future<size_t> populate_snapshot_sstables_from_manifests(sstables::storage_manager& sm, db::system_distributed_keyspace& sys_dist_ks, sstring endpoint, sstring bucket, sstring expected_snapshot_name, utils::chunked_vector<sstring> manifest_prefixes, db::consistency_level cl = db::consistency_level::EACH_QUORUM);

--- a/test/boost/CMakeLists.txt
+++ b/test/boost/CMakeLists.txt
@@ -312,6 +312,8 @@ add_scylla_test(address_map_test
   KIND SEASTAR)
 add_scylla_test(object_storage_upload_test
   KIND SEASTAR)
+add_scylla_test(tablet_aware_restore_test
+  KIND SEASTAR)
 
 add_scylla_test(combined_tests
   KIND SEASTAR

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -56,6 +56,7 @@
 #include "db/system_keyspace.hh"
 #include "db/view/view_builder.hh"
 #include "replica/mutation_dump.hh"
+#include "test/boost/database_test.hh"
 
 using namespace std::chrono_literals;
 using namespace sstables;
@@ -519,75 +520,10 @@ SEASTAR_THREAD_TEST_CASE(test_distributed_loader_with_pending_delete) {
     }, test_config).get();
 }
 
-// Snapshot tests and their helpers
-// \param func: function to be called back, in a seastar thread.
-future<> do_with_some_data_in_thread(std::vector<sstring> cf_names, std::function<void (cql_test_env&)> func, bool create_mvs = false, shared_ptr<db::config> db_cfg_ptr = {}, size_t num_keys = 2) {
-    return seastar::async([cf_names = std::move(cf_names), func = std::move(func), create_mvs,  db_cfg_ptr = std::move(db_cfg_ptr), num_keys] () mutable {
-        lw_shared_ptr<tmpdir> tmpdir_for_data;
-        if (!db_cfg_ptr) {
-            tmpdir_for_data = make_lw_shared<tmpdir>();
-            db_cfg_ptr = make_shared<db::config>();
-            db_cfg_ptr->data_file_directories(std::vector<sstring>({ tmpdir_for_data->path().string() }));
-        }
-        do_with_cql_env_thread([cf_names = std::move(cf_names), func = std::move(func), create_mvs, num_keys] (cql_test_env& e) {
-            for (const auto& cf_name : cf_names) {
-                e.create_table([&cf_name] (std::string_view ks_name) {
-                    return *schema_builder(ks_name, cf_name)
-                            .with_column("p1", utf8_type, column_kind::partition_key)
-                            .with_column("c1", int32_type, column_kind::clustering_key)
-                            .with_column("c2", int32_type, column_kind::clustering_key)
-                            .with_column("r1", int32_type)
-                            .build();
-                }).get();
-                auto stmt = e.prepare(fmt::format("insert into {} (p1, c1, c2, r1) values (?, ?, ?, ?)", cf_name)).get();
-                auto make_key = [] (int64_t k) {
-                    std::string s = fmt::format("key{}", k);
-                    return cql3::raw_value::make_value(utf8_type->decompose(s));
-                };
-                auto make_val = [] (int64_t x) {
-                    return cql3::raw_value::make_value(int32_type->decompose(int32_t{x}));
-                };
-                for (size_t i = 0; i < num_keys; ++i) {
-                    auto key = tests::random::get_int<int32_t>(1, 1000000);
-                    e.execute_prepared(stmt, {make_key(key), make_val(key), make_val(key + 1), make_val(key + 2)}).get();
-                    e.execute_prepared(stmt, {make_key(key), make_val(key + 1), make_val(key + 1), make_val(key + 2)}).get();
-                    e.execute_prepared(stmt, {make_key(key), make_val(key + 2), make_val(key + 1), make_val(key + 2)}).get();
-                }
-
-                if (create_mvs) {
-                    auto f1 = e.local_view_builder().wait_until_built("ks", seastar::format("view_{}", cf_name));
-                    e.execute_cql(seastar::format("create materialized view view_{0} as select * from {0} where p1 is not null and c1 is not null and c2 is "
-                                                  "not null primary key (p1, c1, c2)",
-                                                  cf_name))
-                        .get();
-                    f1.get();
-
-                    auto f2 = e.local_view_builder().wait_until_built("ks", "index_cf_index");
-                    e.execute_cql(seastar::format("CREATE INDEX index_{0} ON {0} (r1);", cf_name)).get();
-                    f2.get();
-                }
-            }
-
-            func(e);
-        }, db_cfg_ptr).get();
-    });
-}
-
 future<> do_with_some_data(std::vector<sstring> cf_names, std::function<future<> (cql_test_env&)> func, bool create_mvs = false, shared_ptr<db::config> db_cfg_ptr = {}) {
     co_await do_with_some_data_in_thread(cf_names, [&] (cql_test_env& e) {
         func(e).get();
     }, create_mvs, db_cfg_ptr);
-}
-
-future<> take_snapshot(cql_test_env& e, sstring ks_name = "ks", sstring cf_name = "cf", sstring snapshot_name = "test", db::snapshot_options opts = {}) {
-    try {
-        auto uuid = e.db().local().find_uuid(ks_name, cf_name);
-        co_await replica::database::snapshot_table_on_all_shards(e.db(), uuid, snapshot_name, opts);
-    } catch (...) {
-        testlog.error("Could not take snapshot for {}.{} snapshot_name={} skip_flush={}: {}",
-                ks_name, cf_name, snapshot_name, opts.skip_flush, std::current_exception());
-        throw;
-    }
 }
 
 future<std::set<sstring>> collect_files(fs::path path) {

--- a/test/boost/database_test.hh
+++ b/test/boost/database_test.hh
@@ -1,0 +1,81 @@
+
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include "db/snapshot-ctl.hh"
+#include "db/config.hh"
+#include "test/lib/cql_test_env.hh"
+#include "db/view/view_builder.hh"
+
+
+// Snapshot tests and their helpers
+// \param func: function to be called back, in a seastar thread.
+inline future<> do_with_some_data_in_thread(std::vector<sstring> cf_names, std::function<void (cql_test_env&)> func, bool create_mvs = false, shared_ptr<db::config> db_cfg_ptr = {}, size_t num_keys = 2) {
+    return seastar::async([cf_names = std::move(cf_names), func = std::move(func), create_mvs,  db_cfg_ptr = std::move(db_cfg_ptr), num_keys] () mutable {
+        lw_shared_ptr<tmpdir> tmpdir_for_data;
+        if (!db_cfg_ptr) {
+            tmpdir_for_data = make_lw_shared<tmpdir>();
+            db_cfg_ptr = make_shared<db::config>();
+            db_cfg_ptr->data_file_directories(std::vector<sstring>({ tmpdir_for_data->path().string() }));
+        }
+        do_with_cql_env_thread([cf_names = std::move(cf_names), func = std::move(func), create_mvs, num_keys] (cql_test_env& e) {
+            for (const auto& cf_name : cf_names) {
+                e.create_table([&cf_name] (std::string_view ks_name) {
+                    return *schema_builder(ks_name, cf_name)
+                            .with_column("p1", utf8_type, column_kind::partition_key)
+                            .with_column("c1", int32_type, column_kind::clustering_key)
+                            .with_column("c2", int32_type, column_kind::clustering_key)
+                            .with_column("r1", int32_type)
+                            .build();
+                }).get();
+                auto stmt = e.prepare(fmt::format("insert into {} (p1, c1, c2, r1) values (?, ?, ?, ?)", cf_name)).get();
+                auto make_key = [] (int64_t k) {
+                    std::string s = fmt::format("key{}", k);
+                    return cql3::raw_value::make_value(utf8_type->decompose(s));
+                };
+                auto make_val = [] (int64_t x) {
+                    return cql3::raw_value::make_value(int32_type->decompose(int32_t{x}));
+                };
+                for (size_t i = 0; i < num_keys; ++i) {
+                    auto key = tests::random::get_int<int32_t>(1, 1000000);
+                    e.execute_prepared(stmt, {make_key(key), make_val(key), make_val(key + 1), make_val(key + 2)}).get();
+                    e.execute_prepared(stmt, {make_key(key), make_val(key + 1), make_val(key + 1), make_val(key + 2)}).get();
+                    e.execute_prepared(stmt, {make_key(key), make_val(key + 2), make_val(key + 1), make_val(key + 2)}).get();
+                }
+
+                if (create_mvs) {
+                    auto f1 = e.local_view_builder().wait_until_built("ks", seastar::format("view_{}", cf_name));
+                    e.execute_cql(seastar::format("create materialized view view_{0} as select * from {0} where p1 is not null and c1 is not null and c2 is "
+                                                  "not null primary key (p1, c1, c2)",
+                                                  cf_name))
+                        .get();
+                    f1.get();
+
+                    auto f2 = e.local_view_builder().wait_until_built("ks", "index_cf_index");
+                    e.execute_cql(seastar::format("CREATE INDEX index_{0} ON {0} (r1);", cf_name)).get();
+                    f2.get();
+                }
+            }
+
+            func(e);
+        }, db_cfg_ptr).get();
+    });
+}
+
+inline future<> take_snapshot(cql_test_env& e, sstring ks_name = "ks", sstring cf_name = "cf", sstring snapshot_name = "test", db::snapshot_options opts = {}) {
+    try {
+        auto uuid = e.db().local().find_uuid(ks_name, cf_name);
+        co_await replica::database::snapshot_table_on_all_shards(e.db(), uuid, snapshot_name, opts);
+    } catch (...) {
+        testlog.error("Could not take snapshot for {}.{} snapshot_name={} skip_flush={}: {}",
+                ks_name, cf_name, snapshot_name, opts.skip_flush, std::current_exception());
+        throw;
+    }
+}

--- a/test/boost/tablet_aware_restore_test.cc
+++ b/test/boost/tablet_aware_restore_test.cc
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+
+
+#include "test/lib/cql_test_env.hh"
+#include "utils/assert.hh"
+#include <seastar/core/sstring.hh>
+#include <fmt/ranges.h>
+#include <fmt/format.h>
+
+#include <seastar/core/future.hh>
+#include <seastar/testing/test_case.hh>
+#include <seastar/testing/test_fixture.hh>
+
+#include "db/config.hh"
+#include "sstables/object_storage_client.hh"
+#include "sstables/storage.hh"
+
+#include "test/lib/test_utils.hh"
+#include "test/lib/random_utils.hh"
+#include "test/lib/sstable_test_env.hh"
+#include "sstables_loader.hh"
+#include "replica/database_fwd.hh"
+#include "tasks/task_handler.hh"
+#include "db/system_distributed_keyspace.hh"
+#include "service/storage_proxy.hh"
+#include "test/boost/database_test.hh"
+
+using namespace sstables;
+
+future<> backup(cql_test_env& env, sstring endpoint, sstring bucket) {
+    sharded<db::snapshot_ctl> ctl;
+    co_await ctl.start(std::ref(env.db()), std::ref(env.get_task_manager()), std::ref(env.get_sstorage_manager()), db::snapshot_ctl::config{});
+    auto prefix = "/backup";
+
+    auto task_id = co_await ctl.local().start_backup(endpoint, bucket, prefix, "ks", "cf", "snapshot", false);
+    auto task = tasks::task_handler{env.get_task_manager().local(), task_id};
+    auto status = co_await task.wait_for_task(30s);
+    BOOST_REQUIRE(status.state == tasks::task_manager::task_state::done);
+
+    co_await ctl.stop();
+}
+
+future<> check_snapshot_sstables(cql_test_env& env) {
+    auto& topology = env.get_storage_proxy().local().get_token_metadata_ptr()->get_topology();
+    auto dc = topology.get_datacenter();
+    auto rack = topology.get_rack();
+    auto sstables = co_await env.get_system_distributed_keyspace().local().get_snapshot_sstables("snapshot", "ks", "cf", dc, rack, db::consistency_level::ONE);
+
+    // Check that the sstables in system_distributed.snapshot_sstables match the sstables in the snapshot directory on disk
+    auto& cf = env.local_db().find_column_family("ks", "cf");
+    auto tabledir = tests::table_dir(cf);
+    auto snapshot_dir = tabledir / sstables::snapshots_dir / "snapshot";
+    std::set<sstring> expected_sstables;
+    directory_lister lister(snapshot_dir, lister::dir_entry_types::of<directory_entry_type::regular>());
+    while (auto de = co_await lister.get()) {
+        if (!de->name.ends_with("-TOC.txt")) {
+            continue;
+        }
+        expected_sstables.insert(de->name);
+    }
+
+    BOOST_CHECK_EQUAL(sstables.size(), expected_sstables.size());
+
+    for (const auto& sstable : sstables) {
+        BOOST_CHECK(expected_sstables.contains(sstable.toc_name));
+    }
+}
+
+SEASTAR_TEST_CASE(test_populate_snapshot_sstables_from_manifests, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
+    using namespace sstables;
+
+    auto db_cfg_ptr = make_shared<db::config>();
+    db_cfg_ptr->tablets_mode_for_new_keyspaces(db::tablets_mode_t::mode::enabled);
+    db_cfg_ptr->experimental_features({db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS});
+    auto storage_options = make_test_object_storage_options("S3");
+    db_cfg_ptr->object_storage_endpoints(make_storage_options_config(storage_options));
+
+    return do_with_some_data_in_thread({"cf"}, [storage_options = std::move(storage_options)] (cql_test_env& env) {
+            take_snapshot(env, "ks", "cf", "snapshot").get();
+
+            auto ep = storage_options.to_map()["endpoint"];
+            auto bucket = storage_options.to_map()["bucket"];
+            backup(env, ep, bucket).get();
+
+            BOOST_REQUIRE_THROW(populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), ep, bucket, "unexpected_snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get(), std::runtime_error);;
+
+            // populate system_distributed.snapshot_sstables with the content of the snapshot manifest
+            populate_snapshot_sstables_from_manifests(env.get_sstorage_manager().local(), env.get_system_distributed_keyspace().local(), ep, bucket, "snapshot", {"/backup/manifest.json"}, db::consistency_level::ONE).get();
+
+            check_snapshot_sstables(env).get();
+    }, false, db_cfg_ptr, 10);
+}

--- a/test/lib/test_services.hh
+++ b/test/lib/test_services.hh
@@ -69,3 +69,9 @@ struct table_for_tests {
     void set_tombstone_gc_enabled(bool tombstone_gc_enabled) noexcept;
     void set_repair_sstable_classifier(replica::repair_classifier_func repair_sstable_classifier);
 };
+
+namespace sstables {
+
+std::vector<db::object_storage_endpoint_param> make_storage_options_config(const data_dictionary::storage_options& so);
+
+}


### PR DESCRIPTION
This change adds functionality for parsing backup and populating system_distributed.snapshot_sstables with the content of the manifests.

This change is useful for tablet-aware restore. The function introduced here will be called by the topology coordinator when restore starts to populate the snapshot_sstables table with the data that workers need to execute the restore process.

The added test adds some data, take a snapshot, backs it up to object storage, calls the topology_coordinator function to populate snapshot_sstables and then checks if the sstables from the local snapshot can be found in the table.

This PR depends on https://github.com/scylladb/scylladb/pull/28436 which adds the system table.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-264