### PR TITLE
Don't materialize collections into intermediate representations

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2302,12 +2302,12 @@ public:
     void del(const bytes& name, api::timestamp_type ts) {
         add(name, atomic_cell::make_dead(ts, gc_clock::now()));
     }
-    collection_mutation_description to_mut() {
-        collection_mutation_description ret;
+    collection_mutation to_mut() {
+        collection_mutation_writer ret(tombstone{});
         for (auto&& e : collected) {
-            ret.cells.emplace_back(e.first, std::move(e.second));
+            ret.push_back(bytes_view(e.first), std::move(e.second));
         }
-        return ret;
+        return std::move(ret).finish();
     }
     bool empty() const {
         return collected.empty();
@@ -2655,7 +2655,7 @@ mutation put_or_delete_item::build(schema_ptr schema, api::timestamp_type ts) co
     }
     auto attrs = attrs_column(*schema);
     if (!attrs_collector.empty()) {
-        auto serialized_map = attrs_collector.to_mut().serialize();
+        auto serialized_map = attrs_collector.to_mut();
         row.cells().apply(attrs, std::move(serialized_map));
     }
     // To allow creation of an item with no attributes, we need a row marker.
@@ -2678,7 +2678,7 @@ mutation put_or_delete_item::build(schema_ptr schema, api::timestamp_type ts) co
     //    Scylla to handle collection replacements in CQL (see #6084, PR #6491,
     //    e.g. cql3::maps::setter::execute()) and we utilize it to avoid
     //    emitting the REMOVE event (resolving #6930).
-    row.cells().apply(attrs, collection_mutation_description{tombstone{ts - 1, gc_clock::now()}}.serialize());
+    row.cells().apply(attrs, collection_mutation_writer(tombstone{ts - 1, gc_clock::now()}).finish());
     // Note that for old tables created with regular LSI and GSI key columns,
     // we must also delete the regular columns that are not part of the new
     // schema consisting of pk, ck, and :attrs.
@@ -4310,7 +4310,7 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
         apply_attribute_updates(previous_item, ts, row, modified_attrs, any_updates, any_deletes);
     }
     if (!modified_attrs.empty()) {
-        auto serialized_map = modified_attrs.to_mut().serialize();
+        auto serialized_map = modified_attrs.to_mut();
         row.cells().apply(attrs_column(*_schema), std::move(serialized_map));
     }
     // To allow creation of an item with no attributes, we need a row marker.

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1280,15 +1280,13 @@ regular_column_transformation::result extract_from_attrs_column_computation::com
         return regular_column_transformation::result();
     }
     collection_mutation_view cmv = attrs->as_collection_mutation();
-    return cmv.with_deserialized(*attrs_col->type, [this] (const collection_mutation_view_description& cmvd) {
-        for (auto&& [key, cell] : cmvd.cells) {
-            if (key == _attr_name) {
-                return regular_column_transformation::result(cell,
-                    std::bind(serialized_value_if_type, std::placeholders::_1, _desired_type));
-            }
+    for (auto&& [key, cell] : cmv) {
+        if (key == managed_bytes_view(_attr_name)) {
+            return regular_column_transformation::result(cell,
+                std::bind(serialized_value_if_type, std::placeholders::_1, _desired_type));
         }
-        return regular_column_transformation::result();
-    });
+    }
+    return regular_column_transformation::result();
 }
 
 // extract_from_attrs_column_computation needs the whole row to compute

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2657,7 +2657,7 @@ mutation put_or_delete_item::build(schema_ptr schema, api::timestamp_type ts) co
     }
     auto attrs = attrs_column(*schema);
     if (!attrs_collector.empty()) {
-        auto serialized_map = attrs_collector.to_mut().serialize(*attrs_type());
+        auto serialized_map = attrs_collector.to_mut().serialize();
         row.cells().apply(attrs, std::move(serialized_map));
     }
     // To allow creation of an item with no attributes, we need a row marker.
@@ -2680,7 +2680,7 @@ mutation put_or_delete_item::build(schema_ptr schema, api::timestamp_type ts) co
     //    Scylla to handle collection replacements in CQL (see #6084, PR #6491,
     //    e.g. cql3::maps::setter::execute()) and we utilize it to avoid
     //    emitting the REMOVE event (resolving #6930).
-    row.cells().apply(attrs, collection_mutation_description{tombstone{ts - 1, gc_clock::now()}}.serialize(*attrs.type));
+    row.cells().apply(attrs, collection_mutation_description{tombstone{ts - 1, gc_clock::now()}}.serialize());
     // Note that for old tables created with regular LSI and GSI key columns,
     // we must also delete the regular columns that are not part of the new
     // schema consisting of pk, ck, and :attrs.
@@ -4312,7 +4312,7 @@ std::optional<mutation> update_item_operation::apply(std::unique_ptr<rjson::valu
         apply_attribute_updates(previous_item, ts, row, modified_attrs, any_updates, any_deletes);
     }
     if (!modified_attrs.empty()) {
-        auto serialized_map = modified_attrs.to_mut().serialize(*attrs_type());
+        auto serialized_map = modified_attrs.to_mut().serialize();
         row.cells().apply(attrs_column(*_schema), std::move(serialized_map));
     }
     // To allow creation of an item with no attributes, we need a row marker.

--- a/cdc/change_visitor.hh
+++ b/cdc/change_visitor.hh
@@ -88,7 +88,7 @@ namespace cdc {
 template <typename V>
 concept CollectionVisitor = requires(V v,
         const tombstone& t,
-        bytes_view key,
+        managed_bytes_view key,
         const atomic_cell_view& cell) {
 
     { v.collection_tombstone(t) }         -> std::same_as<void>;
@@ -99,8 +99,8 @@ concept CollectionVisitor = requires(V v,
 
 struct dummy_collection_visitor {
     void collection_tombstone(const tombstone&) {}
-    void live_collection_cell(bytes_view, const atomic_cell_view&) {}
-    void dead_collection_cell(bytes_view, const atomic_cell_view&) {}
+    void live_collection_cell(managed_bytes_view, const atomic_cell_view&) {}
+    void dead_collection_cell(managed_bytes_view, const atomic_cell_view&) {}
     bool finished() { return false; }
 };
 
@@ -170,31 +170,31 @@ void inspect_row_cells(const schema& s, column_kind ckind, const row& r, V& v) {
             return stop_iteration(v.finished());
         }
 
-        acoc.as_collection_mutation().with_deserialized(*cdef.type, [&v, &cdef] (collection_mutation_view_description view) {
-            v.collection_column(cdef, [&view] (CollectionVisitor auto& cv) {
+        auto cmv = acoc.as_collection_mutation();
+        auto tomb = cmv.tomb();
+        v.collection_column(cdef, [&cmv, &tomb] (CollectionVisitor auto& cv) {
+            if (cv.finished()) {
+                return;
+            }
+
+            if (tomb) {
+                cv.collection_tombstone(tomb);
                 if (cv.finished()) {
                     return;
                 }
+            }
 
-                if (view.tomb) {
-                    cv.collection_tombstone(view.tomb);
-                    if (cv.finished()) {
-                        return;
-                    }
+            for (auto& [key, cell] : cmv) {
+                if (cell.is_live()) {
+                    cv.live_collection_cell(key, cell);
+                } else {
+                    cv.dead_collection_cell(key, cell);
                 }
 
-                for (auto& [key, cell]: view.cells) {
-                    if (cell.is_live()) {
-                        cv.live_collection_cell(key, cell);
-                    } else {
-                        cv.dead_collection_cell(key, cell);
-                    }
-
-                    if (cv.finished()) {
-                        return;
-                    }
+                if (cv.finished()) {
+                    return;
                 }
-            });
+            }
         });
 
         return stop_iteration(v.finished());

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -1319,7 +1319,7 @@ struct process_row_visitor {
                 _is_column_delete = true;
             }
 
-            void dead_collection_cell(bytes_view key, const atomic_cell_view&) {
+            void dead_collection_cell(managed_bytes_view key, const atomic_cell_view&) {
                 _deleted_keys.push_back(key);
             }
 
@@ -1338,7 +1338,7 @@ struct process_row_visitor {
 
                     set_visitor(ttl_opt& ttl_column) : collection_visitor(ttl_column) {}
 
-                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                    void live_collection_cell(managed_bytes_view key, const atomic_cell_view& cell) {
                         this->_ttl_column = get_ttl(cell);
                         _added_keys.emplace_back(key);
                     }
@@ -1364,7 +1364,7 @@ struct process_row_visitor {
                     udt_visitor(ttl_opt& ttl_column, size_t num_keys)
                         : collection_visitor(ttl_column), _added_cells(num_keys) {}
 
-                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                    void live_collection_cell(managed_bytes_view key, const atomic_cell_view& cell) {
                         this->_ttl_column = get_ttl(cell);
                         _added_cells[deserialize_field_index(key)].emplace(cell.value());
                     }
@@ -1392,7 +1392,7 @@ struct process_row_visitor {
                     map_or_list_visitor(ttl_opt& ttl_column)
                         : collection_visitor(ttl_column) {}
 
-                    void live_collection_cell(bytes_view key, const atomic_cell_view& cell) {
+                    void live_collection_cell(managed_bytes_view key, const atomic_cell_view& cell) {
                         this->_ttl_column = get_ttl(cell);
                         _added_cells.emplace_back(key, cell.value());
                     }

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -639,7 +639,7 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : sr_update.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
-                m.set_static_cell(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
+                m.set_static_cell(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
             }
             processor.process_change(m);
         }
@@ -654,7 +654,7 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : cr_insert.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
-                row.cells().apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
+                row.cells().apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
             }
             row.apply(cr_insert.marker);
 
@@ -671,7 +671,7 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : cr_update.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
-                row.apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize(*cdef.type));
+                row.apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
             }
 
             processor.process_change(m);

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -639,7 +639,13 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : sr_update.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::static_column, nonatomic_update.id);
-                m.set_static_cell(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
+                m.set_static_cell(cdef, [&]() {
+                    collection_mutation_writer w(nonatomic_update.t);
+                    for (auto& [k, v] : nonatomic_update.cells) {
+                        w.push_back(bytes_view(k), atomic_cell_view(v));
+                    }
+                    return std::move(w).finish();
+                }());
             }
             processor.process_change(m);
         }
@@ -654,7 +660,13 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : cr_insert.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
-                row.cells().apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
+                row.cells().apply(cdef, [&]() {
+                    collection_mutation_writer w(nonatomic_update.t);
+                    for (auto& [k, v] : nonatomic_update.cells) {
+                        w.push_back(bytes_view(k), atomic_cell_view(v));
+                    }
+                    return std::move(w).finish();
+                }());
             }
             row.apply(cr_insert.marker);
 
@@ -671,7 +683,13 @@ void process_changes_with_splitting(const mutation& base_mutation, change_proces
             }
             for (auto& nonatomic_update : cr_update.nonatomic_entries) {
                 auto& cdef = base_schema->column_at(column_kind::regular_column, nonatomic_update.id);
-                row.apply(cdef, collection_mutation_description{nonatomic_update.t, std::move(nonatomic_update.cells)}.serialize());
+                row.apply(cdef, [&]() {
+                    collection_mutation_writer w(nonatomic_update.t);
+                    for (auto& [k, v] : nonatomic_update.cells) {
+                        w.push_back(bytes_view(k), atomic_cell_view(v));
+                    }
+                    return std::move(w).finish();
+                }());
             }
 
             processor.process_change(m);

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -193,7 +193,7 @@ private:
     data_type get_value_type(bytes_view);
     */
 
-    void cell(bytes_view key, const atomic_cell_view& c) {
+    void cell(managed_bytes_view key, const atomic_cell_view& c) {
         auto& entry = get_or_append_entry(c.timestamp(), get_ttl(c));
         entry.cells.emplace_back(to_bytes(key), atomic_cell(*static_cast<V&>(*this).get_value_type(key), c));
     }
@@ -207,11 +207,11 @@ public:
         entry.t = t;
     }
 
-    void live_collection_cell(bytes_view key, const atomic_cell_view& c) {
+    void live_collection_cell(managed_bytes_view key, const atomic_cell_view& c) {
         cell(key, c);
     }
 
-    void dead_collection_cell(bytes_view key, const atomic_cell_view& c) {
+    void dead_collection_cell(managed_bytes_view key, const atomic_cell_view& c) {
         cell(key, c);
     }
 
@@ -245,7 +245,7 @@ struct extract_row_visitor {
                 collection_visitor(column_id id, std::map<change_key_t, row_update>& updates, const collection_type_impl& ctype)
                     : extract_collection_visitor<collection_visitor>(id, updates), _value_type(ctype.value_comparator()) {}
 
-                data_type get_value_type(bytes_view) {
+                data_type get_value_type(managed_bytes_view) {
                     return _value_type;
                 }
             } v(cdef.id, _updates, ctype);
@@ -259,7 +259,7 @@ struct extract_row_visitor {
                 udt_visitor(column_id id, std::map<change_key_t, row_update>& updates, const user_type_impl& utype)
                     : extract_collection_visitor<udt_visitor>(id, updates), _utype(utype) {}
 
-                data_type get_value_type(bytes_view key) {
+                data_type get_value_type(managed_bytes_view key) {
                     return _utype.type(deserialize_field_index(key));
                 }
             } v(cdef.id, _updates, utype);
@@ -430,8 +430,8 @@ struct find_timestamp_visitor {
         // with cdc$time using timestamp T + 1 instead of T.
         visit(t.timestamp + 1);
     }
-    void live_collection_cell(bytes_view, const atomic_cell_view& cell) { visit(cell); }
-    void dead_collection_cell(bytes_view, const atomic_cell_view& cell) { visit(cell); }
+    void live_collection_cell(managed_bytes_view, const atomic_cell_view& cell) { visit(cell); }
+    void dead_collection_cell(managed_bytes_view, const atomic_cell_view& cell) { visit(cell); }
     void collection_column(const column_definition&, auto&& visit_collection) { visit_collection(*this); }
     void marker(const row_marker& rm) { visit(rm.timestamp()); }
     void static_row_cells(auto&& visit_row_cells) { visit_row_cells(*this); }
@@ -516,14 +516,14 @@ struct should_split_visitor {
 
     void collection_tombstone(const tombstone& t) { visit(t.timestamp + 1); }
 
-    virtual void live_collection_cell(bytes_view, const atomic_cell_view& cell) {
+    virtual void live_collection_cell(managed_bytes_view, const atomic_cell_view& cell) {
         if (_had_row_marker) {
             // nonatomic updates cannot be expressed with an INSERT.
             return stop();
         }
         visit(cell);
     }
-    void dead_collection_cell(bytes_view, const atomic_cell_view& cell) { visit(cell); }
+    void dead_collection_cell(managed_bytes_view, const atomic_cell_view& cell) { visit(cell); }
     void collection_column(const column_definition&, auto&& visit_collection) { visit_collection(*this); }
 
     virtual void marker(const row_marker& rm) {
@@ -574,7 +574,7 @@ class alternator_should_split_visitor : public should_split_visitor {
 public:
     ~alternator_should_split_visitor() override = default;
 
-    void live_collection_cell(bytes_view, const atomic_cell_view& cell) override {
+    void live_collection_cell(managed_bytes_view, const atomic_cell_view& cell) override {
         visit(cell.timestamp());
     }
 

--- a/compaction/compaction_garbage_collector.hh
+++ b/compaction/compaction_garbage_collector.hh
@@ -113,12 +113,12 @@ extern max_purgeable_fn can_never_purge;
 
 class atomic_cell;
 class row_marker;
-struct collection_mutation_description;
+class collection_mutation;
 
 class compaction_garbage_collector {
 public:
     virtual ~compaction_garbage_collector() = default;
     virtual void collect(column_id id, atomic_cell) = 0;
-    virtual void collect(column_id id, collection_mutation_description) = 0;
+    virtual void collect(column_id id, collection_mutation) = 0;
     virtual void collect(row_marker) = 0;
 };

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -53,10 +53,7 @@ constants::subtracter::execute(mutation& m, const clustering_key_prefix& prefix,
 
 void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params) {
     if (column.type->is_multi_cell()) {
-        collection_mutation_description coll_m;
-        coll_m.tomb = params.make_tombstone();
-
-        m.set_cell(prefix, column, coll_m.serialize());
+        m.set_cell(prefix, column, collection_mutation_writer(params.make_tombstone()).finish());
     } else {
         m.set_cell(prefix, column, params.make_dead_cell());
     }

--- a/cql3/constants.cc
+++ b/cql3/constants.cc
@@ -56,7 +56,7 @@ void constants::deleter::execute(mutation& m, const clustering_key_prefix& prefi
         collection_mutation_description coll_m;
         coll_m.tomb = params.make_tombstone();
 
-        m.set_cell(prefix, column, coll_m.serialize(*column.type));
+        m.set_cell(prefix, column, coll_m.serialize());
     } else {
         m.set_cell(prefix, column, params.make_dead_cell());
     }

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -40,10 +40,7 @@ void
 lists::setter::execute(mutation& m, const clustering_key_prefix& prefix, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
     if (column.type->is_multi_cell()) {
         // Delete all cells first, then append new ones
-        collection_mutation_view_description mut;
-        mut.tomb = params.make_tombstone_just_before();
-
-        m.set_cell(prefix, column, mut.serialize());
+        m.set_cell(prefix, column, collection_mutation_writer(params.make_tombstone_just_before()).finish());
     }
     do_append(value, m, prefix, column, params);
 }
@@ -85,16 +82,15 @@ lists::setter_by_index::execute(mutation& m, const clustering_key_prefix& prefix
     auto ltype = static_cast<const list_type_impl*>(column.type.get());
     const data_value& eidx_dv = existing_list[idx].first;
     bytes eidx = eidx_dv.type()->decompose(eidx_dv);
-    collection_mutation_description mut;
-    mut.cells.reserve(1);
+    collection_mutation_writer mut(tombstone{});
     if (value.is_null()) {
-        mut.cells.emplace_back(std::move(eidx), params.make_dead_cell());
+        mut.push_back(managed_bytes_view(eidx), params.make_dead_cell());
     } else {
-        mut.cells.emplace_back(std::move(eidx),
+        mut.push_back(managed_bytes_view(eidx),
                 params.make_cell(*ltype->value_comparator(), value.view(), atomic_cell::collection_member::yes));
     }
 
-    m.set_cell(prefix, column, mut.serialize());
+    m.set_cell(prefix, column, std::move(mut).finish());
 }
 
 bool
@@ -116,18 +112,17 @@ lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix,
 
     auto ltype = static_cast<const list_type_impl*>(column.type.get());
 
-    collection_mutation_description mut;
-    mut.cells.reserve(1);
+    collection_mutation_writer mut(tombstone{});
 
     if (value.is_null()) {
-        mut.cells.emplace_back(std::move(index).to_bytes(), params.make_dead_cell());
+        mut.push_back(index.to_managed_bytes_view(), params.make_dead_cell());
     } else {
-        mut.cells.emplace_back(
-                    std::move(index).to_bytes(),
+        mut.push_back(
+                    index.to_managed_bytes_view(),
                     params.make_cell(*ltype->value_comparator(), value.view(), atomic_cell::collection_member::yes));
     }
 
-    m.set_cell(prefix, column, mut.serialize());
+    m.set_cell(prefix, column, std::move(mut).finish());
 }
 
 void
@@ -153,26 +148,25 @@ lists::do_append(const cql3::raw_value& list_value,
         auto ltype = static_cast<const list_type_impl*>(column.type.get());
 
         auto&& to_add = expr::get_list_elements(list_value);
-        collection_mutation_description appended;
-        appended.cells.reserve(to_add.size());
+        collection_mutation_writer appended(tombstone{});
         for (auto&& e : to_add) {
             try {
                 auto uuid1 = utils::UUID_gen::get_time_UUID_bytes_from_micros_and_submicros(
                     std::chrono::microseconds{params.timestamp()},
                     params._options.next_list_append_seq());
-                auto uuid = bytes(reinterpret_cast<const int8_t*>(uuid1.data()), uuid1.size());
+                auto uuid = bytes_view(reinterpret_cast<const int8_t*>(uuid1.data()), uuid1.size());
                 if (!e) {
                     throw exceptions::invalid_request_exception("Invalid NULL element in list");
                 }
                 // FIXME: can e be empty?
-                appended.cells.emplace_back(
-                    std::move(uuid),
+                appended.push_back(
+                    uuid,
                     params.make_cell(*ltype->value_comparator(), *e, atomic_cell::collection_member::yes));
             } catch (utils::timeuuid_submicro_out_of_range&) {
                 throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
             }
         }
-        m.set_cell(prefix, column, appended.serialize());
+        m.set_cell(prefix, column, std::move(appended).finish());
     } else {
         auto ltype = static_cast<const list_type_impl*>(column.type.get());
         // for frozen lists, we're overwriting the whole cell value
@@ -217,9 +211,8 @@ lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, cons
         throw exceptions::invalid_request_exception("List prepend custom timestamp must be greater than Jan 1 2010 00:00:00");
     }
 
-    collection_mutation_description mut;
+    collection_mutation_writer mut(tombstone{});
     utils::chunked_vector<managed_bytes_opt> list_elements = expr::get_list_elements(lvalue);
-    mut.cells.reserve(list_elements.size());
 
     auto ltype = static_cast<const list_type_impl*>(column.type.get());
     int clockseq = params._options.next_list_prepend_seq(list_elements.size(), utils::UUID_gen::SUBMICRO_LIMIT);
@@ -229,12 +222,12 @@ lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, cons
             if (!v) {
                 throw exceptions::invalid_request_exception("Invalid NULL element in list");
             }
-            mut.cells.emplace_back(bytes(uuid.data(), uuid.size()), params.make_cell(*ltype->value_comparator(), *v, atomic_cell::collection_member::yes));
+            mut.push_back(bytes_view(uuid.data(), uuid.size()), params.make_cell(*ltype->value_comparator(), *v, atomic_cell::collection_member::yes));
         } catch (utils::timeuuid_submicro_out_of_range&) {
             throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
         }
     }
-    m.set_cell(prefix, column, mut.serialize());
+    m.set_cell(prefix, column, std::move(mut).finish());
 }
 
 bool
@@ -271,7 +264,7 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
     // the read-before-write this operation requires limits its usefulness on big lists, so in practice
     // toDiscard will be small and keeping a list will be more efficient.
     auto&& to_discard = expr::get_list_elements(lvalue);
-    collection_mutation_description mnew;
+    collection_mutation_writer mnew(tombstone{});
     auto ensure = [] (const managed_bytes_opt& v) {
         if (!v) {
             // Note: for discarder operation, we might just ignore NULLs
@@ -287,10 +280,10 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
         bytes eidx = cell.first.type()->decompose(cell.first);
         bytes value = cell.second.type()->decompose(cell.second);
         if (has_value(value)) {
-            mnew.cells.emplace_back(std::move(eidx), params.make_dead_cell());
+            mnew.push_back(managed_bytes_view(eidx), params.make_dead_cell());
         }
     }
-    m.set_cell(prefix, column, mnew.serialize());
+    m.set_cell(prefix, column, std::move(mnew).finish());
 }
 
 bool
@@ -316,11 +309,11 @@ lists::discarder_by_index::execute(mutation& m, const clustering_key_prefix& pre
     if (idx < 0 || size_t(idx) >= existing_list.size()) {
         throw exceptions::invalid_request_exception(format("List index {:d} out of bound, list has size {:d}", idx, existing_list.size()));
     }
-    collection_mutation_description mut;
+    collection_mutation_writer mut(tombstone{});
     const data_value& eidx_dv = existing_list[idx].first;
     bytes eidx = eidx_dv.type()->decompose(eidx_dv);
-    mut.cells.emplace_back(std::move(eidx), params.make_dead_cell());
-    m.set_cell(prefix, column, mut.serialize());
+    mut.push_back(managed_bytes_view(eidx), params.make_dead_cell());
+    m.set_cell(prefix, column, std::move(mut).finish());
 }
 
 }

--- a/cql3/lists.cc
+++ b/cql3/lists.cc
@@ -43,7 +43,7 @@ lists::setter::execute(mutation& m, const clustering_key_prefix& prefix, const u
         collection_mutation_view_description mut;
         mut.tomb = params.make_tombstone_just_before();
 
-        m.set_cell(prefix, column, mut.serialize(*column.type));
+        m.set_cell(prefix, column, mut.serialize());
     }
     do_append(value, m, prefix, column, params);
 }
@@ -94,7 +94,7 @@ lists::setter_by_index::execute(mutation& m, const clustering_key_prefix& prefix
                 params.make_cell(*ltype->value_comparator(), value.view(), atomic_cell::collection_member::yes));
     }
 
-    m.set_cell(prefix, column, mut.serialize(*ltype));
+    m.set_cell(prefix, column, mut.serialize());
 }
 
 bool
@@ -127,7 +127,7 @@ lists::setter_by_uuid::execute(mutation& m, const clustering_key_prefix& prefix,
                     params.make_cell(*ltype->value_comparator(), value.view(), atomic_cell::collection_member::yes));
     }
 
-    m.set_cell(prefix, column, mut.serialize(*ltype));
+    m.set_cell(prefix, column, mut.serialize());
 }
 
 void
@@ -172,7 +172,7 @@ lists::do_append(const cql3::raw_value& list_value,
                 throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
             }
         }
-        m.set_cell(prefix, column, appended.serialize(*ltype));
+        m.set_cell(prefix, column, appended.serialize());
     } else {
         auto ltype = static_cast<const list_type_impl*>(column.type.get());
         // for frozen lists, we're overwriting the whole cell value
@@ -234,7 +234,7 @@ lists::prepender::execute(mutation& m, const clustering_key_prefix& prefix, cons
             throw exceptions::invalid_request_exception("Too many list values per single CQL statement or batch");
         }
     }
-    m.set_cell(prefix, column, mut.serialize(*ltype));
+    m.set_cell(prefix, column, mut.serialize());
 }
 
 bool
@@ -290,7 +290,7 @@ lists::discarder::execute(mutation& m, const clustering_key_prefix& prefix, cons
             mnew.cells.emplace_back(std::move(eidx), params.make_dead_cell());
         }
     }
-    m.set_cell(prefix, column, mnew.serialize(*ltype));
+    m.set_cell(prefix, column, mnew.serialize());
 }
 
 bool
@@ -320,7 +320,7 @@ lists::discarder_by_index::execute(mutation& m, const clustering_key_prefix& pre
     const data_value& eidx_dv = existing_list[idx].first;
     bytes eidx = eidx_dv.type()->decompose(eidx_dv);
     mut.cells.emplace_back(std::move(eidx), params.make_dead_cell());
-    m.set_cell(prefix, column, mut.serialize(*column.type));
+    m.set_cell(prefix, column, mut.serialize());
 }
 
 }

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -31,7 +31,7 @@ maps::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
         // Delete all cells first, then put new ones
         collection_mutation_description mut;
         mut.tomb = params.make_tombstone_just_before();
-        m.set_cell(row_key, column, mut.serialize(*column.type));
+        m.set_cell(row_key, column, mut.serialize());
     }
     do_put(m, row_key, params, value, column);
 }
@@ -58,7 +58,7 @@ maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, c
     collection_mutation_description update;
     update.cells.emplace_back(std::move(key).to_bytes(), std::move(avalue));
 
-    m.set_cell(prefix, column, update.serialize(*ctype));
+    m.set_cell(prefix, column, update.serialize());
 }
 
 void
@@ -83,7 +83,7 @@ maps::do_put(mutation& m, const clustering_key_prefix& prefix, const update_para
             mut.cells.emplace_back(to_bytes(e.first), params.make_cell(*ctype->get_values_type(), raw_value_view::make_value(e.second), atomic_cell::collection_member::yes));
         }
 
-        m.set_cell(prefix, column, mut.serialize(*ctype));
+        m.set_cell(prefix, column, mut.serialize());
     } else {
         // for frozen maps, we're overwriting the whole cell
         if (map_value.is_null()) {
@@ -104,7 +104,7 @@ maps::discarder_by_key::execute(mutation& m, const clustering_key_prefix& prefix
     collection_mutation_description mut;
     mut.cells.emplace_back(std::move(key).to_bytes(), params.make_dead_cell());
 
-    m.set_cell(prefix, column, mut.serialize(*column.type));
+    m.set_cell(prefix, column, mut.serialize());
 }
 
 }

--- a/cql3/maps.cc
+++ b/cql3/maps.cc
@@ -29,9 +29,7 @@ void
 maps::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
     if (column.type->is_multi_cell()) {
         // Delete all cells first, then put new ones
-        collection_mutation_description mut;
-        mut.tomb = params.make_tombstone_just_before();
-        m.set_cell(row_key, column, mut.serialize());
+        m.set_cell(row_key, column, collection_mutation_writer(params.make_tombstone_just_before()).finish());
     }
     do_put(m, row_key, params, value, column);
 }
