### PR TITLE
[RFC] Commitlog groups

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -2173,7 +2173,7 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
     }
 
     // Now get a set of used CF ids:
-    std::unordered_set<cf_id_type> ids;
+    std::unordered_map<cf_id_type, replay_position> ids;
 
     uint64_t n = size_to_remove;
     uint64_t flushing = 0;
@@ -2198,7 +2198,8 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
         flushing += size - waste;
 
         for (auto& id : s->_cf_dirty |  std::views::keys) {
-            ids.insert(id);
+            auto& target_high = ids[id];
+            target_high = std::max(target_high, rp);
         }
 
         if (size_to_remove != 0) {
@@ -2214,11 +2215,11 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
 
     // For each CF id: for each callback c: call c(id, high)
     for (auto& f : callbacks) {
-        for (auto& id : ids) {
+        for (auto& [id, hp] : ids) {
             try {
-                f(id, high);
+                f(id, hp);
             } catch (...) {
-                clogger.error("Exception during flush request {}/{}: {}", id, high, std::current_exception());
+                clogger.error("Exception during flush request {}/{}: {} ({})", id, hp, high, std::current_exception());
             }
         }
     }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -94,6 +94,8 @@ public:
     virtual void release_cf_count(const cf_id_type&, const replay_position&) = 0;
 };
 
+const db::replay_position db::replay_position::max = db::replay_position(std::numeric_limits<db::segment_id_type>::max(), std::numeric_limits<db::position_type>::max());
+
 db::commitlog::config db::commitlog::config::from_db_config(const db::config& cfg, seastar::scheduling_group sg, size_t shard_available_memory) {
     config c;
 

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -342,10 +342,11 @@ public:
     };
 
     using group_ptr = shared_ptr<segment_group>;
-    using group_id = uint64_t;
-    using opt_group_id = std::optional<group_id>;
 
     static constexpr group_id default_group_id = 0;
+
+    group_id create_group();
+    future<> remove_group(group_id);
 
     template<typename T, typename R = typename T::result_type>
     requires std::derived_from<T, db::commitlog::entry_writer> && std::same_as<R, decltype(std::declval<T>().result())>
@@ -470,16 +471,16 @@ public:
     future<> shutdown_all_segments();
     future<> shutdown();
 
+    inline auto filter_groups(opt_group_id gid) const {
+        return _groups | std::views::filter([gid](auto& p) { return p.first == gid.value_or(p.first); });
+    }
+
     template<typename Func>
-    size_t accumulate_groups(Func f) const {
-        auto v = _groups | std::views::values;
+    size_t accumulate_groups(Func f, opt_group_id gid = {}) const {
+        auto v = filter_groups(gid) | std::views::values;
         return std::accumulate(v.begin(), v.end(), size_t{}, [&](size_t n, const group_ptr& g) {
             return n + f(g);
         });
-    }
-
-    inline auto filter_groups(opt_group_id gid) const {
-        return _groups | std::views::filter([gid](auto& p) { return p.first == gid.value_or(p.first); });
     }
 
     void create_counters(const sstring& metrics_category_name);
@@ -506,9 +507,9 @@ public:
         }
     }
 
-    std::vector<sstring> get_active_names() const;
-    uint64_t get_num_dirty_segments() const;
-    uint64_t get_num_active_segments() const;
+    std::vector<sstring> get_active_names(opt_group_id = {}) const;
+    uint64_t get_num_dirty_segments(opt_group_id = {}) const;
+    uint64_t get_num_active_segments(opt_group_id = {}) const;
 
     using buffer_type = fragmented_temporary_buffer;
 
@@ -1988,6 +1989,33 @@ void db::commitlog::segment_manager::update_configuration(const config& new_cfg)
     // maybe do more later on...   
 } 
 
