### PR TITLE
Alternator stream tests migration

### DIFF
--- a/test/cluster/dtest/alternator/utils/enums.py
+++ b/test/cluster/dtest/alternator/utils/enums.py
@@ -1,0 +1,22 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+
+from enum import Enum
+
+
+class StreamViewType(Enum):
+    KEYS_ONLY = 'KEYS_ONLY'
+    NEW_IMAGE = 'NEW_IMAGE'
+    OLD_IMAGE = 'OLD_IMAGE'
+    NEW_AND_OLD_IMAGES = 'NEW_AND_OLD_IMAGES'
+
+
+class StreamSpecification(Enum):
+    KEYS_ONLY = {'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': StreamViewType.KEYS_ONLY.value}}
+    NEW_IMAGE = {'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': StreamViewType.NEW_IMAGE.value}}
+    OLD_IMAGE = {'StreamSpecification': {'StreamEnabled': True, 'StreamViewType': StreamViewType.OLD_IMAGE.value}}
+    NEW_AND_OLD_IMAGE = {'StreamSpecification': {
+        'StreamEnabled': True, 'StreamViewType': StreamViewType.NEW_AND_OLD_IMAGES.value}}

--- a/test/cluster/dtest/alternator/utils/enums.py
+++ b/test/cluster/dtest/alternator/utils/enums.py
@@ -1,7 +1,7 @@
 #
 # Copyright (C) 2026-present ScyllaDB
 #
-# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
 from enum import Enum

