### PR TITLE
select_statement: fix sort order when combining IN and ORDER BY

### DIFF
--- a/cql3/statements/raw/select_statement.hh
+++ b/cql3/statements/raw/select_statement.hh
@@ -137,6 +137,7 @@ private:
 
     select_statement::ordering_comparator_type get_ordering_comparator(
         const prepared_orderings_type&,
+        bool is_reversed,
         selection::selection& selection,
         const restrictions::statement_restrictions& restrictions);
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -969,9 +969,6 @@ select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::resul
 
         if (needs_post_query_ordering()) {
             rs->sort(_ordering_comparator);
-            if (_is_reversed) {
-                rs->reverse();
-            }
             rs->trim(cmd->get_row_limit());
         }
         update_stats_rows_read(rs->size());
@@ -2413,8 +2410,8 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
                 prepared_orderings_type prepared_orderings = prepare_orderings(*schema);
                 verify_ordering_is_valid(prepared_orderings, *schema, *restrictions);
 
-                ordering_comparator = get_ordering_comparator(prepared_orderings, *selection, *restrictions);
                 is_reversed_ = is_ordering_reversed(prepared_orderings);
+                ordering_comparator = get_ordering_comparator(prepared_orderings, is_reversed_, *selection, *restrictions);
             }
         }, orderings.front().second);
     }
@@ -2743,6 +2740,7 @@ void select_statement::verify_ordering_is_valid(const prepared_orderings_type& o
 }
 
 select_statement::ordering_comparator_type select_statement::get_ordering_comparator(const prepared_orderings_type& orderings,
+    bool is_reversed,
     selection::selection& selection,
     const restrictions::statement_restrictions& restrictions) {
     if (!restrictions.key_is_in_relation()) {
@@ -2767,19 +2765,19 @@ select_statement::ordering_comparator_type select_statement::get_ordering_compar
         sorters.emplace_back(index, column_def->type);
     }
 
-    return [sorters = std::move(sorters)] (const result_row_type& r1, const result_row_type& r2) mutable {
+    return [sorters = std::move(sorters), is_reversed] (const result_row_type& r1, const result_row_type& r2) mutable {
         for (auto&& e : sorters) {
             auto& c1 = r1[e.first];
             auto& c2 = r2[e.first];
             auto type = e.second;
 
             if (bool(c1) != bool(c2)) {
-                return bool(c2);
+                return bool(c2) != is_reversed;
             }
             if (c1) {
                 auto result = type->compare(*c1, *c2);
                 if (result != 0) {
-                    return result < 0;
+                    return (result < 0) != is_reversed;
                 }
             }
         }

--- a/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_limit_test.py
@@ -19,7 +19,6 @@ def testSparseTable(cql, test_keyspace):
                 execute(cql, table, "INSERT INTO %s (userid, url, day, month, year) VALUES (?, ?, 1, 'jan', 2012)", i, f"http://foo.{tld}")
         assertRowCount(execute(cql, table, "SELECT * FROM %s LIMIT 4"), 4)
 
-@pytest.mark.xfail(reason="issues #15099")
 def testPerPartitionLimit(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, c int, PRIMARY KEY (a, b))") as table:
         for i in range(5):
@@ -284,7 +283,6 @@ def testLimitWithDeletedRowsAndStaticColumns(cql, test_keyspace):
                    row(1, -1, 1, 1),
                    row(5, -1, 1, 1))
 
-@pytest.mark.xfail(reason="issue #15099")
 def testFilteringOnClusteringColumnsWithLimitAndStaticColumns(cql, test_keyspace):
     # With only one clustering column
     with create_table(cql, test_keyspace, "(a int, b int, s int static, c int, PRIMARY KEY (a, b))") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/select_order_by_test.py
@@ -345,22 +345,19 @@ def testOrderByForInClauseWithNullValue(cql, test_keyspace):
         execute(cql, table, "UPDATE %s SET s = 3 WHERE a = 3")
 
         for _ in before_and_after_flush(cql, table):
-            # Commenting this test out - there are ties for b, so the correct
-            # order isn't completely specified, and happens to be different in
-            # Scylla and Cassandra.
-            #assert_rows(execute_without_paging(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a IN (1, 2, 3) ORDER BY b DESC"),
-            #           [2, 2, 2, 1, 2],
-            #           [2, 2, 1, 1, 2],
-            #           [1, 1, 2, 1, 1],
-            #           [1, 1, 1, 1, 1],
-            #           [3, None, None, None, 3])
+            assert_rows(execute_without_paging(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a IN (1, 2, 3) ORDER BY b DESC"),
+                       [2, 2, 2, 1, 2],
+                       [2, 2, 1, 1, 2],
+                       [1, 1, 2, 1, 1],
+                       [1, 1, 1, 1, 1],
+                       [3, None, None, None, 3])
 
-            #assert_rows(execute_without_paging(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a IN (1, 2, 3) ORDER BY b ASC"),
-            #           [3, None, None, None, 3],
-            #           [1, 1, 1, 1, 1],
-            #           [1, 1, 2, 1, 1],
-            #           [2, 2, 1, 1, 2],
-            #           [2, 2, 2, 1, 2])
+            assert_rows(execute_without_paging(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a IN (1, 2, 3) ORDER BY b ASC"),
+                       [3, None, None, None, 3],
+                       [1, 1, 1, 1, 1],
+                       [1, 1, 2, 1, 1],
+                       [2, 2, 1, 1, 2],
+                       [2, 2, 2, 1, 2])
 
             assert_rows(execute_without_paging(cql, table, "SELECT a, b, c, d, s FROM %s WHERE a IN (1, 2, 3) ORDER BY b DESC , c DESC"),
                        [2, 2, 2, 1, 2],


### PR DESCRIPTION
When a query has both IN and ORDER BY, Scylla needs to read the different partitions specified in IN, collect the matching rows, and finally sort everything by the ORDER BY order. Scylla (and Cassandra) only allow this if the query is not paged, so this sorting can actually be done. With ties in ordering columns the correct order isn't completely specified, and for DESC order happens to be different in Scylla and Cassandra.

For ASC both implementations seem to solve ties with the token order. For DESC Cassandra solves ties with ascending token order. In Scylla it is a reversed ASC order (descending token order for ties).

This patch changes this behaviour in Scylla to be compatible with Cassandra.

Fixes #15099

Minor change in unspecified behaviour, no need to backport.