### PR TITLE
gitignore: add missing rust build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ compile_commands.json
 clang_build
 .idea/
 nuke
-rust/target
+rust/**/target
+rust/**/Cargo.lock
+test/resource/wasm/rust/target


### PR DESCRIPTION
## Summary
- Add `rust/**/target` to cover `rust/inc/target/` and `rust/wasmtime_bindings/target/` (the existing `rust/target` only matched the top-level directory)
- Add `rust/**/Cargo.lock` for generated lock files under subdirectories
- Add `test/resource/wasm/rust/target` for WASM test build artifacts

These show up as untracked files after building.