### PR TITLE
streaming: add oos protection in mutation based streaming

### DIFF
--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2531,6 +2531,7 @@ future<> sstable::write_components(
     return seastar::async([this, mr = std::move(mr), estimated_partitions, schema = std::move(schema), cfg, stats] () mutable {
         auto close_mr = deferred_close(mr);
         auto wr = get_writer(*schema, estimated_partitions, cfg, stats);
+        utils::get_local_injector().inject("write_components_writer_created", utils::wait_for_message(std::chrono::seconds(30))).get();
         mr.consume_in_thread(std::move(wr));
     }).finally([this] {
         assert_large_data_handler_is_running();

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -2531,7 +2531,14 @@ future<> sstable::write_components(
     return seastar::async([this, mr = std::move(mr), estimated_partitions, schema = std::move(schema), cfg, stats] () mutable {
         auto close_mr = deferred_close(mr);
         auto wr = get_writer(*schema, estimated_partitions, cfg, stats);
-        utils::get_local_injector().inject("write_components_writer_created", utils::wait_for_message(std::chrono::seconds(30))).get();
+        utils::get_local_injector().inject("write_components_writer_created", [&schema] (auto& handler) -> future<> {
+            if (schema->ks_name() != handler.get("ks_name") || schema->cf_name() != handler.get("cf_name")) {
+                co_return;
+            }
+            sstlog.info("write_components_writer_created: waiting for message");
+            co_await handler.wait_for_message(std::chrono::steady_clock::now() + std::chrono::seconds(30));
+            sstlog.info("write_components_writer_created: message received");
+        }).get();
         mr.consume_in_thread(std::move(wr));
     }).finally([this] {
         assert_large_data_handler_is_running();

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -538,6 +538,17 @@ future<> filesystem_storage::wipe(const sstable& sst, sync_dir sync) noexcept {
                     sstlog.debug("Forgiving ENOENT when deleting file {}", fname);
                 }
             });
+            // TemporaryHashes is not tracked in recognized_components (and thus
+            // not in all_components()), because it is a transient file created
+            // during SSTable writing and removed before sealing.  If the write
+            // failed before sealing, the file may still be on disk and must be
+            // cleaned up explicitly.
+            // Use file_exists() to avoid a C++ exception on the common path
+            // where the file was already removed before sealing.
+            auto temp_hashes = filename(sst, dir_name.native(), sst._generation, component_type::TemporaryHashes);
+            if (co_await file_exists(temp_hashes)) {
+                co_await sst.sstable_write_io_check(remove_file, std::move(temp_hashes));
+            }
             if (sync) {
                 co_await sst.sstable_write_io_check(sync_directory, dir_name.native());
             }

--- a/streaming/stream_session.cc
+++ b/streaming/stream_session.cc
@@ -27,6 +27,7 @@
 #include "sstables/sstable_set.hh"
 #include "db/view/view_update_checks.hh"
 #include "replica/database.hh"
+#include "replica/exceptions.hh"
 #include "streaming/stream_mutation_fragments_cmd.hh"
 #include "consumer.hh"
 #include "readers/generating.hh"
@@ -147,9 +148,9 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                 })));
             }
 