@@ -55,10 +53,10 @@ maps::setter_by_key::execute(mutation& m, const clustering_key_prefix& prefix, c
     auto avalue = !value.is_null() ?
                      params.make_cell(*ctype->get_values_type(), value.view(), atomic_cell::collection_member::yes)
                     : params.make_dead_cell();
-    collection_mutation_description update;
-    update.cells.emplace_back(std::move(key).to_bytes(), std::move(avalue));
+    collection_mutation_writer update(tombstone{});
+    update.push_back(key.to_managed_bytes_view(), std::move(avalue));
 
-    m.set_cell(prefix, column, update.serialize());
+    m.set_cell(prefix, column, std::move(update).finish());
 }
 
 void
@@ -76,14 +74,14 @@ maps::do_put(mutation& m, const clustering_key_prefix& prefix, const update_para
             return;
         }
 
-        collection_mutation_description mut;
+        collection_mutation_writer mut(tombstone{});
 
         auto ctype = static_cast<const map_type_impl*>(column.type.get());
         for (auto&& e : expr::get_map_elements(map_value)) {
-            mut.cells.emplace_back(to_bytes(e.first), params.make_cell(*ctype->get_values_type(), raw_value_view::make_value(e.second), atomic_cell::collection_member::yes));
+            mut.push_back(e.first, params.make_cell(*ctype->get_values_type(), raw_value_view::make_value(e.second), atomic_cell::collection_member::yes));
         }
 
-        m.set_cell(prefix, column, mut.serialize());
+        m.set_cell(prefix, column, std::move(mut).finish());
     } else {
         // for frozen maps, we're overwriting the whole cell
         if (map_value.is_null()) {
@@ -101,10 +99,10 @@ maps::discarder_by_key::execute(mutation& m, const clustering_key_prefix& prefix
     if (key.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null map key");
     }
-    collection_mutation_description mut;
-    mut.cells.emplace_back(std::move(key).to_bytes(), params.make_dead_cell());
+    collection_mutation_writer mut(tombstone{});
+    mut.push_back(key.to_managed_bytes_view(), params.make_dead_cell());
 
-    m.set_cell(prefix, column, mut.serialize());
+    m.set_cell(prefix, column, std::move(mut).finish());
 }
 
 }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -26,7 +26,7 @@ sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const u
         // Delete all cells first, then add new ones
         collection_mutation_description mut;
         mut.tomb = params.make_tombstone_just_before();
-        m.set_cell(row_key, column, mut.serialize(*column.type));
+        m.set_cell(row_key, column, mut.serialize());
     }
     adder::do_add(m, row_key, params, value, column);
 }
@@ -63,7 +63,7 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
             mut.cells.emplace_back(to_bytes(*e), params.make_cell(*set_type.value_comparator(), bytes_view(), atomic_cell::collection_member::yes));
         }
 
-        m.set_cell(row_key, column, mut.serialize(set_type));
+        m.set_cell(row_key, column, mut.serialize());
     } else if (!value.is_null()) {
         // for frozen sets, we're overwriting the whole cell
         value.view().with_value([&] (const FragmentedView auto& v) {
@@ -93,7 +93,7 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
         }
         mut.cells.push_back({to_bytes(*e), params.make_dead_cell()});
     }
-    m.set_cell(row_key, column, mut.serialize(*column.type));
+    m.set_cell(row_key, column, mut.serialize());
 }
 
 void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params)
@@ -105,7 +105,7 @@ void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& 
     }
     collection_mutation_description mut;
     mut.cells.emplace_back(std::move(elt).to_bytes(), params.make_dead_cell());
-    m.set_cell(row_key, column, mut.serialize(*column.type));
+    m.set_cell(row_key, column, mut.serialize());
 }
 
 }

--- a/cql3/sets.cc
+++ b/cql3/sets.cc
@@ -24,9 +24,7 @@ void
 sets::setter::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params, const column_definition& column, const cql3::raw_value& value) {
     if (column.type->is_multi_cell()) {
         // Delete all cells first, then add new ones
-        collection_mutation_description mut;
-        mut.tomb = params.make_tombstone_just_before();
-        m.set_cell(row_key, column, mut.serialize());
+        m.set_cell(row_key, column, collection_mutation_writer(params.make_tombstone_just_before()).finish());
     }
     adder::do_add(m, row_key, params, value, column);
 }
@@ -53,17 +51,16 @@ sets::adder::do_add(mutation& m, const clustering_key_prefix& row_key, const upd
             return;
         }
 
-        // FIXME: collection_mutation_view_description? not compatible with params.make_cell().
-        collection_mutation_description mut;
+        collection_mutation_writer mut(tombstone{});
 
         for (auto&& e : set_elements) {
             if (!e) {
                 throw exceptions::invalid_request_exception("Invalid NULL value in set");
             }
-            mut.cells.emplace_back(to_bytes(*e), params.make_cell(*set_type.value_comparator(), bytes_view(), atomic_cell::collection_member::yes));
+            mut.push_back(managed_bytes_view(*e), params.make_cell(*set_type.value_comparator(), bytes_view(), atomic_cell::collection_member::yes));
         }
 
-        m.set_cell(row_key, column, mut.serialize());
+        m.set_cell(row_key, column, std::move(mut).finish());
     } else if (!value.is_null()) {
         // for frozen sets, we're overwriting the whole cell
         value.view().with_value([&] (const FragmentedView auto& v) {
@@ -84,16 +81,15 @@ sets::discarder::execute(mutation& m, const clustering_key_prefix& row_key, cons
         return;
     }
 
-    collection_mutation_description mut;
+    collection_mutation_writer mut(tombstone{});
     utils::chunked_vector<managed_bytes_opt> set_elements = expr::get_set_elements(svalue);
-    mut.cells.reserve(set_elements.size());
     for (auto&& e : set_elements) {
         if (!e) {
             throw exceptions::invalid_request_exception("Invalid NULL value in set");
         }
-        mut.cells.push_back({to_bytes(*e), params.make_dead_cell()});
+        mut.push_back(managed_bytes_view(*e), params.make_dead_cell());
     }
-    m.set_cell(row_key, column, mut.serialize());
+    m.set_cell(row_key, column, std::move(mut).finish());
 }
 
 void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params)
@@ -103,9 +99,9 @@ void sets::element_discarder::execute(mutation& m, const clustering_key_prefix& 
     if (elt.is_null()) {
         throw exceptions::invalid_request_exception("Invalid null set element");
     }
-    collection_mutation_description mut;
-    mut.cells.emplace_back(std::move(elt).to_bytes(), params.make_dead_cell());
-    m.set_cell(row_key, column, mut.serialize());
+    collection_mutation_writer mut(tombstone{});
+    mut.push_back(elt.to_managed_bytes_view(), params.make_dead_cell());
+    m.set_cell(row_key, column, std::move(mut).finish());
 }
 
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -60,7 +60,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
             }
         }
 
-        m.set_cell(row_key, column, mut.serialize(type));
+        m.set_cell(row_key, column, mut.serialize());
     } else {
         if (!ut_value.is_null()) {
             m.set_cell(row_key, column, params.make_cell(type, ut_value.view()));
@@ -82,7 +82,7 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
                 ? params.make_cell(*type.type(_field_idx), value.view(), atomic_cell::collection_member::yes)
                 : params.make_dead_cell());
 
-    m.set_cell(row_key, column, mut.serialize(type));
+    m.set_cell(row_key, column, mut.serialize());
 }
 
 void user_types::deleter_by_field::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
@@ -91,7 +91,7 @@ void user_types::deleter_by_field::execute(mutation& m, const clustering_key_pre
     collection_mutation_description mut;
     mut.cells.emplace_back(serialize_field_index(_field_idx), params.make_dead_cell());
 
-    m.set_cell(row_key, column, mut.serialize(*column.type));
+    m.set_cell(row_key, column, mut.serialize());
 }
 
 }