--- a/test/cluster/dtest/alternator_stream_tests.py
+++ b/test/cluster/dtest/alternator_stream_tests.py
@@ -1,0 +1,552 @@
+#
+# Copyright (C) 2020-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import logging
+import random
+from pprint import pformat
+
+import pytest
+from alternator.utils import enums
+from alternator_utils import (
+    NUM_OF_ITEMS,
+    TABLE_NAME,
+    BaseAlternatorStream,
+    StreamsTable,
+)
+from test.pylib.skip_types import skip_not_implemented
+from tools.retrying import retrying
+from tools.cluster import new_node
+
+logger = logging.getLogger(__name__)
+
+
+class TestAlternatorStreams(BaseAlternatorStream):
+    @pytest.fixture(autouse=True)
+    def skip_if_tablets(self):
+        if self.dtest_config.tablets:
+            skip_not_implemented("Alternator Streams not yet supported with tablets (issue #23838)")
+
+    def test_verify_all_nodes_have_same_stream(self):
+        num_of_items = NUM_OF_ITEMS
+        self.prepare_dynamodb_cluster(num_of_nodes=3)
+        node1 = self.cluster.nodelist()[0]
+        stream_arn = self.prefill_dynamodb_table(node=node1, stream_specification=enums.StreamSpecification.KEYS_ONLY.value, num_of_items=num_of_items)[0]
+        expected_items = [{self._table_primary_key: item[self._table_primary_key]} for item in self.create_items()]
+
+        for node in self.cluster.nodelist():
+            responses = self.get_responses(node=node, stream_arn=stream_arn, num_of_requests=num_of_items)
+            records = self.extract_data_from_responses(responses, event_names=frozenset(("INSERT",)))
+            diff = self.compare_table_keys_only_data(expected_table_data=expected_items, table_data=records)
+            assert not diff, f"The following keys are missing '{pformat(diff)}'"
+
+    @pytest.mark.cluster_options(uuid_sstable_identifiers_enabled=False)
+    def test_verify_stream_records_after_topology_changed(self):  # noqa: PLR0915
+        """
+        The tests verify the data after topology changes - Stream during maintenance operations that alter topology
+         (ex. Decommission/stop/delete/add node).
+        Create a test that checks there are no new events after reading multiple records from different nodes.
+        """
+
+        def _add_new_nodes(nodes_size):
+            new_nodes = []
+            for node_idx in range(cluster_size + 1, cluster_size + 1 + nodes_size):
+                logger.info(f"Adding new node{node_idx} to cluster")
+                node = new_node(self.cluster, bootstrap=True)
+                node.start(wait_for_binary_proto=True, wait_other_notice=True)
+                self.wait_for_alternator(node=node)
+                logger.info(f"The node{node_idx} was successfully added")
+                new_nodes.append(node)
+            return new_nodes
+
+        def _verify_items(_node, _expected_table_data, _num_of_requests, event_names):
+            logger.info(f'Verifying the new items exists in "{_node.name}" node, expecting "{_num_of_requests}" items')
+            responses = self.get_responses(node=_node, stream_arn=stream_arn, num_of_requests=_num_of_requests)
+            records = self.extract_data_from_responses(responses, event_names)
+            diff = self.compare_table_keys_only_data(expected_table_data=_expected_table_data, table_data=records)
+            assert not diff, f"The following keys are missing '{pformat(diff)}'"
+
+        stream_specification = enums.StreamSpecification.KEYS_ONLY.value
+        table_name = TABLE_NAME
+        cluster_size = 3
+        self.prepare_dynamodb_cluster(num_of_nodes=cluster_size)
+        node1, node2, node3 = self.cluster.nodelist()
+
+        logger.info(f'Pre setup - Creating "{table_name}" table via "{node1.name}" node with "{stream_specification}" stream key')
+        self.create_table(node=node1, table_name=table_name, stream_specification=stream_specification)
+        items = self.create_items(num_of_items=400)
+        logger.info(f'Waiting until stream of "{table_name}" table be active')
+        stream_arn = self.wait_for_active_stream(node=node1, table_name=table_name)[0]
+
+        node4, node5 = _add_new_nodes(nodes_size=2)
+        selected_node = node1
+        expected_table_data = new_items = items[:100]
+        logger.info(f'Step 1 - Adding "{len(new_items)}" new items from "{node1.name}" node')
+        self.batch_write_actions(table_name=table_name, node=node1, new_items=new_items)
+        _verify_items(_node=selected_node, _expected_table_data=expected_table_data, _num_of_requests=len(expected_table_data), event_names=frozenset(("INSERT",)))
+
+        new_items = items[100:200]
+        expected_table_data.extend(new_items)
+        logger.info(f'Step 2 - Adding "{len(new_items)}" new items from "{node2.name}" node')
+        self.batch_write_actions(table_name=table_name, node=node2, new_items=new_items)
+        logger.info(f'Decommission the "{selected_node.name}" node')
+        selected_node.decommission()
+        _verify_items(_node=node4, _expected_table_data=expected_table_data, _num_of_requests=len(expected_table_data), event_names=frozenset(("INSERT",)))
+
+        new_items = items[200:300]
+        expected_table_data.extend(new_items)
+        logger.info(f'Step 3 - Adding "{len(new_items)}" new items from "{node3.name}" node')
+        self.batch_write_actions(table_name=table_name, node=node3, new_items=new_items)
+        logger.info(f'Stopping the "{node4.name}" node')
+        node4.stop(wait_other_notice=True)
+        logger.info(f'Starting the "{node4.name}" node')
+        node4.start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.wait_for_alternator(node=node4)
+        _verify_items(_node=node3, _expected_table_data=expected_table_data, _num_of_requests=len(expected_table_data), event_names=frozenset(("INSERT",)))
+
+        new_items = items[300:400]
+        expected_table_data.extend(new_items)
+        logger.info(f'Step 4 - Adding 100 new items from "{node4.name}" node')
+        self.batch_write_actions(table_name=table_name, node=node4, new_items=new_items)
+        logger.info(f'Deleting the "{node4.name}" node')
+        self.cluster.remove(node4, wait_other_notice=True)
+        _verify_items(_node=node5, _expected_table_data=expected_table_data, _num_of_requests=len(expected_table_data), event_names=frozenset(("INSERT",)))
+
+    def test_list_streams_limit_parameter(self):
+        """
+        Test the list_streams command limit parameter.
+        See that when the response is large enough, it can be paged
+        correctly according the 'limit' value.
+        Test steps:
+        1. create and enable streams for 20 tables.
+        2. read variable size chunks of these tables streams in list_streams command via random node.
+        3. where using and verifying different 'limit' values + its total output.
+        """
+        stream_specification = enums.StreamSpecification.KEYS_ONLY.value
+        self.prepare_dynamodb_cluster(num_of_nodes=3)
+        node1 = self.cluster.nodelist()[0]
+        table_names = [TABLE_NAME + str(idx) for idx in range(20)]
+        for table_name in table_names:
+            self.create_table(node=node1, table_name=table_name, stream_specification=stream_specification)
+        tables_arns = [self.wait_for_active_stream(node=node1, table_name=table_name)[0] for table_name in table_names]
+        total_limited_stream_responses = []
+        last_evaluated_stream_arn = None
+        for limit in [5, 7, 3, 1, 4]:  # slice the created 20 tables to various size chunks
+            params = {"Limit": limit}
+            if last_evaluated_stream_arn:
+                params["ExclusiveStartStreamArn"] = last_evaluated_stream_arn
+            dynamodb_api = self.get_dynamodb_api(node=random.choice(self.cluster.nodelist()))
+            result = dynamodb_api.stream.list_streams(**params)
+            assert len(result["Streams"]) == limit, f"Got unexpected number of streams [{len(result['Streams'])}] for [{limit}] requested!"
+            total_limited_stream_responses += result["Streams"]
+            last_evaluated_stream_arn = result["LastEvaluatedStreamArn"]
+        assert sorted(tables_arns) == sorted([stream["StreamArn"] for stream in total_limited_stream_responses]), f"Got unexpected ARN values by list streams paged responses: {total_limited_stream_responses}"
+        empty_streams_list = dynamodb_api.stream.list_streams(ExclusiveStartStreamArn=last_evaluated_stream_arn)["Streams"]
+        assert len(empty_streams_list) == 0, f"Got unexpected list of Streams after the last evaluated Stream: {empty_streams_list}"
+
+    def test_updated_shards_during_add_decommission_node(self):
+        """
+        Verify Streams stays healthy across a one-shot decommission+add-node workflow.
+
+        For vnode-based CDC we expect stream metadata to change after topology
+        changes. For tablet-based CDC topology changes should not affect the
+        number of streams, so we verify the open shard count is unchanged and
+        matches the CDC log tablet count.
+        """
+        self.fixture_dtest_setup.ignore_log_patterns += [
+            r"storage_proxy - exception during mutation.*exceptions::mutation_write_timeout_exception"
+        ]
+
+        stream_specification = enums.StreamSpecification.KEYS_ONLY.value
+        self.prepare_dynamodb_cluster(num_of_nodes=4)
+        node1 = self.cluster.nodelist()[0]
+
+        logger.info(
+            f'Pre setup - Creating "{TABLE_NAME}" table via "{node1.name}" '
+            f'with "{stream_specification}" stream key'
+        )
+        stream_arn = self.prefill_dynamodb_table(
+            node=node1,
+            stream_specification=stream_specification,
+        )[0]
+
+        stress_thread = self.run_write_stress(
+            table_name=TABLE_NAME,
+            node=node1,
+            num_of_item=1000,
+            ignore_errors=True,
+        )
+
+        try:
+            streams_table = StreamsTable(
+                stream_arn=stream_arn,
+                dynamodb_api=self.get_dynamodb_api(node=node1),
+            )
+
+            initial_open_shard_ids = set(streams_table.open_shard_ids_set)
+            initial_shard_ids = set(streams_table.shard_ids_set)
+            initial_open_shard_count = streams_table.count_open_shards()
+
+            topology_result = self.run_decommission_add_node_once()
+
+            if self.dtest_config.tablets:
+                # With tablets, topology changes should NOT affect the number
+                # of streams — only tablet splits/merges do.  Verify the open
+                # shard count is unchanged and still matches the tablet count.
+                cql_session = self.patient_cql_connection(node1)
+                wait_for_stable_alternator_api(
+                    test=self,
+                    node=node1,
+                    table_name=TABLE_NAME,
+                    probes=2,
+                )
+                assert_open_shards_match_tablet_count(
+                    cql_session=cql_session,
+                    table_name=TABLE_NAME,
+                    streams_table=streams_table,
+                )
+                streams_table.update_shards()
+                post_open_shard_count = streams_table.count_open_shards()
+                assert post_open_shard_count == initial_open_shard_count, (
+                    f"Open shard count changed after topology operation "
+                    f"({initial_open_shard_count} -> {post_open_shard_count}), "
+                    f"but topology changes should not affect tablet-based streams"
+                )
+            else:
+                logger.debug("Waiting for stream metadata to change after topology operation")
+                check_vnode_streams_changed_after_topology(
+                    test=self,
+                    node=node1,
+                    table_name=TABLE_NAME,
+                    streams_table=streams_table,
+                    initial_open_shard_ids=initial_open_shard_ids,
+                    initial_shard_ids=initial_shard_ids,
+                )
+            wait_for_expected_topology_effect(
+                test=self,
+                removed_node_name=topology_result["removed_node_name"],
+                added_node=topology_result["added_node"],
+                table_name=TABLE_NAME,
+            )
+        finally:
+            stress_thread.join()
+
+    def test_sequence_numbers_during_add_decommission_node(self):
+        """
+        Verify streams/shards behavior on topology changes.
+
+        For vnode-based CDC:
+          1) new start sequence numbers eventually appear,
+          2) new start sequence numbers are monotonically increasing,
+          3) closed shards have EndingSequenceNumber > StartingSequenceNumber.
+
+        For tablet-based CDC:
+          topology changes should not affect the number of streams.
+          Verify that open shard count remains stable and matches
+          the CDC log tablet count after each topology round.
+        """
+        stream_specification = enums.StreamSpecification.KEYS_ONLY.value
+        self.prepare_dynamodb_cluster(num_of_nodes=4)
+        node1 = self.cluster.nodelist()[0]
+
+        logger.info(
+            f'Pre setup - Creating "{TABLE_NAME}" table via "{node1.name}" '
+            f'with "{stream_specification}" stream key'
+        )
+        stream_arn = self.prefill_dynamodb_table(
+            node=node1,
+            stream_specification=stream_specification,
+        )[0]
+
+        times = 1000 if self.cluster.scylla_mode != "debug" else 20
+
+        self.put_table_items(
+            table_name=TABLE_NAME,
+            node=node1,
+            num_of_items=times,
+        )
+
+        streams_table = StreamsTable(
+            stream_arn=stream_arn,
+            dynamodb_api=self.get_dynamodb_api(node=node1),
+        )
+
+        rounds = 2
+
+        for round_idx in range(rounds):
+            logger.info("Starting topology round %s", round_idx + 1)
+
+            streams_table.update_shards()
+            original_start_sequence_numbers_set = set(streams_table.start_sequence_numbers_set)
+            original_start_sequence_numbers = list(streams_table.start_sequence_numbers_list)
+            max_original_start_sequence_number = (
+                max(original_start_sequence_numbers)
+                if original_start_sequence_numbers else -1
+            )
+            initial_open_shard_count = streams_table.count_open_shards()
+
+            topology_result = self.run_decommission_add_node_once()
+
+            if self.dtest_config.tablets:
+                # With tablets, topology changes should NOT affect the number
+                # of streams — only tablet splits/merges do.
+                wait_for_stable_alternator_api(
+                    test=self,
+                    node=node1,
+                    table_name=TABLE_NAME,
+                    probes=2,
+                )
+                cql_session = self.patient_cql_connection(node1)
+                assert_open_shards_match_tablet_count(
+                    cql_session=cql_session,
+                    table_name=TABLE_NAME,
+                    streams_table=streams_table,
+                )
+                streams_table.update_shards()
+                post_open_shard_count = streams_table.count_open_shards()
+                assert post_open_shard_count == initial_open_shard_count, (
+                    f"Open shard count changed after topology round {round_idx + 1} "
+                    f"({initial_open_shard_count} -> {post_open_shard_count}), "
+                    f"but topology changes should not affect tablet-based streams"
+                )
+            else:
+                wait_for_vnode_sequence_change_after_topology(
+                    test=self,
+                    node=node1,
+                    table_name=TABLE_NAME,
+                    streams_table=streams_table,
+                    old_start_sequence_numbers_set=original_start_sequence_numbers_set,
+                    writes_per_probe=times,
+                )
+
+                new_start_sequence_numbers = [
+                    seq_num
+                    for seq_num in streams_table.start_sequence_numbers_list
+                    if seq_num not in original_start_sequence_numbers
+                ]
+
+                assert new_start_sequence_numbers, \
+                    f"No new start sequence numbers after topology round {round_idx + 1}"
+
+                assert min(new_start_sequence_numbers) > max_original_start_sequence_number, \
+                    f"New Start sequence number is not greater than previous one in round {round_idx + 1}"
+
+                closed_shards = [
+                    shard for shard in streams_table.shards
+                    if not streams_table.is_shard_open(shard)
+                ]
+                assert closed_shards, \
+                    f"No closed shards found after topology round {round_idx + 1}"
+
+                for shard in closed_shards:
+                    assert int(shard["SequenceNumberRange"]["EndingSequenceNumber"]) > int(
+                        shard["SequenceNumberRange"]["StartingSequenceNumber"]
+                    ), "EndingSequenceNumber is not greater than StartingSequenceNumber"
+
+            wait_for_expected_topology_effect(
+                test=self,
+                removed_node_name=topology_result["removed_node_name"],
+                added_node=topology_result["added_node"],
+                table_name=TABLE_NAME,
+            )
+
+    def test_added_node_gets_closed_shards(self):
+        """
+        test scenario:
+            1. create a table with Streams.
+            2. run alternator stress. (or multiple stresses to multiple nodes needed?)
+            3. add new node to cluster.
+            4. wait for new node bootstrap.
+            5. run streams APIs queries, connecting to the new node.
+            6. see that it returns some 'closed' shards with EndingSequenceNumber.
+            https://github.com/scylladb/scylla/pull/8209#issuecomment-790625323
+
+        https://github.com/scylladb/scylladb/issues/15260
+        """
+        stream_specification = enums.StreamSpecification.KEYS_ONLY.value
+        self.prepare_dynamodb_cluster(num_of_nodes=3)
+        node1 = self.cluster.nodelist()[0]
+
+        logger.info(f'Pre setup - Creating "{TABLE_NAME}" table via "{node1.name}" node with "{stream_specification}" stream key')
+        stream_arn = self.prefill_dynamodb_table(node=node1, stream_specification=stream_specification)[0]
+        stress_thread = self.run_write_stress(table_name=TABLE_NAME, node=node1, num_of_item=1000, ignore_errors=True)
+        logger.info("Adding new node to cluster")
+        node4 = new_node(self.cluster, bootstrap=True)
+        node4.start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.wait_for_alternator(node=node4)
+        logger.info(f"{node4.name} was successfully added")
+        streams_table = StreamsTable(stream_arn=stream_arn, dynamodb_api=self.get_dynamodb_api(node=node4))
+        closed_shards = [shard for shard in streams_table.shards if not streams_table.is_shard_open(shard)]
+        assert closed_shards, f"New node {node4.name} has no closed shards"
+        stress_thread.join()
+
+
+@retrying(num_attempts=60, sleep_time=2, allowed_exceptions=AssertionError)
+def wait_for_expected_topology_effect(test, removed_node_name, added_node, table_name):
+    """
+    Verify the one-shot topology operation converged to the expected observable state:
+    - removed node is not running anymore
+    - added node is running and serves Alternator
+    """
+    nodes = test.cluster.nodelist()
+
+    removed_nodes = [node for node in nodes if node.name == removed_node_name]
+    if removed_nodes:
+        assert not removed_nodes[0].is_running(), \
+            f"Removed node {removed_node_name} is still running"
+
+    assert added_node.is_running(), f"Added node {added_node.name} is not running"
+
+    wait_for_stable_alternator_api(
+        test=test,
+        node=added_node,
+        table_name=table_name,
+        probes=2,
+    )
+
+
+@retrying(num_attempts=30, sleep_time=1, allowed_exceptions=AssertionError)
+def wait_for_stable_alternator_api(test, node, table_name=None, probes=3):
+    """
+    Verify Alternator serves real API requests repeatedly, not just a single HTTP probe.
+    """
+    dynamodb_api = test.get_dynamodb_api(node=node)
+
+    for _ in range(probes):
+        test.wait_for_alternator(node=node, timeout=5)
+        if table_name:
+            response = dynamodb_api.client.describe_table(TableName=table_name)
+            assert response["Table"]["TableStatus"] in ("ACTIVE", "UPDATING"), \
+                f"Unexpected table status: {response['Table']['TableStatus']}"
+        else:
+            dynamodb_api.client.list_tables()
+
+
+@retrying(num_attempts=30, sleep_time=1, allowed_exceptions=AssertionError)
+def wait_for_vnode_sequence_change_after_topology(
+    test,
+    node,
+    table_name,
+    streams_table,
+    old_start_sequence_numbers_set,
+    writes_per_probe,
+):
+    test.put_table_items(
+        table_name=table_name,
+        node=node,
+        num_of_items=writes_per_probe,
+    )
+
+    wait_for_stable_alternator_api(
+        test=test,
+        node=node,
+        table_name=table_name,
+        probes=2,
+    )
+
+    streams_table.update_shards()
+    new_start_sequence_numbers_set = (
+        streams_table.start_sequence_numbers_set - old_start_sequence_numbers_set
+    )
+    assert new_start_sequence_numbers_set, \
+        "Start-sequence-numbers are not changed after topology operation"
+
+
+@retrying(num_attempts=30, sleep_time=2, allowed_exceptions=AssertionError)
+def assert_open_shards_match_tablet_count(
+    cql_session,
+    table_name: str,
+    streams_table: StreamsTable,
+) -> None:
+    """
+    Post-topology-change invariant check for tablet-aware Alternator Streams.
+
+    With the tablets-based CDC implementation each tablet in the CDC log table
+    (``<table_name>_scylla_cdc_log``) maps to exactly one active CDC stream,
+    which in turn surfaces as a single *open* shard in the DynamoDB Streams API.
+
+    Therefore, after topology convergence the following invariant must hold::
+
+        open_shard_count == tablet_count(cdc_log_table)
+
+    Only call this when tablets are enabled (caller's responsibility — see the
+    ``if self.dtest_config.tablets`` guard at the call site).
+
+    Decorated with ``@retrying`` so it keeps polling until the cluster's tablet
+    metadata converges after a node operation (~60 s total).
+
+    :param cql_session: Active cassandra-driver ``Session``.  Should be created
+        **once** by the caller so the same connection is reused across retries.
+    :param table_name: Alternator (DynamoDB) table name, e.g. ``"user_table"``.
+    :param streams_table: :class:`StreamsTable` tracking the table's stream ARN.
+    """
+    ks_name = f"alternator_{table_name}"
+    cdc_log_table = f"{table_name}_scylla_cdc_log"
+
+    # Issue a read barrier so the queried node reflects the latest committed
+    # (group-0-replicated) tablet metadata before we read system.tablets.
+    cql_session.execute("DROP TABLE IF EXISTS nosuchkeyspace.nosuchtable")
+
+    # Resolve the table_id for the CDC log table from system_schema.tables.
+    schema_rows = cql_session.execute(
+        f"SELECT id FROM system_schema.tables "
+        f"WHERE keyspace_name = '{ks_name}' AND table_name = '{cdc_log_table}'"
+    )
+    schema_row = schema_rows.one()
+    assert schema_row is not None, (
+        f"CDC log table {ks_name}.{cdc_log_table} not found in system_schema.tables"
+    )
+    table_id = schema_row.id
+
+    # Each row in system.tablets (per table_id partition) represents one tablet.
+    cnt_rows = cql_session.execute(
+        f"SELECT count(*) AS cnt FROM system.tablets WHERE table_id = {table_id}"
+    )
+    tablet_count = int(cnt_rows.one().cnt)
+    assert tablet_count > 0, (
+        f"No tablets found for {ks_name}.{cdc_log_table} in system.tablets"
+    )
+
+    # Refresh Streams API metadata and count the open (active) shards.
+    # An open shard has no EndingSequenceNumber – it corresponds to a live CDC stream.
+    streams_table.update_shards()
+    open_shard_count = streams_table.count_open_shards()
+
+    assert open_shard_count == tablet_count, (
+        f"Open Streams shards ({open_shard_count}) != "
+        f"tablet count ({tablet_count}) for {ks_name}.{cdc_log_table}. "
+        f"Open shard IDs: {streams_table.open_shard_ids_set}"
+    )
+    logger.info(
+        "Verified: %d open shards == %d tablets for %s.%s",
+        open_shard_count,
+        tablet_count,
+        ks_name,
+        cdc_log_table,
+    )
+
+
+@retrying(num_attempts=30, sleep_time=1, allowed_exceptions=AssertionError)
+def check_vnode_streams_changed_after_topology(
+    test,
+    node,
+    table_name,
+    streams_table,
+    initial_open_shard_ids,
+    initial_shard_ids,
+):
+    wait_for_stable_alternator_api(
+        test=test,
+        node=node,
+        table_name=table_name,
+        probes=2,
+    )
+
+    streams_table.update_shards()
+    open_shards_changed = streams_table.open_shard_ids_set != initial_open_shard_ids
+    shard_set_changed = streams_table.shard_ids_set != initial_shard_ids
+
+    assert open_shards_changed or shard_set_changed, \
+        "Shard metadata did not change after topology operation"

