### PR TITLE
Modify issue trigger types in workflow

### DIFF
--- a/.github/workflows/close_issue_for_scylla_associate.yml
+++ b/.github/workflows/close_issue_for_scylla_associate.yml
@@ -2,7 +2,7 @@ name: Close issues created by Scylla associates
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened]
 
 permissions:
   issues: write


### PR DESCRIPTION
Restrict the workflow to only trigger on opened issues.

Issues that needs to be reopened should stay in GitHub.
Some issues have dependencies in dtest and closing them incorrectly cause tests to fail and break CI and nightly runs.
e.g: https://jenkins.scylladb.com/job/scylla-master/job/scylla-ci/26620/testReport/junit/replace_address_test/TestReplaceAddress/release___dtest_with_tablets___test_replace_with_background_workload_rbo_disabled_/