--- a/cql3/user_types.cc
+++ b/cql3/user_types.cc
@@ -28,8 +28,6 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
     if (type.is_multi_cell()) {
         // Non-frozen user defined type.
 
-        collection_mutation_description mut;
-
         // Setting a non-frozen (multi-cell) UDT means overwriting all cells.
         // We start by deleting all existing cells.
 
@@ -41,7 +39,7 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
         // insert into cf json '{"a": 1, "b":{"a":1}}' default unset;
         // currently this would set b.b to null. However, by specifying 'default unset',
         // perhaps the user intended to leave b.a unchanged.
-        mut.tomb = params.make_tombstone_just_before();
+        collection_mutation_writer mut(params.make_tombstone_just_before());
 
         if (!ut_value.is_null()) {
             const auto& elems = expr::get_user_type_elements(ut_value, type);
@@ -55,12 +53,12 @@ void user_types::setter::execute(mutation& m, const clustering_key_prefix& row_k
                     continue;
                 }
 
-                mut.cells.emplace_back(serialize_field_index(i),
+                mut.push_back(managed_bytes_view(serialize_field_index(i)),
                         params.make_cell(*type.type(i), *elems[i], atomic_cell::collection_member::yes));
             }
         }
 
-        m.set_cell(row_key, column, mut.serialize());
+        m.set_cell(row_key, column, std::move(mut).finish());
     } else {
         if (!ut_value.is_null()) {
             m.set_cell(row_key, column, params.make_cell(type, ut_value.view()));
@@ -77,21 +75,21 @@ void user_types::setter_by_field::execute(mutation& m, const clustering_key_pref
 
     auto& type = static_cast<const user_type_impl&>(*column.type);
 
-    collection_mutation_description mut;
-    mut.cells.emplace_back(serialize_field_index(_field_idx), !value.is_null()
+    collection_mutation_writer mut(tombstone{});
+    mut.push_back(managed_bytes_view(serialize_field_index(_field_idx)), !value.is_null()
                 ? params.make_cell(*type.type(_field_idx), value.view(), atomic_cell::collection_member::yes)
                 : params.make_dead_cell());
 
-    m.set_cell(row_key, column, mut.serialize());
+    m.set_cell(row_key, column, std::move(mut).finish());
 }
 
 void user_types::deleter_by_field::execute(mutation& m, const clustering_key_prefix& row_key, const update_parameters& params) {
     throwing_assert(column.type->is_user_type() && column.type->is_multi_cell());
 
-    collection_mutation_description mut;
-    mut.cells.emplace_back(serialize_field_index(_field_idx), params.make_dead_cell());
+    collection_mutation_writer mut(tombstone{});
+    mut.push_back(managed_bytes_view(serialize_field_index(_field_idx)), params.make_dead_cell());
 
-    m.set_cell(row_key, column, mut.serialize());
+    m.set_cell(row_key, column, std::move(mut).finish());
 }
 
 }

--- a/cql3/values.hh
+++ b/cql3/values.hh
@@ -231,6 +231,15 @@ public:
     explicit operator bool() const {
         return is_value();
     }
+    managed_bytes_view to_managed_bytes_view() const {
+        return std::visit(overloaded_functor{
+            [](const bytes& bytes_val) -> managed_bytes_view { return managed_bytes_view(bytes_val); },
+            [](const managed_bytes& managed_bytes_val) -> managed_bytes_view { return managed_bytes_val; },
+            [](const null_value&) -> managed_bytes_view {
+                throw std::runtime_error("to_bytes() called on raw value that is null");
+            },
+        }, _data);
+    }
     bytes to_bytes() && {
         return std::visit(overloaded_functor{
             [](bytes&& bytes_val) { return std::move(bytes_val); },

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1127,7 +1127,7 @@ make_map_mutation(const Map& map,
             mut.cells.emplace_back(ktyp->decompose(data_value(te.first)), atomic_cell::make_live(*vtyp, timestamp, vtyp->decompose(data_value(te.second)), atomic_cell::collection_member::yes));
         }
 
-        return mut.serialize(*column_type);
+        return mut.serialize();
     } else {
         map_type_impl::native_type tmp;
         tmp.reserve(map.size());
@@ -1390,7 +1390,7 @@ make_list_mutation(const std::vector<T, Args...>& values,
                 atomic_cell::make_live(*vtyp, timestamp, vtyp->decompose(std::move(dv)), atomic_cell::collection_member::yes));
         }
 
-        return m.serialize(*column_type);
+        return m.serialize();
     } else {
         list_type_impl::native_type tmp;
         tmp.reserve(values.size());

--- a/db/schema_tables.cc
+++ b/db/schema_tables.cc
@@ -1120,14 +1120,14 @@ make_map_mutation(const Map& map,
     auto vtyp = column_type->get_values_type();
 
     if (column_type->is_multi_cell()) {
-        collection_mutation_description mut;
+        collection_mutation_writer mut(tombstone{});
 
         for (auto&& entry : map) {
             auto te = f(entry);
-            mut.cells.emplace_back(ktyp->decompose(data_value(te.first)), atomic_cell::make_live(*vtyp, timestamp, vtyp->decompose(data_value(te.second)), atomic_cell::collection_member::yes));
+            mut.push_back(managed_bytes_view(ktyp->decompose(data_value(te.first))), atomic_cell::make_live(*vtyp, timestamp, vtyp->decompose(data_value(te.second)), atomic_cell::collection_member::yes));
         }
 
-        return mut.serialize();
+        return std::move(mut).finish();
     } else {
         map_type_impl::native_type tmp;
         tmp.reserve(map.size());
@@ -1377,20 +1377,17 @@ make_list_mutation(const std::vector<T, Args...>& values,
     auto vtyp = column_type->get_elements_type();
 
     if (column_type->is_multi_cell()) {
-        collection_mutation_description m;
-        m.cells.reserve(values.size());
-        m.tomb.timestamp = timestamp - 1;
-        m.tomb.deletion_time = gc_clock::now();
+        collection_mutation_writer m(tombstone{timestamp - 1, gc_clock::now()});
 
         for (auto&& value : values) {
             auto dv = f(value);
             auto uuid = utils::UUID_gen::get_time_UUID_bytes();
-            m.cells.emplace_back(
-                bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size()),
+            m.push_back(
+                managed_bytes_view(bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size())),
                 atomic_cell::make_live(*vtyp, timestamp, vtyp->decompose(std::move(dv)), atomic_cell::collection_member::yes));
         }
 
-        return m.serialize();
+        return std::move(m).finish();
     } else {
         list_type_impl::native_type tmp;
         tmp.reserve(values.size());

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -725,12 +725,11 @@ static atomic_cell make_empty(const atomic_cell_view& ac) {
 static collection_mutation make_empty(
         const collection_mutation_view& cm,
         const abstract_type& type) {
-    collection_mutation_description n;
-    n.tomb = cm.tomb();
+    collection_mutation_writer n(cm.tomb());
     for (auto&& [key, cell] : cm) {
-        n.cells.emplace_back(to_bytes(key), make_empty(cell));
+        n.push_back(key, make_empty(cell));
     }
-    return n.serialize();
+    return std::move(n).finish();
 }
 
 // In some cases, we need to copy to a view table even columns which have not

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -726,12 +726,10 @@ static collection_mutation make_empty(
         const collection_mutation_view& cm,
         const abstract_type& type) {
     collection_mutation_description n;
-    cm.with_deserialized(type, [&] (collection_mutation_view_description m_view) {
-        n.tomb = m_view.tomb;
-        for (auto&& c : m_view.cells) {
-            n.cells.emplace_back(c.first, make_empty(c.second));
-        }
-    });
+    n.tomb = cm.tomb();
+    for (auto&& [key, cell] : cm) {
+        n.cells.emplace_back(to_bytes(key), make_empty(cell));
+    }
     return n.serialize();
 }
 

--- a/db/view/view.cc
+++ b/db/view/view.cc
@@ -732,7 +732,7 @@ static collection_mutation make_empty(
             n.cells.emplace_back(c.first, make_empty(c.second));
         }
     });
-    return n.serialize(type);
+    return n.serialize();
 }
 
 // In some cases, we need to copy to a view table even columns which have not

--- a/mutation/atomic_cell.cc
+++ b/mutation/atomic_cell.cc
@@ -140,8 +140,8 @@ bool atomic_cell_or_collection::equals(const abstract_type& type, const atomic_c
     }
 
     if (type.is_atomic()) {
-        auto a = atomic_cell_view::from_bytes(type, _data);
-        auto b = atomic_cell_view::from_bytes(type, other._data);
+        auto a = atomic_cell_view::from_bytes(_data);
+        auto b = atomic_cell_view::from_bytes(other._data);
         if (a.timestamp() != b.timestamp()) {
             return false;
         }

--- a/mutation/atomic_cell.hh
+++ b/mutation/atomic_cell.hh
@@ -297,10 +297,10 @@ class atomic_cell_view final : public basic_atomic_cell_view<mutable_view::no> {
         : basic_atomic_cell_view<mutable_view::no>(view) {}
     friend class atomic_cell;
 public:
-    static atomic_cell_view from_bytes(const abstract_type& t, managed_bytes_view v) {
+    static atomic_cell_view from_bytes(managed_bytes_view v) {
         return atomic_cell_view(v);
     }
-    static atomic_cell_view from_bytes(const abstract_type& t, bytes_view v) {
+    static atomic_cell_view from_bytes(bytes_view v) {
         return atomic_cell_view(managed_bytes_view(v));
     }
 
@@ -325,7 +325,7 @@ class atomic_cell_mutable_view final : public basic_atomic_cell_view<mutable_vie
     atomic_cell_mutable_view(managed_bytes_mutable_view data)
         : basic_atomic_cell_view(data) {}
 public:
-    static atomic_cell_mutable_view from_bytes(const abstract_type& t, managed_bytes_mutable_view v) {
+    static atomic_cell_mutable_view from_bytes(managed_bytes_mutable_view v) {
         return atomic_cell_mutable_view(v);
     }
 

--- a/mutation/atomic_cell_hash.hh
+++ b/mutation/atomic_cell_hash.hh
@@ -20,13 +20,11 @@ template<>
 struct appending_hash<collection_mutation_view> {
     template<typename Hasher>
     void operator()(Hasher& h, collection_mutation_view cell, const column_definition& cdef) const {
-        cell.with_deserialized(*cdef.type, [&] (collection_mutation_view_description m_view) {
-            ::feed_hash(h, m_view.tomb);
-            for (auto&& key_and_value : m_view.cells) {
-                ::feed_hash(h, key_and_value.first);
-                ::feed_hash(h, key_and_value.second, cdef);
-            }
-      });
+        ::feed_hash(h, cell.tomb());
+        for (auto&& [key, value] : cell) {
+            ::feed_hash(h, key);
+            ::feed_hash(h, value, cdef);
+        }
     }
 };
 

--- a/mutation/atomic_cell_or_collection.hh
+++ b/mutation/atomic_cell_or_collection.hh
@@ -31,7 +31,7 @@ public:
     static atomic_cell_or_collection from_atomic_cell(atomic_cell data) { return { std::move(data._data) }; }
     atomic_cell_view as_atomic_cell(const column_definition& cdef) const { return atomic_cell_view::from_bytes(_data); }
     atomic_cell_mutable_view as_mutable_atomic_cell(const column_definition& cdef) { return atomic_cell_mutable_view::from_bytes(_data); }
-    atomic_cell_or_collection(collection_mutation cm) : _data(std::move(cm._data)) { }
+    atomic_cell_or_collection(collection_mutation cm) : _data(std::move(cm).data()) { }
     atomic_cell_or_collection copy(const abstract_type&) const;
     explicit operator bool() const {
         return !_data.empty();
@@ -39,7 +39,7 @@ public:
     static constexpr bool can_use_mutable_view() {
         return true;
     }
-    static atomic_cell_or_collection from_collection_mutation(collection_mutation data) { return std::move(data._data); }
+    static atomic_cell_or_collection from_collection_mutation(collection_mutation data) { return std::move(data).data(); }
     collection_mutation_view as_collection_mutation() const;
     bytes_view serialize() const;
     bool equals(const abstract_type& type, const atomic_cell_or_collection& other) const;

--- a/mutation/atomic_cell_or_collection.hh
+++ b/mutation/atomic_cell_or_collection.hh
@@ -29,8 +29,8 @@ public:
     atomic_cell_or_collection(atomic_cell ac) : _data(std::move(ac._data)) {}
     atomic_cell_or_collection(const abstract_type& at, atomic_cell_view acv);
     static atomic_cell_or_collection from_atomic_cell(atomic_cell data) { return { std::move(data._data) }; }
-    atomic_cell_view as_atomic_cell(const column_definition& cdef) const { return atomic_cell_view::from_bytes(*cdef.type, _data); }
-    atomic_cell_mutable_view as_mutable_atomic_cell(const column_definition& cdef) { return atomic_cell_mutable_view::from_bytes(*cdef.type, _data); }
+    atomic_cell_view as_atomic_cell(const column_definition& cdef) const { return atomic_cell_view::from_bytes(_data); }
+    atomic_cell_mutable_view as_mutable_atomic_cell(const column_definition& cdef) { return atomic_cell_mutable_view::from_bytes(_data); }
     atomic_cell_or_collection(collection_mutation cm) : _data(std::move(cm._data)) { }
     atomic_cell_or_collection copy(const abstract_type&) const;
     explicit operator bool() const {

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -467,12 +467,16 @@ collection_mutation collection_mutation_writer::finish() && {
 
 template <typename C>
 requires std::is_base_of_v<abstract_type, std::remove_reference_t<C>>
-static collection_mutation_view_description
-merge(collection_mutation_view_description a, collection_mutation_view_description b, C&& key_type) {
-    using element_type = std::pair<bytes_view, atomic_cell_view>;
+static collection_mutation
+merge(collection_mutation_view a, collection_mutation_view b, C&& key_type) {
+    using element_type = collection_mutation_view::iterator::value_type;
 
     auto compare = [&] (const element_type& e1, const element_type& e2) {
-        return key_type.less(e1.first, e2.first);
+        return e1.first.with_linearized([&] (bytes_view k1) {
+            return e2.first.with_linearized([&] (bytes_view k2) {
+                return key_type.less(k1, k2);
+            });
+        });
     };
 
     auto merge = [] (const element_type& e1, const element_type& e2) {
@@ -482,49 +486,47 @@ merge(collection_mutation_view_description a, collection_mutation_view_descripti
 
     // applied to a tombstone, returns a predicate checking whether a cell is killed by
     // the tombstone
-    auto cell_killed = [] (const std::optional<tombstone>& t) {
-        return [&t] (const element_type& e) {
+    auto filter_cells = [&] (const collection_mutation_view& v, tombstone t) {
+        return v | std::views::filter([t] (const element_type& e) {
             if (!t) {
-                return false;
+                return true;
             }
             // tombstone wins if timestamps equal here, unlike row tombstones
-            if (t->timestamp < e.second.timestamp()) {
-                return false;
+            if (t.timestamp < e.second.timestamp()) {
+                return true;
             }
-            return true;
+            return false;
             // FIXME: should we consider TTLs too?
-        };
+        });
     };
 
-    collection_mutation_view_description merged;
-    merged.cells.reserve(a.cells.size() + b.cells.size());
+    collection_mutation_writer merged(std::max(a.tomb(), b.tomb()));
 
-    combine(a.cells.begin(), std::remove_if(a.cells.begin(), a.cells.end(), cell_killed(b.tomb)),
-            b.cells.begin(), std::remove_if(b.cells.begin(), b.cells.end(), cell_killed(a.tomb)),
-            std::back_inserter(merged.cells),
+    auto a_filtered = filter_cells(a, b.tomb());
+    auto b_filtered = filter_cells(b, a.tomb());
+
+    combine(
+            a_filtered.begin(), a_filtered.end(),
+            b_filtered.begin(), b_filtered.end(),
+            std::back_inserter(merged),
             compare,
             merge);
-    merged.tomb = std::max(a.tomb, b.tomb);
 
-    return merged;
+    return std::move(merged).finish();
 }
 
 collection_mutation merge(const abstract_type& type, collection_mutation_view a, collection_mutation_view b) {
-    return a.with_deserialized(type, [&] (collection_mutation_view_description a_view) {
-        return b.with_deserialized(type, [&] (collection_mutation_view_description b_view) {
-            return visit(type, make_visitor(
-            [&] (const collection_type_impl& ctype) {
-                return merge(std::move(a_view), std::move(b_view), *ctype.name_comparator());
-            },
-            [&] (const user_type_impl& utype) {
-                return merge(std::move(a_view), std::move(b_view), *short_type);
-            },
-            [] (const abstract_type& o) -> collection_mutation_view_description {
-                throw std::runtime_error(format("collection_mutation merge: unknown type: {}", o.name()));
-            }
-            )).serialize();
-        });
-    });
+    return visit(type, make_visitor(
+        [&] (const collection_type_impl& ctype) {
+            return merge(std::move(a), std::move(b), *ctype.name_comparator());
+        },
+        [&] (const user_type_impl& utype) {
+            return merge(std::move(a), std::move(b), *short_type);
+        },
+        [] (const abstract_type& o) -> collection_mutation {
+            throw std::runtime_error(format("collection_mutation merge: unknown type: {}", o.name()));
+        }
+    ));
 }
 
 template <typename C>

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -54,7 +54,28 @@ collection_mutation_view atomic_cell_or_collection::as_collection_mutation() con
     return collection_mutation_view{managed_bytes_view(_data)};
 }
 
-bool collection_mutation_view::is_empty() const {
+namespace {
+
+// Reads (and consumes) the tombstone prefix from `v`. Returns the tombstone,
+// which is empty if the has_tombstone flag was not set.
+tombstone read_collection_tombstone(managed_bytes_view& v) {
+    if (read_simple<uint8_t>(v)) {
+        auto timestamp = read_simple<api::timestamp_type>(v);
+        auto deletion_time = read_simple<gc_clock::duration::rep>(v);
+        return tombstone{timestamp, gc_clock::time_point(gc_clock::duration(deletion_time))};
+    }
+    return tombstone{};
+}
+
+// Reads (and consumes) the cell-count field from `v`, assuming the tombstone
+// prefix has already been consumed.
+uint32_t read_collection_size(managed_bytes_view& v) {
+    return read_simple<uint32_t>(v);
+}
+
+} // anonymous namespace
+
+bool collection_mutation_view::empty() const {
     auto in = collection_mutation_input_stream(data);
     auto has_tomb = in.read_trivial<uint8_t>();
     return !has_tomb && in.read_trivial<uint32_t>() == 0;
@@ -102,6 +123,42 @@ api::timestamp_type collection_mutation_view::last_update(const abstract_type& t
     }
 
     return max;
+}
+
+tombstone collection_mutation_view::tomb() const {
+    auto v = data;
+    return read_collection_tombstone(v);
+}
+
+uint32_t collection_mutation_view::size() const {
+    auto v = data;
+    read_collection_tombstone(v); // skip tombstone if present
+    return read_collection_size(v);
+}
+
+collection_mutation_view::iterator::iterator(managed_bytes_view data) {
+    read_collection_tombstone(data); // skip tombstone if present
+    _remaining_count = read_collection_size(data);
+    _remaining = data;
+    ++*this;
+}
+
+void collection_mutation_view::iterator::advance() {
+    auto key_size = read_simple<uint32_t>(_remaining);
+    auto key = _remaining.prefix(key_size);
+    _remaining.remove_prefix(key_size);
+    auto vsize = read_simple<uint32_t>(_remaining);
+    auto value = _remaining.prefix(vsize);
+    _remaining.remove_prefix(vsize);
+    _current = value_type{key, atomic_cell_view::from_bytes(value)};
+}
+
+collection_mutation_view::iterator collection_mutation_view::begin() const {
+    return iterator(data);
+}
+
+collection_mutation_view::iterator collection_mutation_view::end() const {
+    return iterator{};
 }
 
 auto fmt::formatter<collection_mutation_view::printer>::format(const collection_mutation_view::printer& cmvp, fmt::format_context& ctx) const

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -33,6 +33,12 @@ bool collection_mutation_input_stream::empty() const {
     return _src.empty();
 }
 
+collection_mutation::collection_mutation() : _data(managed_bytes::initialized_later{}, sizeof(uint8_t) + sizeof(int32_t)) {
+    auto out = managed_bytes_mutable_view(_data);
+    write<uint8_t>(out, uint8_t(false)); // No tombstone
+    write<int32_t>(out, 0); // No cells
+}
+
 collection_mutation::collection_mutation(collection_mutation_view v)
     : _data(v.data) {}
 

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -142,26 +142,26 @@ auto fmt::formatter<collection_mutation_view::printer>::format(const collection_
     -> decltype(ctx.out()) {
     auto out = ctx.out();
     out = fmt::format_to(out, "{{collection_mutation_view ");
-    cmvp._cmv.with_deserialized(cmvp._type, [&out, &type = cmvp._type] (const collection_mutation_view_description& cmvd) {
-        bool first = true;
-        out = fmt::format_to(out, "tombstone {}", cmvd.tomb);
-        visit(type, make_visitor(
+    const auto& cmv = cmvp._cmv;
+    bool first = true;
+    out = fmt::format_to(out, "tombstone {}", cmv.tomb());
+    visit(cmvp._type, make_visitor(
         [&] (const collection_type_impl& ctype) {
             auto&& key_type = ctype.name_comparator();
             auto&& value_type = ctype.value_comparator();
             out = fmt::format_to(out, " collection cells {{");
-            for (auto&& [key, value] : cmvd.cells) {
+            for (auto&& [key, value] : cmv) {
                 if (!first) {
                     out = fmt::format_to(out, ", ");
                 }
-                fmt::format_to(out, "{}: {}", key_type->to_string(key), atomic_cell_view::printer(*value_type, value));
+                fmt::format_to(out, "{}: {}", key_type->to_string(key.linearize()), atomic_cell_view::printer(*value_type, value));
                 first = false;
             }
             out = fmt::format_to(out, "}}");
         },
         [&] (const user_type_impl& utype) {
             out = fmt::format_to(out, " user-type cells {{");
-            for (auto&& [raw_idx, value] : cmvd.cells) {
+            for (auto&& [raw_idx, value] : cmv) {
                 if (first) {
                     out = fmt::format_to(out, " ");
                 } else {
@@ -175,10 +175,9 @@ auto fmt::formatter<collection_mutation_view::printer>::format(const collection_
         },
         [&] (const abstract_type& o) {
             // Not throwing exception in this likely-to-be debug context
-            out = fmt::format_to(out, " attempted to pretty-print collection_mutation_view_description with type {}", o.name());
+            out = fmt::format_to(out, " attempted to pretty-print collection_mutation_view with type {}", o.name());
         }
-        ));
-    });
+    ));
     return fmt::format_to(out, "}}");
 }
 

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -209,10 +209,24 @@ collection_mutation_view_description::materialize(const abstract_type& type) con
     return m;
 }
 
-compact_and_expire_result collection_mutation_description::compact_and_expire(column_id id, row_tombstone base_tomb, gc_clock::time_point query_time,
-    can_gc_fn& can_gc, gc_clock::time_point gc_before, compaction_garbage_collector* collector)
-{
+namespace {
+struct atomic_cell_adaptor;
+}
+
+template <typename Adaptor, typename Iterator>
+static collection_mutation serialize_collection_mutation(const tombstone& tomb, std::ranges::subrange<Iterator> cells);
+
+collection_mutation_compact_and_expire_result compact_and_expire(
+        collection_mutation_view cmv,
+        column_id id,
+        const abstract_type& type,
+        row_tombstone base_tomb,
+        gc_clock::time_point query_time,
+        can_gc_fn& can_gc,
+        gc_clock::time_point gc_before,
+        compaction_garbage_collector* collector) {
     compact_and_expire_result res{};
+    auto tomb = cmv.tomb();
     if (tomb) {
         res.collection_tombstones++;
     }
@@ -225,10 +239,9 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
         tomb = tombstone();
     }
     t.apply(base_tomb.regular());
-    utils::chunked_vector<std::pair<bytes, atomic_cell>> survivors;
+    collection_mutation_writer survivors(tomb);
     collection_mutation_writer losers(purged_tomb);
-    for (auto&& name_and_cell : cells) {
-        atomic_cell& cell = name_and_cell.second;
+    for (auto& [key, cell] : cmv) {
         auto cannot_erase_cell = [&] {
             // Only row tombstones can be shadowable, (collection) cell tombstones aren't
             return cell.deletion_time() >= gc_before || !can_gc(tombstone(cell.timestamp(), cell.deletion_time()), is_shadowable::no);
@@ -239,30 +252,29 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
             continue;
         }
         if (cell.has_expired(query_time)) {
+            auto dead = atomic_cell::make_dead(cell.timestamp(), cell.deletion_time());
             if (cannot_erase_cell()) {
-                survivors.emplace_back(std::make_pair(
-                    std::move(name_and_cell.first), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time())));
+                survivors.push_back(std::move(key), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time()));
             } else if (collector) {
-                losers.push_back(managed_bytes_view(name_and_cell.first), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time()));
+                losers.push_back(std::move(key), std::move(dead));
             }
             res.dead_cells++;
         } else if (!cell.is_live()) {
             if (cannot_erase_cell()) {
-                survivors.emplace_back(std::move(name_and_cell));
+                survivors.push_back(std::move(key), atomic_cell(type, cell));
             } else if (collector) {
-                losers.push_back(managed_bytes_view(name_and_cell.first), std::move(name_and_cell.second));
+                losers.push_back(key, atomic_cell(type, cell));
             }
             res.dead_cells++;
         } else {
-            survivors.emplace_back(std::move(name_and_cell));
+            survivors.push_back(key, atomic_cell(type, cell));
             res.live_cells++;
         }
     }
     if (collector) {
         collector->collect(id, std::move(losers).finish());
     }
-    cells = std::move(survivors);
-    return res;
+    return {std::move(survivors).finish(), std::move(res)};
 }
 
 /// A CollectionMutationAdaptor is a static interface that adapts a collection

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -18,21 +18,6 @@
 
 #include "collection_mutation.hh"
 
-bytes_view collection_mutation_input_stream::read_linearized(size_t n) {
-    managed_bytes_view mbv = ::read_simple_bytes(_src, n);
-    if (mbv.is_linearized()) {
-        return mbv.current_fragment();
-    } else {
-        return _linearized.emplace_front(linearized(mbv));
-    }
-}
-managed_bytes_view collection_mutation_input_stream::read_fragmented(size_t n) {
-    return ::read_simple_bytes(_src, n);
-}
-bool collection_mutation_input_stream::empty() const {
-    return _src.empty();
-}
-
 collection_mutation::collection_mutation() : _data(managed_bytes::initialized_later{}, sizeof(uint8_t) + sizeof(int32_t)) {
     auto out = managed_bytes_mutable_view(_data);
     write<uint8_t>(out, uint8_t(false)); // No tombstone
@@ -181,37 +166,6 @@ auto fmt::formatter<collection_mutation_view::printer>::format(const collection_
     return fmt::format_to(out, "}}");
 }
 
-
-collection_mutation_description
-collection_mutation_view_description::materialize(const abstract_type& type) const {
-    collection_mutation_description m;
-    m.tomb = tomb;
-    m.cells.reserve(cells.size());
-
-    visit(type, make_visitor(
-    [&] (const collection_type_impl& ctype) {
-        auto& value_type = *ctype.value_comparator();
-        for (auto&& e : cells) {
-            m.cells.emplace_back(to_bytes(e.first), atomic_cell(value_type, e.second));
-        }
-    },
-    [&] (const user_type_impl& utype) {
-        for (auto&& e : cells) {
-            m.cells.emplace_back(to_bytes(e.first), atomic_cell(*utype.type(deserialize_field_index(e.first)), e.second));
-        }
-    },
-    [&] (const abstract_type& o) {
-        throw std::runtime_error(format("attempted to materialize collection_mutation_view_description with type {}", o.name()));
-    }
-    ));
-
-    return m;
-}
-
-namespace {
-struct atomic_cell_adaptor;
-}
-
 template <typename Adaptor, typename Iterator>
 static collection_mutation serialize_collection_mutation(const tombstone& tomb, std::ranges::subrange<Iterator> cells);
 
@@ -323,38 +277,6 @@ static collection_mutation serialize_collection_mutation(
         writev(kv);
     }
     return collection_mutation(std::move(ret));
-}
-
-namespace {
-
-/// A key-value pair where the key is bytes-like and the value is an atomic_cell-like type
-/// with a serialize() method returning managed_bytes_view.
-template <typename T>
-concept AtomicCellKV = requires(const T& kv) {
-    { kv.first.size() } -> std::convertible_to<size_t>;
-    { kv.second.serialize() } -> std::convertible_to<managed_bytes_view>;
-};
-
-struct atomic_cell_adaptor {
-    static size_t key_size(const AtomicCellKV auto& v) { return v.first.size(); }
-    static size_t value_size(const AtomicCellKV auto& v) { return v.second.serialize().size(); }
-
-    static void write_key(const AtomicCellKV auto& v, managed_bytes_mutable_view& out) {
-        write_fragmented(out, single_fragmented_view(v.first));
-    }
-    static void write_value(const AtomicCellKV auto& v, managed_bytes_mutable_view& out) {
-        write_fragmented(out, v.second.serialize());
-    }
-};
-
-}
-
-collection_mutation collection_mutation_description::serialize() const {
-    return serialize_collection_mutation<atomic_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
-}
-
-collection_mutation collection_mutation_view_description::serialize() const {
-    return serialize_collection_mutation<atomic_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 namespace {
@@ -576,58 +498,5 @@ collection_mutation difference(const abstract_type& type, collection_mutation_vi
         [] (const abstract_type& o) -> collection_mutation {
             throw std::runtime_error(format("collection_mutation difference: unknown type: {}", o.name()));
         }
-    ));
-}
-
-template <typename F>
-requires std::is_invocable_r_v<std::pair<bytes_view, atomic_cell_view>, F, collection_mutation_input_stream&>
-static collection_mutation_view_description
-deserialize_collection_mutation(collection_mutation_input_stream& in, F&& read_kv) {
-    collection_mutation_view_description ret;
-
-    auto has_tomb = in.read_trivial<uint8_t>();
-    if (has_tomb) {
-        auto ts = in.read_trivial<api::timestamp_type>();
-        auto ttl = in.read_trivial<gc_clock::duration::rep>();
-        ret.tomb = tombstone{ts, gc_clock::time_point(gc_clock::duration(ttl))};
-    }
-
-    auto nr = in.read_trivial<uint32_t>();
-    ret.cells.reserve(nr);
-    for (uint32_t i = 0; i != nr; ++i) {
-        ret.cells.push_back(read_kv(in));
-    }
-
-    SCYLLA_ASSERT(in.empty());
-    return ret;
-}
-
-collection_mutation_view_description
-deserialize_collection_mutation(const abstract_type& type, collection_mutation_input_stream& in) {
-    return visit(type, make_visitor(
-    [&] (const collection_type_impl& ctype) {
-        // value_comparator(), ugh
-        return deserialize_collection_mutation(in, [] (collection_mutation_input_stream& in) {
-            // FIXME: we could probably avoid the need for size
-            auto ksize = in.read_trivial<uint32_t>();
-            auto key = in.read_linearized(ksize);
-            auto vsize = in.read_trivial<uint32_t>();
-            auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
-            return std::make_pair(key, value);
-        });
-    },
-    [&] (const user_type_impl& utype) {
-        return deserialize_collection_mutation(in, [] (collection_mutation_input_stream& in) {
-            // FIXME: we could probably avoid the need for size
-            auto ksize = in.read_trivial<uint32_t>();
-            auto key = in.read_linearized(ksize);
-            auto vsize = in.read_trivial<uint32_t>();
-            auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
-            return std::make_pair(key, value);
-        });
-    },
-    [&] (const abstract_type& o) -> collection_mutation_view_description {
-        throw std::runtime_error(format("deserialize_collection_mutation: unknown type {}", o.name()));
-    }
     ));
 }

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -249,7 +249,7 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
     }
     t.apply(base_tomb.regular());
     utils::chunked_vector<std::pair<bytes, atomic_cell>> survivors;
-    utils::chunked_vector<std::pair<bytes, atomic_cell>> losers;
+    collection_mutation_writer losers(purged_tomb);
     for (auto&& name_and_cell : cells) {
         atomic_cell& cell = name_and_cell.second;
         auto cannot_erase_cell = [&] {
@@ -266,15 +266,14 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
                 survivors.emplace_back(std::make_pair(
                     std::move(name_and_cell.first), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time())));
             } else if (collector) {
-                losers.emplace_back(std::pair(
-                        std::move(name_and_cell.first), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time())));
+                losers.push_back(managed_bytes_view(name_and_cell.first), atomic_cell::make_dead(cell.timestamp(), cell.deletion_time()));
             }
             res.dead_cells++;
         } else if (!cell.is_live()) {
             if (cannot_erase_cell()) {
                 survivors.emplace_back(std::move(name_and_cell));
             } else if (collector) {
-                losers.emplace_back(std::move(name_and_cell));
+                losers.push_back(managed_bytes_view(name_and_cell.first), std::move(name_and_cell.second));
             }
             res.dead_cells++;
         } else {
@@ -283,7 +282,7 @@ compact_and_expire_result collection_mutation_description::compact_and_expire(co
         }
     }
     if (collector) {
-        collector->collect(id, collection_mutation_description{purged_tomb, std::move(losers)});
+        collector->collect(id, std::move(losers).finish());
     }
     cells = std::move(survivors);
     return res;

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -531,48 +531,53 @@ collection_mutation merge(const abstract_type& type, collection_mutation_view a,
 
 template <typename C>
 requires std::is_base_of_v<abstract_type, std::remove_reference_t<C>>
-static collection_mutation_view_description
-difference(collection_mutation_view_description a, collection_mutation_view_description b, C&& key_type)
+static collection_mutation
+difference(collection_mutation_view a, collection_mutation_view b, C&& key_type)
 {
-    collection_mutation_view_description diff;
-    diff.cells.reserve(std::max(a.cells.size(), b.cells.size()));
+    using element_type = collection_mutation_view::iterator::value_type;
 
-    auto it = b.cells.begin();
-    for (auto&& c : a.cells) {
-        while (it != b.cells.end() && key_type.less(it->first, c.first)) {
+    tombstone diff_tomb;
+    if (a.tomb() > b.tomb()) {
+        diff_tomb = a.tomb();
+    }
+    collection_mutation_writer diff(diff_tomb);
+
+    auto less = [&] (const element_type& e1, const element_type& e2) {
+        return e1.first.with_linearized([&] (bytes_view k1) {
+            return e2.first.with_linearized([&] (bytes_view k2) {
+                return key_type.less(k1, k2);
+            });
+        });
+    };
+
+    auto it = b.begin();
+    for (auto&& c : a) {
+        while (it != b.end() && less(*it, c)) {
             ++it;
         }
-        if (it == b.cells.end() || !key_type.equal(it->first, c.first)
+        if (it == b.end() || !key_type.equal(it->first, c.first)
             || compare_atomic_cell_for_merge(c.second, it->second) > 0) {
 
-            auto cell = std::make_pair(c.first, c.second);
-            diff.cells.emplace_back(std::move(cell));
+            diff.push_back(c.first, c.second);
         }
     }
-    if (a.tomb > b.tomb) {
-        diff.tomb = a.tomb;
-    }
 
-    return diff;
+    return std::move(diff).finish();
 }
 
 collection_mutation difference(const abstract_type& type, collection_mutation_view a, collection_mutation_view b)
 {
-    return a.with_deserialized(type, [&] (collection_mutation_view_description a_view) {
-        return b.with_deserialized(type, [&] (collection_mutation_view_description b_view) {
-            return visit(type, make_visitor(
-            [&] (const collection_type_impl& ctype) {
-                return difference(std::move(a_view), std::move(b_view), *ctype.name_comparator());
-            },
-            [&] (const user_type_impl& utype) {
-                return difference(std::move(a_view), std::move(b_view), *short_type);
-            },
-            [] (const abstract_type& o) -> collection_mutation_view_description {
-                throw std::runtime_error(format("collection_mutation difference: unknown type: {}", o.name()));
-            }
-            )).serialize();
-        });
-    });
+    return visit(type, make_visitor(
+        [&] (const collection_type_impl& ctype) {
+            return difference(std::move(a), std::move(b), *ctype.name_comparator());
+        },
+        [&] (const user_type_impl& utype) {
+            return difference(std::move(a), std::move(b), *short_type);
+        },
+        [] (const abstract_type& o) -> collection_mutation {
+            throw std::runtime_error(format("collection_mutation difference: unknown type: {}", o.name()));
+        }
+    ));
 }
 
 template <typename F>

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -33,10 +33,10 @@ bool collection_mutation_input_stream::empty() const {
     return _src.empty();
 }
 
-collection_mutation::collection_mutation(const abstract_type& type, collection_mutation_view v)
+collection_mutation::collection_mutation(collection_mutation_view v)
     : _data(v.data) {}
 
-collection_mutation::collection_mutation(const abstract_type& type, managed_bytes data)
+collection_mutation::collection_mutation(managed_bytes data)
     : _data(std::move(data)) {}
 
 collection_mutation::operator collection_mutation_view() const
@@ -241,7 +241,6 @@ concept CollectionMutationAdaptor = requires(const Element& e, managed_bytes_mut
 template <typename Adaptor, typename Iterator>
     requires CollectionMutationAdaptor<Adaptor, std::iter_value_t<Iterator>>
 static collection_mutation serialize_collection_mutation(
-        const abstract_type& type,
         const tombstone& tomb,
         std::ranges::subrange<Iterator> cells) {
     auto element_size = [] (size_t c, auto&& e) -> size_t {
@@ -273,7 +272,7 @@ static collection_mutation serialize_collection_mutation(
         writek(kv);
         writev(kv);
     }
-    return collection_mutation(type, std::move(ret));
+    return collection_mutation(std::move(ret));
 }
 
 namespace {
@@ -300,12 +299,12 @@ struct atomic_cell_adaptor {
 
 }
 
-collection_mutation collection_mutation_description::serialize(const abstract_type& type) const {
-    return serialize_collection_mutation<atomic_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+collection_mutation collection_mutation_description::serialize() const {
+    return serialize_collection_mutation<atomic_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
-collection_mutation collection_mutation_view_description::serialize(const abstract_type& type) const {
-    return serialize_collection_mutation<atomic_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+collection_mutation collection_mutation_view_description::serialize() const {
+    return serialize_collection_mutation<atomic_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 namespace {
@@ -364,7 +363,7 @@ struct serialized_cell_adaptor {
 collection_mutation read_from_collection_cell_view(const abstract_type& type, const ser::collection_cell_view& collection) {
     auto tomb = collection.tomb();
     auto cells = collection.elements();
-    return serialize_collection_mutation<serialized_cell_adaptor>(type, tomb, std::ranges::subrange(cells.begin(), cells.end()));
+    return serialize_collection_mutation<serialized_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
 template <typename C>
@@ -424,7 +423,7 @@ collection_mutation merge(const abstract_type& type, collection_mutation_view a,
             [] (const abstract_type& o) -> collection_mutation_view_description {
                 throw std::runtime_error(format("collection_mutation merge: unknown type: {}", o.name()));
             }
-            )).serialize(type);
+            )).serialize();
         });
     });
 }
@@ -470,7 +469,7 @@ collection_mutation difference(const abstract_type& type, collection_mutation_vi
             [] (const abstract_type& o) -> collection_mutation_view_description {
                 throw std::runtime_error(format("collection_mutation difference: unknown type: {}", o.name()));
             }
-            )).serialize(type);
+            )).serialize();
         });
     });
 }

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -68,7 +68,7 @@ bool collection_mutation_view::is_any_live(const abstract_type& type, tombstone 
         auto key_size = in.read_trivial<uint32_t>();
         in.read_fragmented(key_size); // Skip
         auto vsize = in.read_trivial<uint32_t>();
-        auto value = atomic_cell_view::from_bytes(type, in.read_fragmented(vsize));
+        auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
         if (value.is_live(tomb, now, false)) {
             return true;
         }
@@ -91,7 +91,7 @@ api::timestamp_type collection_mutation_view::last_update(const abstract_type& t
         const auto key_size = in.read_trivial<uint32_t>();
         in.read_fragmented(key_size); // Skip
         auto vsize = in.read_trivial<uint32_t>();
-        auto value = atomic_cell_view::from_bytes(type, in.read_fragmented(vsize));
+        auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
         max = std::max(value.timestamp(), max);
     }
 
@@ -503,22 +503,22 @@ deserialize_collection_mutation(const abstract_type& type, collection_mutation_i
     return visit(type, make_visitor(
     [&] (const collection_type_impl& ctype) {
         // value_comparator(), ugh
-        return deserialize_collection_mutation(in, [&ctype] (collection_mutation_input_stream& in) {
+        return deserialize_collection_mutation(in, [] (collection_mutation_input_stream& in) {
             // FIXME: we could probably avoid the need for size
             auto ksize = in.read_trivial<uint32_t>();
             auto key = in.read_linearized(ksize);
             auto vsize = in.read_trivial<uint32_t>();
-            auto value = atomic_cell_view::from_bytes(*ctype.value_comparator(), in.read_fragmented(vsize));
+            auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
             return std::make_pair(key, value);
         });
     },
     [&] (const user_type_impl& utype) {
-        return deserialize_collection_mutation(in, [&utype] (collection_mutation_input_stream& in) {
+        return deserialize_collection_mutation(in, [] (collection_mutation_input_stream& in) {
             // FIXME: we could probably avoid the need for size
             auto ksize = in.read_trivial<uint32_t>();
             auto key = in.read_linearized(ksize);
             auto vsize = in.read_trivial<uint32_t>();
-            auto value = atomic_cell_view::from_bytes(*utype.type(deserialize_field_index(key)), in.read_fragmented(vsize));
+            auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
             return std::make_pair(key, value);
         });
     },

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -76,26 +76,14 @@ uint32_t read_collection_size(managed_bytes_view& v) {
 } // anonymous namespace
 
 bool collection_mutation_view::empty() const {
-    auto in = collection_mutation_input_stream(data);
-    auto has_tomb = in.read_trivial<uint8_t>();
-    return !has_tomb && in.read_trivial<uint32_t>() == 0;
+    auto v = data;
+    auto tomb = read_collection_tombstone(v);
+    return !tomb && read_collection_size(v) == 0;
 }
 
 bool collection_mutation_view::is_any_live(const abstract_type& type, tombstone tomb, gc_clock::time_point now) const {
-    auto in = collection_mutation_input_stream(data);
-    auto has_tomb = in.read_trivial<uint8_t>();
-    if (has_tomb) {
-        auto ts = in.read_trivial<api::timestamp_type>();
-        auto ttl = in.read_trivial<gc_clock::duration::rep>();
-        tomb.apply(tombstone{ts, gc_clock::time_point(gc_clock::duration(ttl))});
-    }
-
-    auto nr = in.read_trivial<uint32_t>();
-    for (uint32_t i = 0; i != nr; ++i) {
-        auto key_size = in.read_trivial<uint32_t>();
-        in.read_fragmented(key_size); // Skip
-        auto vsize = in.read_trivial<uint32_t>();
-        auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
+    tomb.apply(this->tomb());
+    for (auto& [key, value] : *this) {
         if (value.is_live(tomb, now, false)) {
             return true;
         }
@@ -105,20 +93,9 @@ bool collection_mutation_view::is_any_live(const abstract_type& type, tombstone 
 }
 
 api::timestamp_type collection_mutation_view::last_update(const abstract_type& type) const {
-    auto in = collection_mutation_input_stream(data);
-    api::timestamp_type max = api::missing_timestamp;
-    auto has_tomb = in.read_trivial<uint8_t>();
-    if (has_tomb) {
-        max = std::max(max, in.read_trivial<api::timestamp_type>());
-        (void)in.read_trivial<gc_clock::duration::rep>();
-    }
-
-    auto nr = in.read_trivial<uint32_t>();
-    for (uint32_t i = 0; i != nr; ++i) {
-        const auto key_size = in.read_trivial<uint32_t>();
-        in.read_fragmented(key_size); // Skip
-        auto vsize = in.read_trivial<uint32_t>();
-        auto value = atomic_cell_view::from_bytes(in.read_fragmented(vsize));
+    auto tomb = this->tomb();
+    api::timestamp_type max = tomb.timestamp;
+    for (auto& [key, value] : *this) {
         max = std::max(value.timestamp(), max);
     }
 

--- a/mutation/collection_mutation.cc
+++ b/mutation/collection_mutation.cc
@@ -372,6 +372,54 @@ collection_mutation read_from_collection_cell_view(const abstract_type& type, co
     return serialize_collection_mutation<serialized_cell_adaptor>(tomb, std::ranges::subrange(cells.begin(), cells.end()));
 }
 
+collection_mutation_writer::collection_mutation_writer(::tombstone tomb) : _tomb(tomb) {
+    auto oit = _out.write_begin();
+    write<uint8_t>(oit, uint8_t(bool(tomb)));
+    if (tomb) {
+        write<int64_t>(oit, tomb.timestamp);
+        write<int64_t>(oit, tomb.deletion_time.time_since_epoch().count());
+    }
+    _size_buffer = _out.write_place_holder<int32_t>().ptr;
+}
+
+void collection_mutation_writer::push_back(managed_bytes_view key, atomic_cell_view value) {
+    {
+        auto oit = _out.write_begin();
+        write<int32_t>(oit, key.size());
+        _out.write(key);
+    }
+
+    {
+        auto oit = _out.write_begin();
+        const auto value_bytes = value.serialize();
+        write<int32_t>(oit, value_bytes.size());
+        _out.write(value_bytes);
+    }
+
+    ++_size;
+}
+
+collection_mutation collection_mutation_writer::finish() && {
+    if (empty()) {
+        return {};
+    }
+
+    write<int32_t>(_size_buffer, _size);
+    // Force a copy of the serialized collection, for 2 reasons:
+    // * Shrink the allocated memory to actually needed size.
+    // * Ensure we are using the correct allocator: bytes_ostream uses the
+    //   standard allocator, but we may be in an LSA context here.
+    auto& outer_allocator = current_allocator();
+    return with_allocator(standard_allocator(), [&] {
+        // bytes_ostream uses malloc(), so we need to force standard
+        // allocator context here when the buffer is destroyed.
+        const auto tmp = std::move(_out).to_managed_bytes();
+        return with_allocator(outer_allocator, [&] {
+            return collection_mutation(tmp);
+        });
+    });
+}
+
 template <typename C>
 requires std::is_base_of_v<abstract_type, std::remove_reference_t<C>>
 static collection_mutation_view_description

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -130,6 +130,39 @@ public:
     operator collection_mutation_view() const;
 };
 
+class collection_mutation_writer {
+public:
+    using value_type = std::pair<managed_bytes_view, atomic_cell_view>;
+
+private:
+    bytes_ostream _out;
+    bytes::value_type* _size_buffer;
+
+    tombstone _tomb;
+    int32_t _size{0};
+public:
+    explicit collection_mutation_writer(tombstone tomb);
+
+    bool empty() const {
+        return !_tomb && _size == 0;
+    }
+
+    tombstone tombstone() const {
+        return _tomb;
+    }
+
+    void push_back(managed_bytes_view key, atomic_cell_view value);
+    void push_back(managed_bytes_view key, atomic_cell value) {
+        push_back(std::move(key), atomic_cell_view(value));
+    }
+
+    void push_back(value_type kv) {
+        push_back(std::move(kv.first), std::move(kv.second));
+    }
+
+    collection_mutation finish() &&;
+};
+
 collection_mutation merge(const abstract_type&, collection_mutation_view, collection_mutation_view);
 
 collection_mutation difference(const abstract_type&, collection_mutation_view, collection_mutation_view);

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -16,6 +16,8 @@
 #include "compaction/compaction_garbage_collector.hh"
 #include <iosfwd>
 #include <forward_list>
+#include <iterator>
+#include <optional>
 
 class abstract_type;
 class compaction_garbage_collector;
@@ -83,7 +85,7 @@ public:
     managed_bytes_view data;
 
     // Is this a noop mutation?
-    bool is_empty() const;
+    bool empty() const;
 
     // Is any of the stored cells live (not deleted nor expired) at the time point `tp`,
     // given the later of the tombstones `t` and the one stored in the mutation (if any)?
@@ -100,6 +102,66 @@ public:
         collection_mutation_input_stream stream(data);
         return f(deserialize_collection_mutation(type, stream));
     }
+
+    // Returns the collection-level tombstone, or an empty tombstone if none is present.
+    tombstone tomb() const;
+
+    // Returns the number of cells stored in the mutation.
+    uint32_t size() const;
+
+    // Forward iterator that deserializes cells on the fly.
+    // Each element is a (key, value) pair where key is a managed_bytes_view of the serialized
+    // cell key (path) and value is an atomic_cell_view of the serialized cell value.
+    // The iterator does not require type information to advance.
+    // The underlying collection_mutation_view must outlive the iterator.
+    class iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept = std::forward_iterator_tag;
+        using value_type = std::pair<managed_bytes_view, atomic_cell_view>;
+        using difference_type = std::ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+    private:
+        managed_bytes_view _remaining;
+        uint32_t _remaining_count = 0;
+        std::optional<value_type> _current;
+
+        void advance();
+        explicit iterator(managed_bytes_view data);
+    public:
+        // Default-constructs an end iterator.
+        iterator() = default;
+
+        reference operator*() const { return *_current; }
+        pointer operator->() const { return &*_current; }
+
+        iterator& operator++() {
+            if (_remaining_count) {
+                advance();
+                --_remaining_count;
+            } else {
+                _current.reset();
+            }
+            return *this;
+        }
+
+        iterator operator++(int) {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
+
+        bool operator==(const iterator& o) const {
+            // End iterator has _remaining = 0 and _current = nullopt.
+            return _remaining_count == o._remaining_count && bool(_current) == bool(o._current);
+        }
+
+        friend class collection_mutation_view;
+    };
+
+    iterator begin() const;
+    iterator end() const;
 
     class printer {
         const abstract_type& _type;

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -122,13 +122,15 @@ public:
 //  for user types: the key is an index identifying the field, the cell contains the value of the field.
 //  The mutation may also contain a collection-wide tombstone.
 class collection_mutation {
-public:
     managed_bytes _data;
 
+public:
     collection_mutation();
     collection_mutation(collection_mutation_view);
     collection_mutation(managed_bytes);
     operator collection_mutation_view() const;
+
+    managed_bytes&& data() && { return std::move(_data); }
 };
 
 class collection_mutation_writer {

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -44,7 +44,7 @@ struct collection_mutation_description {
         can_gc_fn&, gc_clock::time_point gc_before, compaction_garbage_collector* collector = nullptr);
 
     // Packs the data to a serialized blob.
-    collection_mutation serialize(const abstract_type&) const;
+    collection_mutation serialize() const;
 };
 
 // Similar to collection_mutation_description, except that it doesn't store the cells' data, only observes it.
@@ -57,7 +57,7 @@ struct collection_mutation_view_description {
     collection_mutation_description materialize(const abstract_type&) const;
 
     // Packs the data to a serialized blob.
-    collection_mutation serialize(const abstract_type&) const;
+    collection_mutation serialize() const;
 };
 
 class collection_mutation_input_stream {
@@ -125,8 +125,8 @@ public:
     managed_bytes _data;
 
     collection_mutation() {}
-    collection_mutation(const abstract_type&, collection_mutation_view);
-    collection_mutation(const abstract_type&, managed_bytes);
+    collection_mutation(collection_mutation_view);
+    collection_mutation(managed_bytes);
     operator collection_mutation_view() const;
 };
 

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -23,57 +23,9 @@ class abstract_type;
 class compaction_garbage_collector;
 class row_tombstone;
 
-class collection_mutation;
-
 namespace ser {
 class collection_cell_view;
 }
-
-// An auxiliary struct used to (de)construct collection_mutations.
-// Unlike collection_mutation which is a serialized blob, this struct allows to inspect logical units of information
-// (tombstone and cells) inside the mutation easily.
-struct collection_mutation_description {
-    tombstone tomb;
-    // FIXME: use iterators?
-    // we never iterate over `cells` more than once, so there is no need to store them in memory.
-    // In some cases instead of constructing the `cells` vector, it would be more efficient to provide
-    // a one-time-use forward iterator which returns the cells.
-    utils::chunked_vector<std::pair<bytes, atomic_cell>> cells;
-
-    // Packs the data to a serialized blob.
-    collection_mutation serialize() const;
-};
-
-// Similar to collection_mutation_description, except that it doesn't store the cells' data, only observes it.
-struct collection_mutation_view_description {
-    tombstone tomb;
-    // FIXME: use iterators? See the fixme in collection_mutation_description; the same considerations apply here.
-    utils::chunked_vector<std::pair<bytes_view, atomic_cell_view>> cells;
-
-    // Copies the observed data, storing it in a collection_mutation_description.
-    collection_mutation_description materialize(const abstract_type&) const;
-
-    // Packs the data to a serialized blob.
-    collection_mutation serialize() const;
-};
-
-class collection_mutation_input_stream {
-    std::forward_list<bytes> _linearized;
-    managed_bytes_view _src;
-public:
-    collection_mutation_input_stream(const managed_bytes_view& src) : _src(src) {}
-    template <Trivial T>
-    T read_trivial() {
-        return ::read_simple<T>(_src);
-    }
-    bytes_view read_linearized(size_t n);
-    managed_bytes_view read_fragmented(size_t n);
-    bool empty() const;
-};
-
-// Given a collection_mutation_view, returns an auxiliary struct allowing the inspection of each cell.
-// The function needs to be given the type of stored data to reconstruct the structural information.
-collection_mutation_view_description deserialize_collection_mutation(const abstract_type&, collection_mutation_input_stream&);
 
 class collection_mutation_view {
 public:
@@ -89,14 +41,6 @@ public:
 
     // The maximum of timestamps of the mutation's cells and tombstone.
     api::timestamp_type last_update(const abstract_type&) const;
-
-    // Given a function that operates on a collection_mutation_view_description,
-    // calls it on the corresponding description of `this`.
-    template <typename F>
-    inline decltype(auto) with_deserialized(const abstract_type& type, F f) const {
-        collection_mutation_input_stream stream(data);
-        return f(deserialize_collection_mutation(type, stream));
-    }
 
     // Returns the collection-level tombstone, or an empty tombstone if none is present.
     tombstone tomb() const;

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -40,11 +40,6 @@ struct collection_mutation_description {
     // a one-time-use forward iterator which returns the cells.
     utils::chunked_vector<std::pair<bytes, atomic_cell>> cells;
 
-    // Expires cells based on query_time. Expires tombstones based on max_purgeable and gc_before.
-    // Removes cells covered by tomb or this->tomb.
-    compact_and_expire_result compact_and_expire(column_id id, row_tombstone tomb, gc_clock::time_point query_time,
-        can_gc_fn&, gc_clock::time_point gc_before, compaction_garbage_collector* collector = nullptr);
-
     // Packs the data to a serialized blob.
     collection_mutation serialize() const;
 };
@@ -224,6 +219,23 @@ public:
 
     collection_mutation finish() &&;
 };
+
+struct collection_mutation_compact_and_expire_result {
+    collection_mutation collection; // can be empty
+    compact_and_expire_result result;
+};
+
+// Expires cells based on query_time. Expires tombstones based on max_purgeable and gc_before.
+// Removes cells covered by base_tomb or cmv.tomb.
+collection_mutation_compact_and_expire_result compact_and_expire(
+        collection_mutation_view cmv,
+        column_id id,
+        const abstract_type& type,
+        row_tombstone base_tomb,
+        gc_clock::time_point query_time,
+        can_gc_fn& can_gc,
+        gc_clock::time_point gc_before,
+        compaction_garbage_collector* collector);
 
 collection_mutation merge(const abstract_type&, collection_mutation_view, collection_mutation_view);
 

--- a/mutation/collection_mutation.hh
+++ b/mutation/collection_mutation.hh
@@ -124,7 +124,7 @@ class collection_mutation {
 public:
     managed_bytes _data;
 
-    collection_mutation() {}
+    collection_mutation();
     collection_mutation(collection_mutation_view);
     collection_mutation(managed_bytes);
     operator collection_mutation_view() const;

--- a/mutation/converting_mutation_partition_applier.cc
+++ b/mutation/converting_mutation_partition_applier.cc
@@ -87,7 +87,7 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
     ));
 
     if (new_view.tomb || !new_view.cells.empty()) {
-        dst.apply(new_def, new_view.serialize(*new_def.type));
+        dst.apply(new_def, new_view.serialize());
     }
   });
 }

--- a/mutation/converting_mutation_partition_applier.cc
+++ b/mutation/converting_mutation_partition_applier.cc
@@ -46,10 +46,10 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
         return;
     }
 
-  cell.with_deserialized(old_type, [&] (collection_mutation_view_description old_view) {
     collection_mutation_description new_view;
-    if (old_view.tomb.timestamp > new_def.dropped_at()) {
-        new_view.tomb = old_view.tomb;
+    auto tomb = cell.tomb();
+    if (tomb.timestamp > new_def.dropped_at()) {
+        new_view.tomb = tomb;
     }
 
     visit(old_type, make_visitor(
@@ -60,10 +60,10 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
             auto& new_value_type = *new_ctype.value_comparator();
             auto& old_value_type = *old_ctype.value_comparator();
 
-            for (auto& c : old_view.cells) {
-                if (c.second.timestamp() > new_def.dropped_at()) {
-                    new_view.cells.emplace_back(c.first, upgrade_cell(
-                            new_value_type, old_value_type, c.second, atomic_cell::collection_member::yes));
+            for (auto& [key, c] : cell) {
+                if (c.timestamp() > new_def.dropped_at()) {
+                    new_view.cells.emplace_back(to_bytes(key), upgrade_cell(
+                            new_value_type, old_value_type, c, atomic_cell::collection_member::yes));
                 }
             }
         },
@@ -71,13 +71,13 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
             SCYLLA_ASSERT(new_def.type->is_user_type()); // because is_compatible
             auto& new_utype = static_cast<const user_type_impl&>(*new_def.type);
 
-            for (auto& c : old_view.cells) {
-                if (c.second.timestamp() > new_def.dropped_at()) {
-                    auto idx = deserialize_field_index(c.first);
+            for (auto& [key, c] : cell) {
+                if (c.timestamp() > new_def.dropped_at()) {
+                    auto idx = deserialize_field_index(key);
                     SCYLLA_ASSERT(idx < new_utype.size() && idx < old_utype.size());
 
-                    new_view.cells.emplace_back(c.first, upgrade_cell(
-                            *new_utype.type(idx), *old_utype.type(idx), c.second, atomic_cell::collection_member::yes));
+                    new_view.cells.emplace_back(to_bytes(key), upgrade_cell(
+                            *new_utype.type(idx), *old_utype.type(idx), c, atomic_cell::collection_member::yes));
                 }
             }
         },
@@ -89,7 +89,6 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
     if (new_view.tomb || !new_view.cells.empty()) {
         dst.apply(new_def, new_view.serialize());
     }
-  });
 }
 
 converting_mutation_partition_applier::converting_mutation_partition_applier(

--- a/mutation/converting_mutation_partition_applier.cc
+++ b/mutation/converting_mutation_partition_applier.cc
@@ -46,11 +46,8 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
         return;
     }
 
-    collection_mutation_description new_view;
     auto tomb = cell.tomb();
-    if (tomb.timestamp > new_def.dropped_at()) {
-        new_view.tomb = tomb;
-    }
+    collection_mutation_writer new_view(tomb.timestamp > new_def.dropped_at() ? tomb : tombstone{});
 
     visit(old_type, make_visitor(
         [&] (const collection_type_impl& old_ctype) {
@@ -62,7 +59,7 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
 
             for (auto& [key, c] : cell) {
                 if (c.timestamp() > new_def.dropped_at()) {
-                    new_view.cells.emplace_back(to_bytes(key), upgrade_cell(
+                    new_view.push_back(key, upgrade_cell(
                             new_value_type, old_value_type, c, atomic_cell::collection_member::yes));
                 }
             }
@@ -76,7 +73,7 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
                     auto idx = deserialize_field_index(key);
                     SCYLLA_ASSERT(idx < new_utype.size() && idx < old_utype.size());
 
-                    new_view.cells.emplace_back(to_bytes(key), upgrade_cell(
+                    new_view.push_back(key, upgrade_cell(
                             *new_utype.type(idx), *old_utype.type(idx), c, atomic_cell::collection_member::yes));
                 }
             }
@@ -86,8 +83,8 @@ converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, c
         }
     ));
 
-    if (new_view.tomb || !new_view.cells.empty()) {
-        dst.apply(new_def, new_view.serialize());
+    if (!new_view.empty()) {
+        dst.apply(new_def, std::move(new_view).finish());
     }
 }
 

--- a/mutation/json.hh
+++ b/mutation/json.hh
@@ -23,7 +23,7 @@ class counter_cell_view;
 class row;
 class row_marker;
 class tombstone;
-struct collection_mutation_view_description;
+class collection_mutation_view;
 
 namespace mutation_json {
 
@@ -69,7 +69,7 @@ class mutation_partition_json_writer {
     json_writer _writer;
 
 private:
-    void write_each_collection_cell(const collection_mutation_view_description& mv, data_type type, std::function<void(atomic_cell_view, data_type)> func);
+    void write_each_collection_cell(collection_mutation_view cmv, data_type type, std::function<void(atomic_cell_view, data_type)> func);
 
 public:
     explicit mutation_partition_json_writer(const schema& s, std::ostream& os = std::cout)
@@ -80,13 +80,13 @@ public:
 
     sstring to_string(gc_clock::time_point tp);
     void write_atomic_cell_value(const atomic_cell_view& cell, data_type type);
-    void write_collection_value(const collection_mutation_view_description& mv, data_type type);
+    void write_collection_value(collection_mutation_view cmv, data_type type);
     void write(gc_clock::duration ttl, gc_clock::time_point expiry);
     void write(const tombstone& t);
     void write(const row_marker& m);
     void write(counter_cell_view cv);
     void write(const atomic_cell_view& cell, data_type type, bool include_value = true);
-    void write(const collection_mutation_view_description& mv, data_type type, bool include_value = true);
+    void write(collection_mutation_view cmv, data_type type, bool include_value = true);
     void write(const atomic_cell_or_collection& cell, const column_definition& cdef, bool include_value = true);
     void write(const row& r, column_kind kind, bool include_value = true);
 };

--- a/mutation/mutation.cc
+++ b/mutation/mutation.cc
@@ -321,27 +321,31 @@ auto fmt::formatter<mutation>::format(const mutation& m, fmt::format_context& ct
 
 namespace mutation_json {
 
-void mutation_partition_json_writer::write_each_collection_cell(const collection_mutation_view_description& mv, data_type type,
+void mutation_partition_json_writer::write_each_collection_cell(collection_mutation_view cmv, data_type type,
         std::function<void(atomic_cell_view, data_type)> func) {
-    std::function<void(size_t, bytes_view)> write_key;
+    std::function<void(size_t, managed_bytes_view)> write_key;
     std::function<void(size_t, atomic_cell_view)> write_value;
     if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
-        write_key = [this, t = t->name_comparator()] (size_t, bytes_view k) { _writer.String(t->to_string(k)); };
+        write_key = [this, t = t->name_comparator()] (size_t, managed_bytes_view k) {
+            k.with_linearized([&](bytes_view bv) { _writer.String(t->to_string(bv)); });
+        };
         write_value = [t = t->value_comparator(), &func] (size_t, atomic_cell_view v) { func(v, t); };
     } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
-        write_key = [this] (size_t i, bytes_view) { _writer.String(""); };
+        write_key = [this] (size_t i, managed_bytes_view) { _writer.String(""); };
         write_value = [t, &func] (size_t i, atomic_cell_view v) { func(v, t->type(i)); };
     }
 
     if (write_key && write_value) {
         _writer.StartArray();
-        for (size_t i = 0; i < mv.cells.size(); ++i) {
+        size_t i = 0;
+        for (auto&& [key, cell] : cmv) {
             _writer.StartObject();
             _writer.Key("key");
-            write_key(i, mv.cells[i].first);
+            write_key(i, key);
             _writer.Key("value");
-            write_value(i, mv.cells[i].second);
+            write_value(i, cell);
             _writer.EndObject();
+            ++i;
         }
         _writer.EndArray();
     } else {
@@ -365,8 +369,8 @@ void mutation_partition_json_writer::write_atomic_cell_value(const atomic_cell_v
     }
 }
 
-void mutation_partition_json_writer::write_collection_value(const collection_mutation_view_description& mv, data_type type) {
-    write_each_collection_cell(mv, type, [&] (atomic_cell_view v, data_type t) {
+void mutation_partition_json_writer::write_collection_value(collection_mutation_view cmv, data_type type) {
+    write_each_collection_cell(cmv, type, [&] (atomic_cell_view v, data_type t) {
         if (v.is_live()) {
             write_atomic_cell_value(v, t);
         } else {
@@ -451,17 +455,18 @@ void mutation_partition_json_writer::write(const atomic_cell_view& cell, data_ty
     }
     _writer.EndObject();
 }
-void mutation_partition_json_writer::write(const collection_mutation_view_description& mv, data_type type, bool include_value) {
+void mutation_partition_json_writer::write(collection_mutation_view cmv, data_type type, bool include_value) {
     _writer.StartObject();
 
-    if (mv.tomb) {
+    auto tomb = cmv.tomb();
+    if (tomb) {
         _writer.Key("tombstone");
-        write(mv.tomb);
+        write(tomb);
     }
 
     _writer.Key("cells");
 
-    write_each_collection_cell(mv, type, [&] (atomic_cell_view v, data_type t) { write(v, t, include_value); });
+    write_each_collection_cell(cmv, type, [&] (atomic_cell_view v, data_type t) { write(v, t, include_value); });
 
     _writer.EndObject();
 }
@@ -470,9 +475,7 @@ void mutation_partition_json_writer::write(const atomic_cell_or_collection& cell
     if (cdef.is_atomic()) {
         write(cell.as_atomic_cell(cdef), cdef.type, include_value);
     } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-        cell.as_collection_mutation().with_deserialized(*cdef.type, [&, this] (collection_mutation_view_description mv) {
-            write(mv, cdef.type, include_value);
-        });
+        write(cell.as_collection_mutation(), cdef.type, include_value);
     } else {
         _writer.Null();
     }

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -85,10 +85,10 @@ public:
     virtual void collect(column_id id, atomic_cell cell) override {
         _row.apply(_schema.column_at(_kind, id), std::move(cell));
     }
-    virtual void collect(column_id id, collection_mutation_description mut) override {
-        if (mut.tomb || !mut.cells.empty()) {
+    virtual void collect(column_id id, collection_mutation mut) override {
+        if (!collection_mutation_view(mut).empty()) {
             const auto& cdef = _schema.column_at(_kind, id);
-            _row.apply(cdef, mut.serialize());
+            _row.apply(cdef, std::move(mut));
         }
     }
     virtual void collect(row_marker marker) override {

--- a/mutation/mutation_compactor.hh
+++ b/mutation/mutation_compactor.hh
@@ -88,7 +88,7 @@ public:
     virtual void collect(column_id id, collection_mutation_description mut) override {
         if (mut.tomb || !mut.cells.empty()) {
             const auto& cdef = _schema.column_at(_kind, id);
-            _row.apply(cdef, mut.serialize(*cdef.type));
+            _row.apply(cdef, mut.serialize());
         }
     }
     virtual void collect(row_marker marker) override {

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1658,15 +1658,13 @@ compact_and_expire_result row::compact_and_expire(
                 res.live_cells++;
             }
         } else {
-            c.as_collection_mutation().with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
-                auto m = m_view.materialize(*def.type);
-                res += m.compact_and_expire(id, tomb, query_time, can_gc, gc_before, collector);
-                if (m.cells.empty() && m.tomb <= tomb.tomb()) {
-                    erase = true;
-                } else {
-                    c = m.serialize();
-                }
-            });
+            auto compact_res = ::compact_and_expire(c.as_collection_mutation(), id, *def.type, tomb, query_time, can_gc, gc_before, collector);
+            res += compact_res.result;
+            if (collection_mutation_view(compact_res.collection).empty()) {
+                 erase = true;
+            } else {
+                c = std::move(compact_res.collection);
+            }
         }
         return erase;
     });

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1664,7 +1664,7 @@ compact_and_expire_result row::compact_and_expire(
                 if (m.cells.empty() && m.tomb <= tomb.tomb()) {
                     erase = true;
                 } else {
-                    c = m.serialize(*def.type);
+                    c = m.serialize();
                 }
             });
         }

--- a/mutation/mutation_partition.cc
+++ b/mutation/mutation_partition.cc
@@ -1782,7 +1782,7 @@ row row::difference(const schema& s, column_kind kind, const row& other) const
         } else {
             auto diff = ::difference(*cdef.type,
                     c->cell.as_collection_mutation(), it->cell.as_collection_mutation());
-            if (!static_cast<collection_mutation_view>(diff).is_empty()) {
+            if (!static_cast<collection_mutation_view>(diff).empty()) {
                 r.append_cell(c.key(), std::move(diff));
             }
         }

--- a/mutation/mutation_partition_serializer.cc
+++ b/mutation/mutation_partition_serializer.cc
@@ -74,20 +74,18 @@ auto write_dead_cell(Writer&& writer, atomic_cell_view c)
 template<typename Writer>
 auto write_collection_cell(Writer&& collection_writer, collection_mutation_view cmv, const column_definition& def)
 {
-  return cmv.with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
-    auto cells_writer = std::move(collection_writer).write_tomb(m_view.tomb).start_elements();
-    for (auto&& c : m_view.cells) {
-        auto cell_writer = cells_writer.add().write_key(c.first);
-        if (!c.second.is_live()) {
-            write_dead_cell(std::move(cell_writer).start_value_dead_cell(), c.second).end_collection_element();
-        } else if (c.second.is_live_and_has_ttl()) {
-            write_expiring_cell(std::move(cell_writer).start_value_expiring_cell(), c.second).end_collection_element();
+  auto cells_writer = std::move(collection_writer).write_tomb(cmv.tomb()).start_elements();
+    for (auto&& [key, cell] : cmv) {
+        auto cell_writer = cells_writer.add().write_fragmented_key(fragment_range(key));
+        if (!cell.is_live()) {
+            write_dead_cell(std::move(cell_writer).start_value_dead_cell(), cell).end_collection_element();
+        } else if (cell.is_live_and_has_ttl()) {
+            write_expiring_cell(std::move(cell_writer).start_value_expiring_cell(), cell).end_collection_element();
         } else {
-            write_live_cell(std::move(cell_writer).start_value_live_cell(), c.second).end_collection_element();
+            write_live_cell(std::move(cell_writer).start_value_live_cell(), cell).end_collection_element();
         }
     }
     return std::move(cells_writer).end_elements().end_collection_cell();
-  });
 }
 
 template<typename Writer>

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -290,7 +290,7 @@ timestamp_based_splitting_mutation_writer::split_collection(atomic_cell_or_colle
         }
 
         for (auto&& [bucket, bucket_mv] : mutations_by_bucket) {
-            pieces_by_bucket.emplace(bucket, bucket_mv.serialize(*cdef.type));
+            pieces_by_bucket.emplace(bucket, bucket_mv.serialize());
         }
     });
 

--- a/mutation_writer/timestamp_based_splitting_writer.cc
+++ b/mutation_writer/timestamp_based_splitting_writer.cc
@@ -199,20 +199,19 @@ std::optional<timestamp_based_splitting_mutation_writer::bucket_id> timestamp_ba
         return _classifier(cell.as_atomic_cell(cdef).timestamp());
     }
     if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-        return cell.as_collection_mutation().with_deserialized(*cdef.type, [this] (collection_mutation_view_description mv) {
-            std::optional<bucket_id> bucket;
-            if (mv.tomb) {
-                bucket = _classifier(mv.tomb.timestamp);
+        auto cmv = cell.as_collection_mutation();
+        std::optional<bucket_id> bucket;
+        if (auto tomb = cmv.tomb(); tomb) {
+            bucket = _classifier(tomb.timestamp);
+        }
+        for (auto&& c : cmv) {
+            const auto this_bucket = _classifier(c.second.timestamp());
+            if (bucket && *bucket != this_bucket) {
+                return std::optional<bucket_id>{};
             }
-            for (auto&& c : mv.cells) {
-                const auto this_bucket = _classifier(c.second.timestamp());
-                if (bucket && *bucket != this_bucket) {
-                    return std::optional<bucket_id>{};
-                }
-                bucket = this_bucket;
-            }
-            return bucket;
-        });
+            bucket = this_bucket;
+        }
+        return bucket;
     }
     throw std::runtime_error(fmt::format("Cannot classify timestamp of cell (column {} of unknown type {})", cdef.name_as_text(), cdef.type->name()));
 }
@@ -280,19 +279,29 @@ small_flat_map<timestamp_based_splitting_mutation_writer::bucket_id, atomic_cell
 timestamp_based_splitting_mutation_writer::split_collection(atomic_cell_or_collection&& collection, const column_definition& cdef) {
     small_flat_map<bucket_id, atomic_cell_or_collection, 4> pieces_by_bucket;
 
-    collection.as_collection_mutation().with_deserialized(*cdef.type, [&, this] (collection_mutation_view_description original_mv) {
-        small_flat_map<bucket_id, collection_mutation_view_description, 4> mutations_by_bucket;
-        for (auto&& c : original_mv.cells) {
-            mutations_by_bucket[_classifier(c.second.timestamp())].cells.push_back(c);
-        }
-        if (original_mv.tomb) {
-            mutations_by_bucket[_classifier(original_mv.tomb.timestamp)].tomb = original_mv.tomb;
-        }
+    const auto cmv = collection.as_collection_mutation();
 
-        for (auto&& [bucket, bucket_mv] : mutations_by_bucket) {
-            pieces_by_bucket.emplace(bucket, bucket_mv.serialize());
+    small_flat_map<bucket_id, collection_mutation_writer, 4> mutations_by_bucket;
+
+    if (cmv.tomb()) {
+        mutations_by_bucket.emplace(_classifier(cmv.tomb().timestamp), cmv.tomb());
+    }
+
+    auto get_bucket = [&] (int64_t bucket) {
+        if (auto it = mutations_by_bucket.find(bucket); it != mutations_by_bucket.end()) {
+            return &it->second;
         }
-    });
+        // The bucket writer which owns the collection tombstone is already created.
+        return &mutations_by_bucket.emplace(bucket, tombstone{}).first->second;
+    };
+
+    for (auto&& [key, value] : cmv) {
+        get_bucket(_classifier(value.timestamp()))->push_back(std::move(key), std::move(value));
+    }
+
+    for (auto&& [bucket, bucket_writer] : mutations_by_bucket) {
+        pieces_by_bucket.emplace(bucket, std::move(bucket_writer).finish());
+    }
 
     return pieces_by_bucket;
 }

--- a/partition_builder.hh
+++ b/partition_builder.hh
@@ -46,7 +46,7 @@ public:
     }
 
     virtual void accept_static_cell(column_id id, collection_mutation_view collection) override {
-        accept_static_cell(id, collection_mutation(*_schema.static_column_at(id).type, std::move(collection)));
+        accept_static_cell(id, collection_mutation(std::move(collection)));
     }
 
     void accept_static_cell(column_id id, collection_mutation&& collection) {
@@ -76,7 +76,7 @@ public:
     }
 
     virtual void accept_row_cell(column_id id, collection_mutation_view collection) override {
-        accept_row_cell(id, collection_mutation(*_schema.regular_column_at(id).type, std::move(collection)));
+        accept_row_cell(id, collection_mutation(std::move(collection)));
     }
 
     void accept_row_cell(column_id id, collection_mutation collection) {
@@ -136,7 +136,7 @@ public:
 
     virtual void accept_static_cell(column_id id, collection_mutation_view collection) override {
         row& r = _partition->static_row().maybe_create();
-        r.append_cell(id, collection_mutation(*_schema->static_column_at(id).type, std::move(collection)));
+        r.append_cell(id, collection_mutation(std::move(collection)));
     }
 
     virtual future<> accept_row_tombstone(const range_tombstone& rt) override {
@@ -166,7 +166,7 @@ public:
 
     virtual void accept_row_cell(column_id id, collection_mutation_view collection) override {
         row& r = _current_row->cells();
-        r.append_cell(id, collection_mutation(*_schema->regular_column_at(id).type, std::move(collection)));
+        r.append_cell(id, collection_mutation(std::move(collection)));
     }
 
     virtual future<> accept_end_of_partition() override {

--- a/replica/memtable.cc
+++ b/replica/memtable.cc
@@ -61,17 +61,16 @@ void memtable::memtable_encoding_stats_collector::update(const ::schema& s, cons
         if (col.is_atomic()) {
             update(item.as_atomic_cell(col));
         } else {
-            item.as_collection_mutation().with_deserialized(*col.type, [&] (collection_mutation_view_description mview) {
+            auto cmv = item.as_collection_mutation();
             // Note: when some of the collection cells are dead and some are live
             // we need to encode a "live" deletion_time for the living ones.
             // It is not strictly required to update encoding_stats for the latter case
             // since { <int64_t>.min(), <int32_t>.max() } will not affect the encoding_stats
             // minimum values.  (See #4035)
-            update(mview.tomb);
-            for (auto& entry : mview.cells) {
+            update(cmv.tomb());
+            for (auto& entry : cmv) {
                 update(entry.second);
             }
-            });
         }
     });
 }

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -302,9 +302,7 @@ private:
                     writer.writer().Null();
                 }
             } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-                cell.as_collection_mutation().with_deserialized(*cdef.type, [&] (collection_mutation_view_description mv) {
-                    writer.write_collection_value(mv, cdef.type);
-                });
+                writer.write_collection_value(cell.as_collection_mutation(), cdef.type);
             } else {
                 writer.writer().Null();
             }

--- a/schema/column_computation.hh
+++ b/schema/column_computation.hh
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "bytes.hh"
+#include "utils/managed_bytes.hh"
 #include <memory>
 
 class schema;
@@ -116,7 +117,7 @@ class collection_column_computation final : public column_computation {
     const kind _kind;
     collection_column_computation(const bytes& collection_name, kind kind) : _collection_name(collection_name), _kind(kind) {}
 
-    using collection_kv = std::pair<bytes_view, atomic_cell_view>;
+    using collection_kv = std::pair<managed_bytes_view, atomic_cell_view>;
     void operate_on_collection_entries(
             std::invocable<collection_kv*, collection_kv*, tombstone> auto&& old_and_new_row_func, const schema& schema,
             const partition_key& key, const db::view::clustering_or_static_row& update, const std::optional<db::view::clustering_or_static_row>& existing) const;

--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -15,6 +15,7 @@
 #include "mutation/timestamp.hh"
 #include "utils/assert.hh"
 #include "utils/UUID_gen.hh"
+#include "utils/fragment_range.hh"
 #include "cql3/column_identifier.hh"
 #include "cql3/util.hh"
 #include "schema.hh"
@@ -2299,29 +2300,26 @@ void collection_column_computation::operate_on_collection_entries(
 
     const column_definition* cdef = schema.get_column_definition(_collection_name);
 
-    decltype(collection_mutation_view_description::cells) update_cells, existing_cells;
+    using cells_type = utils::chunked_vector<std::pair<managed_bytes_view, atomic_cell_view>>;
+    cells_type update_cells, existing_cells;
 
     const auto* update_cell = update.cells().find_cell(cdef->id);
     tombstone update_tombstone = update.tomb().tomb();
     if (update_cell) {
         collection_mutation_view update_col_view = update_cell->as_collection_mutation();
-        update_col_view.with_deserialized(*(cdef->type), [&update_cells, &update_tombstone] (collection_mutation_view_description descr) {
-            update_tombstone.apply(descr.tomb);
-            update_cells = descr.cells;
-        });
+        update_tombstone.apply(update_col_view.tomb());
+        update_cells = cells_type(std::from_range_t{}, update_col_view);
     }
     if (existing) {
         const auto* existing_cell = existing->cells().find_cell(cdef->id);
         if (existing_cell) {
             collection_mutation_view existing_col_view = existing_cell->as_collection_mutation();
-            existing_col_view.with_deserialized(*(cdef->type), [&existing_cells] (collection_mutation_view_description descr) {
-                existing_cells = descr.cells;
-            });
+            existing_cells = cells_type(std::from_range_t{}, existing_col_view);
         }
     }
 
     auto compare = [](const collection_kv& p1, const collection_kv& p2) {
-        return p1.first <=> p2.first;
+        return compare_unsigned(p1.first, p2.first);
     };
 
     // Both collections are assumed to be sorted by the keys.
@@ -2367,17 +2365,17 @@ bytes collection_column_computation::compute_value(const schema&, const partitio
 
 std::vector<db::view::view_key_and_action> collection_column_computation::compute_values_with_action(const schema& schema, const partition_key& key,
         const db::view::clustering_or_static_row& update, const std::optional<db::view::clustering_or_static_row>& existing) const {
-    using collection_kv = std::pair<bytes_view, atomic_cell_view>;
+    using collection_kv = std::pair<managed_bytes_view, atomic_cell_view>;
     auto serialize_cell = [_kind = _kind](const collection_kv& kv) -> bytes {
         using kind = collection_column_computation::kind;
         auto& [key, value] = kv;
         switch (_kind) {
             case kind::keys:
-                return bytes(key);
+                return to_bytes(key);
             case kind::values:
                 return value.value().linearize();
             case kind::entries:
-                bytes_opt elements[] = {bytes(key), value.value().linearize()};
+                bytes_opt elements[] = {to_bytes(key), value.value().linearize()};
                 return tuple_type_impl::build_value(elements);
         }
         std::abort(); // compiler will error

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -59,17 +59,17 @@ Builder& topology_mutation_builder_base<Builder>::apply_set(const char* cell, co
         cset.insert(vtype->decompose(data_value(v)));
     }
 
-    collection_mutation_description cm;
-    cm.cells.reserve(cset.size());
-    for (const bytes& raw : cset) {
-        cm.cells.emplace_back(raw, atomic_cell::make_live(*bytes_type, self().timestamp(), bytes_view(), self().ttl()));
-    }
-
+    tombstone tomb;
     if (apply_mode == collection_apply_mode::overwrite) {
-        cm.tomb = tombstone(self().timestamp() - 1, gc_clock::now());
+        tomb = tombstone(self().timestamp() - 1, gc_clock::now());
     }
 
-    self().row().apply(*cdef, cm.serialize());
+    collection_mutation_writer cm(tomb);
+    for (const bytes& raw : cset) {
+        cm.push_back(bytes_view(raw), atomic_cell::make_live(*bytes_type, self().timestamp(), bytes_view(), self().ttl()));
+    }
+
+    self().row().apply(*cdef, std::move(cm).finish());
     return self();
 }
 
@@ -82,9 +82,7 @@ Builder& topology_mutation_builder_base<Builder>::del(const char* cell) {
     if (!cdef->type->is_multi_cell()) {
         self().row().apply(*cdef, atomic_cell::make_dead(self().timestamp(), gc_clock::now()));
     } else {
-        collection_mutation_description cm;
-        cm.tomb = tombstone{self().timestamp(), gc_clock::now()};
-        self().row().apply(*cdef, cm.serialize());
+        self().row().apply(*cdef, collection_mutation_writer(tombstone{self().timestamp(), gc_clock::now()}).finish());
     }
     return self();
 }

--- a/service/topology_mutation.cc
+++ b/service/topology_mutation.cc
@@ -69,7 +69,7 @@ Builder& topology_mutation_builder_base<Builder>::apply_set(const char* cell, co
         cm.tomb = tombstone(self().timestamp() - 1, gc_clock::now());
     }
 
-    self().row().apply(*cdef, cm.serialize(*cdef->type));
+    self().row().apply(*cdef, cm.serialize());
     return self();
 }
 
@@ -84,7 +84,7 @@ Builder& topology_mutation_builder_base<Builder>::del(const char* cell) {
     } else {
         collection_mutation_description cm;
         cm.tomb = tombstone{self().timestamp(), gc_clock::now()};
-        self().row().apply(*cdef, cm.serialize(*cdef->type));
+        self().row().apply(*cdef, cm.serialize());
     }
     return self();
 }

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -233,7 +233,8 @@ private:
     class collection_mutation {
         const column_definition *_cdef;
     public:
-        collection_mutation_description cm;
+        tombstone tomb;
+        utils::chunked_vector<std::pair<bytes, atomic_cell>> cells;
 
         // We need to get a copy of the prefix here, because the outer object may be short lived.
         collection_mutation(const column_definition *cdef)
@@ -252,7 +253,11 @@ private:
             if (!_cdef) {
                 return;
             }
-            auto ac = atomic_cell_or_collection::from_collection_mutation(cm.serialize());
+            collection_mutation_writer writer(tomb);
+            for (const auto& [k, v] : cells) {
+                writer.push_back(bytes_view(k), atomic_cell_view(v));
+            }
+            auto ac = atomic_cell_or_collection::from_collection_mutation(std::move(writer).finish());
             if (_cdef->is_static()) {
                 mf.mutate_as_static_row(s, [&] (static_row& sr) mutable {
                     sr.set_cell(*_cdef, std::move(ac));
@@ -308,11 +313,11 @@ private:
     }
 
     void update_pending_collection(const column_definition *cdef, bytes&& col, atomic_cell&& ac) {
-        pending_collection(cdef).cm.cells.emplace_back(std::move(col), std::move(ac));
+        pending_collection(cdef).cells.emplace_back(std::move(col), std::move(ac));
     }
 
     void update_pending_collection(const column_definition *cdef, tombstone&& t) {
-        pending_collection(cdef).cm.tomb = std::move(t);
+        pending_collection(cdef).tomb = std::move(t);
     }
 
     void flush_pending_collection(const schema& s) {

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -252,7 +252,7 @@ private:
             if (!_cdef) {
                 return;
             }
-            auto ac = atomic_cell_or_collection::from_collection_mutation(cm.serialize(*_cdef->type));
+            auto ac = atomic_cell_or_collection::from_collection_mutation(cm.serialize());
             if (_cdef->is_static()) {
                 mf.mutate_as_static_row(s, [&] (static_row& sr) mutable {
                     sr.set_cell(*_cdef, std::move(ac));

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -74,7 +74,7 @@ public:
         atomic_cell_or_collection val;
     };
     std::vector<cell> _cells;
-    collection_mutation_description _cm;
+    std::optional<collection_mutation_writer> _cm;
 
     data_consumer::proceed consume_range_tombstone_start(clustering_key_prefix ck, bound_kind k, tombstone t) {
         sstlog.trace("mp_row_consumer_m {}: consume_range_tombstone_start(ck={}, k={}, t={})", fmt::ptr(this), ck, k, t);
@@ -422,7 +422,7 @@ public:
                                                     ttl,
                                                     local_deletion_time,
                                                     atomic_cell::collection_member::yes);
-            _cm.cells.emplace_back(to_bytes(cell_path), std::move(ac));
+            _cm->push_back(cell_path, std::move(ac));
         } else {
             auto ac = is_deleted ? atomic_cell::make_dead(timestamp, local_deletion_time)
                                  : make_atomic_cell(*column_def.type, timestamp, value, ttl, local_deletion_time,
@@ -435,26 +435,24 @@ public:
     data_consumer::proceed consume_complex_column_start(const sstables::column_translation::column_info& column_info,
                                                  tombstone tomb) {
         sstlog.trace("mp_row_consumer_m {}: consume_complex_column_start({}, {})", fmt::ptr(this), column_info.id, tomb);
-        _cm.tomb = tomb;
-        _cm.cells.clear();
+        _cm.emplace(tomb);
         return data_consumer::proceed::yes;
     }
 
     data_consumer::proceed consume_complex_column_end(const sstables::column_translation::column_info& column_info) {
         const std::optional<column_id>& column_id = column_info.id;
         sstlog.trace("mp_row_consumer_m {}: consume_complex_column_end({})", fmt::ptr(this), column_id);
-        if (_cm.tomb) {
-            check_column_missing_in_current_schema(column_info, _cm.tomb.timestamp);
+        if (_cm->tombstone()) {
+            check_column_missing_in_current_schema(column_info, _cm->tombstone().timestamp);
         }
         if (column_id) {
             const column_definition& column_def = get_column_definition(column_id);
-            if (!_cm.cells.empty() || (_cm.tomb && _cm.tomb.timestamp > column_def.dropped_at())) {
+            if (!_cm->empty() || (_cm->tombstone() && _cm->tombstone().timestamp > column_def.dropped_at())) {
                 check_schema_mismatch(column_info, column_def);
-                _cells.push_back({column_def.id, _cm.serialize()});
+                _cells.push_back({column_def.id, std::move(*_cm).finish()});
             }
         }
-        _cm.tomb = {};
-        _cm.cells.clear();
+        _cm.reset();
         return data_consumer::proceed::yes;
     }
 

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -450,7 +450,7 @@ public:
             const column_definition& column_def = get_column_definition(column_id);
             if (!_cm.cells.empty() || (_cm.tomb && _cm.tomb.timestamp > column_def.dropped_at())) {
                 check_schema_mismatch(column_info, column_def);
-                _cells.push_back({column_def.id, _cm.serialize(*column_def.type)});
+                _cells.push_back({column_def.id, _cm.serialize()});
             }
         }
         _cm.tomb = {};

--- a/sstables/mx/writer.cc
+++ b/sstables/mx/writer.cc
@@ -1397,23 +1397,23 @@ void writer::write_collection(bytes_ostream& writer, const clustering_key_prefix
         bool has_complex_deletion) {
     uint64_t current_pos = writer.size();
     uint64_t collection_elements = 0;
-    collection.with_deserialized(*cdef.type, [&] (collection_mutation_view_description mview) {
-        if (has_complex_deletion) {
-            write_delta_deletion_time(writer, mview.tomb);
-            _c_stats.update(mview.tomb);
-        }
-
-        collection_elements = mview.cells.size();
-        write_vint(writer, collection_elements);
-        if (!mview.cells.empty()) {
-            ++_c_stats.column_count;
-        }
-        for (const auto& [cell_path, cell]: mview.cells) {
-            write_cell(writer, clustering_key, cell, cdef, properties, cell_path);
-            thread::maybe_yield();
-        }
-        _c_stats.cells_count += collection_elements;
-    });
+    auto tomb = collection.tomb();
+    if (has_complex_deletion) {
+        write_delta_deletion_time(writer, tomb);
+        _c_stats.update(tomb);
+    }
+    collection_elements = collection.size();
+    write_vint(writer, collection_elements);
+    if (collection_elements > 0) {
+        ++_c_stats.column_count;
+    }
+    for (const auto& [cell_path, cell] : collection) {
+        cell_path.with_linearized([&](bytes_view path) {
+            write_cell(writer, clustering_key, cell, cdef, properties, path);
+        });
+        thread::maybe_yield();
+    }
+    _c_stats.cells_count += collection_elements;
     uint64_t size = writer.size() - current_pos;
     maybe_record_large_cells(_sst, *_partition_key, clustering_key, cdef, size, collection_elements);
 }
@@ -1475,12 +1475,11 @@ static bool row_has_complex_deletion(const schema& s, const row& r, column_kind 
         if (cdef.is_atomic()) {
             return stop_iteration::no;
         }
-        return c.as_collection_mutation().with_deserialized(*cdef.type, [&] (collection_mutation_view_description mview) {
-            if (mview.tomb) {
-                result = true;
-            }
-            return stop_iteration(static_cast<bool>(mview.tomb));
-        });
+        auto tomb = c.as_collection_mutation().tomb();
+        if (tomb) {
+            result = true;
+        }
+        return stop_iteration(static_cast<bool>(tomb));
     });
 
     return result;

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -245,7 +245,7 @@ SEASTAR_THREAD_TEST_CASE(test_freeze_unfreeze_with_large_collection_cells) {
         for (size_t i = 0; i < num_entries; ++i) {
             cmd.cells.emplace_back(int32_type->decompose(int32_t(i)), make_atomic_cell(atomic_cell::collection_member::yes));
         }
-        m.set_clustered_cell(ck, cdef_collection, atomic_cell_or_collection(cmd.serialize(*collection_type)));
+        m.set_clustered_cell(ck, cdef_collection, atomic_cell_or_collection(cmd.serialize()));
     }
 
     for (auto do_freeze_gently : {false, true}) {

--- a/test/boost/frozen_mutation_test.cc
+++ b/test/boost/frozen_mutation_test.cc
@@ -241,11 +241,12 @@ SEASTAR_THREAD_TEST_CASE(test_freeze_unfreeze_with_large_collection_cells) {
 
         m.set_clustered_cell(ck, cdef_atomic, atomic_cell_or_collection(make_atomic_cell(atomic_cell::collection_member::no)));
 
-        collection_mutation_description cmd;
+        collection_mutation_writer w({});
         for (size_t i = 0; i < num_entries; ++i) {
-            cmd.cells.emplace_back(int32_type->decompose(int32_t(i)), make_atomic_cell(atomic_cell::collection_member::yes));
+            auto k = int32_type->decompose(int32_t(i));
+            w.push_back(bytes_view(k), make_atomic_cell(atomic_cell::collection_member::yes));
         }
-        m.set_clustered_cell(ck, cdef_collection, atomic_cell_or_collection(cmd.serialize()));
+        m.set_clustered_cell(ck, cdef_collection, atomic_cell_or_collection(std::move(w).finish()));
     }
 
     for (auto do_freeze_gently : {false, true}) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -227,6 +227,141 @@ collection_mutation_description make_collection_mutation(tombstone t, bytes key1
     return m;
 }
 
+// Unit tests for collection_mutation_writer and collection_mutation_view::iterator,
+// which provide direct, zero-copy access to the serialized collection format.
+
+// Verifies that collection_mutation_writer correctly serializes a collection
+// and that collection_mutation_view (size(), tomb(), empty()) reads it back faithfully.
+SEASTAR_THREAD_TEST_CASE(test_collection_mutation_writer) {
+    // empty() with no tombstone and no cells
+    {
+        collection_mutation_writer w({});
+        BOOST_REQUIRE(w.empty());
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+        BOOST_REQUIRE(cmv.empty());
+        BOOST_REQUIRE(!cmv.tomb());
+        BOOST_REQUIRE_EQUAL(cmv.size(), 0u);
+    }
+
+    // empty() is false when a tombstone is present even if there are no cells
+    {
+        tombstone t(api::new_timestamp(), gc_clock::now());
+        collection_mutation_writer w(t);
+        BOOST_REQUIRE(!w.empty());
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+        BOOST_REQUIRE(!cmv.empty());
+        BOOST_REQUIRE_EQUAL(cmv.tomb(), t);
+        BOOST_REQUIRE_EQUAL(cmv.size(), 0u);
+    }
+
+    // size() and tomb() after pushing cells
+    {
+        auto key1 = int32_type->decompose(1);
+        auto key2 = int32_type->decompose(2);
+        auto key3 = int32_type->decompose(3);
+
+        auto cell1 = atomic_cell::make_live(*bytes_type, 1, bytes("v1"), atomic_cell::collection_member::yes);
+        auto cell2 = atomic_cell::make_live(*bytes_type, 2, bytes("v2"), atomic_cell::collection_member::yes);
+        auto cell3 = atomic_cell::make_dead(3, gc_clock::now());
+
+        tombstone t(api::new_timestamp(), gc_clock::now());
+        collection_mutation_writer w(t);
+        w.push_back(bytes_view(key1), atomic_cell_view(cell1));
+        w.push_back(bytes_view(key2), atomic_cell_view(cell2));
+        w.push_back(bytes_view(key3), atomic_cell_view(cell3));
+        BOOST_REQUIRE(!w.empty());
+
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+
+        BOOST_REQUIRE(!cmv.empty());
+        BOOST_REQUIRE_EQUAL(cmv.tomb(), t);
+        BOOST_REQUIRE_EQUAL(cmv.size(), 3u);
+    }
+}
+
+// Verifies the collection_mutation_view accessors (tomb(), size(), empty(),
+// begin()/end()) across all variants: default-constructed, tombstone only,
+// cells only, and tombstone with cells.
+SEASTAR_THREAD_TEST_CASE(test_collection_mutation_view) {
+    auto cells_equal = [] (const auto& c1, const auto& c2) {
+        return c1.first == c2.first && c1.second.value().linearize() == c2.second.value().linearize();
+    };
+
+    // default-constructed collection_mutation is semantically empty
+    {
+        collection_mutation cm;
+        collection_mutation_view cmv = cm;
+        BOOST_REQUIRE(cmv.empty());
+        BOOST_REQUIRE(!cmv.tomb());
+        BOOST_REQUIRE_EQUAL(cmv.size(), 0u);
+        BOOST_REQUIRE(cmv.begin() == cmv.end());
+    }
+
+    // Iterating an empty collection produces no elements
+    {
+        collection_mutation_writer w({});
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+        BOOST_REQUIRE(cmv.begin() == cmv.end());
+    }
+
+    // Iterating with a tombstone but no cells also produces no elements
+    {
+        tombstone t(api::new_timestamp(), gc_clock::now());
+        collection_mutation_writer w(t);
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+        BOOST_REQUIRE(cmv.begin() == cmv.end());
+    }
+
+    // Round-trip: cells written by the writer are produced by the iterator
+    // in the same order with the same key and value.
+    {
+        auto key1 = int32_type->decompose(10);
+        auto key2 = int32_type->decompose(20);
+        auto key3 = int32_type->decompose(30);
+
+        auto cell1 = atomic_cell::make_live(*bytes_type, 1, bytes("value1"), atomic_cell::collection_member::yes);
+        auto cell2 = atomic_cell::make_live(*bytes_type, 2, bytes("value2"), atomic_cell::collection_member::yes);
+        auto cell3 = atomic_cell::make_live(*bytes_type, 3, bytes("value3"), atomic_cell::collection_member::yes);
+
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(key1), atomic_cell_view(cell1));
+        w.push_back(bytes_view(key2), atomic_cell_view(cell2));
+        w.push_back(bytes_view(key3), atomic_cell_view(cell3));
+        auto cm = std::move(w).finish();
+        collection_mutation_view cmv = cm;
+
+        BOOST_REQUIRE_EQUAL(cmv.size(), 3u);
+
+        auto it = cmv.begin();
+        BOOST_REQUIRE(it != cmv.end());
+        BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(bytes_view(key1), cell1)));
+
+        ++it;
+        BOOST_REQUIRE(it != cmv.end());
+        BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(bytes_view(key2), cell2)));
+
+        ++it;
+        BOOST_REQUIRE(it != cmv.end());
+        BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(bytes_view(key3), cell3)));
+
+        ++it;
+        BOOST_REQUIRE(it == cmv.end());
+
+        // A second traversal of the same view yields the same results
+        size_t count = 0;
+        for (auto& [k, v] : cmv) {
+            (void)k; (void)v;
+            ++count;
+        }
+        BOOST_REQUIRE_EQUAL(count, 3u);
+    }
+}
+
 SEASTAR_TEST_CASE(test_map_mutations) {
     return seastar::async([] {
         tests::reader_concurrency_semaphore_wrapper semaphore;

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -242,19 +242,19 @@ SEASTAR_TEST_CASE(test_map_mutations) {
         auto& column = *s->get_column_definition("s1");
         auto mmut1 = make_collection_mutation({}, int32_type->decompose(101), make_collection_member(utf8_type, sstring("101")));
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize(*my_map_type));
+        m1.set_static_cell(column, mmut1.serialize());
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, int32_type->decompose(102), make_collection_member(utf8_type, sstring("102")));
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize(*my_map_type));
+        m2.set_static_cell(column, mmut2.serialize());
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, int32_type->decompose(103), make_collection_member(utf8_type, sstring("103")));
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize(*my_map_type));
+        m3.set_static_cell(column, mmut3.serialize());
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, int32_type->decompose(102), make_collection_member(utf8_type, sstring("102 override")));
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize(*my_map_type));
+        m2o.set_static_cell(column, mmut2o.serialize());
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -283,19 +283,19 @@ SEASTAR_TEST_CASE(test_set_mutations) {
         auto& column = *s->get_column_definition("s1");
         auto mmut1 = make_collection_mutation({}, int32_type->decompose(101), make_atomic_cell());
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize(*my_set_type));
+        m1.set_static_cell(column, mmut1.serialize());
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, int32_type->decompose(102), make_atomic_cell());
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize(*my_set_type));
+        m2.set_static_cell(column, mmut2.serialize());
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, int32_type->decompose(103), make_atomic_cell());
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize(*my_set_type));
+        m3.set_static_cell(column, mmut3.serialize());
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, int32_type->decompose(102), make_atomic_cell());
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize(*my_set_type));
+        m2o.set_static_cell(column, mmut2o.serialize());
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -325,19 +325,19 @@ SEASTAR_TEST_CASE(test_list_mutations) {
         auto make_key = [] { return timeuuid_type->decompose(utils::UUID_gen::get_time_UUID()); };
         auto mmut1 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 101));
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize(*my_list_type));
+        m1.set_static_cell(column, mmut1.serialize());
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 102));
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize(*my_list_type));
+        m2.set_static_cell(column, mmut2.serialize());
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 103));
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize(*my_list_type));
+        m3.set_static_cell(column, mmut3.serialize());
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 102));
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize(*my_list_type));
+        m2o.set_static_cell(column, mmut2o.serialize());
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -373,19 +373,19 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     auto mut1 = make_collection_mutation({}, serialize_field_index(0), make_collection_member(int32_type, 0),
             serialize_field_index(2), make_collection_member(long_type, int64_t(2)));
     mutation m1(s, key);
-    m1.set_static_cell(column, mut1.serialize(*ut));
+    m1.set_static_cell(column, mut1.serialize());
     mt->apply(m1);
 
     // {d: "text"}
     auto mut2 = make_collection_mutation({}, serialize_field_index(3), make_collection_member(utf8_type, "text"));
     mutation m2(s, key);
-    m2.set_static_cell(column, mut2.serialize(*ut));
+    m2.set_static_cell(column, mut2.serialize());
     mt->apply(m2);
 
     // {c: 3}
     auto mut3 = make_collection_mutation({}, serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
     mutation m3(s, key);
-    m3.set_static_cell(column, mut3.serialize(*ut));
+    m3.set_static_cell(column, mut3.serialize());
     mt->apply(m3);
 
     auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -446,7 +446,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
         mutation mut(schema, pk);
 
         row r;
-        r.apply(cdef, atomic_cell_or_collection(cmd.serialize(*collection_type)));
+        r.apply(cdef, atomic_cell_or_collection(cmd.serialize()));
         mut.apply(mutation_fragment(*schema, semaphore.make_permit(), clustering_row(clustering_key_prefix::make_empty(), {}, {}, std::move(r))));
 
         return mut;
@@ -507,10 +507,10 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_serialization_exception_safety) {
     }
 
     // We need an undisturbed run first to create all thread_local variables.
-    cmd.serialize(*collection_type);
+    cmd.serialize();
 
     memory::with_allocation_failures([&] {
-        cmd.serialize(*collection_type);
+        cmd.serialize();
     });
 }
 
@@ -1277,7 +1277,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m1.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 2, bytes_type->decompose(data_value(bytes("v2:value4")))));
         auto mset1 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell(), int32_type->decompose(2), make_atomic_cell());
-        m1.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset1.serialize(*my_set_type));
+        m1.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset1.serialize());
 
         mutation m2(s, partition_key::from_single_value(*s, "key1"));
         m2.set_clustered_cell(ckey1, *s->get_column_definition("v1"),
@@ -1290,7 +1290,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m2.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 3, bytes_type->decompose(data_value(bytes("v2:value4a")))));
         auto mset2 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell(), int32_type->decompose(3), make_atomic_cell());
-        m2.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset2.serialize(*my_set_type));
+        m2.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset2.serialize());
 
         mutation m3(s, partition_key::from_single_value(*s, "key1"));
         m3.set_clustered_cell(ckey1, *s->get_column_definition("v1"),
@@ -1301,7 +1301,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m3.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 3, bytes_type->decompose(data_value(bytes("v2:value4a")))));
         auto mset3 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell());
-        m3.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset3.serialize(*my_set_type));
+        m3.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset3.serialize());
 
         mutation m12(s, partition_key::from_single_value(*s, "key1"));
         m12.apply(m1);
@@ -1992,12 +1992,12 @@ SEASTAR_TEST_CASE(test_collection_cell_diff) {
         mcol1.cells.emplace_back(
                 bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size()),
                 atomic_cell::make_live(*bytes_type, api::timestamp_type(1), to_bytes("element")));
-        m1.set_clustered_cell(clustering_key::make_empty(), col, mcol1.serialize(*col.type));
+        m1.set_clustered_cell(clustering_key::make_empty(), col, mcol1.serialize());
 
         mutation m2(s, k);
         collection_mutation_description mcol2;
         mcol2.tomb = tombstone(api::timestamp_type(2), gc_clock::now());
-        m2.set_clustered_cell(clustering_key::make_empty(), col, mcol2.serialize(*col.type));
+        m2.set_clustered_cell(clustering_key::make_empty(), col, mcol2.serialize());
 
         mutation m12 = m1;
         m12.apply(m2);
@@ -2621,7 +2621,7 @@ SEASTAR_THREAD_TEST_CASE(test_cell_external_memory_usage) {
         auto collection_type = map_type_impl::get_instance(int32_type, bytes_type, true);
 
         auto m = make_collection_mutation({ }, int32_type->decompose(0), make_collection_member(bytes_type, data_value(bytes(bv))));
-        auto cell = atomic_cell_or_collection(m.serialize(*collection_type));
+        auto cell = atomic_cell_or_collection(m.serialize());
 
         with_allocator(alloc, [&] {
             auto before = alloc.allocated_bytes();
@@ -3881,7 +3881,7 @@ SEASTAR_TEST_CASE(test_compact_and_expire_cell_stats) {
         collection_mutation_description desc;
         desc.tomb = tomb;
         do_make_collection(desc, std::forward<decltype(cells)>(cells)...);
-        return desc.serialize(*collection_type);
+        return desc.serialize();
     };
 
     const auto check = [&] (row_content rc, row_tombstone rt, compact_and_expire_result expected_res, std::source_location sl = std::source_location::current()) {
@@ -3898,7 +3898,7 @@ SEASTAR_TEST_CASE(test_compact_and_expire_cell_stats) {
             }
             if (rc.collection_column) {
                 const auto cdef = *s.get_column_definition(column_names.at(col_kind)[1]);
-                r.apply(cdef, atomic_cell_or_collection(collection_mutation(*collection_type, *rc.collection_column)));
+                r.apply(cdef, atomic_cell_or_collection(collection_mutation(*rc.collection_column)));
             }
             auto res = r.compact_and_expire(s, col_kind, rt, now, always_gc, now);
             BOOST_REQUIRE_EQUAL(res, expected_res);

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -2837,37 +2837,41 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     auto value = data_value(to_bytes("value"));
 
     // No collection tombstone, row tombstone covers all cells
-    auto cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
+    auto cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value)).serialize();
     auto row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
-    auto res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!res.is_live());
-    BOOST_CHECK(!cmut.tomb);
-    BOOST_CHECK(cmut.cells.empty());
+    auto [out1, res1] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
+    BOOST_CHECK(!res1.is_live());
+    BOOST_CHECK(collection_mutation_view(out1).empty());
 
     // No collection tombstone, row tombstone doesn't cover anything
-    cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
+    cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value)).serialize();
     row_tomb = row_tombstone(tombstone { -1, gc_clock::time_point() });
-    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(res.is_live());
-    BOOST_CHECK(!cmut.tomb);
-    BOOST_CHECK_EQUAL(cmut.cells.size(), 1);
+    auto [out2, res2] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
+    BOOST_CHECK(res2.is_live());
+    {
+        collection_mutation_view v = out2;
+        BOOST_CHECK(!v.tomb());
+        BOOST_CHECK_EQUAL(v.size(), 1);
+    }
 
     // Collection tombstone covers everything
-    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
+    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value)).serialize();
     row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
