### PR TITLE
db: fix UB in system.clients row sorting

### DIFF
--- a/db/virtual_tables.cc
+++ b/db/virtual_tables.cc
@@ -835,7 +835,10 @@ class clients_table : public streaming_virtual_table {
             auto& clients = cd_map[dip.ip];
 
             std::ranges::sort(clients, [] (const foreign_ptr<std::unique_ptr<client_data>>& a, const foreign_ptr<std::unique_ptr<client_data>>& b) {
-                return a->port < b->port || a->client_type_str() < b->client_type_str();
+                if (a->port != b->port) {
+                    return a->port < b->port;
+                }
+                return a->client_type_str() < b->client_type_str();
             });
 
             for (const auto& cd : clients) {


### PR DESCRIPTION
The comparator used to sort per-IP client rows was not a strict-weak-ordering (it could return true in both directions for some pairs), which makes `std::ranges::sort` behavior undefined. A concrete pair that breaks it (and is realistic in system.clients):
a = (port=9042, client_type="cql")
b = (port=10000, client_type="alternator")
With the current comparator:
cmp(a,b) = (9042 < 10000) || ("cql" < "alternator") = true || false = true
cmp(b,a) = (10000 < 9042) || ("alternator" < "cql") = false || true = true
So both directions are true, meaning there is no valid ordering that sort can achieve.

The fix is to sort lexicographically by (port, client_type) to match the table's clustering key and ensure deterministic ordering.

No need to backport, not a catastrophic bug. 

[tgrabiec] Fixes https://scylladb.atlassian.net/browse/SCYLLADB-4232