--- a/test/cluster/dtest/alternator_utils.py
+++ b/test/cluster/dtest/alternator_utils.py
@@ -16,23 +16,27 @@ import tempfile
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from copy import deepcopy
+from copy import copy, deepcopy
 from decimal import Decimal
 from enum import Enum
 from itertools import chain
+from pprint import pformat
 from typing import TYPE_CHECKING
 
 import boto3
 import botocore.client
 import pytest
 import requests
+from boto3.dynamodb.types import TypeDeserializer
 from deepdiff import DeepDiff
 from requests.exceptions import ConnectionError
 
-from test.cluster.dtest.alternator.utils import schemas
+from test.cluster.dtest.alternator.utils import enums, schemas
 from test.cluster.dtest.dtest_class import Tester, get_ip_from_node
+from test.cluster.dtest.dtest_setup_overrides import DTestSetupOverrides
 from test.cluster.dtest.tools.cluster import new_node
 from test.cluster.dtest.tools.cluster_topology import generate_cluster_topology
+from test.cluster.dtest.tools.retrying import retrying
 from test.cluster.dtest.tools.sslkeygen import create_self_signed_x509_certificate
 
 if TYPE_CHECKING:
@@ -538,6 +542,34 @@ class BaseAlternator(Tester):
         logger.info(f"Node successfully added!")
         time.sleep(5)
 
