### PR TITLE
vector_index: wire rescoring through temporaries_provider infrastructure

### DIFF
--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -302,6 +302,9 @@ struct aggregation_split_result {
 //
 // If the expressions don't contain aggregates, inner_loop and initial_values_for_temporaries
 // are empty, and outer_loop should be evaluated for each loop.
-aggregation_split_result split_aggregation(std::span<const expression> aggregation);
+//
+// `starting_temp_index` is the first temporary index that may be used for aggregation.
+// It allows to omit the temporary slots that have been reserved for other purposes.
+aggregation_split_result split_aggregation(std::span<const expression> aggregation, size_t starting_temp_index = 0);
 
 }

--- a/cql3/expr/expression.cc
+++ b/cql3/expr/expression.cc
@@ -2588,8 +2588,8 @@ levellize_aggregation_depth(const cql3::expr::expression& e, unsigned desired_de
 }
 
 aggregation_split_result
-split_aggregation(std::span<const expression> aggregation) {
-    size_t nr_temporaries = 0;
+split_aggregation(std::span<const expression> aggregation, size_t starting_temp_index) {
+    size_t nr_temporaries = starting_temp_index;
     auto allocate_temporary = [&] () -> size_t {
         return nr_temporaries++;
     };

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -154,6 +154,16 @@ protected:
         virtual bool is_aggregate() const override {
             return false;
         }
+
+        virtual bool inject_temporaries(
+                const temporaries_provider* provider,
+                std::span<const bytes> partition_key,
+                std::span<const bytes> clustering_key,
+                const query::result_row_view& static_row,
+                const query::result_row_view* row) override
+        {
+            return true;
+        }
     };
 
     std::unique_ptr<selectors> new_selectors() const override {
@@ -206,7 +216,10 @@ private:
     std::vector<expr::expression> _inner_loop;
     std::vector<expr::expression> _outer_loop;
     std::vector<raw_value> _initial_values_for_temporaries;
+    // Slots [0, _reserved_temporaries_end) are reserved for provider injection; aggregation starts here.
+    size_t _reserved_temporaries_end = 0;
 public:
+    size_t get_reserved_temporaries_end() const { return _reserved_temporaries_end; }
     selection_with_processing(schema_ptr schema, std::vector<const column_definition*> columns,
             std::vector<lw_shared_ptr<column_specification>> metadata,
             std::vector<expr::expression> selectors)
@@ -216,10 +229,30 @@ public:
             contains_collection_mutation_attribute(expr::tuple_constructor{selectors}))
         , _selectors(std::move(selectors))
     {
-        auto agg_split = expr::split_aggregation(_selectors);
+        // Find the maximum temporary index used in selectors (for non-aggregation temporaries)
+        size_t max_non_agg_temp_index = 0;
+        for (const auto& expr : _selectors) {
+            expr::for_each_expression<expr::temporary>(expr, [&] (const expr::temporary& t) {
+                max_non_agg_temp_index = std::max(max_non_agg_temp_index, t.index + 1);
+            });
+        }
+        _reserved_temporaries_end = max_non_agg_temp_index;
+
+        // Split aggregation, passing the starting index for aggregation temporaries
+        auto agg_split = expr::split_aggregation(_selectors, max_non_agg_temp_index);
         _outer_loop = std::move(agg_split.outer_loop);
         _inner_loop = std::move(agg_split.inner_loop);
-        _initial_values_for_temporaries = std::move(agg_split.initial_values_for_temporaries);
+
+        // Initialize temporaries: NULLs for non-aggregation temporaries, then aggregation initial values
+        _initial_values_for_temporaries.reserve(max_non_agg_temp_index + agg_split.initial_values_for_temporaries.size());
+        for (size_t i = 0; i < max_non_agg_temp_index; ++i) {
+            _initial_values_for_temporaries.push_back(cql3::raw_value::make_null());
+        }
+        _initial_values_for_temporaries.insert(
+            _initial_values_for_temporaries.end(),
+            std::make_move_iterator(agg_split.initial_values_for_temporaries.begin()),
+            std::make_move_iterator(agg_split.initial_values_for_temporaries.end())
+        );
     }
 
     virtual uint32_t add_column_for_post_processing(const column_definition& c) override {
@@ -393,6 +426,19 @@ protected:
             return !_sel._inner_loop.empty();
         }
 
+        virtual bool inject_temporaries(
+                const temporaries_provider* provider,
+                std::span<const bytes> partition_key,
+                std::span<const bytes> clustering_key,
+                const query::result_row_view& static_row,
+                const query::result_row_view* row) override
+        {
+            if (!provider) {
+                return true;
+            }
+            return provider->try_fill(_temporaries, partition_key, clustering_key, static_row, row);
+        }
+
         virtual std::vector<managed_bytes_opt> transform_input_row(result_set_builder& rs) override {
             std::vector<managed_bytes_opt> output_row;
             output_row.reserve(_sel._selectors.size());
@@ -404,7 +450,7 @@ protected:
                     .options = rs._options,
                     .static_and_regular_timestamps = rs._timestamps,
                     .static_and_regular_ttls = rs._ttls,
-                    .temporaries = {},
+                    .temporaries = _temporaries,
                     .collection_element_metadata = rs._collection_element_metadata,
             };
             for (auto&& e : _sel._selectors) {
@@ -446,8 +492,9 @@ protected:
                     .temporaries = _temporaries,
                     .collection_element_metadata = rs._collection_element_metadata,
             };
+            const auto agg_offset = _sel.get_reserved_temporaries_end();
             for (size_t i = 0; i != _sel._inner_loop.size(); ++i) {
-                _temporaries[i] = expr::evaluate(_sel._inner_loop[i], inputs);
+                _temporaries[agg_offset + i] = expr::evaluate(_sel._inner_loop[i], inputs);
             }
             ++_input_row_count;
         }