-    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!res.is_live());
-    BOOST_CHECK(cmut.tomb);
-    BOOST_CHECK_EQUAL(cmut.tomb.timestamp, 2);
-    BOOST_CHECK(cmut.cells.empty());
+    auto [out3, res3] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
+    BOOST_CHECK(!res3.is_live());
+    {
+        collection_mutation_view v = out3;
+        BOOST_CHECK(v.tomb());
+        BOOST_CHECK_EQUAL(v.tomb().timestamp, 2);
+        BOOST_CHECK_EQUAL(v.size(), 0);
+    }
 
     // Collection tombstone covered by row tombstone
-    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
+    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value)).serialize();
     row_tomb = row_tombstone(tombstone { 3, gc_clock::time_point() });
-    res = cmut.compact_and_expire(0, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point());
-    BOOST_CHECK(!res.is_live());
-    BOOST_CHECK(!cmut.tomb);
-    BOOST_CHECK(cmut.cells.empty());
+    auto [out4, res4] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
+    BOOST_CHECK(!res4.is_live());
+    BOOST_CHECK(collection_mutation_view(out4).empty());
 }
 
 namespace {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -210,21 +210,19 @@ SEASTAR_TEST_CASE(test_row_tombstone_updates) {
     return make_ready_future<>();
 }
 
-collection_mutation_description make_collection_mutation(tombstone t, bytes key, atomic_cell cell)
+collection_mutation make_collection_mutation(tombstone t, bytes key, atomic_cell cell)
 {
-    collection_mutation_description m;
-    m.tomb = t;
-    m.cells.emplace_back(std::move(key), std::move(cell));
-    return m;
+    collection_mutation_writer w(t);
+    w.push_back(bytes_view(key), atomic_cell_view(cell));
+    return std::move(w).finish();
 }
 
-collection_mutation_description make_collection_mutation(tombstone t, bytes key1, atomic_cell cell1,  bytes key2, atomic_cell cell2)
+collection_mutation make_collection_mutation(tombstone t, bytes key1, atomic_cell cell1,  bytes key2, atomic_cell cell2)
 {
-    collection_mutation_description m;
-    m.tomb = t;
-    m.cells.emplace_back(std::move(key1), std::move(cell1));
-    m.cells.emplace_back(std::move(key2), std::move(cell2));
-    return m;
+    collection_mutation_writer w(t);
+    w.push_back(bytes_view(key1), atomic_cell_view(cell1));
+    w.push_back(bytes_view(key2), atomic_cell_view(cell2));
+    return std::move(w).finish();
 }
 
 // Unit tests for collection_mutation_writer and collection_mutation_view::iterator,
@@ -377,19 +375,19 @@ SEASTAR_TEST_CASE(test_map_mutations) {
         auto& column = *s->get_column_definition("s1");
         auto mmut1 = make_collection_mutation({}, int32_type->decompose(101), make_collection_member(utf8_type, sstring("101")));
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize());
+        m1.set_static_cell(column, std::move(mmut1));
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, int32_type->decompose(102), make_collection_member(utf8_type, sstring("102")));
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize());
+        m2.set_static_cell(column, std::move(mmut2));
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, int32_type->decompose(103), make_collection_member(utf8_type, sstring("103")));
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize());
+        m3.set_static_cell(column, std::move(mmut3));
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, int32_type->decompose(102), make_collection_member(utf8_type, sstring("102 override")));
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize());
+        m2o.set_static_cell(column, std::move(mmut2o));
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -416,19 +414,19 @@ SEASTAR_TEST_CASE(test_set_mutations) {
         auto& column = *s->get_column_definition("s1");
         auto mmut1 = make_collection_mutation({}, int32_type->decompose(101), make_atomic_cell());
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize());
+        m1.set_static_cell(column, std::move(mmut1));
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, int32_type->decompose(102), make_atomic_cell());
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize());
+        m2.set_static_cell(column, std::move(mmut2));
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, int32_type->decompose(103), make_atomic_cell());
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize());
+        m3.set_static_cell(column, std::move(mmut3));
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, int32_type->decompose(102), make_atomic_cell());
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize());
+        m2o.set_static_cell(column, std::move(mmut2o));
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -456,19 +454,19 @@ SEASTAR_TEST_CASE(test_list_mutations) {
         auto make_key = [] { return timeuuid_type->decompose(utils::UUID_gen::get_time_UUID()); };
         auto mmut1 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 101));
         mutation m1(s, key);
