### PR TITLE
test/vector_search: enhance boost tests error logging

### DIFF
--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -95,7 +95,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_request_is_aborted) {
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as);
 
     BOOST_CHECK(client.is_up());
-    BOOST_CHECK(!res);
+    BOOST_REQUIRE(!res);
     BOOST_CHECK(std::holds_alternative<aborted_error>(res.error()));
 
     co_await client.close();
@@ -144,7 +144,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_server_is_not_available) 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
     BOOST_CHECK(!client.is_up());
-    BOOST_CHECK(!res);
+    BOOST_REQUIRE(!res);
     BOOST_CHECK(std::holds_alternative<service_unavailable_error>(res.error()));
 
     co_await client.close();
@@ -208,7 +208,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_connection_times_out) {
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
     BOOST_CHECK(!client.is_up());
-    BOOST_CHECK(!res);
+    BOOST_REQUIRE(!res);
     BOOST_CHECK(std::holds_alternative<service_unavailable_error>(res.error()));
 
     co_await unreachable.close();

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -45,7 +45,7 @@ future<std::unique_ptr<vs_mock_server>> make_available(std::unique_ptr<unavailab
 
 } // namespace
 
-SEASTAR_TEST_CASE(is_up_after_construction) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_after_construction) {
     auto server = co_await make_vs_mock_server();
     client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
@@ -55,7 +55,7 @@ SEASTAR_TEST_CASE(is_up_after_construction) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_server_returned_ok_status) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_ok_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
@@ -69,7 +69,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_ok_status) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_server_returned_client_error_status) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_client_error_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::bad_request, "Bad request"});
@@ -85,7 +85,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_client_error_status) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_request_is_aborted) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_request_is_aborted) {
     abort_source as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::ok, "{}"});
@@ -102,7 +102,7 @@ SEASTAR_TEST_CASE(is_up_when_request_is_aborted) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_server_returned_server_error_status) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_server_error_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::internal_server_error, "Internal Server Error"});
@@ -119,7 +119,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_server_error_status) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_service_unavailable_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::service_unavailable, "Service Unavailable"});
@@ -136,7 +136,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
     co_await server->stop();
 }
 
