### PR TITLE
build-scylla.yaml: add missing workflow permissions

### DIFF
--- a/.github/workflows/build-scylla.yaml
+++ b/.github/workflows/build-scylla.yaml
@@ -12,6 +12,9 @@ on:
         description: 'the md5sum for scylla executable'
         value: ${{ jobs.build.outputs.md5sum }}
 
+permissions:
+  contents: read
+
 jobs:
   read-toolchain:
     uses: ./.github/workflows/read-toolchain.yaml


### PR DESCRIPTION
## Summary

Fixes code scanning alerts #140, #141.

- Adds explicit `permissions: contents: read` block to the `build-scylla.yaml` reusable workflow, following the principle of least privilege consistent with other workflows in this repo (e.g., `seastar.yaml`, `docs-pr.yaml`).
- Without explicit permissions, the `GITHUB_TOKEN` receives the default permissions which may be overly broad depending on org/repo settings.

Ref: https://github.com/scylladb/scylladb/security/code-scanning