### PR TITLE
mutation_compactor: Fix tombstone GC metrics to account for only expired

### DIFF
--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -272,25 +272,27 @@ private:
 
     bool can_purge_tombstone(const tombstone& t, is_shadowable is_shadowable, const gc_clock::time_point deletion_time) {
         max_purgeable::can_purge_result purge_res { };
+        std::optional<bool> expired;
 
         if (_tombstone_gc_state.cheap_to_get_gc_before(_schema)) {
             // if retrieval of grace period is cheap, can_gc() will only be
             // called for tombstones that are older than grace period, in
             // order to avoid unnecessary bloom filter checks when calculating
             // max purgeable timestamp.
-            purge_res.can_purge = satisfy_grace_period(deletion_time);
+            expired = purge_res.can_purge = satisfy_grace_period(deletion_time);
             if (purge_res.can_purge) {
                 purge_res = can_gc(t, is_shadowable);
             }
         } else {
             purge_res = can_gc(t, is_shadowable);
             if (purge_res.can_purge) {
-                purge_res.can_purge = satisfy_grace_period(deletion_time);
+                expired = purge_res.can_purge = satisfy_grace_period(deletion_time);
             }
         }
 
         if constexpr (sstable_compaction()) {
-            if (!_tombstone_stats || !t) {
+            // Tombstone GC stats only account for expired tombstones (those eligible for GC).
+            if (!_tombstone_stats || !t || !expired.value_or(satisfy_grace_period(deletion_time))) {
                 return purge_res.can_purge;
             }
 


### PR DESCRIPTION
There are 3 metrics (that goes in every compaction_history entry):
total_tombstone_purge_attempt
total_tombstone_purge_failure_due_to_overlapping_with_memtable total_tombstone_purge_failure_due_to_overlapping_with_uncompacting_sstable

When a tombstone is not expired (e.g. doesn't satisfy "gc_before" or grace period), it can be currently accounted as failure due to overlapping with either memtable or uncompacting sstable. So those 2 last metrics have noise of *unexpired* tombstones.

What we should do is to only account for expired tombstones in all those 3 metrics. We lose the info of knowing the amount of tombstones processed by compaction, now we'll only know about the expired ones. But those metrics were primarily added for explaining why expired tombstones cannot be removed.
We could have alternatively added a new field purge_failure_due_to_being_unexpired or something, but it requires adding a new field to compaction_history.

Refs https://scylladb.atlassian.net/browse/CUSTOMER-189
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-737

These statistics were introduced in 2025.3 (https://github.com/scylladb/scylladb/commit/485df63fd50f70d8e6601e2836a7e008acbdedb6), need backport to >= 2025.3.