-SEASTAR_TEST_CASE(is_down_when_server_is_not_available) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_server_is_not_available) {
     abort_source_timeout as;
     auto down_server = co_await make_unavailable_server();
     client client{client_test_logger, make_endpoint(down_server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
@@ -151,7 +151,7 @@ SEASTAR_TEST_CASE(is_down_when_server_is_not_available) {
     co_await down_server->stop();
 }
 
-SEASTAR_TEST_CASE(becomes_up_when_server_status_is_serving) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(becomes_up_when_server_status_is_serving) {
     abort_source_timeout as;
     auto down_server = co_await make_unavailable_server();
     client client{client_test_logger, make_endpoint(down_server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
@@ -170,7 +170,7 @@ SEASTAR_TEST_CASE(becomes_up_when_server_status_is_serving) {
     co_await down_server->stop();
 }
 
-SEASTAR_TEST_CASE(remains_down_when_server_status_is_not_serving) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(remains_down_when_server_status_is_not_serving) {
     abort_source_timeout as;
     std::vector<sstring> non_serving_statuses{
             "INITIALIZING",
@@ -199,7 +199,7 @@ SEASTAR_TEST_CASE(remains_down_when_server_status_is_not_serving) {
     }
 }
 
-SEASTAR_TEST_CASE(is_down_when_connection_times_out) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_connection_times_out) {
     abort_source_timeout as;
     auto unreachable = co_await make_unreachable_socket();
     client client{client_test_logger, client::endpoint_type{unreachable.host, unreachable.port, seastar::net::inet_address(unreachable.host)},

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_server_erro
 
     BOOST_CHECK(client.is_up());
     BOOST_CHECK(res);
-    BOOST_CHECK(res->status == seastar::http::reply::status_type::internal_server_error);
+    BOOST_CHECK_EQUAL(res->status, seastar::http::reply::status_type::internal_server_error);
 
     co_await client.close();
     co_await server->stop();
@@ -130,7 +130,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_service_una
 
     BOOST_CHECK(client.is_up());
     BOOST_CHECK(res);
-    BOOST_CHECK(res->status == seastar::http::reply::status_type::service_unavailable);
+    BOOST_CHECK_EQUAL(res->status, seastar::http::reply::status_type::service_unavailable);
 
     co_await client.close();
     co_await server->stop();

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -78,7 +78,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_client_erro
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
     BOOST_CHECK(client.is_up());
-    BOOST_CHECK(res);
+    if (!res) {
+        BOOST_FAIL("Expected successful request, but got error: " << std::visit(error_visitor{}, res.error()));
+    }
     BOOST_CHECK_EQUAL(res.value().status, seastar::http::reply::status_type::bad_request);
 
     co_await client.close();
@@ -96,7 +98,8 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_request_is_aborted) {
 
     BOOST_CHECK(client.is_up());
     BOOST_REQUIRE(!res);
-    BOOST_CHECK(std::holds_alternative<aborted_error>(res.error()));
+    BOOST_CHECK_MESSAGE(std::holds_alternative<aborted_error>(res.error()),
+            "Expected aborted_error, got: " << std::visit(error_visitor{}, res.error()));
 
     co_await client.close();
     co_await server->stop();
@@ -112,7 +115,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_server_erro
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
     BOOST_CHECK(client.is_up());
-    BOOST_CHECK(res);
+    if (!res) {
+        BOOST_FAIL("Expected successful request, but got error: " << std::visit(error_visitor{}, res.error()));
+    }
     BOOST_CHECK_EQUAL(res->status, seastar::http::reply::status_type::internal_server_error);
 
     co_await client.close();
@@ -129,7 +134,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_up_when_server_returned_service_una
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
     BOOST_CHECK(client.is_up());
-    BOOST_CHECK(res);
+    if (!res) {
+        BOOST_FAIL("Expected successful request, but got error: " << std::visit(error_visitor{}, res.error()));
+    }
     BOOST_CHECK_EQUAL(res->status, seastar::http::reply::status_type::service_unavailable);
 
     co_await client.close();
@@ -145,7 +152,8 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_server_is_not_available) 
 
     BOOST_CHECK(!client.is_up());
     BOOST_REQUIRE(!res);
-    BOOST_CHECK(std::holds_alternative<service_unavailable_error>(res.error()));
+    BOOST_CHECK_MESSAGE(std::holds_alternative<service_unavailable_error>(res.error()),
+            "Expected service_unavailable_error, got: " << std::visit(error_visitor{}, res.error()));
 
     co_await client.close();
     co_await down_server->stop();
@@ -163,7 +171,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(becomes_up_when_server_status_is_servi
     auto became_up = co_await repeat_until([&client]() -> future<bool> {
         co_return client.is_up();
     });
-    BOOST_CHECK(became_up);
+    BOOST_CHECK_MESSAGE(became_up, "Timed out waiting for client to become up");
 
     co_await client.close();
     co_await server->stop();
@@ -190,7 +198,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(remains_down_when_server_status_is_not
             // waiting for 2 status requests to be sure that node had a chance to become up
             co_return server->status_requests().size() >= 2;
         });
-        BOOST_CHECK(got_2_status_requests);
+        BOOST_CHECK_MESSAGE(got_2_status_requests, "Timed out waiting for 2 status requests");
         BOOST_CHECK(!client.is_up());
 
         co_await client.close();
@@ -209,7 +217,8 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(is_down_when_connection_times_out) {
 
     BOOST_CHECK(!client.is_up());
     BOOST_REQUIRE(!res);
-    BOOST_CHECK(std::holds_alternative<service_unavailable_error>(res.error()));
+    BOOST_CHECK_MESSAGE(std::holds_alternative<service_unavailable_error>(res.error()),
+            "Expected service_unavailable_error, got: " << std::visit(error_visitor{}, res.error()));
 
     co_await unreachable.close();
     co_await client.close();

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -14,6 +14,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
 #include "utils/rjson.hh"
+#include "utils.hh"
 #include "vector_search/filter.hh"
 
 BOOST_AUTO_TEST_SUITE(filter_test)
@@ -58,7 +59,7 @@ sstring get_restrictions_json(const restrictions::statement_restrictions& restr,
 
 } // anonymous namespace
 
-SEASTAR_TEST_CASE(to_json_empty_restrictions) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_empty_restrictions) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -70,7 +71,7 @@ SEASTAR_TEST_CASE(to_json_empty_restrictions) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_with_allow_filtering) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_with_allow_filtering) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -82,7 +83,7 @@ SEASTAR_TEST_CASE(to_json_with_allow_filtering) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_eq) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_eq) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -94,7 +95,7 @@ SEASTAR_TEST_CASE(to_json_single_column_eq) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_lt) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_lt) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -106,7 +107,7 @@ SEASTAR_TEST_CASE(to_json_single_column_lt) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_gt) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_gt) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -118,7 +119,7 @@ SEASTAR_TEST_CASE(to_json_single_column_gt) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_lte) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_lte) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -130,7 +131,7 @@ SEASTAR_TEST_CASE(to_json_single_column_lte) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_gte) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_gte) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -142,7 +143,7 @@ SEASTAR_TEST_CASE(to_json_single_column_gte) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_single_column_in) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_single_column_in) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -154,7 +155,7 @@ SEASTAR_TEST_CASE(to_json_single_column_in) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_string_value) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_string_value) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk text, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -166,7 +167,7 @@ SEASTAR_TEST_CASE(to_json_string_value) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_eq) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_eq) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -178,7 +179,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_eq) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_lt) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_lt) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -190,7 +191,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_lt) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_gt) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_gt) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -202,7 +203,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_gt) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_lte) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_lte) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -214,7 +215,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_lte) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_gte) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_gte) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -226,7 +227,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_gte) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multi_column_in) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multi_column_in) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -238,7 +239,7 @@ SEASTAR_TEST_CASE(to_json_multi_column_in) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_multiple_restrictions) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_multiple_restrictions) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -250,7 +251,7 @@ SEASTAR_TEST_CASE(to_json_multiple_restrictions) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_with_boolean_value) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_with_boolean_value) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck boolean, v vector<float, 3>, primary key(pk, ck))");
 
@@ -262,7 +263,7 @@ SEASTAR_TEST_CASE(to_json_with_boolean_value) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_partition_key) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_partition_key) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -278,7 +279,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_partition_key) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_clustering_key) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_clustering_key) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -296,7 +297,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_clustering_key) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_different_values) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_different_values) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -317,7 +318,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_different_values) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_string_value) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_string_value) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk text, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -333,7 +334,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_string_value) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_mixed_literals_and_bind_markers) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_mixed_literals_and_bind_markers) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -349,7 +350,7 @@ SEASTAR_TEST_CASE(to_json_mixed_literals_and_bind_markers) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_in_list) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_in_list) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -368,7 +369,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_in_list) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_bind_marker_multi_column) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_bind_marker_multi_column) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck1 int, ck2 int, v vector<float, 3>, primary key(pk, ck1, ck2))");
 
@@ -387,7 +388,7 @@ SEASTAR_TEST_CASE(to_json_bind_marker_multi_column) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_no_bind_markers_uses_cache) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_no_bind_markers_uses_cache) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -407,7 +408,7 @@ SEASTAR_TEST_CASE(to_json_no_bind_markers_uses_cache) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_nonprimary_key_eq) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_nonprimary_key_eq) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, r int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -419,7 +420,7 @@ SEASTAR_TEST_CASE(to_json_nonprimary_key_eq) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_nonprimary_key_range) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_nonprimary_key_range) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, r int, v vector<float, 3>, primary key(pk, ck))");
 
@@ -431,7 +432,7 @@ SEASTAR_TEST_CASE(to_json_nonprimary_key_range) {
     });
 }
 
