### PR TITLE
vector_search/clients: fix HTTPS client test flakiness

### DIFF
--- a/vector_search/clients.cc
+++ b/vector_search/clients.cc
@@ -70,9 +70,18 @@ clients::clients(
 future<clients::request_result> clients::request(
         seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content, seastar::abort_source& as) {
 
+    auto last_error = request_error{service_unavailable_error{}};
+
     for (auto retries = 0; retries < REQUEST_RETRIES; ++retries) {
         auto clients = co_await get_clients(as);
         if (!clients) {
+            if (std::holds_alternative<addr_unavailable_error>(clients.error())) {
+                // No clients available yet (e.g. DNS refresh or TLS credential initialization still in progress).
+                // Trigger a refresh and retry — the addresses may become available on the next attempt.
+                last_error = addr_unavailable_error{};
+                _trigger_refresh();
+                continue;
+            }
             co_return make_unexpected<clients::request_error>(clients.error());
         }
 
@@ -88,10 +97,11 @@ future<clients::request_result> clients::request(
             }
             co_return make_unexpected<clients::request_error>(result.error());
         }
+        last_error = service_unavailable_error{};
         _trigger_refresh();
     }
 
-    co_return std::unexpected{service_unavailable_error{}};
+    co_return std::unexpected{last_error};
 }
 
 /// Get the current http client or wait for a new one to be available.


### PR DESCRIPTION
Fix two issues that cause the vector_store_client_https test to fail:

1. In `request()`: when `get_clients()` returns `addr_unavailable_error` (e.g. because TLS credential initialization via `truststore::get()` hasn't completed within the `wait_for_client_timeout`), the request immediately failed instead of retrying. Now we trigger a DNS refresh and retry, giving the async TLS setup time to complete.

2. In `handle_changed()`: the old code called `clear()` first, emptying `_clients`, then created new clients one-by-one with `co_await`. During this async gap (significant for HTTPS due to `truststore::get()`), the `sequential_producer` factory could observe empty `_clients` and time out. Now we build the new client list into a separate vector first, then swap atomically.

Fixes: VECTOR-547, SCYLLADB-802

Backport up to 2025.4 - it was detected in 2025.4 CI.