### PR TITLE
test: pylib: utils: add safe gather helper with expected-exception filtering

### DIFF
--- a/test/pylib_test/test_util.py
+++ b/test/pylib_test/test_util.py
@@ -1,7 +1,9 @@
+import asyncio
 import os
 import tempfile
 import pathlib
-from test.pylib.util import read_last_line
+import pytest
+from test.pylib.util import read_last_line, gather_safely_and_ignore_specific_exceptions
 
 def test_read_last_line():
     test_cases = [
@@ -26,3 +28,122 @@ def test_read_last_line():
             file_path = pathlib.Path(f.name)
             actual = read_last_line(file_path, test_case[2]) if len(test_case) == 3 else read_last_line(file_path)
             assert(actual == test_case[1])
+
+
+def test_gather_safely_and_ignore_specific_exceptions_string_pattern_does_not_match_per_character() -> None:
+    async def _fails() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions(
+            [_fails()],
+            "connection is closed",
+        ))
+
+
+@pytest.mark.parametrize(
+    "error_message, patterns",
+    [
+        pytest.param("connection was closed", ("connection was closed",), id="iterable-patterns"),
+        pytest.param("some message", ("runtimeerror",), id="exception-type-name"),
+        pytest.param("  Timed Out While Closing ", ("", "   ", " timed out "), id="normalized-patterns"),
+    ],
+)
+def test_gather_safely_and_ignore_specific_exceptions_legacy_mode_matches_expected(error_message, patterns) -> None:
+    async def _fails() -> None:
+        raise RuntimeError(error_message)
+
+    results = asyncio.run(gather_safely_and_ignore_specific_exceptions(
+        [_fails()],
+        patterns,
+    ))
+
+    assert isinstance(results[0], RuntimeError)
+
+
+def test_gather_safely_and_ignore_specific_exceptions_varargs_form() -> None:
+    async def _ok() -> int:
+        return 7
+
+    async def _fails() -> None:
+        raise RuntimeError("Connection IS Closed")
+
+    results = asyncio.run(gather_safely_and_ignore_specific_exceptions(
+        _ok(),
+        _fails(),
+        "connection is closed",
+    ))
+
+    assert results[0] == 7
+    assert isinstance(results[1], RuntimeError)
+
+
+def test_gather_safely_and_ignore_specific_exceptions_raises_unexpected_error() -> None:
+    async def _fails() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions(
+            [_fails()],
+            ["connection is closed"],
+        ))
+
+
+@pytest.mark.parametrize(
+    "ignore_patterns, error_match",
+    [
+        pytest.param(1, "string or an iterable of strings", id="non-iterable-patterns"),  # type: ignore[arg-type]
+        pytest.param(["ok", 2], "iterable of strings", id="mixed-iterable-patterns"),  # type: ignore[list-item]
+    ],
+)
+def test_gather_safely_and_ignore_specific_exceptions_rejects_invalid_patterns(ignore_patterns, error_match) -> None:
+    with pytest.raises(TypeError, match=error_match):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions([], ignore_patterns))
+
+
+@pytest.mark.parametrize(
+    "args, error_match",
+    [
+        pytest.param(([1], "boom"), "awaitables iterable should contain only awaitables", id="invalid-awaitable-iterable"),  # type: ignore[list-item]
+        pytest.param((1, "connection is closed"), "invalid argument type for gather", id="invalid-vararg-type"),  # type: ignore[arg-type]
+    ],
+)
+def test_gather_safely_and_ignore_specific_exceptions_rejects_invalid_inputs(args, error_match) -> None:
+    with pytest.raises(TypeError, match=error_match):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions(*args))
+
+
+def test_gather_safely_and_ignore_specific_exceptions_rejects_awaitable_after_patterns() -> None:
+    async def _ok() -> int:
+        return 1
+
+    coro = _ok()
+    with pytest.raises(TypeError, match="awaitables must come before"):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions("connection is closed", coro))
+    coro.close()
+
+
+def test_gather_safely_and_ignore_specific_exceptions_fails_when_no_patterns_match() -> None:
+    async def _fails() -> None:
+        raise ValueError("not ignored")
+
+    with pytest.raises(ValueError, match="not ignored"):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions([_fails()], []))
+
+
+def test_gather_safely_and_ignore_specific_exceptions_fails_on_unexpected_with_mixed_results() -> None:
+    async def _ok() -> int:
+        return 9
+
+    async def _ignored() -> None:
+        raise RuntimeError("connection is closed")
+
+    async def _unexpected() -> None:
+        raise ValueError("fatal")
+
+    with pytest.raises(ValueError, match="fatal"):
+        asyncio.run(gather_safely_and_ignore_specific_exceptions(
+            [_ok(), _ignored(), _unexpected()],
+            ["connection is closed"],
+        ))
+


### PR DESCRIPTION
This patch introduces gather_safely_and_ignore_specific_exceptions() in test/pylib/util.py to simplify concurrent test flows where a subset of failures is expected during teardown/race windows.

asyncio.gather() with default settings can return early on the first exception, leaving sibling awaitables running in the background.
  gather_safely() already fixes that by waiting for all tasks and then re-raising.
  Some cluster tests still need a variant that tolerates known transient failures (shutdown/abort/connection-close class errors) while preserving strict failure behavior for unexpected exceptions.

  - Adds gather_safely_and_ignore_specific_exceptions():
      - always gathers with return_exceptions=True
      - re-raises unexpected exceptions - ignores exceptions matching configured patterns (case-insensitive) - also matches by exception type name
  - Supports both call styles: - legacy form: (awaitables_iterable, ignore_exceptions) - varargs form: (*awaitables, *ignore_exception_strings)
  - Adds internal helpers for:
      - input extraction/validation (_extract_gather_inputs)
      - pattern normalization (_normalize_ignore_exception_patterns)
  - Tightens validation: - rejects invalid argument ordering/types - validates iterable pattern contents are strings

  Added focused unit coverage in test/pylib_test/test_util.py
  and validated with  pytest -k gather_safely_and_ignore_specific_exceptions test/pylib_test/test_util.py passed.

AI Assisted for testing

backport: not required its a test library enhancement
