### PR TITLE
alternator: add application-defined write timestamps

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -7,6 +7,7 @@
  */
 
 #include <fmt/ranges.h>
+#include <cstdlib>
 #include <seastar/core/on_internal_error.hh>
 #include "alternator/executor.hh"
 #include "alternator/executor_util.hh"
@@ -118,6 +119,17 @@ const sstring TABLE_CREATION_TIME_TAG_KEY("system:table_creation_time");
 // configured by UpdateTimeToLive to be the expiration-time attribute for
 // this table.
 extern const sstring TTL_TAG_KEY("system:ttl_attribute");
+// If this tag is present, it stores the name of an attribute whose numeric
+// value (in microseconds since the Unix epoch) is used as the write timestamp
+// for write operations (PutItem, UpdateItem, DeleteItem, and BatchWriteItem's
+// PutRequest and DeleteRequest). When the named attribute is present in a
+// write request, its value is used as the timestamp of the write, and the
+// attribute itself is NOT stored in the item. This feature allows users to
+// control write ordering for last-write-wins semantics. Because LWT does not
+// allow setting a custom write timestamp, operations using this feature are
+// incompatible with conditions (which require LWT), and with the LWT_ALWAYS
+// write isolation mode; such operations are rejected.
+static const sstring TIMESTAMP_TAG_KEY("system:timestamp_attribute");
 // This will be set to 1 in a case, where user DID NOT specify a range key.
 // The way GSI / LSI is implemented by Alternator assumes user specified keys will come first
 // in materialized view's key list. Then, if needed missing keys are added (current implementation
