### PR TITLE
test/cluster/test_data_resurrection_in_memtable.py: use explicit CL

### DIFF
--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -53,9 +53,9 @@ async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: l
                     "     AND compaction = {'class': 'NullCompactionStrategy'}")
 
         for write_statement, delete_statement in statement_pairs:
-            execute_with_tracing(cql, write_statement.format(ks=ks), log = True)
+            execute_with_tracing(cql, SimpleStatement(write_statement.format(ks=ks), consistency_level=ConsistencyLevel.ALL), log = True)
             await manager.api.enable_injection(node3.ip_addr, "database_apply", one_shot=False, parameters={"ks_name": ks, "cf_name": "tbl", "what": "throw"})
-            execute_with_tracing(cql, delete_statement.format(ks=ks), log = True)
+            execute_with_tracing(cql, SimpleStatement(delete_statement.format(ks=ks), consistency_level=ConsistencyLevel.LOCAL_QUORUM), log = True)
             await manager.api.disable_injection(node3.ip_addr, "database_apply")
 
         def check_data(host, data):


### PR DESCRIPTION
The test has expectation w.r.t which write makes it to which nodes:
* inserts make it to all nodes
* delete makes it to all-1 (QUORUM) node

However, this was not expressed with CL, and the default CL=ONE allowed for some nodes missing the writes and this violating the tests expectations on what data is persent on which nodes. This resulted on the test being flaky and failing on the data checks.

Use explicit CL for the ingestion to prevent this.

The improvements to the test introduced in
a8dd13731fcea13981b037d37b61f7d5259085ca was of great help in investigating this: traces are now available and the check happens after the data was dumped to logs.

Fixes: SCYLLADB-870
Fixes: SCYLLADB-812
Fixes: SCYLLADB-1102

Backport: problematic test was introduced in 34b18d7ef41, needs backport to 2025.4