### PR TITLE
call_backport_with_jira.yaml: add missing workflow permissions

### DIFF
--- a/.github/workflows/call_backport_with_jira.yaml
+++ b/.github/workflows/call_backport_with_jira.yaml
@@ -14,6 +14,11 @@ on:
       - next-*.*
       - branch-*.*
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   backport-on-push:
     if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

Fixes code scanning alerts #181, #182, #183.

- Adds explicit `permissions` block (`contents: read`, `pull-requests: write`, `issues: write`) matching the requirements of the called reusable workflow (`scylladb/github-automation/.github/workflows/backport-with-jira.yaml`), which declares `pull-requests: write` and `issues: write` at job level.
- Follows the principle of least privilege consistent with other workflows in this repo.

Ref: https://github.com/scylladb/scylladb/security/code-scanning