### PR TITLE
view_building: fix tombstone_warn_threshold warnings

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -2750,7 +2750,7 @@ future<mutation> system_keyspace::make_remove_view_build_status_on_host_mutation
 
 static constexpr auto VIEW_BUILDING_KEY = "view_building";
 
-future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
+future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> system_keyspace::get_view_building_tasks() {
     using namespace db::view;
 
     // When the VIEW_BUILDING_TASKS_MIN_TASK_ID feature is active, read the static
@@ -2815,7 +2815,7 @@ future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
                 NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
         co_await _qp.query_internal(full_query, std::move(process_row));
     }
-    co_return tasks;
+    co_return std::pair{std::move(tasks), std::move(min_task_id)};
 }
 
 future<mutation> system_keyspace::make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task) {

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1309,6 +1309,7 @@ schema_ptr system_keyspace::view_building_tasks() {
         return schema_builder(NAME, VIEW_BUILDING_TASKS, std::make_optional(id))
                 .with_column("key", utf8_type, column_kind::partition_key)
                 .with_column("id", timeuuid_type, column_kind::clustering_key)
+                .with_column("min_task_id", timeuuid_type, column_kind::static_column)
                 .with_column("type", utf8_type)
                 .with_column("aborted", boolean_type)
                 .with_column("base_id", uuid_type)
@@ -2750,11 +2751,35 @@ future<mutation> system_keyspace::make_remove_view_build_status_on_host_mutation
 static constexpr auto VIEW_BUILDING_KEY = "view_building";
 
 future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
-    static const sstring query = format("SELECT id, type, aborted, base_id, view_id, last_token, host_id, shard FROM {}.{} WHERE key = '{}'", NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
     using namespace db::view;
 
+    // When the VIEW_BUILDING_TASKS_MIN_TASK_ID feature is active, read the static
+    // column min_task_id first and use it as a lower bound for the clustering row
+    // scan. This skips tombstoned rows below the boundary, avoiding dead-cell
+    // warnings from the tombstone_warn_threshold check.
+    std::optional<utils::UUID> min_task_id;
+    if (_db.features().view_building_tasks_min_task_id) {
+        auto schema = view_building_tasks();
+        auto pk = partition_key::from_single_value(*schema, data_value(VIEW_BUILDING_KEY).serialize_nonnull());
+        auto dk = dht::decorate_key(*schema, pk);
+        auto col_id = schema->get_column_definition("min_task_id")->id;
+        query::partition_slice slice(
+            query::clustering_row_ranges{},
+            {col_id},
+            {},
+            query::partition_slice::option_set::of<query::partition_slice::option::always_return_static_content>());
+        auto cmd = query::read_command(schema->id(), schema->version(), slice,
+                _db.get_query_max_result_size(), query::tombstone_limit::max);
+        auto [qr, _cache_temp] = co_await _db.query(schema, cmd, query::result_options::only_result(),
+                {dht::partition_range::make_singular(dk)}, nullptr, db::no_timeout);
+        auto rs = query::result_set::from_raw_result(schema, slice, *qr);
+        if (!rs.empty()) {
+            min_task_id = rs.row(0).get<utils::UUID>("min_task_id");
+        }
+    }
+
     building_tasks tasks;
-    co_await _qp.query_internal(query, [&] (const cql3::untyped_result_set_row& row) -> future<stop_iteration> {
+    auto process_row = [&] (const cql3::untyped_result_set_row& row) -> future<stop_iteration> {
         auto id = row.get_as<utils::UUID>("id");
         auto type = task_type_from_string(row.get_as<sstring>("type"));
         auto aborted = row.get_as<bool>("aborted");
@@ -2779,7 +2804,17 @@ future<db::view::building_tasks> system_keyspace::get_view_building_tasks() {
             break;
         }
         co_return stop_iteration::no;
-    });
+    };
+
+    if (min_task_id) {
+        static const sstring bounded_query = format("SELECT id, type, aborted, base_id, view_id, last_token, host_id, shard FROM {}.{} WHERE key = '{}' AND id >= ?",
+                NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
+        co_await _qp.query_internal(bounded_query, db::consistency_level::LOCAL_ONE, {*min_task_id}, 1000, std::move(process_row));
+    } else {
+        static const sstring full_query = format("SELECT id, type, aborted, base_id, view_id, last_token, host_id, shard FROM {}.{} WHERE key = '{}'",
+                NAME, VIEW_BUILDING_TASKS, VIEW_BUILDING_KEY);
+        co_await _qp.query_internal(full_query, std::move(process_row));
+    }
     co_return tasks;
 }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -572,7 +572,7 @@ public:
     future<mutation> make_remove_view_build_status_on_host_mutation(api::timestamp_type ts, system_keyspace_view_name view_name, locator::host_id host_id);
 
     // system.view_building_tasks
-    future<db::view::building_tasks> get_view_building_tasks();
+    future<std::pair<db::view::building_tasks, std::optional<utils::UUID>>> get_view_building_tasks();
     future<mutation> make_view_building_task_mutation(api::timestamp_type ts, const db::view::view_building_task& task);
     future<mutation> make_remove_view_building_task_mutation(api::timestamp_type ts, utils::UUID id);
 

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -241,6 +241,13 @@ future<> view_building_coordinator::clean_finished_tasks() {
             builder.del_all_tasks();
         }
 
+        if (_db.features().view_building_tasks_min_task_id) {
+            // If min_alive_uuid == std::nullopt, set min_task_id to a fresh UUID,
+            // so future scans start past all the just-deleted rows (new tasks created
+            // later will have larger UUIDs).
+            builder.set_min_task_id(min_alive_uuid ? *min_alive_uuid : utils::UUID_gen::get_time_UUID());
+        }
+
         co_await commit_mutations(std::move(guard), {builder.build()}, "remove finished view building tasks");
         for (auto& [_, tasks_set]: _finished_tasks) {
             tasks_set.clear();

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -180,7 +180,7 @@ future<> view_building_coordinator::clean_finished_tasks() {
         co_return;
     }
 
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
 
     // Collect tasks eligible for deletion: must still be in state and not aborted.
     std::vector<utils::UUID> tasks_to_delete;
@@ -587,7 +587,7 @@ void view_building_coordinator::generate_tablet_migration_updates(utils::chunked
     }
 
     auto last_token = tmap.get_last_token(gid.tablet);
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
 
     auto create_task_copy_on_pending_replica = [&] (const view_building_task& task) {
         auto new_id = builder.new_id();
@@ -655,7 +655,7 @@ void view_building_coordinator::generate_tablet_resize_updates(utils::chunked_ve
         return;
     }
     bool is_split = old_tmap.tablet_count() < new_tmap.tablet_count();
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
 
     auto create_task_copy = [&] (const view_building_task& task, dht::token last_token) -> utils::UUID {
         auto new_id = builder.new_id();
@@ -725,7 +725,7 @@ void view_building_coordinator::abort_tasks(utils::chunked_vector<canonical_muta
     }
     vbc_logger.debug("Generating abort mutations for tasks for table {}", table_id);
 
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
     auto abort_task_map = [&] (const task_map& task_map) {
         for (auto& [id, _]: task_map) {
             vbc_logger.debug("Aborting task {}", id);
@@ -754,7 +754,7 @@ void abort_view_building_tasks(const view_building_state_machine& vb_sm,
     }
     vbc_logger.debug("Generating abort mutations for tasks for table {} on replica {} and last token {}", table_id, replica, last_token);
 
-    view_building_task_mutation_builder builder(write_timestamp);
+    view_building_task_mutation_builder builder(write_timestamp, vb_sm.building_state.make_task_uuid_generator(write_timestamp));
     auto abort_task_map = [&] (const task_map& task_map) {
         for (auto& [id, task]: task_map) {
             if (task.last_token == last_token) {
@@ -796,7 +796,7 @@ void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<can
         return;
     }
 
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
     auto& base_tasks = _vb_sm.building_state.tasks_state.at(table_id);
     for (auto& [_, replica_tasks]: base_tasks) {
         for (auto& [_, building_task_map]: replica_tasks.view_tasks) {
@@ -813,7 +813,7 @@ void view_building_coordinator::rollback_aborted_tasks(utils::chunked_vector<can
         return;
     }
 
-    view_building_task_mutation_builder builder(guard.write_timestamp());
+    view_building_task_mutation_builder builder(guard.write_timestamp(), _vb_sm.building_state.make_task_uuid_generator(guard.write_timestamp()));
     auto& replica_tasks = _vb_sm.building_state.tasks_state.at(table_id).at(replica);
     for (auto& [_, building_task_map]: replica_tasks.view_tasks) {
         rollback_task_map(builder, building_task_map);

--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -11,6 +11,7 @@
 #include <exception>
 #include <ranges>
 #include <seastar/core/abort_source.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
 #include <seastar/core/on_internal_error.hh>
 #include "db/view/view_building_coordinator.hh"
@@ -180,6 +181,9 @@ future<> view_building_coordinator::clean_finished_tasks() {
     }
 
     view_building_task_mutation_builder builder(guard.write_timestamp());
+
+    // Collect tasks eligible for deletion: must still be in state and not aborted.
+    std::vector<utils::UUID> tasks_to_delete;
     for (auto& [replica, tasks]: _finished_tasks) {
         for (auto& task_id: tasks) {
             // The task might be aborted in the meantime. In this case we cannot remove it because we need it to create a new task.
@@ -189,15 +193,58 @@ future<> view_building_coordinator::clean_finished_tasks() {
             //       If yes, we can just remove it instead of aborting it.
             auto task_opt = _vb_sm.building_state.get_task(*_vb_sm.building_state.currently_processed_base_table, replica, task_id);
             if (task_opt && !task_opt->get().aborted) {
-                builder.del_task(task_id);
-                vbc_logger.debug("Removing finished task with ID: {}", task_id);
+                tasks_to_delete.push_back(task_id);
             }
         }
     }
 
-    co_await commit_mutations(std::move(guard), {builder.build()}, "remove finished view building tasks");
-    for (auto& [_, tasks_set]: _finished_tasks) {
-        tasks_set.clear();
+    if (!tasks_to_delete.empty()) {
+        // Find the minimum UUID (by timeuuid ordering) among tasks that are NOT being
+        // deleted — i.e., alive tasks that must remain in the table.
+        // Everything strictly below this boundary is safe to cover with one range tombstone.
+        const std::unordered_set<utils::UUID> to_delete_set(tasks_to_delete.begin(), tasks_to_delete.end());
+        std::optional<utils::UUID> min_alive_uuid;
+        for (auto& [base_id, base_tasks] : _vb_sm.building_state.tasks_state) {
+            for (auto& [replica, rep_tasks] : base_tasks) {
+                auto check = [&](const utils::UUID& id) {
+                    if (!to_delete_set.contains(id)
+                            && (!min_alive_uuid || timeuuid_tri_compare(id, *min_alive_uuid) < 0)) {
+                        min_alive_uuid = id;
+                    }
+                };
+                for (auto& [id, task] : rep_tasks.staging_tasks) {
+                    check(id);
+                }
+                for (auto& [view_id, task_m] : rep_tasks.view_tasks) {
+                    for (auto& [id, task] : task_m) {
+                        check(id);
+                    }
+                }
+                co_await coroutine::maybe_yield();
+            }
+        }
+
+        if (min_alive_uuid) {
+            vbc_logger.debug("Removing finished tasks before ID: {} using range tombstone", *min_alive_uuid);
+            builder.del_tasks_before(*min_alive_uuid);
+            for (auto& task_id : tasks_to_delete) {
+                // Tasks below min_alive_uuid are already covered by the range tombstone.
+                if (timeuuid_tri_compare(task_id, *min_alive_uuid) < 0) {
+                    continue;
+                }
+                vbc_logger.debug("Removing finished task with ID: {}", task_id);
+                builder.del_task(task_id);
+            }
+        } else {
+            // No alive tasks remain — one range tombstone covers everything.
+            vbc_logger.debug("No alive tasks remain, removing all finished tasks using range tombstone");
+            builder.del_all_tasks();
+        }
+
+        co_await commit_mutations(std::move(guard), {builder.build()}, "remove finished view building tasks");
+        for (auto& [_, tasks_set]: _finished_tasks) {
+            tasks_set.clear();
+        }
     }
 }
 

--- a/db/view/view_building_state.cc
+++ b/db/view/view_building_state.cc
@@ -8,6 +8,7 @@
  */
 
 #include "db/view/view_building_state.hh"
+#include "utils/UUID_gen.hh"
 
 namespace db {
 
@@ -126,6 +127,24 @@ std::map<dht::token, std::vector<view_building_task>> view_building_state::colle
         tasks[task.last_token].push_back(task);
     }
     return tasks;
+}
+
+task_uuid_generator::task_uuid_generator(api::timestamp_type base_ts)
+        : _next_ts(base_ts) {}
+
+utils::UUID task_uuid_generator::operator()() {
+    return utils::UUID_gen::get_random_time_UUID_from_micros(
+            std::chrono::microseconds{_next_ts++});
+}
+
+task_uuid_generator view_building_state::make_task_uuid_generator(api::timestamp_type ts) const {
+    if (min_alive_uuid) {
+        auto lower_bound = utils::UUID_gen::micros_timestamp(*min_alive_uuid);
+        if (ts <= lower_bound) {
+            ts = lower_bound + 1;
+        }
+    }
+    return task_uuid_generator{ts};
 }
 
 }

--- a/db/view/view_building_state.cc
+++ b/db/view/view_building_state.cc
@@ -22,9 +22,10 @@ view_building_task::view_building_task(utils::UUID id, task_type type, bool abor
         , replica(replica)
         , last_token(last_token) {}
 
-view_building_state::view_building_state(building_tasks tasks_state, std::optional<table_id> processed_base_table)
+view_building_state::view_building_state(building_tasks tasks_state, std::optional<table_id> processed_base_table, std::optional<utils::UUID> min_alive_uuid)
         : tasks_state(std::move(tasks_state))
-        , currently_processed_base_table(std::move(processed_base_table)) {}
+        , currently_processed_base_table(std::move(processed_base_table))
+        , min_alive_uuid(std::move(min_alive_uuid)) {}
 
 views_state::views_state(std::map<table_id, std::vector<table_id>> views_per_base, view_build_status_map status_map)
         : views_per_base(std::move(views_per_base))

--- a/db/view/view_building_state.hh
+++ b/db/view/view_building_state.hh
@@ -73,8 +73,9 @@ using building_tasks = std::map<table_id, base_table_tasks>;
 struct view_building_state {
     building_tasks tasks_state;
     std::optional<table_id> currently_processed_base_table;
+    std::optional<utils::UUID> min_alive_uuid;
 
-    view_building_state(building_tasks tasks_state, std::optional<table_id> processed_base_table);
+    view_building_state(building_tasks tasks_state, std::optional<table_id> processed_base_table, std::optional<utils::UUID> min_alive_uuid);
     view_building_state() = default;
     
     std::optional<std::reference_wrapper<const view_building_task>> get_task(table_id base_id, locator::tablet_replica replica, utils::UUID id) const;

--- a/db/view/view_building_state.hh
+++ b/db/view/view_building_state.hh
@@ -14,6 +14,7 @@
 #include "db/view/view_build_status.hh"
 #include "locator/host_id.hh"
 #include "locator/tablets.hh"
+#include "mutation/timestamp.hh"
 #include "utils/UUID.hh"
 #include <fmt/base.h>
 #include "schema/schema_fwd.hh"
@@ -64,6 +65,16 @@ struct replica_tasks {
 using base_table_tasks = std::map<locator::tablet_replica, replica_tasks>;
 using building_tasks = std::map<table_id, base_table_tasks>;
 
+// Generates unique timeuuids with strictly increasing microsecond timestamps.
+// Each call to operator() returns a new timeuuid whose timestamp is one
+// microsecond greater than the previous one.
+class task_uuid_generator {
+    api::timestamp_type _next_ts;
+public:
+    explicit task_uuid_generator(api::timestamp_type base_ts);
+    utils::UUID operator()();
+};
+
 // Represents cluster-wide view building state (only for tablet-based views).
 // The state stores all unfinished view building tasks for all tablet-based views
 // and table_id of currently processed base table by view building coordinator.
@@ -82,6 +93,13 @@ struct view_building_state {
     std::vector<std::reference_wrapper<const view_building_task>> get_tasks_for_host(table_id base_id, locator::host_id host) const;
     std::map<dht::token, std::vector<view_building_task>> collect_tasks_by_last_token(table_id base_table_id) const;
     std::map<dht::token, std::vector<view_building_task>> collect_tasks_by_last_token(table_id base_table_id, const locator::tablet_replica& replica) const;
+
+    // Creates a generator that produces unique timeuuids suitable for view
+    // building task IDs. The generated uuids have strictly increasing
+    // microsecond timestamps starting from write_timestamp. If min_alive_uuid
+    // is set, all generated uuids are guaranteed to be greater than
+    // *min_alive_uuid in timeuuid order.
+    task_uuid_generator make_task_uuid_generator(api::timestamp_type write_timestamp) const;
 };
 
 // Represents global state of tablet-based views.

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -14,7 +14,7 @@ namespace db {
 namespace view {
 
 utils::UUID view_building_task_mutation_builder::new_id() {
-    return utils::UUID_gen::get_time_UUID();
+    return _uuid_gen();
 }
 
 clustering_key view_building_task_mutation_builder::get_ck(utils::UUID id) {

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -52,6 +52,25 @@ view_building_task_mutation_builder& view_building_task_mutation_builder::del_ta
     return *this;
 }
 
+view_building_task_mutation_builder& view_building_task_mutation_builder::del_tasks_before(utils::UUID id) {
+    auto ck = get_ck(id);
+    range_tombstone rt(
+        position_in_partition::before_all_clustered_rows(),
+        position_in_partition_view(ck, bound_weight::before_all_prefixed),
+        tombstone{_ts, gc_clock::now()});
+    _m.partition().apply_row_tombstone(*_s, std::move(rt));
+    return *this;
+}
+
+view_building_task_mutation_builder& view_building_task_mutation_builder::del_all_tasks() {
+    range_tombstone rt(
+        position_in_partition::before_all_clustered_rows(),
+        position_in_partition::after_all_clustered_rows(),
+        tombstone{_ts, gc_clock::now()});
+    _m.partition().apply_row_tombstone(*_s, std::move(rt));
+    return *this;
+}
+
 }
 
 }

--- a/db/view/view_building_task_mutation_builder.cc
+++ b/db/view/view_building_task_mutation_builder.cc
@@ -71,6 +71,11 @@ view_building_task_mutation_builder& view_building_task_mutation_builder::del_al
     return *this;
 }
 
+view_building_task_mutation_builder& view_building_task_mutation_builder::set_min_task_id(utils::UUID id) {
+    _m.set_static_cell("min_task_id", data_value(id), _ts);
+    return *this;
+}
+
 }
 
 }

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "db/view/view_building_state.hh"
 #include "mutation/mutation.hh"
 #include "db/system_keyspace.hh"
 #include "mutation/timestamp.hh"
@@ -19,17 +20,19 @@ namespace view {
 // Factory for mutations to `system.view_building_tasks` table.
 class view_building_task_mutation_builder {
     api::timestamp_type _ts;
+    task_uuid_generator _uuid_gen;
     schema_ptr _s;
     mutation _m;
 
 public:
-    view_building_task_mutation_builder(api::timestamp_type ts)
+    view_building_task_mutation_builder(api::timestamp_type ts, task_uuid_generator uuid_gen)
             : _ts(ts)
+            , _uuid_gen(std::move(uuid_gen))
             , _s(db::system_keyspace::view_building_tasks())
             , _m(_s, partition_key::from_single_value(*_s, data_value("view_building").serialize_nonnull()))
     { }
 
-    static utils::UUID new_id();
+    utils::UUID new_id();
 
     view_building_task_mutation_builder& set_type(utils::UUID id, db::view::view_building_task::task_type type);
     view_building_task_mutation_builder& set_aborted(utils::UUID id, bool aborted);

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -42,6 +42,8 @@ public:
     view_building_task_mutation_builder& del_tasks_before(utils::UUID id);
     // Deletes all tasks using a range tombstone covering the entire clustering range.
     view_building_task_mutation_builder& del_all_tasks();
+    // Sets the static column min_task_id to `id`.
+    view_building_task_mutation_builder& set_min_task_id(utils::UUID id);
 
     mutation build() {
         return std::move(_m);

--- a/db/view/view_building_task_mutation_builder.hh
+++ b/db/view/view_building_task_mutation_builder.hh
@@ -38,6 +38,10 @@ public:
     view_building_task_mutation_builder& set_last_token(utils::UUID id, dht::token last_token);
     view_building_task_mutation_builder& set_replica(utils::UUID id, const locator::tablet_replica& replica);
     view_building_task_mutation_builder& del_task(utils::UUID id);
+    // Deletes all tasks with clustering key < id using a range tombstone.
+    view_building_task_mutation_builder& del_tasks_before(utils::UUID id);
+    // Deletes all tasks using a range tombstone covering the entire clustering range.
+    view_building_task_mutation_builder& del_all_tasks();
 
     mutation build() {
         return std::move(_m);

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -275,11 +275,12 @@ future<> view_building_worker::create_staging_sstable_tasks() {
 
     utils::chunked_vector<canonical_mutation> cmuts;
     auto guard = co_await _group0.client().start_operation(_as);
+    auto uuid_gen = _vb_state_machine.building_state.make_task_uuid_generator(guard.write_timestamp());
     auto my_host_id = _db.get_token_metadata().get_topology().my_host_id();
     for (auto& [table_id, sst_infos]: _sstables_to_register) {
         for (auto& sst_info: sst_infos) {
             view_building_task task {
-                utils::UUID_gen::get_time_UUID(), view_building_task::task_type::process_staging, false,
+                uuid_gen(), view_building_task::task_type::process_staging, false,
                 table_id, ::table_id{}, {my_host_id, sst_info.shard}, sst_info.last_token
             };
             auto mut = co_await _sys_ks.make_view_building_task_mutation(guard.write_timestamp(), task);

--- a/docs/dev/view-building-coordinator.md
+++ b/docs/dev/view-building-coordinator.md
@@ -106,6 +106,7 @@ The most important table is `system.view_building_tasks`, which stores all unfin
 CREATE TABLE system.view_building_tasks (
     key text,
     id timeuuid,
+    min_task_id timeuuid STATIC, -- lower bound for task scans; see "Tombstone avoidance" below
     type text,
     aborted boolean,
     base_id uuid,
@@ -116,6 +117,26 @@ CREATE TABLE system.view_building_tasks (
     PRIMARY KEY (key, id)
 )
 ```
+
+### Tombstone avoidance
+
+`system.view_building_tasks` is a single partition. When `finished_task_gc_fiber()` removes
+finished tasks in batches, the deleted rows remain as tombstones in SSTables until compaction,
+causing `tombstone_warn_threshold` warnings on subsequent reloads in large clusters.
+
+Two mechanisms address this:
+
+**Range tombstone on GC.** Instead of one row tombstone per deleted task, the coordinator emits
+a single range tombstone `[before_all, min_alive_uuid)` where `min_alive_uuid` is the smallest
+timeuuid among surviving tasks. Tasks above the boundary (rare) still get individual row tombstones.
+When all tasks are deleted, a single full-partition range tombstone is used.
+
+**Bounded scan on reload.** Physical rows remain until compaction and are still counted as dead cells.
+After each GC batch, `min_task_id = min_alive_uuid` is written atomically as a static cell (same Raft
+batch as the range tombstone). On reload, `min_task_id` is read using a **static-only partition slice**
+(empty `_row_ranges` + `always_return_static_content`) — this makes the SSTable reader stop immediately
+after the static row, before any clustering tombstones, so zero dead cells are counted. The value is
+then used as `AND id >= min_task_id` to skip all tombstoned rows in the main scan.
 
 The view building coordinator stores currently processing base table in `system.scylla_local` 
 under `view_building_processing_base` key. 

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -183,6 +183,7 @@ public:
     gms::feature arbitrary_tablet_boundaries { *this, "ARBITRARY_TABLET_BOUNDARIES"sv };
     gms::feature large_data_virtual_tables { *this, "LARGE_DATA_VIRTUAL_TABLES"sv };
     gms::feature keyspace_multi_rf_change { *this, "KEYSPACE_MULTI_RF_CHANGE"sv };
+    gms::feature view_building_tasks_min_task_id { *this, "VIEW_BUILDING_TASKS_MIN_TASK_ID"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -793,16 +793,18 @@ static future<> add_view_building_tasks_mutations(storage_proxy& sp, view_ptr vi
 
     auto& db = sp.local_db();
     auto& sys_ks = sp.system_keyspace();
+    auto& vb_sm = sp.view_building_state_machine();
 
     auto base_id = view->view_info()->base_id();
     auto& base_cf = db.find_column_family(base_id);
     auto erm = base_cf.get_effective_replication_map();
     auto& tablet_map = erm->get_token_metadata().tablets().get_tablet_map(base_id);
+    auto uuid_gen = vb_sm.building_state.make_task_uuid_generator(ts);
 
     co_await tablet_map.for_each_tablet([&] (auto tid, const auto& tablet_info) -> future<> {
         auto last_token = tablet_map.get_last_token(tid);
         for (auto& replica: tablet_info.replicas) {
-            auto id = utils::UUID_gen::get_time_UUID();
+            auto id = uuid_gen();
             view_building_task task {
                 id, view_building_task::task_type::build_range, false,
                 base_id, view->id(), replica, last_token

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -806,7 +806,7 @@ future<> storage_service::view_building_state_load() {
     };
 
 
-    auto vb_tasks = co_await _sys_ks.local().get_view_building_tasks();
+    auto [vb_tasks, min_alive_uuid] = co_await _sys_ks.local().get_view_building_tasks();
     auto processing_base_table = co_await _sys_ks.local().get_view_building_processing_base_id();
 
     std::map<table_id, std::vector<table_id>> views_per_base;
@@ -825,7 +825,7 @@ future<> storage_service::view_building_state_load() {
         })
         | std::ranges::to<db::view::views_state::view_build_status_map>();
 
-    db::view::view_building_state building_state {std::move(vb_tasks), std::move(processing_base_table)};
+    db::view::view_building_state building_state {std::move(vb_tasks), std::move(processing_base_table), std::move(min_alive_uuid)};
     db::view::views_state views_state {std::move(views_per_base), std::move(status_map)};
 
     _view_building_state_machine.building_state = std::move(building_state);

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -1016,3 +1016,36 @@ async def test_all_good_on_node_restart(manager: ManagerClient):
     log = await manager.server_open_log(servers[0].server_id)
     warnings = await log.grep(expr="view_building_state_observer failed with")
     assert len(warnings) == 0, f"Found view building state observer warnings: {warnings}"
+
+# Reproduces SCYLLADB-657
+#
+# Test that view building does not trigger tombstone_warn_threshold warnings.
+# Uses a high tablet count (2048) to create many tasks, which produces many
+# tombstones when tasks are cleaned up. Verifies no warnings appear in logs.
+@pytest.mark.asyncio
+async def test_tombstone_warn_threshold(manager: ManagerClient):
+    node_count = 1
+    servers = await manager.servers_add(node_count, cmdline=cmdline_loggers, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+    ])
+    cql, _ = await manager.get_ready_cql(servers)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': true, 'initial': 2048}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
+        await populate_base_table(cql, ks, "tab")
+
+        await pause_view_build_coordinator(manager)
+
+        logs = await asyncio.gather(*(manager.server_open_log(s.server_id) for s in servers))
+        marks = await asyncio.gather(*(l.mark() for l in logs))
+
+        await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view1 AS SELECT * FROM {ks}.tab "
+                        "WHERE c IS NOT NULL and key IS NOT NULL AND v IS NOT NULL PRIMARY KEY (c, key, v) ")
+        await unpause_view_build_coordinator(manager)
+        await wait_for_view(cql, 'mv_cf_view1', node_count)
+        await check_view_contents(cql, ks, "tab", "mv_cf_view1")
+
+        matches = await asyncio.gather(*(l.grep("system.view_building_tasks.*tombstone_warn_threshold", from_mark=m) for (l, m) in zip(logs, marks)))
+        for server_matches in matches:
+            assert len(server_matches) == 0


### PR DESCRIPTION
## Problem

`system.view_building_tasks` is a single-partition Raft group0 table (pk = `"view_building"`, CK = timeuuid). When `clean_finished_tasks()` deletes hundreds of finished tasks, the physical rows remain in SSTables until compaction. Any subsequent read of the partition counts every column of every tombstoned row
  as a dead cell, triggering `tombstone_warn_threshold` warnings in large clusters.

## Solution

Two-part fix:

**1. Range tombstones instead of row tombstones (commits 2–3)**

Instead of one row tombstone per finished task, find the minimum alive task UUID (`min_alive_uuid`) and emit a single range tombstone `[before_all, min_alive_uuid)` covering all tasks below that boundary. This reduces the tombstone count significantly and also benefits future compaction.

**2. Bounded scan with `min_task_id` (commits 4–6)**

Even with range tombstones, physical rows remain until compaction and still count as dead cells during reads. The only way to avoid them is to not read them at all.

   - Add a `min_task_id timeuuid` static column to `system.view_building_tasks`.
   - On every GC, write `min_task_id = min_alive_uuid` atomically with the range tombstone (same Raft batch).
   - On reload, read `min_task_id` first using a **static-only partition slice** (empty `_row_ranges` + `always_return_static_content`): the SSTable reader stops immediately after the static row before processing any clustering tombstones — zero dead cells counted.
   - Use `AND id >= min_task_id` as a lower bound for the main task scan, skipping all tombstoned rows.

The static-only read and the bounded scan are gated on the `VIEW_BUILDING_TASKS_MIN_TASK_ID` cluster feature so mixed-version clusters fall back to the full scan.

The issue is not critical, so the fix shouldn't be backported.

Fixes SCYLLADB-657