-SEASTAR_TEST_CASE(to_json_nonprimary_key_bind_marker) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(to_json_nonprimary_key_bind_marker) {
     return do_with_cql_env_thread([](cql_test_env& e) {
         cquery_nofail(e, "create table ks.t(pk int, ck int, r int, v vector<float, 3>, primary key(pk, ck))");
 

--- a/test/vector_search/load_balancer_test.cc
+++ b/test/vector_search/load_balancer_test.cc
@@ -29,7 +29,7 @@ BOOST_AUTO_TEST_CASE(next_returns_all_elements_in_random_order) {
         read.push_back(n);
     }
 
-    BOOST_CHECK_EQUAL(read.size(), 3);
+    BOOST_REQUIRE_EQUAL(read.size(), 3);
     BOOST_CHECK_EQUAL(*read[0], 2);
     BOOST_CHECK_EQUAL(*read[1], 3);
     BOOST_CHECK_EQUAL(*read[2], 1);

--- a/test/vector_search/rescoring_test.cc
+++ b/test/vector_search/rescoring_test.cc
@@ -337,9 +337,11 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(similarity_function_returns_correctly_
                         BOOST_CHECK_EQUAL(rows.size(), 2);
                         BOOST_CHECK_EQUAL(rms->rs().result_set().get_metadata().column_count(), 2);
                         BOOST_CHECK_EQUAL(get_id_col_value(rows.at(0)), 1);
-                        BOOST_CHECK(is_similarity_eq(get_similarity_col_value(rows.at(0)), params.expected_similarity[0]));
+                        BOOST_CHECK_MESSAGE(is_similarity_eq(get_similarity_col_value(rows.at(0)), params.expected_similarity[0]),
+                                "Similarity mismatch for row 0: got " << get_similarity_col_value(rows.at(0)) << ", expected " << params.expected_similarity[0]);
                         BOOST_CHECK_EQUAL(get_id_col_value(rows.at(1)), 2);
-                        BOOST_CHECK(is_similarity_eq(get_similarity_col_value(rows.at(1)), params.expected_similarity[1]));
+                        BOOST_CHECK_MESSAGE(is_similarity_eq(get_similarity_col_value(rows.at(1)), params.expected_similarity[1]),
+                                "Similarity mismatch for row 1: got " << get_similarity_col_value(rows.at(1)) << ", expected " << params.expected_similarity[1]);
                     }
                 },
                 make_config(format("http://server.node:{}", server->port())))
@@ -414,9 +416,11 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(select_similarity_function_other_than_
                 BOOST_CHECK_EQUAL(rows.size(), 2);
                 BOOST_CHECK_EQUAL(rms->rs().result_set().get_metadata().column_count(), 2);
                 BOOST_CHECK_EQUAL(get_id_col_value(rows.at(0)), 1);
-                BOOST_CHECK(is_similarity_eq(get_similarity_col_value(rows.at(0)), params.expected_similarity[1]));
+                BOOST_CHECK_MESSAGE(is_similarity_eq(get_similarity_col_value(rows.at(0)), params.expected_similarity[1]),
+                        "Similarity mismatch for row 0: got " << get_similarity_col_value(rows.at(0)) << ", expected " << params.expected_similarity[1]);
                 BOOST_CHECK_EQUAL(get_id_col_value(rows.at(1)), 2);
-                BOOST_CHECK(is_similarity_eq(get_similarity_col_value(rows.at(1)), params.expected_similarity[0]));
+                BOOST_CHECK_MESSAGE(is_similarity_eq(get_similarity_col_value(rows.at(1)), params.expected_similarity[0]),
+                        "Similarity mismatch for row 1: got " << get_similarity_col_value(rows.at(1)) << ", expected " << params.expected_similarity[0]);
             },
             make_config(format("http://server.node:{}", server->port())))
             .finally(seastar::coroutine::lambda([&] -> future<> {

--- a/test/vector_search/rescoring_test.cc
+++ b/test/vector_search/rescoring_test.cc
@@ -107,7 +107,7 @@ struct print_log_value<std::vector<float>> {
 };
 }
 
-SEASTAR_TEST_CASE(index_option_quantization_valid_values) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_quantization_valid_values) {
     std::vector<sstring> supported_quantizations = {"f32", "f16", "bf16", "i8", "b1", "F32", "F16", "BF16", "I8", "B1"};
     for (const auto& quantization : supported_quantizations) {
         co_await do_with_cql_env(
@@ -121,7 +121,7 @@ SEASTAR_TEST_CASE(index_option_quantization_valid_values) {
     }
 }
 
-SEASTAR_TEST_CASE(index_option_quantization_invalid_value) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_quantization_invalid_value) {
     co_await do_with_cql_env(
             [](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "cf");
@@ -133,7 +133,7 @@ SEASTAR_TEST_CASE(index_option_quantization_invalid_value) {
             make_config());
 }
 
-SEASTAR_TEST_CASE(index_option_oversampling_valid_values) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_oversampling_valid_values) {
     std::vector<sstring> valid_factors = {"1.0", "50.5", "100.0", "10", "1e1", "1000000e-4", "0x10", "  10  "};
     for (const auto& factor : valid_factors) {
         co_await do_with_cql_env(
@@ -147,7 +147,7 @@ SEASTAR_TEST_CASE(index_option_oversampling_valid_values) {
     }
 }
 
-SEASTAR_TEST_CASE(index_option_oversampling_invalid_values) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_oversampling_invalid_values) {
     std::vector<sstring> invalid_factors = {"0.9", "100.1", "0", "-5", "abc", "   ", "NaN", "inf"};
     for (const auto& factor : invalid_factors) {
         co_await do_with_cql_env(
@@ -163,7 +163,7 @@ SEASTAR_TEST_CASE(index_option_oversampling_invalid_values) {
     }
 }
 
-SEASTAR_TEST_CASE(index_option_rescoring_valid_values) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_rescoring_valid_values) {
     std::vector<sstring> valid_rescoring = {"true", "false", "True", "False", "TRUE", "FALSE"};
     for (const auto& rescoring : valid_rescoring) {
         co_await do_with_cql_env(
@@ -177,7 +177,7 @@ SEASTAR_TEST_CASE(index_option_rescoring_valid_values) {
     }
 }
 
-SEASTAR_TEST_CASE(index_option_rescoring_invalid_value) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(index_option_rescoring_invalid_value) {
     std::vector<sstring> invalid_rescoring = {"invalid_value", "0", "1", " true", "false "};
     for (const auto& rescoring : invalid_rescoring) {
         co_await do_with_cql_env(
@@ -193,7 +193,7 @@ SEASTAR_TEST_CASE(index_option_rescoring_invalid_value) {
     }
 }
 
-SEASTAR_TEST_CASE(oversampling_multiplies_limit_for_vector_store_query) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(oversampling_multiplies_limit_for_vector_store_query) {
     auto server = co_await make_vs_mock_server();
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -214,7 +214,7 @@ SEASTAR_TEST_CASE(oversampling_multiplies_limit_for_vector_store_query) {
             }));
 }
 
-SEASTAR_TEST_CASE(oversampled_vector_store_results_are_limited_to_cql_limit) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(oversampled_vector_store_results_are_limited_to_cql_limit) {
     auto server = co_await make_vs_mock_server();
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
@@ -244,7 +244,7 @@ SEASTAR_TEST_CASE(oversampled_vector_store_results_are_limited_to_cql_limit) {
             }));
 }
 
-SEASTAR_TEST_CASE(result_returned_by_vector_store_is_rescored) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(result_returned_by_vector_store_is_rescored) {
 
     for (const auto& params : test_data) {
         auto server = co_await make_vs_mock_server();
@@ -277,7 +277,7 @@ SEASTAR_TEST_CASE(result_returned_by_vector_store_is_rescored) {
     }
 }
 
-SEASTAR_TEST_CASE(f32_quantization_disables_rescoring) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(f32_quantization_disables_rescoring) {
 
     auto server = co_await make_vs_mock_server();
     co_await do_with_cql_env(
@@ -308,7 +308,7 @@ SEASTAR_TEST_CASE(f32_quantization_disables_rescoring) {
             }));
 }
 
-SEASTAR_TEST_CASE(similarity_function_returns_correctly_rescored_results) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(similarity_function_returns_correctly_rescored_results) {
     // This is a dedicated test that uses a similarity function in the SELECT clause.
     // We want to keep two tests, one with and one without (see `result_returned_by_vector_store_is_rescored`)
     // a similarity function in the SELECT clause, to ensure both code paths are covered.
@@ -349,7 +349,7 @@ SEASTAR_TEST_CASE(similarity_function_returns_correctly_rescored_results) {
     }
 }
 
-SEASTAR_TEST_CASE(wildcard_select_is_correctly_rescored) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(wildcard_select_is_correctly_rescored) {
     // Another case with slightly different path of processing is "SELECT * ...".
 
     for (const auto& params : test_data) {
@@ -385,7 +385,7 @@ SEASTAR_TEST_CASE(wildcard_select_is_correctly_rescored) {
     }
 }
 
-SEASTAR_TEST_CASE(select_similarity_function_other_than_ann_ordering) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(select_similarity_function_other_than_ann_ordering) {
     // Another tricky case with similarity column with argument different from ANN ordering vector.
     // Especially if we use prepared statement and the difference is only seen at execution time.
     const auto& params = test_data[0];
@@ -426,7 +426,7 @@ SEASTAR_TEST_CASE(select_similarity_function_other_than_ann_ordering) {
 
 // Rescoring does not filter out NULL embeddings yet, but they should be sorted as last.
 // So this test is expected to report error on result set size, but passes if the first element is correct.
-SEASTAR_TEST_CASE(no_nulls_in_rescored_results, *boost::unit_test::expected_failures(3)) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(no_nulls_in_rescored_results, *boost::unit_test::expected_failures(3)) {
 
     for (const auto& params : test_data) {
         auto server = co_await make_vs_mock_server();
@@ -462,7 +462,7 @@ SEASTAR_TEST_CASE(no_nulls_in_rescored_results, *boost::unit_test::expected_fail
 }
 
 // Reproducer for SCYLLADB-456
-SEASTAR_TEST_CASE(rescoring_with_zerovector_query) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(rescoring_with_zerovector_query) {
     for (const auto& params : test_data) {
         auto server = co_await make_vs_mock_server();
         co_await do_with_cql_env(
@@ -478,16 +478,12 @@ SEASTAR_TEST_CASE(rescoring_with_zerovector_query) {
                     })"});
 
                     // For cosine similarity the ANN vector query would fail as `similarity_cosine` function did not support zero vectors.
-                    try {
-                        auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0, 0] LIMIT 3;");
+                    auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0, 0] LIMIT 3;");
 
-                        auto rms = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
-                        BOOST_REQUIRE(rms);
-                        const auto& rows = rms->rs().result_set().rows();
-                        BOOST_REQUIRE_EQUAL(rows.size(), 3);
-                    } catch (const std::exception& e) {
-                        BOOST_FAIL(e.what());
-                    }
+                    auto rms = dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg);
+                    BOOST_REQUIRE(rms);
+                    const auto& rows = rms->rs().result_set().rows();
+                    BOOST_REQUIRE_EQUAL(rows.size(), 3);
                 },
                 make_config(format("http://server.node:{}", server->port())))
                 .finally(seastar::coroutine::lambda([&] -> future<> {

--- a/test/vector_search/utils.hh
+++ b/test/vector_search/utils.hh
@@ -16,9 +16,24 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/http/httpd.hh>
 #include <seastar/net/api.hh>
+#include <seastar/testing/test_case.hh>
 #include <seastar/util/tmp_file.hh>
 #include <functional>
 #include <chrono>
+
+// Wrapper for SEASTAR_TEST_CASE that catches std::exception and fails with the exception message.
+// This is useful for tests that use co_await and want to catch exceptions that are thrown
+// by the coroutine, which would otherwise be silently swallowed.
+#define SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(name, ...)        \
+    static seastar::future<> name##_impl();                         \
+    SEASTAR_TEST_CASE(name __VA_OPT__(,) __VA_ARGS__) {            \
+        try {                                                       \
+            co_await name##_impl();                                 \
+        } catch (const std::exception& e) {                         \
+            BOOST_FAIL(e.what());                                   \
+        }                                                           \
+    }                                                               \
+    static seastar::future<> name##_impl()
 
 namespace test::vector_search {
 

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -385,7 +385,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_request) 
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().path, "/api/v1/indexes/ks/idx2/ann");
                 BOOST_REQUIRE(!keys);
                 auto* err = std::get_if<vector_store_client::service_error>(&keys.error());
-                BOOST_CHECK(err != nullptr);
+                BOOST_REQUIRE(err != nullptr);
                 BOOST_CHECK_EQUAL(err->status, status_type::not_found);
                 BOOST_CHECK_EQUAL(err->message, "idx2 not found");
 
@@ -857,7 +857,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_node_recovery_afte
                 // Send request to unavailable node - this will put the node to backoff.
                 auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
-                BOOST_CHECK(!result);
+                BOOST_REQUIRE(!result);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(result.error()));
 
                 // Replace the unavailable server with an available one.

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(vector_store_client_test_ctor) {
 }
 
 /// Resolving of the hostname is started in start_background_tasks()
-SEASTAR_TEST_CASE(vector_store_client_test_dns_started) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_started) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     auto vs = vector_store_client{cfg};
@@ -138,7 +138,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_started) {
 }
 
 /// Unable to resolve the hostname
-SEASTAR_TEST_CASE(vector_store_client_test_dns_resolve_failure) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_resolve_failure) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     auto as = abort_source_timeout();
@@ -155,7 +155,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_resolve_failure) {
 }
 
 /// Resolving of the hostname is repeated after errors
-SEASTAR_TEST_CASE(vector_store_client_test_dns_resolving_repeated) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_resolving_repeated) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     auto vs = vector_store_client{cfg};
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_resolving_repeated) {
 }
 
 /// Minimal interval between DNS refreshes is respected
-SEASTAR_TEST_CASE(vector_store_client_test_dns_refresh_respects_interval) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_refresh_respects_interval) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     auto vs = vector_store_client{cfg};
@@ -257,7 +257,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_refresh_respects_interval) {
 }
 
 /// DNS refresh could be aborted
