### PR TITLE
trigger-scylla-ci.yaml: add missing workflow permissions

### DIFF
--- a/.github/workflows/trigger-scylla-ci.yaml
+++ b/.github/workflows/trigger-scylla-ci.yaml
@@ -7,6 +7,8 @@ on:
     types:
       - unlabeled
 
+permissions: {}
+
 jobs:
   trigger-jenkins:
     if: (github.event_name == 'issue_comment' && github.event.comment.user.login != 'scylladbbot') || github.event.label.name == 'conflicts'


### PR DESCRIPTION
## Summary

Fixes code scanning alert #184.

- Adds explicit `permissions: {}` block since this workflow only triggers Jenkins via `curl` with its own secrets and requires no `GITHUB_TOKEN` permissions.
- Follows the principle of least privilege consistent with other workflows in this repo.

Ref: https://github.com/scylladb/scylladb/security/code-scanning