### PR TITLE
table: Add formatter for group_id argument in tablet merge exception …

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3380,7 +3380,7 @@ void tablet_storage_group_manager::handle_tablet_merge_completion(const locator:
 
             auto it = _storage_groups.find(group_id);
             if (it == _storage_groups.end()) {
-                throw std::runtime_error(format("Unable to find sibling tablet of id for table {}", group_id, table_id));
+                throw std::runtime_error(format("Unable to find sibling tablet of id {} for table {}", group_id, table_id));
             }
             auto& sg = it->second;
             sg->for_each_compaction_group([&new_sg, new_range, new_tid, group_id] (const compaction_group_ptr& cg) {


### PR DESCRIPTION
…message

fixes: SCYLLADB-1432

Present in 2025.1 and above. Fix is cheap. Worth backporting