-SEASTAR_TEST_CASE(vector_store_client_test_dns_refresh_aborted) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_refresh_aborted) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     seastar::condition_variable wait_for_abort;
@@ -282,7 +282,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_dns_refresh_aborted) {
     co_await vs.stop();
 }
 
-SEASTAR_TEST_CASE(vector_store_client_ann_test_disabled) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_ann_test_disabled) {
     co_await do_with_cql_env([](cql_test_env& env) -> future<> {
         auto as = abort_source_timeout();
         auto schema = co_await create_test_table(env, "ks", "vs");
@@ -294,7 +294,7 @@ SEASTAR_TEST_CASE(vector_store_client_ann_test_disabled) {
     });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_addr_unavailable) {
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set("http://bad.authority.here:6080");
     co_await do_with_cql_env(
@@ -316,7 +316,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_addr_unavailable) {
             cfg);
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_service_unavailable) {
     auto cfg = make_config();
     auto server = co_await make_unavailable_server();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
@@ -339,7 +339,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_unavailable) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_service_aborted) {
     auto cfg = make_config();
     auto server = co_await make_unavailable_server();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
@@ -367,7 +367,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_service_aborted) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_request) {
     auto server = co_await make_vs_mock_server();
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
@@ -447,7 +447,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_request) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_filtering_ann_request) {
     auto server = co_await make_vs_mock_server();
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
@@ -475,7 +475,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_request) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_cql) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_filtering_ann_cql) {
     // Similar to `vector_store_client_test_filtering_ann_request`,
     // but uses CQL query to verify that the WHERE clause expression (this time with IN operator) is handled correctly.
     using namespace test::vector_search;
@@ -513,7 +513,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_cql) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_uri_update_to_empty) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update_to_empty) {
     auto cfg = config();
     auto count = 0;
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
@@ -541,7 +541,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update_to_empty) {
     co_await vs.stop();
 }
 