+    def run_decommission_add_node_once(self):
+        """
+        Run a single decommission+add-node topology operation and return
+        details that tests can verify afterwards.
+        The replacement node is added to the same DC and rack as the decommissioned node.
+        """
+        node_to_remove = self.cluster.nodelist()[-1]
+        removed_node_name = node_to_remove.name
+        dc = node_to_remove.data_center
+        rack = node_to_remove.rack
+
+        logger.info(f"Decommissioning {removed_node_name} (dc={dc}, rack={rack})..")
+        node_to_remove.decommission()
+
+        logger.info(f"Adding new node to cluster in dc={dc}, rack={rack}..")
+        # Preserve the DC and rack of the decommissioned node.
+        node = self.cluster.populate({dc: {rack: 1}}).nodelist()[-1]
+        node.start(wait_for_binary_proto=True, wait_other_notice=True)
+        self.wait_for_alternator(node=node)
+
+        logger.info(f"Node {node.name} successfully re-added!")
+        return {
+            "removed_node": node_to_remove,
+            "removed_node_name": removed_node_name,
+            "added_node": node,
+            "added_node_name": node.name,
+        }
+
     def run_create_table(self):
         try:
             node1 = self.cluster.nodelist()[0]
@@ -669,7 +701,6 @@ class BaseAlternator(Tester):
         return self.batch_write_actions(table_name=table_name, node=node, new_items=new_items)
 
 
