### PR TITLE
cql3: track CQL parsing memory cost and use it for admission control

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -618,6 +618,7 @@ scylla_tests = set([
     'test/boost/reservoir_sampling_test',
     'test/boost/result_utils_test',
     'test/boost/rest_client_test',
+    'test/boost/rolling_max_tracker_test',
     'test/boost/reusable_buffer_test',
     'test/boost/rust_test',
     'test/boost/s3_test',
@@ -1586,6 +1587,7 @@ pure_boost_tests = set([
     'test/boost/wrapping_interval_test',
     'test/boost/range_tombstone_list_test',
     'test/boost/reservoir_sampling_test',
+    'test/boost/rolling_max_tracker_test',
     'test/boost/serialization_test',
     'test/boost/small_vector_test',
     'test/boost/top_k_test',
@@ -1734,6 +1736,7 @@ deps['test/boost/url_parse_test'] = ['utils/http.cc', 'test/boost/url_parse_test
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc', 'utils/labels.cc']
 deps['test/boost/log_heap_test'] = ['test/boost/log_heap_test.cc']
+deps['test/boost/rolling_max_tracker_test'] = ['test/boost/rolling_max_tracker_test.cc']
 deps['test/boost/estimated_histogram_test'] = ['test/boost/estimated_histogram_test.cc']
 deps['test/boost/summary_test'] = ['test/boost/summary_test.cc']
 deps['test/boost/anchorless_list_test'] = ['test/boost/anchorless_list_test.cc']

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -11,6 +11,7 @@
 #include "cql3/query_processor.hh"
 
 #include <seastar/core/metrics.hh>
+#include <seastar/core/memory.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/coroutine/as_future.hh>
@@ -768,6 +769,10 @@ prepared_cache_key_type query_processor::compute_id(
 
 std::unique_ptr<prepared_statement>
 query_processor::get_statement(const std::string_view& query, const service::client_state& client_state, dialect d) {
+    // Measuring allocation cost requires that no yield points exist
+    // between bytes_before and bytes_after. It needs fixing if this
+    // function is ever futurized.
+    auto bytes_before = seastar::memory::stats().total_bytes_allocated();
     std::unique_ptr<raw::parsed_statement> statement = parse_statement(query, d);
 
     // Set keyspace for statement that require login
@@ -783,6 +788,8 @@ query_processor::get_statement(const std::string_view& query, const service::cli
         audit_info->set_query_string(query);
         p->statement->sanitize_audit_info();
     }
+    auto bytes_after = seastar::memory::stats().total_bytes_allocated();
+    _parsing_cost_tracker.add_sample(bytes_after - bytes_before);
     return p;
 }
 

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -31,6 +31,7 @@
 #include "vector_search/vector_store_client.hh"
 #include "utils/assert.hh"
 #include "utils/observable.hh"
+#include "utils/rolling_max_tracker.hh"
 #include "service/raft/raft_group0_client.hh"
 #include "types/types.hh"
 #include "db/consistency_level_type.hh"
@@ -134,6 +135,9 @@ private:
     prepared_statements_cache _prepared_cache;
     authorized_prepared_statements_cache _authorized_prepared_cache;
 
+    // Tracks the rolling maximum of gross bytes allocated during CQL parsing
+    utils::rolling_max_tracker _parsing_cost_tracker{1000};
+
     std::function<void(uint32_t)> _auth_prepared_cache_cfg_cb;
     serialized_action _authorized_prepared_cache_config_action;
     utils::observer<uint32_t> _authorized_prepared_cache_update_interval_in_ms_observer;
@@ -210,6 +214,11 @@ public:
 
     cql_stats& get_cql_stats() {
         return _cql_stats;
+    }
+
+    /// Returns the estimated peak memory cost of CQL parsing.
+    size_t parsing_cost_estimate() const noexcept {
+        return _parsing_cost_tracker.current_max();
     }
 
     lang::manager& lang() { return _lang_manager; }

--- a/stdafx.hh
+++ b/stdafx.hh
@@ -92,6 +92,9 @@
 #include <cstring>
 #include <ctime>
 #include <deque>
+
+#include "utils/rolling_max_tracker.hh"
+
 #include <endian.h>
 #include <exception>
 #if __has_include(<execinfo.h>)

--- a/test/boost/rolling_max_tracker_test.cc
+++ b/test/boost/rolling_max_tracker_test.cc
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#define BOOST_TEST_MODULE rolling_max_tracker
+
+#include <boost/test/unit_test.hpp>
+#include <algorithm>
+
+#include <seastar/core/bitops.hh>
+
+#include "utils/rolling_max_tracker.hh"
+
+// Helper: compute the expected current_max for a given raw value.
+// Mirrors the tracker's internal rounding: clamp to 1, take log2ceil,
+// then raise back to a power of two.
+static size_t rounded(size_t v) {
+    return size_t(1) << seastar::log2ceil(std::max(v, size_t(1)));
+}
+
+BOOST_AUTO_TEST_CASE(test_empty_tracker_returns_zero) {
+    utils::rolling_max_tracker tracker(10);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), 0u);
+}
+
+BOOST_AUTO_TEST_CASE(test_single_sample) {
+    utils::rolling_max_tracker tracker(10);
+    tracker.add_sample(100);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+}
+
+BOOST_AUTO_TEST_CASE(test_max_tracks_largest_in_window) {
+    utils::rolling_max_tracker tracker(10);
+    tracker.add_sample(5);
+    tracker.add_sample(20);
+    tracker.add_sample(10);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(20));
+}
+
+BOOST_AUTO_TEST_CASE(test_increasing_samples) {
+    utils::rolling_max_tracker tracker(5);
+    for (size_t i = 1; i <= 10; ++i) {
+        tracker.add_sample(i);
+        BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(i));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_decreasing_samples) {
+    utils::rolling_max_tracker tracker(5);
+    tracker.add_sample(100);
+    tracker.add_sample(90);
+    tracker.add_sample(80);
+    tracker.add_sample(70);
+    tracker.add_sample(60);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+
+    tracker.add_sample(50);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(90));
+
+    tracker.add_sample(40);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(80));
+
+    tracker.add_sample(30);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(70));
+
+    tracker.add_sample(20);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(60));
+}
+
+BOOST_AUTO_TEST_CASE(test_max_expires_from_window) {
+    utils::rolling_max_tracker tracker(3);
+    tracker.add_sample(100);
+    tracker.add_sample(1);
+    tracker.add_sample(2);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+
+    tracker.add_sample(3);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(3));
+}
+
+BOOST_AUTO_TEST_CASE(test_new_max_replaces_smaller_entries) {
+    utils::rolling_max_tracker tracker(5);
+    tracker.add_sample(10);
+    tracker.add_sample(5);
+    tracker.add_sample(3);
+    tracker.add_sample(1);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(10));
+
+    tracker.add_sample(50);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(50));
+
+    tracker.add_sample(1);
+    tracker.add_sample(1);
+    tracker.add_sample(1);
+    tracker.add_sample(1);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(50));
+
+    tracker.add_sample(1);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(1));
+}
+
+BOOST_AUTO_TEST_CASE(test_window_size_one) {
+    utils::rolling_max_tracker tracker(1);
+    tracker.add_sample(100);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+
+    tracker.add_sample(5);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+
+    tracker.add_sample(200);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(200));
+}
+
+BOOST_AUTO_TEST_CASE(test_window_size_two) {
+    utils::rolling_max_tracker tracker(2);
+    tracker.add_sample(100);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+
+    tracker.add_sample(5);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+
+    tracker.add_sample(200);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(200));
+
+    tracker.add_sample(10);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(200));
+
+    tracker.add_sample(10);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(10));
+}
+
+BOOST_AUTO_TEST_CASE(test_equal_values) {
+    utils::rolling_max_tracker tracker(5);
+    tracker.add_sample(42);
+    tracker.add_sample(42);
+    tracker.add_sample(42);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(42));
+
+    for (int i = 0; i < 20; ++i) {
+        tracker.add_sample(42);
+        BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(42));
+    }
+
+    tracker.add_sample(100);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(100));
+}
+
+BOOST_AUTO_TEST_CASE(test_staircase_pattern) {
+    utils::rolling_max_tracker tracker(6);
+
+    for (size_t i = 1; i <= 5; ++i) {
+        tracker.add_sample(i);
+    }
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+
+    tracker.add_sample(4);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+
+    tracker.add_sample(3);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+
+    tracker.add_sample(2);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+
+    tracker.add_sample(1);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), rounded(5));
+}
+
+BOOST_AUTO_TEST_CASE(test_zero_sample_clamped_to_one) {
+    utils::rolling_max_tracker tracker(3);
+    tracker.add_sample(0);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), 1);
+
+    tracker.add_sample(0);
+    tracker.add_sample(0);
+    BOOST_REQUIRE_EQUAL(tracker.current_max(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_current_max_is_upper_bound) {
+    // For any value, current_max() >= value (never underestimates).
+    utils::rolling_max_tracker tracker(1);
+    for (size_t v = 1; v <= 1024; ++v) {
+        tracker.add_sample(v);
+        BOOST_REQUIRE_GE(tracker.current_max(), v);
+        // And at most 2x the value
+        BOOST_REQUIRE_LE(tracker.current_max(), 2 * v);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_sliding_window_correctness) {
+    const size_t window = 7;
+    const size_t n = 100;
+    utils::rolling_max_tracker tracker(window);
+    std::vector<size_t> values;
+    values.reserve(n);
+
+    for (size_t i = 0; i < n; ++i) {
+        values.push_back((i * 37 + 13) % 50);
+    }
+
+    for (size_t i = 0; i < n; ++i) {
+        tracker.add_sample(values[i]);
+
+        size_t start = (i + 1 > window) ? (i + 1 - window) : 0;
+        size_t expected_max = 0;
+        for (size_t j = start; j <= i; ++j) {
+            expected_max = std::max(expected_max, rounded(values[j]));
+        }
+        BOOST_REQUIRE_EQUAL(tracker.current_max(), expected_max);
+    }
+}

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -286,6 +286,7 @@ cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_s
     , _query_processor(qp)
     , _config(std::move(config))
     , _memory_available(ml.get_semaphore())
+    , _total_memory(ml.total_memory())
     , _notifier(std::make_unique<event_notifier>(*this))
     , _auth_service(auth_service)
     , _sl_controller(sl_controller)
@@ -786,6 +787,12 @@ future<> cql_server::connection::process_request() {
                 .then([this] { return _read_buf.close(); })
                 .then([this] { return util::skip_entire_stream(_read_buf); });
         }
+        // Add some upper bound estimation from previous parsing
+        if (op == uint8_t(cql_binary_opcode::QUERY) || op == uint8_t(cql_binary_opcode::PREPARE)) {
+            mem_estimate += _server._query_processor.local().parsing_cost_estimate();
+        }
+        // Cap the estimate, otherwise get_units call later would deadlock
+        mem_estimate = std::min(mem_estimate, _server._total_memory);
 
         if (_server._stats.requests_serving > _server._config.max_concurrent_requests) {
             ++_server._stats.requests_shed;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -203,6 +203,7 @@ private:
     sharded<cql3::query_processor>& _query_processor;
     cql_server_config _config;
     semaphore& _memory_available;
+    const uint32_t _total_memory;
     seastar::metrics::metric_groups _metrics;
     std::unique_ptr<event_notifier> _notifier;
 private:

--- a/utils/rolling_max_tracker.hh
+++ b/utils/rolling_max_tracker.hh
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2025-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+#include <seastar/core/bitops.hh>
+#include <seastar/core/circular_buffer_fixed_capacity.hh>
+
+namespace utils {
+
+/// Tracks the rolling maximum over the last `window_size` samples
+/// using in amortized cost O(1) per sample. Current_max()
+/// returns an upper bound that is a power of two, at most 2x the
+/// true maximum) for efficiency.
+class rolling_max_tracker {
+    // With the sample clamp to 1, log2ceil produces values
+    // in [0, 63] for 64-bit size_t, so at most 64 entries.
+    seastar::circular_buffer_fixed_capacity<std::pair<uint64_t, unsigned>, 64> _buf;
+    uint64_t _seq = 0;
+    size_t _window_size;
+
+public:
+    explicit rolling_max_tracker(size_t window_size) noexcept
+        : _window_size(window_size) {
+    }
+
+    void add_sample(size_t value) noexcept {
+        // Clamp to 1 to avoid undefined log2ceil(0)
+        auto v = seastar::log2ceil(std::max(value, size_t(1)));
+        // Maintain the monotonic (decreasing) property:
+        // remove all entries from the back that are <= the new value,
+        // since they can never be the maximum while this entry is in the window.
+        while (!_buf.empty() && _buf.back().second <= v) {
+            _buf.pop_back();
+        }
+        _buf.emplace_back(_seq, v);
+        ++_seq;
+        // Remove entries that have fallen out of the window from the front.
+        while (_buf.front().first + _window_size < _seq) {
+            _buf.pop_front();
+        }
+    }
+
+    size_t current_max() const noexcept {
+        return _buf.empty() ? 0 : size_t(1) << _buf.cbegin()->second;
+    }
+};
+
+} // namespace utils


### PR DESCRIPTION
Use rolling_max_tracker to record gross bytes allocated during each
CQL parse.  The rolling maximum is then added to the memory estimate
for incoming QUERY and PREPARE requests so that the admission control
in the CQL transport layer accounts for parsing overhead.

The measured memory footprint serves as upper bound rather than
exact number but it's purpose is to prevent OOMs under unprepared
statements heavy load.

In benchmark 1G memory node shows decrease of non-LSA memory usage
from peak 320MB (our coordinator budget is 10% of 1G) to 96MB. While
tps drops from 1.2 kops to 0.8 kops. Drop in tps is expected as
memory admission kicks in trying to prevent OOM.

This is phase 1 of OOM prevention, potential next steps:
- add second admission in query_processor::get_statement trying to prevent potential thundering herd problem
- decrease cql_server memory pool size
- count reads in the memory pool
- add per service level memory pool and a shared one

Related https://scylladb.atlassian.net/browse/SCYLLADB-740
Fixes https://scylladb.atlassian.net/browse/SCYLLADB-938

Backport: no, new feature, but we may reconsider if some customer needs it