-SEASTAR_TEST_CASE(vector_store_client_uri_update_to_non_empty) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update_to_non_empty) {
     auto cfg = config();
     std::vector<std::string> resolved;
     auto vs = vector_store_client{cfg};
@@ -563,7 +563,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update_to_non_empty) {
     co_await vs.stop();
 }
 
-SEASTAR_TEST_CASE(vector_store_client_uri_update_to_invalid) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update_to_invalid) {
     auto cfg = config();
     cfg.vector_store_primary_uri.set("http://good.authority.here:6080");
     auto vs = vector_store_client{cfg};
@@ -578,7 +578,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update_to_invalid) {
     co_await vs.stop();
 }
 
-SEASTAR_TEST_CASE(vector_store_client_uri_update) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update) {
     // Test verifies that when vector store uri is update, the client
     // will switch to the new uri within the DNS refresh interval.
     auto s1 = co_await make_vs_mock_server();
@@ -614,7 +614,7 @@ SEASTAR_TEST_CASE(vector_store_client_uri_update) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_multiple_ips_high_availability) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_ips_high_availability) {
 
     auto responding_s = co_await make_vs_mock_server();
     auto unavail_s = co_await make_unavailable_server(responding_s->port());
@@ -648,7 +648,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_high_availability) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_multiple_ips_load_balancing) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_ips_load_balancing) {
 
     auto s1 = co_await make_vs_mock_server();
     auto s2 = co_await make_vs_mock_server(s1->port());
@@ -679,7 +679,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_ips_load_balancing) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_multiple_uris_high_availability) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_uris_high_availability) {
 
     auto responding_s = co_await make_vs_mock_server();
     auto unavail_s = co_await make_unavailable_server();
@@ -713,7 +713,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_high_availability) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_uris_load_balancing) {
 
     auto s1 = co_await make_vs_mock_server();
     auto s2 = co_await make_vs_mock_server();
@@ -744,7 +744,7 @@ SEASTAR_TEST_CASE(vector_store_client_multiple_uris_load_balancing) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_search_metrics_test) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_search_metrics_test) {
 
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set("http://good.authority.here:6080");
@@ -766,7 +766,7 @@ SEASTAR_TEST_CASE(vector_search_metrics_test) {
             cfg);
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_paging_warning) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_paging_warning) {
     auto s1 = co_await make_vs_mock_server();
 
     auto cfg = make_config();
@@ -792,7 +792,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_paging_warning) {
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_paging_disabled) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_paging_warning_doesnt_show_when_paging_disabled) {
     auto s1 = co_await make_vs_mock_server();
 
     auto cfg = make_config();
@@ -817,7 +817,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_pagin
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_limit_less_than_page_size) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_paging_warning_doesnt_show_when_limit_less_than_page_size) {
     auto s1 = co_await make_vs_mock_server();
 
     auto cfg = make_config();
@@ -842,7 +842,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_paging_warning_doesnt_show_when_limit
             });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_node_recovery_after_backoff) {
     auto unavail_server = co_await make_unavailable_server();
     std::unique_ptr<vs_mock_server> avail_server;
     constexpr auto HOSTNAME = "server.node";
@@ -882,7 +882,7 @@ SEASTAR_TEST_CASE(vector_store_client_node_recovery_after_backoff) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failures) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_single_status_check_after_concurrent_failures) {
     using keys = std::expected<vector_store_client::primary_keys, vector_store_client::ann_error>;
 
     auto unavail_s = co_await make_unavailable_server();
@@ -927,7 +927,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_connection_timeout_cfg) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_updates_backoff_max_time_from_read_connection_timeout_cfg) {
     auto unavail_s = co_await make_unavailable_server();
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unavail.node:{}", unavail_s->port()));
@@ -973,7 +973,7 @@ SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_connect
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_secondary_uri) {
     auto primary = co_await make_unavailable_server();
     auto secondary = co_await make_vs_mock_server();
     auto cfg = make_config();
@@ -999,7 +999,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_secondary_uri_only) {
     auto secondary = co_await make_vs_mock_server();
     auto cfg = make_config();
     cfg.db_config->vector_store_secondary_uri.set(format("http://secondary.node:{}", secondary->port()));
@@ -1021,7 +1021,7 @@ SEASTAR_TEST_CASE(vector_store_client_secondary_uri_only) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_https) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https) {
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
     auto cfg = make_config();
@@ -1047,7 +1047,7 @@ SEASTAR_TEST_CASE(vector_store_client_https) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_rewrite_ca_cert) {
     auto broken_cert = co_await seastar::make_tmp_file();
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
@@ -1102,7 +1102,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_rewrite_ca_cert) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_https_wrong_hostname) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_hostname) {
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
     const auto hostname = fmt::format("wrong.{}", certs.server_cert_cn());
@@ -1128,7 +1128,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_hostname) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_cacert_verification_error) {
     auto broken_cert = co_await seastar::make_tmp_file();
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
@@ -1155,7 +1155,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error_host_is_ip) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_cacert_verification_error_host_is_ip) {
     auto broken_cert = co_await seastar::make_tmp_file();
     certificates certs;
     auto server = co_await make_vs_mock_server(co_await make_server_credentials(certs));
@@ -1182,7 +1182,7 @@ SEASTAR_TEST_CASE(vector_store_client_https_wrong_cacert_verification_error_host
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_high_availability_unreachable) {
     auto server = co_await make_vs_mock_server();
     auto unreachable = co_await make_unreachable_socket();
 
@@ -1218,7 +1218,7 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_abort_due_to_query_timeout) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_abort_due_to_query_timeout) {
     auto server = co_await make_vs_mock_server();
     server->ann_response_delay(std::chrono::seconds(10));
 
@@ -1246,7 +1246,7 @@ SEASTAR_TEST_CASE(vector_store_client_abort_due_to_query_timeout) {
 
 /// Verify that the HTTP error description from the vector store is propagated
 /// through the CQL interface as part of the invalid_request_exception message.
-SEASTAR_TEST_CASE(vector_store_client_cql_error_contains_http_error_description) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_cql_error_contains_http_error_description) {
     co_await do_with_vector_store_mock([](cql_test_env& env, vs_mock_server& server) -> future<> {
         co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding) USING 'vector_index'");
 
@@ -1268,7 +1268,7 @@ SEASTAR_TEST_CASE(vector_store_client_cql_error_contains_http_error_description)
 // on the SELECT query:
 //     ANN ordering by vector requires the column to be indexed using 'vector_index'.
 // Reproduces SCYLLADB-635.
-SEASTAR_TEST_CASE(vector_store_client_vector_index_with_additional_filtering_column) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_vector_index_with_additional_filtering_column) {
     co_await do_with_vector_store_mock([](cql_test_env& env, vs_mock_server&) -> future<> {
         // Create a vector index on the embedding column, including ck1 for filtered ANN search support.
         co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding, ck1) USING 'vector_index'");
@@ -1277,7 +1277,7 @@ SEASTAR_TEST_CASE(vector_store_client_vector_index_with_additional_filtering_col
     });
 }
 
-SEASTAR_TEST_CASE(vector_store_client_local_vector_index) {
+SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_local_vector_index) {
     co_await do_with_vector_store_mock([](cql_test_env& env, vs_mock_server&) -> future<> {
         // Create a local vector index on the 'embedding' column.
         co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test ((pk1, pk2), embedding) USING 'vector_index'");

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -781,7 +781,7 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_paging_warnin
                 auto msg = co_await env.execute_cql("SELECT * FROM ks.test ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 100;", std::move(qo));
                 auto warns = msg->warnings();
                 BOOST_REQUIRE_EQUAL(warns.size(), 1);
-                BOOST_CHECK(warns[0] == "Paging is not supported for Vector Search queries. The entire result set has been returned.");
+                BOOST_CHECK_EQUAL(warns[0], "Paging is not supported for Vector Search queries. The entire result set has been returned.");
             },
             cfg)
             .finally([&s1] {

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -173,18 +173,18 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_resolving
     vs.start_background_tasks();
 
     // Wait for the DNS resolution to fail
-    BOOST_CHECK(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
         auto addrs = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
         co_return addrs.empty();
-    }));
+    }), "Timed out waiting for DNS resolution to fail");
 
     fail_dns_resolution = false;
 
     // Wait for the DNS resolution to succeed
