### PR TITLE
logging: guard expensive argument evaluation in debug/trace log calls

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -946,7 +946,7 @@ sstables::shared_sstable sstables_task_executor::consume_sstable() {
     auto sst = _sstables.back();
     _sstables.pop_back();
     --_cm._stats.pending_tasks; // from this point on, switch_state(pending|active) works the same way as any other task
-    cmlog.debug("{}", format("consumed {}", sst->get_filename()));
+    cmlog.debug("consumed {}", sst->get_filename());
     return sst;
 }
 
@@ -1208,7 +1208,6 @@ future<> compaction_manager::await_tasks(std::vector<shared_ptr<compaction_task_
 
 std::vector<shared_ptr<compaction_task_executor>>
 compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bool(const compaction_group_view*)> filter, std::optional<compaction_type> type_opt) noexcept {
-    auto ongoing_compactions = get_compactions(filter).size();
     auto tasks = _tasks
             | std::views::filter([&filter, type_opt] (const auto& task) {
                 return filter(task.compacting_table()) && (!type_opt || task.compaction_type() == *type_opt);
@@ -1217,6 +1216,7 @@ compaction_manager::do_stop_ongoing_compactions(sstring reason, std::function<bo
             | std::ranges::to<std::vector<shared_ptr<compaction_task_executor>>>();
     logging::log_level level = tasks.empty() ? log_level::debug : log_level::info;
     if (cmlog.is_enabled(level)) {
+        auto ongoing_compactions = get_compactions(filter).size();
         std::string scope = "";
         if (!tasks.empty()) {
             const compaction_group_view* t = tasks.front()->compacting_table();
@@ -1426,11 +1426,17 @@ protected:
             compaction_strategy cs = t.get_compaction_strategy();
             compaction_descriptor descriptor = co_await cs.get_sstables_for_compaction(t, _cm.get_strategy_control());
             int weight = calculate_weight(descriptor);
-            cmlog.debug("Started minor compaction sstables={} sstables_reapired_at={} range={} uuid={} compaction_uuid={}",
-                    descriptor.sstables, compacting_table()->get_sstables_repaired_at(),
-                    compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
+            bool debug_enabled = cmlog.is_enabled(log_level::debug);
+            if (debug_enabled) {
+                cmlog.debug("Started minor compaction sstables={} sstables_reapired_at={} range={} uuid={} compaction_uuid={}",
+                        descriptor.sstables, compacting_table()->get_sstables_repaired_at(),
+                        compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
+            }
 
-            auto old_sstables = ::format("{}", descriptor.sstables);
+            sstring old_sstables;
+            if (debug_enabled) {
+                old_sstables = ::format("{}", descriptor.sstables);
+            }
 
             if (descriptor.sstables.empty() || !can_proceed() || t.is_auto_compaction_disabled_by_user()) {
                 cmlog.debug("{}: sstables={} can_proceed={} auto_compaction={}", *this, descriptor.sstables.size(), can_proceed(), t.is_auto_compaction_disabled_by_user());
@@ -1460,8 +1466,10 @@ protected:
             try {
                 bool should_update_history = this->should_update_history(descriptor.options.type());
                 compaction_result res = co_await compact_sstables(std::move(descriptor), _compaction_data, on_replace);
-                cmlog.debug("Finished minor compaction old_sstables={} new_sstables={} sstables_reapired_at={} range={} uuid={} compaction_uuid={}",
-                        old_sstables, res.new_sstables, compacting_table()->get_sstables_repaired_at(), compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
+                if (debug_enabled) {
+                    cmlog.debug("Finished minor compaction old_sstables={} new_sstables={} sstables_reapired_at={} range={} uuid={} compaction_uuid={}",
+                            old_sstables, res.new_sstables, compacting_table()->get_sstables_repaired_at(), compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
+                }
                 finish_compaction();
                 if (should_update_history) {
                     // update_history can take a long time compared to

--- a/compaction/leveled_compaction_strategy.cc
+++ b/compaction/leveled_compaction_strategy.cc
@@ -33,8 +33,10 @@ future<compaction_descriptor> leveled_compaction_strategy::get_sstables_for_comp
     auto candidate = manifest.get_compaction_candidates(*state->last_compacted_keys, state->compaction_counter);
 
     if (!candidate.sstables.empty()) {
-        auto main_set = co_await table_s.main_sstable_set();
-        leveled_manifest::logger.debug("leveled: Compacting {} out of {} sstables", candidate.sstables.size(), main_set->size());
+        if (leveled_manifest::logger.is_enabled(logging::log_level::debug)) {
+            auto main_set = co_await table_s.main_sstable_set();
+            leveled_manifest::logger.debug("leveled: Compacting {} out of {} sstables", candidate.sstables.size(), main_set->size());
+        }
         co_return candidate;
     }
 

--- a/compaction/time_window_compaction_strategy.cc
+++ b/compaction/time_window_compaction_strategy.cc
@@ -15,6 +15,7 @@
 #include "compaction_strategy_state.hh"
 #include "utils/error_injection.hh"
 
+#include <seastar/util/lazy.hh>
 #include <ranges>
 
 namespace compaction {
@@ -260,8 +261,12 @@ time_window_compaction_strategy::get_reshaping_job(std::vector<sstables::shared_
 
     clogger.debug("time_window_compaction_strategy::get_reshaping_job: offstrategy_threshold={} max_sstables={} multi_window={} disjoint={} single_window={} disjoint={}",
             offstrategy_threshold, max_sstables,
-            multi_window.size(), !multi_window.empty() && sstable_set_overlapping_count(schema, multi_window) == 0,
-            single_window.size(), !single_window.empty() && sstable_set_overlapping_count(schema, single_window) == 0);
+            multi_window.size(), seastar::value_of([&] {
+                return !multi_window.empty() && sstable_set_overlapping_count(schema, multi_window) == 0;
+            }),
+            single_window.size(), seastar::value_of([&] {
+                return !single_window.empty() && sstable_set_overlapping_count(schema, single_window) == 0;
+            }));
 
     auto get_job_size = [] (const std::vector<sstables::shared_sstable>& ssts) {
         return std::ranges::fold_left(ssts | std::views::transform(std::mem_fn(&sstables::sstable::bytes_on_disk)), uint64_t(0), std::plus{});

--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -355,7 +355,7 @@ future<> gossiper::handle_ack_msg(locator::host_id id, gossip_digest_ack ack_msg
                 logger.debug("Handle queued gossip ack msg digests from node {}, ack_msg_digest={}, pending={}",
                         from, p.ack_msg_digest, p.pending);
                 ack_msg_digest = std::move(p.ack_msg_digest.value());
-                p.ack_msg_digest= {};
+                p.ack_msg_digest = {};
                 continue;
             } else {
                 // No more pending ack msg digests to process
@@ -400,9 +400,15 @@ future<> gossiper::do_send_ack2_msg(locator::host_id from, utils::chunked_vector
         }
     }
     gms::gossip_digest_ack2 ack2_msg(std::move(delta_ep_state_map));
-    logger.debug("Calling do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
+    sstring ack2_msg_str;
+    if (logger.is_enabled(logging::log_level::debug)) {
+        ack2_msg_str = fmt::format("{}", ack2_msg);
+        logger.debug("Calling do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg_str);
+    }
     co_await ser::gossip_rpc_verbs::send_gossip_digest_ack2(&_messaging, from, std::move(ack2_msg));
-    logger.debug("finished do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
+    if (logger.is_enabled(logging::log_level::debug)) {
+        logger.debug("finished do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg_str);
+    }
 }
 
 // Depends on

--- a/locator/topology.cc
+++ b/locator/topology.cc
@@ -240,11 +240,11 @@ const node& topology::add_node(node_holder nptr) {
 
 void topology::update_node(node& node, std::optional<host_id> opt_id, std::optional<endpoint_dc_rack> opt_dr, std::optional<node::state> opt_st, std::optional<shard_id> opt_shard_count) {
     tlogger.debug("topology[{}]: update_node: {}: to: host_id={} dc={} rack={} state={} shard_count={}, at {}", fmt::ptr(this), node_printer(&node),
-        opt_id ? format("{}", *opt_id) : "unchanged",
-        opt_dr ? format("{}", opt_dr->dc) : "unchanged",
-        opt_dr ? format("{}", opt_dr->rack) : "unchanged",
-        opt_st ? format("{}", *opt_st) : "unchanged",
-        opt_shard_count ? format("{}", *opt_shard_count) : "unchanged",
+        seastar::value_of([&] { return opt_id ? format("{}", *opt_id) : "unchanged"; }),
+        seastar::value_of([&] { return opt_dr ? format("{}", opt_dr->dc) : "unchanged"; }),
+        seastar::value_of([&] { return opt_dr ? format("{}", opt_dr->rack) : "unchanged"; }),
+        seastar::value_of([&] { return opt_st ? format("{}", *opt_st) : "unchanged"; }),
+        seastar::value_of([&] { return opt_shard_count ? format("{}", *opt_shard_count) : "unchanged"; }),
         lazy_backtrace());
 
     bool changed = false;

--- a/repair/repair.cc
+++ b/repair/repair.cc
@@ -36,6 +36,7 @@
 
 #include <seastar/core/gate.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/lazy.hh>
 #include <seastar/core/metrics_registration.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
@@ -1113,12 +1114,12 @@ future<> repair::shard_repair_task_impl::do_repair_ranges() {
             }
             rlogger.debug("repair[{}]: node ops progress bootstrap={}, replace={}, rebuild={}, decommission={}, removenode={}, repair={}",
                 global_repair_id.uuid(),
-                rs.get_metrics().bootstrap_finished_percentage(),
-                rs.get_metrics().replace_finished_percentage(),
-                rs.get_metrics().rebuild_finished_percentage(),
-                rs.get_metrics().decommission_finished_percentage(),
-                rs.get_metrics().removenode_finished_percentage(),
-                rs.get_metrics().repair_finished_percentage());
+                seastar::value_of([&] { return rs.get_metrics().bootstrap_finished_percentage(); }),
+                seastar::value_of([&] { return rs.get_metrics().replace_finished_percentage(); }),
+                seastar::value_of([&] { return rs.get_metrics().rebuild_finished_percentage(); }),
+                seastar::value_of([&] { return rs.get_metrics().decommission_finished_percentage(); }),
+                seastar::value_of([&] { return rs.get_metrics().removenode_finished_percentage(); }),
+                seastar::value_of([&] { return rs.get_metrics().repair_finished_percentage(); }));
         });
 
         if (_reason != streaming::stream_reason::repair) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -3253,10 +3253,13 @@ private:
             // sequentially because the rows from repair follower 1 to
             // repair master might reduce the amount of missing data
             // between repair master and repair follower 2.
-            repair_hash_set set_diff = get_set_diff(master.peer_row_hash_sets(node_idx), master.working_row_hashes().get());
+            auto working_hashes = master.working_row_hashes().get();
+            repair_hash_set set_diff = get_set_diff(master.peer_row_hash_sets(node_idx), working_hashes);
             // Request missing sets from peer node
-            rlogger.debug("Before get_row_diff to node {}, local={}, peer={}, set_diff={}",
-                    node, master.working_row_hashes().get().size(), master.peer_row_hash_sets(node_idx).size(), set_diff.size());
+            if (rlogger.is_enabled(logging::log_level::debug)) {
+                rlogger.debug("Before get_row_diff to node {}, local={}, peer={}, set_diff={}",
+                        node, working_hashes.size(), master.peer_row_hash_sets(node_idx).size(), set_diff.size());
+            }
             // If we need to pull all rows from the peer. We can avoid
             // sending the row hashes on wire by setting needs_all_rows flag.
             auto needs_all_rows = repair_meta::needs_all_rows_t(set_diff.size() == master.peer_row_hash_sets(node_idx).size());
@@ -3269,7 +3272,9 @@ private:
                 master.get_row_diff(std::move(set_diff), needs_all_rows, node, node_idx, dst_cpu_id);
                 ns.state = repair_state::get_row_diff_finished;
             }
-            rlogger.debug("After get_row_diff node {}, hash_sets={}", master.myhostid(), master.working_row_hashes().get().size());
+            if (rlogger.is_enabled(logging::log_level::debug)) {
+                rlogger.debug("After get_row_diff node {}, hash_sets={}", master.myhostid(), master.working_row_hashes().get().size());
+            }
           } catch (...) {
             rlogger.warn("repair[{}]: get_row_diff: got error from node={}, keyspace={}, table={}, range={}, error={}",
                     _shard_task.global_repair_id.uuid(), node, _shard_task.get_keyspace(), _cf_name, _range, std::current_exception());

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -12,6 +12,7 @@
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 #include <seastar/core/rwlock.hh>
+#include <seastar/util/lazy.hh>
 #include "db/view/view.hh"
 #include "locator/network_topology_strategy.hh"
 #include "locator/tablets.hh"
@@ -3255,7 +3256,9 @@ future<> database::clear_snapshot(sstring tag, std::vector<sstring> keyspace_nam
             auto data_dir = fs::path(parent_dir);
             auto data_dir_lister = directory_lister(data_dir, lister::dir_entry_types::of<directory_entry_type::directory>(), filter);
             auto close_data_dir_lister = deferred_close(data_dir_lister);
-            dblog.debug("clear_snapshot: listing data dir {} with filter={}", data_dir, ks_names_set.empty() ? "none" : fmt::format("{}", ks_names_set));
+            dblog.debug("clear_snapshot: listing data dir {} with filter={}", data_dir, seastar::value_of([&] {
+                return ks_names_set.empty() ? "none" : fmt::format("{}", ks_names_set);
+            }));
             while (auto ks_ent = data_dir_lister.get().get()) {
                 auto ks_name = ks_ent->name;
                 auto ks_dir = data_dir / ks_name;

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -350,7 +350,6 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
                     co_await authorize(req, scope);
                 }
                 auto content = co_await util::read_entire_stream_contiguous(_in);
-                auto error_msg = get_gcp_error_message(std::string_view(content));
                 gcp_storage.debug("Got unexpected response status: {}, content: {}", rep._status, content);
                 co_await coroutine::return_exception_ptr(std::make_exception_ptr(httpd::unexpected_status_error(rep._status)));
                 }
@@ -629,7 +628,7 @@ future<> utils::gcp::storage::client::object_data_sink::remove_upload() {
         co_return;
     }
 
-    gcp_storage.debug("Removing incomplete upload {}:{} ()", _bucket, _object_name, _session_path);
+    gcp_storage.debug("Removing incomplete upload {}:{} ({})", _bucket, _object_name, _session_path);
 
     auto res = co_await _impl->send_with_retry(_session_path
         , GCP_OBJECT_SCOPE_READ_WRITE

--- a/utils/logalloc.cc
+++ b/utils/logalloc.cc
@@ -1583,7 +1583,7 @@ void reclaim_timer::report() const noexcept {
     if (_memory_released > 0) {
         auto bytes_per_second =
             static_cast<float>(_memory_released) / std::chrono::duration_cast<std::chrono::duration<float>>(_duration).count();
-        timing_logger.log(info_level, "- reclamation rate = {} MiB/s", format("{:.3f}", bytes_per_second / MiB));
+        timing_logger.log(info_level, "- reclamation rate = {:.3f} MiB/s", bytes_per_second / MiB);
     }
 
     if (_debug_enabled) {


### PR DESCRIPTION
## Motivation

Preparing variables for logging output may be expensive - if they end up not being used - specifically, when the logging level is not INFO.
This AI-driven patchset looked at all modules and was asked to see if we have opportunities to reduce that impact.
Either delaying or moving the variables to where it is most likely will be eventually needed.

I've asked it to split it to a commit per file, so we can cherry pick if needed (for example, do we need it for gossiper as the code gets removed / re-arranged? donno).
I donno if 20 PRs make sense, but I don't like 20 changes in the same commit either - open to suggestions here.

Implemented with Opus 4.6, reviewed by GPT-5.4 and I'll let CoPi with whatever it uses to review it as well


## What was changed

This PR audits the codebase for log messages at `debug` and `trace` levels
where the argument evaluation is expensive and adds `is_enabled()` guards or
`seastar::value_of()` lazy wrappers. Each file is in its own commit (to allow
cherry-picking individual fixes). The commit messages describe the severity of
each issue.

Additionally, several small bug fixes were included:

- **utils/gcp/object_storage.cc**: Fixed a format string bug (`()` → `({})`)
  where `_session_path` was passed but never rendered, and removed a dead
  `error_msg` variable that was computed but never used.
- **gms/gossiper.cc**: Fixed a use-after-move where `ack2_msg` was logged
  after being `std::move`'d into the RPC send call.
- **utils/logalloc.cc** and **compaction/compaction_manager.cc**: Removed
  redundant nested `format()` wrappers around values already passed to a
  format-capable logger.

**10 files changed:**

### Compaction (3 files)
- **compaction_manager.cc**: Remove redundant `format()` wrapper in
  `consume_sstable()`; move eager `get_compactions()` call inside the existing
  `is_enabled()` guard; cache `debug_enabled` flag to guard sstable list
  formatting and "Started"/"Finished" minor compaction debug logs
- **time_window_compaction_strategy.cc**: Wrap O(n²) `sstable_set_overlapping_count()`
  computations in `seastar::value_of()` so they are only evaluated when the
  debug log line is actually formatted
- **leveled_compaction_strategy.cc**: Guard `co_await table_s.main_sstable_set()`
  (coroutine I/O) used only in a debug log with `is_enabled()` check

### Repair (2 files)
- **row_level.cc**: Cache `working_row_hashes().get()` into a local variable to
  avoid a redundant call; guard two debug log statements with `is_enabled()`
- **repair.cc**: Wrap six `*_finished_percentage()` metric calls in
  `seastar::value_of()` so they are only evaluated at debug level

### Gossip (1 file)
- **gossiper.cc**: Pre-format `ack2_msg` before `std::move` to fix a
  use-after-move bug on the "finished" log line; guard both debug log
  statements with `is_enabled()`; minor whitespace fix

### Locator (1 file)
- **topology.cc**: Wrap five `format()` ternary expressions in
  `seastar::value_of()` lambdas so they are only evaluated at debug level

### Replica (1 file)
- **database.cc**: Wrap `fmt::format("{}", ks_names_set)` in
  `seastar::value_of()` to avoid eager formatting of `unordered_set`

### Utils (2 files)
- **logalloc.cc**: Replace redundant `format("{:.3f}", ...)` wrapper with
  inline format spec `{:.3f}` directly in the log format string
- **gcp/object_storage.cc**: Fix format string bug (missing `{}` placeholder
  for `_session_path`); remove unused `error_msg` variable

## How it was tested

- **Built successfully** in all three modes with `--disable-dpdk`:
  - `dev` (1121 targets)
  - `release` (1176 targets)
  - `debug` (1193 targets)
- **Boost unit tests passed** in all three modes:
  - `dev`: 3221 passed (42 pre-existing S3/minio infrastructure failures)
  - `release`: 3219 passed (same 42 S3 failures)
  - `debug`: 3214 passed (same 42 S3 failures)
- The 42 failures across all modes are identical pre-existing infrastructure
  issues (S3/minio service not available in the test environment, 1 commitlog
  test) — none related to this change.