-
 def random_string(length: int, chars=string.ascii_uppercase + string.digits):
     return "".join(random.choices(chars, k=length))
 
@@ -701,3 +732,369 @@ def full_query(table, consistent_read=True, **kwargs):
         response = table.query(ExclusiveStartKey=response["LastEvaluatedKey"], **kwargs)
         items.extend(response["Items"])
     return items
+
+
+class BaseAlternatorStream(BaseAlternator):
+    @property
+    def boto_config(self):
+        return botocore.client.Config(retries={"max_attempts": 5}, read_timeout=300)
+
+    @pytest.fixture(scope="function", autouse=True)
+    def fixture_dtest_setup_overrides(self, dtest_config):
+        ring_delay_sec = 5
+        dtest_setup_overrides = DTestSetupOverrides()
+        dtest_setup_overrides.cluster_options = {
+            "experimental_features": ["cdc", "alternator-streams"],
+            "ring_delay_ms": ring_delay_sec * 1000,
+            "hinted_handoff_enabled": False,
+        }
+        return dtest_setup_overrides
+
+    def _add_api_for_node(self, node: ScyllaNode, timeout: int = 300) -> None:
+        super()._add_api_for_node(node=node, timeout=timeout)
+        node_stream_address = self.get_alternator_api_url(node=node)
+        self.alternator_apis[node.name].stream = boto3.client(
+            service_name="dynamodbstreams",
+            endpoint_url=node_stream_address,
+            **self.dynamo_params,
+        )
+
+    def prepare_dynamodb_cluster(  # noqa: PLR0913
+            self,
+            num_of_nodes: int = NUM_OF_NODES,
+            is_multi_dc: bool = False,
+            is_encrypted: bool = False,
+            extra_config: dict | None = None,
+            timeout: int = 300,
+    ) -> None:
+        """Override to start nodes sequentially for CDC/Streams tests.
+
+        All nodes are materialized first so their addresses are known before
+        startup. This allows generating a certificate that covers the full
+        cluster while still starting nodes one by one.
+        """
+        logger.debug(
+            f"Populating a cluster with {num_of_nodes} nodes for "
+            f"{'single DC' if not is_multi_dc else 'multi DC'} (sequential).."
+        )
+
+        self.alternator_urls = {}
+        self.alternator_apis = {}
+        self.is_encrypted = is_encrypted
+
+        cluster_config = {
+            "start_native_transport": True,
+            "alternator_write_isolation": "always",
+        }
+
+        key_file: str | None = None
+
+        if self.is_encrypted:
+            # Paths are interpreted relative to each node's workdir.
+            self.cert_file = "scylla.crt"
+            key_file = "scylla.key"
+            cluster_config["alternator_encryption_options"] = {
+                "certificate": self.cert_file,
+                "keyfile": key_file,
+            }
+            cluster_config["alternator_https_port"] = ALTERNATOR_SECURE_PORT
+        else:
+            cluster_config["alternator_port"] = ALTERNATOR_PORT
+
+        if extra_config:
+            cluster_config.update(extra_config)
+
+        logger.debug(f"configure_dynamodb_cluster: {cluster_config}")
+        self.cluster.set_configuration_options(cluster_config)
+
+        # Materialize all nodes first so their IPs are known before startup.
+        # We still start them one by one below.
+        self.cluster.populate(num_of_nodes)
+        nodes = self.cluster.nodelist()
+
+        if self.is_encrypted:
+            assert key_file is not None
+            cert_dir = nodes[0].get_path()
+            cert_path = os.path.join(cert_dir, self.cert_file)
+            key_path = os.path.join(cert_dir, key_file)
+
+            create_self_signed_x509_certificate(
+                test_path=cert_dir,
+                cert_file=cert_path,
+                key_file=key_path,
+                ip_list=[node.address() for node in nodes],
+            )
+
+        logger.debug("Starting node 1")
+        nodes[0].start(wait_for_binary_proto=True, wait_other_notice=True)
+
+        for i, node in enumerate(nodes[1:], start=2):
+            logger.debug(f"Starting node {i}")
+            node.start(wait_for_binary_proto=True, wait_other_notice=True)
+
+        self.wait_for_alternator(timeout=timeout)
+
+    def wait_for_active_stream(self, node: ScyllaNode, table_name: str = TABLE_NAME, timeout: int = 60):
+        dynamodb_api = self.get_dynamodb_api(node=node)
+
+        @retrying(num_attempts=timeout, sleep_time=1, allowed_exceptions=(ValueError,),
+                  message=f"The stream ARN of '{table_name}' table not found")
+        def get_stream_arn():
+            for stream in dynamodb_api.stream.list_streams(TableName=table_name)["Streams"]:
+                arn = stream["StreamArn"]
+                if arn:
+                    describe_stream = dynamodb_api.stream.describe_stream(StreamArn=arn)["StreamDescription"]
+                    if "StreamStatus" not in describe_stream or describe_stream.get("StreamStatus") == "ENABLED":
+                        return arn, stream["StreamLabel"]
+            raise ValueError("The ARN value not found!")
+
+        return get_stream_arn()
+
+    def prefill_dynamodb_table(self, node: ScyllaNode, table_name: str = TABLE_NAME,
+                               num_of_items: int = NUM_OF_ITEMS,
+                               wait_for_active_stream: bool = True, **kwargs):
+        self.create_table(table_name=table_name, node=node, **kwargs)
+        stream_arn_details = None
+        if wait_for_active_stream:
+            stream_arn_details = self.wait_for_active_stream(node=node, table_name=table_name)
+        new_items = self.create_items(num_of_items=num_of_items)
+        self.batch_write_actions(table_name=table_name, node=node, new_items=new_items)
+        return stream_arn_details
+
+    @staticmethod
+    def extract_data_from_responses(responses, event_names) -> list[dict]:
+        """
+        Extract the data from each response according the stream's type.
+        Also, removing all the additional DynamoDB fields that were added by the stream.
+        The method returns a list of dictionaries, like the list of items that we generate.
+        """
+        deserializer = TypeDeserializer()
+        response_key_translate = {
+            enums.StreamViewType.KEYS_ONLY.value: "Keys",
+            enums.StreamViewType.NEW_AND_OLD_IMAGES.value: "NewImage",
+            enums.StreamViewType.NEW_IMAGE.value: "NewImage",
+            enums.StreamViewType.OLD_IMAGE.value: "OldImage",
+        }
+        records = []
+        for response in responses:
+            if response["eventName"] in event_names:
+                response_data = response["dynamodb"][response_key_translate[response["dynamodb"]["StreamViewType"]]]
+                records.append({key: deserializer.deserialize(value) for key, value in response_data.items()})
+        return records
+
+    def get_responses(self, node: ScyllaNode, stream_arn: str, num_of_requests: int, timeout: int | None = None):
+        """
+        The function extracts "num_of_requests" requests from the stream. For each request, the method extracts
+        the information itself and does not return until all requested details are received from the stream.
+        """
+        dynamodb_api = self.get_dynamodb_api(node=node)
+        # According to the following https://github.com/scylladb/scylla/issues/6929 issue, there is a delay of 10
+        #  seconds between the insertion until the stream is updated
+        soft_timeout = 60
+        alternator_streams_time_window = 60 * 5
+        hard_timeout = timeout or alternator_streams_time_window
+
+        def get_responses():
+            logger.debug(f'Search "{num_of_requests}" requests in "{node.name}"')
+            _responses, shard_iterators, next_iterators = [], [], []
+            describe_stream = dynamodb_api.stream.describe_stream(StreamArn=stream_arn)
+            logger.info(f'Describe stream is: {describe_stream}')
+            while True:
+                for shard in describe_stream["StreamDescription"]["Shards"]:
+                    shard_iterators.append(
+                        dynamodb_api.stream.get_shard_iterator(
+                            StreamArn=stream_arn,
+                            ShardId=shard["ShardId"],
+                            ShardIteratorType="AT_SEQUENCE_NUMBER",
+                            SequenceNumber=shard["SequenceNumberRange"]["StartingSequenceNumber"],
+                        )["ShardIterator"]
+                    )
+                last_shard = describe_stream["StreamDescription"].get("LastEvaluatedShardId")
+                if not last_shard:
+                    break
+                describe_stream = dynamodb_api.stream.describe_stream(StreamArn=stream_arn, ExclusiveStartShardId=last_shard)
+
+            is_loop_stop = False
+            _start_time = time.time()
+            while len(_responses) < num_of_requests and not is_loop_stop:
+                for shard_iterator in shard_iterators:
+                    elapsed_time = time.time() - _start_time
+                    if elapsed_time > soft_timeout:
+                        logger.error(f"Did not get all shard iterators by timeout threshold of {soft_timeout}")
+                        time.sleep(10)
+                    if elapsed_time > hard_timeout:
+                        logger.error(f"Did not get all shard iterators by timeout threshold of {hard_timeout}")
+                        is_loop_stop = True
+                        break
+                    response = dynamodb_api.stream.get_records(ShardIterator=shard_iterator, Limit=1000)
+                    if response.get("NextShardIterator"):
+                        next_iterators.append(response["NextShardIterator"])
+                    if response.get("Records"):
+                        _responses.extend(response["Records"])
+
+                shard_iterators = copy(next_iterators)
+                next_iterators.clear()
+            return _responses
+
+        start_time = time.time()
+        responses = get_responses()
+        is_continue_loop = True
+        while len(responses) < num_of_requests and is_continue_loop:
+            logger.info(f'Found "{len(responses)}" responses and not "{num_of_requests}" responses.')
+            time_diff = hard_timeout - (time.time() - start_time)
+            if time_diff > 0:
+                logger.info(f'Sleeping "{time_diff:.4}", and searching the missing "{num_of_requests - len(responses)}" responses.')
+                time.sleep(time_diff)
+            responses = get_responses()
+            is_continue_loop = (hard_timeout - (time.time() - start_time)) > 0
+
+        logger.info(f'Finding "{len(responses)}" response after "{(time.time() - start_time):.6}"')
+        return responses
+
+    def compare_table_keys_only_data(  # noqa: PLR0913
+        self,
+        expected_table_data: list[dict[str, str]],
+        table_name: str | None = None,
+        node: ScyllaNode = None,
+        ignore_order: bool = True,
+        consistent_read: bool = True,
+        table_data: list[dict[str, str]] | None = None,
+        **kwargs,
+    ) -> DeepDiff:
+        if table_data is None:
+            logger.debug("No table data was requested, running a table scan to get it")
+            table_data = self.scan_table(table_name=table_name, node=node, ConsistentRead=consistent_read, **kwargs)
+        expected_table_data = [{self._table_primary_key: item[self._table_primary_key]} for item in expected_table_data]
+        diff = DeepDiff(t1=expected_table_data, t2=table_data, ignore_order=ignore_order, ignore_numeric_type_changes=True)
+        if diff:
+            logger.debug("Found a diff in the following comparison:")
+            logger.debug(f"expected table data: {expected_table_data}")
+            logger.debug(f"Actual received data: {table_data}")
+            logger.debug(f"The following keys are missing '{pformat(diff)}'")
+        return diff
+
+
+class StreamsTable:
+    """Store and track a Streams processed table state."""
+
+    def __init__(self, stream_arn: str, dynamodb_api):
+        self.stream_arn = stream_arn
+        self.dynamodb_api = dynamodb_api
+        self.describe_stream = {}
+        self.shards = []
+        self.update_shards()
+
+    def get_describe_stream(self, shard_id=None):
+        if shard_id:
+            return self.dynamodb_api.stream.describe_stream(StreamArn=self.stream_arn, ExclusiveStartShardId=shard_id)
+        return self.dynamodb_api.stream.describe_stream(StreamArn=self.stream_arn)
+
+    def update_shards(self):
+        self.describe_stream = describe_stream = self.get_describe_stream()
+        shards = describe_stream["StreamDescription"]["Shards"]
+        last_shard = describe_stream["StreamDescription"].get("LastEvaluatedShardId")
+        while last_shard:
+            describe_stream = self.get_describe_stream(shard_id=last_shard)
+            shards.extend(describe_stream["StreamDescription"]["Shards"])
+            last_shard = describe_stream["StreamDescription"].get("LastEvaluatedShardId")
+        logger.info("Shards updated status is:")
+        logger.info(f"Existing number of shards [{len(self.shards)}] is updated to: [{len(shards)}]")
+        logger.info(f"Existing number of open shards [{self.count_open_shards()}] is updated to: [{self.count_open_shards(shards)}]")
+        self.shards = shards
+
+    @staticmethod
+    def is_shard_open(shard) -> bool:
+        return "EndingSequenceNumber" not in shard["SequenceNumberRange"] or not shard["SequenceNumberRange"]["EndingSequenceNumber"]
+
+    @property
+    def shard_ids_set(self):
+        return {shard["ShardId"] for shard in self.shards}
+
+    @property
+    def open_shard_ids_set(self):
+        return {shard["ShardId"] for shard in self.shards if self.is_shard_open(shard)}
+
+    @property
+    def closed_shard_ids_set(self):
+        return {shard["ShardId"] for shard in self.shards if not self.is_shard_open(shard)}
+
+    def count_open_shards(self, shards: list | None = None):
+        shards = shards or self.shards
+        return len([shard for shard in shards if self.is_shard_open(shard=shard)])
+
+    def _get_sequence_number_shard_iterator(self, shard_id, shard_iterator_type, sequence_number):
+        return self.dynamodb_api.stream.get_shard_iterator(
+            StreamArn=self.stream_arn, ShardId=shard_id,
+            ShardIteratorType=shard_iterator_type, SequenceNumber=sequence_number,
+        )["ShardIterator"]
+
+    def _get_trim_horizon_shard_iterator(self, shard_id):
+        return self.dynamodb_api.stream.get_shard_iterator(
+            StreamArn=self.stream_arn, ShardId=shard_id, ShardIteratorType="TRIM_HORIZON",
+        )["ShardIterator"]
+
+    def get_shard_iterators(self, shards: list | None = None, shard_iterator_type: str = "TRIM_HORIZON", verbose=True) -> list:
+        shards = shards or self.shards
+        shard_iterators = list()
+
+        if shard_iterator_type == "TRIM_HORIZON":
+            for shard in shards:
+                shard_iterators.append(self._get_trim_horizon_shard_iterator(shard_id=shard["ShardId"]))
+        else:
+            for shard in shards:
+                # Currently getting shard iterators only by shard's StartingSequenceNumber
+                sequence_number = shard["SequenceNumberRange"]["StartingSequenceNumber"]
+                shard_iterators.append(self._get_sequence_number_shard_iterator(
+                    shard_id=shard["ShardId"], shard_iterator_type=shard_iterator_type, sequence_number=sequence_number,
+                ))
+        if verbose:
+            logger.debug(f"Found {len(shard_iterators)} shard iterators for {len(shards)} shards.")
+        return shard_iterators
+
+    def get_iterators_records(self, shard_iterators: list | None = None) -> tuple[list, list]:
+        records_responses = list()
+        next_iterators = list()
+        shard_iterators = shard_iterators or self.get_shard_iterators()
+        for shard_iterator in shard_iterators:
+            response = self.dynamodb_api.stream.get_records(ShardIterator=shard_iterator, Limit=1000)
+            if response.get("NextShardIterator"):
+                next_iterators.append(response["NextShardIterator"])
+            if response.get("Records"):
+                records_responses.extend(response["Records"])
+
+        return records_responses, next_iterators
+
+    def get_records(self, shard_iterators: list | None = None, timeout: int = 15, multiple_iterators: bool = True, verbose=True) -> list:
+        """Getting Stream records by shard iterators.
+        :param shard_iterators: shard iterators list.
+        :param timeout: for how long it'll run queries for more records.
+        :param multiple_iterators: should it continue query by the 'next' received iterators.
+        :return: the records found by given shard iterators.
+        """
+        records_responses, next_iterators = self.get_iterators_records(shard_iterators=shard_iterators)
+        total_iterators_num = len(shard_iterators)
+        if multiple_iterators:
+            _start_time = time.time()
+            timeout_exceeded = False
+            while next_iterators and not timeout_exceeded:
+                total_iterators_num += len(next_iterators)
+                next_records_response, next_iterators = self.get_iterators_records(shard_iterators=next_iterators)
+                if next_records_response:
+                    records_responses.extend(next_records_response)
+                timeout_exceeded = (time.time() - _start_time) > timeout
+        if verbose:
+            logger.debug(f"Found {len(records_responses)} records for {total_iterators_num} shard iterators.")
+        return records_responses
+
+    def get_open_shards_records(self):
+        open_shards = [shard for shard in self.shards if self.is_shard_open(shard)]
+        open_shard_iterators = self.get_shard_iterators(shards=open_shards)
+        return self.get_records(shard_iterators=open_shard_iterators)
+
+    @property
+    def start_sequence_numbers_set(self):
+        return set([shard["SequenceNumberRange"]["StartingSequenceNumber"] for shard in self.shards])
+
+    @property
+    def start_sequence_numbers_list(self):
+        return [int(sequence_number) for sequence_number in self.start_sequence_numbers_set]