-    BOOST_CHECK(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
         auto addrs = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
         co_return addrs.size() == 1;
-    }));
+    }), "Timed out waiting for DNS resolution to succeed");
     auto addrs1 = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
     BOOST_REQUIRE_EQUAL(addrs1.size(), 1);
     BOOST_CHECK_EQUAL(print_addr(addrs1[0]), "127.0.0.1");
@@ -195,20 +195,20 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_dns_resolving
     vector_store_client_tester::trigger_dns_resolver(vs);
 
     // Wait for the DNS resolution to fail again
-    BOOST_CHECK(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
         auto addrs = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
         co_return addrs.empty();
-    }));
+    }), "Timed out waiting for DNS resolution to fail again");
 
     // Resolve to a different address
     address = inet_address("127.0.0.2");
     fail_dns_resolution = false;
 
     // Wait for the DNS resolution to succeed
-    BOOST_CHECK(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until(seconds(1), [&vs, &as]() -> future<bool> {
         auto addrs = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
         co_return addrs.size() == 1;
-    }));
+    }), "Timed out waiting for DNS resolution to succeed with new address");
     auto addrs2 = co_await vector_store_client_tester::resolve_hostname(vs, as.reset());
     BOOST_REQUIRE_EQUAL(addrs2.size(), 1);
     BOOST_CHECK_EQUAL(print_addr(addrs2[0]), "127.0.0.2");
