### PR TITLE
Add Vnodes to Tablets Migration Procedure

### DIFF
--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3207,6 +3207,26 @@
          }]
       },
       {
+         "path":"/storage_service/vnode_tablet_migrations/keyspaces/{keyspace}/finalization",
+         "operations":[{
+             "method":"POST",
+             "summary":"Finalize vnodes-to-tablets migration for all tables in a keyspace",
+             "type":"void",
+             "nickname":"finalize_vnode_tablet_migration",
+             "produces":["application/json"],
+             "parameters":[
+                 {
+                     "name":"keyspace",
+                     "description":"Keyspace name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                 }
+             ]
+         }]
+      },
+      {
          "path":"/storage_service/quiesce_topology",
          "operations":[
             {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3167,6 +3167,26 @@
       },
 
       {
+         "path":"/storage_service/vnode_tablet_migrations/keyspaces/{keyspace}",
+         "operations":[{
+             "method":"POST",
+             "summary":"Start vnodes-to-tablets migration for all tables in a keyspace",
+             "type":"void",
+             "nickname":"create_vnode_tablet_migration",
+             "produces":["application/json"],
+             "parameters":[
+                 {
+                     "name":"keyspace",
+                     "description":"Keyspace name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                 }
+             ]
+         }]
+      },
+      {
          "path":"/storage_service/quiesce_topology",
          "operations":[
             {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3184,6 +3184,23 @@
                      "paramType":"path"
                  }
              ]
+         },
+         {
+             "method":"GET",
+             "summary":"Get a keyspace's vnodes-to-tablets migration status",
+             "type":"vnode_tablet_migration_status",
+             "nickname":"get_vnode_tablet_migration",
+             "produces":["application/json"],
+             "parameters":[
+                 {
+                     "name":"keyspace",
+                     "description":"Keyspace name",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"path"
+                 }
+             ]
          }]
       },
       {
@@ -3841,6 +3858,45 @@
             "ratio":{
                "type":"float",
                "description":"The resulting compression ratio (estimated on a random sample of files)"
+            }
+         }
+      },
+      "vnode_tablet_migration_node_status":{
+         "id":"vnode_tablet_migration_node_status",
+         "description":"Node storage mode info during vnodes-to-tablets migration",
+         "properties":{
+            "host_id":{
+               "type":"string",
+               "description":"The host ID"
+            },
+            "current_mode":{
+               "type":"string",
+               "description":"The current storage mode: `vnodes` or `tablets`"
+            },
+            "intended_mode":{
+               "type":"string",
+               "description":"The intended storage mode: `vnodes` or `tablets`"
+            }
+         }
+      },
+      "vnode_tablet_migration_status":{
+         "id":"vnode_tablet_migration_status",
+         "description":"Vnodes-to-tablets migration status for a keyspace",
+         "properties":{
+            "keyspace":{
+               "type":"string",
+               "description":"The keyspace name"
+            },
+            "status":{
+               "type":"string",
+               "description":"The migration status: `vnodes` (not started), `migrating_to_tablets` (in progress), or `tablets` (complete)"
+            },
+            "nodes":{
+               "type":"array",
+               "items":{
+                  "$ref":"vnode_tablet_migration_node_status"
+               },
+               "description":"Per-node storage mode information. Empty if the keyspace is not being migrated."
             }
          }
       }

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -3187,6 +3187,26 @@
          }]
       },
       {
+         "path":"/storage_service/vnode_tablet_migrations/node/storage_mode",
+         "operations":[{
+             "method":"PUT",
+             "summary":"Set the intended storage mode for this node during vnodes-to-tablets migration",
+             "type":"void",
+             "nickname":"set_vnode_tablet_migration_node_storage_mode",
+             "produces":["application/json"],
+             "parameters":[
+                 {
+                     "name":"intended_mode",
+                     "description":"Intended storage mode (tablets or vnodes)",
+                     "required":true,
+                     "allowMultiple":false,
+                     "type":"string",
+                     "paramType":"query"
+                 }
+             ]
+         }]
+      },
+      {
          "path":"/storage_service/quiesce_topology",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1729,6 +1729,18 @@ rest_tablet_balancing_enable(sharded<service::storage_service>& ss, std::unique_
 
 static
 future<json::json_return_type>
+rest_create_vnode_tablet_migration(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    if (!ss.local().get_feature_service().vnodes_to_tablets_migrations) {
+        apilog.warn("create_vnode_tablet_migration: called before the cluster feature was enabled");
+        throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
+    }
+    auto keyspace = validate_keyspace(ctx, req);
+    co_await ss.local().prepare_for_tablets_migration(keyspace);
+    co_return json_void();
+}
+
+static
+future<json::json_return_type>
 rest_quiesce_topology(sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         co_await ss.local().await_topology_quiesced();
         co_return json_void();
@@ -1877,6 +1889,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::del_tablet_replica.set(r, rest_bind(rest_del_tablet_replica, ctx, ss));
     ss::repair_tablet.set(r, rest_bind(rest_repair_tablet, ctx, ss));
     ss::tablet_balancing_enable.set(r, rest_bind(rest_tablet_balancing_enable, ss));
+    ss::create_vnode_tablet_migration.set(r, rest_bind(rest_create_vnode_tablet_migration, ctx, ss));
     ss::quiesce_topology.set(r, rest_bind(rest_quiesce_topology, ss));
     sp::get_schema_versions.set(r, rest_bind(rest_get_schema_versions, ss));
     ss::drop_quarantined_sstables.set(r, rest_bind(rest_drop_quarantined_sstables, ctx, ss));
@@ -1956,6 +1969,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::del_tablet_replica.unset(r);
     ss::repair_tablet.unset(r);
     ss::tablet_balancing_enable.unset(r);
+    ss::create_vnode_tablet_migration.unset(r);
     ss::quiesce_topology.unset(r);
     sp::get_schema_versions.unset(r);
     ss::drop_quarantined_sstables.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1742,6 +1742,30 @@ rest_create_vnode_tablet_migration(http_context& ctx, sharded<service::storage_s
 
 static
 future<json::json_return_type>
+rest_get_vnode_tablet_migration(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    if (!ss.local().get_feature_service().vnodes_to_tablets_migrations) {
+        apilog.warn("get_vnode_tablet_migration: called before the cluster feature was enabled");
+        throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
+    }
+    auto keyspace = validate_keyspace(ctx, req);
+    auto status = co_await ss.local().get_tablets_migration_status(keyspace);
+
+    ss::vnode_tablet_migration_status result;
+    result.keyspace = status.keyspace;
+    result.status = status.status;
+    result.nodes._set = true;
+    for (const auto& node : status.nodes) {
+        ss::vnode_tablet_migration_node_status n;
+        n.host_id = fmt::to_string(node.host_id);
+        n.current_mode = node.current_mode;
+        n.intended_mode = node.intended_mode;
+        result.nodes.push(n);
+    }
+    co_return result;
+}
+
+static
+future<json::json_return_type>
 rest_set_vnode_tablet_migration_node_storage_mode(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
     if (!ss.local().get_feature_service().vnodes_to_tablets_migrations) {
         apilog.warn("set_vnode_tablet_migration_node_storage_mode: called before the cluster feature was enabled");
@@ -1918,6 +1942,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::repair_tablet.set(r, rest_bind(rest_repair_tablet, ctx, ss));
     ss::tablet_balancing_enable.set(r, rest_bind(rest_tablet_balancing_enable, ss));
     ss::create_vnode_tablet_migration.set(r, rest_bind(rest_create_vnode_tablet_migration, ctx, ss));
+    ss::get_vnode_tablet_migration.set(r, rest_bind(rest_get_vnode_tablet_migration, ctx, ss));
     ss::set_vnode_tablet_migration_node_storage_mode.set(r, rest_bind(rest_set_vnode_tablet_migration_node_storage_mode, ctx, ss));
     ss::finalize_vnode_tablet_migration.set(r, rest_bind(rest_finalize_vnode_tablet_migration, ctx, ss));
     ss::quiesce_topology.set(r, rest_bind(rest_quiesce_topology, ss));
@@ -2000,6 +2025,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::repair_tablet.unset(r);
     ss::tablet_balancing_enable.unset(r);
     ss::create_vnode_tablet_migration.unset(r);
+    ss::get_vnode_tablet_migration.unset(r);
     ss::set_vnode_tablet_migration_node_storage_mode.unset(r);
     ss::finalize_vnode_tablet_migration.unset(r);
     ss::quiesce_topology.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -30,6 +30,7 @@
 #include <fmt/ranges.h>
 #include "service/raft/raft_group0_client.hh"
 #include "service/storage_service.hh"
+#include "service/topology_state_machine.hh"
 #include "service/load_meter.hh"
 #include "gms/feature_service.hh"
 #include "gms/gossiper.hh"
@@ -1741,6 +1742,19 @@ rest_create_vnode_tablet_migration(http_context& ctx, sharded<service::storage_s
 
 static
 future<json::json_return_type>
+rest_set_vnode_tablet_migration_node_storage_mode(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    if (!ss.local().get_feature_service().vnodes_to_tablets_migrations) {
+        apilog.warn("set_vnode_tablet_migration_node_storage_mode: called before the cluster feature was enabled");
+        throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
+    }
+    auto mode_str = req->get_query_param("intended_mode");
+    auto mode = service::intended_storage_mode_from_string(mode_str);
+    co_await ss.local().set_node_intended_storage_mode(mode);
+    co_return json_void();
+}
+
+static
+future<json::json_return_type>
 rest_quiesce_topology(sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         co_await ss.local().await_topology_quiesced();
         co_return json_void();
@@ -1890,6 +1904,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::repair_tablet.set(r, rest_bind(rest_repair_tablet, ctx, ss));
     ss::tablet_balancing_enable.set(r, rest_bind(rest_tablet_balancing_enable, ss));
     ss::create_vnode_tablet_migration.set(r, rest_bind(rest_create_vnode_tablet_migration, ctx, ss));
+    ss::set_vnode_tablet_migration_node_storage_mode.set(r, rest_bind(rest_set_vnode_tablet_migration_node_storage_mode, ctx, ss));
     ss::quiesce_topology.set(r, rest_bind(rest_quiesce_topology, ss));
     sp::get_schema_versions.set(r, rest_bind(rest_get_schema_versions, ss));
     ss::drop_quarantined_sstables.set(r, rest_bind(rest_drop_quarantined_sstables, ctx, ss));
@@ -1970,6 +1985,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::repair_tablet.unset(r);
     ss::tablet_balancing_enable.unset(r);
     ss::create_vnode_tablet_migration.unset(r);
+    ss::set_vnode_tablet_migration_node_storage_mode.unset(r);
     ss::quiesce_topology.unset(r);
     sp::get_schema_versions.unset(r);
     ss::drop_quarantined_sstables.unset(r);

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1755,6 +1755,20 @@ rest_set_vnode_tablet_migration_node_storage_mode(http_context& ctx, sharded<ser
 
 static
 future<json::json_return_type>
+rest_finalize_vnode_tablet_migration(http_context& ctx, sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
+    if (!ss.local().get_feature_service().vnodes_to_tablets_migrations) {
+        apilog.warn("finalize_vnode_tablet_migration: called before the cluster feature was enabled");
+        throw std::runtime_error("vnodes-to-tablets migration requires all nodes to support the VNODES_TO_TABLETS_MIGRATIONS cluster feature");
+    }
+    auto keyspace = validate_keyspace(ctx, req);
+    validate_keyspace(ctx, keyspace);
+
+    co_await ss.local().finalize_tablets_migration(keyspace);
+    co_return json_void();
+}
+
+static
+future<json::json_return_type>
 rest_quiesce_topology(sharded<service::storage_service>& ss, std::unique_ptr<http::request> req) {
         co_await ss.local().await_topology_quiesced();
         co_return json_void();
@@ -1905,6 +1919,7 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
     ss::tablet_balancing_enable.set(r, rest_bind(rest_tablet_balancing_enable, ss));
     ss::create_vnode_tablet_migration.set(r, rest_bind(rest_create_vnode_tablet_migration, ctx, ss));
     ss::set_vnode_tablet_migration_node_storage_mode.set(r, rest_bind(rest_set_vnode_tablet_migration_node_storage_mode, ctx, ss));
+    ss::finalize_vnode_tablet_migration.set(r, rest_bind(rest_finalize_vnode_tablet_migration, ctx, ss));
     ss::quiesce_topology.set(r, rest_bind(rest_quiesce_topology, ss));
     sp::get_schema_versions.set(r, rest_bind(rest_get_schema_versions, ss));
     ss::drop_quarantined_sstables.set(r, rest_bind(rest_drop_quarantined_sstables, ctx, ss));
@@ -1986,6 +2001,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::tablet_balancing_enable.unset(r);
     ss::create_vnode_tablet_migration.unset(r);
     ss::set_vnode_tablet_migration_node_storage_mode.unset(r);
+    ss::finalize_vnode_tablet_migration.unset(r);
     ss::quiesce_topology.unset(r);
     sp::get_schema_versions.unset(r);
     ss::drop_quarantined_sstables.unset(r);

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -44,6 +44,7 @@
 #include "dht/partition_filter.hh"
 #include "mutation_writer/shard_based_splitting_writer.hh"
 #include "mutation_writer/partition_based_splitting_writer.hh"
+#include "mutation_writer/token_group_based_splitting_writer.hh"
 #include "mutation/mutation_source_metadata.hh"
 #include "mutation/mutation_fragment_stream_validator.hh"
 #include "utils/assert.hh"
@@ -1933,6 +1934,7 @@ class resharding_compaction final : public compaction {
     };
     std::vector<estimated_values> _estimation_per_shard;
     std::vector<sstables::run_id> _run_identifiers;
+    bool _reshard_vnodes;
 private:
     // return estimated partitions per sstable for a given shard
     uint64_t partitions_per_sstable(shard_id s) const {
@@ -1945,7 +1947,11 @@ public:
         : compaction(table_s, std::move(descriptor), cdata, progress_monitor, use_backlog_tracker::no)
         , _estimation_per_shard(smp::count)
         , _run_identifiers(smp::count)
+        , _reshard_vnodes(descriptor.options.as<compaction_type_options::reshard>().vnodes_resharding)
     {
+        if (_reshard_vnodes && !_owned_ranges) {
+            on_internal_error(clogger, "Resharding vnodes requires owned_ranges");
+        }
         for (auto& sst : _sstables) {
             const auto& shards = sst->get_shards_for_this_sstable();
             auto size = sst->bytes_on_disk();
@@ -1983,8 +1989,25 @@ public:
     }
 
     mutation_reader_consumer make_interposer_consumer(mutation_reader_consumer end_consumer) override {
-        return [end_consumer = std::move(end_consumer)] (mutation_reader reader) mutable -> future<> {
-            return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
+        auto owned_ranges = _reshard_vnodes ? _owned_ranges : nullptr;
+        return [end_consumer = std::move(end_consumer), owned_ranges = std::move(owned_ranges)] (mutation_reader reader) mutable -> future<> {
+            if (owned_ranges) {
+                auto classify = [owned_ranges, it = owned_ranges->begin(), idx = mutation_writer::token_group_id(0)] (dht::token t) mutable -> mutation_writer::token_group_id {
+                    dht::token_comparator cmp;
+                    while (it != owned_ranges->end() && it->after(t, cmp)) {
+                        clogger.debug("Token {} is after current range {}: advancing to the next range", t, *it);
+                        ++it;
+                        ++idx;
+                    }
+                    if (it == owned_ranges->end() || !it->contains(t, cmp)) {
+                        on_internal_error(clogger, fmt::format("Token {} is outside of owned ranges", t));
+                    }
+                    return idx;
+                };
+                return mutation_writer::segregate_by_token_group(std::move(reader), std::move(classify), std::move(end_consumer));
+            } else {
+                return mutation_writer::segregate_by_shard(std::move(reader), std::move(end_consumer));
+            }
         };
     }
 

--- a/compaction/compaction_descriptor.hh
+++ b/compaction/compaction_descriptor.hh
@@ -87,6 +87,8 @@ public:
         drop_unfixable_sstables drop_unfixable = drop_unfixable_sstables::no;
     };
     struct reshard {
+        // If set, resharding compaction will apply the owned_ranges to segregate sstables in vnode boundaries.
+        bool vnodes_resharding = false;
     };
     struct reshape {
     };
@@ -115,8 +117,8 @@ public:
         return compaction_type_options(reshape{});
     }
 
-    static compaction_type_options make_reshard() {
-        return compaction_type_options(reshard{});
+    static compaction_type_options make_reshard(bool vnodes_resharding = false) {
+        return compaction_type_options(reshard{.vnodes_resharding = vnodes_resharding});
     }
 
     static compaction_type_options make_regular() {

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -160,7 +160,16 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
     // There is a semaphore inside the compaction manager in run_resharding_jobs. So we
     // parallel_for_each so the statistics about pending jobs are updated to reflect all
     // jobs. But only one will run in parallel at a time
-    auto& t = table.try_get_compaction_group_view_with_static_sharding();
+    //
+    // The compaction group view is used here only for job registration and gate-holding;
+    // resharding never reads or writes the group's own SSTables. With static (vnode)
+    // sharding there is exactly one group per shard; with tablets there may be many.
+    // In either case, any registered group suffices.
+    auto* cg = table.get_any_compaction_group();
+    if (!cg) {
+        on_internal_error(tasks::tmlogger, format("No compaction group found for table {}.{}", table.schema()->ks_name(), table.schema()->cf_name()));
+    }
+    auto& t = cg->view_for_unrepaired_data();
     co_await coroutine::parallel_for_each(buckets, [&] (std::vector<sstables::shared_sstable>& sstlist) mutable {
         return table.get_compaction_manager().run_custom_job(t, compaction_type::Reshard, "Reshard compaction", [&] (compaction_data& info, compaction_progress_monitor& progress_monitor) -> future<> {
             auto erm = table.get_effective_replication_map(); // keep alive around compaction.

--- a/compaction/task_manager_module.cc
+++ b/compaction/task_manager_module.cc
@@ -132,7 +132,7 @@ distribute_reshard_jobs(sstables::sstable_directory::sstable_open_info_vector so
 // A creator function must be passed that will create an SSTable object in the correct shard,
 // and an I/O priority must be specified.
 future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::sstable_open_info_vector shared_info, replica::table& table,
-                           compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr, tasks::task_info parent_info)
+                           compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr, bool vnodes_resharding, tasks::task_info parent_info)
 {
     // Resharding doesn't like empty sstable sets, so bail early. There is nothing
     // to reshard in this shard.
@@ -166,7 +166,7 @@ future<> reshard(sstables::sstable_directory& dir, sstables::sstable_directory::
             auto erm = table.get_effective_replication_map(); // keep alive around compaction.
 
             compaction_descriptor desc(sstlist);
-            desc.options = compaction_type_options::make_reshard();
+            desc.options = compaction_type_options::make_reshard(vnodes_resharding);
             desc.creator = creator;
             desc.sharder = &erm->get_sharder(*table.schema());
             desc.owned_ranges = owned_ranges_ptr;
@@ -906,7 +906,7 @@ future<> table_resharding_compaction_task_impl::run() {
         if (_owned_ranges_ptr) {
             local_owned_ranges_ptr = make_lw_shared<const dht::token_range_vector>(*_owned_ranges_ptr);
         }
-        auto task = co_await compaction_module.make_and_start_task<shard_resharding_compaction_task_impl>(parent_info, _status.keyspace, _status.table, _status.id, _dir, db, _creator, std::move(local_owned_ranges_ptr), destinations);
+        auto task = co_await compaction_module.make_and_start_task<shard_resharding_compaction_task_impl>(parent_info, _status.keyspace, _status.table, _status.id, _dir, db, _creator, std::move(local_owned_ranges_ptr), _vnodes_resharding, destinations);
         co_await task->done();
     }));
 
@@ -926,12 +926,14 @@ shard_resharding_compaction_task_impl::shard_resharding_compaction_task_impl(tas
         replica::database& db,
         compaction_sstable_creator_fn creator,
         compaction::owned_ranges_ptr local_owned_ranges_ptr,
+        bool vnodes_resharding,
         std::vector<replica::reshard_shard_descriptor>& destinations) noexcept
     : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), 0, "shard", std::move(keyspace), std::move(table), "", parent_id)
     , _dir(dir)
     , _db(db)
     , _creator(std::move(creator))
     , _local_owned_ranges_ptr(std::move(local_owned_ranges_ptr))
+    , _vnodes_resharding(vnodes_resharding)
     , _destinations(destinations)
 {
     _expected_workload = _destinations[this_shard_id()].size();
@@ -941,7 +943,7 @@ future<> shard_resharding_compaction_task_impl::run() {
     auto& table = _db.find_column_family(_status.keyspace, _status.table);
     auto info_vec = std::move(_destinations[this_shard_id()].info_vec);
     tasks::task_info info{_status.id, _status.shard};
-    co_await reshard(_dir.local(), std::move(info_vec), table, _creator, std::move(_local_owned_ranges_ptr), info);
+    co_await reshard(_dir.local(), std::move(info_vec), table, _creator, std::move(_local_owned_ranges_ptr), _vnodes_resharding, info);
     co_await _dir.local().move_foreign_sstables(_dir);
 }
 

--- a/compaction/task_manager_module.hh
+++ b/compaction/task_manager_module.hh
@@ -693,6 +693,7 @@ private:
     sharded<replica::database>& _db;
     compaction_sstable_creator_fn _creator;
     compaction::owned_ranges_ptr _owned_ranges_ptr;
+    bool _vnodes_resharding;
 public:
     table_resharding_compaction_task_impl(tasks::task_manager::module_ptr module,
             std::string keyspace,
@@ -700,12 +701,14 @@ public:
             sharded<sstables::sstable_directory>& dir,
             sharded<replica::database>& db,
             compaction_sstable_creator_fn creator,
-            compaction::owned_ranges_ptr owned_ranges_ptr) noexcept
+            compaction::owned_ranges_ptr owned_ranges_ptr,
+            bool vnodes_resharding) noexcept
         : resharding_compaction_task_impl(module, tasks::task_id::create_random_id(), module->new_sequence_number(), "table", std::move(keyspace), std::move(table), "", tasks::task_id::create_null_id())
         , _dir(dir)
         , _db(db)
         , _creator(std::move(creator))
         , _owned_ranges_ptr(std::move(owned_ranges_ptr))
+        , _vnodes_resharding(vnodes_resharding)
     {}
 protected:
     virtual future<> run() override;
@@ -718,6 +721,7 @@ private:
     replica::database& _db;
     compaction_sstable_creator_fn _creator;
     compaction::owned_ranges_ptr _local_owned_ranges_ptr;
+    bool _vnodes_resharding;
     std::vector<replica::reshard_shard_descriptor>& _destinations;
 public:
     shard_resharding_compaction_task_impl(tasks::task_manager::module_ptr module,
@@ -728,6 +732,7 @@ public:
             replica::database& db,
             compaction_sstable_creator_fn creator,
             compaction::owned_ranges_ptr local_owned_ranges_ptr,
+            bool vnodes_resharding,
             std::vector<replica::reshard_shard_descriptor>& destinations) noexcept;
 protected:
     virtual future<> run() override;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -324,6 +324,7 @@ schema_ptr system_keyspace::topology_requests() {
             .with_column("snapshot_tag", utf8_type)
             .with_column("snapshot_expiry", timestamp_type)
             .with_column("snapshot_skip_flush", boolean_type)
+            .with_column("finalize_migration_ks_name", utf8_type)
             .set_comment("Topology request tracking")
             .with_hash_version()
             .build();
@@ -3511,6 +3512,9 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
         if (row.has("snapshot_expiry")) {
             entry.snapshot_expiry = row.get_as<db_clock::time_point>("snapshot_expiry");
         }
+    }
+    if (row.has("finalize_migration_ks_name")) {
+        entry.finalize_migration_ks_name = row.get_as<sstring>("finalize_migration_ks_name");
     }
 
     return entry;

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -281,6 +281,7 @@ schema_ptr system_keyspace::topology() {
             .with_column("cleanup_status", utf8_type)
             .with_column("supported_features", set_type_impl::get_instance(utf8_type, true))
             .with_column("request_id", timeuuid_type)
+            .with_column("intended_storage_mode", utf8_type)
             .with_column("ignore_nodes", set_type_impl::get_instance(uuid_type, true), column_kind::static_column)
             .with_column("new_cdc_generation_data_uuid", timeuuid_type, column_kind::static_column)
             .with_column("new_keyspace_rf_change_ks_name", utf8_type, column_kind::static_column) // deprecated
@@ -3169,6 +3170,11 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             }
         }
 
+        std::optional<service::intended_storage_mode> storage_mode;
+        if (row.has("intended_storage_mode")) {
+            storage_mode = service::intended_storage_mode_from_string(row.get_as<sstring>("intended_storage_mode"));
+        }
+
         std::unordered_map<raft::server_id, service::replica_state>* map = nullptr;
         if (nstate == service::node_state::normal) {
             map = &ret.normal_nodes;
@@ -3193,7 +3199,7 @@ future<service::topology> system_keyspace::load_topology_state(const std::unorde
             map->emplace(host_id, service::replica_state{
                 nstate, std::move(datacenter), std::move(rack), std::move(release_version),
                 ring_slice, shard_count, ignore_msb, std::move(supported_features),
-                service::cleanup_status_from_string(cleanup_status), request_id});
+                service::cleanup_status_from_string(cleanup_status), request_id, storage_mode});
         }
     }
 

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -427,6 +427,7 @@ public:
         std::optional<sstring> snapshot_tag;
         std::optional<db_clock::time_point> snapshot_expiry;
         bool snapshot_skip_flush;
+        std::optional<sstring> finalize_migration_ks_name;
     };
     using topology_requests_entries = std::unordered_map<utils::UUID, system_keyspace::topology_requests_entry>;
 

--- a/docs/dev/system_keyspace.md
+++ b/docs/dev/system_keyspace.md
@@ -1611,6 +1611,7 @@ CREATE TABLE system.topology (
     cleanup_status text,
     datacenter text,
     ignore_msb int,
+    intended_storage_mode text,
     node_state text,
     num_tokens int,
     rack text,
@@ -1663,6 +1664,7 @@ CREATE TABLE system.topology (
 - `tokens_string`: Alternative representation of tokens
 - `shard_count`: Number of shards on the node
 - `ignore_msb`: MSB bits to ignore for token calculation
+- `intended_storage_mode`: Intended storage mode for tables under vnodes-to-tablets migration. The node switches to this mode on next restart.
 - `cleanup_status`: Status of cleanup operations
 - `supported_features`: Features supported by this node
 - `request_id`: ID of the current topology request for this node

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -700,6 +700,7 @@ CREATE TABLE system.topology (
     host_id uuid,
     datacenter text,
     ignore_msb int,
+    intended_storage_mode text,
     node_state text,
     num_tokens int,
     rack text,
@@ -741,6 +742,7 @@ Each node has a clustering row in the table where its `host_id` is the clusterin
 - `datacenter`         -  a name of the datacenter the node belongs to
 - `rack`               -  a name of the rack the node belongs to
 - `ignore_msb`         -  the value of the node's `murmur3_partitioner_ignore_msb_bits` parameter
+- `intended_storage_mode` - if set, it indicates the intended storage mode for tables under vnodes-to-tablets migration
 - `shard_count`        -  the node's `smp::count`
 - `release_version`    -  the node's `version::current()` (corresponding to a Cassandra version, used by drivers)
 - `node_state`         -  current state of the node (as described earlier)

--- a/docs/operating-scylla/procedures/config-change/index.rst
+++ b/docs/operating-scylla/procedures/config-change/index.rst
@@ -10,6 +10,7 @@ ScyllaDB Configuration Procedures
    How to do a Rolling Restart <rolling-restart>
    Advanced Internode (RPC) Compression <advanced-internode-compression>
    Shared-dictionary compression for SSTables <sstable-dictionary-compression>
+   Migrate a Keyspace from Vnodes to Tablets <migrate-vnodes-to-tablets>
 
 Procedures to change ScyllaDB Configuration settings.
 
@@ -22,3 +23,5 @@ Procedures to change ScyllaDB Configuration settings.
 * :doc:`Advanced Internode (RPC) Compression </operating-scylla/procedures/config-change/advanced-internode-compression>`
 
 * :doc:`Shared-dictionary compression for SSTables </operating-scylla/procedures/config-change/sstable-dictionary-compression>`
+
+* :doc:`Migrate a Keyspace from Vnodes to Tablets </operating-scylla/procedures/config-change/migrate-vnodes-to-tablets>`

--- a/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
+++ b/docs/operating-scylla/procedures/config-change/migrate-vnodes-to-tablets.rst
@@ -1,0 +1,393 @@
+Migrate a Keyspace from Vnodes to Tablets
+==========================================
+
+This procedure describes how to migrate an existing keyspace from vnodes
+to tablets. Tablets are designed to be the long-term replacement for vnodes,
+offering numerous benefits such as faster topology operations, automatic load
+balancing, automatic cleanups, and improved streaming performance. Migrating to
+tablets is strongly recommended. See :doc:`Data Distribution with Tablets </architecture/tablets/>`
+for details.
+
+.. note::
+
+   The migration is an online operation. This means that the keyspace remains
+   fully available to users throughout the migration, provided that its
+   replication factor is greater than 1. Reads and writes continue to be served
+   using vnodes until the migration is finished.
+
+.. warning::
+
+   During the migration, you should expect degraded performance on the migrating
+   keyspace. The reasons are the following:
+
+   * **Rolling restart**: Each node must upgrade its storage from vnodes to
+     tablets. This is an offline operation happening on startup, so a restart is
+     needed. Upon restart, each node performs a heavy and time-consuming
+     resharding operation to reorganize its data based on tablets, and remains
+     offline until this operation completes. Resharding may last from minutes to
+     hours, depending on the amount of data that the node holds. At this time,
+     the node cannot serve any requests.
+   * **Unbalanced tablets**: The initial tablet layout mirrors the vnode layout.
+     The tablet load balancer does not rebalance tablets until the migration is
+     finished, so some shards may carry more data than others during the
+     migration. The imbalance is expected to be more prominent in clusters with
+     very large nodes (hundreds of vCPUs).
+   * **Loss of shard awareness**: During the migration and until the rolling
+     restart is complete, the cluster is in a mixed state with some nodes using
+     vnodes and others using tablets. In this state, queries may cause
+     cross-shard operations within nodes, reducing performance.
+
+   The performance will return to normal after the migration finishes and the
+   tablet load balancer rebalances the data.
+
+Prerequisites
+-------------
+
+* All nodes in the cluster must be **up and running**. You can check the status
+  of all nodes with
+  :doc:`nodetool status </operating-scylla/nodetool-commands/status/>`.
+* All nodes must be running ScyllaDB 2026.2 or later.
+
+Limitations
+-----------
+
+The current migration procedure has the following limitations:
+
+* The total number of **vnode tokens** in the cluster must be a **power of two**
+  and the tokens must be **evenly spaced** across the token ring. This is
+  verified automatically when starting the migration.
+* **No schema changes** during the migration. Do not create, alter, or drop
+  tables in the migrating keyspace until the migration is finished.
+* **No topology changes** during the migration. Do not add, remove, decommission,
+  or replace nodes while a migration is in progress.
+* **No TRUNCATE** on tables in the migrating keyspace during the migration.
+* Only **CQL base tables** can be migrated. Materialized views, secondary
+  indexes, CDC tables, and Alternator tables are not supported.
+* Tables with **counters** or **LWTs** cannot be migrated.
+
+Overview
+--------
+
+The migration consists of three phases:
+
+1. **Prepare**: Create tablet maps for all tables in the keyspace. Each tablet
+   inherits its token range and replica set from the corresponding vnode range.
+2. **Storage upgrade**: Restart each node one at a time, upgrading its storage
+   from vnodes to tablets. Upon restart, the node begins resharding data into
+   tablets. This is a storage-layer operation and is unrelated to ScyllaDB
+   version upgrades.
+3. **Finalize**: Once all nodes have been upgraded, commit the migration by
+   clearing the migration state and switching the keyspace schema to tablets.
+
+During the first two phases, the migration is reversible; you can roll back to
+vnodes. However, once the migration is finalized, it cannot be reversed.
+
+.. note::
+
+   In the following sections, any reference to "upgrade" or "downgrade" of a
+   node will refer to the migration of its storage from vnodes to tablets or
+   vice versa. Do not confuse it with version upgrades/downgrades.
+
+Procedure
+---------
+
+#. Prepare the keyspace for migration:
+
+   #. Create tablet maps for all tables in the keyspace:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets start <keyspace>
+
+   #. Verify that the keyspace is in ``migrating_to_tablets`` state and all nodes are still using vnodes:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace>
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets status ks
+         Keyspace: ks
+         Status: migrating_to_tablets
+
+         Nodes:
+         Host ID                                Status
+         99d8de76-3954-4727-911a-6a07251b180c   uses vnodes
+         0b5fd6f6-9670-4faf-a480-ad58cf119007   uses vnodes
+         017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+   .. _upgrade-nodes:
+
+#. Upgrade all nodes to tablets:
+
+   #. Pick a node.
+
+   #. Mark the node for upgrade to tablets:
+
+      .. note::
+
+         This is a node-local operation. Use the IP address of the node that
+         you are upgrading.
+
+      .. caution::
+
+         Do not mark more than one node for upgrade at the same time. Even if
+         you restart them serially, unexpected restarts can happen for various
+         reasons (crashes, power failures, etc.) leading to parallel node
+         upgrades which can reduce availability.
+
+      .. code-block:: console
+
+         scylla nodetool -h <node-ip> migrate-to-tablets upgrade
+
+   #. Verify that the node status changed from ``vnodes`` to ``migrating to tablets``:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace>
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets status ks
+         Keyspace: ks
+         Status: migrating_to_tablets
+
+         Nodes:
+         Host ID                                Status
+         99d8de76-3954-4727-911a-6a07251b180c   migrating to tablets  <---
+         0b5fd6f6-9670-4faf-a480-ad58cf119007   uses vnodes
+         017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+   #. Drain and stop the node:
+
+      .. code-block:: console
+
+         scylla nodetool -h <node-ip> drain
+
+      .. include:: /rst_include/scylla-commands-stop-index.rst
+
+   #. Restart the node:
+
+      .. include:: /rst_include/scylla-commands-start-index.rst
+
+   #. Wait until the node is UP and has returned to the ScyllaDB cluster using :doc:`nodetool status </operating-scylla/nodetool-commands/status/>`.
+      This operation may take a long time due to resharding. To monitor
+      resharding progress, use the task manager API:
+
+      .. code-block:: console
+
+         scylla nodetool tasks list compaction -h <node-ip> --keyspace <keyspace> | grep -i reshard
+
+   #. Verify that the node status changed from ``migrating to tablets`` to ``uses tablets``:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace>
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets status ks
+         Keyspace: ks
+         Status: migrating_to_tablets
+
+         Nodes:
+         Host ID                                Status
+         99d8de76-3954-4727-911a-6a07251b180c   uses tablets  <---
+         0b5fd6f6-9670-4faf-a480-ad58cf119007   uses vnodes
+         017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+   #. Move to the next node and repeat from step a until all nodes are upgraded.
+
+#. Finalize the migration:
+
+   .. warning::
+
+      Finalization **cannot be undone**. Once the migration is finalized, the
+      keyspace cannot be switched back to vnodes.
+
+   #. Issue the finalization request:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets finalize <keyspace>
+
+   #. Verify that the keyspace status changed to ``tablets``:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace>
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets finalize ks
+         Keyspace: ks
+         Status: tablets
+
+Rollback Procedure
+------------------
+
+.. note::
+
+   Rollback is only possible **before finalization**. Once the migration is
+   finalized, it cannot be reversed.
+
+If you need to abort the migration **before finalization**, you can roll back
+by downgrading each node back to vnodes. The rollback procedure is the
+following:
+
+#. Find all nodes that have been upgraded to tablets (status: ``uses tablets``)
+   or they are in the process of upgrading to tablets (status: ``migrating to tablets``):
+
+   .. code-block:: console
+
+      scylla nodetool migrate-to-tablets status <keyspace>
+
+   **Example:**
+
+   .. code-block:: console
+
+      $ scylla nodetool migrate-to-tablets status ks
+      Keyspace: ks
+      Status: migrating_to_tablets
+
+      Nodes:
+      Host ID                                Status
+      99d8de76-3954-4727-911a-6a07251b180c   uses tablets  <---
+      0b5fd6f6-9670-4faf-a480-ad58cf119007   migrating to tablets  <---
+      017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+#. For **each upgraded or upgrading node** in the cluster, perform a downgrade
+   (one node at a time):
+
+   #. Mark the node for downgrade:
+
+      .. code-block:: console
+
+         scylla nodetool -h <node-ip> migrate-to-tablets downgrade
+
+   #. Check the node status. The status for a previously upgraded node should
+      change from ``uses tablets`` to ``migrating to vnodes``. The status for a
+      previously upgrading node should change from ``migrating to tablets`` to
+      ``uses vnodes`` or ``migrating to vnodes``:
+
+      .. code-block:: console
+
+         scylla nodetool migrate-to-tablets status <keyspace>
+
+      **Example:**
+
+      .. code-block:: console
+
+         $ scylla nodetool migrate-to-tablets status ks
+         Keyspace: ks
+         Status: migrating_to_tablets
+
+         Nodes:
+         Host ID                                Status
+         99d8de76-3954-4727-911a-6a07251b180c   migrating to vnodes  <---
+         0b5fd6f6-9670-4faf-a480-ad58cf119007   migrating to tablets
+         017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+   #. If the node status is ``uses vnodes``, the downgrade is complete. Move to
+      the next node and repeat from step a.
+
+   #. If the node is ``migrating to vnodes``, restart it to complete the
+      downgrade:
+
+      #. Drain and stop the node:
+
+         .. code-block:: console
+
+            scylla nodetool -h <node-ip> drain
+
+         .. include:: /rst_include/scylla-commands-stop-index.rst
+
+      #. Restart the node:
+
+         .. include:: /rst_include/scylla-commands-start-index.rst
+
+      #. Wait until the node is UP and has returned to the ScyllaDB cluster using :doc:`nodetool status </operating-scylla/nodetool-commands/status/>`.
+         This operation may take a long time due to resharding. To monitor
+         resharding progress, use the task manager API:
+
+         .. code-block:: console
+
+            scylla nodetool tasks list compaction -h <node-ip> --keyspace <keyspace> | grep -i reshard
+
+      #. Verify that the node status changed from ``migrating to vnodes`` to ``uses vnodes``:
+
+         .. code-block:: console
+
+            scylla nodetool migrate-to-tablets status <keyspace>
+
+         **Example:**
+
+         .. code-block:: console
+
+            $ scylla nodetool migrate-to-tablets status ks
+            Keyspace: ks
+            Status: migrating_to_tablets
+
+            Nodes:
+            Host ID                                Status
+            99d8de76-3954-4727-911a-6a07251b180c   uses vnodes  <---
+            0b5fd6f6-9670-4faf-a480-ad58cf119007   migrating to tablets
+            017dd39a-3d06-4c8a-8ac4-379f9e595607   uses vnodes
+
+      #. Move to the next node and repeat from step a until all nodes are
+         downgraded.
+
+#. Once all nodes have been downgraded, finalize the rollback:
+
+   .. code-block:: console
+
+      scylla nodetool migrate-to-tablets finalize <keyspace>
+
+Migrating multiple keyspaces
+----------------------------
+
+Migrating multiple keyspaces simultaneously is supported. The procedure is the
+same as with a single keyspace except that the preparation and finalization
+steps need to be repeated for each keyspace. However, note that a new migration
+cannot be started once another migration is in the upgrade phase. The migrations
+need to be prepared and finalized together.
+
+To migrate multiple keyspaces simultaneously, follow these steps:
+
+#. For **each keyspace**, prepare it for migration:
+
+   .. code-block:: console
+
+      scylla nodetool migrate-to-tablets start <keyspace1>
+      scylla nodetool migrate-to-tablets start <keyspace2>
+      ...
+
+   Verify that all keyspaces are in ``migrating_to_tablets`` state before
+   proceeding:
+
+   .. code-block:: console
+
+      scylla nodetool migrate-to-tablets status <keyspace1>
+      scylla nodetool migrate-to-tablets status <keyspace2>
+      ...
+
+#. Upgrade all nodes in the cluster following the same :ref:`procedure <upgrade-nodes>`
+   as for a single keyspace. Each node restart reshards all keyspaces under
+   migration in one pass.
+
+#. For **each keyspace**, finalize the migration:
+
+   .. code-block:: console
+
+      scylla nodetool migrate-to-tablets finalize <keyspace1>
+      scylla nodetool migrate-to-tablets finalize <keyspace2>
+      ...

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -179,6 +179,7 @@ public:
     gms::feature topology_noop_request { *this, "TOPOLOGY_NOOP_REQUEST"sv };
     gms::feature tablets_intermediate_fallback_cleanup { *this, "TABLETS_INTERMEDIATE_FALLBACK_CLEANUP"sv };
     gms::feature batchlog_v2 { *this, "BATCHLOG_V2"sv };
+    gms::feature vnodes_to_tablets_migrations { *this, "VNODES_TO_TABLETS_MIGRATIONS"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/readers/mutation_reader.hh
+++ b/readers/mutation_reader.hh
@@ -137,6 +137,9 @@ public:
         // unless the reader is fast-forwarded to a new range.
         bool _end_of_stream = false;
 
+        // Set by fill buffer for segregating output by partition range.
+        std::optional<dht::partition_range> _next_range;
+
         schema_ptr _schema;
         reader_permit _permit;
         friend class mutation_reader;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -811,7 +811,7 @@ bool database::is_in_critical_disk_utilization_mode() const {
     return false;
 }
 
-future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks) {
+future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks, std::optional<service::intended_storage_mode> storage_mode) {
     using namespace db::schema_tables;
     co_await do_parse_schema_tables(proxy, db::schema_tables::KEYSPACES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         auto scylla_specific_rs = co_await extract_scylla_specific_keyspace_info(proxy, v);
@@ -849,7 +849,7 @@ future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, s
     co_await do_parse_schema_tables(proxy, db::schema_tables::TABLES, coroutine::lambda([&] (schema_result_value_type &v) -> future<> {
         std::map<sstring, schema_ptr> tables = co_await create_tables_from_tables_partition(proxy, v.second);
         co_await coroutine::parallel_for_each(tables, [&] (auto& t) -> future<> {
-            co_await this->add_column_family_and_make_directory(t.second, replica::database::is_new_cf::no);
+            co_await this->add_column_family_and_make_directory(t.second, replica::database::is_new_cf::no, storage_mode);
             auto s = t.second;
             // Recreate missing column mapping entries in case
             // we failed to persist them for some reason after a schema change
@@ -864,7 +864,7 @@ future<> database::parse_system_tables(sharded<service::storage_proxy>& proxy, s
         std::vector<view_ptr> views = co_await create_views_from_schema_partition(proxy, v.second);
         co_await coroutine::parallel_for_each(views, [&] (auto&& v) -> future<> {
             check_no_legacy_secondary_index_mv_schema(*this, v, nullptr);
-            co_await this->add_column_family_and_make_directory(v, replica::database::is_new_cf::no);
+            co_await this->add_column_family_and_make_directory(v, replica::database::is_new_cf::no, storage_mode);
         });
     }));
 }
@@ -1156,7 +1156,7 @@ db::commitlog* database::commitlog_for(const schema_ptr& schema) {
         : _commitlog.get();
 }
 
-void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata) {
+void database::add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata, std::optional<service::intended_storage_mode> storage_mode) {
     schema = local_schema_registry().learn(schema);
     auto&& rs = ks.get_replication_strategy();
     locator::effective_replication_map_ptr erm;
@@ -1168,7 +1168,21 @@ void database::add_column_family(keyspace& ks, schema_ptr schema, column_family:
         }
         erm = pt_rs->make_replication_map(schema->id(), metadata_ptr);
     } else {
-        erm = ks.get_static_effective_replication_map();
+        auto metadata_ptr = not_commited_new_metadata ? not_commited_new_metadata : _shared_token_metadata.get();
+        auto table_is_migrating = metadata_ptr->tablets().has_tablet_map(schema->id());
+        if (table_is_migrating && storage_mode.has_value() && storage_mode.value() == service::intended_storage_mode::tablets) {
+            // Table under vnode-to-tablet migration: the keyspace uses vnode-based
+            // replication but this table already has a tablet map persisted in group0.
+            // Build a tablet-aware RS with the same replication options so the table
+            // gets a tablet ERM (and thus a tablet_storage_group_manager).
+            locator::replication_strategy_params params(rs.get_config_options(), 0, std::nullopt);
+            auto tablet_rs = locator::abstract_replication_strategy::create_replication_strategy(
+                    ks.metadata()->strategy_name(), params, metadata_ptr->get_topology());
+            auto pt_rs = tablet_rs->maybe_as_per_table();
+            erm = pt_rs->make_replication_map(schema->id(), metadata_ptr);
+        } else {
+            erm = ks.get_static_effective_replication_map();
+        }
     }
     // avoid self-reporting
     auto& sst_manager = get_sstables_manager(*schema);
@@ -1211,12 +1225,12 @@ future<> database::make_column_family_directory(schema_ptr schema) {
     co_await cf.init_storage();
 }
 
-future<> database::add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new) {
+future<> database::add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::intended_storage_mode> storage_mode) {
     auto lock = co_await get_tables_metadata().hold_write_lock();
     auto& ks = find_keyspace(schema->ks_name());
     std::exception_ptr ex;
     try {
-        add_column_family(ks, schema, ks.make_column_family_config(*schema, *this), is_new);
+        add_column_family(ks, schema, ks.make_column_family_config(*schema, *this), is_new, nullptr, storage_mode);
     } catch (...) {
         ex = std::current_exception();
     }

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1825,7 +1825,7 @@ public:
 
     // Load the schema definitions kept in schema tables from disk and initialize in-memory schema data structures
     // (keyspace/table definitions, column mappings etc.)
-    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&);
+    future<> parse_system_tables(sharded<service::storage_proxy>&, sharded<db::system_keyspace>&, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
 
     database(const db::config&, database_config dbcfg, service::migration_notifier& mn, gms::feature_service& feat, locator::shared_token_metadata& stm,
             compaction::compaction_manager& cm, sstables::storage_manager& sstm, lang::manager& langm, sstables::directory_semaphore& sst_dir_sem, sstable_compressor_factory&,
@@ -1883,9 +1883,9 @@ public:
     void init_schema_commitlog();
 
     using is_new_cf = bool_class<struct is_new_cf_tag>;
-    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr);
+    void add_column_family(keyspace& ks, schema_ptr schema, column_family::config cfg, is_new_cf is_new, locator::token_metadata_ptr not_commited_new_metadata = nullptr, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
     future<> make_column_family_directory(schema_ptr schema);
-    future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new);
+    future<> add_column_family_and_make_directory(schema_ptr schema, is_new_cf is_new, std::optional<service::intended_storage_mode> storage_mode = std::nullopt);
 
 
     /* throws no_such_column_family if missing */

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -724,6 +724,9 @@ private:
 
     std::unique_ptr<storage_group_manager> make_storage_group_manager();
     compaction_group* get_compaction_group(size_t id) const;
+public:
+    compaction_group* get_any_compaction_group() const;
+private:
     // NOTE: all readers must only operate on storage groups, which can provide all data belonging to
     // a given tablet replica. Interfaces below should only be used in the context of writes, for
     // example, to append data to memtable. Iterating on compaction groups is susceptible to races

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -555,8 +555,16 @@ future<> distributed_loader::init_system_keyspace(sharded<db::system_keyspace>& 
 future<> distributed_loader::init_non_system_keyspaces(sharded<replica::database>& db,
         sharded<service::storage_proxy>& proxy, sharded<db::system_keyspace>& sys_ks) {
     return seastar::async([&db, &proxy, &sys_ks] {
-        db.invoke_on_all([&proxy, &sys_ks] (replica::database& db) {
-            return db.parse_system_tables(proxy, sys_ks);
+        // Load the node's intended storage mode from topology.
+        // This determines the ERM flavor and resharding direction for tables
+        // under vnodes-to-tablets migration.
+        auto topology = sys_ks.local().load_topology_state({}).get();
+        auto host_id = db.local().get_token_metadata().get_my_id();
+        auto node = topology.normal_nodes.find(raft::server_id{host_id.uuid()});
+        std::optional<service::intended_storage_mode> storage_mode = node != topology.normal_nodes.end() ? node->second.storage_mode : std::nullopt;
+
+        db.invoke_on_all([&proxy, &sys_ks, &storage_mode] (replica::database& db) {
+            return db.parse_system_tables(proxy, sys_ks, storage_mode);
         }).get();
 
         const auto& cfg = db.local().get_config();

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -288,13 +288,15 @@ class table_populator {
     global_table_ptr& _global_table;
     std::vector<lw_shared_ptr<sharded<sstables::sstable_directory>>> _sstable_directories;
     sstables::sstable_version_types _version_for_reshaping = sstables::oldest_writable_sstable_format;
+    bool _migrate_to_tablets = false;
 
 public:
-    table_populator(global_table_ptr& ptr, sharded<replica::database>& db, sstring ks, sstring cf)
+    table_populator(global_table_ptr& ptr, sharded<replica::database>& db, sstring ks, sstring cf, bool migrate_to_tablets = false)
         : _db(db)
         , _ks(std::move(ks))
         , _cf(std::move(cf))
         , _global_table(ptr)
+        , _migrate_to_tablets(migrate_to_tablets)
     {
     }
 
@@ -400,7 +402,20 @@ sstables::shared_sstable make_sstable(replica::table& table, sstables::sstable_s
 
 future<> table_populator::populate_subdir(sharded<sstables::sstable_directory>& directory) {
     auto state = directory.local().state();
-    dblog.debug("Populating {}/{}/{} state={}", _ks, _cf, _global_table->get_storage_options(), state);
+    dblog.debug("Populating {}/{}/{} state={} resharding_mode={}", _ks, _cf, _global_table->get_storage_options(), state, _migrate_to_tablets ? "vnodes-to-tablets" : "normal");
+
+    compaction::owned_ranges_ptr owned_ranges_ptr = nullptr;
+    if (_migrate_to_tablets) {
+        // Build owned_ranges from the tablet map.
+        auto table_uuid = _global_table->schema()->id();
+        auto& tmap = _db.local().get_shared_token_metadata().get()->tablets().get_tablet_map(table_uuid);
+        dht::token_range_vector ranges;
+        ranges.reserve(tmap.tablet_count());
+        for (auto tid : tmap.tablet_ids()) {
+            ranges.push_back(tmap.get_token_range(tid));
+        }
+        owned_ranges_ptr = compaction::make_owned_ranges_ptr(std::move(ranges));
+    }
 
     co_await distributed_loader::reshard(directory, _db, _ks, _cf, [this, state] (shard_id shard) mutable {
         auto gen = smp::submit_to(shard, [this] () {
@@ -408,7 +423,7 @@ future<> table_populator::populate_subdir(sharded<sstables::sstable_directory>& 
         }).get();
 
         return make_sstable(*_global_table, state, gen, _version_for_reshaping);
-    });
+    }, owned_ranges_ptr, _migrate_to_tablets);
 
     // The node is offline at this point so we are very lenient with what we consider
     // offstrategy.
@@ -452,7 +467,12 @@ future<> distributed_loader::populate_keyspace(sharded<replica::database>& db,
 
         dblog.info("Keyspace {}: Reading CF {} id={} version={} storage={}", ks_name, cfname, uuid, s->version(), cf.get_storage_options());
 
-        auto metadata = table_populator(gtable, db, ks_name, cfname);
+        bool migrating_to_tablets = cf.uses_tablets() && !ks.uses_tablets();
+        if (migrating_to_tablets) {
+            dblog.info("Keyspace {}: CF {} is in vnodes-to-tablets migration mode", ks_name, cfname);
+        }
+
+        auto metadata = table_populator(gtable, db, ks_name, cfname, migrating_to_tablets);
         std::exception_ptr ex;
 
         try {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -101,9 +101,9 @@ distributed_loader::lock_table(global_table_ptr& table, sharded<sstables::sstabl
 //  - The second part calls each shard's distributed object to reshard the SSTables they were
 //    assigned.
 future<>
-distributed_loader::reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr) {
+distributed_loader::reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr, bool vnodes_resharding) {
     auto& compaction_module = db.local().get_compaction_manager().get_task_manager_module();
-    auto task = co_await compaction_module.make_and_start_task<compaction::table_resharding_compaction_task_impl>({}, std::move(ks_name), std::move(table_name), dir, db, std::move(creator), std::move(owned_ranges_ptr));
+    auto task = co_await compaction_module.make_and_start_task<compaction::table_resharding_compaction_task_impl>({}, std::move(ks_name), std::move(table_name), dir, db, std::move(creator), std::move(owned_ranges_ptr), vnodes_resharding);
     co_await task->done();
 }
 

--- a/replica/distributed_loader.hh
+++ b/replica/distributed_loader.hh
@@ -70,7 +70,7 @@ class distributed_loader {
     static future<> reshape(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, compaction::reshape_mode mode,
             sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, std::function<bool (const sstables::shared_sstable&)> filter);
     static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator,
-            compaction::owned_ranges_ptr owned_ranges_ptr = nullptr);
+            compaction::owned_ranges_ptr owned_ranges_ptr = nullptr, bool vnodes_resharding = false);
     static future<> process_sstable_dir(sharded<sstables::sstable_directory>& dir, sstables::sstable_directory::process_flags flags);
     static future<> lock_table(global_table_ptr&, sharded<sstables::sstable_directory>& dir);
     static future<size_t> make_sstables_available(sstables::sstable_directory& dir,

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1280,6 +1280,14 @@ compaction_group* table::get_compaction_group(size_t id) const {
     return storage_group_for_id(id).main_compaction_group().get();
 }
 
+compaction_group* table::get_any_compaction_group() const {
+    auto& groups = _sg_manager->storage_groups();
+    if (groups.empty()) {
+        return nullptr;
+    }
+    return groups.begin()->second->main_compaction_group().get();
+}
+
 storage_group& table::storage_group_for_token(dht::token token) const {
     return _sg_manager->storage_group_for_token(token);
 }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4124,6 +4124,81 @@ future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) 
     }
 }
 
+future<> storage_service::set_node_intended_storage_mode(intended_storage_mode mode) {
+    if (this_shard_id() != 0) {
+        co_return co_await container().invoke_on(0, [mode] (auto& ss) {
+            return ss.set_node_intended_storage_mode(mode);
+        });
+    }
+
+    auto& raft_server = _group0->group0_server();
+    auto holder = _group0->hold_group0_gate();
+
+    slogger.info("Setting intended storage mode for node {} to {}", raft_server.id(), mode);
+
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+
+        // Make sure that a migration has been started, i.e.,
+        // prepare_for_tablets_migration() has been called for at least one
+        // keyspace. prepare_for_tablets_migration() will fail if
+        // intended_storage_mode is already set for any node.
+        const auto& tablet_metadata = get_token_metadata().tablets();
+        bool has_any_migrating_table = false;
+        for (const auto& ks : _db.local().get_non_system_keyspaces()) {
+            auto& keyspace = _db.local().find_keyspace(ks);
+            if (!keyspace.uses_tablets()) {
+                for (const auto& schema : keyspace.metadata()->tables()) {
+                    if (tablet_metadata.has_tablet_map(schema->id())) {
+                        has_any_migrating_table = true;
+                        break;
+                    }
+                }
+            }
+            if (has_any_migrating_table) {
+                break;
+            }
+        }
+        if (!has_any_migrating_table) {
+            throw std::runtime_error(::format("Cannot set intended storage mode to {}: no migration is in progress. You need to start a migration first.", mode));
+        }
+
+        auto it = _topology_state_machine._topology.find(raft_server.id());
+        if (!it) {
+            throw std::runtime_error(::format("Node {} is not a member of the cluster", raft_server.id()));
+        }
+
+        const auto& rs = it->second;
+
+        if (rs.state != node_state::normal) {
+            throw std::runtime_error(::format("Node {} is not in the normal state (current state: {})", raft_server.id(), rs.state));
+        }
+
+        if (rs.storage_mode == mode) {
+            slogger.info("Node {} already has intended storage mode set to {}, skipping", raft_server.id(), mode);
+            co_return;
+        }
+
+        topology_mutation_builder builder(guard.write_timestamp());
+        builder.with_node(raft_server.id())
+               .set("intended_storage_mode", mode);
+
+        topology_change change{{builder.build()}};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
+            ::format("set intended storage mode for node {} to {}", raft_server.id(), mode));
+
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as);
+        } catch (group0_concurrent_modification&) {
+            slogger.info("set_node_intended_storage_mode: concurrent modification, retrying");
+            continue;
+        }
+        break;
+    }
+
+    slogger.info("Successfully set intended storage mode for node {} to {}", raft_server.id(), mode);
+}
+
 future<> storage_service::process_tablet_split_candidate(table_id table) noexcept {
     tasks::task_info tablet_split_task_info;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4199,6 +4199,78 @@ future<> storage_service::set_node_intended_storage_mode(intended_storage_mode m
     slogger.info("Successfully set intended storage mode for node {} to {}", raft_server.id(), mode);
 }
 
+future<> storage_service::finalize_tablets_migration(const sstring& ks_name) {
+    if (this_shard_id() != 0) {
+        co_return co_await container().invoke_on(0, [&ks_name] (auto& ss) {
+            return ss.finalize_tablets_migration(ks_name);
+        });
+    }
+
+    slogger.info("Finalizing vnodes-to-tablets migration for keyspace '{}'", ks_name);
+
+    utils::UUID request_id;
+
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+
+        auto& db = _db.local();
+        auto& ks = db.find_keyspace(ks_name);
+
+        if (ks.uses_tablets()) {
+            throw std::runtime_error(fmt::format("Keyspace '{}' already uses tablets", ks_name));
+        }
+
+        const auto& tm = get_token_metadata();
+        const auto& tablet_metadata = tm.tablets();
+
+        auto tables = ks.metadata()->tables();
+        if (tables.empty()) {
+            throw std::runtime_error(fmt::format("Keyspace '{}' has no tables", ks_name));
+        }
+
+        for (const auto& schema : tables) {
+            if (!tablet_metadata.has_tablet_map(schema->id())) {
+                throw std::runtime_error(fmt::format("Table {}.{} does not have a tablet map; "
+                    "all tables in keyspace '{}' must be prepared for migration before finalizing",
+                    ks_name, schema->cf_name(), ks_name));
+            }
+        }
+
+        slogger.info("All {} table(s) in keyspace '{}' have tablet maps, submitting finalization request",
+                     tables.size(), ks_name);
+
+        request_id = guard.new_group0_state_id();
+
+        topology_mutation_builder builder(guard.write_timestamp());
+        builder.queue_global_topology_request_id(request_id);
+
+        topology_request_tracking_mutation_builder rtbuilder(request_id, _feature_service.topology_requests_type_column);
+        rtbuilder.set("done", false)
+                 .set("start_time", db_clock::now())
+                 .set("request_type", global_topology_request::finalize_migration)
+                 .set_finalize_migration_data(ks_name);
+
+        topology_change change{{builder.build(), rtbuilder.build()}};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
+            fmt::format("finalize vnodes-to-tablets migration for keyspace '{}'", ks_name));
+
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
+        } catch (group0_concurrent_modification&) {
+            slogger.info("finalize_tablets_migration: concurrent modification, retrying");
+            continue;
+        }
+        break;
+    }
+
+    auto error = co_await wait_for_topology_request_completion(request_id);
+    if (!error.empty()) {
+        throw std::runtime_error(fmt::format("Migration finalization failed for keyspace '{}': {}", ks_name, error));
+    }
+
+    slogger.info("Successfully finalized vnodes-to-tablets migration for keyspace '{}'", ks_name);
+}
+
 future<> storage_service::process_tablet_split_candidate(table_id table) noexcept {
     tasks::task_info tablet_split_task_info;
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4199,6 +4199,82 @@ future<> storage_service::set_node_intended_storage_mode(intended_storage_mode m
     slogger.info("Successfully set intended storage mode for node {} to {}", raft_server.id(), mode);
 }
 
+future<storage_service::keyspace_migration_status> storage_service::get_tablets_migration_status(const sstring& ks_name) {
+    if (this_shard_id() != 0) {
+        co_return co_await container().invoke_on(0, [&ks_name] (auto& ss) {
+            return ss.get_tablets_migration_status(ks_name);
+        });
+    }
+
+    auto& db = _db.local();
+    auto& ks = db.find_keyspace(ks_name);
+
+    keyspace_migration_status result;
+    result.keyspace = ks_name;
+
+    if (ks.uses_tablets()) {
+        result.status = "tablets";
+        co_return result;
+    }
+
+    const auto& tm = get_token_metadata();
+    const auto& tablet_metadata = tm.tablets();
+
+    auto tables = ks.metadata()->tables();
+
+    // Check whether all tables have tablet maps (i.e. migration was started).
+    bool has_tablet_maps = !tables.empty() && std::ranges::all_of(tables, [&] (const auto& schema) {
+        return tablet_metadata.has_tablet_map(schema->id());
+    });
+
+    if (!has_tablet_maps) {
+        result.status = "vnodes";
+        co_return result;
+    }
+
+    result.status = "migrating_to_tablets";
+
+    // Pick one table and query system.tablet_sizes to find which nodes
+    // report tablet sizes (i.e. have loaded tablet-based ERMs).
+    auto sample_table_id = tables.front()->id();
+
+    // FIXME: system.tablet_sizes might return stale data (load stats in the topology coordinator are cached).
+    auto rs = co_await _qp.execute_internal(
+            "SELECT replicas FROM system.tablet_sizes WHERE table_id = ?",
+            {sample_table_id.uuid()},
+            cql3::query_processor::cache_internal::no);
+
+    // Collect all host_ids that appear in the replicas map across all tablets.
+    std::unordered_set<locator::host_id> nodes_reporting_tablets;
+    for (const auto& row : *rs) {
+        if (row.has("replicas")) {
+            auto replicas_map = row.get_map<utils::UUID, int64_t>("replicas");
+            for (const auto& [host_uuid, size] : replicas_map) {
+                nodes_reporting_tablets.insert(locator::host_id(host_uuid));
+            }
+        }
+    }
+
+    const auto& topo = _topology_state_machine._topology;
+    for (const auto& [server_id, rs] : topo.normal_nodes) {
+        auto host_id = locator::host_id{server_id.uuid()};
+        bool reports_tablets = nodes_reporting_tablets.contains(host_id);
+
+        auto current_mode = reports_tablets
+            ? intended_storage_mode::tablets
+            : intended_storage_mode::vnodes;
+        auto intended_mode = rs.storage_mode.value_or(intended_storage_mode::vnodes);
+
+        result.nodes.push_back(node_migration_status{
+            .host_id = host_id,
+            .current_mode = fmt::format("{}", current_mode),
+            .intended_mode = fmt::format("{}", intended_mode),
+        });
+    }
+
+    co_return result;
+}
+
 future<> storage_service::finalize_tablets_migration(const sstring& ks_name) {
     if (this_shard_id() != 0) {
         co_return co_await container().invoke_on(0, [&ks_name] (auto& ss) {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -68,6 +68,7 @@
 #include <seastar/core/thread.hh>
 #include <algorithm>
 #include "locator/local_strategy.hh"
+#include "locator/tablet_replication_strategy.hh"
 #include "utils/user_provided_param.hh"
 #include "version.hh"
 #include "streaming/stream_blob.hh"
@@ -2237,7 +2238,26 @@ future<token_metadata_change> storage_service::prepare_token_metadata_change(mut
                 if (auto pt_rs = rs->maybe_as_per_table()) {
                     erm = pt_rs->make_replication_map(id, tmptr);
                 } else {
-                    erm = change.pending_effective_replication_maps[this_shard_id()][table_schema->ks_name()];
+                    const locator::abstract_replication_strategy *old_rs = ss.get_database().column_family_exists(id)
+                            ? &ss.get_database().find_column_family(id).get_effective_replication_map()->get_replication_strategy()
+                            : nullptr;
+                    if (old_rs && old_rs->uses_tablets()) {
+                        // The table is under vnodes-to-tablets migration:
+                        // the keyspace uses vnodes, but the table uses a tablet-based ERM.
+                        // Preserve the tablet flavor of the ERM.
+                        // The ERM flavor is a node-local setting that expresses
+                        // the node's storage organization, which can change only
+                        // on startup after resharding (while the node is offline).
+                        // It is determined on startup by the distributed loader.
+                        auto old_tablet_rs = old_rs->maybe_as_tablet_aware();
+                        locator::replication_strategy_params params(rs->get_config_options(), old_tablet_rs->get_initial_tablets(), old_tablet_rs->get_consistency());
+                        auto& ks = ss.get_database().find_keyspace(table_schema->ks_name());
+                        auto tablet_rs = locator::abstract_replication_strategy::create_replication_strategy(ks.metadata()->strategy_name(), params, tmptr->get_topology());
+                        auto pt_rs = tablet_rs->maybe_as_per_table();
+                        erm = pt_rs->make_replication_map(id, tmptr);
+                    } else {
+                        erm = change.pending_effective_replication_maps[this_shard_id()][table_schema->ks_name()];
+                    }
                 }
                 if (table_schema->is_view()) {
                     change.pending_view_erms[this_shard_id()].emplace(id, std::move(erm));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -3988,6 +3988,142 @@ future<> storage_service::update_tablet_metadata(const locator::tablet_metadata_
     wake_up_topology_state_machine();
 }
 
+future<> storage_service::prepare_for_tablets_migration(const sstring& ks_name) {
+    if (this_shard_id() != 0) {
+        co_return co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.prepare_for_tablets_migration(ks_name);
+        });
+    }
+
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(_group0_as);
+
+        auto& db = _db.local();
+        auto& ks = db.find_keyspace(ks_name);
+
+        if (ks.uses_tablets()) {
+            throw std::runtime_error(fmt::format("Keyspace {} already uses tablets", ks_name));
+        }
+
+        const auto& cf_meta_data = ks.metadata().get()->cf_meta_data();
+        if (cf_meta_data.empty()) {
+            throw std::runtime_error(fmt::format("Keyspace {} has no tables to migrate. To use tablets, recreate the keyspace with tablets enabled", ks_name));
+        }
+
+        const auto& tm = get_token_metadata();
+        const auto& sorted_tokens = tm.sorted_tokens();
+        size_t tablet_count = sorted_tokens.size();
+        if (!std::has_single_bit(tablet_count)) {
+            throw std::runtime_error(fmt::format("Table migration requires vnodes to be a power of two. Current value: {}", tablet_count));
+        }
+
+        auto topology = co_await get_system_keyspace().load_topology_state({});
+        for (const auto& [server_id, replica_state]: topology.normal_nodes) {
+            if (replica_state.storage_mode) {
+                throw std::runtime_error(fmt::format("Another migration is in progress (node '{}' has intended storage mode '{}') - cannot start tablets migration."
+                        " Please wait for the current migration to finish and retry.",
+                        server_id, *replica_state.storage_mode));
+            }
+        }
+
+        // Stateful lambdas for round-robin shard assignment per node.
+        std::unordered_map<locator::host_id, std::function<shard_id()>> next_shard_for;
+        tm.for_each_token_owner([&] (const locator::node& node) {
+            auto host = node.host_id();
+            next_shard_for[host] = [num_shards = node.get_shard_count(), idx = 0u]() mutable {
+                return shard_id(idx++ % num_shards);
+            };
+        });
+
+        slogger.info("Building tablet maps for tables in keyspace {} with {} tablet(s)", ks_name, tablet_count);
+
+        // Build a tablet_map from vnode token boundaries.
+        //
+        // The map contains one tablet per vnode. The replicas of each tablet are
+        // the same as the replicas of the corresponding vnode. Shards are assigned
+        // in round-robin fashion per node so that tablets are evenly distributed
+        // within each node.
+        // (FIXME: we should consider tablet sizes as well)
+        //
+        // This map will serve as a template for per-table tablet map mutations.
+        // Each table in the keyspace receives its own tablet map, but all maps
+        // have identical tablet boundaries and replica placement.
+
+        auto erm = ks.get_static_effective_replication_map();
+
+        locator::tablet_map tmap(tablet_count);
+        for (size_t i = 0; i < tablet_count; ++i) {
+            auto tablet = locator::tablet_id(i);
+            auto vnode_replica_hosts = erm->get_natural_replicas(sorted_tokens[i], true);
+            locator::tablet_replica_set tablet_replicas;
+            for (auto host : vnode_replica_hosts) {
+                tablet_replicas.push_back(locator::tablet_replica{host, next_shard_for[host]()});
+            }
+            tmap.set_tablet(tablet, locator::tablet_info(std::move(tablet_replicas)));
+            if (tmap.get_last_token(tablet) != sorted_tokens[i]) {
+                throw std::runtime_error(fmt::format("vnode token {} is not aligned; cannot be used as tablet boundary (expected: {})", sorted_tokens[i], tmap.get_last_token(tablet)));
+            }
+        }
+
+        std::vector<std::pair<table_id, sstring>> tables_to_migrate;
+
+        for (const auto& [name, schema] : cf_meta_data) {
+            auto tid = schema->id();
+            auto& cf = db.find_column_family(tid);
+
+            if (cf.uses_tablets()) {
+                slogger.info("Table {}.{} already uses tablets, skipping", ks_name, name);
+                continue;
+            }
+            tables_to_migrate.push_back({tid, name});
+        }
+
+        if (tables_to_migrate.empty()) {
+            slogger.info("All tables in keyspace {} already use tablets, nothing to do", ks_name);
+            co_return;
+        }
+
+        // Build tablet map mutations for all tables and persist them to group0 (system.tablets)
+        // in a single command.
+        //
+        // FIXME: Tablet map mutations for large keyspaces should be split into
+        // multiple group0 commands to avoid hitting the command size limit.
+        // To maintain atomicity against concurrent migration requests
+        // (e.g., finalization) and prevent failures from group0 conflicts, we
+        // should turn this into a topology request.
+        utils::chunked_vector<canonical_mutation> updates;
+        for (const auto& [tid, cf_name] : tables_to_migrate) {
+            co_await replica::tablet_map_to_mutations(
+                tmap,
+                tid,
+                ks_name,
+                cf_name,
+                guard.write_timestamp(),
+                _feature_service,
+                [&] (mutation m) -> future<> {
+                    updates.emplace_back(co_await make_canonical_mutation_gently(m));
+                });
+        }
+
+        topology_change change{std::move(updates)};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
+            fmt::format("migrate keyspace {} to tablets", ks_name));
+
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as);
+        } catch (group0_concurrent_modification&) {
+            slogger.info("migrate_to_tablets: concurrent modification, retrying");
+            continue;
+        }
+
+        for (const auto& [tid, cf_name] : tables_to_migrate) {
+            slogger.info("Successfully built tablet map for table {}.{} ({} tablet(s))",
+                         ks_name, cf_name, tablet_count);
+        }
+        break;
+    }
+}
+
 future<> storage_service::process_tablet_split_candidate(table_id table) noexcept {
     tasks::task_info tablet_split_task_info;
 
@@ -5459,6 +5595,8 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
         }
     }
 }
+
+
 
 future<> storage_service::await_topology_quiesced() {
     auto holder = _async_gate.hold();

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -289,6 +289,7 @@ public:
     // persists them to group0.
     future<> prepare_for_tablets_migration(const sstring& ks_name);
     future<> set_node_intended_storage_mode(intended_storage_mode mode);
+    future<> finalize_tablets_migration(const sstring& ks_name);
 
     void start_tablet_split_monitor();
 private:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -288,6 +288,7 @@ public:
     // Builds tablet maps from vnode token boundaries for all tables and
     // persists them to group0.
     future<> prepare_for_tablets_migration(const sstring& ks_name);
+    future<> set_node_intended_storage_mode(intended_storage_mode mode);
 
     void start_tablet_split_monitor();
 private:

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -288,6 +288,20 @@ public:
     // Builds tablet maps from vnode token boundaries for all tables and
     // persists them to group0.
     future<> prepare_for_tablets_migration(const sstring& ks_name);
+
+    struct node_migration_status {
+        locator::host_id host_id;
+        sstring current_mode;  // "vnodes" or "tablets"
+        sstring intended_mode; // "vnodes" or "tablets"
+    };
+
+    struct keyspace_migration_status {
+        sstring keyspace;
+        sstring status; // "vnodes", "migrating_to_tablets", or "tablets"
+        std::vector<node_migration_status> nodes;
+    };
+
+    future<keyspace_migration_status> get_tablets_migration_status(const sstring& ks_name);
     future<> set_node_intended_storage_mode(intended_storage_mode mode);
     future<> finalize_tablets_migration(const sstring& ks_name);
 

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -284,6 +284,11 @@ public:
     void wake_up_topology_state_machine() noexcept;
     future<> update_tablet_metadata(const locator::tablet_metadata_change_hint& hint);
 
+    // Prepares a vnode-based keyspace for migration to tablets.
+    // Builds tablet maps from vnode token boundaries for all tables and
+    // persists them to group0.
+    future<> prepare_for_tablets_migration(const sstring& ks_name);
+
     void start_tablet_split_monitor();
 private:
     using acquire_merge_lock = bool_class<class acquire_merge_lock_tag>;

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1175,6 +1175,9 @@ public:
     future<> consider_scheduled_load(node_load_map& nodes) {
         const locator::topology& topo = _tm->get_topology();
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             for (auto&& [tid, trinfo]: tmap.transitions()) {
                 co_await coroutine::maybe_yield();
@@ -1233,6 +1236,9 @@ public:
         utils::chunked_vector<repair_plan> plans;
         auto migration_tablet_ids = co_await mplan.get_migration_tablet_ids();
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             co_await coroutine::maybe_yield();
             auto config = tmap.get_repair_scheduler_config();
@@ -1465,6 +1471,9 @@ public:
         table_resize_plan resize_plan;
 
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             if (!tmap.needs_merge()) {
                 continue;
@@ -1689,6 +1698,18 @@ public:
         return rs;
     }
 
+    // Returns true if the table is under vnodes-to-tablets migration.
+    // Such tables have a tablet map but their keyspace RS doesn't use tablets.
+    // They should be excluded from load balancing.
+    bool is_migrating_table(table_id table) {
+        auto t = _db.get_tables_metadata().get_table_if_exists(table);
+        if (!t) {
+            return false;
+        }
+        auto& ks = _db.find_keyspace(t->schema()->ks_name());
+        return !ks.get_replication_strategy().uses_tablets();
+    }
+
     struct table_sizing {
         size_t current_tablet_count; // Tablet count in group0.
         size_t target_tablet_count; // Tablet count wanted by scheduler.
@@ -1886,6 +1907,9 @@ public:
         };
 
         for (const auto& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             auto [s, rs] = get_schema_and_rs(table);
 
@@ -3581,6 +3605,9 @@ public:
         // Compute tablet load on nodes.
 
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
 
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
@@ -3717,6 +3744,9 @@ public:
         _disk_used_per_table.clear();
 
         for (auto&& [table, tables] : _tm->tablets().all_table_groups()) {
+            if (is_migrating_table(table)) {
+                continue;
+            }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             uint64_t total_tablet_count = 0;
             uint64_t total_tablet_sizes = 0;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1169,6 +1169,164 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             co_await update_topology_state(std::move(guard), {builder.build()}, "SNAPSHOT TABLES requested");
         }
         break;
+        case global_topology_request::finalize_migration: {
+            rtlogger.info("finalize_migration requested");
+
+            auto ks_name = *req_entry.finalize_migration_ks_name;
+            utils::chunked_vector<canonical_mutation> updates;
+            sstring error;
+
+            if (_db.has_keyspace(ks_name)) {
+                try {
+                    auto& ks = _db.find_keyspace(ks_name);
+                    if (ks.uses_tablets()) {
+                        throw std::runtime_error(fmt::format("Keyspace '{}' already uses tablets", ks_name));
+                    }
+
+                    auto tmptr = get_token_metadata_ptr();
+                    const auto& tablet_metadata = tmptr->tablets();
+                    auto tables = ks.metadata()->tables();
+
+                    // Verify all tables have tablet maps.
+                    for (const auto& schema : tables) {
+                        if (!tablet_metadata.has_tablet_map(schema->id())) {
+                            throw std::runtime_error(fmt::format(
+                                "Table {}.{} does not have a tablet map", ks_name, schema->cf_name()));
+                        }
+                    }
+
+                    // Find the migration direction (tablets or rollback to vnodes).
+                    // Nodes that haven't set their intended mode are treated as vnodes (the default).
+                    std::optional<intended_storage_mode> global_intended_mode;
+                    for (const auto& [server_id, replica_state] : _topo_sm._topology.normal_nodes) {
+                        auto replica_intended_mode = replica_state.storage_mode ? *replica_state.storage_mode : intended_storage_mode::vnodes;
+                        if (!global_intended_mode) {
+                            global_intended_mode = replica_intended_mode;
+                        } else if (replica_intended_mode != *global_intended_mode) {
+                            throw std::runtime_error(fmt::format(
+                                "Cannot finalize migration for keyspace '{}': node {} has intended storage mode '{}', expected '{}'",
+                                ks_name, server_id, replica_intended_mode, *global_intended_mode));
+                        }
+                    }
+                    if (!global_intended_mode) {
+                        on_internal_error(rtlogger, fmt::format(
+                            "finalize_migration: no normal nodes found while finalizing migration for keyspace '{}'", ks_name));
+                    }
+                    bool rollback = *global_intended_mode == intended_storage_mode::vnodes;
+
+                    rtlogger.info("Finalizing migration for keyspace '{}': direction={}",
+                        ks_name, rollback ? "rollback to vnodes" : "forward to tablets");
+
+                    co_await _tablet_load_stats_refresh.trigger();
+
+                    // Verify that the actual storage mode matches the intended mode for all normal nodes.
+                    // A node that has migrated a table's storage to tablets will report it in its load_stats.
+                    for (const auto& [node_id, _] : _topo_sm._topology.normal_nodes) {
+                        auto host_id = to_host_id(node_id);
+                        auto it = _load_stats_per_node.find(host_id);
+                        if (!rollback) { // forward path (vnodes to tablets)
+                            if (it == _load_stats_per_node.end()) {
+                                throw std::runtime_error(fmt::format(
+                                    "No load stats available for node {}", host_id));
+                            }
+                            const auto& node_stats = it->second;
+                            for (const auto& schema : tables) {
+                                if (!node_stats.tables.contains(schema->id())) {
+                                    throw std::runtime_error(fmt::format(
+                                        "Node {} has not yet migrated table {}.{} to tablets",
+                                        host_id, ks_name, schema->cf_name()));
+                                }
+                            }
+                        } else { // rollback path (tablets to vnodes)
+                            if (it != _load_stats_per_node.end()) {
+                                const auto& node_stats = it->second;
+                                for (const auto& schema : tables) {
+                                    if (node_stats.tables.contains(schema->id())) {
+                                        throw std::runtime_error(fmt::format(
+                                            "Node {} still reports table {}.{} as tablet-based, rollback not complete",
+                                            host_id, ks_name, schema->cf_name()));
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if (!rollback) {
+                        // All nodes have been migrated. ALTER the keyspace to use tablets.
+                        auto old_md = ks.metadata();
+                        auto new_md = data_dictionary::keyspace_metadata::new_keyspace(
+                            old_md->name(),
+                            old_md->strategy_name(),
+                            old_md->strategy_options(),
+                            std::optional<unsigned>(0), // initial_tablets=0 means auto
+                            old_md->consistency_option(),
+                            old_md->durable_writes(),
+                            old_md->get_storage_options());
+                        auto schema_muts = prepare_keyspace_update_announcement(_db, new_md, guard.write_timestamp());
+                        for (auto& m : schema_muts) {
+                            updates.emplace_back(m);
+                        }
+                    } else {
+                        // Rollback: delete tablet maps for all tables in the keyspace.
+                        for (const auto& schema : tables) {
+                            updates.emplace_back(replica::make_drop_tablet_map_mutation(schema->id(), guard.write_timestamp()));
+                        }
+                    }
+                } catch (const std::exception& e) {
+                    error = e.what();
+                    rtlogger.error("Couldn't process global_topology_request::finalize_migration for keyspace '{}': {}",
+                                   ks_name, std::current_exception());
+                    updates.clear();
+                }
+            } else {
+                error = fmt::format("Keyspace '{}' does not exist", ks_name);
+            }
+
+            topology_mutation_builder tbuilder(guard.write_timestamp());
+            tbuilder.del_global_topology_request()
+                    .del_global_topology_request_id()
+                    .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id);
+
+            if (error.empty()) {
+                // Only clear intended_storage_mode if no other keyspace is still under migration.
+                auto tmptr = get_token_metadata_ptr();
+                const auto& tmd = tmptr->tablets();
+                bool has_other_migrating_ks = false;
+                for (const auto& other_ks_name : _db.get_non_system_keyspaces()) {
+                    if (other_ks_name == ks_name) {
+                        continue;
+                    }
+                    auto& other_ks = _db.find_keyspace(other_ks_name);
+                    if (other_ks.uses_tablets()) {
+                        continue;
+                    }
+                    bool other_ks_has_tablet_map = std::ranges::any_of(other_ks.metadata()->tables(), [&](const auto& s) {
+                        return tmd.has_tablet_map(s->id());
+                    });
+                    if (other_ks_has_tablet_map) {
+                        has_other_migrating_ks = true;
+                        break;
+                    }
+                }
+                if (!has_other_migrating_ks) {
+                    for (const auto& [node_id, _] : _topo_sm._topology.normal_nodes) {
+                        tbuilder.with_node(node_id).del("intended_storage_mode");
+                    }
+                }
+            }
+
+            updates.push_back(canonical_mutation(
+                    topology_request_tracking_mutation_builder(req_id)
+                         .done(error)
+                         .build()));
+            updates.push_back(canonical_mutation(tbuilder.build()));
+
+            sstring reason = fmt::format("finalize vnode-to-tablet migration for keyspace '{}'", ks_name);
+            mixed_change change{std::move(updates)};
+            group0_command g0_cmd = _group0.client().prepare_command(std::move(change), guard, reason);
+            co_await _group0.client().add_entry(std::move(g0_cmd), std::move(guard), _as);
+        }
+        break;
         }
     }
 

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -125,6 +125,11 @@ Builder& topology_mutation_builder_base<Builder>::set(const char* cell, cleanup_
 }
 
 template<typename Builder>
+Builder& topology_mutation_builder_base<Builder>::set(const char* cell, intended_storage_mode value) {
+    return apply_atomic(cell, sstring{::format("{}", value)});
+}
+
+template<typename Builder>
 Builder& topology_mutation_builder_base<Builder>::set(const char* cell, const utils::UUID& value) {
     return apply_atomic(cell, value);
 }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -385,6 +385,12 @@ topology_request_tracking_mutation_builder& topology_request_tracking_mutation_b
     return *this;
 }
 
+topology_request_tracking_mutation_builder& topology_request_tracking_mutation_builder::set_finalize_migration_data(
+        const sstring& ks_name) {
+    apply_atomic("finalize_migration_ks_name", ks_name);
+    return *this;
+}
+
 
 template class topology_mutation_builder_base<topology_mutation_builder>;
 template class topology_mutation_builder_base<topology_node_mutation_builder>;

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -160,6 +160,7 @@ public:
     topology_request_tracking_mutation_builder& set_truncate_table_data(const table_id& table_id);
     topology_request_tracking_mutation_builder& set_new_keyspace_rf_change_data(const sstring& ks_name, const std::map<sstring, sstring>& rf_per_dc);
     topology_request_tracking_mutation_builder& set_snapshot_tables_data(const std::unordered_set<table_id>&, const sstring& tag, bool);
+    topology_request_tracking_mutation_builder& set_finalize_migration_data(const sstring& ks_name);
 
     canonical_mutation build() { return canonical_mutation{std::move(_m)}; }
 };

--- a/service/topology_mutation.hh
+++ b/service/topology_mutation.hh
@@ -51,6 +51,7 @@ protected:
     Builder& set(const char* cell, const raft::server_id& value);
     Builder& set(const char* cell, const uint32_t& value);
     Builder& set(const char* cell, cleanup_status value);
+    Builder& set(const char* cell, intended_storage_mode value);
     Builder& set(const char* cell, const utils::UUID& value);
     Builder& set(const char* cell, bool value);
     Builder& set(const char* cell, const char* value);

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -210,6 +210,7 @@ static std::unordered_map<global_topology_request, sstring> global_topology_requ
     {global_topology_request::truncate_table, "truncate_table"},
     {global_topology_request::snapshot_tables, "snapshot_tables"},
     {global_topology_request::noop_request, "noop_request"},
+    {global_topology_request::finalize_migration, "finalize_migration"},
 };
 
 global_topology_request global_topology_request_from_string(const sstring& s) {

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -237,6 +237,20 @@ cleanup_status cleanup_status_from_string(const sstring& s) {
     throw std::runtime_error(fmt::format("cannot map name {} to cleanup_status", s));
 }
 
+static std::unordered_map<intended_storage_mode, sstring> intended_storage_mode_to_name_map = {
+    {intended_storage_mode::vnodes, "vnodes"},
+    {intended_storage_mode::tablets, "tablets"},
+};
+
+intended_storage_mode intended_storage_mode_from_string(const sstring& s) {
+    for (auto&& e : intended_storage_mode_to_name_map) {
+        if (e.second == s) {
+            return e.first;
+        }
+    }
+    throw std::runtime_error(fmt::format("cannot map name {} to intended_storage_mode", s));
+}
+
 future<> topology_state_machine::await_not_busy() {
     while (_topology.is_busy()) {
         co_await event.wait();
@@ -387,6 +401,11 @@ future<> topology_state_machine::abort_request(service::raft_group0& group0,
 auto fmt::formatter<service::cleanup_status>::format(service::cleanup_status status,
                                                      fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", service::cleanup_status_to_name_map[status]);
+}
+
+auto fmt::formatter<service::intended_storage_mode>::format(service::intended_storage_mode mode,
+                                                     fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}", service::intended_storage_mode_to_name_map[mode]);
 }
 
 auto fmt::formatter<service::topology::transition_state>::format(service::topology::transition_state s,

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -88,6 +88,7 @@ enum class global_topology_request: uint16_t {
     // Ensures that all later requests and tablet scheduler will see prior updates to group0.
     noop_request,
     snapshot_tables,
+    finalize_migration,
 };
 
 struct ring_slice {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -94,6 +94,18 @@ struct ring_slice {
     std::unordered_set<dht::token> tokens;
 };
 
+// The intended storage mode for a node during vnodes-to-tablets migration.
+//
+// When migrating a table from vnodes to tablets, each node needs to reshard
+// its local SSTables on vnode boundaries. Conversely, SSTables need to be
+// resharded in the opposite direction (i.e., with the static sharder) when the
+// operation is rolled back. This property is an indicator that a node needs to
+// perform resharding on restart, and it declares the resharding direction.
+enum class intended_storage_mode : uint16_t {
+    vnodes,
+    tablets,
+};
+
 struct replica_state {
     node_state state;
     seastar::sstring datacenter;
@@ -105,6 +117,7 @@ struct replica_state {
     std::set<sstring> supported_features;
     cleanup_status cleanup;
     utils::UUID request_id; // id of the current request for the node or the last one if no current one exists
+    std::optional<intended_storage_mode> storage_mode;
 };
 
 struct topology_features {
@@ -326,11 +339,17 @@ std::optional<topology_request> try_topology_request_from_string(const sstring& 
 topology_request topology_request_from_string(const sstring& s);
 global_topology_request global_topology_request_from_string(const sstring&);
 cleanup_status cleanup_status_from_string(const sstring& s);
+intended_storage_mode intended_storage_mode_from_string(const sstring& s);
 }
 
 template <> struct fmt::formatter<service::cleanup_status> {
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
     auto format(service::cleanup_status status, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <> struct fmt::formatter<service::intended_storage_mode> {
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+    auto format(service::intended_storage_mode mode, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
 
 template <> struct fmt::formatter<service::fencing_token> : fmt::formatter<string_view> {

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -8,9 +8,11 @@
 
 
 #include <fmt/format.h>
+#include <functional>
 #include <seastar/core/smp.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/file.hh>
+#include "dht/token.hh"
 #include "sstables/generation_type.hh"
 #undef SEASTAR_TESTING_MAIN
 #include <seastar/testing/test_case.hh>
@@ -41,8 +43,8 @@ public:
         auto gtable = co_await replica::get_table_on_all_shards(db, ks_name, cf_name);
         co_await replica::distributed_loader::lock_table(gtable, dir);
     }
-    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr = nullptr) {
-        return replica::distributed_loader::reshard(dir, db, std::move(ks_name), std::move(table_name), std::move(creator), std::move(owned_ranges_ptr));
+    static future<> reshard(sharded<sstables::sstable_directory>& dir, sharded<replica::database>& db, sstring ks_name, sstring table_name, compaction::compaction_sstable_creator_fn creator, compaction::owned_ranges_ptr owned_ranges_ptr = nullptr, bool vnodes_resharding = false) {
+        return replica::distributed_loader::reshard(dir, db, std::move(ks_name), std::move(table_name), std::move(creator), std::move(owned_ranges_ptr), vnodes_resharding);
     }
 };
 
@@ -73,13 +75,13 @@ make_sstable_for_this_shard(std::function<sstables::shared_sstable()> sst_factor
 /// Arguments passed to the function are passed to table::make_sstable
 template <typename... Args>
 sstables::shared_sstable
-make_sstable_for_all_shards(replica::table& table, sstables::sstable_state state, sstables::generation_type generation) {
+make_sstable_for_all_shards(replica::table& table, sstables::sstable_state state, sstables::generation_type generation, unsigned num_shards = smp::count) {
     // Unlike the previous helper, we'll assume we're in a thread here. It's less flexible
     // but the users are usually in a thread, and rewrite_toc_without_component requires
     // a thread. We could fix that, but deferring that for now.
     auto s = table.schema();
     auto mt = make_lw_shared<replica::memtable>(s);
-    for (shard_id shard = 0; shard < smp::count; ++shard) {
+    for (shard_id shard = 0; shard < num_shards; ++shard) {
         auto key = tests::generate_partition_key(s, shard);
         mutation m(s, key);
         m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
@@ -327,6 +329,26 @@ future<> verify_that_all_sstables_are_local(sharded<sstable_directory>& sstdir, 
             co_return ret;
         }, 0, std::plus<unsigned>());
         THREADSAFE_BOOST_REQUIRE_EQUAL(count, expected_sstables);
+}
+
+future<> verify_that_all_sstables_are_contained_in_ranges(sharded<sstable_directory>& sstdir, compaction::owned_ranges_ptr owned_ranges) {
+        auto all_ok = co_await sstdir.map_reduce0([owned_ranges] (sstable_directory& d) -> future<bool> {
+            bool ret = true;
+            co_await d.do_for_each_sstable([&ret, &owned_ranges] (sstables::shared_sstable sst) {
+                dht::token_range sst_range(sst->get_first_decorated_key().token(), sst->get_last_decorated_key().token());
+                bool found = false;
+                for (const auto& r : *owned_ranges) {
+                    if (r.contains(sst_range, dht::token_comparator{})) {
+                        found = true;
+                        break;
+                    }
+                }
+                ret &= found;
+                return make_ready_future<>();
+            });
+            co_return ret;
+        }, true, std::logical_and<>{});
+        THREADSAFE_BOOST_REQUIRE(all_ok);
 }
 
 // Test that all SSTables are seen as unshared, if the generation numbers match what their
@@ -860,6 +882,53 @@ SEASTAR_TEST_CASE(test_pending_log_garbage_collection) {
             BOOST_REQUIRE_EQUAL(expected, collected);
         });
       }
+    });
+}
+
+SEASTAR_TEST_CASE(sstable_directory_test_reshard_vnodes) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("create table cf (p text PRIMARY KEY, c int)").get();
+        auto& cf = e.local_db().find_column_family("ks", "cf");
+
+        e.db().invoke_on_all([] (replica::database& db) {
+            auto& cf = db.find_column_family("ks", "cf");
+            return cf.disable_auto_compaction();
+        }).get();
+
+        unsigned num_sstables = 10 * smp::count;
+
+        sharded<sstables::sstable_generation_generator> sharded_gen;
+        sharded_gen.start().get();
+        auto stop_generator = deferred_stop(sharded_gen);
+
+        for (unsigned nr = 0; nr < num_sstables; ++nr) {
+            auto generation = sharded_gen.invoke_on(nr % smp::count, [] (auto& gen) {
+                return gen();
+            }).get();
+            make_sstable_for_all_shards(cf, sstables::sstable_state::upload, generation, smp::count);
+        }
+
+        with_sstable_directory(e.db(), "ks", "cf", sstables::sstable_state::upload, [&] (sharded<sstables::sstable_directory>& sstdir) {
+            distributed_loader_for_tests::process_sstable_dir(sstdir, { .throw_on_missing_toc = true }).get();
+
+            sharded<sstables::sstable_generation_generator> sharded_gen;
+            sharded_gen.start().get();
+            auto stop_generator = deferred_stop(sharded_gen);
+
+            auto make_sstable = [&e, &sharded_gen] (shard_id shard) {
+                auto generation = sharded_gen.invoke_on(shard, [] (auto& gen) {
+                    return gen();
+                }).get();
+                auto& cf = e.local_db().find_column_family("ks", "cf");
+                return cf.get_sstables_manager().make_sstable(cf.schema(), cf.get_storage_options(), generation, sstables::sstable_state::upload);
+            };
+
+            const auto& erm = e.local_db().find_keyspace("ks").get_static_effective_replication_map();
+            auto owned_ranges_ptr = compaction::make_owned_ranges_ptr(e.local_db().get_keyspace_local_ranges(erm).get());
+            bool vnodes_resharding = true;
+            distributed_loader_for_tests::reshard(sstdir, e.db(), "ks", "cf", std::move(make_sstable), owned_ranges_ptr, vnodes_resharding).get();
+            verify_that_all_sstables_are_contained_in_ranges(sstdir, owned_ranges_ptr).get();
+        });
     });
 }
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -272,6 +272,126 @@ async def test_migration(manager: ManagerClient):
 
 
 @pytest.mark.asyncio
+async def test_migration_rollback(manager: ManagerClient):
+    """Verify rollback of vnodes-to-tablets migration on a single-node cluster.
+
+    Same as test_migration(), but after the first restart (which reshards on
+    vnode boundaries), the node is marked for downgrade back to vnodes and
+    restarted again. After finalization the keyspace must still use vnodes, and
+    the group0 state (tablet map, intended_storage_mode) must have been
+    cleared.
+
+    Steps:
+    1. Start a single node with multiple shards and power-of-2 aligned vnodes.
+    2. Create a vnode table and inject data.
+    3. Start the migration by creating a tablet map for the table.
+    4. Mark the node for upgrade and restart (triggers resharding).
+    5. Mark the node for downgrade back to vnodes and restart again.
+    6. Finalize the migration.
+       - Verify that the keyspace schema still uses vnodes.
+       - Verify that the tablet map has been cleared.
+       - Verify that intended_storage_mode is cleared.
+       - Verify data integrity.
+    """
+    num_shards = 3
+    tokens_per_node = 16
+    num_keys = 5000
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
+    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
+    token_list = tokens[1]  # server_id 1
+    initial_token = ','.join([str(t) for t in token_list])
+    servers = (await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token, '--logger-log-level', 'compaction=debug']))
+    server = servers[0]
+    host_id = await manager.get_host_id(server.server_id)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logger.info("Creating keyspace and table with vnodes")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}")
+
+        logger.info("Populating table in batches, flushing after each batch to produce multiple SSTables")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        num_flushes = 5
+        keys_per_sstable = num_keys // num_flushes
+        for batch_start in range(0, num_keys, keys_per_sstable):
+            batch_end = min(batch_start + keys_per_sstable, num_keys)
+            await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(batch_start, batch_end)))
+            await manager.api.keyspace_flush(server.ip_addr, ks, "test")
+
+        logger.info("Starting vnodes-to-tablets migration (creating a tablet map)")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying that the tablet map was created")
+        tablet_count = await get_tablet_count(manager, server, ks, 'test')
+        assert tablet_count == tokens_per_node, \
+            f"Expected {tokens_per_node} tablet(s), got {tablet_count}"
+
+        logger.info("Marking node for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        logger.info("Restarting the node to trigger resharding")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying data integrity after first restart")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Verifying migration status after first restart (node should now use tablets)")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('tablets', 'tablets')})
+
+        logger.info("Marking node for downgrade back to vnodes")
+        await manager.api.downgrade_node_to_vnodes(server.ip_addr)
+
+        logger.info("Verifying migration status after marking node for downgrade")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('tablets', 'vnodes')})
+
+        logger.info("Restarting the node to trigger resharding back to vnodes")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        logger.info("Verifying data integrity after second restart (downgrade)")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Verifying migration status after second restart (node should be back on vnodes)")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'vnodes')})
+
+        logger.info("Finalizing migration (rollback path)")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying that the keyspace schema still uses vnodes")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+        assert len(res) == 0, \
+            f"Expected keyspace to still use vnodes after rollback"
+
+        logger.info("Verifying that the tablet map has been cleared")
+        tablet_count = await get_tablet_count(manager, server, ks, 'test')
+        assert tablet_count == 0, \
+            f"Expected 0 tablets after rollback, got {tablet_count}"
+
+        logger.info("Verifying that intended_storage_mode is cleared after finalization")
+        rows = await cql.run_async("SELECT host_id, intended_storage_mode FROM system.topology WHERE key = 'topology'")
+        for row in rows:
+            assert row.intended_storage_mode is None, \
+                f"Expected intended_storage_mode=None for node {row.host_id} after rollback finalization, got '{row.intended_storage_mode}'"
+
+        logger.info("Verifying migration status after rollback finalization")
+        await verify_migration_status(manager, server, ks, expected_status='vnodes', expected_node_statuses={})
+
+        logger.info("Final data integrity check")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+
+@pytest.mark.asyncio
 async def test_migration_multinode(manager: ManagerClient):
     """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
 

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -14,6 +14,7 @@ from collections import defaultdict
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
+from test.pylib.rest_client import read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace, reconnect_driver
@@ -268,3 +269,146 @@ async def test_migration(manager: ManagerClient):
 
         logger.info("Verifying migration status after finalization")
         await verify_migration_status(manager, server, ks, expected_status='tablets', expected_node_statuses={})
+
+
+@pytest.mark.asyncio
+async def test_migration_multinode(manager: ManagerClient):
+    """Verify vnodes-to-tablets migration for a single table on a multi-node cluster with rolling restarts.
+
+    Steps:
+    1. Start a 2-node cluster with RF=2, multiple shards, and power-of-2 aligned vnodes.
+    2. Create a vnode table and inject data at CL=QUORUM.
+    3. Create tablet map — verify one tablet replica per node, tablet tokens match vnode tokens.
+    4. Rolling restart — for each node: mark for upgrade, verify intended_storage_mode
+       in system.topology, restart, then verify reads/writes at CL=QUORUM from every node.
+    5. Finalize — verify keyspace schema has tablets enabled, intended_storage_mode is cleared
+       for all nodes.
+    """
+    num_nodes = 2
+    num_shards = 3
+    tokens_per_node = 64
+    num_keys = 1000
+
+    logger.info(f"Starting {num_nodes} nodes with {num_shards} shards each, ~{tokens_per_node} power-of-2 aligned tokens per node")
+    calculated_tokens = calculate_powof2_tokens(num_nodes=num_nodes, tokens_per_node=tokens_per_node)
+    total_vnodes = sum(len(t) for t in calculated_tokens.values())
+    logger.info(f"Total vnodes: {total_vnodes}")
+
+    servers = []
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
+    for i, tokens in calculated_tokens.items():
+        cmdline = [
+            '--smp', str(num_shards),
+            '--logger-log-level', 'compaction=debug',
+            f"--initial-token={','.join([str(t) for t in tokens])}",
+        ]
+        servers.append(await manager.server_add(cmdline=cmdline, property_file={"dc": "dc1", "rack": f"rack{i}"}, config=cfg))
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    server_to_host_map = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
+    host_ids = set(server_to_host_map.values())
+
+    logger.info(f"Creating keyspace and table with vnodes (RF={num_nodes})")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {num_nodes}}} AND tablets = {{'enabled': false}}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+
+        logger.info(f"Populating table with {num_keys} rows at CL=QUORUM")
+        insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        insert_stmt.consistency_level = ConsistencyLevel.QUORUM
+        await asyncio.gather(*(cql.run_async(insert_stmt, [k, k]) for k in range(num_keys)))
+
+        logger.info("Starting vnodes-to-tablets migration (creating tablet map)")
+        await manager.api.create_vnode_tablet_migration(servers[0].ip_addr, ks)
+
+        logger.info("Verifying migration status after creating tablet map")
+        await verify_migration_status(manager, servers[0], ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'vnodes') for host_id in host_ids})
+
+        logger.info("Verifying tablet map")
+        tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, 'test')
+        assert len(tablet_replicas) == total_vnodes, \
+            f"Expected {total_vnodes} tablets, got {len(tablet_replicas)}"
+
+        all_vnode_tokens = sorted([t for tokens in calculated_tokens.values() for t in tokens])
+        tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
+        assert tablet_tokens == all_vnode_tokens, \
+            f"Tablet tokens do not match vnode tokens"
+
+        for tr in tablet_replicas:
+            replica_hosts = set(r[0] for r in tr.replicas)
+            assert replica_hosts == host_ids, \
+                f"Tablet at token {tr.last_token}: replica hosts {replica_hosts} != expected {host_ids}"
+
+        logger.info("Verifying data integrity before rolling restart")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Starting rolling restarts: mark each node for upgrade, restart it, verify reads/writes at CL=QUORUM from every node")
+        for restart_idx, s in enumerate(servers):
+            logger.info(f"Marking node {s.server_id} for tablets migration")
+            await manager.api.upgrade_node_to_tablets(s.ip_addr)
+
+            logger.info(f"Verifying intended_storage_mode='tablets' on node {s.server_id}")
+            # It is important to verify the intended_storage_mode value on the
+            # local group0 copy of the node that is about to be restarted
+            # because the upgrade is an offline operation happening on startup,
+            # so the node's group0 copy must be up-to-date.
+            host_obj = cql.cluster.metadata.get_host(s.ip_addr)
+            node_host_id = server_to_host_map[s.server_id]
+            rows = await cql.run_async(f"SELECT intended_storage_mode FROM system.topology WHERE key = 'topology' AND host_id = {node_host_id}", host=host_obj)
+            assert len(rows) == 1, f"Expected 1 row for host_id {node_host_id}, got {len(rows)}"
+            assert rows[0].intended_storage_mode == "tablets", \
+                f"Expected intended_storage_mode='tablets' for node {s.server_id}, got '{rows[0].intended_storage_mode}'"
+
+            logger.info(f"Restarting node {s.server_id}")
+            await manager.server_restart(s.server_id)
+            await reconnect_driver(manager)
+            cql, _ = await manager.get_ready_cql(servers)
+
+            # Run 10 read/write queries from each node at CL=QUORUM to verify
+            # correctness. The cluster is in a semi-migrated state, so some
+            # nodes use a tablet ERM and some nodes use a vnode ERM.
+            logger.info(f"Running read/write verification from all nodes after restarting node {s.server_id}")
+            insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+            insert_stmt.consistency_level = ConsistencyLevel.QUORUM
+            select_stmt = cql.prepare(f"SELECT c FROM {ks}.test WHERE pk = ?")
+            select_stmt.consistency_level = ConsistencyLevel.QUORUM
+            for node_idx, node in enumerate(servers):
+                host_obj = cql.cluster.metadata.get_host(node.ip_addr)
+                base_key = num_keys + restart_idx * num_nodes * 10 + node_idx * 10
+                for i in range(10):
+                    key = base_key + i
+                    await cql.run_async(insert_stmt, [key, key], host=host_obj)
+                    rows = await cql.run_async(select_stmt, [key], host=host_obj)
+                    assert len(rows) == 1 and rows[0].c == key, \
+                        f"Read/write verification failed: node {node.server_id}, key {key}"
+
+        logger.info("Verifying migration status after rolling restarts")
+        await verify_migration_status(manager, servers[0], ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('tablets', 'tablets') for host_id in host_ids},
+            retries=1, retry_interval=1) # the status is derived from the topology coordinator's load stats which are refreshed every second; give it one retry after 1 second
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(servers[0].ip_addr, ks)
+
+        # Barrier on an arbitrary node to ensure we can observe the latest group0 state from it.
+        await read_barrier(manager.api, servers[1].ip_addr)
+        host1 = cql.cluster.metadata.get_host(servers[1].ip_addr)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'", host=host1)
+        assert len(res) == 1 and res[0].initial_tablets is not None, \
+            "Keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying intended_storage_mode is cleared for all nodes after finalization")
+        rows = await cql.run_async(f"SELECT host_id, intended_storage_mode FROM system.topology WHERE key = 'topology'", host=host1)
+        assert len(rows) == num_nodes, f"Expected {num_nodes} rows, got {len(rows)}"
+        for row in rows:
+            assert row.intended_storage_mode is None, \
+                f"Expected intended_storage_mode=None for node {row.host_id} after finalization, got '{row.intended_storage_mode}'"
+
+        logger.info("Final data integrity check")
+        total_keys = num_keys + num_nodes * num_nodes * 10 # original keys + 10 keys per node inserted during rolling restarts
+        await verify_data_integrity(cql, ks, "test", total_keys)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -1,0 +1,270 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.0
+#
+import os
+import glob
+import json
+import pytest
+import asyncio
+import logging
+import subprocess
+from collections import defaultdict
+from cassandra.query import SimpleStatement, ConsistencyLevel
+
+from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+from test.cluster.util import new_test_keyspace, reconnect_driver
+
+logger = logging.getLogger(__name__)
+
+def calculate_powof2_tokens(num_nodes: int, tokens_per_node: int) -> dict[int, list[int]]:
+    exp = 0
+    while 2**exp < num_nodes * tokens_per_node:
+        exp += 1
+    n = 2**exp
+    new_tokens_combined = [int(i * 2**64 // n - 2**63 - 1) for i in range(1, n+1)]
+    calculated_new_tokens = defaultdict(list)
+    new_server_id = 1
+    for i, t in enumerate(new_tokens_combined):
+        calculated_new_tokens[new_server_id  + (i % num_nodes)].append(t)
+    for s, tokens in calculated_new_tokens.items():
+        calculated_new_tokens[s] = sorted(tokens)
+    logger.debug(f"{calculated_new_tokens=}")
+    return calculated_new_tokens
+
+
+def get_sstable_token_ranges(scylla_path: str, scylla_yaml: str, sstable_data_files: list[str]) -> list[tuple[int, int]]:
+    """Run 'scylla sstable dump-scylla-metadata' and return a list of (first_token, last_token) per SSTable.
+
+    Extracts the first and last token from the sharding metadata in the Scylla.db component.
+
+    Args:
+        scylla_path: Path to the scylla executable.
+        scylla_yaml: Path to the scylla.yaml config file.
+        sstable_data_files: List of SSTable Data.db file paths.
+
+    Returns:
+        A list of (first_token, last_token) tuples, one per SSTable.
+    """
+    try:
+        result = subprocess.check_output(
+            [scylla_path, "sstable", "dump-scylla-metadata",
+             "--scylla-yaml-file", scylla_yaml,
+             "--sstables"] + sstable_data_files,
+            stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        logger.error(f"scylla sstable dump-scylla-metadata failed with exit code {e.returncode}")
+        logger.error(f"stdout: {e.output.decode('utf-8', 'ignore')}")
+        logger.error(f"stderr: {e.stderr.decode('utf-8', 'ignore')}")
+        raise
+    metadata = json.loads(result.decode('utf-8', 'ignore'))
+    ranges = []
+    for sstable_name, info in metadata["sstables"].items():
+        sharding = info["sharding"]
+        assert not sharding[0]["left"]["exclusive"], f"SSTable {sstable_name}: Expected the left bound of the first sharding range to be inclusive"
+        assert not sharding[-1]["right"]["exclusive"], f"SSTable {sstable_name}: Expected the right bound of the last sharding range to be inclusive"
+        first_token = int(sharding[0]["left"]["token"])
+        last_token = int(sharding[-1]["right"]["token"])
+        ranges.append((first_token, last_token))
+    return ranges
+
+
+def sstable_range_within_vnode(first_token: int, last_token: int, vnode_boundaries: list[int]) -> bool:
+    """Check whether an SSTable's token range falls entirely within a single vnode range.
+
+    Args:
+        first_token: The first token in the SSTable.
+        last_token: The last token in the SSTable.
+        vnode_boundaries: Sorted list of vnode token boundaries.
+
+    Returns:
+        True if both first_token and last_token fall within the same vnode range.
+    """
+    def find_owning_vnode(token: int) -> int:
+        """Return the index of the vnode that owns this token."""
+        for i, boundary in enumerate(vnode_boundaries):
+            if token <= boundary:
+                return i
+        # Token is above the last boundary, wraps to vnode 0
+        return 0
+
+    return find_owning_vnode(first_token) == find_owning_vnode(last_token)
+
+
+async def verify_data_integrity(cql, ks, table, num_keys, cl=ConsistencyLevel.QUORUM):
+    stmt = SimpleStatement(f"SELECT * FROM {ks}.{table}")
+    stmt.consistency_level = cl
+    rows = await cql.run_async(stmt)
+    data = {r.pk: r.c for r in rows}
+    expected = {k: k for k in range(num_keys)}
+    if data != expected:
+        missing = expected.keys() - data.keys()
+        extra = data.keys() - expected.keys()
+        wrong = {k: (data[k], expected[k]) for k in data.keys() & expected.keys() if data[k] != expected[k]}
+        assert False, f"Data mismatch: missing keys {missing}, extra keys {extra}, wrong values {wrong}"
+
+
+async def verify_migration_status(manager: ManagerClient, server: ServerInfo,
+                                  ks: str, expected_status: str,
+                                  expected_node_statuses: dict[str, tuple[str, str]],
+                                  retries: int = 0, retry_interval: float = 0):
+    async def _check():
+        status = await manager.api.get_vnode_tablet_migration_status(server.ip_addr, ks)
+        actual_node_statuses = {n['host_id']: (n['current_mode'], n['intended_mode']) for n in status['nodes']}
+        assert status['status'] == expected_status, f"Expected migration status '{expected_status}', got '{status['status']}'"
+        assert actual_node_statuses == expected_node_statuses, f"Expected node statuses {expected_node_statuses}, got {actual_node_statuses}"
+
+    for attempt in range(retries + 1):
+        try:
+            await _check()
+            return
+        except AssertionError:
+            if attempt < retries and retry_interval > 0:
+                await asyncio.sleep(retry_interval)
+            else:
+                raise
+
+
+@pytest.mark.asyncio
+async def test_migration(manager: ManagerClient):
+    """Verify vnodes-to-tablets migration for a single table on a single-node cluster.
+
+    Steps:
+    1. Start a single node with multiple shards and power-of-2 aligned vnodes.
+    2. Create a vnode table and inject data.
+    3. Start the migration by creating a tablet map for the table.
+       - Verify that the tablet map was created and tablet tokens match vnode tokens.
+    4. Mark the node for upgrade on next restart.
+    5. Restart the node (triggers resharding on vnode boundaries).
+       - Verify that the new SSTables are properly segregated within vnode boundaries.
+       - Verify data integrity.
+    6. Finalize the migration.
+       - Verify that the keyspace schema has tablets enabled.
+    """
+    num_shards = 3
+    tokens_per_node = 16
+    num_keys = 5000
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
+    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
+    token_list = tokens[1]  # server_id 1
+    initial_token = ','.join([str(t) for t in token_list])
+    servers = (await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token, '--logger-log-level', 'compaction=debug']))
+    server = servers[0]
+    host_id = await manager.get_host_id(server.server_id)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    logger.info("Creating keyspace and table with vnodes")
+    async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': false}}") as ks:
+        # Create the table with minor compaction disabled to ensure that Scylla
+        # won't delete SSTables while we're checking them.
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'IncrementalCompactionStrategy', 'enabled': false}}")
+
+        logger.info("Populating table in batches, flushing after each batch to produce multiple SSTables")
+        stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
+        num_flushes = 5
+        keys_per_sstable = num_keys // num_flushes
+        for batch_start in range(0, num_keys, keys_per_sstable):
+            batch_end = min(batch_start + keys_per_sstable, num_keys)
+            await asyncio.gather(*(cql.run_async(stmt, [k, k]) for k in range(batch_start, batch_end)))
+            await manager.api.keyspace_flush(server.ip_addr, ks, "test")
+
+        logger.info("Collecting pre-migration SSTable info")
+        node_workdir = await manager.server_get_workdir(server.server_id)
+        scylla_path = await manager.server_get_exe(server.server_id)
+        scylla_yaml = os.path.join(node_workdir, "conf", "scylla.yaml")
+        table_data_dir = glob.glob(os.path.join(node_workdir, "data", ks, "test-*"))[0]
+        pre_migration_sstables = glob.glob(os.path.join(table_data_dir, "*-Data.db"))
+        logger.info(f"Pre-migration SSTable count: {len(pre_migration_sstables)}")
+        assert len(pre_migration_sstables) == num_shards * num_flushes
+
+        logger.info("Verifying that at least one pre-migration SSTable spans multiple vnode ranges (ensures that resharding will have work to do)")
+        vnode_boundaries = sorted(token_list)
+        pre_migration_ranges = get_sstable_token_ranges(scylla_path, scylla_yaml, pre_migration_sstables)
+        cross_vnode_count = sum(1 for first, last in pre_migration_ranges
+                                if not sstable_range_within_vnode(first, last, vnode_boundaries))
+        logger.info(f"Pre-migration: {cross_vnode_count}/{len(pre_migration_ranges)} SSTables span multiple vnodes")
+        assert cross_vnode_count >= 1, \
+            "Expected at least one pre-migration SSTable to span multiple vnode ranges, but none was found. The test is malformed."
+
+        logger.info("Verifying migration status before starting migration")
+        await verify_migration_status(manager, server, ks, expected_status='vnodes', expected_node_statuses={})
+
+        logger.info("Starting vnodes-to-tablets migration (creating a tablet map)")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying migration status after creating tablet map")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'vnodes')})
+
+        logger.info("Verifying that the tablet map was created")
+        tablet_count = await get_tablet_count(manager, server, ks, 'test')
+        assert tablet_count == tokens_per_node, \
+            f"Expected {tokens_per_node} tablet(s), got {tablet_count}"
+
+        tablet_replicas = await get_all_tablet_replicas(manager, server, ks, 'test')
+        assert len(tablet_replicas) == tokens_per_node, \
+            f"Expected {tokens_per_node} tablet replica entries, got {len(tablet_replicas)}"
+
+        logger.info("Verifying that tablet tokens match vnode tokens")
+        tablet_tokens = sorted([tr.last_token for tr in tablet_replicas])
+        assert tablet_tokens == vnode_boundaries, \
+            f"Tablet tokens {tablet_tokens} do not match vnode tokens {vnode_boundaries}"
+
+        logger.info("Verifying data integrity after building tablet map and before resharding")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Marking node for tablets migration")
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        logger.info("Verifying migration status after marking node for upgrade")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('vnodes', 'tablets')})
+
+        logger.info("Verifying data integrity after marking the node for upgrade and before resharding (ensures that the node is still using the vnode-based ERM)")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Restarting the node to trigger resharding")
+        await manager.server_restart(server.server_id)
+        await reconnect_driver(manager)
+        cql, _ = await manager.get_ready_cql(servers)
+
+        # After restart, resharding should have produced new SSTables
+        post_restart_sstables = glob.glob(os.path.join(table_data_dir, "*-Data.db"))
+        logger.info(f"Post-restart SSTable count: {len(post_restart_sstables)}")
+
+        post_restart_ranges = get_sstable_token_ranges(scylla_path, scylla_yaml, post_restart_sstables)
+        logger.info(f"Post-restart SSTable token ranges:")
+        for i, (first, last) in enumerate(post_restart_ranges):
+            within = sstable_range_within_vnode(first, last, vnode_boundaries)
+            logger.info(f"  SSTable {i}: tokens [{first}, {last}], within single vnode: {within}")
+
+        logger.info("Verifying that every post-restart SSTable falls within a single vnode range")
+        for i, (first, last) in enumerate(post_restart_ranges):
+            assert sstable_range_within_vnode(first, last, vnode_boundaries), \
+                f"Post-restart SSTable {i} with token range [{first}, {last}] " \
+                f"spans multiple vnode ranges (boundaries: {vnode_boundaries})"
+
+        logger.info("Verifying data integrity after restart")
+        await verify_data_integrity(cql, ks, "test", num_keys)
+
+        logger.info("Verifying migration status after node restart (node should now use tablets)")
+        await verify_migration_status(manager, server, ks,
+            expected_status='migrating_to_tablets',
+            expected_node_statuses={host_id: ('tablets', 'tablets')})
+
+        logger.info("Finalizing tablets migration")
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        logger.info("Verifying that the keyspace schema has tablets enabled")
+        res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks}'")
+        assert len(res) == 1 and res[0].initial_tablets is not None, "keyspace is still using vnodes after migration finalization"
+
+        logger.info("Verifying migration status after finalization")
+        await verify_migration_status(manager, server, ks, expected_status='tablets', expected_node_statuses={})

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -14,7 +14,7 @@ from collections import defaultdict
 from cassandra.query import SimpleStatement, ConsistencyLevel
 
 from test.pylib.tablets import get_tablet_count, get_all_tablet_replicas
-from test.pylib.rest_client import read_barrier
+from test.pylib.rest_client import HTTPError, read_barrier
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace, reconnect_driver
@@ -532,3 +532,107 @@ async def test_migration_multinode(manager: ManagerClient):
         logger.info("Final data integrity check")
         total_keys = num_keys + num_nodes * num_nodes * 10 # original keys + 10 keys per node inserted during rolling restarts
         await verify_data_integrity(cql, ks, "test", total_keys)
+
+
+async def setup_single_node_with_powof2_tokens(manager: ManagerClient):
+    """Start a single node with power-of-2 aligned tokens for migration error tests."""
+    tokens_per_node = 16
+    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
+    token_list = tokens[1]
+    initial_token = ','.join([str(t) for t in token_list])
+    server = await manager.server_add(cmdline=['--smp', '2', '--initial-token', initial_token])
+    cql, _ = await manager.get_ready_cql([server])
+    return server, cql
+
+
+@pytest.mark.asyncio
+async def test_migration_nonexistent_keyspace(manager: ManagerClient):
+    """Verify that migration APIs fail on a non-existent keyspace."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    with pytest.raises(HTTPError, match="Can't find a keyspace"):
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, "ks")
+    with pytest.raises(HTTPError, match="Can't find a keyspace"):
+        await manager.api.get_vnode_tablet_migration_status(server.ip_addr, "ks")
+    with pytest.raises(HTTPError, match="Can't find a keyspace"):
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, "ks")
+
+
+@pytest.mark.asyncio
+async def test_migration_already_tablets(manager: ManagerClient):
+    """Verify that starting migration on a keyspace that already uses tablets fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks_tablets:
+        with pytest.raises(HTTPError, match="already uses tablets"):
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_tablets)
+
+
+@pytest.mark.asyncio
+async def test_migration_empty_keyspace(manager: ManagerClient):
+    """Verify that starting migration on a keyspace with no tables fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks_empty:
+        with pytest.raises(HTTPError, match="has no tables to migrate"):
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks_empty)
+
+
+@pytest.mark.asyncio
+async def test_migration_finalize_without_migration(manager: ManagerClient):
+    """Verify that finalizing migration without starting one first fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks_vnodes:
+        await cql.run_async(f"CREATE TABLE {ks_vnodes}.t (pk int PRIMARY KEY)")
+        with pytest.raises(HTTPError, match="does not have a tablet map"):
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks_vnodes)
+
+
+@pytest.mark.asyncio
+async def test_migration_upgrade_without_migration(manager: ManagerClient):
+    """Verify that upgrading a node to tablets without an active migration fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    with pytest.raises(HTTPError, match="no migration is in progress"):
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+
+@pytest.mark.asyncio
+async def test_migration_overlapping_migrations(manager: ManagerClient):
+    """Verify that starting a second migration while one is already in progress fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks1:
+        await cql.run_async(f"CREATE TABLE {ks1}.t (pk int PRIMARY KEY)")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks1)
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks2:
+            await cql.run_async(f"CREATE TABLE {ks2}.t (pk int PRIMARY KEY)")
+            with pytest.raises(HTTPError, match="Another migration is in progress"):
+                await manager.api.create_vnode_tablet_migration(server.ip_addr, ks2)
+
+        # Rollback: schema changes are not yet supported for migrating keyspaces.
+        # TODO: Remove this once support is added.
+        await manager.api.downgrade_node_to_vnodes(server.ip_addr)
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)
+
+
+@pytest.mark.asyncio
+async def test_migration_finalize_before_upgrade(manager: ManagerClient):
+    """Verify that finalizing migration before the node has finished upgrading fails."""
+    server, cql = await setup_single_node_with_powof2_tokens(manager)
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
+        await manager.api.create_vnode_tablet_migration(server.ip_addr, ks)
+        await manager.api.upgrade_node_to_tablets(server.ip_addr)
+
+        with pytest.raises(HTTPError, match=fr"Migration finalization failed for keyspace '{ks}': Node .* has not yet migrated table {ks}.t to tablets"):
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+        # Rollback: schema changes are not yet supported for migrating keyspaces.
+        # TODO: Remove this once support is added.
+        await manager.api.downgrade_node_to_vnodes(server.ip_addr)
+        await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)

--- a/test/cluster/test_vnodes_to_tablets_migration.py
+++ b/test/cluster/test_vnodes_to_tablets_migration.py
@@ -636,3 +636,76 @@ async def test_migration_finalize_before_upgrade(manager: ManagerClient):
         # TODO: Remove this once support is added.
         await manager.api.downgrade_node_to_vnodes(server.ip_addr)
         await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks)
+
+
+@pytest.mark.asyncio
+async def test_migration_multiple_keyspaces(manager: ManagerClient):
+    """Verify that two keyspaces can be migrated from vnodes to tablets simultaneously."""
+    num_shards = 3
+    tokens_per_node = 16
+
+    logger.info(f"Starting a node with {num_shards} shards and {tokens_per_node} power-of-2 aligned tokens")
+    tokens = calculate_powof2_tokens(num_nodes=1, tokens_per_node=tokens_per_node)
+    token_list = tokens[1]
+    initial_token = ','.join([str(t) for t in token_list])
+    servers = await manager.servers_add(1, cmdline=['--smp', str(num_shards), '--initial-token', initial_token])
+    server = servers[0]
+    host_id = await manager.get_host_id(server.server_id)
+
+    cql, _ = await manager.get_ready_cql(servers)
+
+    ks_opts = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}"
+
+    logger.info("Creating two vnode keyspaces with tables")
+    async with new_test_keyspace(manager, ks_opts) as ks1:
+        async with new_test_keyspace(manager, ks_opts) as ks2:
+            await cql.run_async(f"CREATE TABLE {ks1}.t (pk int PRIMARY KEY, c int)")
+            await cql.run_async(f"CREATE TABLE {ks2}.t (pk int PRIMARY KEY, c int)")
+
+            logger.info("Preparing both keyspaces for migration (creating tablet maps)")
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks1)
+            await manager.api.create_vnode_tablet_migration(server.ip_addr, ks2)
+
+            logger.info("Marking node for tablets migration and restarting")
+            await manager.api.upgrade_node_to_tablets(server.ip_addr)
+            await manager.server_restart(server.server_id)
+            await reconnect_driver(manager)
+            cql, _ = await manager.get_ready_cql(servers)
+
+            logger.info("Verifying both keyspaces show as migrating")
+            await verify_migration_status(manager, server, ks1,
+                expected_status='migrating_to_tablets',
+                expected_node_statuses={host_id: ('tablets', 'tablets')},
+                retries=1, retry_interval=1)
+            await verify_migration_status(manager, server, ks2,
+                expected_status='migrating_to_tablets',
+                expected_node_statuses={host_id: ('tablets', 'tablets')},
+                retries=1, retry_interval=1)
+
+            logger.info("Finalizing migration for ks1")
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks1)
+
+            logger.info("Verifying ks1 has tablets enabled")
+            res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks1}'")
+            assert len(res) == 1 and res[0].initial_tablets is not None, \
+                f"ks1 should use tablets after finalization"
+
+            logger.info("Verifying intended_storage_mode is preserved (ks2 still migrating)")
+            rows = await cql.run_async("SELECT host_id, intended_storage_mode FROM system.topology WHERE key = 'topology'")
+            for row in rows:
+                assert row.intended_storage_mode is not None, \
+                    f"intended_storage_mode should be preserved for node {row.host_id} while ks2 is still migrating"
+
+            logger.info("Finalizing migration for ks2")
+            await manager.api.finalize_vnode_tablet_migration(server.ip_addr, ks2)
+
+            logger.info("Verifying ks2 has tablets enabled")
+            res = await cql.run_async(f"SELECT * FROM system_schema.scylla_keyspaces WHERE keyspace_name = '{ks2}'")
+            assert len(res) == 1 and res[0].initial_tablets is not None, \
+                f"ks2 should use tablets after finalization"
+
+            logger.info("Verifying intended_storage_mode is cleared (no more migrating keyspaces)")
+            rows = await cql.run_async("SELECT host_id, intended_storage_mode FROM system.topology WHERE key = 'topology'")
+            for row in rows:
+                assert row.intended_storage_mode is None, \
+                    f"intended_storage_mode should be cleared for node {row.host_id} after all migrations are done, got '{row.intended_storage_mode}'"

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -324,6 +324,10 @@ class ScyllaRESTAPIClient:
     async def disable_tablet_balancing(self, node_ip: str) -> None:
         await self.client.post(f"/storage_service/tablets/balancing", host=node_ip, params={"enabled": "false"})
 
+    async def create_vnode_tablet_migration(self, node_ip: str, ks: str) -> None:
+        """Start vnodes-to-tablets migration for all tables in a keyspace"""
+        await self.client.post(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}", host=node_ip)
+
     async def keyspace_upgrade_sstables(self, node_ip: str, ks: str) -> None:
         await self.client.get(f"/storage_service/keyspace_upgrade_sstables/{ks}", host=node_ip)
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -336,6 +336,10 @@ class ScyllaRESTAPIClient:
         """Set the node's intended storage mode to vnodes"""
         await self.client.put_json(f"/storage_service/vnode_tablet_migrations/node/storage_mode?intended_mode=vnodes", host=node_ip)
 
+    async def finalize_vnode_tablet_migration(self, node_ip: str, ks: str) -> None:
+        """Finalize vnodes-to-tablets migration for all tables in a keyspace"""
+        await self.client.post(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}/finalization", host=node_ip)
+
     async def keyspace_upgrade_sstables(self, node_ip: str, ks: str) -> None:
         await self.client.get(f"/storage_service/keyspace_upgrade_sstables/{ks}", host=node_ip)
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -328,6 +328,14 @@ class ScyllaRESTAPIClient:
         """Start vnodes-to-tablets migration for all tables in a keyspace"""
         await self.client.post(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}", host=node_ip)
 
+    async def upgrade_node_to_tablets(self, node_ip: str) -> None:
+        """Set the node's intended storage mode to tablets"""
+        await self.client.put_json(f"/storage_service/vnode_tablet_migrations/node/storage_mode?intended_mode=tablets", host=node_ip)
+
+    async def downgrade_node_to_vnodes(self, node_ip: str) -> None:
+        """Set the node's intended storage mode to vnodes"""
+        await self.client.put_json(f"/storage_service/vnode_tablet_migrations/node/storage_mode?intended_mode=vnodes", host=node_ip)
+
     async def keyspace_upgrade_sstables(self, node_ip: str, ks: str) -> None:
         await self.client.get(f"/storage_service/keyspace_upgrade_sstables/{ks}", host=node_ip)
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -336,6 +336,10 @@ class ScyllaRESTAPIClient:
         """Set the node's intended storage mode to vnodes"""
         await self.client.put_json(f"/storage_service/vnode_tablet_migrations/node/storage_mode?intended_mode=vnodes", host=node_ip)
 
+    async def get_vnode_tablet_migration_status(self, node_ip: str, ks: str) -> dict:
+        """Get vnodes-to-tablets migration status for a keyspace"""
+        return await self.client.get_json(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}", host=node_ip)
+
     async def finalize_vnode_tablet_migration(self, node_ip: str, ks: str) -> None:
         """Finalize vnodes-to-tablets migration for all tables in a keyspace"""
         await self.client.post(f"/storage_service/vnode_tablet_migrations/keyspaces/{ks}/finalization", host=node_ip)

--- a/test/pylib/tablets.py
+++ b/test/pylib/tablets.py
@@ -113,4 +113,4 @@ async def get_tablet_count(manager: ManagerClient, server: ServerInfo, keyspace_
     table_id = await get_base_table(manager, table_id)
     rows = await manager.cql.run_async(f"SELECT tablet_count FROM system.tablets where "
                                        f"table_id = {table_id}", host=host)
-    return rows[0].tablet_count
+    return rows[0].tablet_count if len(rows) > 0 else 0

--- a/tools/scylla-nodetool.cc
+++ b/tools/scylla-nodetool.cc
@@ -290,6 +290,14 @@ public:
         return do_request("GET", std::move(path), std::move(params));
     }
 
+    rjson::value put(sstring path, std::unordered_map<sstring, sstring> params = {}) {
+        return do_request("PUT", std::move(path), std::move(params));
+    }
+
+    rjson::value put(sstring path, http::request::query_parameters_type params) {
+        return do_request("PUT", std::move(path), std::move(params));
+    }
+
     // delete is a reserved keyword, using del instead
     rjson::value del(sstring path, std::unordered_map<sstring, sstring> params = {}) {
         return do_request("DELETE", std::move(path), std::move(params));
@@ -2438,6 +2446,68 @@ void cluster_snapshot_operation(scylla_rest_client& client, const bpo::variables
     fmt::print(std::cout, "Snapshot directory: {}\n", params["tag"]);
 }
 
+void migrate_to_tablets_start_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (vm["keyspace"].empty()) {
+        throw std::invalid_argument("keyspace is required");
+    }
+    auto keyspace = vm["keyspace"].as<sstring>();
+    client.post(fmt::format("/storage_service/vnode_tablet_migrations/keyspaces/{}", keyspace));
+}
+
+void migrate_to_tablets_upgrade_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.put("/storage_service/vnode_tablet_migrations/node/storage_mode", {{"intended_mode", "tablets"}});
+}
+
+void migrate_to_tablets_downgrade_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    client.put("/storage_service/vnode_tablet_migrations/node/storage_mode", {{"intended_mode", "vnodes"}});
+}
+
+void migrate_to_tablets_status_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (vm["keyspace"].empty()) {
+        throw std::invalid_argument("keyspace is required");
+    }
+    auto keyspace = vm["keyspace"].as<sstring>();
+    auto res = client.get(fmt::format("/storage_service/vnode_tablet_migrations/keyspaces/{}", keyspace));
+
+    auto node_status = [] (std::string_view current_mode, std::string_view intended_mode) -> std::string_view {
+        if (intended_mode == "vnodes" && current_mode == "vnodes") {
+            return "uses vnodes";
+        } else if (intended_mode == "tablets" && current_mode == "tablets") {
+            return "uses tablets";
+        } else if (intended_mode == "tablets" && current_mode == "vnodes") {
+            return "migrating to tablets";
+        } else {
+            return "migrating to vnodes";
+        }
+    };
+
+    fmt::print(std::cout, "Keyspace: {}\n", rjson::to_string_view(res["keyspace"]));
+    fmt::print(std::cout, "Status: {}\n", rjson::to_string_view(res["status"]));
+
+    const auto& nodes = res["nodes"].GetArray();
+    if (!nodes.Empty()) {
+        fmt::print(std::cout, "\nNodes:\n");
+        Tabulate table;
+        table.add("Host ID", "Status");
+        for (const auto& node : nodes) {
+            auto current = rjson::to_string_view(node["current_mode"]);
+            auto intended = rjson::to_string_view(node["intended_mode"]);
+            table.add(
+                std::string(rjson::to_string_view(node["host_id"])),
+                std::string(node_status(current, intended)));
+        }
+        table.print();
+    }
+}
+
+void migrate_to_tablets_finalize_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
+    if (vm["keyspace"].empty()) {
+        throw std::invalid_argument("keyspace is required");
+    }
+    auto keyspace = vm["keyspace"].as<sstring>();
+    client.post(fmt::format("/storage_service/vnode_tablet_migrations/keyspaces/{}/finalization", keyspace));
+}
+
 void sstableinfo_operation(scylla_rest_client& client, const bpo::variables_map& vm) {
     std::vector<keyspace_and_table> requests;
     if (vm.contains("table")) {
@@ -4341,6 +4411,88 @@ For more information, see: {}
             },
             {
                 listsnapshots_operation
+            }
+        },
+        {
+            {
+                "migrate-to-tablets",
+                "Manage vnodes-to-tablets migration",
+R"(
+Migrate a keyspace from vnodes to tablets.
+
+Subcommands:
+  start <keyspace>     Prepare a keyspace for migration from vnodes to tablets
+  upgrade              Set this node's intended storage mode to tablets
+  downgrade            Set this node's intended storage mode back to vnodes
+  status <keyspace>    Show migration status for a keyspace
+  finalize <keyspace>  Finalize the migration for a keyspace
+)",
+                { },
+                {
+                    typed_option<sstring>("command", "The name of the subcommand", 1),
+                },
+                {
+                    {
+                        "start",
+                        "Prepare a keyspace for migration from vnodes to tablets",
+                        "",
+                        { },
+                        {
+                            typed_option<sstring>("keyspace", "The keyspace to migrate", 1),
+                        },
+                    },
+                    {
+                        "upgrade",
+                        "Set this node's intended storage mode to tablets",
+                        "",
+                        { },
+                        { },
+                    },
+                    {
+                        "downgrade",
+                        "Set this node's intended storage mode back to vnodes",
+                        "",
+                        { },
+                        { },
+                    },
+                    {
+                        "status",
+                        "Show migration status for a keyspace",
+                        "",
+                        { },
+                        {
+                            typed_option<sstring>("keyspace", "The keyspace to check status for", 1),
+                        },
+                    },
+                    {
+                        "finalize",
+                        "Finalize the migration for a keyspace",
+                        "",
+                        { },
+                        {
+                            typed_option<sstring>("keyspace", "The keyspace to finalize", 1),
+                        },
+                    },
+                }
+            },
+            {
+                {
+                    {
+                        "start", { migrate_to_tablets_start_operation },
+                    },
+                    {
+                        "upgrade", { migrate_to_tablets_upgrade_operation },
+                    },
+                    {
+                        "downgrade", { migrate_to_tablets_downgrade_operation },
+                    },
+                    {
+                        "status", { migrate_to_tablets_status_operation },
+                    },
+                    {
+                        "finalize", { migrate_to_tablets_finalize_operation },
+                    },
+                }
             }
         },
         {


### PR DESCRIPTION
This PR introduces the vnodes-to-tablets migration procedure, which enables converting an existing vnode-based keyspace to tablets.

The migration is implemented as a manual, operator-driven process executed in several stages. The core idea is to first create tablet maps with the same token boundaries and replica hosts as the vnodes, and then incrementally convert the storage of each node to the tablets layout. At a high level, the procedure is the following:
1. Create tablet maps for all tables in the keyspace.
2. Sequentially upgrade all nodes from vnodes to tablets:
    1. Mark a node for upgrade in the topology state.
    2. Restart the node. During startup, while the node is offline, it reshards the SSTables on vnode boundaries and switches to a tablet ERM.
    3. Wait for the node to return online before proceeding to the next node.
4. Finalize the migration:
    1. Update the keyspace schema to mark it as tablet-based.
    2. Clear the group0 state related to the migration.

From the client's perspective, the migration is online; the cluster can still serve requests on that keyspace, although performance may be temporarily degraded.

During the migration, some nodes use vnode ERMs while others use tablet ERMs. Cluster-level algorithms such as load balancing will treat the keyspace's tables as vnode-based. Once migration is finalized, the keyspace is permanently switched to tablets and cannot be reverted back to vnodes. However, a rollback procedure is available before finalization. 

The patch series consists of:
* Load balancer adjustments to ignore tablets belonging to a migrating keyspace.
* A new vnode-based resharding mode, where SSTables are segregated on vnode boundaries rather than with the static sharder.
* A new per-node `intended_storage_mode` column in `system.topology`. Represents migration intent (whether migration should occur on restart) and direction.
* Four new REST endpoints for driving the migration (start, node upgrade/downgrade, finalize, status), along with `nodetool` wrappers. The finalization is implemented as a global topology request.
* Wiring of the migration process into the startup logic: the `distributed_loader` determines a migrating table's ERM flavor from the `intended_storage_mode` and the ERM flavor determines the `table_populator`'s resharding mode. Token metadata changes have been adjusted to preserve the ERM flavor.
* Cluster tests for the migration process.

Fixes SCYLLADB-722.
Fixes SCYLLADB-723.
Fixes SCYLLADB-725.
Fixes SCYLLADB-779.
Fixes SCYLLADB-948.

New feature, no backport is needed.