--- a/test/cluster/dtest/ccmlib/scylla_cluster.py
+++ b/test/cluster/dtest/ccmlib/scylla_cluster.py
@@ -224,6 +224,20 @@ class ScyllaCluster:
                 self.manager.server_update_config(server_id=node.server_id, config_options=values)
         return self
 
+    def remove(self, node: ScyllaNode, wait_other_notice: bool = False) -> None:
+        """Remove a node from the cluster (stop + removenode).
+
+        Mirrors the old ccmlib ``Cluster.remove(node)`` semantics: the node
+        is stopped first, then a running peer initiates the Scylla removenode
+        operation so the node is properly evicted from the topology.
+        """
+        if node.is_running():
+            node.stop(gently=False, wait_other_notice=wait_other_notice)
+        live_nodes = [n for n in self.nodelist() if n.is_running() and n.server_id != node.server_id]
+        assert live_nodes, "No live nodes to initiate removenode"
+        initiator = live_nodes[0]
+        self.manager.remove_node(initiator.server_id, node.server_id)
+
     def flush(self) -> None:
         self.nodetool("flush")
 

--- a/test/cluster/test_config.yaml
+++ b/test/cluster/test_config.yaml
@@ -48,5 +48,6 @@ run_in_dev:
   - dtest/commitlog_test
   - dtest/cfid_test
   - dtest/rebuild_test
+  - dtest/alternator_stream_tests
 run_in_debug:
   - random_failures/test_random_failures


### PR DESCRIPTION
migrating alternator_stream_tests.py module to scylla repo as part of dtest framework deprecation

Some helpers were adapted to the new framework, so this is not a 1:1 mechanical port. The goal was to preserve the behavior and test intent relevant to these scenarios, while mapping the old helper logic onto the new cluster lifecycle.

Enable the test in test_config.yaml (run in dev mode only)

Fixes SCYLLADB-945