-        m1.set_static_cell(column, mmut1.serialize());
+        m1.set_static_cell(column, std::move(mmut1));
         mt->apply(m1);
         auto mmut2 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 102));
         mutation m2(s, key);
-        m2.set_static_cell(column, mmut2.serialize());
+        m2.set_static_cell(column, std::move(mmut2));
         mt->apply(m2);
         auto mmut3 = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 103));
         mutation m3(s, key);
-        m3.set_static_cell(column, mmut3.serialize());
+        m3.set_static_cell(column, std::move(mmut3));
         mt->apply(m3);
         auto mmut2o = make_collection_mutation({}, make_key(), make_collection_member(int32_type, 102));
         mutation m2o(s, key);
-        m2o.set_static_cell(column, mmut2o.serialize());
+        m2o.set_static_cell(column, std::move(mmut2o));
         mt->apply(m2o);
 
         auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -502,19 +500,19 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     auto mut1 = make_collection_mutation({}, serialize_field_index(0), make_collection_member(int32_type, 0),
             serialize_field_index(2), make_collection_member(long_type, int64_t(2)));
     mutation m1(s, key);
-    m1.set_static_cell(column, mut1.serialize());
+    m1.set_static_cell(column, std::move(mut1));
     mt->apply(m1);
 
     // {d: "text"}
     auto mut2 = make_collection_mutation({}, serialize_field_index(3), make_collection_member(utf8_type, "text"));
     mutation m2(s, key);