@@ -287,7 +287,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_ann_test_disabled)
 
         auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
         BOOST_REQUIRE(!keys);
-        BOOST_CHECK(std::holds_alternative<vector_store_client::disabled>(keys.error()));
+        BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::disabled>(keys.error()),
+
+                "Expected disabled, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
     });
 }
 
@@ -308,7 +310,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_addr_unav
 
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::addr_unavailable>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::addr_unavailable>(keys.error()),
+
+                        "Expected addr_unavailable, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg);
 }
@@ -328,7 +332,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_service_u
 
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()),
+
+                        "Expected service_unavailable, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg)
             .finally([&server] {
@@ -356,7 +362,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_service_a
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset(milliseconds(10)));
 
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::aborted>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::aborted>(keys.error()),
+
+                        "Expected aborted, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg)
             .finally([&server] {
@@ -396,37 +404,49 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_test_ann_request) 
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().body, R"({"vector":[0.1,0.2,0.3],"limit":2})");
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().path, "/api/v1/indexes/ks/idx/ann");
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // missing distances in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances1":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // missing pk1 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk11":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // missing ck1 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck11":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // wrong size of pk2 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // wrong size of ck2 key in the reply - service should return format error
                 server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2]},"distances":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()),
+
+                        "Expected service_reply_format_error, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
 
                 // correct reply - service should return keys
                 server->next_ann_response({status_type::ok, CORRECT_RESPONSE_FOR_TEST_TABLE});
@@ -523,9 +543,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update_to_empt
     vs.start_background_tasks();
 
     // Wait for initial DNS resolution
-    BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
         co_return count > 0;
-    }));
+    }), "Timed out waiting for initial DNS resolution");
 
     cfg.vector_store_primary_uri.set("");
     vector_store_client_tester::trigger_dns_resolver(vs);
@@ -553,9 +573,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update_to_non_
 
     BOOST_CHECK(!vs.is_disabled());
     // Wait for the DNS resolver to be called
-    BOOST_CHECK(co_await repeat_until(std::chrono::seconds(1), [&]() -> future<bool> {
+    BOOST_CHECK_MESSAGE(co_await repeat_until(std::chrono::seconds(1), [&]() -> future<bool> {
         co_return resolved.size() > 0;
-    }));
+    }), "Timed out waiting for DNS resolver to be called");
     BOOST_CHECK_EQUAL(resolved.back(), "good.authority.here");
     co_await vs.stop();
 }
@@ -598,11 +618,11 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_uri_update) {
 
                 // Wait until requests are handled by s2
                 // To avoid race condition we wait twice long as DNS refresh interval before checking the result.
-                BOOST_CHECK(co_await repeat_until(DNS_REFRESH_INTERVAL * 2, [&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until(DNS_REFRESH_INTERVAL * 2, [&]() -> future<bool> {
                     auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     BOOST_CHECK(keys);
                     co_return s2->ann_requests().size() > 0;
-                }));
+                }), "Timed out waiting for requests to be handled by s2");
             },
             cfg)
             .finally(seastar::coroutine::lambda([&s1, &s2] -> future<> {
@@ -629,14 +649,16 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_ips_high_
 
                 // Because requests are distributed in random order due to load balancing,
                 // repeat the ANN query until the unavailable server is queried.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     co_return unavail_s->connections().size() > 1;
-                }));
+                }), "Timed out waiting for unavailable server to be queried");
 
                 // The query is successful because the client falls back to the available server
                 // when the attempt to connect to the unavailable one fails.
-                BOOST_CHECK(keys);
+                if (!keys) {
+                    BOOST_FAIL("Expected successful ANN result, but got error: " << std::visit(vector_search::error_visitor{}, keys.error()));
+                }
             },
             cfg)
             .finally(seastar::coroutine::lambda([&responding_s, &unavail_s] -> future<> {
@@ -663,11 +685,11 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_ips_load_
                 // Wait until requests are handled by both servers.
                 // The load balancing algorithm is random, so we send requests in a loop
                 // until both servers have received at least one, verifying that load is distributed.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     BOOST_CHECK(keys);
                     co_return !s1->ann_requests().empty() && !s2->ann_requests().empty();
-                }));
+                }), "Timed out waiting for both servers to receive requests");
             },
             cfg)
             .finally(seastar::coroutine::lambda([&s1, &s2] -> future<> {
@@ -694,14 +716,16 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_uris_high
 
                 // Because requests are distributed in random order due to load balancing,
                 // repeat the ANN query until the unavailable server is queried.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     co_return unavail_s->connections().size() > 1;
-                }));
+                }), "Timed out waiting for unavailable server to be queried");
 
                 // The query is successful because the client falls back to the available server
                 // when the attempt to connect to the unavailable one fails.
