### PR TITLE
Make collection unfreezing more efficient

### DIFF
--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -48,8 +48,8 @@ static void set_field(atomic_cell_value& out, unsigned offset, T val) {
 }
 
 template <FragmentRange Buffer>
-static void set_value(managed_bytes& b, unsigned value_offset, const Buffer& value) {
-    auto v = managed_bytes_mutable_view(b).substr(value_offset, value.size_bytes());
+static void set_value(atomic_cell_value_mutable_view b, unsigned value_offset, const Buffer& value) {
+    auto v = b.substr(value_offset, value.size_bytes());
     for (auto frag : value) {
         write_fragmented(v, single_fragmented_view(frag));
     }
@@ -141,20 +141,36 @@ public:
         SCYLLA_ASSERT(is_live_and_has_ttl(cell));
         return gc_clock::duration(get_field<int32_t>(cell, ttl_offset));
     }
-    static managed_bytes make_dead(api::timestamp_type timestamp, gc_clock::time_point deletion_time) {
-        managed_bytes b(managed_bytes::initialized_later(), flags_size + timestamp_size + deletion_time_size);
+    static size_t dead_serialized_size() {
+        return flags_size + timestamp_size + deletion_time_size;
+    }
+    static size_t live_serialized_size(size_t value_size) {
+        return flags_size + timestamp_size + value_size;
+    }
+    static size_t live_expiring_serialized_size(size_t value_size) {
+        return flags_size + timestamp_size + expiry_size + ttl_size + value_size;
+    }
+    static void write_dead(atomic_cell_value_mutable_view b, api::timestamp_type timestamp, gc_clock::time_point deletion_time) {
         b[0] = 0;
         set_field(b, timestamp_offset, timestamp);
         set_field(b, deletion_time_offset, static_cast<int64_t>(deletion_time.time_since_epoch().count()));
+    }
+    static managed_bytes make_dead(api::timestamp_type timestamp, gc_clock::time_point deletion_time) {
+        managed_bytes b(managed_bytes::initialized_later(), dead_serialized_size());
+        write_dead(b, timestamp, deletion_time);
         return b;
     }
     template <FragmentRange Buffer>
-    static managed_bytes make_live(api::timestamp_type timestamp, const Buffer& value) {
+    static void write_live(atomic_cell_value_mutable_view b, api::timestamp_type timestamp, const Buffer& value) {
         auto value_offset = flags_size + timestamp_size;
-        managed_bytes b(managed_bytes::initialized_later(), value_offset + value.size_bytes());
         b[0] = LIVE_FLAG;
         set_field(b, timestamp_offset, timestamp);
         set_value(b, value_offset, value);
+    }
+    template <FragmentRange Buffer>
+    static managed_bytes make_live(api::timestamp_type timestamp, const Buffer& value) {
+        managed_bytes b(managed_bytes::initialized_later(), live_serialized_size(value.size_bytes()));
+        write_live(b, timestamp, value);
         return b;
     }
     static managed_bytes make_live_counter_update(api::timestamp_type timestamp, int64_t value) {
@@ -166,14 +182,18 @@ public:
         return b;
     }
     template <FragmentRange Buffer>
-    static managed_bytes make_live(api::timestamp_type timestamp, const Buffer& value, gc_clock::time_point expiry, gc_clock::duration ttl) {
+    static void write_live(atomic_cell_value_mutable_view b, api::timestamp_type timestamp, const Buffer& value, gc_clock::time_point expiry, gc_clock::duration ttl) {
         auto value_offset = flags_size + timestamp_size + expiry_size + ttl_size;
-        managed_bytes b(managed_bytes::initialized_later(), value_offset + value.size_bytes());
         b[0] = EXPIRY_FLAG | LIVE_FLAG;
         set_field(b, timestamp_offset, timestamp);
         set_field(b, expiry_offset, static_cast<int64_t>(expiry.time_since_epoch().count()));
         set_field(b, ttl_offset, static_cast<int32_t>(ttl.count()));
         set_value(b, value_offset, value);
+    }
+    template <FragmentRange Buffer>
+    static managed_bytes make_live(api::timestamp_type timestamp, const Buffer& value, gc_clock::time_point expiry, gc_clock::duration ttl) {
+        managed_bytes b(managed_bytes::initialized_later(), live_expiring_serialized_size(value.size_bytes()));
+        write_live(b, timestamp, value, expiry, ttl);
         return b;
     }
     static managed_bytes make_live_uninitialized(api::timestamp_type timestamp, size_t size) {

--- a/mutation/canonical_mutation.cc
+++ b/mutation/canonical_mutation.cc
@@ -113,10 +113,10 @@ auto fmt::formatter<canonical_mutation>::format(const canonical_mutation& cm, fm
             auto&& entry = _cm.static_column_at(id);
             _os = fmt::format_to(_os, "static column {} {}", bytes_to_text(entry.name()), atomic_cell::printer(*entry.type(), ac));
         }
-        virtual void accept_static_cell(column_id id, collection_mutation_view cmv) override {
+        virtual void accept_static_cell(column_id id, collection_mutation cm) override {
             print_separator();
             auto&& entry = _cm.static_column_at(id);
-            _os = fmt::format_to(_os, "static column {} {}", bytes_to_text(entry.name()), collection_mutation_view::printer(*entry.type(), cmv));
+            _os = fmt::format_to(_os, "static column {} {}", bytes_to_text(entry.name()), collection_mutation_view::printer(*entry.type(), cm));
         }
         virtual stop_iteration accept_row_tombstone(range_tombstone rt) override {
             print_separator();
@@ -137,10 +137,10 @@ auto fmt::formatter<canonical_mutation>::format(const canonical_mutation& cm, fm
             auto&& entry = _cm.regular_column_at(id);
             _os = fmt::format_to(_os, "column {} {}", bytes_to_text(entry.name()), atomic_cell::printer(*entry.type(), ac));
         }
-        virtual void accept_row_cell(column_id id, collection_mutation_view cmv) override {
+        virtual void accept_row_cell(column_id id, collection_mutation cm) override {
             print_separator();
             auto&& entry = _cm.regular_column_at(id);
-            _os = fmt::format_to(_os, "column {} {}", bytes_to_text(entry.name()), collection_mutation_view::printer(*entry.type(), cmv));
+            _os = fmt::format_to(_os, "column {} {}", bytes_to_text(entry.name()), collection_mutation_view::printer(*entry.type(), cm));
         }
         out_t finalize() {
             if (_in_row) {

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -7,12 +7,14 @@
  */
 
 #include "utils/assert.hh"
+#include "utils/on_internal_error.hh"
 #include "types/collection.hh"
 #include "types/user.hh"
 #include "types/concrete_types.hh"
 #include "mutation/mutation_partition.hh"
 #include "compaction/compaction_garbage_collector.hh"
 #include "combine.hh"
+#include "idl/mutation.dist.impl.hh"
 
 #include "collection_mutation.hh"
 
@@ -304,6 +306,65 @@ collection_mutation collection_mutation_description::serialize(const abstract_ty
 
 collection_mutation collection_mutation_view_description::serialize(const abstract_type& type) const {
     return serialize_collection_mutation<atomic_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+}
+
+namespace {
+
+struct serialized_cell_adaptor {
+    static size_t key_size(const ser::collection_element_view& v) {
+        return v.key().view().size_bytes();
+    }
+
+    static size_t value_size(const ser::collection_element_view& v) {
+        struct collection_cell_visitor {
+            size_t operator()(const ser::live_cell_view& lcv) const { return atomic_cell_type::live_serialized_size(lcv.value().view().size_bytes()); }
+            size_t operator()(const ser::expiring_cell_view& ecv) const { return atomic_cell_type::live_expiring_serialized_size(ecv.c().value().view().size_bytes()); }
+            size_t operator()(const ser::dead_cell_view& dcv) const { return atomic_cell_type::dead_serialized_size(); }
+            size_t operator()(const ser::counter_cell_view& ccv) const { utils::on_internal_error("Trying to deserialize counter cell from collection"); }
+            size_t operator()(const ser::unknown_variant_type&) const { utils::on_internal_error("Trying to deserialize cell in unknown state"); };
+        };
+        return boost::apply_visitor(collection_cell_visitor{}, v.value());
+    }
+
+    static void write_key(const ser::collection_element_view& v, managed_bytes_mutable_view& out) {
+        write_fragmented(out, v.key().view());
+    }
+
+    static void write_value(const ser::collection_element_view& v, managed_bytes_mutable_view& out) {
+        struct collection_cell_visitor {
+            managed_bytes_mutable_view& out;
+
+            void operator()(const ser::live_cell_view& lcv) const {
+                const auto v = lcv.value().view();
+                atomic_cell_type::write_live(out, lcv.created_at(), v);
+                out.remove_prefix(atomic_cell_type::live_serialized_size(v.size_bytes()));
+            }
+            void operator()(const ser::expiring_cell_view& ecv) const {
+                const auto v = ecv.c().value().view();
+                atomic_cell_type::write_live(out, ecv.c().created_at(), v, ecv.expiry(), ecv.ttl());
+                out.remove_prefix(atomic_cell_type::live_expiring_serialized_size(v.size_bytes()));
+            }
+            void operator()(const ser::dead_cell_view& dcv) const {
+                atomic_cell_type::write_dead(out, dcv.tomb().timestamp(), dcv.tomb().deletion_time());
+                out.remove_prefix(atomic_cell_type::dead_serialized_size());
+            }
+            void operator()(const ser::counter_cell_view& ccv) const {
+                utils::on_internal_error("Trying to deserialize counter cell from collection");
+            }
+            void operator()(const ser::unknown_variant_type&) const {
+                utils::on_internal_error("Trying to deserialize cell in unknown state");
+            }
+        };
+        boost::apply_visitor(collection_cell_visitor{out}, v.value());
+    }
+};
+
+}
+
+collection_mutation read_from_collection_cell_view(const abstract_type& type, const ser::collection_cell_view& collection) {
+    auto tomb = collection.tomb();
+    auto cells = collection.elements();
+    return serialize_collection_mutation<serialized_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 template <typename C>

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -224,13 +224,26 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
     return res;
 }
 
-template <typename Iterator>
+/// A CollectionMutationAdaptor is a static interface that adapts a collection
+/// element (an iterator value type) to the serialization requirements of
+/// serialize_collection_mutation(). It provides static methods to measure the
+/// serialized sizes and to write the key and value of each element into a buffer.
+template <typename Adaptor, typename Element>
+concept CollectionMutationAdaptor = requires(const Element& e, managed_bytes_mutable_view& out) {
+    { Adaptor::key_size(e) } -> std::convertible_to<size_t>;
+    { Adaptor::value_size(e) } -> std::convertible_to<size_t>;
+    { Adaptor::write_key(e, out) };
+    { Adaptor::write_value(e, out) };
+};
+
+template <typename Adaptor, typename Iterator>
+    requires CollectionMutationAdaptor<Adaptor, std::iter_value_t<Iterator>>
 static collection_mutation serialize_collection_mutation(
         const abstract_type& type,
         const tombstone& tomb,
         std::ranges::subrange<Iterator> cells) {
     auto element_size = [] (size_t c, auto&& e) -> size_t {
-        return c + 8 + e.first.size() + e.second.serialize().size();
+        return c + 8 + Adaptor::key_size(e) + Adaptor::value_size(e);
     };
     auto size = std::ranges::fold_left(cells, (size_t)4, element_size);
     size += 1;
@@ -244,32 +257,53 @@ static collection_mutation serialize_collection_mutation(
         write<int64_t>(out, tomb.timestamp);
         write<int64_t>(out, tomb.deletion_time.time_since_epoch().count());
     }
-    auto writek = [&out] (bytes_view v) {
-        write<int32_t>(out, v.size());
-        write_fragmented(out, single_fragmented_view(v));
+    auto writek = [&out] (auto& kv) {
+        write<int32_t>(out, Adaptor::key_size(kv));
+        Adaptor::write_key(kv, out);
     };
-    auto writev = [&out] (managed_bytes_view v) {
-        write<int32_t>(out, v.size());
-        write_fragmented(out, v);
+    auto writev = [&out] (auto& kv) {
+        write<int32_t>(out, Adaptor::value_size(kv));
+        Adaptor::write_value(kv, out);
     };
     // FIXME: overflow?
     write<int32_t>(out, std::ranges::distance(cells));
     for (auto&& kv : cells) {
-        auto&& k = kv.first;
-        auto&& v = kv.second;
-        writek(k);
-
-        writev(v.serialize());
+        writek(kv);
+        writev(kv);
     }
     return collection_mutation(type, std::move(ret));
 }
 
+namespace {
+
+/// A key-value pair where the key is bytes-like and the value is an atomic_cell-like type
+/// with a serialize() method returning managed_bytes_view.
+template <typename T>
+concept AtomicCellKV = requires(const T& kv) {
+    { kv.first.size() } -> std::convertible_to<size_t>;
+    { kv.second.serialize() } -> std::convertible_to<managed_bytes_view>;
+};
+
+struct atomic_cell_adaptor {
+    static size_t key_size(const AtomicCellKV auto& v) { return v.first.size(); }
+    static size_t value_size(const AtomicCellKV auto& v) { return v.second.serialize().size(); }
+
+    static void write_key(const AtomicCellKV auto& v, managed_bytes_mutable_view& out) {
+        write_fragmented(out, single_fragmented_view(v.first));
+    }
+    static void write_value(const AtomicCellKV auto& v, managed_bytes_mutable_view& out) {
+        write_fragmented(out, v.second.serialize());
+    }
+};
+
+}
+
 collection_mutation collection_mutation_description::serialize(const abstract_type& type) const {
-    return serialize_collection_mutation(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+    return serialize_collection_mutation<atomic_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 collection_mutation collection_mutation_view_description::serialize(const abstract_type& type) const {
-    return serialize_collection_mutation(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+    return serialize_collection_mutation<atomic_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 template <typename C>

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -23,6 +23,10 @@ class row_tombstone;
 
 class collection_mutation;
 
+namespace ser {
+class collection_cell_view;
+}
+
 // An auxiliary struct used to (de)construct collection_mutations.
 // Unlike collection_mutation which is a serialized blob, this struct allows to inspect logical units of information
 // (tombstone and cells) inside the mutation easily.
@@ -129,6 +133,12 @@ public:
 collection_mutation merge(const abstract_type&, collection_mutation_view, collection_mutation_view);
 
 collection_mutation difference(const abstract_type&, collection_mutation_view, collection_mutation_view);
+
+// Transcode a collection from the IDL representation directly into the
+// collection_mutation serialization format, without using any intermediary representation.
+// Only the final collection-mutation blob is allocated, no intermediate allocations needed.
+// Safe to use in LSA, it won't produce garbage.
+collection_mutation read_from_collection_cell_view(const abstract_type&, const ser::collection_cell_view&);
 
 // Serializes the given collection of cells to a sequence of bytes ready to be sent over the CQL protocol.
 bytes_ostream serialize_for_cql(const abstract_type&, collection_mutation_view);

--- a/mutation/frozen_mutation.hh
+++ b/mutation/frozen_mutation.hh
@@ -97,9 +97,9 @@ public:
         r.append_cell(id, atomic_cell_or_collection(std::move(cell)));
     }
 
-    virtual void accept_static_cell(column_id id, collection_mutation_view collection) override {
+    virtual void accept_static_cell(column_id id, collection_mutation collection) override {
         row& r = _static_row.maybe_create();
-        r.append_cell(id, collection_mutation(*_schema.static_column_at(id).type, std::move(collection)));
+        r.append_cell(id, std::move(collection));
     }
 
     virtual stop_iteration accept_row_tombstone(range_tombstone rt) override {
@@ -125,9 +125,9 @@ public:
         r.append_cell(id, std::move(cell));
     }
 
-    virtual void accept_row_cell(column_id id, collection_mutation_view collection) override {
+    virtual void accept_row_cell(column_id id, collection_mutation collection) override {
         row& r = _current_row->cells();
-        r.append_cell(id, collection_mutation(*_schema.regular_column_at(id).type, std::move(collection)));
+        r.append_cell(id, std::move(collection));
     }
 
     auto on_end_of_partition() {

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -198,8 +198,8 @@ void mutation_partition_view::do_accept(const column_mapping& cm, Visitor& visit
         void accept_atomic_cell(column_id id, atomic_cell ac) const {
            _visitor.accept_static_cell(id, std::move(ac));
         }
-        void accept_collection(column_id id, const collection_mutation& cm) const {
-           _visitor.accept_static_cell(id, cm);
+        void accept_collection(column_id id, collection_mutation cm) const {
+           _visitor.accept_static_cell(id, std::move(cm));
         }
     };
     read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
@@ -218,8 +218,8 @@ void mutation_partition_view::do_accept(const column_mapping& cm, Visitor& visit
             void accept_atomic_cell(column_id id, atomic_cell ac) const {
                _visitor.accept_row_cell(id, std::move(ac));
             }
-            void accept_collection(column_id id, const collection_mutation& cm) const {
-               _visitor.accept_row_cell(id, cm);
+            void accept_collection(column_id id, collection_mutation cm) const {
+               _visitor.accept_row_cell(id, std::move(cm));
             }
         };
         read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});

--- a/mutation/mutation_partition_view.cc
+++ b/mutation/mutation_partition_view.cc
@@ -86,37 +86,6 @@ atomic_cell read_atomic_cell(const abstract_type& type, atomic_cell_variant cv, 
     return boost::apply_visitor(atomic_cell_visitor(type, cm), cv);
 }
 
-collection_mutation read_collection_cell(const abstract_type& type, ser::collection_cell_view cv)
-{
-    collection_mutation_description mut;
-    mut.tomb = cv.tomb();
-    auto&& elements = cv.elements();
-    mut.cells.reserve(elements.size());
-
-    visit(type, make_visitor(
-        [&] (const collection_type_impl& ctype) {
-            auto& value_type = *ctype.value_comparator();
-            for (auto&& e : elements) {
-                mut.cells.emplace_back(e.key(), read_atomic_cell(value_type, e.value(), atomic_cell::collection_member::yes));
-            }
-        },
-        [&] (const user_type_impl& utype) {
-            for (auto&& e : elements) {
-                bytes key = e.key();
-                auto idx = deserialize_field_index(key);
-                SCYLLA_ASSERT(idx < utype.size());
-
-                mut.cells.emplace_back(key, read_atomic_cell(*utype.type(idx), e.value(), atomic_cell::collection_member::yes));
-            }
-        },
-        [&] (const abstract_type& o) {
-            throw std::runtime_error(format("attempted to read a collection cell with type: {}", o.name()));
-        }
-    ));
-
-    return mut.serialize(type);
-}
-
 template<typename Visitor>
 void read_and_visit_row(ser::row_view rv, const column_mapping& cm, column_kind kind, Visitor&& visitor)
 {
@@ -142,14 +111,7 @@ void read_and_visit_row(ser::row_view rv, const column_mapping& cm, column_kind 
                 if (_col.is_atomic()) {
                     throw std::runtime_error("An atomic cell expected, got a collection");
                 }
-                // FIXME: Pass view to cell to avoid copy
-                auto&& outer = current_allocator();
-                with_allocator(standard_allocator(), [&] {
-                    auto cell = read_collection_cell(*_col.type(), ccv);
-                    with_allocator(outer, [&] {
-                        _visitor.accept_collection(_id, cell);
-                    });
-                });
+                _visitor.accept_collection(_id, read_from_collection_cell_view(*_col.type(), ccv));
             }
             void operator()(ser::unknown_variant_type&) const {
                 throw std::runtime_error("Trying to deserialize unknown cell type");
@@ -240,8 +202,8 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
         void accept_atomic_cell(column_id id, atomic_cell ac) const {
            _visitor.accept_static_cell(id, std::move(ac));
         }
-        void accept_collection(column_id id, const collection_mutation& cm) const {
-           _visitor.accept_static_cell(id, cm);
+        void accept_collection(column_id id, collection_mutation cm) const {
+           _visitor.accept_static_cell(id, std::move(cm));
         }
     };
     read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
@@ -263,8 +225,8 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Vis
             void accept_atomic_cell(column_id id, atomic_cell ac) const {
                _visitor.accept_row_cell(id, std::move(ac));
             }
-            void accept_collection(column_id id, const collection_mutation& cm) const {
-               _visitor.accept_row_cell(id, cm);
+            void accept_collection(column_id id, collection_mutation cm) const {
+               _visitor.accept_row_cell(id, std::move(cm));
             }
         };
         read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
@@ -286,8 +248,8 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Asy
         void accept_atomic_cell(column_id id, atomic_cell ac) const {
            _visitor.accept_static_cell(id, std::move(ac));
         }
-        void accept_collection(column_id id, const collection_mutation& cm) const {
-           _visitor.accept_static_cell(id, cm);
+        void accept_collection(column_id id, collection_mutation cm) const {
+           _visitor.accept_static_cell(id, std::move(cm));
         }
     };
     read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
@@ -308,8 +270,8 @@ future<> mutation_partition_view::do_accept_gently(const column_mapping& cm, Asy
             void accept_atomic_cell(column_id id, atomic_cell ac) const {
                _visitor.accept_row_cell(id, std::move(ac));
             }
-            void accept_collection(column_id id, const collection_mutation& cm) const {
-               _visitor.accept_row_cell(id, cm);
+            void accept_collection(column_id id, collection_mutation cm) const {
+               _visitor.accept_row_cell(id, std::move(cm));
             }
         };
         read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
@@ -337,8 +299,8 @@ mutation_partition_view::accept_ordered_result mutation_partition_view::do_accep
             void accept_atomic_cell(column_id id, atomic_cell ac) const {
                 _visitor.accept_static_cell(id, std::move(ac));
             }
-            void accept_collection(column_id id, const collection_mutation& cm) const {
-                _visitor.accept_static_cell(id, cm);
+            void accept_collection(column_id id, collection_mutation cm) const {
+                _visitor.accept_static_cell(id, std::move(cm));
             }
         };
         read_and_visit_row(mpv.static_row(), cm, column_kind::static_column, static_row_cell_visitor{visitor});
@@ -376,8 +338,8 @@ mutation_partition_view::accept_ordered_result mutation_partition_view::do_accep
             void accept_atomic_cell(column_id id, atomic_cell ac) const {
                 _visitor.accept_row_cell(id, std::move(ac));
             }
-            void accept_collection(column_id id, const collection_mutation& cm) const {
-                _visitor.accept_row_cell(id, cm);
+            void accept_collection(column_id id, collection_mutation cm) const {
+                _visitor.accept_row_cell(id, std::move(cm));
             }
         };
         read_and_visit_row(cr.cells(), cm, column_kind::regular_column, cell_visitor{visitor});
@@ -501,44 +463,40 @@ mutation_partition_view mutation_partition_view::from_view(ser::mutation_partiti
 
 clustering_row read_clustered_row(const schema& s, ser::clustering_row_view crv) {
     class clustering_row_builder {
-        const schema& _s;
         clustering_row _row;
     public:
-        clustering_row_builder(const schema& s, clustering_key key, row_tombstone t, row_marker m)
-            : _s(s), _row(std::move(key), std::move(t), std::move(m), row()) { }
+        clustering_row_builder(clustering_key key, row_tombstone t, row_marker m)
+            : _row(std::move(key), std::move(t), std::move(m), row()) { }
         void accept_atomic_cell(column_id id, atomic_cell ac) {
             _row.cells().append_cell(id, std::move(ac));
         }
-        void accept_collection(column_id id, const collection_mutation& cm) {
-            _row.cells().append_cell(id, collection_mutation(*_s.regular_column_at(id).type, cm));
+        void accept_collection(column_id id, collection_mutation cm) {
+            _row.cells().append_cell(id, std::move(cm));
         }
         clustering_row get() && { return std::move(_row); }
     };
 
     auto cr = crv.row();
     auto t = row_tombstone(cr.deleted_at(), shadowable_tombstone(cr.shadowable_deleted_at()));
-    clustering_row_builder builder(s, cr.key(), std::move(t), read_row_marker(cr.marker()));
+    clustering_row_builder builder(cr.key(), std::move(t), read_row_marker(cr.marker()));
     read_and_visit_row(cr.cells(), s.get_column_mapping(), column_kind::regular_column, builder);
     return std::move(builder).get();
 }
 
 static_row read_static_row(const schema& s, ser::static_row_view sr) {
     class static_row_builder {
-        const schema& _s;
         static_row _row;
     public:
-        explicit static_row_builder(const schema& s)
-            : _s(s) { }
         void accept_atomic_cell(column_id id, atomic_cell ac) {
             _row.cells().append_cell(id, std::move(ac));
         }
-        void accept_collection(column_id id, const collection_mutation& cm) {
-            _row.cells().append_cell(id, collection_mutation(*_s.static_column_at(id).type, cm));
+        void accept_collection(column_id id, collection_mutation cm) {
+            _row.cells().append_cell(id, std::move(cm));
         }
         static_row get() && { return std::move(_row); }
     };
 
-    static_row_builder builder(s);
+    static_row_builder builder;
     read_and_visit_row(sr.cells(), s.get_column_mapping(), column_kind::static_column, builder);
     return std::move(builder).get();
 }

--- a/mutation/mutation_partition_view.hh
+++ b/mutation/mutation_partition_view.hh
@@ -23,31 +23,31 @@ class converting_mutation_partition_applier;
 
 template<typename T>
 concept MutationViewVisitor = requires (T& visitor, tombstone t, atomic_cell ac,
-                                             collection_mutation_view cmv, range_tombstone rt,
+                                             collection_mutation cm, range_tombstone rt,
                                              position_in_partition_view pipv, row_tombstone row_tomb,
                                              row_marker rm) {
     visitor.accept_partition_tombstone(t);
     visitor.accept_static_cell(column_id(), std::move(ac));
-    visitor.accept_static_cell(column_id(), cmv);
+    visitor.accept_static_cell(column_id(), std::move(cm));
     visitor.accept_row_tombstone(rt);
     visitor.accept_row(pipv, row_tomb, rm,
             is_dummy::no, is_continuous::yes);
     visitor.accept_row_cell(column_id(), std::move(ac));
-    visitor.accept_row_cell(column_id(), cmv);
+    visitor.accept_row_cell(column_id(), std::move(cm));
 };
 
 template<typename T>
 concept AsyncMutationViewVisitor = requires (T& visitor, tombstone t, atomic_cell ac,
-                                             collection_mutation_view cmv, range_tombstone rt,
+                                             collection_mutation cm, range_tombstone rt,
                                              position_in_partition_view pipv, row_tombstone row_tomb,
                                              row_marker rm) {
     { visitor.accept_partition_tombstone(t) } -> std::same_as<void>;
     { visitor.accept_static_cell(column_id(), std::move(ac)) } -> std::same_as<void>;
-    { visitor.accept_static_cell(column_id(), cmv) } -> std::same_as<void>;
+    { visitor.accept_static_cell(column_id(), std::move(cm)) } -> std::same_as<void>;
     { visitor.accept_row_tombstone(rt) } -> std::same_as<future<>>;
     { visitor.accept_row(pipv, row_tomb, rm, is_dummy::no, is_continuous::yes) } -> std::same_as<future<>>;
     { visitor.accept_row_cell(column_id(), std::move(ac)) } -> std::same_as<void>;
-    { visitor.accept_row_cell(column_id(), cmv) } -> std::same_as<void>;
+    { visitor.accept_row_cell(column_id(), std::move(cm)) } -> std::same_as<void>;
     { visitor.accept_end_of_partition() } -> std::same_as<future<>>;
 };
 
@@ -56,11 +56,11 @@ public:
     virtual ~mutation_partition_view_virtual_visitor();
     virtual void accept_partition_tombstone(tombstone t) = 0;
     virtual void accept_static_cell(column_id, atomic_cell ac) = 0;
-    virtual void accept_static_cell(column_id, collection_mutation_view cmv) = 0;
+    virtual void accept_static_cell(column_id, collection_mutation cm) = 0;
     virtual stop_iteration accept_row_tombstone(range_tombstone rt) = 0;
     virtual stop_iteration accept_row(position_in_partition_view pipv, row_tombstone rt, row_marker rm, is_dummy, is_continuous) = 0;
     virtual void accept_row_cell(column_id, atomic_cell ac) = 0;
-    virtual void accept_row_cell(column_id, collection_mutation_view cmv) = 0;
+    virtual void accept_row_cell(column_id, collection_mutation cm) = 0;
 };
 
 // View on serialized mutation partition. See mutation_partition_serializer.

--- a/partition_builder.hh
+++ b/partition_builder.hh
@@ -46,8 +46,12 @@ public:
     }
 
     virtual void accept_static_cell(column_id id, collection_mutation_view collection) override {
+        accept_static_cell(id, collection_mutation(*_schema.static_column_at(id).type, std::move(collection)));
+    }
+
+    void accept_static_cell(column_id id, collection_mutation&& collection) {
         row& r = _partition.static_row().maybe_create();
-        r.append_cell(id, collection_mutation(*_schema.static_column_at(id).type, std::move(collection)));
+        r.append_cell(id, std::move(collection));
     }
 
     virtual void accept_row_tombstone(const range_tombstone& rt) override {
@@ -72,8 +76,12 @@ public:
     }
 
     virtual void accept_row_cell(column_id id, collection_mutation_view collection) override {
+        accept_row_cell(id, collection_mutation(*_schema.regular_column_at(id).type, std::move(collection)));
+    }
+
+    void accept_row_cell(column_id id, collection_mutation collection) {
         row& r = _current_row->cells();
-        r.append_cell(id, collection_mutation(*_schema.regular_column_at(id).type, std::move(collection)));
+        r.append_cell(id, std::move(collection));
     }
 };
 

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -15,13 +15,17 @@
 
 #include "mutation/frozen_mutation.hh"
 #include "mutation/async_utils.hh"
+#include "mutation/collection_mutation.hh"
 #include "schema/schema_builder.hh"
 #include "test/lib/mutation_assertions.hh"
 #include "test/lib/mutation_source_test.hh"
+#include "test/lib/random_utils.hh"
 #include "test/lib/reader_concurrency_semaphore.hh"
+#include "types/map.hh"
 
 #include <seastar/core/thread.hh>
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/memory.hh>
 #include "readers/from_mutations.hh"
 #include "readers/mutation_fragment_v1_stream.hh"
 
@@ -205,4 +209,70 @@ SEASTAR_TEST_CASE(frozen_mutation_is_consumed_in_order) {
 
     validate_consume(s, fm, m);
     co_await validate_consume_gently(s, fm, m);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_freeze_unfreeze_with_large_collection_cells) {
+    const auto collection_type = map_type_impl::get_instance(int32_type, bytes_type, true);
+    schema_ptr s = new_table()
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("v_atomic", bytes_type)
+        .with_column("v_collection", collection_type)
+        .build();
+
+    constexpr size_t cell_size_min = 8 * 1024;
+    constexpr size_t cell_size_max = 15 * 1024;
+    constexpr size_t num_entries = 50;
+    constexpr size_t num_rows = 10;
+
+    const partition_key pk = partition_key::from_single_value(*s, serialized("key"));
+    mutation m(s, pk);
+    const auto& cdef_atomic = *s->get_column_definition("v_atomic");
+    const auto& cdef_collection = *s->get_column_definition("v_collection");
+
+    auto make_atomic_cell = [&] (atomic_cell::collection_member cm) {
+        const auto cell_size = tests::random::get_int(cell_size_min, cell_size_max);
+        auto cell_value = tests::random::get_bytes(cell_size);
+        return atomic_cell::make_live(*bytes_type, new_timestamp(), std::move(cell_value), cm);
+    };
+
+    for (size_t r = 0; r < num_rows; ++r) {
+        const auto ck = clustering_key::from_single_value(*s, serialized(format("ck_{}", r)));
+
+        m.set_clustered_cell(ck, cdef_atomic, atomic_cell_or_collection(make_atomic_cell(atomic_cell::collection_member::no)));
+
+        collection_mutation_description cmd;
+        for (size_t i = 0; i < num_entries; ++i) {
+            cmd.cells.emplace_back(int32_type->decompose(int32_t(i)), make_atomic_cell(atomic_cell::collection_member::yes));
+        }
+        m.set_clustered_cell(ck, cdef_collection, atomic_cell_or_collection(cmd.serialize(*collection_type)));
+    }
+
+    for (auto do_freeze_gently : {false, true}) {
+        for (auto do_unfreeze_gently : {false, true}) {
+            testlog.debug("test_freeze_unfreeze_with_large_collection_cells: freeze_gently={} unfreeze_gently={}", do_freeze_gently, do_unfreeze_gently);
+            auto frozen = do_freeze_gently ? freeze_gently(m).get() : freeze(m);
+            auto unfrozen = do_unfreeze_gently ? unfreeze_gently(frozen, s).get() : frozen.unfreeze(s);
+            assert_that(unfrozen).is_equal_to(m);
+        }
+    }
+
+    // Verify that unfreeze allocates far fewer objects than the old O(num_entries * num_rows) approach.
+    // With the old code, each cell in a collection required a separate allocation, resulting in
+    // O(num_entries * num_rows) allocations just for collection cells. With read_from_collection_cell_view(),
+    // the entire collection is read into a single managed_bytes, so allocations are O(num_rows).
+    {
+        auto frozen = freeze(m);
+        const auto mallocs_before = seastar::memory::stats().mallocs();
+        auto unfrozen = frozen.unfreeze(s);
+        const auto mallocs_during_unfreeze = seastar::memory::stats().mallocs() - mallocs_before;
+        assert_that(unfrozen).is_equal_to(m);
+
+        // The old O(num_entries * num_rows) code would do at least num_entries * num_rows allocations.
+        // The new code should do significantly fewer.
+        const auto old_code_alloc_lower_bound = num_entries * num_rows;
+        testlog.info("test_freeze_unfreeze_with_large_collection_cells: mallocs during unfreeze: {} (old code lower bound: {})",
+                mallocs_during_unfreeze, old_code_alloc_lower_bound);
+        BOOST_REQUIRE_LT(mallocs_during_unfreeze, old_code_alloc_lower_bound);
+    }
 }

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -21,6 +21,7 @@
 
 #include "db/config.hh"
 #include "schema/schema_builder.hh"
+#include "types/map.hh"
 #include "service/storage_proxy.hh"
 #include "cql3/query_processor.hh"
 #include "db/config.hh"
@@ -37,14 +38,37 @@ static bytes make_key(uint64_t sequence) {
     return b;
 };
 
-static void execute_update_for_key(cql_test_env& env, const bytes& key) {
+static sstring make_collection_literal(unsigned n) {
+    if (n == 0) {
+        return "{}";
+    }
+    // Fixed blob value for all cells, similar to C0..C4 column values
+    static constexpr std::string_view cell_value =
+        "0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a";
+    sstring result = "{";
+    for (unsigned i = 0; i < n; ++i) {
+        if (i > 0) {
+            result += ", ";
+        }
+        // Key is the 8-byte big-endian encoding of the cell index as a blob
+        result += fmt::format("0x{:016x}: {}", i, cell_value);
+    }
+    result += "}";
+    return result;
+}
+
+static void execute_update_for_key(cql_test_env& env, const bytes& key, unsigned collection) {
+    sstring col_suffix;
+    if (collection > 0) {
+        col_suffix = fmt::format(", \"CC\" = {}", make_collection_literal(collection));
+    }
     env.execute_cql(fmt::format("UPDATE cf SET "
         "\"C0\" = 0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a,"
         "\"C1\" = 0xa8761a2127160003033a8f4f3d1069b7833ebe24ef56b3beee728c2b686ca516fa51,"
         "\"C2\" = 0x583449ce81bfebc2e1a695eb59aad5fcc74d6d7311fc6197b10693e1a161ca2e1c64,"
         "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
-        "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27 "
-        "WHERE \"KEY\"= 0x{};", to_hex(key))).get();
+        "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27{} "
+        "WHERE \"KEY\"= 0x{};", col_suffix, to_hex(key))).get();
 };
 
 static void execute_counter_update_for_key(cql_test_env& env, const bytes& key) {
@@ -72,6 +96,7 @@ struct test_config {
     sstring timeout;
     bool bypass_cache;
     std::optional<unsigned> initial_tablets;
+    unsigned collection = 0;
 };
 
 std::ostream& operator<<(std::ostream& os, const test_config::run_mode& m) {
@@ -89,6 +114,7 @@ std::ostream& operator<<(std::ostream& os, const test_config& cfg) {
            << ", mode=" << cfg.mode
            << ", query_single_key=" << (cfg.query_single_key ? "yes" : "no")
            << ", counters=" << (cfg.counters ? "yes" : "no")
+           << ", collection=" << cfg.collection
            << "}";
 }
 
@@ -99,7 +125,7 @@ static void create_partitions(cql_test_env& env, test_config& cfg) {
         if (cfg.counters) {
             execute_counter_update_for_key(env, make_key(sequence));
         } else {
-            execute_update_for_key(env, make_key(sequence));
+            execute_update_for_key(env, make_key(sequence), cfg.collection);
         }
         if (sequence + 1 >= next_flush) {
             env.db().invoke_on_all(&replica::database::flush_all_memtables).get();
@@ -123,7 +149,11 @@ static bytes make_random_key(test_config& cfg) {
 
 static std::vector<perf_result> test_read(cql_test_env& env, test_config& cfg) {
     create_partitions(env, cfg);
-    sstring query = "select \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" from cf where \"KEY\" = ?";
+    sstring query = "select \"C0\", \"C1\", \"C2\", \"C3\", \"C4\"";
+    if (cfg.collection > 0) {
+        query += ", \"CC\"";
+    }
+    query += " from cf where \"KEY\" = ?";
     if (cfg.bypass_cache) {
         query += " bypass cache";
     }
@@ -142,13 +172,17 @@ static std::vector<perf_result> test_write(cql_test_env& env, test_config& cfg) 
     if (!cfg.timeout.empty()) {
         usings += "USING TIMEOUT " + cfg.timeout;
     }
+    sstring col_suffix;
+    if (cfg.collection > 0) {
+        col_suffix = fmt::format(", \"CC\" = {}", make_collection_literal(cfg.collection));
+    }
     sstring query = format("UPDATE cf {}SET "
             "\"C0\" = 0x8f75da6b3dcec90c8a404fb9a5f6b0621e62d39c69ba5758e5f41b78311fbb26cc7a,"
             "\"C1\" = 0xa8761a2127160003033a8f4f3d1069b7833ebe24ef56b3beee728c2b686ca516fa51,"
             "\"C2\" = 0x583449ce81bfebc2e1a695eb59aad5fcc74d6d7311fc6197b10693e1a161ca2e1c64,"
             "\"C3\" = 0x62bcb1dbc0ff953abc703bcb63ea954f437064c0c45366799658bd6b91d0f92908d7,"
-            "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27 "
-            "WHERE \"KEY\" = ?", usings);
+            "\"C4\" = 0x222fcbe31ffa1e689540e1499b87fa3f9c781065fccd10e4772b4c7039c2efd0fb27{} "
+            "WHERE \"KEY\" = ?", usings, col_suffix);
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
@@ -162,7 +196,11 @@ static std::vector<perf_result> test_delete(cql_test_env& env, test_config& cfg)
     if (!cfg.timeout.empty()) {
         usings += "USING TIMEOUT " + cfg.timeout;
     }
-    sstring query = format("DELETE \"C0\", \"C1\", \"C2\", \"C3\", \"C4\" FROM cf {}WHERE \"KEY\" = ?", usings);
+    sstring col_suffix;
+    if (cfg.collection > 0) {
+        col_suffix = ", \"CC\"";
+    }
+    sstring query = format("DELETE \"C0\", \"C1\", \"C2\", \"C3\", \"C4\"{} FROM cf {}WHERE \"KEY\" = ?", col_suffix, usings);
     auto id = env.prepare(query).get();
     return time_parallel([&env, &cfg, id] {
             bytes key = make_random_key(cfg);
@@ -206,14 +244,17 @@ static std::vector<perf_result> do_cql_test(cql_test_env& env, test_config& cfg)
         if (cfg.counters) {
             return *make_counter_schema(ks_name);
         }
-        return *schema_builder(ks_name, "cf")
+        auto sb = schema_builder(ks_name, "cf")
                 .with_column("KEY", bytes_type, column_kind::partition_key)
                 .with_column("C0", bytes_type)
                 .with_column("C1", bytes_type)
                 .with_column("C2", bytes_type)
                 .with_column("C3", bytes_type)
-                .with_column("C4", bytes_type)
-                .build();
+                .with_column("C4", bytes_type);
+        if (cfg.collection > 0) {
+            sb.with_column("CC", map_type_impl::get_instance(bytes_type, bytes_type, true));
+        }
+        return *sb.build();
     }).get();
 
     std::cout << "Disabling auto compaction" << std::endl;
@@ -246,6 +287,9 @@ void write_json_result(std::string result_file, const test_config& cfg, const ag
     params["concurrency,partitions,cpus,duration"] = fmt::format("{},{},{},{}", cfg.concurrency, cfg.partitions, smp::count, cfg.duration_in_seconds);
     if (cfg.initial_tablets) {
         params["initial_tablets"] = cfg.initial_tablets.value();
+    }
+    if (cfg.collection > 0) {
+        params["collection"] = cfg.collection;
     }
 
     std::string test_type;
@@ -285,6 +329,7 @@ int scylla_simple_query_main(int argc, char** argv) {
         ("concurrency", bpo::value<unsigned>()->default_value(100), "workers per core")
         ("operations-per-shard", bpo::value<unsigned>(), "run this many operations per shard (overrides duration)")
         ("counters", "test counters")
+        ("collection", bpo::value<unsigned>()->default_value(0), "add map<text,text> collection column with N cells per row (excludes --counters)")
         ("tablets", "use tablets")
         ("initial-tablets", bpo::value<unsigned>()->default_value(128), "initial number of tablets")
         ("sstable-summary-ratio", bpo::value<double>(), "Generate summary entry, so that summary file size / data file size ~= this ratio")
@@ -349,6 +394,10 @@ int scylla_simple_query_main(int argc, char** argv) {
             cfg.query_single_key = app.configuration().contains("query-single-key");
             cfg.counters = app.configuration().contains("counters");
             cfg.flush_memtables = app.configuration().contains("flush");
+            cfg.collection = app.configuration()["collection"].as<unsigned>();
+            if (cfg.counters && cfg.collection > 0) {
+                throw std::invalid_argument("--collection and --counters are mutually exclusive");
+            }
             if (app.configuration().contains("tablets")) {
                 cfg.initial_tablets = app.configuration()["initial-tablets"].as<unsigned>();
             }


### PR DESCRIPTION
Introduce `read_from_collection_cell_view()` which reads a `collection_mutation` directly from the IDL representation of a collection (`ser::collection_cell_view`). This cuts down the number of allocations required drastically compared to the current method of:

    IDL -> collection_mutatio_description -> collection_mutation

Reduces the number of allocations to unfreeze a collection from O(collection_cell_count) -> O(1) (actually, due to buffer fragmentation, it is O(collection_size)).
The new method is used when unfreezing frozen mutations and frozen mutation fragments. This is on the hot path: all writes with collections benefit.

Add a `--collection` flag to `perf-simple-query` to allow measuring the performance improvement of this PR.
With  `dbuild -it -- build/release/scylla perf-simple-query --collection=16 -c1 -m2G --default-log-level=error --write`  the number of allocations drop from ~123 to 102, which is a significant amount of allocations shaved off.

Refs: https://github.com/scylladb/scylladb/issues/3602 (solves one use-case out of the many listed therein)
Fixes: SCYLLADB-1046
Fixes: SCYLLADB-1077

Backport: this is an optimization so normally not a backport candidate, but we may have to backport to relieve certain customers