+db::commitlog::group_id db::commitlog::segment_manager::create_group() {
+    auto new_id = group_id(_groups.size());
+    while (_groups.count(new_id)) {
+        ++new_id;
+    }
+    _groups.emplace(new_id, make_shared<segment_group>());
+    return new_id;
+}
+
+future<> db::commitlog::segment_manager::remove_group(group_id gid) {
+    if (!_groups.count(gid) || gid == default_group_id) {
+        throw std::invalid_argument("Invalid group: " + std::to_string(gid));
+    }
+    auto n = get_num_dirty_segments(gid);
+    if (n > 0) {
+        throw std::logic_error("Group " + std::to_string(gid) + " not clean");
+    }
+    auto g = _groups.at(gid);
+    if (!g->segments.empty()) {
+        auto s = g->segments.back();
+        if (s->is_still_allocating()) {
+            co_await s->close();
+        }
+    }
+    discard_unused_segments();
+    _groups.erase(gid);
+}
 
 size_t db::commitlog::segment_manager::max_request_controller_units() const {
     return max_mutation_size + db::commitlog::segment::default_size;
@@ -3081,9 +3109,9 @@ void db::commitlog::segment_manager::on_timer() {
     arm();
 }
 
-std::vector<sstring> db::commitlog::segment_manager::get_active_names() const {
+std::vector<sstring> db::commitlog::segment_manager::get_active_names(opt_group_id gid) const {
     std::vector<sstring> res;
-    for (auto& g : _groups | std::views::values) {
+    for (auto& g : filter_groups(gid) | std::views::values) {
         for (auto i: g->segments) {
             if (!i->is_unused()) {
                 // Each shared is located in its own directory
@@ -3094,20 +3122,20 @@ std::vector<sstring> db::commitlog::segment_manager::get_active_names() const {
     return res;
 }
 
-uint64_t db::commitlog::segment_manager::get_num_dirty_segments() const {
+uint64_t db::commitlog::segment_manager::get_num_dirty_segments(opt_group_id gid) const {
     return accumulate_groups([](auto g) {
         return std::count_if(g->segments.begin(), g->segments.end(), [](sseg_ptr s) {
             return !s->is_still_allocating() && !s->is_clean();
         });
-    });
+    }, gid);
 }
 
-uint64_t db::commitlog::segment_manager::get_num_active_segments() const {
+uint64_t db::commitlog::segment_manager::get_num_active_segments(opt_group_id gid) const {
     return accumulate_groups([](auto g) {
         return std::count_if(g->segments.begin(), g->segments.end(), [](sseg_ptr s) {
             return s->is_still_allocating();
         });
-    });
+    }, gid);
 }
 
 temporary_buffer<char> db::commitlog::segment_manager::allocate_single_buffer(size_t s, size_t alignment) {
@@ -3131,7 +3159,7 @@ db::commitlog::segment_manager::buffer_type db::commitlog::segment_manager::acqu
  * Add mutation.
  */
 future<db::rp_handle> db::commitlog::add(const cf_id_type& id,
-        size_t size, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync, serializer_func func) {
+        size_t size, db::timeout_clock::time_point timeout, db::commitlog::force_sync sync, serializer_func func, opt_group_id gid) {
     class serializer_func_entry_writer final : public entry_writer {
         cf_id_type _id;
         serializer_func _func;
@@ -3159,10 +3187,10 @@ future<db::rp_handle> db::commitlog::add(const cf_id_type& id,
             return std::move(res);
         }
     };
-    return _segment_manager->allocate_when_possible(serializer_func_entry_writer(id, size, std::move(func), sync), timeout);
+    return _segment_manager->allocate_when_possible(serializer_func_entry_writer(id, size, std::move(func), sync), timeout, gid.value_or(segment_manager::default_group_id));
 }
 
-future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commitlog_entry_writer& cew, timeout_clock::time_point timeout)
+future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commitlog_entry_writer& cew, timeout_clock::time_point timeout, opt_group_id gid)
 {
     SCYLLA_ASSERT(id == cew.schema()->id());
 
@@ -3202,11 +3230,11 @@ future<db::rp_handle> db::commitlog::add_entry(const cf_id_type& id, const commi
             return std::move(res);
         }
     };
-    return _segment_manager->allocate_when_possible(cl_entry_writer(cew), timeout);
+    return _segment_manager->allocate_when_possible(cl_entry_writer(cew), timeout, gid.value_or(segment_manager::default_group_id));
 }
 
 future<utils::chunked_vector<db::rp_handle>>
-db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout) {
+db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout, opt_group_id gid) {
     class cl_entries_writer final : public entry_writer {
         utils::chunked_vector<commitlog_entry_writer> _writers;
         std::unordered_set<table_schema_version> _known;
@@ -3270,7 +3298,7 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_w
     };
 
     force_sync sync(std::any_of(entry_writers.begin(), entry_writers.end(), [](auto& w) { return bool(w.sync()); }));
-    return _segment_manager->allocate_when_possible(cl_entries_writer(sync, std::move(entry_writers)), timeout);
+    return _segment_manager->allocate_when_possible(cl_entries_writer(sync, std::move(entry_writers)), timeout, gid.value_or(segment_manager::default_group_id));
 }
 
 db::commitlog::commitlog(config cfg)
@@ -3292,6 +3320,18 @@ future<db::commitlog> db::commitlog::create_commitlog(config cfg) {
     commitlog c(std::move(cfg));
     co_await c._segment_manager->init();
     co_return c;
+}
+
+db::commitlog::group_id db::commitlog::create_group() {
+    return _segment_manager->create_group();
+}
+
+/**
+ * Removes a commitlog group. All entries written must have been
+ * released (discard_completed_segments)
+ */
+future<> db::commitlog::remove_group(group_id gid) {
+    return _segment_manager->remove_group(gid);
 }
 
 db::commitlog::flush_handler_anchor::flush_handler_anchor(flush_handler_anchor&& f)
@@ -3329,16 +3369,16 @@ void db::commitlog::remove_flush_handler(flush_handler_id id) {
     _segment_manager->remove_flush_handler(id);
 }
 
-void db::commitlog::discard_completed_segments(const cf_id_type& id, const rp_set& used) {
-    _segment_manager->discard_completed_segments(id, used);
+void db::commitlog::discard_completed_segments(const cf_id_type& id, const rp_set& used, opt_group_id gid) {
+    _segment_manager->discard_completed_segments(id, used, std::move(gid));
 }
 
-void db::commitlog::discard_completed_segments(const cf_id_type& id) {
-    _segment_manager->discard_completed_segments(id);
+void db::commitlog::discard_completed_segments(const cf_id_type& id, opt_group_id gid) {
+    _segment_manager->discard_completed_segments(id, std::move(gid));
 }
 
-future<> db::commitlog::force_new_active_segment() noexcept {
-    co_await _segment_manager->force_new_active_segment();
+future<> db::commitlog::force_new_active_segment(opt_group_id gid) noexcept {
+    co_await _segment_manager->force_new_active_segment(std::move(gid));
 }
 
 future<> db::commitlog::wait_for_pending_deletes() noexcept {
@@ -3950,8 +3990,8 @@ db::commitlog::read_log_file(const replay_state& state, sstring filename, sstrin
     co_await w.read_file();
 }
 
-std::vector<sstring> db::commitlog::get_active_segment_names() const {
-    return _segment_manager->get_active_names();
+std::vector<sstring> db::commitlog::get_active_segment_names(opt_group_id gid) const {
+    return _segment_manager->get_active_names(std::move(gid));
 }
 
 uint64_t db::commitlog::disk_limit() const {
@@ -4005,12 +4045,12 @@ uint64_t db::commitlog::get_num_segments_destroyed() const {
     return _segment_manager->totals.segments_destroyed;
 }
 
-uint64_t db::commitlog::get_num_dirty_segments() const {
-    return _segment_manager->get_num_dirty_segments();
+uint64_t db::commitlog::get_num_dirty_segments(opt_group_id gid) const {
+    return _segment_manager->get_num_dirty_segments(gid);
 }
 
-uint64_t db::commitlog::get_num_active_segments() const {
-    return _segment_manager->get_num_active_segments();
+uint64_t db::commitlog::get_num_active_segments(opt_group_id gid) const {
+    return _segment_manager->get_num_active_segments(gid);
 }
 
 uint64_t db::commitlog::get_num_blocked_on_new_segment() const {

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -336,11 +336,22 @@ public:
         _request_controller.signal(size);
     }
 
+    struct segment_group {
+        std::vector<sseg_ptr> segments;
+        replay_position flush_position;
+    };
+
+    using group_ptr = shared_ptr<segment_group>;
+    using group_id = uint64_t;
+    using opt_group_id = std::optional<group_id>;
+
+    static constexpr group_id default_group_id = 0;
+
     template<typename T, typename R = typename T::result_type>
     requires std::derived_from<T, db::commitlog::entry_writer> && std::same_as<R, decltype(std::declval<T>().result())>
-    future<R> allocate_when_possible(T writer, db::timeout_clock::time_point timeout);
+    future<R> allocate_when_possible(T writer, db::timeout_clock::time_point timeout, group_id = {});
 
-    future<> oversized_allocation(entry_writer&, db::timeout_clock::time_point timeout);
+    future<> oversized_allocation(entry_writer&, db::timeout_clock::time_point timeout, group_ptr);
 
     replay_position min_position();
 
@@ -440,10 +451,15 @@ public:
     }
 
     future<> init();
-    future<sseg_ptr> new_segment();
-    future<sseg_ptr> active_segment(db::timeout_clock::time_point timeout);
+    future<sseg_ptr> new_segment(group_ptr);
+    future<sseg_ptr> active_segment(db::timeout_clock::time_point timeout, group_ptr);
     future<sseg_ptr> allocate_segment();
     future<sseg_ptr> allocate_segment_ex(descriptor, named_file, open_flags);
+
+    /**
+     * Finalize a segment and get a new one
+     */
+    future<sseg_ptr> finish_and_get_new(sseg_ptr s, db::timeout_clock::time_point timeout, group_ptr g);
 
     sstring filename(const descriptor& d) const {
         return cfg.commit_log_location + "/" + d.filename();
@@ -453,6 +469,18 @@ public:
     future<> sync_all_segments();
     future<> shutdown_all_segments();
     future<> shutdown();
+
+    template<typename Func>
+    size_t accumulate_groups(Func f) const {
+        auto v = _groups | std::views::values;
+        return std::accumulate(v.begin(), v.end(), size_t{}, [&](size_t n, const group_ptr& g) {
+            return n + f(g);
+        });
+    }
+
+    inline auto filter_groups(opt_group_id gid) const {
+        return _groups | std::views::filter([gid](auto& p) { return p.first == gid.value_or(p.first); });
+    }
 
     void create_counters(const sstring& metrics_category_name);
 
@@ -464,10 +492,10 @@ public:
     future<> delete_segments(std::vector<sstring>);
 
     void discard_unused_segments() noexcept;
-    void discard_completed_segments(const cf_id_type&) noexcept;
-    void discard_completed_segments(const cf_id_type&, const rp_set&) noexcept;
-    
-    future<> force_new_active_segment() noexcept;
+    void discard_completed_segments(const cf_id_type&, opt_group_id = {}) noexcept;
+    void discard_completed_segments(const cf_id_type&, const rp_set&, opt_group_id = {}) noexcept;
+
+    future<> force_new_active_segment(opt_group_id = {}) noexcept;
     future<> wait_for_pending_deletes() noexcept;
 
     void on_timer();
@@ -490,7 +518,7 @@ public:
     future<std::vector<descriptor>> list_descriptors(sstring dir) const;
     future<std::vector<sstring>> get_segments_to_replay() const;
 
-    gc_clock::time_point min_gc_time(const cf_id_type&) const;
+    gc_clock::time_point min_gc_time(const cf_id_type&, opt_group_id = {}) const;
 
     flush_handler_id add_flush_handler(flush_handler h) {
         auto id = ++_flush_ids;
@@ -515,12 +543,14 @@ private:
 
     size_t max_request_controller_units() const;
     segment_id_type _ids = 0, _low_id = 0;
-    std::vector<sseg_ptr> _segments;
+
+    std::unordered_map<group_id, group_ptr> _groups;
+
     queue<sseg_ptr> _reserve_segments;
     queue<named_file> _recycled_segments;
     std::unordered_map<flush_handler_id, flush_handler> _flush_handlers;
     flush_handler_id _flush_ids = 0;
-    replay_position _flush_position;
+
     timer<clock_type> _timer;
     future<> replenish_reserve();
     future<> _reserve_replenisher;
@@ -905,14 +935,6 @@ public:
             return true;
         }
         return false;
-    }
-    /**
-     * Finalize this segment and get a new one
-     */
-    future<sseg_ptr> finish_and_get_new(db::timeout_clock::time_point timeout) {
-        //FIXME: discarded future.
-        (void)close();
-        return _segment_manager->active_segment(timeout);
     }
     void reset_sync_time() {
         _sync_time = clock_type::now();
@@ -1505,17 +1527,26 @@ public:
 };
 
 db::replay_position db::commitlog::segment_manager::min_position() {
-    if (_segments.empty()) {
-        return {_ids, 0};
-    } else {
-        return {_segments.front()->_desc.id, 0};
+    auto rp = replay_position::max;
+    for (auto& g : _groups | std::views::values) {
+        if (!g->segments.empty()) {
+            rp = std::min(rp, {g->segments.front()->_desc.id, 0});
+        }
     }
+    return rp != replay_position::max ? rp : replay_position{_ids, 0};
 }
 
 template<typename T, typename R>
 requires std::derived_from<T, db::commitlog::entry_writer> && std::same_as<R, decltype(std::declval<T>().result())>
-future<R> db::commitlog::segment_manager::allocate_when_possible(T writer, db::timeout_clock::time_point timeout) {
+future<R> db::commitlog::segment_manager::allocate_when_possible(T writer, db::timeout_clock::time_point timeout, group_id gid) {
     auto size = writer.size();
+
+    if (!_groups.count(gid)) {
+        throw std::invalid_argument("No such group: " + std::to_string(gid));
+    }
+
+    auto g = _groups.at(gid);
+
     // If this is already too big now, we should fall back early. This measurement does not count
     // overhead into the estimate, i.e. it might be worse.
     if (size < max_mutation_size) {
@@ -1527,13 +1558,7 @@ future<R> db::commitlog::segment_manager::allocate_when_possible(T writer, db::t
         scope_increment_counter allocating(totals.active_allocations);
 
         auto permit = co_await std::move(fut);
-        sseg_ptr s;
-
-        if (!_segments.empty() && _segments.back()->is_still_allocating()) {
-            s = _segments.back();
-        } else {
-            s = co_await active_segment(timeout);
-        }
+        sseg_ptr s = co_await active_segment(timeout, g);
 
         bool retry = true;
 
@@ -1547,7 +1572,7 @@ future<R> db::commitlog::segment_manager::allocate_when_possible(T writer, db::t
                     s = co_await with_timeout(timeout, s->sync());
                     continue;
                 case write_result::no_space:
-                    s = co_await s->finish_and_get_new(timeout);
+                    s = co_await finish_and_get_new(s, timeout, g);
                     continue;
                 case write_result::ok_need_batch_sync:
                     s = co_await s->batch_cycle(timeout);
@@ -1564,11 +1589,11 @@ future<R> db::commitlog::segment_manager::allocate_when_possible(T writer, db::t
     }
 
     // really slow path, trying to fit huge thingamabobs...
-    co_await oversized_allocation(writer, timeout);
+    co_await oversized_allocation(writer, timeout, g);
     co_return writer.result();
 }
 
-future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writer, db::timeout_clock::time_point timeout) {
+future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writer, db::timeout_clock::time_point timeout, group_ptr g) {
     clogger.debug("Attempting oversized alloc of {} entry writer", writer.num_entries);
 
     auto size = writer.size();
@@ -1576,7 +1601,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
 
     // check if this cannot be written at all...
     if (!cfg.allow_going_over_size_limit) {
-        auto sector_size = _segments.empty() ? 512 /* worst case */ : _segments.front()->_alignment;
+        auto sector_size = g->segments.empty() ? 512 /* worst case */ : g->segments.front()->_alignment;
         auto size_with_sector_overhead = size + (1 + size/sector_size) * detail::sector_overhead_size;
         // more worst case
         auto size_with_meta_overhead = size_with_sector_overhead
@@ -1697,7 +1722,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
             };
 
             auto get_segment = [&]() -> future<sseg_ptr> {
-                sseg_ptr s = co_await active_segment(timeout);
+                sseg_ptr s = co_await active_segment(timeout, g);
                 if (maybe_clear.empty() || maybe_clear.back().first.get() != s.get()) {
                     if (s->position() > (segment::segment_overhead_size + segment::descriptor_header_size)) {
                         co_await s->sync(); // ensure file pos == restartable.
@@ -1867,7 +1892,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
             s->reset_file_position(fp);
             if (fp == 0) {
                 s->mark_clean();
-                _segments.erase(std::remove(_segments.begin(), _segments.end(), s), _segments.end());
+                g->segments.erase(std::remove(g->segments.begin(), g->segments.end(), s), g->segments.end());
             }
         }
     }
@@ -2048,10 +2073,12 @@ future<std::vector<sstring>> db::commitlog::segment_manager::get_segments_to_rep
     co_return segments_to_replay;
 }
 
-gc_clock::time_point db::commitlog::segment_manager::min_gc_time(const cf_id_type& id) const {
+gc_clock::time_point db::commitlog::segment_manager::min_gc_time(const cf_id_type& id, opt_group_id gid) const {
     auto res = gc_clock::time_point::max();
-    for (auto& s : _segments) {
-        res = std::min(res, s->min_time(id));
+    for (auto& g :  filter_groups(gid) | std::views::values) {
+        for (auto& s : g->segments) {
+            res = std::min(res, s->min_time(id));
+        }
     }
     return res;
 }
@@ -2069,6 +2096,8 @@ future<> db::commitlog::segment_manager::init() {
     _ids = replay_position(this_shard_id(), id).id;
     _low_id = id;
 
+    _groups.emplace(default_group_id, make_shared<segment_group>());
+
     // always run the timer now, since we need to handle segment pre-alloc etc as well.
     _timer.set_callback(std::bind(&segment_manager::on_timer, this));
     auto delay = this_shard_id() * std::ceil(double(cfg.commitlog_sync_period_in_ms) / smp::count);
@@ -2083,14 +2112,22 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
     namespace sm = seastar::metrics;
 
     _metrics.add_group(metrics_category_name, {
-        sm::make_gauge("segments", [this] { return _segments.size(); },
+        sm::make_gauge("segments", [this] { return accumulate_groups([](auto& g) { return g->segments.size(); }); },
                        sm::description("Holds the current number of segments."))(basic_level),
 
-        sm::make_gauge("allocating_segments", [this] { return std::count_if(_segments.begin(), _segments.end(), [] (const sseg_ptr & s) { return s->is_still_allocating(); }); },
+        sm::make_gauge("allocating_segments", [this] { 
+            return accumulate_groups([](auto& g) {
+                return std::count_if(g->segments.begin(), g->segments.end(), [] (const sseg_ptr & s) { return s->is_still_allocating(); }); 
+            });
+        },
                        sm::description("Holds the number of not closed segments that still have some free space. "
                                        "This value should not get too high."))(basic_level),
 
-        sm::make_gauge("unused_segments", [this] { return std::count_if(_segments.begin(), _segments.end(), [] (const sseg_ptr & s) { return s->is_unused(); }); },
+        sm::make_gauge("unused_segments", [this] { 
+            return accumulate_groups([](auto& g) {
+                return std::count_if(g->segments.begin(), g->segments.end(), [] (const sseg_ptr & s) { return s->is_unused(); }); 
+            });
+        },
                        sm::description("Holds the current number of unused segments. "
                                        "A non-zero value indicates that the disk write path became temporary slow."))(basic_level),
 
@@ -2158,62 +2195,82 @@ void db::commitlog::segment_manager::create_counters(const sstring& metrics_cate
 }
 
 void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
-    if (_segments.empty()) {
+    if (std::all_of(_groups.begin(), _groups.end(), [](auto&p) { return p.second->segments.empty(); })) {
         return;
     }
+
     // defensive copy.
     auto callbacks = _flush_handlers | std::views::values | std::ranges::to<std::vector>();
-    auto& active = _segments.back();
-
-    // RP at "start" of segment we leave untouched.
-    replay_position high(active->_desc.id, 0);
-
-    // But if all segments are closed or we force-flush,
-    // include all.
-    if (!active->is_still_allocating()) {
-        high = replay_position(high.id + 1, 0);
-    }
-
     // Now get a set of used CF ids:
     std::unordered_map<cf_id_type, replay_position> ids;
 
     uint64_t n = size_to_remove;
     uint64_t flushing = 0;
 
-    for (auto& s : _segments) {
-        // if a segment is allocating, it should be included in flush request,
-        // because we cannot free anything there anyway. If a segment is allocating,
-        // it is the last one, so just break.
-        if (s->is_still_allocating()) {
-            break;
-        }
+    ssize_t n_groups_rem = ssize_t(_groups.size());
 
-        auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
-        if (rp <= _flush_position) {
-            // already requested.
-            continue;
-        }
+    struct group_info {
+        segment_group* g;
+        typename std::vector<sseg_ptr>::iterator pos;
+    };
 
-        auto size = s->size_on_disk();
-        auto waste = s->_waste;
+    auto tmp = _groups | std::views::transform([](auto& p) { 
+        return group_info{ p.second.get(), p.second->segments.begin() };
+    }) | std::ranges::to<std::vector>();
 
-        flushing += size - waste;
+    std::sort(tmp.begin(), tmp.end(), [](auto& i1, auto& i2) {
+        return i1.g->flush_position < i2.g->flush_position;
+    });
 
-        for (auto& id : s->_cf_dirty |  std::views::keys) {
-            auto& target_high = ids[id];
-            target_high = std::max(target_high, rp);
-        }
+    while (n_groups_rem > 0) {
+        for (auto& info : tmp) {
+            auto*g = info.g;
+            for (auto& s : std::ranges::subrange(info.pos, g->segments.end())) {
+                ++info.pos;
 
-        if (size_to_remove != 0) {
-            if (n <= size) {
-                high = rp;
+                // if a segment is allocating, it should not be included in flush request,
+                // because we cannot free anything there anyway. If a segment is allocating,
+                // it is the last one, so just break.
+                if (s->is_still_allocating()) {
+                    break;
+                }
+                auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
+                if (rp <= g->flush_position) {
+                    // already requested.
+                    continue;
+                }
+
+                g->flush_position = rp;
+                auto size = s->size_on_disk();
+                auto waste = s->_waste;
+
+                flushing += size - waste;
+
+                for (auto& id : s->_cf_dirty |  std::views::keys) {
+                    auto& target_high = ids[id];
+                    target_high = std::max(target_high, rp);
+                }
+
+                if (size_to_remove != 0) {
+                    if (n <= size) {
+                        n_groups_rem = 0;
+                    } else {
+                        n -= s->size_on_disk();
+                    }
+                }
                 break;
             }
-            n -= s->size_on_disk();
+            if (info.pos == g->segments.end()) {
+                --n_groups_rem;
+            }
         }
     }
 
-    clogger.debug("Flushing ({} MB) to {}", flushing/(1024*1024), high);
+    clogger.debug("Flushing ({} MB)", flushing/(1024*1024));
+
+    for (auto& [gid, g] : _groups) {
+        clogger.debug("Group {} flush pos {}", gid, g->flush_position);
+    }
 
     // For each CF id: for each callback c: call c(id, high)
     for (auto& f : callbacks) {
@@ -2221,12 +2278,11 @@ void db::commitlog::segment_manager::flush_segments(uint64_t size_to_remove) {
             try {
                 f(id, hp);
             } catch (...) {
-                clogger.error("Exception during flush request {}/{}: {} ({})", id, hp, high, std::current_exception());
+                clogger.error("Exception during flush request {}/{} ({})", id, hp, std::current_exception());
             }
         }
     }
 
-    _flush_position = high;
     totals.bytes_flush_requested += flushing;
 }
 
@@ -2238,50 +2294,51 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
 
     auto now = gc_clock::now();
 
-    std::unordered_set<cf_id_type> ids;
-    std::optional<replay_position> high;
+    std::unordered_map<cf_id_type, replay_position> ids;
 
-    for (auto& s : _segments) {
-        auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
-        if (rp <= _flush_position) {
-            // already requested.
-            continue;
-        }
-
-        bool any_found = false;
-
-        for (auto [id, low_ts] : s->_cf_min_time) {
-            // Ignore CF:s already released.
-            if (!s->_cf_dirty.count(id)) {
+    for (auto& g : _groups | std::views::values) {
+        for (auto& s : g->segments) {
+            auto rp = replay_position(s->_desc.id, db::position_type(s->size_on_disk()));
+            if (rp <= g->flush_position) {
+                // already requested.
                 continue;
             }
 
-            uint64_t time_since_first_added = std::chrono::duration_cast<std::chrono::seconds>(now - low_ts).count();
-            if (time_since_first_added >= *max) {
-                // There is data in this segment that has lived longer than allowed (might be flushed actually
-                // but can still affect compaction/resurrect stuff on replay). Collect all dirty 
-                // id:s (stuff keeping this segment alive), and ask for them to be memtable flushed
-                for (auto& id : s->_cf_dirty | std::views::keys) {
-                    ids.insert(id);
+            bool any_found = false;
+
+            for (auto [id, low_ts] : s->_cf_min_time) {
+                // Ignore CF:s already released.
+                if (!s->_cf_dirty.count(id)) {
+                    continue;
                 }
 
-                // highest position (so far) is end of segment.
-                high = rp;
+                uint64_t time_since_first_added = std::chrono::duration_cast<std::chrono::seconds>(now - low_ts).count();
+                if (time_since_first_added >= *max) {
+                    // There is data in this segment that has lived longer than allowed (might be flushed actually
+                    // but can still affect compaction/resurrect stuff on replay). Collect all dirty 
+                    // id:s (stuff keeping this segment alive), and ask for them to be memtable flushed
+                    for (auto& id : s->_cf_dirty | std::views::keys) {
+                        auto& target_high = ids[id];
+                        target_high = std::max(target_high, rp);
+                    }
 
-                // If this segment is actually the active one, we must close it. Otherwise flushing 
-                // won't help.
-                if (s->is_still_allocating()) {
-                    // fixme. discarded future.
-                    (void)s->close();
+                    g->flush_position = rp;
+
+                    // If this segment is actually the active one, we must close it. Otherwise flushing 
+                    // won't help.
+                    if (s->is_still_allocating()) {
+                        // fixme. discarded future.
+                        (void)s->close();
+                    }
+                    any_found = true;
+                    break;
                 }
-                any_found = true;
+            }
+
+            // segments are sequential. Can't start becoming older.
+            if (!any_found) {
                 break;
             }
-        }
-
-        // segments are sequential. Can't start becoming older.
-        if (!any_found) {
-            break;
         }
     }
 
@@ -2289,15 +2346,14 @@ void db::commitlog::segment_manager::check_no_data_older_than_allowed() {
         auto callbacks = _flush_handlers | std::views::values | std::ranges::to<std::vector>();
         // For each CF id: for each callback c: call c(id, high)
         for (auto& f : callbacks) {
-            for (auto& id : ids) {
+            for (auto& [id, rp] : ids) {
                 try {
-                    f(id, *high);
+                    f(id, rp);
                 } catch (...) {
-                    clogger.error("Exception during flush request {}/{}: {}", id, *high, std::current_exception());
+                    clogger.error("Exception during flush request {}/{}: {}", id, rp, std::current_exception());
                 }
             }
         }
-        _flush_position = *high;
     }
 }
 
@@ -2460,8 +2516,8 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
     }
 }
 
-future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::new_segment() {
-    gate::holder g(_gate);
+future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::new_segment(group_ptr g) {
+    gate::holder gh(_gate);
 
     if (_shutdown) {
         co_await coroutine::return_exception(std::runtime_error("Commitlog has been shut down. Cannot add data"));
@@ -2484,17 +2540,18 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
     }
 
     auto s = co_await _reserve_segments.pop_eventually();
-    _segments.push_back(s);
-    _segments.back()->reset_sync_time();
+
+    g->segments.push_back(s);
+    g->segments.back()->reset_sync_time();
     co_return s;
 }
 
-future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::active_segment(db::timeout_clock::time_point timeout) {
+future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager::active_segment(db::timeout_clock::time_point timeout, group_ptr g) {
     // If there is no active segment, try to allocate one using new_segment(). If we time out,
     // make sure later invocations can still pick that segment up once it's ready.
     for (;;) {
-        if (!_segments.empty() && _segments.back()->is_still_allocating()) {
-            co_return _segments.back();
+        if (!g->segments.empty() && g->segments.back()->is_still_allocating()) {
+            co_return g->segments.back();
         }
 
         scope_increment_counter blocked_on_new(totals.blocked_on_new_segment);
@@ -2503,7 +2560,7 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
         // the old one has terminated with either result or exception.
         // Do all waiting through the shared_future
         if (!_segment_allocating) {
-            auto f = new_segment();
+            auto f = new_segment(g);
             // must check that we are not already done.
             try {
                 if (f.available()) {
@@ -2523,42 +2580,55 @@ future<db::commitlog::segment_manager::sseg_ptr> db::commitlog::segment_manager:
     }
 }
 
+future<db::commitlog::segment_manager::sseg_ptr> 
+db::commitlog::segment_manager::finish_and_get_new(sseg_ptr s, db::timeout_clock::time_point timeout, group_ptr g) {
+    //FIXME: discarded future.
+    (void)s->close();
+    return active_segment(timeout, std::move(g));
+}
+
 /**
  * go through all segments, clear id up to pos. if segment becomes clean and unused by this,
  * it is discarded.
  */
-void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id, const rp_set& used) noexcept {
+void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id, const rp_set& used, opt_group_id gid) noexcept {
     auto& usage = used.usage();
 
     clogger.debug("Discarding {}: {}", id, usage);
 
-    for (auto&s : _segments) {
-        auto i = usage.find(s->_desc.id);
-        if (i != usage.end()) {
-            s->mark_clean(id, i->second);
+    for (auto& g : filter_groups(gid) | std::views::values) {
+        for (auto&s : g->segments) {
+            auto i = usage.find(s->_desc.id);
+            if (i != usage.end()) {
+                s->mark_clean(id, i->second);
+            }
         }
     }
     discard_unused_segments();
 }
 
-void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id) noexcept {
+void db::commitlog::segment_manager::discard_completed_segments(const cf_id_type& id, opt_group_id gid) noexcept {
     clogger.debug("Discard all data for {}", id);
-    for (auto&s : _segments) {
-        s->mark_clean(id);
+    for (auto& g : filter_groups(gid) | std::views::values) {
+        for (auto&s : g->segments) {
+            s->mark_clean(id);
+        }
     }
     discard_unused_segments();
 }
 
-future<> db::commitlog::segment_manager::force_new_active_segment() noexcept {
-    if (_segments.empty() || !_segments.back()->is_still_allocating()) {
-        co_return;
-    }
+future<> db::commitlog::segment_manager::force_new_active_segment(opt_group_id gid) noexcept {
+    for (auto& g : filter_groups(gid) | std::views::values) {
+        if (g->segments.empty() || !g->segments.back()->is_still_allocating()) {
+            continue;
+        }
 
-    auto& s = _segments.back();
-    if (s->position()) { // check used.
-        co_await s->close();
-        discard_unused_segments();
+        auto& s = g->segments.back();
+        if (s->position()) { // check used.
+            co_await s->close();
+        }
     }
+    discard_unused_segments();
 }
 
 future<> db::commitlog::segment_manager::wait_for_pending_deletes() noexcept {
@@ -2594,25 +2664,27 @@ struct fmt::formatter<db::commitlog::segment::cf_mark> {
 };
 
 void db::commitlog::segment_manager::discard_unused_segments() noexcept {
-    clogger.trace("Checking for unused segments ({} active)", _segments.size());
+    for (auto& g : _groups | std::views::values) {
+        clogger.trace("Checking for unused segments ({} active)", g->segments.size());
 
-    // #25709 ensure we don't free any segment until after prune.
-    {
-        auto tmp = _segments; 
-        std::erase_if(_segments, [=](sseg_ptr s) {
-            if (s->can_delete()) {
-                clogger.debug("Segment {} is unused", *s);
-                return true;
-            }
-            if (s->is_still_allocating()) {
-                clogger.debug("Not safe to delete segment {}; still allocating.", *s);
-            } else if (!s->is_clean()) {
-                clogger.debug("Not safe to delete segment {}; dirty is {}", *s, segment::cf_mark {*s});
-            } else {
-                clogger.debug("Not safe to delete segment {}; disk ops pending", *s);
-            }
-            return false;
-        });
+        // #25709 ensure we don't free any segment until after prune.
+        {
+            auto tmp = g->segments; 
+            std::erase_if(g->segments, [=](sseg_ptr s) {
+                if (s->can_delete()) {
+                    clogger.debug("Segment {} is unused", *s);
+                    return true;
+                }
+                if (s->is_still_allocating()) {
+                    clogger.debug("Not safe to delete segment {}; still allocating.", *s);
+                } else if (!s->is_clean()) {
+                    clogger.debug("Not safe to delete segment {}; dirty is {}", *s, segment::cf_mark {*s});
+                } else {
+                    clogger.debug("Not safe to delete segment {}; disk ops pending", *s);
+                }
+                return false;
+            });
+        }
     }
 
     // launch in background, but guard with gate so this deletion is
@@ -2647,23 +2719,29 @@ future<> db::commitlog::segment_manager::clear_reserve_segments() {
 
 future<> db::commitlog::segment_manager::sync_all_segments() {
     clogger.debug("Issuing sync for all segments");
-    // #8952 - calls that do sync/cycle can end up altering
-    // _segments (end_flush()->discard_unused())
-    auto def_copy = _segments;
-    co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
-        co_await s->sync();
-        clogger.debug("Synced segment {}", *s);
+    auto groups = _groups;
+    co_await coroutine::parallel_for_each(groups|std::views::values, [](auto g) -> future<> {
+        // #8952 - calls that do sync/cycle can end up altering
+        // _segments (end_flush()->discard_unused())
+        auto def_copy = g->segments;
+        co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
+            co_await s->sync();
+            clogger.debug("Synced segment {}", *s);
+        });
     });
 }
 
 future<> db::commitlog::segment_manager::shutdown_all_segments() {
     clogger.debug("Issuing shutdown for all segments");
-    // #8952 - calls that do sync/cycle can end up altering
-    // _segments (end_flush()->discard_unused())
-    auto def_copy = _segments;
-    co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
-        co_await s->shutdown();
-        clogger.debug("Shutdown segment {}", *s);
+    auto groups = _groups;
+    co_await coroutine::parallel_for_each(groups|std::views::values, [](auto g) -> future<> {
+        // #8952 - calls that do sync/cycle can end up altering
+        // _segments (end_flush()->discard_unused())
+        auto def_copy = g->segments;
+        co_await coroutine::parallel_for_each(def_copy, [] (sseg_ptr s) -> future<> {
+            co_await s->shutdown();
+            clogger.debug("Shutdown segment {}", *s);
+        });
     });
 }
 
@@ -2905,7 +2983,10 @@ future<> db::commitlog::segment_manager::orphan_all() {
     // #25709. the actual process of destroying the elements here
     // might cause a call into discard_unused_segments.
     // ensure the target vector is empty when we get to destructors
-    auto tmp = std::exchange(_segments, {});
+    std::vector<std::vector<sseg_ptr>> tmp;
+    for (auto& g : _groups | std::views::values) {
+        tmp.emplace_back(std::exchange(g->segments, {}));
+    }
     return clear_reserve_segments();
 }
 
@@ -2918,8 +2999,10 @@ future<> db::commitlog::segment_manager::clear() {
     clogger.debug("Clearing commitlog");
     co_await shutdown();
     clogger.debug("Clearing all segments");
-    for (auto& s : _segments) {
-        s->mark_clean();
+    for (auto& g : _groups | std::views::values) {
+        for (auto& s : g->segments) {
+            s->mark_clean();
+        }
     }
     co_await orphan_all();
 }
@@ -2930,9 +3013,11 @@ void db::commitlog::segment_manager::sync() {
     auto f = std::exchange(_background_sync, make_ready_future<>());
     // #8952 - calls that do sync/cycle can end up altering
     // _segments (end_flush()->discard_unused())
-    auto def_copy = _segments;
-    _background_sync = parallel_for_each(def_copy, [](sseg_ptr s) {
-        return s->sync().discard_result();
+    _background_sync = parallel_for_each(_groups | std::views::values, [](group_ptr g) {
+        auto def_copy = g->segments;
+        return parallel_for_each(def_copy, [](sseg_ptr s) {
+            return s->sync().discard_result();
+        });
     }).then([f = std::move(f)]() mutable {
         return std::move(f);
     });
@@ -2998,24 +3083,30 @@ void db::commitlog::segment_manager::on_timer() {
 
 std::vector<sstring> db::commitlog::segment_manager::get_active_names() const {
     std::vector<sstring> res;
-    for (auto i: _segments) {
-        if (!i->is_unused()) {
-            // Each shared is located in its own directory
-            res.push_back(cfg.commit_log_location + "/" + i->get_segment_name());
+    for (auto& g : _groups | std::views::values) {
+        for (auto i: g->segments) {
+            if (!i->is_unused()) {
+                // Each shared is located in its own directory
+                res.push_back(cfg.commit_log_location + "/" + i->get_segment_name());
+            }
         }
     }
     return res;
 }
 
 uint64_t db::commitlog::segment_manager::get_num_dirty_segments() const {
-    return std::count_if(_segments.begin(), _segments.end(), [](sseg_ptr s) {
-        return !s->is_still_allocating() && !s->is_clean();
+    return accumulate_groups([](auto g) {
+        return std::count_if(g->segments.begin(), g->segments.end(), [](sseg_ptr s) {
+            return !s->is_still_allocating() && !s->is_clean();
+        });
     });
 }
 
 uint64_t db::commitlog::segment_manager::get_num_active_segments() const {
-    return std::count_if(_segments.begin(), _segments.end(), [](sseg_ptr s) {
-        return s->is_still_allocating();
+    return accumulate_groups([](auto g) {
+        return std::count_if(g->segments.begin(), g->segments.end(), [](sseg_ptr s) {
+            return s->is_still_allocating();
+        });
     });
 }
 

--- a/db/commitlog/commitlog.hh
+++ b/db/commitlog/commitlog.hh
@@ -79,6 +79,9 @@ public:
 private:
     ::shared_ptr<segment_manager> _segment_manager;
 public:
+    using group_id = uint32_t;
+    using opt_group_id = std::optional<group_id>;
+
     enum class sync_mode {
         PERIODIC, BATCH
     };
@@ -184,13 +187,24 @@ public:
     using serializer_func = std::function<void(output&)>;
 
     /**
+     * Creates a commitlog group.
+     */
+    group_id create_group();
+
+    /**
+     * Removes a commitlog group. All entries written must have been
+     * released (discard_completed_segments)
+     */
+    future<> remove_group(group_id);
+
+    /**
      * Add a "Mutation" to the commit log.
      *
      * Resolves with timed_out_error when timeout is reached.
      *
      * @param mutation_func a function that writes 'size' bytes to the log, representing the mutation.
      */
-    future<rp_handle> add(const cf_id_type& id, size_t size, db::timeout_clock::time_point timeout, force_sync sync, serializer_func mutation_func);
+    future<rp_handle> add(const cf_id_type& id, size_t size, db::timeout_clock::time_point timeout, force_sync sync, serializer_func mutation_func, opt_group_id = {});
 
     /**
      * Template version of add.
@@ -198,10 +212,10 @@ public:
      * @param mu an invocable op that generates the serialized data. (Of size bytes)
      */
     template<typename MutationOp>
-    future<rp_handle> add_mutation(const cf_id_type& id, size_t size, db::timeout_clock::time_point timeout, force_sync sync, MutationOp&& mu) {
+    future<rp_handle> add_mutation(const cf_id_type& id, size_t size, db::timeout_clock::time_point timeout, force_sync sync, MutationOp&& mu, opt_group_id gid = {}) {
         return add(id, size, timeout, sync, [mu = std::forward<MutationOp>(mu)](output& out) {
             mu(out);
-        });
+        }, std::move(gid));
     }
 
     /**
@@ -209,8 +223,8 @@ public:
      * @param mu an invocable op that generates the serialized data. (Of size bytes)
      */
     template<typename MutationOp>
-    future<rp_handle> add_mutation(const cf_id_type& id, size_t size, force_sync sync, MutationOp&& mu) {
-        return add_mutation(id, size, db::timeout_clock::time_point::max(), sync, std::forward<MutationOp>(mu));
+    future<rp_handle> add_mutation(const cf_id_type& id, size_t size, force_sync sync, MutationOp&& mu, opt_group_id gid = {}) {
+        return add_mutation(id, size, db::timeout_clock::time_point::max(), sync, std::forward<MutationOp>(mu), std::move(gid));
     }
 
     /**
@@ -218,14 +232,14 @@ public:
      * Resolves with timed_out_error when timeout is reached.
      * @param entry_writer a writer responsible for writing the entry
      */
-    future<rp_handle> add_entry(const cf_id_type& id, const commitlog_entry_writer& entry_writer, db::timeout_clock::time_point timeout);
+    future<rp_handle> add_entry(const cf_id_type& id, const commitlog_entry_writer& entry_writer, db::timeout_clock::time_point timeout, opt_group_id = {});
 
     /**
      * Add N entries to the commit log as a single operation (in a single segment).
      * Resolves with timed_out_error when timeout is reached.
      * @param entry_writers a vector of writers responsible for writing respective entry
      */
-    future<utils::chunked_vector<rp_handle>> add_entries(utils::chunked_vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout);
+    future<utils::chunked_vector<rp_handle>> add_entries(utils::chunked_vector<commitlog_entry_writer> entry_writers, db::timeout_clock::time_point timeout, opt_group_id = {});
 
     /**
      * Modifies the per-CF dirty cursors of any commit log segments for the column family according to the position
@@ -234,16 +248,16 @@ public:
      * @param cfId    the column family ID that was flushed
      * @param rp_set  the replay positions of the flush
      */
-    void discard_completed_segments(const cf_id_type&, const rp_set&);
+    void discard_completed_segments(const cf_id_type&, const rp_set&, opt_group_id = {});
 
-    void discard_completed_segments(const cf_id_type&);
+    void discard_completed_segments(const cf_id_type&, opt_group_id = {});
 
     /**
      * Forces active segment switch.
      * Called from API calls to help tests that need predictable
      * compaction behaviour.
     */
-    future<> force_new_active_segment() noexcept;
+    future<> force_new_active_segment(opt_group_id = {}) noexcept;
 
     /**
      * Waits for all segment deletes issued up until now to complete.
@@ -289,7 +303,7 @@ public:
     /**
      * Returns a vector of the segment names
      */
-    std::vector<sstring> get_active_segment_names() const;
+    std::vector<sstring> get_active_segment_names(opt_group_id = {}) const;
 
     /**
      * Returns a vector of segment paths which were
@@ -321,11 +335,11 @@ public:
      * Get number of inactive (finished), segments lingering
      * due to still being dirty
      */
-    uint64_t get_num_dirty_segments() const;
+    uint64_t get_num_dirty_segments(opt_group_id = {}) const;
     /**
      * Get number of active segments, i.e. still being allocated to
      */
-    uint64_t get_num_active_segments() const;
+    uint64_t get_num_active_segments(opt_group_id = {}) const;
 
     /**
      * Returns the largest amount of data that can be written in a single "mutation".

--- a/db/commitlog/replay_position.hh
+++ b/db/commitlog/replay_position.hh
@@ -55,6 +55,8 @@ struct replay_position {
 
     template <typename Describer>
     auto describe_type(sstables::sstable_version_types v, Describer f) { return f(id, pos); }
+
+    static const replay_position max;
 };
 
 class commitlog;

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -21,6 +21,7 @@
 #include "replica/logstor/segment_manager.hh"
 #include "sstables/sstable_set.hh"
 #include "utils/chunked_vector.hh"
+#include "db/commitlog/replay_position.hh"
 #include <absl/container/flat_hash_map.h>
 
 #pragma once
@@ -105,6 +106,8 @@ class compaction_group {
     std::vector<future<>> _separator_flushes;
     seastar::semaphore _separator_flush_sem{1};
 
+    db::replay_position _lowest_rp;
+    friend class table;
 private:
     std::unique_ptr<compaction_group_view> make_compacting_view();
     std::unique_ptr<compaction_group_view> make_non_compacting_view();
@@ -174,7 +177,7 @@ public:
     // Clear memtable(s) content
     future<> clear_memtables();
 
-    future<> flush() noexcept;
+    future<> flush(std::optional<db::replay_position> = {}) noexcept;
     bool can_flush() const;
     bool needs_flush() const;
 

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -528,8 +528,6 @@ private:
     db::replay_position _highest_rp;
     // Tracks the highest replay position flushed to a sstable
     db::replay_position _highest_flushed_rp;
-    // Tracks the highest position before flush actually starts
-    db::replay_position _flush_rp;
     db::replay_position _lowest_allowed_rp;
 
     // Provided by the database that owns this commitlog

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -1827,7 +1827,14 @@ public:
 future<>
 table::seal_active_memtable(compaction_group& cg, flush_permit&& flush_permit) noexcept {
     auto old = cg.memtables()->back();
-    tlogger.debug("Sealing active memtable of {}.{}, partitions: {}, occupancy: {}", _schema->ks_name(), _schema->cf_name(), old->partition_count(), old->occupancy());
+    // Reset low marker for CL initiated flush here. As stated above, this function never
+    // fails, and even if it did, all we are saying is that the work of moving data from
+    // _lowest_rp -> wherever is now on us. In any case, actual segment release will not
+    // happen until success and the commitlog callback below
+    // If we are being flushed for any other reason, we still change the RP range
+    // remaining unflushed in the memtable_list (to none)
+    auto old_low = std::exchange(cg._lowest_rp, db::replay_position::max);
+    tlogger.debug("Sealing active memtable of {}.{}, partitions: {}, occupancy: {}, low_rp: {}", _schema->ks_name(), _schema->cf_name(), old->partition_count(), old->occupancy(), old_low);
 
     if (old->empty()) {
         tlogger.debug("Memtable is empty");
@@ -3107,6 +3114,7 @@ compaction_group::compaction_group(table& t, size_t group_id, dht::token_range t
     , _backlog_tracker(t.get_compaction_strategy().make_backlog_tracker())
     , _repair_sstable_classifier(std::move(repair_classifier))
     , _logstor_segments(make_lw_shared<logstor::segment_set>())
+    , _lowest_rp(db::replay_position::max)
 {
 }
 
@@ -4429,7 +4437,14 @@ future<table::snapshot_details> table::get_snapshot_details(fs::path snapshot_di
     co_return details;
 }
 
-future<> compaction_group::flush() noexcept {
+future<> compaction_group::flush(std::optional<db::replay_position> pos) noexcept {
+    if (pos && *pos < _lowest_rp) {
+        return make_ready_future<>();
+    }
+    // Note: _lowest_rp will be reset in seal_active_memtable.
+    // This is a little asymmetric, and not the prettiest. But since we
+    // set the flush function, I guess it is ok. Retaining low until then
+    // for logging purposes as well.
     try {
         return _memtables->flush();
     } catch (...) {
@@ -4474,17 +4489,13 @@ size_t storage_group::memtable_count() const {
 }
 
 future<> table::flush(std::optional<db::replay_position> pos) {
-    if (pos && *pos < _flush_rp) {
-        co_return;
-    }
     // There is nothing to flush if the table was stopped.
     if (_pending_flushes_phaser.is_closed()) {
         co_return;
     }
     auto op = _pending_flushes_phaser.start();
-    auto fp = _highest_rp;
-    co_await parallel_foreach_compaction_group(std::mem_fn(&compaction_group::flush));
-    _flush_rp = std::max(_flush_rp, fp);
+    // no std::bind_back in the clang version I'm on... :-(
+    co_await parallel_foreach_compaction_group([pos](auto& cg) { return cg.flush(pos); });
 }
 
 bool storage_group::can_flush() const {
@@ -4883,6 +4894,11 @@ void table::do_apply(compaction_group& cg, db::rp_handle&& h, Args&&... args) {
     check_valid_rp(rp);
     try {
         cg.memtables()->active_memtable().apply(std::forward<Args>(args)..., std::move(h));
+        // keep track of lowest written RP in compaction group. This is the new
+        // flush range guard.
+        cg._lowest_rp = std::min(cg._lowest_rp, rp);
+        // must also retain highest RP in table, since this is required for
+        // truncation etc.
         _highest_rp = std::max(_highest_rp, rp);
     } catch (...) {
         _failed_counter_applies_to_memtable++;

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -2411,4 +2411,51 @@ SEASTAR_TEST_CASE(test_commitlog_replay_segment_order) {
     });
 }
 
+SEASTAR_TEST_CASE(test_group_clears_independently) {
+    constexpr size_t file_size_in_mb = 1;
+
+    commitlog::config cfg;
+    cfg.commitlog_segment_size_in_mb = file_size_in_mb;
+    return cl_test(cfg, [](commitlog& log) -> future<> {
+        auto uuid1 = make_table_id();
+        auto uuid2 = make_table_id();
+
+        auto g1 = log.create_group();
+        auto g2 = log.create_group();
+        rp_set set1, set2;
+
+        size_t size = 64;
+
+        // add allocation to each group
+        for (auto& [uuid, g, set] : { std::tie(uuid1, g1, set1), std::tie(uuid2, g2, set2) }) {
+            auto h = co_await log.add_mutation(uuid, size, db::commitlog::force_sync::no, [&](db::commitlog::output& dst) {
+                dst.fill('1', size);
+            }, g);
+            set.put(std::move(h));
+        }
+
+        // ensure both groups have exactly one dirty segment
+        for (auto g : { g1, g2 }) {
+            co_await log.force_new_active_segment(g);
+            BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(g), 1);
+        }
+
+        // ensure each uuid has a min gc time
+        for (auto uuid : { uuid1, uuid2 }) {
+            BOOST_REQUIRE_LT(log.min_gc_time(uuid), gc_clock::time_point::max());
+        }
+
+        // now clean out one group
+        log.discard_completed_segments(uuid1, set1, g1);
+
+        // g1 should now be clean and not hold any gc clocks
+        BOOST_REQUIRE_EQUAL(log.get_num_dirty_segments(g1), 0);
+        BOOST_REQUIRE_EQUAL(log.min_gc_time(uuid1), gc_clock::time_point::max());
+
+        co_await log.remove_group(g1);
+
+        BOOST_CHECK_THROW(co_await log.remove_group(g2), std::logic_error);
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes: SCYLLADB-1058
Refs #23656
Fixes #28421

Implements commitlog "groups". A "group" is a set of ID:d data (i.e. CF mutations) which use an
independent segment set. This allows data with different write rates and whatnot to have separate 
flush and clean life cycles, partially to prevent tables with low write rate to "pin" data (GC timestamps)
for other CF:s.

Note: this PR is based on #23678, because it needs some of the functionality created there (mainly the per-CF flush boundaries). 

Includes a minimal test, verifying the basic premiss of the feature, but as the "group" feature is not really used in 
any CF handling, it is not super tested. (Because the actual usage is TBD). 