-                BOOST_CHECK(keys);
+                if (!keys) {
+                    BOOST_FAIL("Expected successful ANN result, but got error: " << std::visit(vector_search::error_visitor{}, keys.error()));
+                }
             },
             cfg)
             .finally(seastar::coroutine::lambda([&responding_s, &unavail_s] -> future<> {
@@ -728,11 +752,11 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_multiple_uris_load
                 // Wait until requests are handled by both servers.
                 // The load balancing algorithm is random, so we send requests in a loop
                 // until both servers have received at least one, verifying that load is distributed.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     BOOST_CHECK(keys);
                     co_return !s1->ann_requests().empty() && !s2->ann_requests().empty();
-                }));
+                }), "Timed out waiting for both servers to receive requests");
             },
             cfg)
             .finally(seastar::coroutine::lambda([&s1, &s2] -> future<> {
@@ -858,17 +882,19 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_node_recovery_afte
                 auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
                 BOOST_REQUIRE(!result);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(result.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_unavailable>(result.error()),
+
+                        "Expected service_unavailable, got: " << std::visit(vector_search::error_visitor{}, result.error()));
 
                 // Replace the unavailable server with an available one.
                 avail_server = std::make_unique<vs_mock_server>();
                 co_await avail_server->start(co_await unavail_server->take_socket());
 
                 // Wait until node is taken out of the backoff state and used for requests again.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     auto result = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                     co_return result.has_value();
-                }));
+                }), "Timed out waiting for node to recover from backoff");
             },
             cfg)
             .finally(coroutine::lambda([&] -> future<> {
@@ -914,9 +940,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_single_status_chec
                 // This prevents the client's backoff mechanism from sending another status request
                 // while the first one is pending, ensuring that exactly one new connection is made.
                 // This makes the test assertion deterministic.
-                BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                     co_return unavail_s->connections().size() == 1;
-                }));
+                }), "Timed out waiting for a single status check connection");
             },
             cfg)
             .finally(coroutine::lambda([&] -> future<> {
@@ -987,7 +1013,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_secondary_uri) {
 
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
-                BOOST_CHECK(keys);
+                if (!keys) {
+                    BOOST_FAIL("Expected successful ANN result, but got error: " << std::visit(vector_search::error_visitor{}, keys.error()));
+                }
             },
             cfg)
             .finally(coroutine::lambda([&] -> future<> {
@@ -1010,7 +1038,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_secondary_uri_only
 
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
-                BOOST_CHECK(keys);
+                if (!keys) {
+                    BOOST_FAIL("Expected successful ANN result, but got error: " << std::visit(vector_search::error_visitor{}, keys.error()));
+                }
             },
             cfg)
             .finally(coroutine::lambda([&] -> future<> {
@@ -1075,22 +1105,23 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_rewrite_ca_c
                 // This avoids a race where an ANN request initiates a TLS handshake using the old (broken) credentials
                 // while the reload is still in progress, which can cause a long hang due to TLS handshake timeout.
                 co_await env.vector_store_client().invoke_on_all([&](this auto, vector_store_client& vs) -> future<> {
-                    BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                    BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                         co_return vector_store_client_tester::truststore_reload_count(vs) >= 1;
-                    }));
+                    }), "Timed out waiting for truststore reload");
                 });
 
                 // Wait for the client to succeed with the reloaded CA cert
                 co_await env.vector_store_client().invoke_on_all([&](this auto, vector_store_client& vs) -> future<> {
                     auto schema = env.local_db().find_schema("ks", "idx");
                     auto as = abort_source_timeout();
-                    BOOST_CHECK(co_await repeat_until([&]() -> future<bool> {
+                    BOOST_CHECK_MESSAGE(co_await repeat_until([&]() -> future<bool> {
                         auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                         co_return keys.has_value();
-                    }));
+                    }), "Timed out waiting for ANN request to succeed with reloaded CA cert");
                 });
 
-                BOOST_CHECK(!server->status_requests().empty());
+                BOOST_CHECK_MESSAGE(!server->status_requests().empty(),
+                        "Expected at least one status request");
             },
             cfg)
             .finally(seastar::coroutine::lambda([&] -> future<> {
@@ -1117,7 +1148,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_hostna
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()),
+
+                        "Expected service_unavailable, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg)
             .finally(seastar::coroutine::lambda([&] -> future<> {
@@ -1143,7 +1176,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_cacert
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()),
+
+                        "Expected service_unavailable, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg)
             .finally(seastar::coroutine::lambda([&] -> future<> {
@@ -1170,7 +1205,9 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_https_wrong_cacert
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
 
                 BOOST_REQUIRE(!keys);
-                BOOST_CHECK(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()));
+                BOOST_CHECK_MESSAGE(std::holds_alternative<vector_store_client::service_unavailable>(keys.error()),
+
+                        "Expected service_unavailable, got: " << std::visit(vector_search::error_visitor{}, keys.error()));
             },
             cfg)
             .finally(seastar::coroutine::lambda([&] -> future<> {
@@ -1206,7 +1243,8 @@ SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING(vector_store_client_high_availability_
                 // so the test expects a normal rows result.
                 auto msg = co_await env.execute_cql("SELECT * FROM ks.test ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 5;");
 
-                BOOST_CHECK(dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg));
+                BOOST_CHECK_MESSAGE(dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg),
+                        "Expected rows result message");
             },
             cfg)
             .finally(seastar::coroutine::lambda([&] -> future<> {

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -22,8 +22,6 @@
 #include "cql3/statements/select_statement.hh"
 #include "test/lib/cql_test_env.hh"
 #include "test/lib/cql_assertions.hh"
-#include "test/lib/log.hh"
-#include <cstdio>
 #include <functional>
 #include <chrono>
 #include <memory>
@@ -40,7 +38,6 @@
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/net/tcp.hh>
-#include <tuple>
 #include <variant>
 #include <vector>
 #include <filesystem>


### PR DESCRIPTION
When a `SEASTAR_TEST_CASE` test fails due to an uncaught exception (e.g. from a `co_await` call), the error is reported as:
```
  seastar/src/testing/seastar_test.cc:93: C++ failure
  unknown location(0): fatal error: ...
```
This happens because exceptions propagating through Seastar's future
framework lose their source location by the time Boost.Test sees them.

Introduce `SEASTAR_TEST_CASE_WITH_EXCEPTION_HANDLING` macro in `utils.hh` that wraps the test body in 
```
try { ... } catch (const std::exception& e) { BOOST_FAIL(e.what()); }
```
so that failures are reported with the actual test file and line number.

Replace all `SEASTAR_TEST_CASE` usages across `client_test.cc`, `filter_test.cc`, `rescoring_test.cc`, and
`vector_store_client_test.cc` with the new macro.

Also remove a now-redundant manual try/catch in `rescoring_test.cc` (`rescoring_with_zerovector_query`) since the macro handles it.

This also makes the error message visible in pytest's error summary field, which was previously empty for exception-based failures.

Fixes: VECTOR-548