-    m2.set_static_cell(column, mut2.serialize());
+    m2.set_static_cell(column, std::move(mut2));
     mt->apply(m2);
 
     // {c: 3}
     auto mut3 = make_collection_mutation({}, serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
     mutation m3(s, key);
-    m3.set_static_cell(column, mut3.serialize());
+    m3.set_static_cell(column, std::move(mut3));
     mt->apply(m3);
 
     auto p = get_partition(semaphore.make_permit(), *mt, key);
@@ -563,13 +561,13 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
     const std::array sizes_kb{size_t(1), size_t(10), size_t(64)};
     auto mt = make_lw_shared<replica::memtable>(schema);
 
-    auto make_mutation_with_collection = [&schema, &semaphore, collection_type] (partition_key pk, collection_mutation_description cmd) {
+    auto make_mutation_with_collection = [&schema, &semaphore, collection_type] (partition_key pk, collection_mutation cmd) {
         const auto& cdef = schema->column_at(column_kind::regular_column, 0);
 
         mutation mut(schema, pk);
 
         row r;
-        r.apply(cdef, atomic_cell_or_collection(cmd.serialize()));
+        r.apply(cdef, atomic_cell_or_collection(std::move(cmd)));
         mut.apply(mutation_fragment(*schema, semaphore.make_permit(), clustering_row(clustering_key_prefix::make_empty(), {}, {}, std::move(r))));
 
         return mut;
@@ -586,16 +584,17 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_allocation) {
         const api::timestamp_type ts1 = 1;
         const api::timestamp_type ts2 = 2;
 
-        collection_mutation_description cmd1;
-        collection_mutation_description cmd2;
+        collection_mutation_writer w1({});
+        collection_mutation_writer w2({});
 
         for (size_t j = 0; j < size_t(8 * 1024 * 1024) / blob_size; ++j) { // we want no more than 8MB total size
-            cmd1.cells.emplace_back(int32_type->decompose(int(j)), atomic_cell::make_live(*value_type, ts1, blob, atomic_cell::collection_member::yes));
-            cmd2.cells.emplace_back(int32_type->decompose(int(j)), atomic_cell::make_live(*value_type, ts2, blob, atomic_cell::collection_member::yes));
+            auto key_bytes = int32_type->decompose(int(j));
+            w1.push_back(bytes_view(key_bytes), atomic_cell::make_live(*value_type, ts1, blob, atomic_cell::collection_member::yes));
+            w2.push_back(bytes_view(key_bytes), atomic_cell::make_live(*value_type, ts2, blob, atomic_cell::collection_member::yes));
         }
 
-        mt->apply(make_mutation_with_collection(pk, std::move(cmd1)));
-        mt->apply(make_mutation_with_collection(pk, std::move(cmd2))); // this should trigger a merge of the two collections
+        mt->apply(make_mutation_with_collection(pk, std::move(w1).finish()));
+        mt->apply(make_mutation_with_collection(pk, std::move(w2).finish())); // this should trigger a merge of the two collections
 
         auto rd = mt->make_mutation_reader(schema, semaphore.make_permit());
         auto close_rd = deferred_close(rd);
@@ -623,17 +622,25 @@ SEASTAR_THREAD_TEST_CASE(test_large_collection_serialization_exception_safety) {
     const bytes blob(blob_size, 'a');
     const api::timestamp_type ts = 1;
 
-    collection_mutation_description cmd;
-
+    std::vector<bytes> keys;
+    keys.reserve(256);
     for (size_t i = 0; i != 256; ++i) {
-        cmd.cells.emplace_back(int32_type->decompose(int(i)), atomic_cell::make_live(*value_type, ts, blob, atomic_cell::collection_member::yes));
+        keys.push_back(int32_type->decompose(int(i)));
     }
 
+    const auto make_cmd = [&]() {
+        collection_mutation_writer w({});
+        for (const auto& k : keys) {
+            w.push_back(bytes_view(k), atomic_cell::make_live(*value_type, ts, blob, atomic_cell::collection_member::yes));
+        }
+        return std::move(w).finish();
+    };
+
     // We need an undisturbed run first to create all thread_local variables.
-    cmd.serialize();
+    make_cmd();
 
     memory::with_allocation_failures([&] {
-        cmd.serialize();
+        make_cmd();
     });
 }
 
@@ -1400,7 +1407,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m1.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 2, bytes_type->decompose(data_value(bytes("v2:value4")))));
         auto mset1 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell(), int32_type->decompose(2), make_atomic_cell());
-        m1.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset1.serialize());
+        m1.set_clustered_cell(ckey2, *s->get_column_definition("v3"), std::move(mset1));
 
         mutation m2(s, partition_key::from_single_value(*s, "key1"));
         m2.set_clustered_cell(ckey1, *s->get_column_definition("v1"),
@@ -1413,7 +1420,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m2.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 3, bytes_type->decompose(data_value(bytes("v2:value4a")))));
         auto mset2 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell(), int32_type->decompose(3), make_atomic_cell());
-        m2.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset2.serialize());
+        m2.set_clustered_cell(ckey2, *s->get_column_definition("v3"), std::move(mset2));
 
         mutation m3(s, partition_key::from_single_value(*s, "key1"));
         m3.set_clustered_cell(ckey1, *s->get_column_definition("v1"),
@@ -1424,7 +1431,7 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         m3.set_clustered_cell(ckey2, *s->get_column_definition("v2"),
             atomic_cell::make_live(*bytes_type, 3, bytes_type->decompose(data_value(bytes("v2:value4a")))));
         auto mset3 = make_collection_mutation({}, int32_type->decompose(1), make_atomic_cell());
-        m3.set_clustered_cell(ckey2, *s->get_column_definition("v3"), mset3.serialize());
+        m3.set_clustered_cell(ckey2, *s->get_column_definition("v3"), std::move(mset3));
 
         mutation m12(s, partition_key::from_single_value(*s, "key1"));
         m12.apply(m1);
@@ -2107,16 +2114,17 @@ SEASTAR_TEST_CASE(test_collection_cell_diff) {
         auto k = dht::decorate_key(*s, partition_key::from_single_value(*s, to_bytes("key")));
         mutation m1(s, k);
         auto uuid = utils::UUID_gen::get_time_UUID_bytes();
-        collection_mutation_description mcol1;
-        mcol1.cells.emplace_back(
-                bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size()),
-                atomic_cell::make_live(*bytes_type, api::timestamp_type(1), to_bytes("element")));
-        m1.set_clustered_cell(clustering_key::make_empty(), col, mcol1.serialize());
+        auto mcol1_key = bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size());
+        auto mcol1_cell = atomic_cell::make_live(*bytes_type, api::timestamp_type(1), to_bytes("element"));
+        collection_mutation_writer mcol1_w({});
+        mcol1_w.push_back(bytes_view(mcol1_key), atomic_cell_view(mcol1_cell));
+        auto mcol1 = std::move(mcol1_w).finish();
+        m1.set_clustered_cell(clustering_key::make_empty(), col, std::move(mcol1));
 
         mutation m2(s, k);
-        collection_mutation_description mcol2;
-        mcol2.tomb = tombstone(api::timestamp_type(2), gc_clock::now());
-        m2.set_clustered_cell(clustering_key::make_empty(), col, mcol2.serialize());
+        collection_mutation_writer mcol2_w(tombstone(api::timestamp_type(2), gc_clock::now()));
+        auto mcol2 = std::move(mcol2_w).finish();
+        m2.set_clustered_cell(clustering_key::make_empty(), col, std::move(mcol2));
 
         mutation m12 = m1;
         m12.apply(m2);
@@ -2740,7 +2748,7 @@ SEASTAR_THREAD_TEST_CASE(test_cell_external_memory_usage) {
         auto collection_type = map_type_impl::get_instance(int32_type, bytes_type, true);
 
         auto m = make_collection_mutation({ }, int32_type->decompose(0), make_collection_member(bytes_type, data_value(bytes(bv))));
-        auto cell = atomic_cell_or_collection(m.serialize());
+        auto cell = atomic_cell_or_collection(std::move(m));
 
         with_allocator(alloc, [&] {
             auto before = alloc.allocated_bytes();
@@ -2821,14 +2829,14 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     auto value = data_value(to_bytes("value"));
 
     // No collection tombstone, row tombstone covers all cells
-    auto cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value)).serialize();
+    auto cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
     auto row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
     auto [out1, res1] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
     BOOST_CHECK(!res1.is_live());
     BOOST_CHECK(collection_mutation_view(out1).empty());
 
     // No collection tombstone, row tombstone doesn't cover anything
-    cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value)).serialize();
+    cmut = make_collection_mutation({}, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { -1, gc_clock::time_point() });
     auto [out2, res2] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
     BOOST_CHECK(res2.is_live());
@@ -2839,7 +2847,7 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     }
 
     // Collection tombstone covers everything
-    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value)).serialize();
+    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { 1, gc_clock::time_point() });
     auto [out3, res3] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
     BOOST_CHECK(!res3.is_live());
@@ -2851,7 +2859,7 @@ SEASTAR_THREAD_TEST_CASE(test_collection_compaction) {
     }
 
     // Collection tombstone covered by row tombstone
-    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value)).serialize();
+    cmut = make_collection_mutation(tombstone { 2, gc_clock::time_point() }, key, make_collection_member(bytes_type, value));
     row_tomb = row_tombstone(tombstone { 3, gc_clock::time_point() });
     auto [out4, res4] = compact_and_expire(cmut, 0, *bytes_type, row_tomb, gc_clock::time_point(), always_gc, gc_clock::time_point(), nullptr);
     BOOST_CHECK(!res4.is_live());
@@ -3960,16 +3968,6 @@ SEASTAR_TEST_CASE(test_tracing_format) {
     return make_ready_future();
  }
 
-void do_make_collection(collection_mutation_description& desc, std::pair<bytes, atomic_cell>&& cell) {
-    desc.cells.push_back(std::move(cell));
-};
-
-template <typename... Cell>
-void do_make_collection(collection_mutation_description& desc, std::pair<bytes, atomic_cell>&& cell, Cell&& ...cells) {
-    desc.cells.push_back(std::move(cell));
-    do_make_collection(desc, std::forward<Cell>(cells)...);
-};
-
 SEASTAR_TEST_CASE(test_compact_and_expire_cell_stats) {
     const auto collection_type = map_type_impl::get_instance(int32_type, int32_type, true);
 
@@ -3998,10 +3996,12 @@ SEASTAR_TEST_CASE(test_compact_and_expire_cell_stats) {
     };
 
     const auto make_collection = [&] (tombstone tomb, auto&&... cells) {
-        collection_mutation_description desc;
-        desc.tomb = tomb;
-        do_make_collection(desc, std::forward<decltype(cells)>(cells)...);
-        return desc.serialize();
+        collection_mutation_writer w(tomb);
+        auto push_cell = [&w](std::pair<bytes, atomic_cell>&& cell) {
+            w.push_back(bytes_view(cell.first), std::move(cell.second));
+        };
+        (..., push_cell(std::forward<decltype(cells)>(cells)));
+        return std::move(w).finish();
     };
 
     const auto check = [&] (row_content rc, row_tombstone rt, compact_and_expire_result expected_res, std::source_location sl = std::source_location::current()) {

--- a/test/boost/mutation_test.cc
+++ b/test/boost/mutation_test.cc
@@ -396,9 +396,7 @@ SEASTAR_TEST_CASE(test_map_mutations) {
         lazy_row& r = p.static_row();
         auto i = r.find_cell(column.id);
         BOOST_REQUIRE(i);
-        i->as_collection_mutation().with_deserialized(*my_map_type, [] (collection_mutation_view_description muts) {
-            BOOST_REQUIRE(muts.cells.size() == 3);
-        });
+        BOOST_REQUIRE(i->as_collection_mutation().size() == 3);
         // FIXME: more strict tests
     });
 }
@@ -437,9 +435,7 @@ SEASTAR_TEST_CASE(test_set_mutations) {
         lazy_row& r = p.static_row();
         auto i = r.find_cell(column.id);
         BOOST_REQUIRE(i);
-        i->as_collection_mutation().with_deserialized(*my_set_type, [] (collection_mutation_view_description muts) {
-            BOOST_REQUIRE(muts.cells.size() == 3);
-        });
+        BOOST_REQUIRE(i->as_collection_mutation().size() == 3);
         // FIXME: more strict tests
     });
 }
@@ -479,9 +475,7 @@ SEASTAR_TEST_CASE(test_list_mutations) {
         lazy_row& r = p.static_row();
         auto i = r.find_cell(column.id);
         BOOST_REQUIRE(i);
-        i->as_collection_mutation().with_deserialized(*my_list_type, [] (collection_mutation_view_description muts) {
-            BOOST_REQUIRE(muts.cells.size() == 4);
-        });
+        BOOST_REQUIRE(i->as_collection_mutation().size() == 4);
         // FIXME: more strict tests
     });
 }
@@ -527,31 +521,25 @@ SEASTAR_THREAD_TEST_CASE(test_udt_mutations) {
     lazy_row& r = p.static_row();
     auto i = r.find_cell(column.id);
     BOOST_REQUIRE(i);
-    i->as_collection_mutation().with_deserialized(*ut, [&] (collection_mutation_view_description m) {
-        // one cell for each field that has been set. mut3 and mut1 should have been merged
-        BOOST_REQUIRE(m.cells.size() == 3);
-        BOOST_REQUIRE(std::all_of(m.cells.begin(), m.cells.end(), [] (const auto& c) { return c.second.is_live(); }));
+    auto cmv = i->as_collection_mutation();
+    // one cell for each field that has been set. mut3 and mut1 should have been merged
+    BOOST_REQUIRE(cmv.size() == 3);
+    BOOST_REQUIRE(std::all_of(cmv.begin(), cmv.end(), [] (const auto& c) { return c.second.is_live(); }));
 
-        auto cells_equal = [] (const auto& c1, const auto& c2) {
-            return c1.first == c2.first && c1.second.value().linearize() == c2.second.value().linearize();
-        };
+    auto cells_equal = [] (const auto& c1, const auto& c2) {
+        return c1.first == c2.first && c1.second.value().linearize() == c2.second.value().linearize();
+    };
 
-        auto cell_a = std::make_pair(serialize_field_index(0), make_collection_member(int32_type, 0));
-        BOOST_REQUIRE(cells_equal(m.cells[0], std::pair<bytes_view, atomic_cell_view>(cell_a.first, cell_a.second)));
+    auto cell_a = std::make_pair(serialize_field_index(0), make_collection_member(int32_type, 0));
+    auto cell_c = std::make_pair(serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
+    auto cell_d = std::make_pair(serialize_field_index(3), make_collection_member(utf8_type, "text"));
 
-        auto cell_c = std::make_pair(serialize_field_index(2), make_collection_member(long_type, int64_t(3)));
-        BOOST_REQUIRE(cells_equal(m.cells[1], std::pair<bytes_view, atomic_cell_view>(cell_c.first, cell_c.second)));
-
-        auto cell_d = std::make_pair(serialize_field_index(3), make_collection_member(utf8_type, "text"));
-        BOOST_REQUIRE(cells_equal(m.cells[2], std::pair<bytes_view, atomic_cell_view>(cell_d.first, cell_d.second)));
-
-        auto mm = m.materialize(*ut);
-        BOOST_REQUIRE(mm.cells.size() == 3);
-
-        BOOST_REQUIRE(cells_equal(mm.cells[0], cell_a));
-        BOOST_REQUIRE(cells_equal(mm.cells[1], cell_c));
-        BOOST_REQUIRE(cells_equal(mm.cells[2], cell_d));
-    });
+    auto it = cmv.begin();
+    BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(cell_a.first, cell_a.second)));
+    ++it;
+    BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(cell_c.first, cell_c.second)));
+    ++it;
+    BOOST_REQUIRE(cells_equal(*it, std::pair<bytes_view, atomic_cell_view>(cell_d.first, cell_d.second)));
 }
 
 // Verify that serializing and unserializing a large collection doesn't
@@ -1449,10 +1437,8 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         BOOST_REQUIRE(m2_1.find_row(*s, ckey2));
         BOOST_REQUIRE(m2_1.find_row(*s, ckey2)->find_cell(2));
         auto cmv = m2_1.find_row(*s, ckey2)->find_cell(2)->as_collection_mutation();
-        cmv.with_deserialized(*my_set_type, [] (collection_mutation_view_description cm) {
-            BOOST_REQUIRE(cm.cells.size() == 1);
-            BOOST_REQUIRE(cm.cells.front().first == int32_type->decompose(3));
-        });
+        BOOST_REQUIRE(cmv.size() == 1);
+        BOOST_REQUIRE(cmv.begin()->first == managed_bytes_view(int32_type->decompose(3)));
 
         mutation m12_1(s, partition_key::from_single_value(*s, "key1"));
         m12_1.apply(m1);
@@ -1467,10 +1453,8 @@ SEASTAR_TEST_CASE(test_mutation_diff) {
         BOOST_REQUIRE(!m1_2.find_row(*s, ckey2)->find_cell(0));
         BOOST_REQUIRE(!m1_2.find_row(*s, ckey2)->find_cell(1));
         cmv = m1_2.find_row(*s, ckey2)->find_cell(2)->as_collection_mutation();
-        cmv.with_deserialized(*my_set_type, [] (collection_mutation_view_description cm) {
-            BOOST_REQUIRE(cm.cells.size() == 1);
-            BOOST_REQUIRE(cm.cells.front().first == int32_type->decompose(2));
-        });
+        BOOST_REQUIRE(cmv.size() == 1);
+        BOOST_REQUIRE(cmv.begin()->first == managed_bytes_view(int32_type->decompose(2)));
 
         mutation m12_2(s, partition_key::from_single_value(*s, "key1"));
         m12_2.apply(m2);
@@ -2917,19 +2901,16 @@ private:
             }
             BOOST_REQUIRE_EQUAL(is_cell_purgeable(cell), OnlyPurged);
         } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-            auto cell = cell_or_collection.as_collection_mutation();
-            cell.with_deserialized(*cdef.type, [&] (collection_mutation_view_description m_view) {
-                BOOST_REQUIRE(m_view.tomb.timestamp == api::missing_timestamp || m_view.tomb.timestamp > tomb.tomb().timestamp ||
-                        is_tombstone_purgeable(m_view.tomb) == OnlyPurged);
-                auto t = m_view.tomb;
-                t.apply(tomb.tomb());
-                for (const auto& [key, cell] : m_view.cells) {
-                    if constexpr (OnlyPurged) {
-                        BOOST_REQUIRE(!cell.is_covered_by(t, false));
-                    }
-                    BOOST_REQUIRE_EQUAL(is_cell_purgeable(cell), OnlyPurged);
+            auto m_view = cell_or_collection.as_collection_mutation();
+            auto t = m_view.tomb();
+            BOOST_REQUIRE(t.timestamp == api::missing_timestamp || t.timestamp > tomb.tomb().timestamp || is_tombstone_purgeable(t) == OnlyPurged);
+            t.apply(tomb.tomb());
+            for (const auto& [key, cell] : m_view) {
+                if constexpr (OnlyPurged) {
+                    BOOST_REQUIRE(!cell.is_covered_by(t, false));
                 }
-            });
+                BOOST_REQUIRE_EQUAL(is_cell_purgeable(cell), OnlyPurged);
+            }
         } else {
             throw std::runtime_error(fmt::format("Cannot check cell {} of unknown type {}", cdef.name_as_text(), cdef.type->name()));
         }

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -229,11 +229,9 @@ private:
         if (cdef.is_atomic()) {
             check_timestamp(cell.as_atomic_cell(cdef).timestamp());
         } else if (cdef.type->is_collection() || cdef.type->is_user_type()) {
-            cell.as_collection_mutation().with_deserialized(*cdef.type, [this] (collection_mutation_view_description mv) {
-                for (const auto& c: mv.cells) {
-                    check_timestamp(c.second.timestamp());
-                }
-            });
+            for (const auto& [key, c] : cell.as_collection_mutation()) {
+                check_timestamp(c.timestamp());
+            }
         } else {
             BOOST_FAIL(fmt::format("Failed to verify column bucket id: column {} is of unknown type {}", cdef.name_as_text(), cdef.type->name()));
         }

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3609,12 +3609,12 @@ SEASTAR_TEST_CASE(test_write_collection_wide_update) {
     mutation mut{s, key};
 
     mut.partition().apply_insert(*s, clustering_key::make_empty(), write_timestamp);
-    collection_mutation_description set_values;
-    set_values.tomb = tombstone {write_timestamp - 1, tp};
-    set_values.cells.emplace_back(int32_type->decompose(2), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-
-    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize());
+    {
+        collection_mutation_writer w(tombstone{write_timestamp - 1, tp});
+        w.push_back(bytes_view(int32_type->decompose(2)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        w.push_back(bytes_view(int32_type->decompose(3)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), std::move(w).finish());
+    }
 
     write_mut_and_validate(env, s, table_name, mut);
   });
@@ -3635,11 +3635,11 @@ SEASTAR_TEST_CASE(test_write_collection_incremental_update) {
     auto key = partition_key::from_deeply_exploded(*s, { 1 });
     mutation mut{s, key};
 
-    collection_mutation_description set_values;
-    set_values.cells.emplace_back(int32_type->decompose(2), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-
-    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize());
-
+    {
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(int32_type->decompose(2)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), std::move(w).finish());
+    }
     write_mut_and_validate(env, s, table_name, mut);
   });
 }