@@ -1013,13 +1025,14 @@ void rmw_operation::set_default_write_isolation(std::string_view value) {
 // Alternator uses tags whose keys start with the "system:" prefix for
 // internal purposes. Those should not be readable by ListTagsOfResource,
 // nor writable with TagResource or UntagResource (see #24098).
-// Only a few specific system tags, currently only "system:write_isolation"
-// and "system:initial_tablets", are deliberately intended to be set and read
-// by the user, so are not considered "internal".
+// Only a few specific system tags, currently only "system:write_isolation",
+// "system:initial_tablets", and "system:timestamp_attribute", are deliberately
+// intended to be set and read by the user, so are not considered "internal".
 static bool tag_key_is_internal(std::string_view tag_key) {
     return tag_key.starts_with("system:")
         && tag_key != rmw_operation::WRITE_ISOLATION_TAG_KEY
-        && tag_key != INITIAL_TABLETS_TAG_KEY;
+        && tag_key != INITIAL_TABLETS_TAG_KEY
+        && tag_key != TIMESTAMP_TAG_KEY;
 }
 
 enum class update_tags_action { add_tags, delete_tags };
@@ -2400,6 +2413,74 @@ void validate_value(const rjson::value& v, const char* caller) {
 // any writing happens (if one of the commands has an error, none of the
 // writes should be done). LWT makes it impossible for the parse step to
 // generate "mutation" objects, because the timestamp still isn't known.
+
+// Convert a DynamoDB number (big_decimal) to an api::timestamp_type
+// (microseconds since the Unix epoch). Fractional microseconds are truncated.
+// Returns nullopt if the value is negative, zero, or cannot be represented
+// as a valid timestamp.
+static std::optional<api::timestamp_type> bigdecimal_to_timestamp(const big_decimal& bd) {
+    if (bd.unscaled_value() <= 0) {
+        return std::nullopt;
+    }
+    if (bd.scale() == 0) {
+        // Fast path: integer value, no decimal adjustment needed.
+        // cpp_int does not throw on narrowing cast that overflows, so we must
+        // check the range explicitly before casting.
+        if (bd.unscaled_value() > std::numeric_limits<api::timestamp_type>::max()) {
+            return std::nullopt;
+        }
+        return static_cast<api::timestamp_type>(bd.unscaled_value());
+    }
+    // General case: adjust for decimal scale.
+    // big_decimal stores value as unscaled_value * 10^(-scale).
+    // scale > 0 means divide by 10^scale (truncate fractional part).
+    // scale < 0 means multiply by 10^|scale| (add trailing zeros).
+    auto str = bd.unscaled_value().str();
+    if (bd.scale() > 0) {
+        int len = str.length();
+        if (len <= bd.scale()) {
+            return std::nullopt;  // Number < 1
+        }
+        str = str.substr(0, len - bd.scale());
+    } else {
+        if (bd.scale() < -18) {
+            // Too large to represent as int64_t
+            return std::nullopt;
+        }
+        for (int i = 0; i < -bd.scale(); i++) {
+            str.push_back('0');
+        }
+    }
+    try {
+        return static_cast<api::timestamp_type>(std::stoll(str));
+    } catch (const std::out_of_range&) {
+        return std::nullopt;
+    }
+}
+
+// Try to extract a write timestamp from a DynamoDB-typed value.
+// The value should be a number ({"N": "..."}), representing microseconds
+// since the Unix epoch. Returns nullopt if the value is not a valid number
+// or doesn't represent a valid timestamp.
+static std::optional<api::timestamp_type> try_get_timestamp(const rjson::value& attr_value) {
+    std::optional<big_decimal> n = try_unwrap_number(attr_value);
+    if (!n) {
+        return std::nullopt;
+    }
+    return bigdecimal_to_timestamp(*n);
+}
+
+// Extract a write timestamp from a DynamoDB-typed value, or throw
+// api_error::validation if the value is not a valid positive number.
+static api::timestamp_type get_timestamp(const rjson::value& attr_value, std::string_view attribute_name) {
+    if (auto t = try_get_timestamp(attr_value)) {
+        return *t;
+    }
+    throw api_error::validation(fmt::format(
+        "The '{}' attribute used as a write timestamp must be a positive number (microseconds since epoch)",
+        attribute_name));
+}
+
 class put_or_delete_item {
 private:
     partition_key _pk;
@@ -2415,11 +2496,17 @@ private:
     // that length can have different meaning depends on the operation but the
     // the calculation of length in bytes to WCU is the same.
     uint64_t _length_in_bytes = 0;
+    // If the table has a system:timestamp_attribute tag, and the named
+    // attribute was found in the item with a valid numeric value, this holds
+    // the extracted timestamp. The attribute is not added to _cells.
+    std::optional<api::timestamp_type> _custom_timestamp;
 public:
     struct delete_item {};
     struct put_item {};
-    put_or_delete_item(const rjson::value& key, schema_ptr schema, delete_item);
-    put_or_delete_item(const rjson::value& item, schema_ptr schema, put_item, std::unordered_map<bytes, std::string> key_attributes);
+    put_or_delete_item(const rjson::value& key, schema_ptr schema, delete_item,
+            const std::optional<bytes>& timestamp_attribute = std::nullopt);
+    put_or_delete_item(const rjson::value& item, schema_ptr schema, put_item, std::unordered_map<bytes, std::string> key_attributes,
+            const std::optional<bytes>& timestamp_attribute = std::nullopt);
     // put_or_delete_item doesn't keep a reference to schema (so it can be
     // moved between shards for LWT) so it needs to be given again to build():
     mutation build(schema_ptr schema, api::timestamp_type ts) const;
@@ -2434,11 +2521,28 @@ public:
     bool is_put_item() noexcept {
         return _cells.has_value();
     }
+    // Returns the custom write timestamp extracted from the timestamp attribute,
+    // if any. If not set, the caller should use api::new_timestamp() instead.
+    std::optional<api::timestamp_type> custom_timestamp() const noexcept {
+        return _custom_timestamp;
+    }
 };
 
-put_or_delete_item::put_or_delete_item(const rjson::value& key, schema_ptr schema, delete_item)
+put_or_delete_item::put_or_delete_item(const rjson::value& key, schema_ptr schema, delete_item, const std::optional<bytes>& timestamp_attribute)
         : _pk(pk_from_json(key, schema)), _ck(ck_from_json(key, schema)) {
-    check_key(key, schema);
+    bool has_timestamp_key = false;
+    if (timestamp_attribute) {
+        // The timestamp attribute may be provided as a "pseudo-key": it is
+        // not a real key column, but can be included in the "Key" object to
+        // carry the custom write timestamp. If found, extract the timestamp
+        // and don't store it in the item.
+        const rjson::value* ts_val = rjson::find(key, to_string_view(*timestamp_attribute));
+        if (ts_val) {
+            has_timestamp_key = true;
+            _custom_timestamp = get_timestamp(*ts_val, to_string_view(*timestamp_attribute));
+        }
+    }
+    check_key(key, schema, has_timestamp_key);
 }
 
 // find_attribute() checks whether the named attribute is stored in the
@@ -2603,7 +2707,8 @@ static void validate_value_if_vector_index_attribute(
     }
 }
 
-put_or_delete_item::put_or_delete_item(const rjson::value& item, schema_ptr schema, put_item, std::unordered_map<bytes, std::string> key_attributes)
+put_or_delete_item::put_or_delete_item(const rjson::value& item, schema_ptr schema, put_item, std::unordered_map<bytes, std::string> key_attributes,
+        const std::optional<bytes>& timestamp_attribute)
         : _pk(pk_from_json(item, schema)), _ck(ck_from_json(item, schema)) {
     _cells = std::vector<cell>();
     _cells->reserve(item.MemberCount());
@@ -2613,6 +2718,14 @@ put_or_delete_item::put_or_delete_item(const rjson::value& item, schema_ptr sche
         validate_value(it->value, "PutItem");
         const column_definition* cdef = find_attribute(*schema, column_name);
         validate_attr_name_length("", column_name.size(), cdef && cdef->is_primary_key());
+        // If this is the timestamp attribute, it must be a valid numeric value
+        // (microseconds since epoch). Use it as the write timestamp and do not
+        // store it in the item data. Reject the write if the value is non-numeric.
+        if (timestamp_attribute && column_name == *timestamp_attribute) {
+            _custom_timestamp = get_timestamp(it->value, to_string_view(*timestamp_attribute));
+            // The attribute is consumed as timestamp, not stored in _cells.
+            continue;
+        }
         _length_in_bytes += column_name.size();
         if (!cdef) {
             // This attribute may be a key column of one of the GSI or LSI,
@@ -2808,6 +2921,13 @@ rmw_operation::rmw_operation(service::storage_proxy& proxy, rjson::value&& reque
     , _returnvalues(parse_returnvalues(_request))
     , _returnvalues_on_condition_check_failure(parse_returnvalues_on_condition_check_failure(_request))
 {
+    const auto tags_ptr = db::get_tags_of_table(_schema);
+    if (tags_ptr) {
+        auto it = tags_ptr->find(TIMESTAMP_TAG_KEY);
+        if (it != tags_ptr->end() && !it->second.empty()) {
+            _timestamp_attribute = to_bytes(it->second);
+        }
+    }
     // _pk and _ck will be assigned later, by the subclass's constructor
     // (each operation puts the key in a slightly different location in
     // the request).
@@ -2941,6 +3061,22 @@ future<executor::request_return_type> rmw_operation::execute(service::storage_pr
         .alternator = true,
         .alternator_streams_increased_compatibility = schema()->cdc_options().enabled() && proxy.data_dictionary().get_config().alternator_streams_increased_compatibility(),
     };
+    // If this operation wants to set a custom write timestamp (i.e., the
+    // attribute specified in the system:timestamp_attribute tag has a value),
+    // LWT cannot be used because LWT requires the timestamp to be set by the
+    // Paxos protocol. Reject the operation if it would need to use LWT.
+    if (has_custom_timestamp()) {
+        bool would_use_lwt = _write_isolation == write_isolation::LWT_ALWAYS ||
+            (needs_read_before_write &&
+             _write_isolation != write_isolation::FORBID_RMW &&
+             _write_isolation != write_isolation::UNSAFE_RMW);
+        if (would_use_lwt) {
+            throw api_error::validation(fmt::format(
+                "Using the system:timestamp_attribute '{}' is not compatible with "
+                "read-modify-write operations or with the 'always' write "
+                "isolation policy.", to_string_view(*_timestamp_attribute)));
+        }
+    }
     if (needs_read_before_write) {
         if (_write_isolation == write_isolation::FORBID_RMW) {
             throw api_error::validation("Read-modify-write operations are disabled by 'forbid_rmw' write isolation policy. Refer to https://github.com/scylladb/scylla/blob/master/docs/alternator/alternator.md#write-isolation-policies for more information.");
@@ -3025,7 +3161,8 @@ public:
     put_item_operation(parsed::expression_cache& parsed_expression_cache, service::storage_proxy& proxy, rjson::value&& request)
         : rmw_operation(proxy, std::move(request))
         , _mutation_builder(rjson::get(_request, "Item"), schema(), put_or_delete_item::put_item{},
-            si_key_attributes(proxy.data_dictionary().find_table(schema()->ks_name(), schema()->cf_name()))) {
+            si_key_attributes(proxy.data_dictionary().find_table(schema()->ks_name(), schema()->cf_name())),
+            _timestamp_attribute) {
         _pk = _mutation_builder.pk();
         _ck = _mutation_builder.ck();
         if (_returnvalues != returnvalues::NONE && _returnvalues != returnvalues::ALL_OLD) {
@@ -3057,6 +3194,9 @@ public:
                check_needs_read_before_write(_condition_expression) ||
                _returnvalues == returnvalues::ALL_OLD;
     }
+    bool has_custom_timestamp() const noexcept override {
+        return _mutation_builder.custom_timestamp().has_value();
+    }
     virtual std::optional<mutation> apply(std::unique_ptr<rjson::value> previous_item, api::timestamp_type ts, cdc::per_request_options& cdc_opts) const override {
         if (!verify_expected(_request, previous_item.get()) ||
             !verify_condition_expression(_condition_expression, previous_item.get())) {
@@ -3074,7 +3214,10 @@ public:
         } else {
             _return_attributes = {};
         }
-        return _mutation_builder.build(_schema, ts);
+        // Use the custom timestamp from the timestamp attribute if available,
+        // otherwise use the provided timestamp.
+        api::timestamp_type effective_ts = _mutation_builder.custom_timestamp().value_or(ts);
+        return _mutation_builder.build(_schema, effective_ts);
     }
     virtual ~put_item_operation() = default;
 };
@@ -3136,7 +3279,7 @@ public:
     parsed::condition_expression _condition_expression;
     delete_item_operation(parsed::expression_cache& parsed_expression_cache, service::storage_proxy& proxy, rjson::value&& request)
         : rmw_operation(proxy, std::move(request))
-        , _mutation_builder(rjson::get(_request, "Key"), schema(), put_or_delete_item::delete_item{}) {
+        , _mutation_builder(rjson::get(_request, "Key"), schema(), put_or_delete_item::delete_item{}, _timestamp_attribute) {
         _pk = _mutation_builder.pk();
         _ck = _mutation_builder.ck();
         if (_returnvalues != returnvalues::NONE && _returnvalues != returnvalues::ALL_OLD) {
@@ -3167,6 +3310,9 @@ public:
                 check_needs_read_before_write(_condition_expression) ||
                 _returnvalues == returnvalues::ALL_OLD;
     }
+    bool has_custom_timestamp() const noexcept override {
+        return _mutation_builder.custom_timestamp().has_value();
+    }
     virtual std::optional<mutation> apply(std::unique_ptr<rjson::value> previous_item, api::timestamp_type ts, cdc::per_request_options& cdc_opts) const override {
         if (!verify_expected(_request, previous_item.get()) ||
             !verify_condition_expression(_condition_expression, previous_item.get())) {
@@ -3187,7 +3333,10 @@ public:
         if (_consumed_capacity._total_bytes == 0) {
             _consumed_capacity._total_bytes = 1;
         }
-        return _mutation_builder.build(_schema, ts);
+        // Use the custom timestamp from the timestamp attribute if available,
+        // otherwise use the provided timestamp.
+        api::timestamp_type effective_ts = _mutation_builder.custom_timestamp().value_or(ts);
+        return _mutation_builder.build(_schema, effective_ts);
     }
     virtual ~delete_item_operation() = default;
 };
@@ -3375,7 +3524,10 @@ future<> executor::do_batch_write(
         api::timestamp_type now = api::new_timestamp();
         bool any_cdc_enabled = false;
         for (auto& b : mutation_builders) {
-            mutations.push_back(b.second.build(b.first, now));
+            // Use custom timestamp from the timestamp attribute if available,
+            // otherwise use the "now" timestamp for all items in this batch.
+            api::timestamp_type ts = b.second.custom_timestamp().value_or(now);
+            mutations.push_back(b.second.build(b.first, ts));
             any_cdc_enabled |= b.first->cdc_options().enabled();
         }
         return _proxy.mutate(std::move(mutations),
@@ -3400,6 +3552,9 @@ future<> executor::do_batch_write(
             schema_decorated_key_equal>;
         auto key_builders = std::make_unique<map_type>(1, schema_decorated_key_hash{}, schema_decorated_key_equal{});
         for (auto&& b : std::move(mutation_builders)) {
+            if (b.second.custom_timestamp().has_value()) {
+                throw api_error::validation("Using the system:timestamp_attribute is not compatible with BatchWriteItem when any table in the batch uses the 'always' write isolation policy.");
+            }
             auto [it, added] = key_builders->try_emplace(schema_decorated_key {
                 .schema = b.first,
                 .dk = dht::decorate_key(*b.first, b.second.pk())
@@ -3497,6 +3652,16 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
 
         std::unordered_set<primary_key, primary_key_hash, primary_key_equal> used_keys(
                 1, primary_key_hash{schema}, primary_key_equal{schema});
+        // Look up the timestamp attribute tag once per table (shared by all
+        // PutRequests and DeleteRequests for this table).
+        std::optional<bytes> ts_attr;
+        const auto tags_ptr = db::get_tags_of_table(schema);
+        if (tags_ptr) {
+            auto tag_it = tags_ptr->find(TIMESTAMP_TAG_KEY);
+            if (tag_it != tags_ptr->end() && !tag_it->second.empty()) {
+                ts_attr = to_bytes(tag_it->second);
+            }
+        }
         for (auto& request : it->value.GetArray()) {
             auto& r = get_single_member(request, "RequestItems element");
             const auto r_name = rjson::to_string_view(r.name);
@@ -3505,7 +3670,8 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 validate_is_object(item, "Item in PutRequest");
                 auto&& put_item = put_or_delete_item(
                         item, schema, put_or_delete_item::put_item{},
-                        si_key_attributes(_proxy.data_dictionary().find_table(schema->ks_name(), schema->cf_name())));
+                        si_key_attributes(_proxy.data_dictionary().find_table(schema->ks_name(), schema->cf_name())),
+                        ts_attr);
                 mutation_builders.emplace_back(schema, std::move(put_item));
                 auto mut_key = std::make_pair(mutation_builders.back().second.pk(), mutation_builders.back().second.ck());
                 if (used_keys.contains(mut_key)) {
@@ -3516,7 +3682,7 @@ future<executor::request_return_type> executor::batch_write_item(client_state& c
                 const rjson::value& key = get_member(r.value, "Key", "DeleteRequest");
                 validate_is_object(key, "Key in DeleteRequest");
                 mutation_builders.emplace_back(schema, put_or_delete_item(
-                        key, schema, put_or_delete_item::delete_item{}));
+                        key, schema, put_or_delete_item::delete_item{}, ts_attr));
                 auto mut_key = std::make_pair(mutation_builders.back().second.pk(),
                         mutation_builders.back().second.ck());
                 if (used_keys.contains(mut_key)) {
@@ -3735,6 +3901,10 @@ public:
     virtual ~update_item_operation() = default;
     virtual std::optional<mutation> apply(std::unique_ptr<rjson::value> previous_item, api::timestamp_type ts, cdc::per_request_options& cdc_opts) const override;
     bool needs_read_before_write() const;
+    // Returns true if the timestamp attribute is being set in this update
+    // (via AttributeUpdates PUT or UpdateExpression SET). Used to detect
+    // whether a custom write timestamp will be used.
+    bool has_custom_timestamp() const noexcept override;
 
 private:
     void delete_attribute(bytes&& column_name, const std::unique_ptr<rjson::value>& previous_item, const api::timestamp_type ts, deletable_row& row,
@@ -3868,6 +4038,44 @@ update_item_operation::needs_read_before_write() const {
            check_needs_read_before_write_attribute_updates(_attribute_updates) ||
            _request.HasMember("Expected") ||
            (_returnvalues != returnvalues::NONE && _returnvalues != returnvalues::UPDATED_NEW);
+}
+
+bool
+update_item_operation::has_custom_timestamp() const noexcept {
+    if (!_timestamp_attribute) {
+        return false;
+    }
+    // Check if the timestamp attribute is being set via AttributeUpdates PUT
+    // with a valid numeric value.
+    if (_attribute_updates) {
+        std::string_view ts_attr = to_string_view(*_timestamp_attribute);
+        for (auto it = _attribute_updates->MemberBegin(); it != _attribute_updates->MemberEnd(); ++it) {
+            if (rjson::to_string_view(it->name) == ts_attr) {
+                const rjson::value* action = rjson::find(it->value, "Action");
+                if (action && rjson::to_string_view(*action) == "PUT" && it->value.HasMember("Value")) {
+                    // Only consider it a custom timestamp if the value is numeric
+                    if (try_get_timestamp((it->value)["Value"])) {
+                        return true;
+                    }
+                }
+                break;
+            }
+        }
+    }
+    // Check if the timestamp attribute is being set via UpdateExpression SET.
+    // We can't check the actual value type without resolving the expression
+    // (which requires previous_item), so we conservatively return true if the
+    // attribute appears in a SET action, and handle the non-numeric case in apply().
+    // A non-numeric value will cause apply() to throw a ValidationException.
+    if (!_update_expression.empty()) {
+        std::string ts_attr(to_string_view(*_timestamp_attribute));
+        auto it = _update_expression.find(ts_attr);
+        if (it != _update_expression.end() && it->second.has_value()) {
+            const auto& action = it->second.get_value();
+            return std::holds_alternative<parsed::update_expression::action::set>(action._action);
+        }
+    }
+    return false;
 }
 
 // action_result() returns the result of applying an UpdateItem action -
@@ -4152,6 +4360,15 @@ inline void update_item_operation::apply_attribute_updates(const std::unique_ptr
             throw api_error::validation(format("UpdateItem cannot update key column {}", rjson::to_string_view(it->name)));
         }
         std::string action = rjson::to_string((it->value)["Action"]);
+        // If this is the timestamp attribute being PUT, it must be a valid
+        // numeric value (microseconds since epoch). Use it as the write
+        // timestamp and skip storing it. Reject if the value is non-numeric.
+        if (_timestamp_attribute && column_name == *_timestamp_attribute && action == "PUT") {
+            if (it->value.HasMember("Value")) {
+                get_timestamp((it->value)["Value"], to_string_view(*_timestamp_attribute));
+                continue;
+            }
+        }
         if (action == "DELETE") {
             // The DELETE operation can do two unrelated tasks. Without a
             // "Value" option, it is used to delete an attribute. With a
@@ -4255,6 +4472,18 @@ inline void update_item_operation::apply_update_expression(const std::unique_ptr
         if (cdef && cdef->is_primary_key()) {
             throw api_error::validation(fmt::format("UpdateItem cannot update key column {}", column_name));
         }
+        // If this is the timestamp attribute being set via UpdateExpression SET,
+        // it must be a valid numeric value (microseconds since epoch). Use it as
+        // the write timestamp and skip storing it. Reject if non-numeric.
+        if (_timestamp_attribute && to_bytes(column_name) == *_timestamp_attribute &&
+                actions.second.has_value() &&
+                std::holds_alternative<parsed::update_expression::action::set>(actions.second.get_value()._action)) {
+            std::optional<rjson::value> result = action_result(actions.second.get_value(), previous_item.get());
+            if (result) {
+                get_timestamp(*result, to_string_view(*_timestamp_attribute));
+                continue;  // Skip - already used as timestamp
+            }
+        }
         if (actions.second.has_value()) {
             // An action on a top-level attribute column_name. The single
             // action is actions.second.get_value(). We can simply invoke
@@ -4303,6 +4532,44 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
         return {};
     }
 
+    // If the table has a timestamp attribute, look for it in the update
+    // (AttributeUpdates PUT or UpdateExpression SET). If found with a valid
+    // numeric value, use it as the write timestamp instead of the provided ts.
+    api::timestamp_type effective_ts = ts;
+    if (_timestamp_attribute) {
+        bool found_ts = false;
+        if (_attribute_updates) {
+            std::string_view ts_attr = to_string_view(*_timestamp_attribute);
+            for (auto it = _attribute_updates->MemberBegin(); it != _attribute_updates->MemberEnd(); ++it) {
+                if (rjson::to_string_view(it->name) == ts_attr) {
+                    const rjson::value* action = rjson::find(it->value, "Action");
+                    if (action && rjson::to_string_view(*action) == "PUT" && it->value.HasMember("Value")) {
+                        if (auto t = try_get_timestamp((it->value)["Value"])) {
+                            effective_ts = *t;
+                            found_ts = true;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        if (!found_ts && !_update_expression.empty()) {
+            std::string ts_attr(to_string_view(*_timestamp_attribute));
+            auto it = _update_expression.find(ts_attr);
+            if (it != _update_expression.end() && it->second.has_value()) {
+                const auto& action = it->second.get_value();
+                if (std::holds_alternative<parsed::update_expression::action::set>(action._action)) {
+                    std::optional<rjson::value> result = action_result(action, previous_item.get());
+                    if (result) {
+                        if (auto t = try_get_timestamp(*result)) {
+                            effective_ts = *t;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // In the ReturnValues=ALL_NEW case, we make a copy of previous_item into
     // _return_attributes and parts of it will be overwritten by the new
     // updates (in do_update() and do_delete()). We need to make a copy and
@@ -4331,10 +4598,10 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
     auto& row = m.partition().clustered_row(*_schema, _ck);
     auto modified_attrs = attribute_collector();
     if (!_update_expression.empty()) {
-        apply_update_expression(previous_item, ts, row, modified_attrs, any_updates, any_deletes);
+        apply_update_expression(previous_item, effective_ts, row, modified_attrs, any_updates, any_deletes);
     }
     if (_attribute_updates) {
-        apply_attribute_updates(previous_item, ts, row, modified_attrs, any_updates, any_deletes);
+        apply_attribute_updates(previous_item, effective_ts, row, modified_attrs, any_updates, any_deletes);
     }
     if (!modified_attrs.empty()) {
         auto serialized_map = modified_attrs.to_mut();
@@ -4345,7 +4612,7 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
     // marker. An update with only DELETE operations must not add a row marker
     // (this was issue #5862) but any other update, even an empty one, should.
     if (any_updates || !any_deletes) {
-        row.apply(row_marker(ts));
+        row.apply(row_marker(effective_ts));
     } else if (_returnvalues == returnvalues::ALL_NEW && !previous_item) {
         // There was no pre-existing item, and we're not creating one, so
         // don't report the new item in the returned Attributes.

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -208,8 +208,9 @@ std::string lsi_name(std::string_view table_name, std::string_view index_name, b
     return view_name(table_name, index_name, "!:", validate_len);
 }
 
-void check_key(const rjson::value& key, const schema_ptr& schema) {
-    if (key.MemberCount() != (schema->clustering_key_size() == 0 ? 1 : 2)) {
+void check_key(const rjson::value& key, const schema_ptr& schema, bool allow_extra_attribute) {
+    const unsigned expected = (schema->clustering_key_size() == 0 ? 1 : 2) + (allow_extra_attribute ? 1 : 0);
+    if (key.MemberCount() != expected) {
         throw api_error::validation("Given key attribute not in schema");
     }
 }

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -169,7 +169,10 @@ std::string lsi_name(std::string_view table_name, std::string_view index_name,
 /// After calling pk_from_json() and ck_from_json() to extract the pk and ck
 /// components of a key, and if that succeeded, call check_key() to further
 /// check that the key doesn't have any spurious components.
-void check_key(const rjson::value& key, const schema_ptr& schema);
+/// Set "allow_extra_attribute" if the key is known to contain one more non-key
+/// attribute (namely, a timestamp pseudo-attribute in the Key given to
+/// DeleteItem or BatchWriteItem's DeleteRequest).
+void check_key(const rjson::value& key, const schema_ptr& schema, bool allow_extra_attribute = false);
 
 /// Fail with api_error::validation if the expression if has unused attribute
 /// names or values. This is how DynamoDB behaves, so we do too.

--- a/docs/alternator/new-apis.md
+++ b/docs/alternator/new-apis.md
@@ -207,3 +207,87 @@ in the CreateTable operation. The value of this tag can be:
 The `system:initial_tablets` tag only has any effect while creating
 a new table with CreateTable - changing it later has no effect.
 
+## Custom write timestamps
+
+DynamoDB doesn't allow clients to set the write timestamp of updates. All
+updates use the current server time as their timestamp, and ScyllaDB uses
+these timestamps for last-write-wins conflict resolution when concurrent
+writes reach different replicas.
+
+ScyllaDB Alternator extends this with the `system:timestamp_attribute` tag,
+which allows specifying a custom write timestamp for each PutItem,
+UpdateItem, DeleteItem, or BatchWriteItem request. To use this feature:
+
+1. Tag the table (at CreateTable time or using TagResource) with
+   `system:timestamp_attribute` set to the name of an attribute that will
+   hold the custom write timestamp.
+
+2. When performing a PutItem, UpdateItem or BatchWriteItem PutRequest,
+   include the named attribute in the request with a positive numeric value.
+   The value represents the write timestamp in **microseconds since the
+   Unix epoch** (this is the same unit used internally by ScyllaDB for
+   timestamps); fractional microseconds are truncated.
+   For a DeleteItem or a BatchWriteItem DeleteRequest, include the named
+   attribute in the `Key` parameter.
+
+3. The named attribute is **not stored** in the item data - it only
+   controls the write timestamp. If you also want to record the timestamp
+   as data, use a separate attribute for that purpose.
+
+4. If the named attribute is absent, the write proceeds normally using the
+   current server time as the timestamp. If the named attribute is present
+   but has a non-numeric value, the write is rejected with a ValidationException.
+
+### Limitations
+
+- **Incompatible with LWT (lightweight transactions)**: Custom write
+  timestamps cannot be used for writes that execute as an LWT, because LWT
+  requires the write timestamp to be set by the Paxos protocol, not by the
+  client. Which writes use LWT depends on the table's write isolation policy:
+
+  - **`always`** (`always_use_lwt`): every write uses LWT, so the
+    `system:timestamp_attribute` feature is entirely unusable on such tables.
+    Consider using `system:write_isolation=only_rmw_uses_lwt` (or `forbid_rmw`)
+    instead.
+  - **`only_rmw_uses_lwt`**: read-modify-write operations — those that include
+    a `ConditionExpression` or the legacy `Expected`, or use an `UpdateExpression`
+    or `AttributeUpdates` that reads existing attribute values, or use
+    `ReturnValues` that needs to read the old item — all use LWT and are
+    therefore rejected with a `ValidationException`. Write-only requests in
+    this mode work normally with custom timestamps.
+  - **`forbid_rmw`** and **`unsafe_rmw`**: writes never use LWT, so custom
+    timestamps are always allowed. (`forbid_rmw` rejects read-modify-write
+    requests outright; `unsafe_rmw` performs them without isolation guarantees.)
+
+- **Timestamps far from the current time**: If you write an item with a
+  timestamp far in the future, subsequent writes that do _not_ specify an
+  explicit timestamp will use the current server time, which will be smaller
+  than that future timestamp and will therefore lose the last-write-wins
+  conflict — effectively making the item immutable until real time catches up.
+  Similarly, writing with a timestamp far in the past risks losing to any
+  concurrent or future write that uses the current server time. Keep explicit
+  timestamps reasonably close to the current wall-clock time to avoid these
+  surprises.
+
+### Example use case
+
+This feature is useful for ingesting data from multiple sources where each
+record has a known logical timestamp. By setting the `system:timestamp_attribute`
+tag, you can ensure that the record with the highest logical timestamp always
+wins, regardless of ingestion order:
+
+```python
+# Create table with timestamp attribute
+dynamodb.create_table(
+    TableName='my_table',
+    ...
+    Tags=[{'Key': 'system:timestamp_attribute', 'Value': 'write_ts'}]
+)
+
+# Write a record with a specific timestamp (in microseconds since epoch)
+table.put_item(Item={
+    'pk': 'my_key',
+    'data': 'new_value',
+    'write_ts': Decimal('1700000000000000'),  # Nov 14, 2023 in microseconds
+})
+```

--- a/test/alternator/test_timestamp_attribute.py
+++ b/test/alternator/test_timestamp_attribute.py
@@ -1,0 +1,761 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for the system:timestamp_attribute Alternator-only feature.
+# This feature allows users to control the write timestamp of PutItem and
+# UpdateItem operations by specifying an attribute name in the table's
+# system:timestamp_attribute tag. When that attribute is present in the
+# write request with a numeric value (microseconds since Unix epoch), it
+# is used as the write timestamp. The attribute itself is not stored in
+# the item data.
+#
+# This is an Alternator-only feature and the tests are skipped on DynamoDB.
+
+import time
+from decimal import Decimal
+
+import pytest
+from botocore.exceptions import ClientError
+
+from .util import new_test_table, random_string
+
+# A large timestamp in microseconds (far future, year ~2033)
+LARGE_TS = Decimal('2000000000000000')
+# A medium timestamp in microseconds (year ~2001)
+MEDIUM_TS = Decimal('1000000000000000')
+# A small timestamp in microseconds (year ~1970)
+SMALL_TS = Decimal('100000000000000')
+
+# Fixtures for tables with the system:timestamp_attribute tag, shared by
+# many tests below. Because system:timestamp_attribute is a Scylla-only
+# feature, all tests using these fixtures are marked scylla_only and skipped
+# on DynamoDB.
+
+# A table with only a hash key and system:timestamp_attribute='ts' tag.
+# We explicitly set write isolation to only_rmw_uses_lwt so the tests remain
+# correct even if the test default changes to always_use_lwt in the future.
+@pytest.fixture(scope="module")
+def test_table_ts(scylla_only, dynamodb):
+    with new_test_table(dynamodb,
+        Tags=[{'Key': 'system:timestamp_attribute', 'Value': 'ts'},
+              {'Key': 'system:write_isolation', 'Value': 'only_rmw_uses_lwt'}],
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        yield table
+
+# A table with string hash and range keys and system:timestamp_attribute='ts'.
+# We explicitly set write isolation to only_rmw_uses_lwt so the tests remain
+# correct even if the test default changes to always_use_lwt in the future.
+@pytest.fixture(scope="module")
+def test_table_ts_ss(scylla_only, dynamodb):
+    with new_test_table(dynamodb,
+        Tags=[{'Key': 'system:timestamp_attribute', 'Value': 'ts'},
+              {'Key': 'system:write_isolation', 'Value': 'only_rmw_uses_lwt'}],
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH'},
+            {'AttributeName': 'c', 'KeyType': 'RANGE'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'c', 'AttributeType': 'S'},
+        ]) as table:
+        yield table
+
+# A table with hash key, system:timestamp_attribute='ts' tag, and
+# system:write_isolation='always' to test rejection in LWT_ALWAYS mode.
+# In always_use_lwt mode, every write uses LWT, so the timestamp attribute
+# feature cannot be used at all.
+@pytest.fixture(scope="module")
+def test_table_ts_lwt(scylla_only, dynamodb):
+    with new_test_table(dynamodb,
+        Tags=[{'Key': 'system:timestamp_attribute', 'Value': 'ts'},
+              {'Key': 'system:write_isolation', 'Value': 'always'}],
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        yield table
+
+# Test that PutItem with the timestamp attribute uses the given numeric
+# value as the write timestamp, and the timestamp attribute is NOT stored
+# in the item.
+def test_timestamp_attribute_put_item_basic(test_table_ts):
+    p = random_string()
+    # Put an item with the timestamp attribute
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+    # Read the item back
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    # 'val' should be stored normally
+    assert item['val'] == 'hello'
+    # 'ts' (the timestamp attribute) should NOT be stored in the item
+    assert 'ts' not in item
+    # We do not check that the desired timestamp was actually used as the
+    # write timestamp, because there is no API to read an item's timestamp
+    # with the DynamoDB API. In the following test we'll use CQL to read
+    # the timestamp, and we also have additional tests below that check the
+    # timestamp's correctness indirectly by verifying that writes with larger
+    # timestamps win over smaller ones.
+
+# As explained in test_timestamp_attribute_put_item_basic above, we couldn't
+# read the write timestamp of an item using the DynamoDB API. So here we use
+# CQL to read the timestamp of an item written with a custom timestamp, and
+# verify that it matches the expected value.
+def test_timestamp_attribute_put_item_read_cql(test_table_ts, cql):
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+    # Read the 'val' attribute's write timestamp via CQL. Alternator stores
+    # non-key attributes in the ':attrs' map<text,blob> column. We can read
+    # the write timestamp of a specific map entry with WRITETIME(col[key]).
+    ks = 'alternator_' + test_table_ts.name
+    rows = list(cql.execute(
+        f'SELECT WRITETIME(":attrs"[\'val\']) FROM "{ks}"."{test_table_ts.name}" WHERE p = %s',
+        [p]))
+    assert rows == [(int(LARGE_TS),)]
+
+# The timestamp attribute is documented to be truncated to whole microseconds
+# if given a fractional value. Verify this exact truncation (not rounding)
+# by writing a timestamp with a fractional microsecond part and reading back
+# the resulting write timestamp via CQL, as in
+# test_timestamp_attribute_put_item_read_cql above.
+def test_timestamp_attribute_put_item_fractional_truncated(test_table_ts, cql):
+    p = random_string()
+    ts = Decimal('1234567890123.456789')
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': ts})
+    ks = 'alternator_' + test_table_ts.name
+    rows = list(cql.execute(
+        f'SELECT WRITETIME(":attrs"[\'val\']) FROM "{ks}"."{test_table_ts.name}" WHERE p = %s',
+        [p]))
+    assert rows == [(1234567890123,)]
+
+# A timestamp given in scientific notation with a positive exponent (e.g.,
+# "1.2345E+14") has a negative decimal "scale", which exercises a different
+# (multiplication, instead of truncation) code path than the plain-integer
+# or fractional cases above. Verify it is handled correctly.
+def test_timestamp_attribute_put_item_scientific_notation(test_table_ts, cql):
+    p = random_string()
+    ts = Decimal('1.2345E+14')
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': ts})
+    ks = 'alternator_' + test_table_ts.name
+    rows = list(cql.execute(
+        f'SELECT WRITETIME(":attrs"[\'val\']) FROM "{ks}"."{test_table_ts.name}" WHERE p = %s',
+        [p]))
+    assert rows == [(123450000000000,)]
+
+# Test that PutItem respects the write timestamp ordering: a write with a
+# larger timestamp should win over a write with a smaller timestamp,
+# regardless of wall-clock order.
+def test_timestamp_attribute_put_item_ordering(test_table_ts):
+    p = random_string()
+    # First, write item with a LARGE timestamp
+    test_table_ts.put_item(Item={'p': p, 'val': 'large_ts', 'ts': LARGE_TS})
+    # Then write item with a SMALL timestamp (should lose since SMALL < LARGE)
+    test_table_ts.put_item(Item={'p': p, 'val': 'small_ts', 'ts': SMALL_TS})
+    # The item with the larger timestamp (val='large_ts') should win
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'large_ts'
+
+    # Now overwrite with a larger timestamp (LARGE_TS + 1) - should win
+    test_table_ts.put_item(Item={'p': p, 'val': 'latest', 'ts': LARGE_TS + 1})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'latest'
+
+# Test that UpdateItem with the timestamp attribute in AttributeUpdates
+# uses the given numeric value as the write timestamp, and the timestamp
+# attribute is NOT stored in the item.
+def test_timestamp_attribute_update_item_attribute_updates(test_table_ts):
+    p = random_string()
+    # Use UpdateItem with AttributeUpdates, setting 'val' and 'ts'
+    test_table_ts.update_item(
+        Key={'p': p},
+        AttributeUpdates={
+            'val': {'Value': 'hello', 'Action': 'PUT'},
+            'ts': {'Value': LARGE_TS, 'Action': 'PUT'},
+        }
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'hello'
+    # 'ts' should NOT be stored in the item
+    assert 'ts' not in item
+
+    # Update with a smaller timestamp - should NOT overwrite
+    test_table_ts.update_item(
+        Key={'p': p},
+        AttributeUpdates={
+            'val': {'Value': 'overwritten', 'Action': 'PUT'},
+            'ts': {'Value': SMALL_TS, 'Action': 'PUT'},
+        }
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'hello'
+    # But update with a larger timestamp (LARGE_TS + 1) should overwrite
+    test_table_ts.update_item(
+        Key={'p': p},
+        AttributeUpdates={
+            'val': {'Value': 'overwritten', 'Action': 'PUT'},
+            'ts': {'Value': LARGE_TS + 1, 'Action': 'PUT'},
+        }
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'overwritten'
+
+# Test that UpdateItem with the timestamp attribute in UpdateExpression
+# uses the given numeric value as the write timestamp, and the timestamp
+# attribute is NOT stored in the item.
+def test_timestamp_attribute_update_item_update_expression(test_table_ts):
+    p = random_string()
+    # Use UpdateItem with UpdateExpression to set 'val' and 'ts'
+    test_table_ts.update_item(
+        Key={'p': p},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'hello', ':t': LARGE_TS}
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'hello'
+    # 'ts' should NOT be stored in the item
+    assert 'ts' not in item
+
+    # Update with a smaller timestamp - should NOT overwrite
+    test_table_ts.update_item(
+        Key={'p': p},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'overwritten', ':t': SMALL_TS}
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'hello'
+
+    # But update with a larger timestamp (LARGE_TS + 1) should overwrite
+    test_table_ts.update_item(
+        Key={'p': p},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'overwritten', ':t': LARGE_TS + 1}
+    )
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'overwritten'
+
+# Test that when the timestamp attribute has an invalid value (non-numeric
+# type or a negative or excessively large number), writes are rejected with a
+# ValidationException. The test covers PutItem, UpdateItem, DeleteItem, and
+# BatchWriteItem.
+def test_timestamp_attribute_invalid_value(test_table_ts):
+    p = random_string()
+    for invalid_ts in ['not_a_number', [1,2,3], Decimal('-1'), Decimal('99999999999999999999')]:
+        with pytest.raises(ClientError, match='ValidationException.*write timestamp'):
+            test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': invalid_ts})
+        with pytest.raises(ClientError, match='ValidationException.*write timestamp'):
+            test_table_ts.update_item(
+                Key={'p': p},
+                AttributeUpdates={
+                    'val': {'Value': 'hello', 'Action': 'PUT'},
+                    'ts': {'Value': invalid_ts, 'Action': 'PUT'},
+                }
+            )
+        with pytest.raises(ClientError, match='ValidationException.*write timestamp'):
+            test_table_ts.update_item(
+                Key={'p': p},
+                UpdateExpression='SET val = :v, ts = :t',
+                ExpressionAttributeValues={':v': 'hello', ':t': invalid_ts}
+            )
+        with pytest.raises(ClientError, match='ValidationException.*write timestamp'):
+            test_table_ts.delete_item(Key={'p': p, 'ts': invalid_ts})
+        with pytest.raises(ClientError, match='ValidationException.*write timestamp'):
+            test_table_ts.meta.client.batch_write_item(RequestItems={
+                test_table_ts.name: [{'PutRequest': {'Item': {'p': p, 'val': 'hello', 'ts': invalid_ts}}}]
+            })
+
+# Test that the timestamp attribute value is interpreted in microseconds since
+# the Unix epoch, and also test that writes without custom timestamps are
+# ordered correctly with respect to writes with custom timestamps.
+def test_timestamp_attribute_microseconds(test_table_ts):
+    # Get current time in microseconds from the Python client side.
+    now_us = int(time.time() * 1_000_000)
+    one_hour_us = 3600 * 1_000_000
+
+    # Part 1: write with one hour in the past as the custom timestamp, then
+    # overwrite without a custom timestamp.  The second write uses the
+    # server's current time, so it should win.
+    past_us = now_us - one_hour_us
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'old', 'ts': Decimal(str(past_us))})
+    test_table_ts.put_item(Item={'p': p, 'val': 'new'})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'new'
+
+    # Part 2: write with a timestamp one hour in the future, then overwrite
+    # without a custom timestamp.  The server's current time is much less
+    # than now_us + one_hour_us, so the first write should win.
+    p = random_string()
+    future_us = now_us + one_hour_us
+    test_table_ts.put_item(Item={'p': p, 'val': 'future', 'ts': Decimal(str(future_us))})
+    test_table_ts.put_item(Item={'p': p, 'val': 'now'})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'future'
+
+# Test that BatchWriteItem also respects the timestamp attribute.
+def test_timestamp_attribute_batch_write(test_table_ts):
+    p = random_string()
+    # Write item via BatchWriteItem with a large timestamp
+    with test_table_ts.batch_writer() as batch:
+        batch.put_item(Item={'p': p, 'val': 'large_ts', 'ts': LARGE_TS})
+    # Write item via BatchWriteItem with a small timestamp (should lose)
+    with test_table_ts.batch_writer() as batch:
+        batch.put_item(Item={'p': p, 'val': 'small_ts', 'ts': SMALL_TS})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'large_ts'
+    assert 'ts' not in item
+
+# Test that DeleteItem respects the timestamp attribute: a delete with a
+# smaller timestamp than the item's write timestamp should not take effect.
+def test_timestamp_attribute_delete_item(test_table_ts):
+    p = random_string()
+    # Write an item with a large timestamp
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+    assert item['val'] == 'hello'
+    # Delete with a small timestamp - the delete should lose (item still exists)
+    test_table_ts.delete_item(Key={'p': p, 'ts': SMALL_TS})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True).get('Item')
+    assert item is not None and item['val'] == 'hello'
+    # Delete with a large timestamp - the delete should win (item is removed)
+    test_table_ts.delete_item(Key={'p': p, 'ts': LARGE_TS + 1})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True).get('Item')
+    assert item is None
+
+# Test that DeleteItem without the timestamp attribute in the key behaves
+# normally (no custom timestamp is applied).
+def test_timestamp_attribute_delete_item_no_ts(test_table_ts):
+    p = random_string()
+    # Use SMALL_TS so the delete (which uses the current server time) wins.
+    # If we used LARGE_TS (far future), the delete without an explicit timestamp
+    # would use current time which is smaller than LARGE_TS and the delete would lose.
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': SMALL_TS})
+    # Delete without a timestamp attribute - should succeed normally
+    test_table_ts.delete_item(Key={'p': p})
+    assert 'Item' not in test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)
+    # Verify that an item written with a far-future timestamp is NOT deleted by
+    # a delete without an explicit timestamp (server time < LARGE_TS).
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+    test_table_ts.delete_item(Key={'p': p})
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True).get('Item')
+    assert item is not None and item['val'] == 'hello'
+
+# Test that BatchWriteItem DeleteRequest also respects the timestamp attribute.
+def test_timestamp_attribute_batch_delete(test_table_ts):
+    p = random_string()
+    # Write an item with a large timestamp
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+    # Delete via BatchWriteItem with a small timestamp - delete should lose
+    test_table_ts.meta.client.batch_write_item(RequestItems={
+        test_table_ts.name: [{'DeleteRequest': {'Key': {'p': p, 'ts': SMALL_TS}}}]
+    })
+    item = test_table_ts.get_item(Key={'p': p}, ConsistentRead=True).get('Item')
+    assert item is not None and item['val'] == 'hello'
+    # Delete via BatchWriteItem with a large timestamp - delete should win
+    test_table_ts.meta.client.batch_write_item(RequestItems={
+        test_table_ts.name: [{'DeleteRequest': {'Key': {'p': p, 'ts': LARGE_TS + 1}}}]
+    })
+    assert 'Item' not in test_table_ts.get_item(Key={'p': p}, ConsistentRead=True)
+
+
+# LWT does not allow custom timestamps (because LWT needs to choose its own
+# timestamp). So any configuration or request type that needs to use LWT to
+# achieve the desired write isolation must reject custom timestamps. The
+# following tests verify that custom timestamps are indeed rejected in the
+# appropriate situations, and accepted when LWT is not required.
+
+# Test that PutItem with a condition (which requires LWT) together with the
+# timestamp attribute is rejected.
+def test_put_item_timestamp_attribute_with_condition_rejected(test_table_ts):
+    p = random_string()
+    # Put an initial item (no timestamp attribute, so LWT is ok)
+    test_table_ts.put_item(Item={'p': p, 'val': 'initial'})
+    # Try to put with a ConditionExpression and a timestamp - should be rejected
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.put_item(
+            Item={'p': p, 'val': 'updated', 'ts': LARGE_TS},
+            ConditionExpression='attribute_exists(p)'
+        )
+    # Also check the old-style Expected condition - should also be rejected
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.put_item(
+            Item={'p': p, 'val': 'updated', 'ts': LARGE_TS},
+            Expected={'p': {'Value': p}}
+        )
+
+# Test that PutItem with a ReturnValues=ALL_OLD, which also requires LWT,
+# rejects a timestamp attribute. If ReturnValues=ALL_NEW was supported,
+# it would not have required LWT and might allow the timestamp attribute,
+# but DynamoDB does not support ReturnValues=ALL_NEW for PutItem.
+def test_put_item_timestamp_attribute_with_returnvalues_rejected(test_table_ts):
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'initial'})
+    # ReturnValues=ALL_OLD requires a read-before-write (LWT), so combining it
+    # with a custom timestamp should be rejected.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.put_item(
+            Item={'p': p, 'val': 'updated', 'ts': LARGE_TS},
+            ReturnValues='ALL_OLD'
+        )
+
+# Test that using the timestamp attribute with the 'always' write isolation
+# policy is rejected, because in always_use_lwt mode every write uses LWT
+# (including unconditional ones), which is incompatible with custom timestamps.
+def test_put_item_timestamp_attribute_lwt_always_rejected(test_table_ts_lwt):
+    p = random_string()
+    # Even a plain PutItem with a timestamp is rejected in LWT_ALWAYS mode
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts_lwt.put_item(Item={'p': p, 'val': 'hello', 'ts': LARGE_TS})
+
+# Test that UpdateItem rejects a custom timestamp in various situations where
+# (in only_rmw_uses_lwt write isolation mode) LWT is required: conditions,
+# ReturnValues, and UpdateExpressions or AttributeUpdates that read
+# the previous value.
+def test_update_item_timestamp_attribute_lwt_rejected(test_table_ts):
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 1})
+    # ConditionExpression requires LWT
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = :v, ts = :t',
+            ExpressionAttributeValues={':v': 2, ':t': LARGE_TS},
+            ConditionExpression='attribute_exists(p)'
+        )
+    # Old-style Expected condition requires LWT
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            AttributeUpdates={'val': {'Value': 2, 'Action': 'PUT'},
+                              'ts':  {'Value': LARGE_TS, 'Action': 'PUT'}},
+            Expected={'p': {'Value': p}}
+        )
+    # ReturnValues=ALL_OLD requires LWT for reading the previous item
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = :v, ts = :t',
+            ExpressionAttributeValues={':v': 2, ':t': LARGE_TS},
+            ReturnValues='ALL_OLD'
+        )
+    # ReturnValues=ALL_NEW also requires reading the current item (to return
+    # attributes that were not modified by the update), so it is also rejected.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = :v, ts = :t',
+            ExpressionAttributeValues={':v': 2, ':t': LARGE_TS},
+            ReturnValues='ALL_NEW'
+        )
+    # ReturnValues=UPDATED_OLD also requires reading the previous item.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = :v, ts = :t',
+            ExpressionAttributeValues={':v': 2, ':t': LARGE_TS},
+            ReturnValues='UPDATED_OLD'
+        )
+    # But ReturnValues=UPDATED_NEW only returns the attributes that were just
+    # set, which are known without reading the previous item, so it doesn't
+    # need LWT, and is allowed to set a custom timestamp.
+    test_table_ts.update_item(
+        Key={'p': p},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 2, ':t': LARGE_TS},
+        ReturnValues='UPDATED_NEW'
+    )
+    # UpdateExpression that reads the previous value requires LWT.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = val + :v, ts = :t',
+            ExpressionAttributeValues={':v': 2, ':t': LARGE_TS}
+        )
+    # UpdateExpression ADD clause reads and modifies the previous value,
+    # so uses LWT. Note: ts must be set via SET (not ADD) for the custom
+    # timestamp to be recognized; ADD is used for the other attribute.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET ts = :t ADD val :v',
+            ExpressionAttributeValues={':v': Decimal('1'), ':t': LARGE_TS}
+        )
+    # UpdateExpression DELETE clause (removes elements from a set) also uses LWT.
+    # Again, ts must be set via SET for the custom timestamp to be recognized.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            UpdateExpression='SET ts = :t DELETE myset :e',
+            ExpressionAttributeValues={':e': {'a'}, ':t': LARGE_TS}
+        )
+    # UpdateExpression that doesn't read the previous value doesn't need
+    # LWT, so is allowed with a custom timestamp.
+    test_table_ts.update_item(
+        Key={'p': p},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 2, ':t': LARGE_TS}
+    )
+    # AttributeUpdates ADD action reads the previous value so needs LWT.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            AttributeUpdates={'counter': {'Value': Decimal('1'), 'Action': 'ADD'},
+                              'ts':      {'Value': LARGE_TS, 'Action': 'PUT'}}
+        )
+    # AttributeUpdates DELETE action with a Value (removes set elements) also uses LWT.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.update_item(
+            Key={'p': p},
+            AttributeUpdates={'myset': {'Value': {'a'}, 'Action': 'DELETE'},
+                              'ts':    {'Value': LARGE_TS, 'Action': 'PUT'}}
+        )
+    # AttributeUpdates DELETE action without a Value just removes the attribute
+    # entirely and does not need to read the previous item, so does not use LWT
+    # and is allowed to have a custom timestamp.
+    test_table_ts.update_item(
+        Key={'p': p},
+        AttributeUpdates={'some_attr': {'Action': 'DELETE'},
+                          'ts':        {'Value': LARGE_TS, 'Action': 'PUT'}}
+    )
+
+# Test that DeleteItem with a condition (ConditionExpression or Expected) and
+# a custom timestamp is rejected, because conditional writes require LWT which
+# is incompatible with custom timestamps.
+def test_timestamp_attribute_delete_item_condition_rejected(test_table_ts):
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello'})
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.delete_item(
+            Key={'p': p, 'ts': SMALL_TS},
+            ConditionExpression='attribute_exists(p)'
+        )
+    # Old-style Expected condition also requires LWT and should be rejected.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.delete_item(
+            Key={'p': p, 'ts': SMALL_TS},
+            Expected={'p': {'Value': p}}
+        )
+
+# Test that DeleteItem with ReturnValues=ALL_OLD and a custom timestamp is
+# rejected, because returning the previous item requires reading it first (LWT).
+def test_timestamp_attribute_delete_item_returnvalues_rejected(test_table_ts):
+    p = random_string()
+    test_table_ts.put_item(Item={'p': p, 'val': 'hello'})
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts.delete_item(
+            Key={'p': p, 'ts': SMALL_TS},
+            ReturnValues='ALL_OLD'
+        )
+
+# Test that DeleteItem with a custom timestamp is rejected when the table uses
+# always_use_lwt isolation, because every write uses LWT in that mode.
+def test_timestamp_attribute_delete_item_lwt_always_rejected(test_table_ts_lwt):
+    p = random_string()
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts_lwt.delete_item(Key={'p': p, 'ts': SMALL_TS})
+
+# Test that BatchWriteItem with a custom timestamp is rejected when the table
+# uses always_use_lwt isolation.
+# Note that BatchWriteItem doesn't support any of the other reasons that make
+# other write operations use LWT (conditions, or update expressions, or return
+# values are not supported by BatchWriteItem), so this test is short.
+def test_timestamp_attribute_batch_write_lwt_always_rejected(test_table_ts_lwt):
+    p = random_string()
+    # Check that both PutRequest and DeleteRequest are rejected, because
+    # the write isolation policy (always_use_lwt) forces it to use LWT
+    # so setting the timestamp attribute is not allowed.
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts_lwt.meta.client.batch_write_item(RequestItems={
+            test_table_ts_lwt.name: [{'PutRequest': {'Item': {'p': p, 'val': 'v', 'ts': SMALL_TS}}}]
+        })
+    with pytest.raises(ClientError, match='ValidationException.*timestamp_attribute'):
+        test_table_ts_lwt.meta.client.batch_write_item(RequestItems={
+            test_table_ts_lwt.name: [{'DeleteRequest': {'Key': {'p': p, 'ts': SMALL_TS}}}]
+        })
+
+
+# All the previous tests were on a table with a partition key only. Test that
+# custom timestamps also work in a table with a range key. We check the four
+# write operations: PutItem, UpdateItem, DeleteItem, and BatchWriteItem.
+def test_timestamp_attribute_with_range_key(test_table_ts_ss):
+    p = random_string()
+
+    ### PutItem:
+    c1 = random_string()
+    test_table_ts_ss.put_item(Item={'p': p, 'c': c1, 'val': 'large', 'ts': LARGE_TS})
+    # Write with a smaller timestamp - should lose
+    test_table_ts_ss.put_item(Item={'p': p, 'c': c1, 'val': 'small', 'ts': SMALL_TS})
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c1}, ConsistentRead=True)['Item']
+    assert item['val'] == 'large'
+    assert 'ts' not in item
+    # Write with a larger timestamp (LARGE_TS + 1) - should win
+    test_table_ts_ss.put_item(Item={'p': p, 'c': c1, 'val': 'larger', 'ts': LARGE_TS + 1})
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c1}, ConsistentRead=True)['Item']
+    assert item['val'] == 'larger'
+
+    ### UpdateItem:
+    c2 = random_string()
+    test_table_ts_ss.update_item(
+        Key={'p': p, 'c': c2},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'update_large', ':t': LARGE_TS}
+    )
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c2}, ConsistentRead=True)['Item']
+    assert item['val'] == 'update_large'
+    # Update with a smaller timestamp - should lose
+    test_table_ts_ss.update_item(
+        Key={'p': p, 'c': c2},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'update_small', ':t': SMALL_TS}
+    )
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c2}, ConsistentRead=True)['Item']
+    assert item['val'] == 'update_large'
+    # Update with a larger timestamp - should win
+    test_table_ts_ss.update_item(
+        Key={'p': p, 'c': c2},
+        UpdateExpression='SET val = :v, ts = :t',
+        ExpressionAttributeValues={':v': 'update_larger', ':t': LARGE_TS + 1}
+    )
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c2}, ConsistentRead=True)['Item']
+    assert item['val'] == 'update_larger'
+
+    ### DeleteItem:
+    c3 = random_string()
+    test_table_ts_ss.put_item(Item={'p': p, 'c': c3, 'val': 'hello', 'ts': LARGE_TS})
+    # Delete with a small timestamp - should lose (item still exists)
+    test_table_ts_ss.delete_item(Key={'p': p, 'c': c3, 'ts': SMALL_TS})
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c3}, ConsistentRead=True).get('Item')
+    assert item is not None and item['val'] == 'hello'
+    # Delete with a large timestamp - should win (item is removed)
+    test_table_ts_ss.delete_item(Key={'p': p, 'c': c3, 'ts': LARGE_TS + 1})
+    assert 'Item' not in test_table_ts_ss.get_item(Key={'p': p, 'c': c3}, ConsistentRead=True)
+
+    ### BatchWriteItem PutRequest:
+    c4 = random_string()
+    test_table_ts_ss.meta.client.batch_write_item(RequestItems={
+        test_table_ts_ss.name: [{'PutRequest': {'Item': {'p': p, 'c': c4, 'val': 'batch_large', 'ts': LARGE_TS}}}]
+    })
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c4}, ConsistentRead=True)['Item']
+    assert item['val'] == 'batch_large'
+    # Write with a smaller timestamp - should lose
+    test_table_ts_ss.meta.client.batch_write_item(RequestItems={
+        test_table_ts_ss.name: [{'PutRequest': {'Item': {'p': p, 'c': c4, 'val': 'batch_small', 'ts': SMALL_TS}}}]
+    })
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c4}, ConsistentRead=True)['Item']
+    assert item['val'] == 'batch_large'
+    # Write with a larger timestamp - should win
+    test_table_ts_ss.meta.client.batch_write_item(RequestItems={
+        test_table_ts_ss.name: [{'PutRequest': {'Item': {'p': p, 'c': c4, 'val': 'batch_larger', 'ts': LARGE_TS + 1}}}]
+    })
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c4}, ConsistentRead=True)['Item']
+    assert item['val'] == 'batch_larger'
+
+    ### BatchWriteItem DeleteRequest:
+    # Delete with a small timestamp - should lose (item still exists)
+    test_table_ts_ss.meta.client.batch_write_item(RequestItems={
+        test_table_ts_ss.name: [{'DeleteRequest': {'Key': {'p': p, 'c': c4, 'ts': SMALL_TS}}}]
+    })
+    item = test_table_ts_ss.get_item(Key={'p': p, 'c': c4}, ConsistentRead=True).get('Item')
+    assert item is not None and item['val'] == 'batch_larger'
+    # Delete with a large enough timestamp (LARGE_TS + 2) - should win (item is removed)
+    test_table_ts_ss.meta.client.batch_write_item(RequestItems={
+        test_table_ts_ss.name: [{'DeleteRequest': {'Key': {'p': p, 'c': c4, 'ts': LARGE_TS + 2}}}]
+    })
+    assert 'Item' not in test_table_ts_ss.get_item(Key={'p': p, 'c': c4}, ConsistentRead=True)
+
+# Test that in unsafe_rmw write isolation mode, even read-modify-write
+# operations (e.g., a ConditionExpression) which normally require LWT and
+# (as tested above) refuse custom timestamps - do allow custom timestamps.
+def test_timestamp_attribute_unsafe_rmw_allows_rmw(scylla_only, dynamodb):
+    with new_test_table(dynamodb,
+        Tags=[{'Key': 'system:timestamp_attribute', 'Value': 'ts'},
+              {'Key': 'system:write_isolation', 'Value': 'unsafe_rmw'}],
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'val': 'initial'})
+        # The following operations all require LWT in other modes, but not in
+        # unsafe_rmw mode, so a custom timestamp is allowed. We confirm the
+        # custom timestamp is honored by checking that we can write the
+        # timestamp attribute ('ts') but it doesn't get stored in the item.
+        # PutItem with ConditionExpression:
+        table.put_item(
+            Item={'p': p, 'val': 'conditional', 'ts': LARGE_TS},
+            ConditionExpression='attribute_exists(p)'
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['val'] == 'conditional'
+        assert 'ts' not in item
+        # PutItem with Expected:
+        table.put_item(
+            Item={'p': p, 'val': 'expected', 'ts': LARGE_TS + 1},
+            Expected={'p': {'Value': p}}
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['val'] == 'expected'
+        # PutItem with ReturnValues=ALL_OLD:
+        table.put_item(
+            Item={'p': p, 'val': 'ret_all_old', 'ts': LARGE_TS + 2},
+            ReturnValues='ALL_OLD'
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['val'] == 'ret_all_old'
+        assert 'ts' not in item
+        # UpdateItem with ConditionExpression:
+        table.update_item(
+            Key={'p': p},
+            UpdateExpression='SET val = :v, ts = :t',
+            ExpressionAttributeValues={':v': 'cond_update', ':t': LARGE_TS + 3},
+            ConditionExpression='attribute_exists(p)'
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['val'] == 'cond_update'
+        assert 'ts' not in item
+        # UpdateItem with ReturnValues=ALL_OLD, ALL_NEW, and UPDATED_OLD:
+        for rv in ['ALL_OLD', 'ALL_NEW', 'UPDATED_OLD']:
+            table.update_item(
+                Key={'p': p},
+                UpdateExpression='SET val = :v, ts = :t',
+                ExpressionAttributeValues={':v': f'rv_{rv}', ':t': LARGE_TS + 4},
+                ReturnValues=rv
+            )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert 'ts' not in item
+        # UpdateItem with UpdateExpression that reads the previous value (ADD clause):
+        table.put_item(Item={'p': p, 'counter': Decimal('10'), 'ts': LARGE_TS + 5})
+        table.update_item(
+            Key={'p': p},
+            UpdateExpression='SET ts = :t ADD counter :inc',
+            ExpressionAttributeValues={':t': LARGE_TS + 6, ':inc': Decimal('1')}
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['counter'] == Decimal('11')
+        assert 'ts' not in item
+        # UpdateItem with AttributeUpdates ADD action (reads previous value):
+        table.update_item(
+            Key={'p': p},
+            AttributeUpdates={'counter': {'Value': Decimal('1'), 'Action': 'ADD'},
+                              'ts':      {'Value': LARGE_TS + 7, 'Action': 'PUT'}}
+        )
+        item = table.get_item(Key={'p': p}, ConsistentRead=True)['Item']
+        assert item['counter'] == Decimal('12')
+        assert 'ts' not in item
+        # DeleteItem with ConditionExpression:
+        table.put_item(Item={'p': p, 'val': 'to_delete', 'ts': LARGE_TS + 8})
+        table.delete_item(
+            Key={'p': p, 'ts': LARGE_TS + 9},
+            ConditionExpression='attribute_exists(p)'
+        )
+        assert 'Item' not in table.get_item(Key={'p': p}, ConsistentRead=True)
+        # DeleteItem with Expected (old-style condition):
+        table.put_item(Item={'p': p, 'val': 'to_delete2', 'ts': LARGE_TS + 10})
+        table.delete_item(
+            Key={'p': p, 'ts': LARGE_TS + 11},
+            Expected={'p': {'Value': p}}
+        )
+        assert 'Item' not in table.get_item(Key={'p': p}, ConsistentRead=True)
+        # DeleteItem with ReturnValues=ALL_OLD:
+        table.put_item(Item={'p': p, 'val': 'to_delete3', 'ts': LARGE_TS + 12})
+        table.delete_item(
+            Key={'p': p, 'ts': LARGE_TS + 13},
+            ReturnValues='ALL_OLD'
+        )
+        assert 'Item' not in table.get_item(Key={'p': p}, ConsistentRead=True)


### PR DESCRIPTION
Before this patch, Alternator always uses the current server time as the write timestamp. This patch adds a feature analogous to CQL's "USING TIMESTAMP", which allows the application to control the timestamp of the write (PutItem, UpdateItem, DeleteItem, or BatchWriteItem operation).

This feature may be useful in some applications to implement last-write- wins semantics based on logical timestamps, e.g., ingesting old and new data where newest record should win. **This is a Scylla-only feature, and has no parallel in DynamoDB.**

To control the timestamp of a write operation, begin by tagging the table with the tag `system:timestamp_attribute` setting it to an attribute name. When a PutItem/UpdateItem/DeleteItem/BatchWriteItem includes that attribute with a numeric value (microseconds since Unix epoch), the value is used as the CQL write timestamp and the attribute is not stored in the item. If the attribute is present with a non-numeric value, the write is rejected with a ValidationException.

For DeleteItem and BatchWriteItem's DeleteRequest, the timestamp attribute is passed in the Key parameter (it is stripped from the key before use).

Note that LWT does *not* allow the application to choose the timestamp. So if a write operation tries to set the timestamp and ALSO needs LWT, the operation is rejected with a ValidationException. In particular, a timestamp can't be set on a conditional write (except for write isolation mode unsafe_rmw), and timestamps can't be set at all in always_use_lwt write isolation mode. In only_rmw_use_lwt mode, timestamps can be set on pure-write operations (those which are not read-modify-write operations).

Fixes #28806
