### PR TITLE
scylla-gdb: display ms-format sstable summary from partitions db footer

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5672,6 +5672,21 @@ class scylla_sstable_summary(gdb.Command):
           position: 0}
 
     Keys are printed in the hexadecimal notation.
+
+    For ms-format (trie-based) sstables, displays data from the
+    partitions db footer instead:
+
+        (gdb) scylla sstable-summary $sst
+        sstable uses ms format (trie-based index).
+        first_key: 63617373616e647261
+        last_key: 63617373616e647261
+        partition_count: 42
+        trie_root_position: 12345
+
+    If the partitions db footer has not been lazily loaded yet (e.g. the
+    sstable was opened but never read from), the command will report:
+
+        sstable uses ms format but partitions db footer is not loaded.
     """
     def __init__(self):
         gdb.Command.__init__(self, 'scylla sstable-summary', gdb.COMMAND_USER, gdb.COMPLETE_NONE, True)
@@ -5693,7 +5708,16 @@ class scylla_sstable_summary(gdb.Command):
             sst = arg
         ms_version = int(gdb.parse_and_eval('sstables::sstable_version_types::ms'))
         if int(sst['_version']) >= ms_version:
-            gdb.write("sstable uses ms format (trie-based index); summary is not populated.\n")
+            footer_opt = std_optional(sst['_partitions_db_footer'])
+            if not footer_opt:
+                gdb.write("sstable uses ms format but partitions db footer is not loaded.\n")
+                return
+            footer = footer_opt.get()
+            gdb.write("sstable uses ms format (trie-based index).\n")
+            gdb.write("first_key: {}\n".format(sstring(footer['first_key']['_bytes'])))
+            gdb.write("last_key: {}\n".format(sstring(footer['last_key']['_bytes'])))
+            gdb.write("partition_count: {}\n".format(footer['partition_count']))
+            gdb.write("trie_root_position: {}\n".format(footer['trie_root_position']))
             return
         summary = seastar_lw_shared_ptr(sst['_components']['_value']).get().dereference()['summary']
 

--- a/test/scylla_gdb/test_sstable_commands.py
+++ b/test/scylla_gdb/test_sstable_commands.py
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 """
-Tests for commands, that need a sstable to work on.
-Each only checks that the command does not fail - but not what it does or returns.
+Tests for commands that need an sstable to work on.
 """
 
 import pytest
@@ -35,3 +34,48 @@ def test_sstable(gdb_cmd, command):
     assert result.returncode == 0, (
         f"GDB command {command} failed. stdout: {result.stdout} stderr: {result.stderr}"
     )
+
+
+def test_sstable_summary_output(gdb_cmd):
+    """Verify sstable-summary produces expected output fields.
+
+    For ms-format sstables with the partitions db footer loaded, the output
+    should contain first_key, last_key, partition_count, and trie_root_position.
+    For ms-format sstables where the footer has not been lazily loaded yet,
+    expects an informational message indicating the footer is not loaded.
+    For legacy formats, it should contain header, first_key, and last_key.
+    """
+
+    result = execute_gdb_command(gdb_cmd, f"sstable-summary $get_sstable()")
+    assert result.returncode == 0, (
+        f"sstable-summary failed. stdout: {result.stdout} stderr: {result.stderr}"
+    )
+    output = result.stdout
+
+    if 'ms format (trie-based index)' in output:
+        # ms-format sstable with footer loaded: data comes from _partitions_db_footer
+        print('test branch: ms-format with footer loaded')
+        assert 'first_key:' in output, (
+            f"Missing first_key in ms-format output: {output}"
+        )
+        assert 'last_key:' in output, (
+            f"Missing last_key in ms-format output: {output}"
+        )
+        assert 'partition_count:' in output, (
+            f"Missing partition_count in ms-format output: {output}"
+        )
+        assert 'trie_root_position:' in output, (
+            f"Missing trie_root_position in ms-format output: {output}"
+        )
+    elif 'ms format' in output:
+        # ms-format sstable but partitions db footer is not loaded yet
+        print('test branch: ms-format with footer NOT loaded')
+        assert (
+            'sstable uses ms format but partitions db footer is not loaded' in output
+        ), f"Unexpected ms-format output: {output}"
+    else:
+        # Legacy format: data comes from summary
+        print('test branch: legacy format')
+        assert 'header:' in output, f"Missing header in legacy output: {output}"
+        assert 'first_key:' in output, f"Missing first_key in legacy output: {output}"
+        assert 'last_key:' in output, f"Missing last_key in legacy output: {output}"


### PR DESCRIPTION
## Summary

Follow-up to #29162. For ms-format (trie-based) sstables, the `scylla sstable-summary` GDB command previously showed only a "not populated" message. This PR replaces that with actual useful output by reading from `_partitions_db_footer`.

### Changes

- Read `sst._partitions_db_footer` (`std::optional<trie::bti_partitions_db_footer>`) using the existing `std_optional` helper
- Display `first_key` and `last_key` (as hex, via the `sstring` helper on the `_bytes` field of `sstables::key`)
- Display `partition_count` and `trie_root_position`
- Handle the case where `_partitions_db_footer` is not engaged (not yet loaded) with an informative message
- Updated the command docstring with an ms-format example

### Example output

For ms-format sstables:
```
(gdb) scylla sstable-summary $sst
sstable uses ms format (trie-based index).
first_key: 63617373616e647261
last_key: 63617373616e647261
partition_count: 42
trie_root_position: 12345
```

Depends on: #29162
Refs: SCYLLADB-1180