### PR TITLE
call_sync_milestone_to_jira.yml: add missing workflow permissions

### DIFF
--- a/.github/workflows/call_sync_milestone_to_jira.yml
+++ b/.github/workflows/call_sync_milestone_to_jira.yml
@@ -4,6 +4,8 @@ on:
   milestone:
     types: [created, closed]
 
+permissions: {}
+
 jobs:
   sync-milestone-to-jira:
     uses: scylladb/github-automation/.github/workflows/main_sync_milestone_to_jira_release.yml@main


### PR DESCRIPTION
## Summary

Fixes code scanning alert #171.

- Adds explicit `permissions: {}` block since this workflow only syncs milestones to Jira using its own secrets and requires no `GITHUB_TOKEN` permissions.
- Follows the principle of least privilege consistent with other workflows in this repo.

Ref: https://github.com/scylladb/scylladb/security/code-scanning