-            auto get_next_mutation_fragment = [guard = std::move(guard), &as, &sm = container(), source, plan_id, from, s, cmd_status, offstrategy_update, permit] () mutable {
+            auto get_next_mutation_fragment = [guard = std::move(guard), &as, &sm = container(), &db = _db, source, plan_id, from, s, cmd_status, offstrategy_update, permit] () mutable {
                 guard.check();
-                return source().then([&sm, &guard, &as, plan_id, from, s, cmd_status, offstrategy_update, permit] (std::optional<std::tuple<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>>> opt) mutable {
+                return source().then([&sm, &db, &guard, &as, plan_id, from, s, cmd_status, offstrategy_update, permit] (std::optional<std::tuple<frozen_mutation_fragment, rpc::optional<stream_mutation_fragments_cmd>>> opt) mutable {
                     if (opt) {
                         auto cmd = std::get<1>(*opt);
                         if (cmd) {
@@ -183,10 +184,13 @@ void stream_manager::init_messaging_service_handler(abort_source& as) {
                                 co_await sleep_abortable(std::chrono::milliseconds(5), as_);
                             }
                             sslog.info("stream_mutation_fragments: released");
-                        }).then([mf = std::move(mf)] () mutable {
+                        }).then([mf = std::move(mf), &db] () mutable {
                             if (utils::get_local_injector().is_enabled("stream_mutation_fragments_rx_error")) {
                                 sslog.info("stream_mutation_fragments_rx_error: throw");
                                 throw std::runtime_error("stream_mutation_fragments_rx_error");
+                            }
+                            if (db.local().is_in_critical_disk_utilization_mode()) {
+                                throw replica::critical_disk_utilization_exception("rejected streamed mutation fragment");
                             }
                             return mutation_fragment_opt(std::move(mf));
                         });

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import psutil
 import pytest
+import shutil
 import time
 import uuid
 from cassandra.cluster import ConsistencyLevel
@@ -646,3 +647,137 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
                     await manager.api.message_injection(servers[1].ip_addr, "tablet_stream_files_end_wait")
 
                     await decomm_task
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(reason="Currently load-and-stream doesn't is not handled by the out of space prevention mechanism")
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient, volumes_factory: Callable) -> None:
+    """
+    Test that load-and-stream (nodetool refresh --load-and-stream) is blocked
+    by out-of-space protection when the target node reaches critical disk utilization
+    during streaming, and that partial SSTables are cleaned up.
+
+    Scenario:
+      - Create a 3-node cluster with limited disk space.
+      - Create and populate a test table, flush and take a snapshot on servers[1].
+      - Stop servers[0], wipe its sstables, restart — so it has no local data.
+      - Copy snapshot sstables from servers[1] to servers[0]'s upload directory.
+      - Start load_new_sstables with load_and_stream=True on servers[0].
+      - Wait for streaming to begin consuming mutation fragments (SSTable is being written).
+      - Push servers[0] above the critical disk utilization level with a filler file.
+      - Release the streaming pause — the next mutation fragment will be rejected.
+      - Expect the operation to fail because servers[0] rejects incoming streamed
+        mutation fragments due to critical disk utilization.
+      - Verify that servers[0] still has no data after the rejected stream.
+    """
+    cmdline = [*global_cmdline,
+               "--logger-log-level", "table=debug",
+               "--logger-log-level", "sstable=debug",
+               "--logger-log-level", "debug_error_injection=debug"]
+    async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=cmdline) as servers:
+        cql, hosts = await manager.get_ready_cql(servers)
+
+        workdir_target = await manager.server_get_workdir(servers[0].server_id)
+        workdir_source = await manager.server_get_workdir(servers[1].server_id)
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
+            for server in servers:
+                await manager.api.disable_autocompaction(server.ip_addr, ks)
+
+            async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
+                table = cf.split('.')[-1]
+
+                logger.info("Write data and flush on the source node")
+                # Use enough data (~100KB) to exceed the queue reader buffer (8KB),
+                # ensuring the producer will still be reading when the consumer resumes.
+                await asyncio.gather(*[cql.run_async(query) for query in write_generator(cf, 100)])
+                await manager.api.flush_keyspace(servers[1].ip_addr, ks)
+
+                logger.info("Take a snapshot on the source node to produce sstable files")
+                snap_tag = f"snap_{uuid.uuid4()}"
+                await manager.api.take_snapshot(servers[1].ip_addr, ks, snap_tag)
+
+                def get_table_data_dir(workdir):
+                    """Return the on-disk table data directory (includes UUID suffix)."""
+                    ks_dir = os.path.join(workdir, 'data', ks)
+                    return os.path.join(ks_dir, os.listdir(ks_dir)[0])
+
+                logger.info("Locate snapshot sstable files on the source node")
+                source_data_dir = get_table_data_dir(workdir_source)
+                snapshots_dir = os.path.join(source_data_dir, 'snapshots', snap_tag)
+                exclude_list = ['manifest.json', 'schema.cql']
+                snapshot_files = [f for f in os.listdir(snapshots_dir) if f not in exclude_list]
+                assert snapshot_files, "Snapshot should contain sstable files"
+
+                logger.info("Wipe sstables on servers[0] so it has no local data")
+                await manager.server_stop_gracefully(servers[0].server_id)
+                await manager.server_wipe_sstables(servers[0].server_id, ks, table)
+                await manager.server_start(servers[0].server_id)
+                cql, hosts = await manager.get_ready_cql(servers)
+                await manager.api.disable_autocompaction(servers[0].ip_addr, ks)
+
+                logger.info("Verify servers[0] has no data after wipe")
+                await asyncio.gather(*[validate_data_existence(cql, [], [hosts[0]], cf, pk) for pk in range(100)])
+
+                logger.info("Copy snapshot sstables to the target node's upload directory")
+                target_data_dir = get_table_data_dir(workdir_target)
+                upload_dir = os.path.join(target_data_dir, 'upload')
+                os.makedirs(upload_dir, exist_ok=True)
+                for fname in snapshot_files:
+                    shutil.copy2(os.path.join(snapshots_dir, fname), os.path.join(upload_dir, fname))
+
+                # Record the data directory contents before streaming to detect orphan SSTables later.
+                def list_sstable_files():
+                    return set(f for f in os.listdir(target_data_dir) if f != 'upload')
+
+                sstable_files_before = list_sstable_files()
+                logger.info(f"Files in target data directory before streaming: {sstable_files_before}")
+
+                # Pause inside write_components after the SSTable writer has been created and files exist on disk,
+                # but before mutation fragments are consumed. Its needed to reliably push the node into critical
+                # disk utilization level.
+                #
+                # Pausing earlier (e.g. before writer creation) would not work because there are no files on disk
+                # to fill up, while pausing later (e.g. after consuming fragments) would be too late to reliably
+                # reach critical disk utilization level.
+                await manager.api.enable_injection(servers[0].ip_addr, "write_components_writer_created", one_shot=True)
+
+                logger.info("Execute load-and-stream (nodetool refresh --load-and-stream) on the target node")
+                load_and_stream_task = asyncio.create_task(
+                    manager.api.load_new_sstables(servers[0].ip_addr, ks, table, load_and_stream=True, scope="all"))
+
+                mark, _ = await log.wait_for("write_components_writer_created: waiting for message", from_mark=mark)
+
+                logger.info("Verify partial SSTable files were created on disk")
+                sstable_files_during = list_sstable_files()
+                partial_files = sstable_files_during - sstable_files_before
+                assert partial_files, "Expected partial SSTable files to exist while writer is paused"
+                logger.info(f"Partial SSTable files: {partial_files}")
+
+                logger.info("Create a big file on the target node to reach critical disk utilization level")
+                disk_info = psutil.disk_usage(workdir_target)
+                filler_size = int(disk_info.total * DISK_FILL_TARGET_RATIO) - disk_info.used
+                with random_content_file(workdir_target, filler_size):
+                    mark, _ = await log.wait_for("Reached the critical disk utilization level", from_mark=mark)
+
+                    logger.info("Release the paused writer — fragments will be consumed and rejected")
+                    await manager.api.message_injection(servers[0].ip_addr, "write_components_writer_created")
+
+                    with pytest.raises(Exception, match="Failed to load new sstables"):
+                        await load_and_stream_task
+
+                    mark, _ = await log.wait_for(
+                        "stream_session.*Failed to handle STREAM_MUTATION_FRAGMENTS.*"
+                        "Critical disk utilization: rejected streamed mutation fragment",
+                        from_mark=mark)
+
+                    logger.info("Verify servers[0] still has no data after rejected load-and-stream")
+                    await asyncio.gather(*[validate_data_existence(cql, [], [hosts[0]], cf, pk) for pk in range(100)])
+
+                    logger.info("Verify partial SSTable files were cleaned up")
+                    sstable_files_after = list_sstable_files()
+                    assert sstable_files_after == sstable_files_before, \
+                        f"Orphan SSTable files found after failed stream: {sstable_files_after - sstable_files_before}"

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -43,6 +43,17 @@ class random_content_file:
         os.unlink(self.filename)
 
 
+async def validate_data_existence(cql, successful_hosts: list[Host], failed_hosts: list[Host], cf: str, pk: int) -> None:
+    """Validate data existence on specific hosts using MUTATION_FRAGMENTS to ensure truly local reads."""
+    stmt = SimpleStatement(f"SELECT * from MUTATION_FRAGMENTS({cf}) where pk = {pk};", consistency_level=ConsistencyLevel.ONE)
+    for host in successful_hosts:
+        res = await cql.run_async(stmt, host=host)
+        assert res, f"Data not found on {host}"
+    for host in failed_hosts:
+        res = await cql.run_async(stmt, host=host)
+        assert not res, f"Data found on {host} but it shouldn't be there"
+
+
 CRITICAL_DISK_UTILIZATION_LEVEL = 0.5
 # Target disk fill ratio used in tests to push the node above the critical
 # utilization level.
@@ -60,15 +71,6 @@ global_cmdline = ["--disk-space-monitor-normal-polling-interval-in-seconds", "1"
 
 @pytest.mark.asyncio
 async def test_user_writes_rejection(manager: ManagerClient, volumes_factory: Callable) -> None:
-    async def validate_data_existence(cql, successful_hosts: list[Host], failed_hosts: list[Host], cf: str, pk: int) -> None:
-        stmt = SimpleStatement(f"SELECT * from MUTATION_FRAGMENTS({cf}) where pk = {pk};", consistency_level=ConsistencyLevel.ONE)
-        for host in successful_hosts:
-            res = await cql.run_async(stmt, host=host)
-            assert res, f"Data not found on {host}"
-        for host in failed_hosts:
-            res = await cql.run_async(stmt, host=host)
-            assert not res, f"Data found on {host} but it shouldn't be there"
-
     async with space_limited_servers(manager, volumes_factory, ["20M"]*3, cmdline=global_cmdline) as servers:
         cql, hosts = await manager.get_ready_cql(servers)
 

--- a/test/cluster/storage/test_out_of_space_prevention.py
+++ b/test/cluster/storage/test_out_of_space_prevention.py
@@ -650,7 +650,6 @@ async def test_sstables_incrementally_released_during_streaming(manager: Manager
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="Currently load-and-stream doesn't is not handled by the out of space prevention mechanism")
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient, volumes_factory: Callable) -> None:
     """
@@ -743,7 +742,12 @@ async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient,
                 # Pausing earlier (e.g. before writer creation) would not work because there are no files on disk
                 # to fill up, while pausing later (e.g. after consuming fragments) would be too late to reliably
                 # reach critical disk utilization level.
-                await manager.api.enable_injection(servers[0].ip_addr, "write_components_writer_created", one_shot=True)
+                # Scope the injection to the test's keyspace/table so unrelated sstable
+                # writes (e.g. system tables) don't trip the pause. The injection is not
+                # one-shot because unrelated writes would otherwise consume it first;
+                # it is disabled after the test table's writer has been released.
+                await manager.api.enable_injection(servers[0].ip_addr, "write_components_writer_created",
+                                                   one_shot=False, parameters={"ks_name": ks, "cf_name": table})
 
                 logger.info("Execute load-and-stream (nodetool refresh --load-and-stream) on the target node")
                 load_and_stream_task = asyncio.create_task(
@@ -762,9 +766,12 @@ async def test_load_and_stream_rejected_on_critical_disk(manager: ManagerClient,
                 filler_size = int(disk_info.total * DISK_FILL_TARGET_RATIO) - disk_info.used
                 with random_content_file(workdir_target, filler_size):
                     mark, _ = await log.wait_for("Reached the critical disk utilization level", from_mark=mark)
+                    for _ in range(2):
+                        mark, _ = await log.wait_for("database - Set critical disk utilization mode: true", from_mark=mark)
 
                     logger.info("Release the paused writer — fragments will be consumed and rejected")
                     await manager.api.message_injection(servers[0].ip_addr, "write_components_writer_created")
+                    await manager.api.disable_injection(servers[0].ip_addr, "write_components_writer_created")
 
                     with pytest.raises(Exception, match="Failed to load new sstables"):
                         await load_and_stream_task

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 GB = 1024 * 1024 * 1024
 
 @pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_balance_empty_tablets(manager: ManagerClient):
 
     # This test checks that size-based load balancing migrates empty tablets of a newly created
@@ -24,7 +25,12 @@ async def test_balance_empty_tablets(manager: ManagerClient):
 
     logger.info('Bootstrapping cluster')
 
-    cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
+    cfg = {
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        # The test overrides disk capacity but the disk usage remains real leading the disk_space_monitor
+        # to announce 100% disk utilization and active OoS prevention mechanisms.
+        'error_injections_at_startup': ['suppress_disk_space_threshold_checks'],
+    }
 
     cfg_small = cfg | { 'data_file_capacity': 50 * GB }
     cfg_large = cfg | { 'data_file_capacity': 100 * GB }

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -19,7 +19,10 @@ logger = logging.getLogger(__name__)
 async def test_load_stats_on_coordinator_failover(manager: ManagerClient):
     cfg = {
         'data_file_capacity': 7000000,
-        'tablet_load_stats_refresh_interval_in_seconds': 1
+        'tablet_load_stats_refresh_interval_in_seconds': 1,
+        # The test overrides disk capacity but the disk usage remains real leading the disk_space_monitor
+        # to announce 100% disk utilization and active OoS prevention mechanisms.
+        'error_injections_at_startup': ['suppress_disk_space_threshold_checks'],
     }
     servers = await manager.servers_add(3, config=cfg)
     host_ids = [await manager.get_host_id(s.server_id) for s in servers]

--- a/utils/disk_space_monitor.cc
+++ b/utils/disk_space_monitor.cc
@@ -14,6 +14,7 @@
 
 #include "utils/disk_space_monitor.hh"
 #include "utils/assert.hh"
+#include "utils/error_injection.hh"
 #include "utils/log.hh"
 
 using namespace std::chrono_literals;
@@ -31,8 +32,9 @@ disk_space_monitor::disk_space_monitor(abort_source& as, std::filesystem::path d
     , _data_dir(std::move(data_dir))
     , _cfg(std::move(cfg))
     , _threshold_subscription(listen([this](const disk_space_monitor& dsm) -> future<> {
+        const bool dsm_disabled = utils::get_local_injector().is_enabled("suppress_disk_space_threshold_checks");
         const float current_disk_utilization = dsm.disk_utilization();
-        if (current_disk_utilization < 0.0f) {
+        if (current_disk_utilization < 0.0f || dsm_disabled) {
             co_return;
         }
 


### PR DESCRIPTION
The mutation-fragment-based streaming path in `stream_session.cc` did not check whether the receiving node was in critical disk utilization mode before accepting incoming mutation fragments. This meant that operations like `nodetool refresh --load-and-stream`, which stream data through the `STREAM_MUTATION_FRAGMENTS` RPC handler, could push data onto a node that had already reached critical disk usage. 

The file-based streaming path in stream_blob.cc already had this protection, but the load&stream path was missing it.

This patch adds a check for `is_in_critical_disk_utilization_mode()` in the `stream_mutation_fragments` handler in `stream_session.cc`, throwing a `replica::critical_disk_utilization_exception` when the node is at critical disk usage. This mirrors the existing protection in the blob streaming path and closes the gap that allowed data to be written to a node that should have been rejecting all incoming writes.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-901

The out of space prevention mechanism was introduced in 2025.4. The fix should be backported there and all later versions.