--- a/cql3/selection/selection.hh
+++ b/cql3/selection/selection.hh
@@ -18,6 +18,7 @@
 #include "selector.hh"
 #include "cql3/column_specification.hh"
 #include "cql3/functions/function.hh"
+#include "cql3/values.hh"
 #include "exceptions/exceptions.hh"
 #include "unimplemented.hh"
 #include <seastar/core/thread.hh>
@@ -36,6 +37,28 @@ namespace selection {
 
 class raw_selector;
 class result_set_builder;
+
+/// Temporaries are per-row scratch slots used during result processing.
+/// Aggregation uses them to hold inter-row state (e.g., running SUM). This
+/// provider interface extends them to also hold externally supplied per-row
+/// computed values (e.g., vector similarity scores), injected after filtering
+/// but before expression evaluation, where they become available to selectors
+/// via temporary{} expressions.
+/// The provider is called once per row and receives the full temporaries
+/// vector. It should fill its reserved slots but this is not enforced.
+/// Returning false from try_fill() causes the current row to be dropped
+/// (external filtering), e.g. to discard NaN/Inf scores.
+class temporaries_provider {
+public:
+    virtual ~temporaries_provider() = default;
+    virtual bool try_fill(
+        std::vector<cql3::raw_value>& temporaries,
+        std::span<const bytes> partition_key,
+        std::span<const bytes> clustering_key,
+        const query::result_row_view& static_row,
+        const query::result_row_view* row
+    ) const = 0;
+};
 
 class selectors {
 public:
@@ -61,6 +84,17 @@ public:
     virtual std::vector<managed_bytes_opt> transform_input_row(result_set_builder& rs) = 0;
 
     virtual void reset() = 0;
+
+    /// Populates the temporaries vector with provider-supplied values (e.g.
+    /// similarity scores) before expression evaluation. Called once per input
+    /// row, after filtering and before transform_input_row / add_input_row.
+    /// Returns false to drop the row (provider rejected it).
+    virtual bool inject_temporaries(
+        const temporaries_provider* provider,
+        std::span<const bytes> partition_key,
+        std::span<const bytes> clustering_key,
+        const query::result_row_view& static_row,
+        const query::result_row_view* row) = 0;
 };
 
 class selection {
@@ -286,9 +320,11 @@ public:
         std::vector<bytes>& _partition_key;
         std::vector<bytes>& _clustering_key;
         Filter _filter;
+        const temporaries_provider* _temporaries_provider;
     public:
         visitor(cql3::selection::result_set_builder& builder, const schema& s,
-                const selection& selection, Filter filter = Filter())
+                const selection& selection, Filter filter = Filter(),
+                const temporaries_provider* temporaries_provider = nullptr)
             : _builder(builder)
             , _schema(s)
             , _selection(selection)
@@ -296,6 +332,7 @@ public:
             , _partition_key(_builder.current_partition_key)
             , _clustering_key(_builder.current_clustering_key)
             , _filter(filter)
+            , _temporaries_provider(temporaries_provider)
         {}
         visitor(visitor&&) = default;
 
@@ -338,9 +375,24 @@ public:
         void accept_new_row(const query::result_row_view& static_row, const query::result_row_view& row) {
             auto static_row_iterator = static_row.iterator();
             auto row_iterator = row.iterator();
+
+            // Filter first, before temporaries are filled
             if (!_filter(_selection, _partition_key, _clustering_key, static_row, &row)) {
                 return;
             }
+
+            // Externally filter and inject provider values into selectors' temporaries vector.
+            if (_temporaries_provider) {
+                if (!_builder._selectors->inject_temporaries(
+                        _temporaries_provider,
+                        _partition_key,
+                        _clustering_key,
+                        static_row,
+                        &row)) {
+                    return;
+                }
+            }
+
             _builder.start_new_row();
             for (auto&& def : _selection.get_columns()) {
                 switch (def->kind) {

--- a/cql3/statements/external_search/external_index_select_statement.cc
+++ b/cql3/statements/external_search/external_index_select_statement.cc
@@ -95,8 +95,10 @@ future<::shared_ptr<cql_transport::messages::result_message>> external_index_sel
 
     command->set_row_limit(get_limit(options, _limit));
 
-    co_return co_await wrap_result_to_error_message([this, command = std::move(command), &options](auto query_result) {
-        return process_results(std::move(query_result), command, options, _query_start_time_point);
+    auto provider = get_temporaries_provider(options);
+
+    co_return co_await wrap_result_to_error_message([this, command = std::move(command), &options, provider_ptr = provider.get()](auto query_result) {
+        return process_results(std::move(query_result), command, options, _query_start_time_point, provider_ptr);
     })(std::move(result));
 }
 

--- a/cql3/statements/external_search/external_index_select_statement.hh
+++ b/cql3/statements/external_search/external_index_select_statement.hh
@@ -55,6 +55,14 @@ protected:
     virtual future<::shared_ptr<cql_transport::messages::result_message>> execute_search(
             query_processor& qp, service::query_state& state, const query_options& options, uint64_t limit) const = 0;
 
+    /// Override to provide a temporaries_provider for custom result processing.
+    /// Called by query_base_table() to inject custom data (e.g., rescoring similarity scores) during result processing.
+    /// \return A temporaries_provider, or nullptr if no custom processing is needed.
+    virtual std::unique_ptr<cql3::selection::temporaries_provider>
+    get_temporaries_provider(const query_options& options) const {
+        return nullptr;
+    }
+
     void update_stats_rows_read(int64_t rows_read) const override {
         _stats.rows_read += rows_read;
         _stats.secondary_index_rows_read += rows_read;

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.cc
@@ -21,6 +21,7 @@
 #include "index/vector_index.hh"
 #include "types/vector.hh"
 
+#include <algorithm>
 #include <cmath>
 #include <seastar/core/future.hh>
 #include <seastar/core/on_internal_error.hh>
@@ -117,6 +118,53 @@ public:
 };
 
 } // anonymous namespace
+
+vector_indexed_table_select_statement::rescoring_config
+vector_indexed_table_select_statement::rescoring_config::make(
+        const secondary_index::index& index,
+        const column_definition* column,
+        const cql3::selection::selection& sel) {
+    rescoring_config cfg;
+    const auto& index_options = index.metadata().options();
+
+    if (secondary_index::vector_index::is_rescoring_enabled(index_options)) {
+        const auto sim_fn_name = secondary_index::vector_index::get_cql_similarity_function_name(index_options);
+        cfg.function = seastar::make_shared<cql3::functions::vector_similarity_fct>(
+            sstring(sim_fn_name), std::vector<data_type>{column->type, column->type});
+
+        cfg.indexed_col_kind = column->kind;
+
+        if (column->is_primary_key()) {
+            cfg.index = column->component_index();
+        } else {
+            size_t stream_pos = 0;
+            for (const column_definition* def : sel.get_columns()) {
+                if (def == column) {
+                    break;
+                }
+                if (column->is_static() ? def->is_static() : def->is_regular()) {
+                    ++stream_pos;
+                }
+            }
+            cfg.index = stream_pos;
+        }
+    }
+    return cfg;
+}
+
+std::unique_ptr<cql3::selection::temporaries_provider>
+vector_indexed_table_select_statement::rescoring_config::make_similarity_provider(
+        const cql3::query_options& options,
+        const cql3::expr::expression& ann_vector_expr,
+        size_t similarity_temporary_index) const {
+    if (!is_enabled()) {
+        return nullptr;
+    }
+    auto query_vec_bytes = cql3::expr::evaluate(ann_vector_expr, options).to_bytes();
+    return std::make_unique<rescoring_similarity_provider>(
+        function, std::move(query_vec_bytes),
+        indexed_col_kind, index, similarity_temporary_index);
+}
 
 std::optional<ann_ordering_info> get_ann_ordering_info(
         data_dictionary::database db,

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.cc
@@ -217,36 +217,21 @@ std::optional<ann_ordering_info> get_ann_ordering_info(
     };
 }
 
-uint32_t add_similarity_function_to_selectors(
+// Appends a temporary expression for the similarity score to prepared_selectors.
+// Returns the index of the appended selector within prepared_selectors.
+uint32_t append_similarity_temporary_selector(
         std::vector<selection::prepared_selector>& prepared_selectors,
-        const ann_ordering_info& ann_ordering_info,
-        data_dictionary::database db,
-        schema_ptr schema) {
-    auto similarity_function_name = secondary_index::vector_index::get_cql_similarity_function_name(ann_ordering_info._index.metadata().options());
-    // Create the function name
-    auto func_name = functions::function_name::native_function(sstring(similarity_function_name));
-
-    // Create the function arguments
-    std::vector<expr::expression> args;
-    args.push_back(expr::column_value(ann_ordering_info._prepared_ann_ordering.first));
-    args.push_back(ann_ordering_info._prepared_ann_ordering.second);
-
-    // Get the function object
-    std::vector<shared_ptr<assignment_testable>> provided_args;
-    provided_args.push_back(expr::as_assignment_testable(args[0], expr::type_of(args[0])));
-    provided_args.push_back(expr::as_assignment_testable(args[1], expr::type_of(args[1])));
-
-    auto func = cql3::functions::instance().get(db, schema->ks_name(), func_name, provided_args, schema->ks_name(), schema->cf_name(), nullptr);
-
-    // Create the function call expression
-    expr::function_call similarity_func_call{
-        .func = func,
-        .args = std::move(args),
+        size_t temp_index) {
+    // Create a temporary expression instead of a function call.
+    // The value will be injected during result processing by rescoring_similarity_provider.
+    expr::temporary similarity_temp{
+        .index = temp_index,
+        .type = float_type,
     };
 
-    // Add the similarity function as a prepared selector (last)
+    // Add the temporary as a prepared selector (last)
     prepared_selectors.push_back(selection::prepared_selector{
-        .expr = std::move(similarity_func_call),
+        .expr = expr::expression(similarity_temp),
         .alias = nullptr,
     });
     return prepared_selectors.size() - 1;
@@ -304,6 +289,9 @@ vector_indexed_table_select_statement::vector_indexed_table_select_statement(sch
     if (selection->is_aggregate()) {
         throw exceptions::invalid_request_exception("Vector ANN queries cannot be run with aggregation");
     }
+
+    // Compute rescoring decision once at prepare time.
+    _rescoring = rescoring_config::make(_index, _prepared_ann_ordering.first, *_selection);
 }
 
 future<shared_ptr<cql_transport::messages::result_message>> vector_indexed_table_select_statement::execute_search(
@@ -325,11 +313,19 @@ future<shared_ptr<cql_transport::messages::result_message>> vector_indexed_table
                 exceptions::invalid_request_exception(std::visit(vector_search::vector_store_client::ann_error_visitor{}, pkeys.error())));
     }
 
-    if (pkeys->size() > limit && !secondary_index::vector_index::is_rescoring_enabled(_index.metadata().options())) {
+    if (pkeys->size() > limit && !_rescoring.is_enabled()) {
         pkeys->erase(pkeys->begin() + limit, pkeys->end());
     }
 
     co_return co_await query_base_table(qp, state, options, pkeys.value(), timeout);
+}
+
+std::unique_ptr<cql3::selection::temporaries_provider>
+vector_indexed_table_select_statement::get_temporaries_provider(const query_options& options) const {
+    return _rescoring.make_similarity_provider(
+        options,
+        _prepared_ann_ordering.second,
+        similarity_temporary_index);
 }
 
 } // namespace statements

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.cc
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.cc
@@ -11,6 +11,7 @@
 #include "cql3/expr/evaluate.hh"
 #include "cql3/expr/expr-utils.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/vector_similarity_fcts.hh"
 #include "cql3/statements/raw/select_statement.hh"
 #include "cql3/query_processor.hh"
 #include "cql3/util.hh"
@@ -20,6 +21,7 @@
 #include "index/vector_index.hh"
 #include "types/vector.hh"
 
+#include <cmath>
 #include <seastar/core/future.hh>
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/coroutine/exception.hh>
@@ -42,6 +44,77 @@ std::vector<float> get_ann_ordering_vector(const select_statement::prepared_ann_
     auto values = value_cast<vector_type_impl::native_type>(ann_column->type->deserialize(std::move(expr_value).to_bytes()));
     return util::to_vector<float>(values);
 }
+
+// Re-computes similarity scores live from the fetched embedding column.
+// Used in rescoring mode: no reliance on VS-provided distances.
+class rescoring_similarity_provider : public cql3::selection::temporaries_provider {
+    const seastar::shared_ptr<cql3::functions::vector_similarity_fct> _similarity_fct;
+    const bytes_opt _query_vec_bytes;
+    // Storage class of the indexed column. All kinds are handled in try_fill,
+    // though in practice this will only be regular or static for vector indexes.
+    const column_kind _col_kind;
+    // Unified index into the relevant data source:
+    //  - partition_key / clustering_key: component offset in the exploded key span.
+    //  - static_column / regular_column: cell-stream offset (only same-kind columns counted).
+    const size_t _index;
+    const size_t _temporary_index;
+public:
+    rescoring_similarity_provider(
+            seastar::shared_ptr<cql3::functions::vector_similarity_fct> similarity_fct,
+            bytes_opt query_vec_bytes,
+            column_kind col_kind,
+            size_t index,
+            size_t temporary_index)
+        : _similarity_fct(std::move(similarity_fct))
+        , _query_vec_bytes(std::move(query_vec_bytes))
+        , _col_kind(col_kind)
+        , _index(index)
+        , _temporary_index(temporary_index) {}
+
+    bool try_fill(
+            std::vector<cql3::raw_value>& temporaries,
+            std::span<const bytes> partition_key,
+            std::span<const bytes> clustering_key,
+            const query::result_row_view& static_row,
+            const query::result_row_view* row) const override {
+        bytes_opt row_vec_bytes;
+        switch (_col_kind) {
+        case column_kind::partition_key:
+            row_vec_bytes = partition_key[_index];
+            break;
+        case column_kind::clustering_key:
+            row_vec_bytes = clustering_key[_index];
+            break;
+        case column_kind::static_column:
+        case column_kind::regular_column: {
+            if (_col_kind == column_kind::regular_column && !row) {
+                return false;
+            }
+            auto iter = (_col_kind == column_kind::static_column) ? static_row.iterator()
+                                                                   : row->iterator();
+            for (size_t i = 0; i < _index; ++i) {
+                iter.next_atomic_cell();
+            }
+            // Vector columns are always single-cell, so next_atomic_cell is sufficient.
+            auto cell = iter.next_atomic_cell();
+            if (cell) {
+                row_vec_bytes = linearized(cell->value());
+            }
+            break;
+        }
+        }
+        auto result_bytes = _similarity_fct->execute(std::array<bytes_opt, 2>{_query_vec_bytes, row_vec_bytes});
+        if (!result_bytes) {
+            return false;
+        }
+        float similarity_value = value_cast<float>(float_type->deserialize(*result_bytes));
+        if (!std::isfinite(similarity_value)) {
+            return false;
+        }
+        temporaries[_temporary_index] = cql3::raw_value::make_value(std::move(*result_bytes));
+        return true;
+    }
+};
 
 } // anonymous namespace
 

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.hh
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.hh
@@ -12,6 +12,7 @@
 #include "cql3/statements/external_search/filter.hh"
 
 #include <optional>
+namespace cql3::functions { class vector_similarity_fct; }
 
 namespace cql3::statements {
 
@@ -44,6 +45,33 @@ select_statement::ordering_comparator_type get_similarity_ordering_comparator(
         uint32_t similarity_column_index);
 
 class vector_indexed_table_select_statement : public external_index_select_statement {
+public:
+    /// Aggregates all rescoring-related state resolved at prepare time.
+    struct rescoring_config {
+        /// Non-null when rescoring is enabled.
+        seastar::shared_ptr<cql3::functions::vector_similarity_fct> function;
+        /// Storage class of the indexed column.
+        column_kind indexed_col_kind = column_kind::regular_column;
+        /// Unified index into the relevant data source for the indexed column:
+        ///  - partition_key / clustering_key: component_index() into the exploded key span.
+        ///  - static_column / regular_column: offset among same-kind columns in selection order
+        ///    (PK/CK columns do not consume result_row_view iterator slots).
+        size_t index = 0;
+
+        static rescoring_config make(const secondary_index::index& index,
+                                     const column_definition* indexed_column,
+                                     const cql3::selection::selection& sel);
+
+        bool is_enabled() const { return bool(function); }
+
+        std::unique_ptr<cql3::selection::temporaries_provider>
+        make_similarity_provider(
+                const cql3::query_options& options,
+                const cql3::expr::expression& ann_vector_expr,
+                size_t similarity_temporary_index) const;
+    };
+
+private:
     prepared_ann_ordering_type _prepared_ann_ordering;
     external_search::prepared_filter _prepared_filter;
 

--- a/cql3/statements/external_search/vector_indexed_table_select_statement.hh
+++ b/cql3/statements/external_search/vector_indexed_table_select_statement.hh
@@ -31,13 +31,11 @@ std::optional<ann_ordering_info> get_ann_ordering_info(
         lw_shared_ptr<const raw::select_statement::parameters> parameters,
         prepare_context& ctx);
 
-/// Adds a similarity function call to prepared_selectors based on the ANN index.
+/// Appends a temporary expression for the similarity score to prepared_selectors.
 /// Returns the index of the appended selector within prepared_selectors.
-uint32_t add_similarity_function_to_selectors(
+uint32_t append_similarity_temporary_selector(
         std::vector<selection::prepared_selector>& prepared_selectors,
-        const ann_ordering_info& ann_ordering_info,
-        data_dictionary::database db,
-        schema_ptr schema);
+        size_t temp_index);
 
 /// Builds an ordering comparator that sorts by descending similarity score.
 select_statement::ordering_comparator_type get_similarity_ordering_comparator(
@@ -74,9 +72,13 @@ public:
 private:
     prepared_ann_ordering_type _prepared_ann_ordering;
     external_search::prepared_filter _prepared_filter;
+    rescoring_config _rescoring;
 
 public:
     static constexpr size_t max_ann_query_limit = 1000;
+    // Index of the similarity score temporary within the temporaries vector.
+    // Fixed at 0: always allocated before any aggregation temporaries.
+    static constexpr size_t similarity_temporary_index = 0;
 
     static ::shared_ptr<cql3::statements::select_statement> prepare(data_dictionary::database db, schema_ptr schema, uint32_t bound_terms,
             lw_shared_ptr<const parameters> parameters, ::shared_ptr<selection::selection> selection,
@@ -97,6 +99,9 @@ private:
 
     future<::shared_ptr<cql_transport::messages::result_message>> execute_search(
             query_processor& qp, service::query_state& state, const query_options& options, uint64_t limit) const override;
+
+    std::unique_ptr<cql3::selection::temporaries_provider>
+    get_temporaries_provider(const query_options& options) const override;
 };
 
 } // namespace cql3::statements

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -965,35 +965,37 @@ future<shared_ptr<cql_transport::messages::result_message>>
 select_statement::process_results(foreign_ptr<lw_shared_ptr<query::result>> results,
                                   lw_shared_ptr<query::read_command> cmd,
                                   const query_options& options,
-                                  gc_clock::time_point now) const
+                                  gc_clock::time_point now,
+                                  const cql3::selection::temporaries_provider* temporaries_provider) const
 {
-    const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !needs_post_filtering();
+    const bool fast_path = !needs_post_query_ordering() && _selection->is_trivial() && !needs_post_filtering() && !temporaries_provider;
     if (fast_path) {
         return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(make_shared<cql_transport::messages::result_message::rows>(result(
             result_generator(_query_schema, std::move(results), std::move(cmd), _selection, _stats),
             _selection->get_result_metadata())
         ));
     }
-    return process_results_complex(std::move(results), std::move(cmd), options, now);
+    return process_results_complex(std::move(results), std::move(cmd), options, now, temporaries_provider);
 }
 
 future<shared_ptr<cql_transport::messages::result_message>>
 select_statement::process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
                                   lw_shared_ptr<query::read_command> cmd,
                                   const query_options& options,
-                                  gc_clock::time_point now) const {
-    cql3::selection::result_set_builder builder(*_selection, now, &options);
+                                  gc_clock::time_point now,
+                                  const cql3::selection::temporaries_provider* temporaries_provider) const {
+    cql3::selection::result_set_builder builder(*_selection, now, &options, {});
     co_return co_await builder.with_thread_if_needed([&] {
         if (needs_post_filtering()) {
             results->ensure_counts();
             _stats.filtered_rows_read_total += *results->row_count();
             query::result_view::consume(*results, cmd->slice,
                     cql3::selection::result_set_builder::visitor(builder, *_query_schema,
-                            *_selection, cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _query_schema, cmd->slice.partition_row_limit())));
+                            *_selection, cql3::selection::result_set_builder::restrictions_filter(_restrictions, options, cmd->get_row_limit(), _query_schema, cmd->slice.partition_row_limit()), temporaries_provider));
         } else {
             query::result_view::consume(*results, cmd->slice,
                     cql3::selection::result_set_builder::visitor(builder, *_query_schema,
-                            *_selection));
+                            *_selection, cql3::selection::result_set_builder::nop_filter(), temporaries_provider));
         }
         auto rs = builder.build();
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -2075,7 +2075,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
         // We have a "SELECT * GROUP BY" or "SELECT * ORDER BY ANN" with rescoring enabled. If we leave prepared_selectors
         // empty, below we choose selection::wildcard() for SELECT *, and either:
         //  - forget to do the "levellize" trick needed for the GROUP BY. See #16531.
-        //  - forget to add the similarity function needed for ORDER BY ANN with rescoring. See below.
+        //  - forget to add the similarity temporary needed for ORDER BY ANN with rescoring. See below.
         // So we need to set prepared_selectors. 
         auto all_columns = selection::selection::wildcard_columns(schema);
         std::vector<::shared_ptr<selection::raw_selector>> select_all;
@@ -2101,7 +2101,7 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     select_statement::ordering_comparator_type ordering_comparator;
     bool hide_last_column = false;
     if (is_ann_query && ann_ordering_info_opt->is_rescoring_enabled) {
-        uint32_t similarity_column_index = add_similarity_function_to_selectors(prepared_selectors, *ann_ordering_info_opt, db, schema);
+        uint32_t similarity_column_index = append_similarity_temporary_selector(prepared_selectors, vector_indexed_table_select_statement::similarity_temporary_index);
         hide_last_column = true;
         ordering_comparator = get_similarity_ordering_comparator(prepared_selectors, similarity_column_index);
     }
@@ -2126,6 +2126,8 @@ std::unique_ptr<prepared_statement> select_statement::prepare(data_dictionary::d
     if (is_ann_query && hide_last_column) {
         // Hide the similarity selector from the client by reducing column_count
         selection->get_result_metadata()->hide_last_column();
+        // Ensure the indexed column is fetched from the base table for rescoring.
+        selection->add_column_for_post_processing(*ann_ordering_info_opt->_prepared_ann_ordering.first);
     }
 
     // Cassandra 5.0.2 disallows PER PARTITION LIMIT with aggregate queries

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -100,7 +100,8 @@ protected:
     std::unique_ptr<cql3::attributes> _attrs;
 private:
     future<shared_ptr<cql_transport::messages::result_message>> process_results_complex(foreign_ptr<lw_shared_ptr<query::result>> results,
-        lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now) const;
+        lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now,
+        const cql3::selection::temporaries_provider* temporaries_provider = nullptr) const;
     void detect_range_scan();
 protected :
     virtual future<::shared_ptr<cql_transport::messages::result_message>> do_execute(query_processor& qp,
@@ -148,7 +149,8 @@ public:
         std::optional<service::cas_shard> cas_shard) const;
 
     future<shared_ptr<cql_transport::messages::result_message>> process_results(foreign_ptr<lw_shared_ptr<query::result>> results,
-        lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now) const;
+        lw_shared_ptr<query::read_command> cmd, const query_options& options, gc_clock::time_point now,
+        const cql3::selection::temporaries_provider* temporaries_provider = nullptr) const;
 
     const sstring& keyspace() const;
 

--- a/test/cqlpy/test_vector_search_rescoring_with_mock.py
+++ b/test/cqlpy/test_vector_search_rescoring_with_mock.py
@@ -249,7 +249,6 @@ def test_select_similarity_function_other_than_ann_ordering(cql, test_keyspace, 
 # an error during cosine rescoring; now similarity_cosine returns NaN for them.
 #
 # Reproduces SCYLLADB-2231
-@pytest.mark.xfail(reason="SCYLLADB-2231 rescoring does not yet filter rows with invalid similarity scores (NaN)")
 def test_filters_invalid_similarity_scores_in_rescored_results(cql, test_keyspace, vector_store_mock, skip_without_tablets):
     for func_name, data in TEST_DATA.items():
         with rescoring_test_table(cql, test_keyspace, data,
@@ -293,7 +292,6 @@ def test_filters_invalid_similarity_scores_in_rescored_results(cql, test_keyspac
 # an empty result set.
 #
 # Reproduces SCYLLADB-2231
-@pytest.mark.xfail(reason="SCYLLADB-2231: rescoring does not yet filter NaN similarity scores")
 def test_rescoring_with_zerovector_query(cql, test_keyspace, vector_store_mock, skip_without_tablets):
     data = TEST_DATA["cosine"]
     with rescoring_test_table(cql, test_keyspace, data) as table:


### PR DESCRIPTION
This PR introduces a new mechanism for injecting external per-row values into CQL result processing.

Vector Search provides a good example of why this is useful. Besides the primary keys of candidate rows, the vector store may also return additional per-row data such as similarity scores. Those values are not stored in the base table, but they are still part of the query result computation, and it is useful to make them available during normal CQL result processing, potentially on equal footing with the real columns read from replicas.

The main challenge is where to attach such values in the pipeline. They need to appear late enough that they are tied to the actual row fetched from the base table, but still early enough to participate in the rest of processing, including filtering, selector evaluation, and final ordering. Without such an integration point, features that use external per-row data need dedicated handling outside the normal CQL result-processing path.

The proposed implementation is based on `temporaries`. So far, temporaries were mainly used for aggregation state, but the underlying mechanism is more general: it is simply a place to keep intermediate per-row values during result processing. This change extends that usage and allows temporaries to hold externally supplied values as well.

This matches the existing processing order well. Once the row has been read from the base table, the result-processing path already has access to the full row contents, and then continues with filtering, expression evaluation, and post-processing such as sorting. The new hook fills temporaries exactly at that point, which makes the injected values available to the normal CQL pipeline instead of handling them through a separate side path.

This PR then moves vector search rescoring to the same mechanism. Previously, rescoring was handled through a more specialized path. Here it is rewritten to produce its result through the same temporary-based mechanism that can also be used for other externally supplied per-row values. For now, this is mainly a move toward a more general solution, while also fixing a small filtering-related issue.

The main value of this refactoring will become clearer as more features are added. In particular, it should make it possible to refer to the same temporary slot regardless of whether its value was computed locally during rescoring or returned directly by the vector store. That gives us a more uniform foundation for exposing values from VS, enabling rescoring per request, adding further filtering stages, and later building analogous functionality for FTS and Hybrid Search.

Fixes: SCYLLADB-2231
Ref: SCYLLADB-2212
Ref: SCYLLADB-426

Groundwork for new features — no backporting.