@@ -4927,11 +4927,12 @@ SEASTAR_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
     mut.partition().apply_insert(*s, ckey, write_timestamp);
     mut.set_cell(ckey, "rc1", data_value{2}, write_timestamp);
 
-    collection_mutation_description set_values;
-    set_values.tomb = tombstone {write_timestamp - 1, write_time_point};
-    set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    set_values.cells.emplace_back(int32_type->decompose(4), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    mut.set_clustered_cell(ckey, *s->get_column_definition("rc4"), set_values.serialize());
+    {
+        collection_mutation_writer w(tombstone{write_timestamp - 1, write_time_point});
+        w.push_back(bytes_view(int32_type->decompose(3)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        w.push_back(bytes_view(int32_type->decompose(4)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        mut.set_clustered_cell(ckey, *s->get_column_definition("rc4"), std::move(w).finish());
+    }
 
     mut.set_cell(ckey, "rc5", data_value{5}, write_timestamp);
 
@@ -4966,11 +4967,12 @@ SEASTAR_TEST_CASE(test_write_static_interleaved_atomic_and_collection_columns) {
     mut.partition().apply_insert(*s, ckey, write_timestamp);
     mut.set_static_cell("st1", data_value{2}, write_timestamp);
 
-    collection_mutation_description set_values;
-    set_values.tomb = tombstone {write_timestamp - 1, write_time_point};
-    set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    set_values.cells.emplace_back(int32_type->decompose(4), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    mut.set_static_cell(*s->get_column_definition("st4"), set_values.serialize());
+    {
+        collection_mutation_writer w(tombstone{write_timestamp - 1, write_time_point});
+        w.push_back(bytes_view(int32_type->decompose(3)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        w.push_back(bytes_view(int32_type->decompose(4)), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
+        mut.set_static_cell(*s->get_column_definition("st4"), std::move(w).finish());
+    }
 
     mut.set_static_cell("st5", data_value{5}, write_timestamp);
 
@@ -5785,10 +5787,10 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
 
     // m[0] = {a: 0, b: 0}
     {
-        collection_mutation_description desc;
-        desc.cells.emplace_back(int32_type->decompose(0),
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(int32_type->decompose(0)),
             atomic_cell::make_live(*ut, write_timestamp, ut->decompose(ut_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *m_cdef, desc.serialize());
+        mut.set_clustered_cell(ckey, *m_cdef, std::move(w).finish());
     }
 
     // fm = {0: {a: 0, b: 0}}
@@ -5796,10 +5798,10 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
 
     // mm[0] = {0: {a: 0, b: 0}},
     {
-        collection_mutation_description desc;
-        desc.cells.emplace_back(int32_type->decompose(0),
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(int32_type->decompose(0)),
             atomic_cell::make_live(*fm_type, write_timestamp, fm_type->decompose(fm_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *mm_cdef, desc.serialize());
+        mut.set_clustered_cell(ckey, *mm_cdef, std::move(w).finish());
     }
 
     // fmm = {0: {0: {a: 0, b: 0}}},
@@ -5807,10 +5809,10 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
 
     // s = s + {{a: 0, b: 0}},
     {
-        collection_mutation_description desc;
-        desc.cells.emplace_back(ut->decompose(ut_val),
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(ut->decompose(ut_val)),
             atomic_cell::make_live(*bytes_type, write_timestamp, bytes{}, atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *s_cdef, desc.serialize());
+        mut.set_clustered_cell(ckey, *s_cdef, std::move(w).finish());
     }
 
     // fs = {{a: 0, b: 0}},
@@ -5818,10 +5820,10 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
 
     // l[scylla_timeuuid_list_index(7fb27e80-7b12-11ea-9fad-f4d108a9e4a3)] = {a: 0, b: 0},
     {
-        collection_mutation_description desc;
-        desc.cells.emplace_back(timeuuid_type->decompose(utils::UUID("7fb27e80-7b12-11ea-9fad-f4d108a9e4a3")),
+        collection_mutation_writer w({});
+        w.push_back(bytes_view(timeuuid_type->decompose(utils::UUID("7fb27e80-7b12-11ea-9fad-f4d108a9e4a3"))),
             atomic_cell::make_live(*ut, write_timestamp, ut->decompose(ut_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *l_cdef, desc.serialize());
+        mut.set_clustered_cell(ckey, *l_cdef, std::move(w).finish());
     }
 
     // fl = [{a: 0, b: 0}]

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -2899,58 +2899,52 @@ SEASTAR_TEST_CASE(test_uncompressed_collections_read) {
                                                          const atomic_cell_or_collection* cell) {
             BOOST_REQUIRE(def.is_multi_cell());
             int idx = 0;
-            cell->as_collection_mutation().with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
-                for (auto&& entry : m_view.cells) {
-                    auto cmp = compare_unsigned(int32_type->decompose(int32_t(val[idx])), entry.first);
-                    if (cmp != 0) {
-                        BOOST_FAIL(format("Expected row with column {} having value {}, but it has value {}",
-                                          def.id,
-                                          int32_type->decompose(int32_t(val[idx])),
-                                          to_hex(entry.first)));
-                    }
-                    ++idx;
+            for (const auto& entry : cell->as_collection_mutation()) {
+                auto cmp = compare_unsigned(int32_type->decompose(int32_t(val[idx])), to_bytes(entry.first));
+                if (cmp != 0) {
+                    BOOST_FAIL(format("Expected row with column {} having value {}, but it has value {}",
+                                      def.id,
+                                      int32_type->decompose(int32_t(val[idx])),
+                                      to_hex(to_bytes(entry.first))));
                 }
-            });
+                ++idx;
+            }
         });
 
         assertions.push_back([val = std::move(list_val)] (const column_definition& def,
                                                           const atomic_cell_or_collection* cell) {
             BOOST_REQUIRE(def.is_multi_cell());
             int idx = 0;
-            cell->as_collection_mutation().with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
-                for (auto&& entry : m_view.cells) {
-                    auto cmp = compare_unsigned(utf8_type->decompose(val[idx]), entry.second.value().linearize());
-                    if (cmp != 0) {
-                        BOOST_FAIL(format("Expected row with column {} having value {}, but it has value {}",
-                                          def.id,
-                                          utf8_type->decompose(val[idx]),
-                                          entry.second.value().linearize()));
-                    }
-                    ++idx;
+            for (const auto& entry : cell->as_collection_mutation()) {
+                auto cmp = compare_unsigned(utf8_type->decompose(val[idx]), entry.second.value().linearize());
+                if (cmp != 0) {
+                    BOOST_FAIL(format("Expected row with column {} having value {}, but it has value {}",
+                                      def.id,
+                                      utf8_type->decompose(val[idx]),
+                                      entry.second.value().linearize()));
                 }
-            });
+                ++idx;
+            }
         });
 
         assertions.push_back([val = std::move(map_val)] (const column_definition& def,
                                                          const atomic_cell_or_collection* cell) {
             BOOST_REQUIRE(def.is_multi_cell());
             int idx = 0;
-            cell->as_collection_mutation().with_deserialized(*def.type, [&] (collection_mutation_view_description m_view) {
-                for (auto&& entry : m_view.cells) {
-                    auto cmp1 = compare_unsigned(int32_type->decompose(int32_t(val[idx].first)), entry.first);
-                    auto cmp2 = compare_unsigned(utf8_type->decompose(val[idx].second), entry.second.value().linearize());
-                    if (cmp1 != 0 || cmp2 != 0) {
-                        BOOST_FAIL(
-                            format("Expected row with column {} having value ({}, {}), but it has value ({}, {})",
-                                   def.id,
-                                   int32_type->decompose(int32_t(val[idx].first)),
-                                   utf8_type->decompose(val[idx].second),
-                                   to_hex(entry.first),
-                                   entry.second.value().linearize()));
-                    }
-                    ++idx;
+            for (const auto& entry : cell->as_collection_mutation()) {
+                auto cmp1 = compare_unsigned(int32_type->decompose(int32_t(val[idx].first)), to_bytes(entry.first));
+                auto cmp2 = compare_unsigned(utf8_type->decompose(val[idx].second), entry.second.value().linearize());
+                if (cmp1 != 0 || cmp2 != 0) {
+                    BOOST_FAIL(
+                        format("Expected row with column {} having value ({}, {}), but it has value ({}, {})",
+                               def.id,
+                               int32_type->decompose(int32_t(val[idx].first)),
+                               utf8_type->decompose(val[idx].second),
+                               to_hex(to_bytes(entry.first)),
+                               entry.second.value().linearize()));
                 }
-            });
+                ++idx;
+            }
         });
 
         return assertions;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3620,7 +3620,7 @@ SEASTAR_TEST_CASE(test_write_collection_wide_update) {
     set_values.cells.emplace_back(int32_type->decompose(2), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
     set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
 
-    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize(*set_of_ints_type));
+    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize());
 
     write_mut_and_validate(env, s, table_name, mut);
   });
@@ -3644,7 +3644,7 @@ SEASTAR_TEST_CASE(test_write_collection_incremental_update) {
     collection_mutation_description set_values;
     set_values.cells.emplace_back(int32_type->decompose(2), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
 
-    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize(*set_of_ints_type));
+    mut.set_clustered_cell(clustering_key::make_empty(), *s->get_column_definition("col"), set_values.serialize());
 
     write_mut_and_validate(env, s, table_name, mut);
   });
@@ -4937,7 +4937,7 @@ SEASTAR_TEST_CASE(test_write_interleaved_atomic_and_collection_columns) {
     set_values.tomb = tombstone {write_timestamp - 1, write_time_point};
     set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
     set_values.cells.emplace_back(int32_type->decompose(4), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    mut.set_clustered_cell(ckey, *s->get_column_definition("rc4"), set_values.serialize(*set_of_ints_type));
+    mut.set_clustered_cell(ckey, *s->get_column_definition("rc4"), set_values.serialize());
 
     mut.set_cell(ckey, "rc5", data_value{5}, write_timestamp);
 
@@ -4976,7 +4976,7 @@ SEASTAR_TEST_CASE(test_write_static_interleaved_atomic_and_collection_columns) {
     set_values.tomb = tombstone {write_timestamp - 1, write_time_point};
     set_values.cells.emplace_back(int32_type->decompose(3), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
     set_values.cells.emplace_back(int32_type->decompose(4), atomic_cell::make_live(*bytes_type, write_timestamp, bytes_view{}));
-    mut.set_static_cell(*s->get_column_definition("st4"), set_values.serialize(*set_of_ints_type));
+    mut.set_static_cell(*s->get_column_definition("st4"), set_values.serialize());
 
     mut.set_static_cell("st5", data_value{5}, write_timestamp);
 
@@ -5794,7 +5794,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
         collection_mutation_description desc;
         desc.cells.emplace_back(int32_type->decompose(0),
             atomic_cell::make_live(*ut, write_timestamp, ut->decompose(ut_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *m_cdef, desc.serialize(*m_type));
+        mut.set_clustered_cell(ckey, *m_cdef, desc.serialize());
     }
 
     // fm = {0: {a: 0, b: 0}}
@@ -5805,7 +5805,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
         collection_mutation_description desc;
         desc.cells.emplace_back(int32_type->decompose(0),
             atomic_cell::make_live(*fm_type, write_timestamp, fm_type->decompose(fm_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *mm_cdef, desc.serialize(*mm_type));
+        mut.set_clustered_cell(ckey, *mm_cdef, desc.serialize());
     }
 
     // fmm = {0: {0: {a: 0, b: 0}}},
@@ -5816,7 +5816,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
         collection_mutation_description desc;
         desc.cells.emplace_back(ut->decompose(ut_val),
             atomic_cell::make_live(*bytes_type, write_timestamp, bytes{}, atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *s_cdef, desc.serialize(*s_type));
+        mut.set_clustered_cell(ckey, *s_cdef, desc.serialize());
     }
 
     // fs = {{a: 0, b: 0}},
@@ -5827,7 +5827,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
         collection_mutation_description desc;
         desc.cells.emplace_back(timeuuid_type->decompose(utils::UUID("7fb27e80-7b12-11ea-9fad-f4d108a9e4a3")),
             atomic_cell::make_live(*ut, write_timestamp, ut->decompose(ut_val), atomic_cell::collection_member::yes));
-        mut.set_clustered_cell(ckey, *l_cdef, desc.serialize(*l_type));
+        mut.set_clustered_cell(ckey, *l_cdef, desc.serialize());
     }
 
     // fl = [{a: 0, b: 0}]

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -135,22 +135,22 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
         mutation m(s, key);
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
-        collection_mutation_description set_mut;
-        set_mut.tomb = tomb;
-        set_mut.cells.emplace_back(to_bytes("1"), make_atomic_cell(bytes_type, {}));
-        set_mut.cells.emplace_back(to_bytes("2"), make_atomic_cell(bytes_type, {}));
-        set_mut.cells.emplace_back(to_bytes("3"), make_atomic_cell(bytes_type, {}));
+        collection_mutation_writer set_mut_writer(tomb);
+        set_mut_writer.push_back(bytes_view(to_bytes("1")), make_atomic_cell(bytes_type, {}));
+        set_mut_writer.push_back(bytes_view(to_bytes("2")), make_atomic_cell(bytes_type, {}));
+        set_mut_writer.push_back(bytes_view(to_bytes("3")), make_atomic_cell(bytes_type, {}));
+        auto set_mut = std::move(set_mut_writer).finish();
 
-        m.set_clustered_cell(c_key, set_col, set_mut.serialize());
+        m.set_clustered_cell(c_key, set_col, set_mut);
 
-        m.set_static_cell(static_set_col, set_mut.serialize());
+        m.set_static_cell(static_set_col, set_mut);
 
         auto key2 = partition_key::from_exploded(*s, {to_bytes("key2")});
         mutation m2(s, key2);
-        collection_mutation_description set_mut_single;
-        set_mut_single.cells.emplace_back(to_bytes("4"), make_atomic_cell(bytes_type, {}));
+        collection_mutation_writer set_mut_single_writer({});
+        set_mut_single_writer.push_back(bytes_view(to_bytes("4")), make_atomic_cell(bytes_type, {}));
 
-        m2.set_clustered_cell(c_key, set_col, set_mut_single.serialize());
+        m2.set_clustered_cell(c_key, set_col, std::move(set_mut_single_writer).finish());
 
         auto mt = make_memtable(s, {std::move(m), std::move(m2)}).get();
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -141,16 +141,16 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
         set_mut.cells.emplace_back(to_bytes("2"), make_atomic_cell(bytes_type, {}));
         set_mut.cells.emplace_back(to_bytes("3"), make_atomic_cell(bytes_type, {}));
 
-        m.set_clustered_cell(c_key, set_col, set_mut.serialize(*set_col.type));
+        m.set_clustered_cell(c_key, set_col, set_mut.serialize());
 
-        m.set_static_cell(static_set_col, set_mut.serialize(*static_set_col.type));
+        m.set_static_cell(static_set_col, set_mut.serialize());
 
         auto key2 = partition_key::from_exploded(*s, {to_bytes("key2")});
         mutation m2(s, key2);
         collection_mutation_description set_mut_single;
         set_mut_single.cells.emplace_back(to_bytes("4"), make_atomic_cell(bytes_type, {}));
 
-        m2.set_clustered_cell(c_key, set_col, set_mut_single.serialize(*set_col.type));
+        m2.set_clustered_cell(c_key, set_col, set_mut_single.serialize());
 
         auto mt = make_memtable(s, {std::move(m), std::move(m2)}).get();
 

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -162,19 +162,18 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
             BOOST_REQUIRE(r->size() == 1);
             auto cell = r->find_cell(set_col.id);
             BOOST_REQUIRE(cell);
-            return cell->as_collection_mutation().with_deserialized(*set_col.type, [&] (collection_mutation_view_description m) {
-                return m.materialize(*set_col.type);
-            });
+            return cell->as_collection_mutation();
         };
 
         auto sstp = verify_mutation(env, env.make_sstable(s), mt, "key1", [&] (mutation_opt& mutation) {
-            auto verify_set = [&tomb] (const collection_mutation_description& m) {
-                BOOST_REQUIRE(bool(m.tomb) == true);
-                BOOST_REQUIRE(m.tomb == tomb);
-                BOOST_REQUIRE(m.cells.size() == 3);
-                BOOST_REQUIRE(m.cells[0].first == to_bytes("1"));
-                BOOST_REQUIRE(m.cells[1].first == to_bytes("2"));
-                BOOST_REQUIRE(m.cells[2].first == to_bytes("3"));
+            auto verify_set = [&tomb] (const collection_mutation_view m) {
+                BOOST_REQUIRE(bool(m.tomb()) == true);
+                BOOST_REQUIRE(m.tomb() == tomb);
+                BOOST_REQUIRE(m.size() == 3);
+                auto it = m.begin();
+                BOOST_REQUIRE(to_bytes(it->first) == to_bytes("1")); ++it;
+                BOOST_REQUIRE(to_bytes(it->first) == to_bytes("2")); ++it;
+                BOOST_REQUIRE(to_bytes(it->first) == to_bytes("3"));
             };
 
             auto& mp = mutation->partition();
@@ -183,9 +182,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
             BOOST_REQUIRE(scol);
 
             // The static set
-            scol->as_collection_mutation().with_deserialized(*static_set_col.type, [&] (collection_mutation_view_description mut) {
-                verify_set(mut.materialize(*static_set_col.type));
-            });
+            verify_set(scol->as_collection_mutation());
 
             // The clustered set
             auto m = verifier(mutation);
@@ -194,9 +191,9 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
 
         verify_mutation(env, sstp, "key2", [&] (mutation_opt& mutation) {
             auto m = verifier(mutation);
-            BOOST_REQUIRE(!m.tomb);
-            BOOST_REQUIRE(m.cells.size() == 1);
-            BOOST_REQUIRE(m.cells[0].first == to_bytes("4"));
+            BOOST_REQUIRE(!m.tomb());
+            BOOST_REQUIRE(m.size() == 1);
+            BOOST_REQUIRE(to_bytes(m.begin()->first) == to_bytes("4"));
         }).get();
     });
 }

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -154,8 +154,8 @@ SEASTAR_TEST_CASE(complex_sst1_k1) {
         match_absent(row1.cells(), *s, "reg_map");
         match_absent(row1.cells(), *s, "reg_fset");
         auto reg_set = match_collection(row1.cells(), *s, "reg_set", tombstone(deletion_time{1431451390, 1431451390209521l}));
-        match_collection_element<status::live>(reg_set.cells[0], to_bytes("1"), bytes_opt{});
-        match_collection_element<status::live>(reg_set.cells[1], to_bytes("2"), bytes_opt{});
+        match_collection_element<status::live>(reg_set[0], to_bytes("1"), bytes_opt{});
+        match_collection_element<status::live>(reg_set[1], to_bytes("2"), bytes_opt{});
 
         auto row2 = clustered_row(mutation, *s, {"cl1.2", "cl2.2"});
         match_live_cell(row2.cells(), *s, "reg", data_value(to_bytes("v2")));
@@ -163,8 +163,8 @@ SEASTAR_TEST_CASE(complex_sst1_k1) {
         match_absent(row2.cells(), *s, "reg_map");
         match_absent(row2.cells(), *s, "reg_fset");
         auto reg_list = match_collection(row2.cells(), *s, "reg_list", tombstone(deletion_time{1431451390, 1431451390213471l}));
-        match_collection_element<status::live>(reg_list.cells[0], bytes_opt{}, to_bytes("2"));
-        match_collection_element<status::live>(reg_list.cells[1], bytes_opt{}, to_bytes("1"));
+        match_collection_element<status::live>(reg_list[0], bytes_opt{}, to_bytes("2"));
+        match_collection_element<status::live>(reg_list[1], bytes_opt{}, to_bytes("1"));
     });
 }
 
@@ -176,10 +176,10 @@ SEASTAR_TEST_CASE(complex_sst1_k2) {
         auto& sr = mutation.partition().static_row().get();
         match_live_cell(sr, *s, "static_obj", data_value(to_bytes("static_value")));
         auto static_set = match_collection(sr, *s, "static_collection", tombstone(deletion_time{1431451390, 1431451390225257l}));
-        match_collection_element<status::live>(static_set.cells[0], to_bytes("1"), bytes_opt{});
-        match_collection_element<status::live>(static_set.cells[1], to_bytes("2"), bytes_opt{});
-        match_collection_element<status::live>(static_set.cells[2], to_bytes("3"), bytes_opt{});
-        match_collection_element<status::live>(static_set.cells[3], to_bytes("4"), bytes_opt{});
+        match_collection_element<status::live>(static_set[0], to_bytes("1"), bytes_opt{});
+        match_collection_element<status::live>(static_set[1], to_bytes("2"), bytes_opt{});
+        match_collection_element<status::live>(static_set[2], to_bytes("3"), bytes_opt{});
+        match_collection_element<status::live>(static_set[3], to_bytes("4"), bytes_opt{});
 
         auto row1 = clustered_row(mutation, *s, {"kcl1.1", "kcl2.1"});
         match_live_cell(row1.cells(), *s, "reg", data_value(to_bytes("v3")));
@@ -187,8 +187,8 @@ SEASTAR_TEST_CASE(complex_sst1_k2) {
         match_absent(row1.cells(), *s, "reg_set");
         match_absent(row1.cells(), *s, "reg_fset");
         auto reg_map = match_collection(row1.cells(), *s, "reg_map", tombstone(deletion_time{1431451390, 1431451390217436l}));
-        match_collection_element<status::live>(reg_map.cells[0], to_bytes("3"), to_bytes("1"));
-        match_collection_element<status::live>(reg_map.cells[1], to_bytes("4"), to_bytes("2"));
+        match_collection_element<status::live>(reg_map[0], to_bytes("3"), to_bytes("1"));
+        match_collection_element<status::live>(reg_map[1], to_bytes("4"), to_bytes("2"));
 
         auto row2 = clustered_row(mutation, *s, {"kcl1.2", "kcl2.2"});
         match_live_cell(row2.cells(), *s, "reg", data_value(to_bytes("v4")));
@@ -212,7 +212,7 @@ SEASTAR_TEST_CASE(complex_sst2_k1) {
 
         auto row = clustered_row(mutation, *s, {"cl1.2", "cl2.2"});
         auto reg_list = match_collection(row.cells(), *s, "reg_list", tombstone(deletion_time{0, api::missing_timestamp}));
-        match_collection_element<status::dead>(reg_list.cells[0], bytes_opt{}, bytes_opt{});
+        match_collection_element<status::dead>(reg_list[0], bytes_opt{}, bytes_opt{});
     });
 }
 
@@ -224,7 +224,7 @@ SEASTAR_TEST_CASE(complex_sst2_k2) {
         auto& sr = mutation.partition().static_row().get();
         match_dead_cell(sr, *s, "static_obj");
         auto static_set = match_collection(sr, *s, "static_collection", tombstone(deletion_time{0, api::missing_timestamp}));
-        match_collection_element<status::dead>(static_set.cells[0], to_bytes("1"), bytes_opt{});
+        match_collection_element<status::dead>(static_set[0], to_bytes("1"), bytes_opt{});
 
         auto row1 = clustered_row(mutation, *s, {"kcl1.1", "kcl2.1"});
         // map dead
@@ -270,10 +270,10 @@ SEASTAR_TEST_CASE(complex_sst3_k1) {
         auto row = clustered_row(mutation, *s, {"cl1.2", "cl2.2"});
 
         auto reg_set = match_collection(row.cells(), *s, "reg_set", tombstone(deletion_time{0, api::missing_timestamp}));
-        match_collection_element<status::live>(reg_set.cells[0], to_bytes("6"), bytes_opt{});
+        match_collection_element<status::live>(reg_set[0], to_bytes("6"), bytes_opt{});
 
         auto reg_list = match_collection(row.cells(), *s, "reg_list", tombstone(deletion_time{0, api::missing_timestamp}));
-        match_collection_element<status::live>(reg_list.cells[0], bytes_opt{}, to_bytes("6"));
+        match_collection_element<status::live>(reg_list[0], bytes_opt{}, to_bytes("6"));
 
         match_absent(row.cells(), *s, "static_obj");
         match_absent(row.cells(), *s, "reg_map");
@@ -292,7 +292,7 @@ SEASTAR_TEST_CASE(complex_sst3_k2) {
 
         auto row = clustered_row(mutation, *s, {"kcl1.1", "kcl2.1"});
         auto reg_map = match_collection(row.cells(), *s, "reg_map", tombstone(deletion_time{0, api::missing_timestamp}));
-        match_collection_element<status::live>(reg_map.cells[0], to_bytes("6"), to_bytes("1"));
+        match_collection_element<status::live>(reg_map[0], to_bytes("6"), to_bytes("1"));
         match_absent(row.cells(), *s, "reg_list");
         match_absent(row.cells(), *s, "reg_set");
         match_absent(row.cells(), *s, "reg");
@@ -464,7 +464,7 @@ SEASTAR_TEST_CASE(broken_ranges_collection) {
             } else if (key_equal("127.0.0.3")) {
                 auto& row = mut->partition().clustered_row(*s, clustering_key::make_empty());
                 auto tokens = match_collection(row.cells(), *s, "tokens", tombstone(deletion_time{0x55E5F2D5, 0x051EB3FC99715Dl }));
-                match_collection_element<status::live>(tokens.cells[0], to_bytes("-8180144272884242102"), bytes_opt{});
+                match_collection_element<status::live>(tokens[0], to_bytes("-8180144272884242102"), bytes_opt{});
             } else {
                 BOOST_REQUIRE(key_equal("127.0.0.2"));
                 auto t = mut->partition().partition_tombstone();

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -302,10 +302,14 @@ match_collection(const row& row, const schema& s, bytes col, const tombstone& t)
 
     BOOST_CHECK_NO_THROW(row.cell_at(cdef->id));
     auto c = row.cell_at(cdef->id).as_collection_mutation();
-    return c.with_deserialized(*cdef->type, [&] (collection_mutation_view_description mut) {
-        BOOST_REQUIRE(mut.tomb == t);
-        return mut.materialize(*cdef->type);
-    });
+    BOOST_REQUIRE(c.tomb() == t);
+    collection_mutation_description result;
+    result.tomb = c.tomb();
+    auto& vtype = *dynamic_cast<const collection_type_impl&>(*cdef->type).value_comparator();
+    for (auto [key, cell] : c) {
+        result.cells.emplace_back(to_bytes(key), atomic_cell(vtype, cell));
+    }
+    return result;
 }
 
 template <status Status>

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -296,18 +296,17 @@ inline void match_absent(const row& row, const schema& s, bytes col) {
     BOOST_REQUIRE(row.find_cell(cdef->id) == nullptr);
 }
 
-inline collection_mutation_description
+inline std::vector<std::pair<bytes, atomic_cell>>
 match_collection(const row& row, const schema& s, bytes col, const tombstone& t) {
     auto cdef = s.get_column_definition(col);
 
     BOOST_CHECK_NO_THROW(row.cell_at(cdef->id));
     auto c = row.cell_at(cdef->id).as_collection_mutation();
     BOOST_REQUIRE(c.tomb() == t);
-    collection_mutation_description result;
-    result.tomb = c.tomb();
+    std::vector<std::pair<bytes, atomic_cell>> result;
     auto& vtype = *dynamic_cast<const collection_type_impl&>(*cdef->type).value_comparator();
     for (auto [key, cell] : c) {
-        result.cells.emplace_back(to_bytes(key), atomic_cell(vtype, cell));
+        result.emplace_back(to_bytes(key), atomic_cell(vtype, cell));
     }
     return result;
 }

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -135,7 +135,7 @@ mutation mutation_description::build(schema_ptr s) const {
                                                                            atomic_cell::collection_member::yes));
                     }
                 }
-                m.set_static_cell(*cdef, mut.serialize(*cdef->type));
+                m.set_static_cell(*cdef, mut.serialize());
             }
         ), value_or_collection);
     }
@@ -186,7 +186,7 @@ mutation mutation_description::build(schema_ptr s) const {
                         }
 
                     }
-                    m.set_clustered_cell(ck, *cdef, mut.serialize(*cdef->type));
+                    m.set_clustered_cell(ck, *cdef, mut.serialize());
                 }
             ), value_or_collection);
         }

--- a/test/lib/data_model.cc
+++ b/test/lib/data_model.cc
@@ -13,6 +13,7 @@
 
 #include "schema/schema_builder.hh"
 #include "types/concrete_types.hh"
+#include "mutation/collection_mutation.hh"
 
 namespace tests::data_model {
 
@@ -120,14 +121,13 @@ mutation mutation_description::build(schema_ptr s) const {
                     }
                 ));
 
-                collection_mutation_description mut;
-                mut.tomb = c.tomb;
+                collection_mutation_writer w(c.tomb);
                 for (auto& [ key, value ] : c.elements) {
                     if (!value.expiring) {
-                        mut.cells.emplace_back(key, atomic_cell::make_live(get_value_type(key), value.timestamp,
+                        w.push_back(bytes_view(key), atomic_cell::make_live(get_value_type(key), value.timestamp,
                                                                             value.value, atomic_cell::collection_member::yes));
                     } else {
-                        mut.cells.emplace_back(key, atomic_cell::make_live(get_value_type(key),
+                        w.push_back(bytes_view(key), atomic_cell::make_live(get_value_type(key),
                                                                            value.timestamp,
                                                                            value.value,
                                                                            value.expiring->expiry_point,
@@ -135,7 +135,7 @@ mutation mutation_description::build(schema_ptr s) const {
                                                                            atomic_cell::collection_member::yes));
                     }
                 }
-                m.set_static_cell(*cdef, mut.serialize());
+                m.set_static_cell(*cdef, std::move(w).finish());
             }
         ), value_or_collection);
     }
@@ -170,14 +170,13 @@ mutation mutation_description::build(schema_ptr s) const {
                         }
                     ));
 
-                    collection_mutation_description mut;
-                    mut.tomb = c.tomb;
+                    collection_mutation_writer w(c.tomb);
                     for (auto& [ key, value ] : c.elements) {
                         if (!value.expiring) {
-                            mut.cells.emplace_back(key, atomic_cell::make_live(get_value_type(key), value.timestamp,
+                            w.push_back(bytes_view(key), atomic_cell::make_live(get_value_type(key), value.timestamp,
                                                                             value.value, atomic_cell::collection_member::yes));
                         } else {
-                            mut.cells.emplace_back(key, atomic_cell::make_live(get_value_type(key),
+                            w.push_back(bytes_view(key), atomic_cell::make_live(get_value_type(key),
                                                                                value.timestamp,
                                                                                value.value,
                                                                                value.expiring->expiry_point,
@@ -186,7 +185,7 @@ mutation mutation_description::build(schema_ptr s) const {
                         }
 
                     }
-                    m.set_clustered_cell(ck, *cdef, mut.serialize());
+                    m.set_clustered_cell(ck, *cdef, std::move(w).finish());
                 }
             ), value_or_collection);
         }

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2272,33 +2272,36 @@ public:
                     }
                     static thread_local std::uniform_int_distribution<int> element_dist{1, 13};
                     static thread_local std::uniform_int_distribution<int64_t> uuid_ts_dist{-12219292800000L, -12219292800000L + 1000};
-                    collection_mutation_description m;
+                    std::vector<std::pair<bytes, atomic_cell>> cells;
                     auto num_cells = element_dist(_gen);
-                    m.cells.reserve(num_cells);
+                    cells.reserve(num_cells);
                     std::unordered_set<bytes> unique_cells;
                     unique_cells.reserve(num_cells);
                     auto ctype = static_pointer_cast<const collection_type_impl>(col.type);
                     for (auto i = 0; i < num_cells; ++i) {
                         auto uuid = utils::UUID_gen::min_time_UUID(std::chrono::milliseconds{uuid_ts_dist(_gen)}).serialize();
                         if (unique_cells.emplace(uuid).second) {
-                            m.cells.emplace_back(
+                            cells.emplace_back(
                                 bytes(reinterpret_cast<const int8_t*>(uuid.data()), uuid.size()),
                                 atomic_cell::make_live(*ctype->value_comparator(), gen_timestamp(timestamp_level::data), _blobs[value_blob_index_dist(_gen)],
                                     atomic_cell::collection_member::yes));
                         }
                     }
-                    std::sort(m.cells.begin(), m.cells.end(), [] (auto&& c1, auto&& c2) {
+                    std::sort(cells.begin(), cells.end(), [] (auto&& c1, auto&& c2) {
                             return timeuuid_type->as_less_comparator()(c1.first, c2.first);
                     });
-                    return m.serialize();
+                    collection_mutation_writer w({});
+                    for (auto& [k, v] : cells) {
+                        w.push_back(bytes_view(k), atomic_cell_view(v));
+                    }
+                    return std::move(w).finish();
                 };
                 auto get_dead_cell = [&] () -> atomic_cell_or_collection{
                     if (col.is_atomic() || col.is_counter()) {
                         return atomic_cell::make_dead(gen_timestamp(timestamp_level::cell_tombstone), new_expiry());
                     }
-                    collection_mutation_description m;
-                    m.tomb = tombstone(gen_timestamp(timestamp_level::collection_tombstone), new_expiry());
-                    return m.serialize();
+                    collection_mutation_writer w(tombstone(gen_timestamp(timestamp_level::collection_tombstone), new_expiry()));
+                    return std::move(w).finish();
 
                 };
                 // FIXME: generate expiring cells

--- a/test/lib/mutation_source_test.cc
+++ b/test/lib/mutation_source_test.cc
@@ -2290,7 +2290,7 @@ public:
                     std::sort(m.cells.begin(), m.cells.end(), [] (auto&& c1, auto&& c2) {
                             return timeuuid_type->as_less_comparator()(c1.first, c2.first);
                     });
-                    return m.serialize(*ctype);
+                    return m.serialize();
                 };
                 auto get_dead_cell = [&] () -> atomic_cell_or_collection{
                     if (col.is_atomic() || col.is_counter()) {
@@ -2298,7 +2298,7 @@ public:
                     }
                     collection_mutation_description m;
                     m.tomb = tombstone(gen_timestamp(timestamp_level::collection_tombstone), new_expiry());
-                    return m.serialize(*col.type);
+                    return m.serialize();
 
                 };
                 // FIXME: generate expiring cells

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -154,8 +154,7 @@ public:
             cmd.cells.emplace_back(k, atomic_cell::make_live(*bytes_type, t, v, atomic_cell::collection_member::yes));
         }
 
-        const auto map_type = get_collection_type();
-        auto serialized_map = cmd.serialize(*map_type);
+        auto serialized_map = cmd.serialize();
         const column_definition& c1_def = *_s->get_column_definition(to_bytes("c1"));
         m.set_clustered_cell(ck, c1_def, atomic_cell_or_collection(std::move(serialized_map)));
         return t;

--- a/test/lib/simple_schema.hh
+++ b/test/lib/simple_schema.hh
@@ -149,14 +149,13 @@ public:
             t = new_timestamp();
         }
 
-        collection_mutation_description cmd;
+        collection_mutation_writer w({});
         for (const auto& [k, v] : kv_map) {
-            cmd.cells.emplace_back(k, atomic_cell::make_live(*bytes_type, t, v, atomic_cell::collection_member::yes));
+            w.push_back(bytes_view(k), atomic_cell::make_live(*bytes_type, t, v, atomic_cell::collection_member::yes));
         }
 
-        auto serialized_map = cmd.serialize();
         const column_definition& c1_def = *_s->get_column_definition(to_bytes("c1"));
-        m.set_clustered_cell(ck, c1_def, atomic_cell_or_collection(std::move(serialized_map)));
+        m.set_clustered_cell(ck, c1_def, atomic_cell_or_collection(std::move(w).finish()));
         return t;
     }
 

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -629,7 +629,7 @@ struct counter_shards_value {
 int counter_shards_value_tostring_l(lua_State* l) {
     auto& csv = pop_userdata_as_ref<counter_shards_value>(l, 1);
     lua_pop(l, 1);
-    auto cv = counter_cell_view(atomic_cell_view::from_bytes(*csv.type, csv.data));
+    auto cv = counter_cell_view(atomic_cell_view::from_bytes(csv.data));
     lua::push_sstring(l, format("{}", cv.total_value()));
     return 1;
 }
@@ -638,7 +638,7 @@ int counter_shards_value_index_l(lua_State* l) {
     auto field = lua_tostring(l, 2);
     auto& csv = pop_userdata_as_ref<counter_shards_value>(l, 1);
     lua_pop(l, 2);
-    auto cv = counter_cell_view(atomic_cell_view::from_bytes(*csv.type, csv.data));
+    auto cv = counter_cell_view(atomic_cell_view::from_bytes(csv.data));
     if (strcmp(field, "value") == 0) {
         lua::push_data_value(l, data_value(cv.total_value()));
     } else if (strcmp(field, "shards") == 0) {

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -742,7 +742,7 @@ struct collection_with_type {
     collection_mutation data;
     data_type type;
 
-    collection_with_type(collection_mutation_view data_view, data_type type) : data(*type, data_view), type(std::move(type)) { }
+    collection_with_type(collection_mutation_view data_view, data_type type) : data(data_view), type(std::move(type)) { }
 };
 
 int collection_index_l(lua_State* l) {

--- a/tools/lua_sstable_consumer.cc
+++ b/tools/lua_sstable_consumer.cc
@@ -750,55 +750,54 @@ int collection_index_l(lua_State* l) {
     auto& ct = pop_userdata_as_ref<collection_with_type>(l, 1);
     auto type = ct.type;
     lua_pop(l, 2);
-    return collection_mutation_view(ct.data).with_deserialized(*type, [l, field, type] (const collection_mutation_view_description& mv) {
-        if (strcmp(field, "tombstone") == 0) {
-            if (!mv.tomb) {
-                return 0;
-            }
-            push_userdata<tombstone>(l, mv.tomb);
-            return 1;
-        } else if (strcmp(field, "type") == 0) {
-            lua_pushliteral(l, "collection");
-            return 1;
-        } else if (strcmp(field, "values") == 0) {
-            const auto size = mv.cells.size();
-            std::function<void(size_t, bytes_view)> push_key;
-            std::function<void(size_t, atomic_cell_view)> push_value;
-            if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
-                push_key = [l, t = t->name_comparator()] (size_t, bytes_view k) {
-                    push_userdata<data_value>(l, t->deserialize(k));
-                };
-                push_value = [l, t = t->value_comparator()] (size_t, atomic_cell_view v) {
-                    push_userdata<atomic_cell_with_type>(l, v, t);
-                };
-            } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
-                push_key = [l] (size_t, bytes_view) { lua_pushliteral(l, ""); };
-                push_value = [l, t] (size_t i, atomic_cell_view v) {
-                    push_userdata<atomic_cell_with_type>(l, v, t->type(i));
-                };
-            } else {
-                return 0;
-            }
-
-            lua_createtable(l, size, 0);
-
-            for (size_t i = 0; i < size; ++i) {
-                const auto& e = mv.cells[i];
-
-                lua_createtable(l, 0, 3);
-
-                push_key(i, e.first);
-                lua_setfield(l, -2, "key");
-
-                push_value(i, e.second);
-                lua_setfield(l, -2, "value");
-
-                lua_seti(l, -2, i + 1); // Lua arrays start from 1
-            }
-            return 1;
+    collection_mutation_view cmv = collection_mutation_view(ct.data);
+    if (strcmp(field, "tombstone") == 0) {
+        auto tomb = cmv.tomb();
+        if (!tomb) {
+            return 0;
         }
-        return 0;
-    });
+        push_userdata<tombstone>(l, tomb);
+        return 1;
+    } else if (strcmp(field, "type") == 0) {
+        lua_pushliteral(l, "collection");
+        return 1;
+    } else if (strcmp(field, "values") == 0) {
+        const auto size = cmv.size();
+        std::function<void(size_t, managed_bytes_view)> push_key;
+        std::function<void(size_t, atomic_cell_view)> push_value;
+        if (auto t = dynamic_cast<const collection_type_impl*>(type.get())) {
+            push_key = [l, t = t->name_comparator()] (size_t, managed_bytes_view k) {
+                k.with_linearized([&](bytes_view bv) {
+                    push_userdata<data_value>(l, t->deserialize(bv));
+                });
+            };
+            push_value = [l, t = t->value_comparator()] (size_t, atomic_cell_view v) {
+                push_userdata<atomic_cell_with_type>(l, v, t);
+            };
+        } else if (auto t = dynamic_cast<const tuple_type_impl*>(type.get())) {
+            push_key = [l] (size_t, managed_bytes_view) { lua_pushliteral(l, ""); };
+            push_value = [l, t] (size_t i, atomic_cell_view v) {
+                push_userdata<atomic_cell_with_type>(l, v, t->type(i));
+            };
+        } else {
+            return 0;
+        }
+
+        lua_createtable(l, size, 0);
+
+        size_t i = 0;
+        for (const auto& e : cmv) {
+            lua_createtable(l, 0, 3);
+            push_key(i, e.first);
+            lua_setfield(l, -2, "key");
+            push_value(i, e.second);
+            lua_setfield(l, -2, "value");
+            lua_seti(l, -2, i + 1); // Lua arrays start from 1
+            ++i;
+        }
+        return 1;
+    }
+    return 0;
 }
 
 int push_cells(lua_State* l, const row& cells, column_kind kind) {

--- a/types/types.cc
+++ b/types/types.cc
@@ -3700,7 +3700,7 @@ static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collectio
 }
 
 bytes_ostream serialize_for_cql(const abstract_type& type, collection_mutation_view v) {
-    SCYLLA_ASSERT(type.is_multi_cell());
+    throwing_assert(type.is_multi_cell());
 
     return v.with_deserialized(type, [&] (collection_mutation_view_description mv) {
         return visit(type, make_visitor(

--- a/types/types.cc
+++ b/types/types.cc
@@ -3719,34 +3719,34 @@ bytes_ostream serialize_for_cql(const abstract_type& type, collection_mutation_v
 bytes_ostream serialize_for_cql_with_timestamps(const abstract_type& type, collection_mutation_view v) {
     throwing_assert(type.is_multi_cell());
 
-        // Step 1: produce regular CQL bytes (copy of mv is made inside serialize_for_cql_aux, mv is still valid after)
-        bytes_ostream cql = serialize_for_cql(type, v);
+    // Step 1: produce regular CQL bytes (copy of mv is made inside serialize_for_cql_aux, mv is still valid after)
+    bytes_ostream cql = serialize_for_cql(type, v);
 
-        // Step 2: build extended format:
-        // [uint32: cql byte length][cql bytes]
-        // [int32: entry count][count entries: (int32 keylen)(key bytes)(int64 timestamp)(int64 expiry, -1 if no TTL)]
-        bytes_ostream out;
-        write_simple<uint32_t>(out, uint32_t(cql.size()));
-        out.append(cql);
-        auto count_slot = out.write_place_holder(collection_size_len());
-        int elements = 0;
-        const auto tomb = v.tomb();
-        for (auto&& e : v) {
-            if (e.second.is_live(tomb, false)) {
-                auto key = e.first;
-                write_simple<int32_t>(out, int32_t(key.size()));
-                out.write(key);
-                write_simple<int64_t>(out, e.second.timestamp());
-                int64_t expiry_raw = -1;
-                if (e.second.is_live_and_has_ttl()) {
-                    expiry_raw = e.second.expiry().time_since_epoch().count();
-                }
-                write_simple<int64_t>(out, expiry_raw);
-                ++elements;
+    // Step 2: build extended format:
+    // [uint32: cql byte length][cql bytes]
+    // [int32: entry count][count entries: (int32 keylen)(key bytes)(int64 timestamp)(int64 expiry, -1 if no TTL)]
+    bytes_ostream out;
+    write_simple<uint32_t>(out, uint32_t(cql.size()));
+    out.append(cql);
+    auto count_slot = out.write_place_holder(collection_size_len());
+    int elements = 0;
+    const auto tomb = v.tomb();
+    for (auto&& e : v) {
+        if (e.second.is_live(tomb, false)) {
+            auto key = e.first;
+            write_simple<int32_t>(out, int32_t(key.size()));
+            out.write(key);
+            write_simple<int64_t>(out, e.second.timestamp());
+            int64_t expiry_raw = -1;
+            if (e.second.is_live_and_has_ttl()) {
+                expiry_raw = e.second.expiry().time_since_epoch().count();
             }
+            write_simple<int64_t>(out, expiry_raw);
+            ++elements;
         }
-        write_collection_size(count_slot, elements);
-        return out;
+    }
+    write_collection_size(count_slot, elements);
+    return out;
 }
 
 bytes serialize_field_index(size_t idx) {

--- a/types/types.cc
+++ b/types/types.cc
@@ -3618,14 +3618,15 @@ std::optional<data_type> abstract_type::update_user_type(const shared_ptr<const 
     return visit(*this, visitor{updated});
 }
 
-static bytes_ostream serialize_for_cql_aux(const map_type_impl&, collection_mutation_view_description mut) {
+static bytes_ostream serialize_for_cql_aux(const map_type_impl&, collection_mutation_view v) {
     bytes_ostream out;
     auto len_slot = out.write_place_holder(collection_size_len());
+    auto tomb = v.tomb();
     int elements = 0;
-    for (auto&& e : mut.cells) {
-        if (e.second.is_live(mut.tomb, false)) {
-            write_collection_value(out, atomic_cell_value_view(e.first));
-            write_collection_value(out, e.second.value());
+    for (auto&& [key, cell] : v) {
+        if (cell.is_live(tomb, false)) {
+            write_collection_value(out, atomic_cell_value_view(key));
+            write_collection_value(out, cell.value());
             elements += 1;
         }
     }
@@ -3633,13 +3634,14 @@ static bytes_ostream serialize_for_cql_aux(const map_type_impl&, collection_muta
     return out;
 }
 
-static bytes_ostream serialize_for_cql_aux(const set_type_impl&, collection_mutation_view_description mut) {
+static bytes_ostream serialize_for_cql_aux(const set_type_impl&, collection_mutation_view v) {
     bytes_ostream out;
     auto len_slot = out.write_place_holder(collection_size_len());
+    auto tomb = v.tomb();
     int elements = 0;
-    for (auto&& e : mut.cells) {
-        if (e.second.is_live(mut.tomb, false)) {
-            write_collection_value(out, atomic_cell_value_view(e.first));
+    for (auto&& [key, cell] : v) {
+        if (cell.is_live(tomb, false)) {
+            write_collection_value(out, atomic_cell_value_view(key));
             elements += 1;
         }
     }
@@ -3647,13 +3649,14 @@ static bytes_ostream serialize_for_cql_aux(const set_type_impl&, collection_muta
     return out;
 }
 
-static bytes_ostream serialize_for_cql_aux(const list_type_impl&, collection_mutation_view_description mut) {
+static bytes_ostream serialize_for_cql_aux(const list_type_impl&, collection_mutation_view v) {
     bytes_ostream out;
     auto len_slot = out.write_place_holder(collection_size_len());
+    auto tomb = v.tomb();
     int elements = 0;
-    for (auto&& e : mut.cells) {
-        if (e.second.is_live(mut.tomb, false)) {
-            write_collection_value(out, e.second.value());
+    for (auto&& [key, cell] : v) {
+        if (cell.is_live(tomb, false)) {
+            write_collection_value(out, cell.value());
             elements += 1;
         }
     }
@@ -3661,15 +3664,15 @@ static bytes_ostream serialize_for_cql_aux(const list_type_impl&, collection_mut
     return out;
 }
 
-static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collection_mutation_view_description mut) {
+static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collection_mutation_view v) {
     SCYLLA_ASSERT(type.is_multi_cell());
-    SCYLLA_ASSERT(mut.cells.size() <= type.size());
 
     bytes_ostream out;
+    auto tomb = v.tomb();
 
     size_t curr_field_pos = 0;
-    for (auto&& e : mut.cells) {
-        auto field_pos = deserialize_field_index(e.first);
+    for (auto&& [key, cell] : v) {
+        auto field_pos = deserialize_field_index(key);
         SCYLLA_ASSERT(field_pos < type.size());
 
         // Some fields don't have corresponding cells -- these fields are null.
@@ -3678,8 +3681,8 @@ static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collectio
             ++curr_field_pos;
         }
 
-        if (e.second.is_live(mut.tomb, false)) {
-            auto value = e.second.value();
+        if (cell.is_live(tomb, false)) {
+            auto value = cell.value();
             write_simple<int32_t>(out, int32_t(value.size_bytes()));
             for (auto&& frag : fragment_range(value)) {
                 out.write(frag);
@@ -3702,31 +3705,22 @@ static bytes_ostream serialize_for_cql_aux(const user_type_impl& type, collectio
 bytes_ostream serialize_for_cql(const abstract_type& type, collection_mutation_view v) {
     throwing_assert(type.is_multi_cell());
 
-    return v.with_deserialized(type, [&] (collection_mutation_view_description mv) {
-        return visit(type, make_visitor(
-            [&] (const map_type_impl& ctype) { return serialize_for_cql_aux(ctype, std::move(mv)); },
-            [&] (const set_type_impl& ctype) { return serialize_for_cql_aux(ctype, std::move(mv)); },
-            [&] (const list_type_impl& ctype) { return serialize_for_cql_aux(ctype, std::move(mv)); },
-            [&] (const user_type_impl& utype) { return serialize_for_cql_aux(utype, std::move(mv)); },
-            [&] (const abstract_type& o) -> bytes_ostream {
-                throw std::runtime_error(format("attempted to serialize a collection of cells with type: {}", o.name()));
-            }
-        ));
-    });
+    return visit(type, make_visitor(
+        [&] (const map_type_impl& ctype) { return serialize_for_cql_aux(ctype, v); },
+        [&] (const set_type_impl& ctype) { return serialize_for_cql_aux(ctype, v); },
+        [&] (const list_type_impl& ctype) { return serialize_for_cql_aux(ctype, v); },
+        [&] (const user_type_impl& utype) { return serialize_for_cql_aux(utype, v); },
+        [&] (const abstract_type& o) -> bytes_ostream {
+            throw std::runtime_error(format("attempted to serialize a collection of cells with type: {}", o.name()));
+        }
+    ));
 }
 
 bytes_ostream serialize_for_cql_with_timestamps(const abstract_type& type, collection_mutation_view v) {
     throwing_assert(type.is_multi_cell());
-    return v.with_deserialized(type, [&] (collection_mutation_view_description mv) -> bytes_ostream {
+
         // Step 1: produce regular CQL bytes (copy of mv is made inside serialize_for_cql_aux, mv is still valid after)
-        bytes_ostream cql = visit(type, make_visitor(
-            [&] (const map_type_impl& ctype) { return serialize_for_cql_aux(ctype, mv); },
-            [&] (const set_type_impl& ctype) { return serialize_for_cql_aux(ctype, mv); },
-            [&] (const user_type_impl& utype) { return serialize_for_cql_aux(utype, mv); },
-            [&] (const abstract_type& o) -> bytes_ostream {
-                throw std::runtime_error(format("serialize_for_cql_with_timestamps: unsupported type {}", o.name()));
-            }
-        ));
+        bytes_ostream cql = serialize_for_cql(type, v);
 
         // Step 2: build extended format:
         // [uint32: cql byte length][cql bytes]
@@ -3736,9 +3730,10 @@ bytes_ostream serialize_for_cql_with_timestamps(const abstract_type& type, colle
         out.append(cql);
         auto count_slot = out.write_place_holder(collection_size_len());
         int elements = 0;
-        for (auto&& e : mv.cells) {
-            if (e.second.is_live(mv.tomb, false)) {
-                bytes_view key = e.first;
+        const auto tomb = v.tomb();
+        for (auto&& e : v) {
+            if (e.second.is_live(tomb, false)) {
+                auto key = e.first;
                 write_simple<int32_t>(out, int32_t(key.size()));
                 out.write(key);
                 write_simple<int64_t>(out, e.second.timestamp());
@@ -3752,7 +3747,6 @@ bytes_ostream serialize_for_cql_with_timestamps(const abstract_type& type, colle
         }
         write_collection_size(count_slot, elements);
         return out;
-    });
 }
 
 bytes serialize_field_index(size_t idx) {


### PR DESCRIPTION
Collections have an age-old problem in ScyllaDB: they had to be unserialized into an intermediate representation for any access or manipulation. The intermediate representation needs effort to produce and also requires additional memory to store. Both can be significant for large collections. This intermediate representation is then either discarded immediately after use, or re-serialized again.
This problem was significant enough for us to consider the use of collections as somewhat of an anti-pattern. But our customers keep using it. Alternator is also a heavy user of collections.

This PR aims to solve this problem once and for all.  The plan is as follows:
* Promote direct use of the serialized collection format:
    - Add accessor methods to `collection_mutation_view` which read from the serialized format directly: `tomb()`, `size()` and `begin()`/`end()`.
    - Add a `collection_mutation_writer` which provides container semantics for generating a serialized `collection_mutation` directly on the go (`push_back()`).
* Replace all usage of `collection_mutation_description`, `collection_mutation_view_description` and friends with use of the new infrastructure.
* Drop the old infrastructure, to avoid accidental regressions.

Continues the work started by https://github.com/scylladb/scylladb/pull/29033 and takes it to its conclusion.

To help focus review, here is a summary of the patches:
* [1, 2] preparatory refactoring: drop some unused abstract_type params
* [3, 6] introduce new infrastructure to write and read serialized collections directly; this is the meat of the PR
* [6, -1) replace all usage of old materializing infrastructure with usage of the new one
* [-1] drop old infrastructure

## Performance Benchmark Report

### Read Benchmark

**Command:**
```
dbuild -it -- build/release/scylla perf-simple-query --collection=16 -c1 -m2G --default-log-level=error
```

| Metric                   |  Before |   After | Change     |
|--------------------------|--------:|--------:|------------|
| Throughput (median tps)  | 315,760 | 332,021 | **+5.1%**  |
| Instructions/op (median) |  53,776 |  48,681 | **-9.5%**  |
| CPU cycles/op (median)   |  17,365 |  16,471 | **-5.1%**  |
| Allocations/op           |    85.1 |    82.1 | **-3.5%**  |

**Significant improvement.** Throughput is up ~5%, and both instruction count and cycle count are meaningfully reduced.

---

### Write Benchmark

**Command:**
```
dbuild -it -- build/release/scylla perf-simple-query --collection=16 -c1 -m2G --default-log-level=error --write
```

| Metric                   |    Before |    After | Change    |
|--------------------------|----------:|---------:|-----------|
| Throughput (median tps)  |   150,823 |  149,678 | **-0.8%** |
| Instructions/op (median) |   108,388 |  103,858 | **-4.2%** |
| CPU cycles/op (median)   |    34,860 |   35,371 | **+1.5%** |
| Allocations/op           | ~105–108  | ~102–103 | **-3.0%** |

**Mixed, mostly neutral.** Throughput is essentially flat (within noise). Instructions/op improved by ~4%, allocations dropped slightly, but cycles/op edged up marginally.

---

### Alternator Benchmark (write workload via DynamoDB-compatible API)

**Command:**
```
dbuild -it -- build/release/scylla perf-alternator --workload write --developer-mode=1 --alternator-port=8000 --alternator-write-isolation=unsafe -c1 -m2G --default-log-level=error
```

| Metric                   |  Before |  After | Change    |
|--------------------------|--------:|-------:|-----------|
| Throughput (median tps)  |  55,777 | 56,051 | **+0.5%** |
| Instructions/op (median) | 246,215 |246,610 | **+0.2%** |
| CPU cycles/op (median)   |  77,641 | 77,020 | **-0.8%** |
| Allocations/op           |   340.4 |  335.4 | **-1.5%** |

**Essentially neutral.** All metrics are within noise margins. Slight reduction in allocations and cycles, negligible otherwise.

---

### Overall Assessment

The change has a **clear, substantial positive effect on reads** (~5% throughput gain, ~9.5% fewer instructions per op).
The write and alternator paths are **unaffected in practice** — changes there are within measurement noise. No regressions are apparent.
This is expected: https://github.com/scylladb/scylladb/pull/29033 did the heavy lifting when it comes to the write path, this PR finishes the job, mostly improving reads.

Fixes: #3602

Improvement, no backport.