### PR TITLE
urgent_issue_reminder.yml: add missing workflow permissions

### DIFF
--- a/.github/workflows/urgent_issue_reminder.yml
+++ b/.github/workflows/urgent_issue_reminder.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '10 8 * * *' # Runs daily at 8 AM
 
+permissions:
+  issues: write
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 


### PR DESCRIPTION
## Summary

Fixes code scanning alert #149.

- Adds explicit `permissions: issues: write` block since this workflow lists issues (`issues.listForRepo`) and creates reminder comments (`issues.createComment`) via `actions/github-script`.
- Follows the principle of least privilege consistent with other workflows in this repo (e.g., `conflict_reminder.yaml`).

Ref: https://github.com/scylladb/scylladb/security/code-scanning