### PR TITLE
cql3: two pass type inference

### DIFF
--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -191,7 +191,7 @@ extern expression search_and_replace(const expression& e,
 expression adjust_for_collection_as_maps(const expression& e);
 
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
-std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
+std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default = false);
 
 // Check that a prepared expression has no aggregate functions. Throws on error.
 void verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors);

--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -191,7 +191,7 @@ extern expression search_and_replace(const expression& e,
 expression adjust_for_collection_as_maps(const expression& e);
 
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
-std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
+std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved = false);
 
 // Check that a prepared expression has no aggregate functions. Throws on error.
 void verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors);

--- a/cql3/expr/expr-utils.hh
+++ b/cql3/expr/expr-utils.hh
@@ -191,7 +191,7 @@ extern expression search_and_replace(const expression& e,
 expression adjust_for_collection_as_maps(const expression& e);
 
 extern expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
-std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved = false);
+std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver);
 
 // Check that a prepared expression has no aggregate functions. Throws on error.
 void verify_no_aggregate_functions(const expression& expr, std::string_view context_for_errors);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1268,57 +1268,21 @@ std::vector<::shared_ptr<assignment_testable>>
 prepare_function_args_for_type_inference(std::span<const expression> args, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt) {
     // Prepare the arguments that can be prepared without a receiver.
     // Prepared expressions have a known type, which helps with finding the right function.
+    // When an argument can't be prepared (e.g. untyped constant without receiver),
+    // fall back to infer_type to provide a default type for overload resolution.
     std::vector<shared_ptr<assignment_testable>> partially_prepared_args;
     for (const expression& argument : args) {
         std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr);
-        auto type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
+        auto type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt))
+                                     : infer_type(argument, db, keyspace, schema_opt);
         auto expr = prepared_arg_opt ? std::move(*prepared_arg_opt) : argument;
         partially_prepared_args.emplace_back(as_assignment_testable(std::move(expr), std::move(type)));
     }
     return partially_prepared_args;
 }
 
-// Special case for count(1) - recognize it as the countRows() function. Note it is quite
-// artificial and we might relax it to the more general count(expression) later.
-static
-std::optional<expression>
-try_prepare_count_rows(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    return std::visit(overloaded_functor{
-        [&] (const functions::function_name& name) -> std::optional<expression> {
-            auto native_name = name;
-            if (!native_name.has_keyspace()) {
-                native_name = name.as_native_function();
-            }
-            // Collapse count(1) into countRows()
-            if (native_name == functions::function_name::native_function("count")) {
-                if (fc.args.size() == 1) {
-                    if (auto uc_arg = expr::as_if<expr::untyped_constant>(&fc.args[0])) {
-                        if (uc_arg->partial_type == expr::untyped_constant::type_class::integer
-                                && uc_arg->raw_text == "1") {
-                            return expr::function_call{
-                                .func = functions::aggregate_fcts::make_count_rows_function(),
-                                .args = {},
-                            };
-                        } else {
-                            throw exceptions::invalid_request_exception(format("count() expects a column or the literal 1 as an argument", fc.args[0]));
-                        }
-                    }
-                }
-            }
-            return std::nullopt;
-        },
-        [] (const shared_ptr<functions::function>&) -> std::optional<expression> {
-            // Already prepared, nothing to do
-            return std::nullopt;
-        },
-    }, fc.func);
-}
-
 std::optional<expression>
 prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    if (auto prepared = try_prepare_count_rows(fc, db, keyspace, schema_opt, receiver)) {
-        return prepared;
-    }
     // Try to extract a column family name from the available information.
     // Most functions can be prepared without information about the column family, usually just the keyspace is enough.
     // One exception is the token() function - in order to prepare system.token() we have to know the partition key of the table,

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -799,11 +799,39 @@ untyped_constant_test_assignment(const untyped_constant& uc, data_dictionary::da
 }
 
 static
+std::optional<data_type>
+infer_default_type(const untyped_constant& uc) {
+    switch (uc.partial_type) {
+        case untyped_constant::type_class::string:          return utf8_type;
+        case untyped_constant::type_class::boolean:         return boolean_type;
+        case untyped_constant::type_class::floating_point:  return double_type;
+        case untyped_constant::type_class::duration:        return duration_type;
+        case untyped_constant::type_class::uuid:            return uuid_type;
+        case untyped_constant::type_class::hex:             return bytes_type;
+        case untyped_constant::type_class::null:            return std::nullopt;
+        case untyped_constant::type_class::integer:
+            // Select the smallest of int, bigint, or varint that fits the value.
+            // tinyint and smallint are never inferred — use CAST to obtain them.
+            // from_string throws marshal_exception if the value overflows,
+            // so we try each type in order of increasing range.
+            try {
+                int32_type->from_string(uc.raw_text);
+                return int32_type;
+            } catch (const marshal_exception&) {}
+            try {
+                long_type->from_string(uc.raw_text);
+                return long_type;
+            } catch (const marshal_exception&) {}
+            return varint_type;
+    }
+    __builtin_unreachable();
+}
+
+static
 std::optional<expression>
 untyped_constant_prepare_expression(const untyped_constant& uc, data_dictionary::database db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver)
 {
     if (!receiver) {
-        // TODO: It is possible to infer the type of a constant by looking at the value and selecting the smallest fit
         return std::nullopt;
     }
     if (!is_assignable(untyped_constant_test_assignment(uc, db, keyspace, *receiver))) {
@@ -939,23 +967,20 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
             keyspace, "unknown_cf", ::make_shared<column_identifier>(receiver_name, true), cast_type);
     }
 
-    auto prepared_arg = try_prepare_expression(c.arg, db, keyspace, schema_opt, nullptr);
-    if (!prepared_arg) {
-        throw exceptions::invalid_request_exception(fmt::format("Could not infer type of cast argument {}", c.arg));
-    }
+    auto prepared_arg = prepare_expression(c.arg, db, keyspace, schema_opt, nullptr);
 
     // cast to the same type should be omitted
-    if (cast_type == type_of(*prepared_arg)) {
+    if (cast_type == type_of(prepared_arg)) {
         return prepared_arg;
     }
 
     // This will throw if a cast is impossible
-    auto fun = functions::get_castas_fctn_as_cql3_function(cast_type, type_of(*prepared_arg));
+    auto fun = functions::get_castas_fctn_as_cql3_function(cast_type, type_of(prepared_arg));
 
     // We implement the cast to a function_call.
     return function_call{
         .func = std::move(fun),
-        .args = std::vector({*prepared_arg}),
+        .args = std::vector({std::move(prepared_arg)}),
     };
 }
 
@@ -1031,6 +1056,152 @@ field_selection_test_assignment(const field_selection& fs, data_dictionary::data
     }
     auto field_type = ut->type(*idx);
     return expression_test_assignment(field_type, receiver);
+}
+
+// Lightweight assignment_testable wrapper around a data_type.
+// Used by infer_type to feed inferred types into functions::get() for overload
+// resolution without producing prepared expressions.
+class assignment_testable_type : public assignment_testable {
+    data_type _type;
+public:
+    explicit assignment_testable_type(data_type type) : _type(std::move(type)) {}
+    test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const override {
+        return expression_test_assignment(_type, receiver);
+    }
+    vector_test_result test_assignment_any_size_float_vector() const override {
+        return {test_result::NOT_ASSIGNABLE, std::nullopt};
+    }
+    sstring assignment_testable_source_context() const override {
+        return _type->as_cql3_type().to_string();
+    }
+    std::optional<data_type> assignment_testable_type_opt() const override {
+        return _type;
+    }
+};
+
+static
+lw_shared_ptr<column_specification>
+make_inferred_receiver(data_type type) {
+    return make_lw_shared<column_specification>(
+        "", "",
+        ::make_shared<column_identifier>("<inferred>", true),
+        std::move(type));
+}
+
+static
+std::optional<data_type>
+infer_type(const expression& e, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt) {
+    return expr::visit(overloaded_functor{
+        [&] (const untyped_constant& uc) -> std::optional<data_type> {
+            return infer_default_type(uc);
+        },
+        [&] (const collection_constructor& cc) -> std::optional<data_type> {
+            if (cc.elements.empty()) {
+                return std::nullopt;
+            }
+            switch (cc.style) {
+            case collection_constructor::style_type::list_or_vector: {
+                auto first_type = infer_type(cc.elements[0], db, keyspace, schema_opt);
+                if (!first_type) {
+                    return std::nullopt;
+                }
+                for (size_t i = 1; i < cc.elements.size(); ++i) {
+                    auto t = infer_type(cc.elements[i], db, keyspace, schema_opt);
+                    if (!t || *t != *first_type) {
+                        return std::nullopt;
+                    }
+                }
+                return list_type_impl::get_instance(*first_type, false);
+            }
+            case collection_constructor::style_type::set: {
+                auto first_type = infer_type(cc.elements[0], db, keyspace, schema_opt);
+                if (!first_type) {
+                    return std::nullopt;
+                }
+                for (size_t i = 1; i < cc.elements.size(); ++i) {
+                    auto t = infer_type(cc.elements[i], db, keyspace, schema_opt);
+                    if (!t || *t != *first_type) {
+                        return std::nullopt;
+                    }
+                }
+                return set_type_impl::get_instance(*first_type, false);
+            }
+            case collection_constructor::style_type::map: {
+                auto& first_entry = expr::as<tuple_constructor>(cc.elements[0]);
+                auto first_key_type = infer_type(first_entry.elements[0], db, keyspace, schema_opt);
+                auto first_value_type = infer_type(first_entry.elements[1], db, keyspace, schema_opt);
+                if (!first_key_type || !first_value_type) {
+                    return std::nullopt;
+                }
+                for (size_t i = 1; i < cc.elements.size(); ++i) {
+                    auto& entry = expr::as<tuple_constructor>(cc.elements[i]);
+                    auto kt = infer_type(entry.elements[0], db, keyspace, schema_opt);
+                    auto vt = infer_type(entry.elements[1], db, keyspace, schema_opt);
+                    if (!kt || *kt != *first_key_type || !vt || *vt != *first_value_type) {
+                        return std::nullopt;
+                    }
+                }
+                return map_type_impl::get_instance(*first_key_type, *first_value_type, false);
+            }
+            case collection_constructor::style_type::vector:
+                return std::nullopt;
+            }
+            return std::nullopt;
+        },
+        [&] (const tuple_constructor& tc) -> std::optional<data_type> {
+            std::vector<data_type> element_types;
+            element_types.reserve(tc.elements.size());
+            for (auto& elem : tc.elements) {
+                auto t = infer_type(elem, db, keyspace, schema_opt);
+                if (!t) {
+                    return std::nullopt;
+                }
+                element_types.push_back(std::move(*t));
+            }
+            return tuple_type_impl::get_instance(std::move(element_types));
+        },
+        [&] (const cast& c) -> std::optional<data_type> {
+            try {
+                return cast_get_prepared_type(c, db, keyspace);
+            } catch (...) {
+                return std::nullopt;
+            }
+        },
+        [&] (const function_call& fc) -> std::optional<data_type> {
+            return std::visit(overloaded_functor{
+                [&] (const functions::function_name& name) -> std::optional<data_type> {
+                    std::vector<shared_ptr<assignment_testable>> testable_args;
+                    testable_args.reserve(fc.args.size());
+                    for (auto& arg : fc.args) {
+                        auto arg_type = infer_type(arg, db, keyspace, schema_opt);
+                        if (!arg_type) {
+                            return std::nullopt;
+                        }
+                        testable_args.push_back(::make_shared<assignment_testable_type>(std::move(*arg_type)));
+                    }
+                    std::optional<std::string_view> cf_name;
+                    if (schema_opt) {
+                        cf_name = std::string_view(schema_opt->cf_name());
+                    }
+                    try {
+                        auto fun = functions::instance().get(db, keyspace, name, testable_args, keyspace, cf_name, nullptr);
+                        if (!fun) {
+                            return std::nullopt;
+                        }
+                        return fun->return_type();
+                    } catch (...) {
+                        return std::nullopt;
+                    }
+                },
+                [&] (const shared_ptr<functions::function>& func) -> std::optional<data_type> {
+                    return func->return_type();
+                },
+            }, fc.func);
+        },
+        [&] (const auto&) -> std::optional<data_type> {
+            return std::nullopt;
+        },
+    }, e);
 }
 
 static
@@ -1617,10 +1788,17 @@ test_assignment_any_size_float_vector(const expression& expr) {
 expression
 prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
     auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver));
-    if (!e_opt) {
-        throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
+    if (e_opt) {
+        return std::move(*e_opt);
     }
-    return std::move(*e_opt);
+    auto inferred = infer_type(expr, db, keyspace, schema_opt);
+    if (inferred) {
+        e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, make_inferred_receiver(std::move(*inferred)));
+        if (e_opt) {
+            return std::move(*e_opt);
+        }
+    }
+    throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
 }
 
 assignment_testable::test_result

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -896,13 +896,7 @@ assignment_testable::test_result
 cast_test_assignment(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
     try {
         data_type casted_type = cast_get_prepared_type(c, db, keyspace);
-        if (receiver.type == casted_type) {
-            return assignment_testable::test_result::EXACT_MATCH;
-        } else if (receiver.type->is_value_compatible_with(*casted_type)) {
-            return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-        } else {
-            return assignment_testable::test_result::NOT_ASSIGNABLE;
-        }
+        return expression_test_assignment(casted_type, receiver);
     } catch (exceptions::invalid_request_exception& e) {
         throwing_assert(0 && "cast_test_assignment exception");
     }
@@ -1058,6 +1052,62 @@ field_selection_test_assignment(const field_selection& fs, data_dictionary::data
     return expression_test_assignment(field_type, receiver);
 }
 
+// Try to widen two types within the same numeric chain.
+// Returns the wider type, or nullopt if the types are not in the same
+// widening chain. Two independent lossless chains:
+//   Integer: byte < short < int32 < int64 < varint
+//   Float:   float < double
+// Cross-chain widening (e.g. int32 → double) is not supported.
+static
+std::optional<data_type>
+try_widen(const data_type& a, const data_type& b) {
+    using kind = abstract_type::kind;
+    static constexpr kind integer_chain[] = {
+        kind::byte, kind::short_kind, kind::int32, kind::long_kind, kind::varint
+    };
+    static constexpr kind float_chain[] = {
+        kind::float_kind, kind::double_kind
+    };
+    auto rank_in = [] (const kind chain[], size_t len, const data_type& t) -> std::optional<size_t> {
+        for (size_t i = 0; i < len; ++i) {
+            if (chain[i] == t->get_kind()) {
+                return i;
+            }
+        }
+        return std::nullopt;
+    };
+    auto kind_to_type = [] (kind k) -> data_type {
+        switch (k) {
+            case kind::byte: return byte_type;
+            case kind::short_kind: return short_type;
+            case kind::int32: return int32_type;
+            case kind::long_kind: return long_type;
+            case kind::varint: return varint_type;
+            case kind::float_kind: return float_type;
+            case kind::double_kind: return double_type;
+            default: abort();
+        }
+    };
+    auto ra = rank_in(integer_chain, std::size(integer_chain), a);
+    auto rb = rank_in(integer_chain, std::size(integer_chain), b);
+    if (ra && rb) {
+        return kind_to_type(integer_chain[std::max(*ra, *rb)]);
+    }
+    ra = rank_in(float_chain, std::size(float_chain), a);
+    rb = rank_in(float_chain, std::size(float_chain), b);
+    if (ra && rb) {
+        return kind_to_type(float_chain[std::max(*ra, *rb)]);
+    }
+    return std::nullopt;
+}
+
+// Check if type `from` can be losslessly widened to type `to`.
+static
+bool is_widenable_to(const data_type& from, const data_type& to) {
+    auto widened = try_widen(from, to);
+    return widened && **widened == *to;
+}
+
 // Lightweight assignment_testable wrapper around a data_type.
 // Used by infer_type to feed inferred types into functions::get() for overload
 // resolution without producing prepared expressions.
@@ -1066,7 +1116,11 @@ class assignment_testable_type : public assignment_testable {
 public:
     explicit assignment_testable_type(data_type type) : _type(std::move(type)) {}
     test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const override {
-        return expression_test_assignment(_type, receiver);
+        auto result = expression_test_assignment(_type, receiver);
+        if (result == test_result::NOT_ASSIGNABLE && is_widenable_to(_type, receiver.type)) {
+            return test_result::WEAKLY_ASSIGNABLE;
+        }
+        return result;
     }
     vector_test_result test_assignment_any_size_float_vector() const override {
         return {test_result::NOT_ASSIGNABLE, std::nullopt};
@@ -1099,49 +1153,54 @@ infer_type(const expression& e, data_dictionary::database db, const sstring& key
             if (cc.elements.empty()) {
                 return std::nullopt;
             }
+            auto find_wide_enough_type = [&] (std::span<const expression> elements, auto&& project) -> std::optional<data_type> {
+                std::optional<data_type> wide_enough_type;
+                for (auto& elem : elements) {
+                    auto t = infer_type(project(elem), db, keyspace, schema_opt);
+                    if (!t) {
+                        return std::nullopt;
+                    }
+                    if (!wide_enough_type) {
+                        wide_enough_type = std::move(t);
+                    } else if (**t != **wide_enough_type) {
+                        auto widened = try_widen(*wide_enough_type, *t);
+                        if (!widened) {
+                            return std::nullopt;
+                        }
+                        wide_enough_type = std::move(widened);
+                    }
+                }
+                return wide_enough_type;
+            };
+            auto identity = [] (const expression& e) -> const expression& { return e; };
             switch (cc.style) {
             case collection_constructor::style_type::list_or_vector: {
-                auto first_type = infer_type(cc.elements[0], db, keyspace, schema_opt);
-                if (!first_type) {
+                auto elem_type = find_wide_enough_type(cc.elements, identity);
+                if (!elem_type) {
                     return std::nullopt;
                 }
-                for (size_t i = 1; i < cc.elements.size(); ++i) {
-                    auto t = infer_type(cc.elements[i], db, keyspace, schema_opt);
-                    if (!t || *t != *first_type) {
-                        return std::nullopt;
-                    }
-                }
-                return list_type_impl::get_instance(*first_type, false);
+                return list_type_impl::get_instance(*elem_type, false);
             }
             case collection_constructor::style_type::set: {
-                auto first_type = infer_type(cc.elements[0], db, keyspace, schema_opt);
-                if (!first_type) {
+                auto elem_type = find_wide_enough_type(cc.elements, identity);
+                if (!elem_type) {
                     return std::nullopt;
                 }
-                for (size_t i = 1; i < cc.elements.size(); ++i) {
-                    auto t = infer_type(cc.elements[i], db, keyspace, schema_opt);
-                    if (!t || *t != *first_type) {
-                        return std::nullopt;
-                    }
-                }
-                return set_type_impl::get_instance(*first_type, false);
+                return set_type_impl::get_instance(*elem_type, false);
             }
             case collection_constructor::style_type::map: {
-                auto& first_entry = expr::as<tuple_constructor>(cc.elements[0]);
-                auto first_key_type = infer_type(first_entry.elements[0], db, keyspace, schema_opt);
-                auto first_value_type = infer_type(first_entry.elements[1], db, keyspace, schema_opt);
-                if (!first_key_type || !first_value_type) {
+                auto key_of = [] (const expression& e) -> const expression& {
+                    return expr::as<tuple_constructor>(e).elements[0];
+                };
+                auto value_of = [] (const expression& e) -> const expression& {
+                    return expr::as<tuple_constructor>(e).elements[1];
+                };
+                auto key_type = find_wide_enough_type(cc.elements, key_of);
+                auto value_type = find_wide_enough_type(cc.elements, value_of);
+                if (!key_type || !value_type) {
                     return std::nullopt;
                 }
-                for (size_t i = 1; i < cc.elements.size(); ++i) {
-                    auto& entry = expr::as<tuple_constructor>(cc.elements[i]);
-                    auto kt = infer_type(entry.elements[0], db, keyspace, schema_opt);
-                    auto vt = infer_type(entry.elements[1], db, keyspace, schema_opt);
-                    if (!kt || *kt != *first_key_type || !vt || *vt != *first_value_type) {
-                        return std::nullopt;
-                    }
-                }
-                return map_type_impl::get_instance(*first_key_type, *first_value_type, false);
+                return map_type_impl::get_instance(*key_type, *value_type, false);
             }
             case collection_constructor::style_type::vector:
                 return std::nullopt;
@@ -1361,6 +1420,8 @@ static assignment_testable::test_result expression_test_assignment(const data_ty
     if (receiver.type->underlying_type() == expr_type->underlying_type() || (receiver.type == long_type && expr_type->is_counter())) {
         return assignment_testable::test_result::EXACT_MATCH;
     } else if (receiver.type->is_value_compatible_with(*expr_type)) {
+        return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
+    } else if (is_widenable_to(expr_type, receiver.type)) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     } else {
         return assignment_testable::test_result::NOT_ASSIGNABLE;

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -37,6 +37,7 @@ static const column_value resolve_column(const unresolved_identifier& col_ident,
 static assignment_testable::test_result expression_test_assignment(const data_type& expr_type,
                                                                    const column_specification& receiver);
 
+static std::optional<data_type> try_widen(const data_type& a, const data_type& b);
 static expression coerce_to(expression e, const data_type& target, data_dictionary::database db, const sstring& keyspace);
 
 static bool is_widenable_to(const data_type& from, const data_type& to);
@@ -90,11 +91,74 @@ struct prepare_memo {
 // Memo-threaded overloads of the public entry points. The public (memo-less) functions
 // create a prepare_memo on the stack and delegate here; the recursive prepare passes the
 // same memo by reference, so it is never global.
-static std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved = false);
+static std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo, bool allow_unresolved = false);
 static assignment_testable::test_result test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
 static expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo);
 static assignment_testable::test_result test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
 static ::shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt, prepare_memo& memo);
+
+struct inferred_elements {
+    data_type element_type;
+    std::vector<expression> prepared;
+};
+
+template <typename Project>
+static std::optional<inferred_elements>
+prepare_and_infer_collection_elements(std::span<const expression> elements,
+        data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, Project&& project, prepare_memo& memo) {
+    std::optional<data_type> result;
+    std::vector<expression> prepared;
+    prepared.reserve(elements.size());
+    for (const expression& e : elements) {
+        std::optional<expression> p = try_prepare_expression(project(e), db, keyspace, schema_opt, nullptr, /*infer_default=*/true, memo);
+        if (!p) {
+            return std::nullopt;
+        }
+        data_type t = type_of(*p);
+        if (!result) {
+            result = t;
+        } else if (**result != *t) {
+            auto widened = try_widen(*result, t);
+            if (!widened) {
+                return std::nullopt;
+            }
+            result = std::move(widened);
+        }
+        prepared.push_back(std::move(*p));
+    }
+    if (!result) {
+        return std::nullopt;
+    }
+    return inferred_elements{std::move(*result), std::move(prepared)};
+}
+
+// Build a collection literal from elements that were already prepared (by
+// prepare_and_infer_collection_elements), coercing each to the collection's element type
+// rather than preparing it again. Folds to a terminal constant when every element is.
+static expression
+build_collection_from_prepared(collection_constructor::style_type style, data_type collection_type,
+        data_type element_type, std::vector<expression> prepared,
+        data_dictionary::database db, const sstring& keyspace) {
+    std::vector<expression> values;
+    values.reserve(prepared.size());
+    bool all_terminal = true;
+    for (auto& p : prepared) {
+        expression elem = coerce_to(std::move(p), element_type, db, keyspace);
+        if (!is<constant>(elem)) {
+            all_terminal = false;
+        }
+        values.push_back(std::move(elem));
+    }
+    collection_constructor value {
+        .style = style,
+        .elements = std::move(values),
+        .type = std::move(collection_type),
+    };
+    if (all_terminal) {
+        return constant(evaluate(value, query_options::DEFAULT), value.type);
+    }
+    return value;
+}
 
 
 static
@@ -306,10 +370,43 @@ map_test_assignment(const collection_constructor& c, data_dictionary::database d
 
 static
 std::optional<expression>
-map_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+map_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo) {
     if (!receiver) {
-        // TODO: It is possible to infer the type of a map from the types of the key/value pairs
-        return std::nullopt;
+        if (!infer_default) {
+            return std::nullopt;
+        }
+        auto key_of = [] (const expression& e) -> const expression& { return expr::as<tuple_constructor>(e).elements[0]; };
+        auto value_of = [] (const expression& e) -> const expression& { return expr::as<tuple_constructor>(e).elements[1]; };
+        auto keys = prepare_and_infer_collection_elements(c.elements, db, keyspace, schema_opt, key_of, memo);
+        auto values = prepare_and_infer_collection_elements(c.elements, db, keyspace, schema_opt, value_of, memo);
+        if (!keys || !values) {
+            return std::nullopt;
+        }
+        data_type map_type = map_type_impl::get_instance(keys->element_type, values->element_type, false);
+        data_type entry_tuple_type = tuple_type_impl::get_instance({keys->element_type, values->element_type});
+        std::vector<expression> entries;
+        entries.reserve(c.elements.size());
+        bool all_terminal = true;
+        for (size_t i = 0; i < c.elements.size(); ++i) {
+            expression k = coerce_to(std::move(keys->prepared[i]), keys->element_type, db, keyspace);
+            expression v = coerce_to(std::move(values->prepared[i]), values->element_type, db, keyspace);
+            if (!is<constant>(k) || !is<constant>(v)) {
+                all_terminal = false;
+            }
+            entries.emplace_back(tuple_constructor {
+                .elements = {std::move(k), std::move(v)},
+                .type = entry_tuple_type,
+            });
+        }
+        collection_constructor map_value {
+            .style = collection_constructor::style_type::map,
+            .elements = std::move(entries),
+            .type = map_type,
+        };
+        if (all_terminal) {
+            return constant(evaluate(map_value, query_options::DEFAULT), map_value.type);
+        }
+        return map_value;
     }
     map_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
@@ -416,10 +513,19 @@ set_test_assignment(const collection_constructor& c, data_dictionary::database d
 
 static
 std::optional<expression>
-set_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+set_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo) {
     if (!receiver) {
-        // TODO: It is possible to infer the type of a set from the types of the values
-        return std::nullopt;
+        if (!infer_default) {
+            return std::nullopt;
+        }
+        auto identity = [] (const expression& e) -> const expression& { return e; };
+        auto inferred = prepare_and_infer_collection_elements(c.elements, db, keyspace, schema_opt, identity, memo);
+        if (!inferred) {
+            return std::nullopt;
+        }
+        return build_collection_from_prepared(collection_constructor::style_type::set,
+                set_type_impl::get_instance(inferred->element_type, false),
+                inferred->element_type, std::move(inferred->prepared), db, keyspace);
     }
     set_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
@@ -640,10 +746,22 @@ list_or_vector_test_assignment(const collection_constructor& c, data_dictionary:
 
 static
 std::optional<expression>
-list_or_vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+list_or_vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo) {
     if (!receiver) {
-        // TODO: It is possible to infer the type of a list or vector from the types of the key/value pairs
-        return std::nullopt;
+        if (!infer_default) {
+            return std::nullopt;
+        }
+        // With no receiver we cannot know a vector's dimension, so a bare list/vector
+        // literal is inferred as a list, built directly from the elements prepared
+        // during inference rather than preparing them a second time.
+        auto identity = [] (const expression& e) -> const expression& { return e; };
+        auto inferred = prepare_and_infer_collection_elements(c.elements, db, keyspace, schema_opt, identity, memo);
+        if (!inferred) {
+            return std::nullopt;
+        }
+        return build_collection_from_prepared(collection_constructor::style_type::list_or_vector,
+                list_type_impl::get_instance(inferred->element_type, false),
+                inferred->element_type, std::move(inferred->prepared), db, keyspace);
     }
 
     // We do not check if the receiver is a list because it is checked later in the list_prepare_expression.
@@ -698,7 +816,7 @@ tuple_constructor_test_assignment(const tuple_constructor& tc, data_dictionary::
 
 static
 std::optional<expression>
-tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo) {
     if (receiver) {
         tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, *receiver, memo);
     }
@@ -709,7 +827,7 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
         if (receiver) {
             component_receiver = component_spec_of(*receiver, i);
         }
-        std::optional<expression> value_opt = try_prepare_expression(tc.elements[i], db, keyspace, schema_opt, component_receiver, memo);
+        std::optional<expression> value_opt = try_prepare_expression(tc.elements[i], db, keyspace, schema_opt, component_receiver, infer_default && !receiver, memo);
         if (!value_opt) {
             return std::nullopt;
         }
@@ -866,11 +984,41 @@ untyped_constant_test_assignment(const untyped_constant& uc, data_dictionary::da
 }
 
 static
+std::optional<data_type>
+default_type_for_constant(const untyped_constant& uc) {
+    switch (uc.partial_type) {
+        case untyped_constant::type_class::string:          return utf8_type;
+        case untyped_constant::type_class::boolean:         return boolean_type;
+        case untyped_constant::type_class::floating_point:  return double_type;
+        case untyped_constant::type_class::duration:        return duration_type;
+        case untyped_constant::type_class::uuid:            return uuid_type;
+        case untyped_constant::type_class::hex:             return bytes_type;
+        case untyped_constant::type_class::null:            return std::nullopt;
+        case untyped_constant::type_class::integer:
+            try {
+                int32_type->from_string(uc.raw_text);
+                return int32_type;
+            } catch (const marshal_exception&) {}
+            try {
+                long_type->from_string(uc.raw_text);
+                return long_type;
+            } catch (const marshal_exception&) {}
+            return varint_type;
+    }
+    on_internal_error(expr_logger, format("unexpected untyped_constant type_class: {}", static_cast<int>(uc.partial_type)));
+}
+
+static
 std::optional<expression>
-untyped_constant_prepare_expression(const untyped_constant& uc, data_dictionary::database db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver)
+untyped_constant_prepare_expression(const untyped_constant& uc, data_dictionary::database db, const sstring& keyspace, lw_shared_ptr<column_specification> receiver, bool infer_default)
 {
     if (!receiver) {
-        // TODO: It is possible to infer the type of a constant by looking at the value and selecting the smallest fit
+        if (infer_default) {
+            if (auto default_type = default_type_for_constant(uc)) {
+                raw_value raw_val = cql3::raw_value::make_value(untyped_constant_parsed_value(uc, *default_type));
+                return constant(std::move(raw_val), std::move(*default_type));
+            }
+        }
         return std::nullopt;
     }
     if (!is_assignable(untyped_constant_test_assignment(uc, db, keyspace, *receiver))) {
@@ -1006,23 +1154,20 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
             keyspace, "unknown_cf", ::make_shared<column_identifier>(receiver_name, true), cast_type);
     }
 
-    auto prepared_arg = try_prepare_expression(c.arg, db, keyspace, schema_opt, nullptr, memo);
-    if (!prepared_arg) {
-        throw exceptions::invalid_request_exception(fmt::format("Could not infer type of cast argument {}", c.arg));
-    }
+    auto prepared_arg = prepare_expression(c.arg, db, keyspace, schema_opt, nullptr, memo);
 
     // cast to the same type should be omitted
-    if (cast_type == type_of(*prepared_arg)) {
+    if (cast_type == type_of(prepared_arg)) {
         return prepared_arg;
     }
 
     // This will throw if a cast is impossible
-    auto fun = functions::get_castas_fctn_as_cql3_function(cast_type, type_of(*prepared_arg));
+    auto fun = functions::get_castas_fctn_as_cql3_function(cast_type, type_of(prepared_arg));
 
     // We implement the cast to a function_call.
     return function_call{
         .func = std::move(fun),
-        .args = std::vector({*prepared_arg}),
+        .args = std::vector({std::move(prepared_arg)}),
     };
 }
 
@@ -1040,7 +1185,7 @@ cast_prepare_expression(const cast& c, data_dictionary::database db, const sstri
 std::optional<expression>
 field_selection_prepare_expression(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     // We can't infer the type of the user defined type from the field being selected
-    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, memo);
+    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, /*infer_default=*/false, memo);
     if (!prepared_structure) {
         throw exceptions::invalid_request_exception(fmt::format("Cannot infer type of {}", fs.structure));
     }
@@ -1074,7 +1219,7 @@ field_selection_prepare_expression(const field_selection& fs, data_dictionary::d
 assignment_testable::test_result
 field_selection_test_assignment(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     // We can't infer the type of the user defined type from the field being selected
-    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, memo);
+    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, /*infer_default=*/false, memo);
     if (!prepared_structure) {
         throw exceptions::invalid_request_exception(fmt::format("Cannot infer type of {}", fs.structure));
     }
@@ -1202,8 +1347,22 @@ prepare_function_args_for_type_inference(std::span<const expression> args, data_
         // A nullopt means the argument can't be resolved without a receiver (e.g. a nested
         // call that is ambiguous until the parameter type is known) - it stays a hole, to be
         // probed against each candidate parameter type and re-prepared once one is chosen.
-        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, memo, /*allow_unresolved=*/true);
-        std::optional<data_type> type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
+        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, /*infer_default=*/false, memo, /*allow_unresolved=*/true);
+        std::optional<data_type> type;
+        if (prepared_arg_opt) {
+            type = type_of(*prepared_arg_opt);
+        } else {
+            // Hole: keep the raw expression as the testable (so overload resolution
+            // still fit-checks untyped constants against narrow parameter types), but
+            // attach a default-type hint for functions that need to know the argument
+            // type up front, such as count() and toJson(). The hint is derived from the
+            // same default inference used elsewhere; the defaulted form itself is not
+            // reused as the prepared argument, so it does not pin a literal to its
+            // default type before the real parameter type is known.
+            if (auto defaulted = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, /*infer_default=*/true, memo, /*allow_unresolved=*/true)) {
+                type = type_of(*defaulted);
+            }
+        }
         expression testable_expr = prepared_arg_opt ? *prepared_arg_opt : argument;
         partially_prepared_args.push_back(partially_prepared_arg{
             .testable = as_assignment_testable(std::move(testable_expr), std::move(type), memo),
@@ -1481,7 +1640,7 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
     bool all_terminal = true;
     for (const expression& child : conj.children) {
         std::optional<expression> prepared_child =
-            try_prepare_expression(child, db, keyspace, schema_opt, child_receiver, memo);
+            try_prepare_expression(child, db, keyspace, schema_opt, child_receiver, /*infer_default=*/false, memo);
         if (!prepared_child.has_value()) {
             throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", child));
         }
@@ -1566,13 +1725,13 @@ prepare_column_mutation_attribute(
 }
 
 std::optional<expression>
-try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default) {
     prepare_memo memo;
-    return try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), memo);
+    return try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), infer_default, memo);
 }
 
 static std::optional<expression>
-try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved) {
+try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool infer_default, prepare_memo& memo, bool allow_unresolved) {
     return expr::visit(overloaded_functor{
         [&] (const constant& value) -> std::optional<expression> {
             if (receiver && !is_assignable(expression_test_assignment(value.type, *receiver))) {
@@ -1628,7 +1787,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             }
             auto& schema = *schema_opt;
 
-            auto sub_col_opt = try_prepare_expression(sub.val, db, keyspace, schema_opt, receiver, memo);
+            auto sub_col_opt = try_prepare_expression(sub.val, db, keyspace, schema_opt, receiver, /*infer_default=*/false, memo);
             if (!sub_col_opt) {
                 return std::nullopt;
             }
@@ -1679,16 +1838,16 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return bind_variable_prepare_expression(bv, db, keyspace, receiver);
         },
         [&] (const untyped_constant& uc) -> std::optional<expression> {
-            return untyped_constant_prepare_expression(uc, db, keyspace, receiver);
+            return untyped_constant_prepare_expression(uc, db, keyspace, receiver, infer_default);
         },
         [&] (const tuple_constructor& tc) -> std::optional<expression> {
-            return tuple_constructor_prepare_nontuple(tc, db, keyspace, schema_opt, receiver, memo);
+            return tuple_constructor_prepare_nontuple(tc, db, keyspace, schema_opt, receiver, infer_default, memo);
         },
         [&] (const collection_constructor& c) -> std::optional<expression> {
             switch (c.style) {
-            case collection_constructor::style_type::list_or_vector: return list_or_vector_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
-            case collection_constructor::style_type::set: return set_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
-            case collection_constructor::style_type::map: return map_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
+            case collection_constructor::style_type::list_or_vector: return list_or_vector_prepare_expression(c, db, keyspace, schema_opt, receiver, infer_default, memo);
+            case collection_constructor::style_type::set: return set_prepare_expression(c, db, keyspace, schema_opt, receiver, infer_default, memo);
+            case collection_constructor::style_type::map: return map_prepare_expression(c, db, keyspace, schema_opt, receiver, infer_default, memo);
             case collection_constructor::style_type::vector:
                 on_internal_error(expr_logger, "vector style type found during prepare, should have been introduced post-prepare");
             }
@@ -1906,7 +2065,15 @@ prepare_expression(const expression& expr, data_dictionary::database db, const s
 
 static expression
 prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
-    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, memo);
+    // Pass 1: contextual typing. Expressions without a type (untyped constants,
+    // collection literals) yield nullopt when no receiver constrains them.
+    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/false, memo);
+    // Pass 2: default-type inference. The same prepare is retried with infer_default
+    // enabled, so untyped constants and collection literals fall back to a default
+    // type at the point where no receiver is available.
+    if (!e_opt) {
+        e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, /*infer_default=*/true, memo);
+    }
     if (!e_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
     }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1372,42 +1372,6 @@ prepare_function_args_for_type_inference(std::span<const expression> args, data_
     return partially_prepared_args;
 }
 
-// Special case for count(1) - recognize it as the countRows() function. Note it is quite
-// artificial and we might relax it to the more general count(expression) later.
-static
-std::optional<expression>
-try_prepare_count_rows(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    return std::visit(overloaded_functor{
-        [&] (const functions::function_name& name) -> std::optional<expression> {
-            auto native_name = name;
-            if (!native_name.has_keyspace()) {
-                native_name = name.as_native_function();
-            }
-            // Collapse count(1) into countRows()
-            if (native_name == functions::function_name::native_function("count")) {
-                if (fc.args.size() == 1) {
-                    if (auto uc_arg = expr::as_if<expr::untyped_constant>(&fc.args[0])) {
-                        if (uc_arg->partial_type == expr::untyped_constant::type_class::integer
-                                && uc_arg->raw_text == "1") {
-                            return expr::function_call{
-                                .func = functions::aggregate_fcts::make_count_rows_function(),
-                                .args = {},
-                            };
-                        } else {
-                            throw exceptions::invalid_request_exception(format("count() expects a column or the literal 1 as an argument, got {}", fc.args[0]));
-                        }
-                    }
-                }
-            }
-            return std::nullopt;
-        },
-        [] (const shared_ptr<functions::function>&) -> std::optional<expression> {
-            // Already prepared, nothing to do
-            return std::nullopt;
-        },
-    }, fc.func);
-}
-
 // Counts entries to prepare_function_call and test_assignment_function_call. Used by
 // tests to guard against re-introducing exponential preparation of nested function calls.
 static thread_local uint64_t g_prepare_function_call_count = 0;
@@ -1445,9 +1409,6 @@ prepare_memo::prepare_memo() : enabled(g_prepare_memo_enabled) {}
 std::optional<expression>
 prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved) {
     ++g_prepare_function_call_count;
-    if (auto prepared = try_prepare_count_rows(fc, db, keyspace, schema_opt, receiver)) {
-        return prepared;
-    }
     // Try to extract a column family name from the available information.
     // Most functions can be prepared without information about the column family, usually just the keyspace is enough.
     // One exception is the token() function - in order to prepare system.token() we have to know the partition key of the table,

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -905,85 +905,6 @@ untyped_constant_parsed_value(const untyped_constant& uc, data_type validator)
 }
 
 static
-assignment_testable::test_result
-untyped_constant_test_assignment(const untyped_constant& uc, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver)
-{
-    bool uc_is_null = uc.partial_type == untyped_constant::type_class::null;
-    auto receiver_type = receiver.type->as_cql3_type();
-    if ((receiver_type.is_collection() || receiver_type.is_user_type() || receiver_type.is_vector()) && !uc_is_null) {
-        return assignment_testable::test_result::NOT_ASSIGNABLE;
-    }
-    if (!receiver_type.is_native()) {
-        return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-    }
-    auto kind = receiver_type.get_kind();
-    switch (uc.partial_type) {
-        case untyped_constant::type_class::string:
-            if (cql3_type::kind_enum_set::frozen<
-                    cql3_type::kind::ASCII,
-                    cql3_type::kind::TEXT,
-                    cql3_type::kind::INET,
-                    cql3_type::kind::TIMESTAMP,
-                    cql3_type::kind::DATE,
-                    cql3_type::kind::TIME>::contains(kind)) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::integer:
-            if (cql3_type::kind_enum_set::frozen<
-                    cql3_type::kind::BIGINT,
-                    cql3_type::kind::COUNTER,
-                    cql3_type::kind::DECIMAL,
-                    cql3_type::kind::DOUBLE,
-                    cql3_type::kind::FLOAT,
-                    cql3_type::kind::INT,
-                    cql3_type::kind::SMALLINT,
-                    cql3_type::kind::TIMESTAMP,
-                    cql3_type::kind::DATE,
-                    cql3_type::kind::TINYINT,
-                    cql3_type::kind::VARINT>::contains(kind)) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::uuid:
-            if (cql3_type::kind_enum_set::frozen<
-                    cql3_type::kind::UUID,
-                    cql3_type::kind::TIMEUUID>::contains(kind)) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::floating_point:
-            if (cql3_type::kind_enum_set::frozen<
-                    cql3_type::kind::DECIMAL,
-                    cql3_type::kind::DOUBLE,
-                    cql3_type::kind::FLOAT>::contains(kind)) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::boolean:
-            if (kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::BOOLEAN>()) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::hex:
-            if (kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::BLOB>()) {
-                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-            }
-            break;
-        case untyped_constant::type_class::duration:
-            if (kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::DURATION>()) {
-                return assignment_testable::test_result::EXACT_MATCH;
-            }
-            break;
-        case untyped_constant::type_class::null:
-            return receiver.type->is_counter()
-                ? assignment_testable::test_result::NOT_ASSIGNABLE
-                : assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-    }
-    return assignment_testable::test_result::NOT_ASSIGNABLE;
-}
-
-static
 std::optional<data_type>
 default_type_for_constant(const untyped_constant& uc) {
     switch (uc.partial_type) {
@@ -1006,6 +927,81 @@ default_type_for_constant(const untyped_constant& uc) {
             return varint_type;
     }
     on_internal_error(expr_logger, format("unexpected untyped_constant type_class: {}", static_cast<int>(uc.partial_type)));
+}
+
+static
+assignment_testable::test_result
+untyped_constant_test_assignment(const untyped_constant& uc, data_dictionary::database db, const sstring& keyspace, const column_specification& receiver)
+{
+    bool uc_is_null = uc.partial_type == untyped_constant::type_class::null;
+    auto receiver_type = receiver.type->as_cql3_type();
+    if ((receiver_type.is_collection() || receiver_type.is_user_type() || receiver_type.is_vector()) && !uc_is_null) {
+        return assignment_testable::test_result::NOT_ASSIGNABLE;
+    }
+    if (!receiver_type.is_native()) {
+        return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
+    }
+    auto kind = receiver_type.get_kind();
+    bool compatible = false;
+    switch (uc.partial_type) {
+        case untyped_constant::type_class::string:
+            compatible = cql3_type::kind_enum_set::frozen<
+                    cql3_type::kind::ASCII,
+                    cql3_type::kind::TEXT,
+                    cql3_type::kind::INET,
+                    cql3_type::kind::TIMESTAMP,
+                    cql3_type::kind::DATE,
+                    cql3_type::kind::TIME>::contains(kind);
+            break;
+        case untyped_constant::type_class::integer:
+            compatible = cql3_type::kind_enum_set::frozen<
+                    cql3_type::kind::BIGINT,
+                    cql3_type::kind::COUNTER,
+                    cql3_type::kind::DECIMAL,
+                    cql3_type::kind::DOUBLE,
+                    cql3_type::kind::FLOAT,
+                    cql3_type::kind::INT,
+                    cql3_type::kind::SMALLINT,
+                    cql3_type::kind::TIMESTAMP,
+                    cql3_type::kind::DATE,
+                    cql3_type::kind::TINYINT,
+                    cql3_type::kind::VARINT>::contains(kind);
+            break;
+        case untyped_constant::type_class::uuid:
+            compatible = cql3_type::kind_enum_set::frozen<
+                    cql3_type::kind::UUID,
+                    cql3_type::kind::TIMEUUID>::contains(kind);
+            break;
+        case untyped_constant::type_class::floating_point:
+            compatible = cql3_type::kind_enum_set::frozen<
+                    cql3_type::kind::DECIMAL,
+                    cql3_type::kind::DOUBLE,
+                    cql3_type::kind::FLOAT>::contains(kind);
+            break;
+        case untyped_constant::type_class::boolean:
+            compatible = kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::BOOLEAN>();
+            break;
+        case untyped_constant::type_class::hex:
+            compatible = kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::BLOB>();
+            break;
+        case untyped_constant::type_class::duration:
+            if (kind == cql3_type::kind_enum_set::prepare<cql3_type::kind::DURATION>()) {
+                return assignment_testable::test_result::EXACT_MATCH;
+            }
+            break;
+        case untyped_constant::type_class::null:
+            return receiver.type->is_counter()
+                ? assignment_testable::test_result::NOT_ASSIGNABLE
+                : assignment_testable::test_result::WEAKLY_ASSIGNABLE;
+    }
+    if (!compatible) {
+        return assignment_testable::test_result::NOT_ASSIGNABLE;
+    }
+    if (auto default_type = default_type_for_constant(uc);
+            default_type && (*default_type)->as_cql3_type().get_kind() == kind) {
+        return assignment_testable::test_result::EXACT_MATCH;
+    }
+    return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
 }
 
 static

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1404,31 +1404,31 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
     // of another, existing, function. In that case, we return true here because we'll throw a proper exception
     // later with a more helpful error message that if we were to return false here.
     auto result = [&] () -> assignment_testable::test_result {
-    try {
-        auto&& fun = std::visit(overloaded_functor{
-            [&] (const functions::function_name& name) {
-                auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt, memo);
-                return functions::instance().get(db, keyspace, name,
-                        args
-                                | std::views::transform(&partially_prepared_arg::testable)
-                                | std::ranges::to<std::vector>(),
-                        receiver.ks_name, receiver.cf_name, &receiver);
-            },
-            [] (const shared_ptr<functions::function>& func) {
-                return func;
-            },
-        }, fc.func);
-        if (fun && receiver.type == fun->return_type()) {
-            return assignment_testable::test_result::EXACT_MATCH;
-        } else if (!fun || receiver.type->is_value_compatible_with(*fun->return_type())
-                        || is_widenable_to(fun->return_type(), receiver.type)) {
+        try {
+            auto&& fun = std::visit(overloaded_functor{
+                [&] (const functions::function_name& name) {
+                    auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt, memo);
+                    return functions::instance().get(db, keyspace, name,
+                            args
+                                    | std::views::transform(&partially_prepared_arg::testable)
+                                    | std::ranges::to<std::vector>(),
+                            receiver.ks_name, receiver.cf_name, &receiver);
+                },
+                [] (const shared_ptr<functions::function>& func) {
+                    return func;
+                },
+            }, fc.func);
+            if (fun && receiver.type == fun->return_type()) {
+                return assignment_testable::test_result::EXACT_MATCH;
+            } else if (!fun || receiver.type->is_value_compatible_with(*fun->return_type())
+                            || is_widenable_to(fun->return_type(), receiver.type)) {
+                return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
+            } else {
+                return assignment_testable::test_result::NOT_ASSIGNABLE;
+            }
+        } catch (exceptions::invalid_request_exception& e) {
             return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-        } else {
-            return assignment_testable::test_result::NOT_ASSIGNABLE;
         }
-    } catch (exceptions::invalid_request_exception& e) {
-        return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
-    }
     }();
 
     if (memo_key) {

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1126,17 +1126,33 @@ coerce_to(expression e, const data_type& target, data_dictionary::database db, c
     return e;
 }
 
+// One function argument, partially processed for overload resolution.
+//   testable - fed to functions::get() to choose the overload.
+//   prepared - the argument, if it could be prepared with no receiver. Reusing it
+//              (instead of preparing again for each candidate) keeps nested calls linear.
+struct partially_prepared_arg {
+    ::shared_ptr<assignment_testable> testable;
+    std::optional<expression> prepared;
+};
+
 static
-std::vector<::shared_ptr<assignment_testable>>
+std::vector<partially_prepared_arg>
 prepare_function_args_for_type_inference(std::span<const expression> args, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt) {
     // Prepare the arguments that can be prepared without a receiver.
     // Prepared expressions have a known type, which helps with finding the right function.
-    std::vector<shared_ptr<assignment_testable>> partially_prepared_args;
+    std::vector<partially_prepared_arg> partially_prepared_args;
+    partially_prepared_args.reserve(args.size());
     for (const expression& argument : args) {
-        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr);
-        auto type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
-        auto expr = prepared_arg_opt ? std::move(*prepared_arg_opt) : argument;
-        partially_prepared_args.emplace_back(as_assignment_testable(std::move(expr), std::move(type)));
+        // A nullopt means the argument can't be resolved without a receiver (e.g. a nested
+        // call that is ambiguous until the parameter type is known) - it stays a hole, to be
+        // probed against each candidate parameter type and re-prepared once one is chosen.
+        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, /*allow_unresolved=*/true);
+        std::optional<data_type> type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
+        expression testable_expr = prepared_arg_opt ? *prepared_arg_opt : argument;
+        partially_prepared_args.push_back(partially_prepared_arg{
+            .testable = as_assignment_testable(std::move(testable_expr), std::move(type)),
+            .prepared = std::move(prepared_arg_opt),
+        });
     }
     return partially_prepared_args;
 }
@@ -1177,8 +1193,21 @@ try_prepare_count_rows(const expr::function_call& fc, data_dictionary::database 
     }, fc.func);
 }
 
+// Counts entries to prepare_function_call. Used by tests to guard against
+// re-introducing exponential preparation of nested function calls.
+static thread_local uint64_t g_prepare_function_call_count = 0;
+
+uint64_t prepare_function_call_count() {
+    return g_prepare_function_call_count;
+}
+
+void reset_prepare_function_call_count() {
+    g_prepare_function_call_count = 0;
+}
+
 std::optional<expression>
-prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved) {
+    ++g_prepare_function_call_count;
     if (auto prepared = try_prepare_count_rows(fc, db, keyspace, schema_opt, receiver)) {
         return prepared;
     }
@@ -1198,18 +1227,36 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     // Prepared expressions have a known type, which helps with finding the right function.
     auto partially_prepared_args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt);
 
-    auto&& fun = std::visit(overloaded_functor{
-        [] (const shared_ptr<functions::function>& func) {
+    auto fun_opt = std::visit(overloaded_functor{
+        [] (const shared_ptr<functions::function>& func) -> std::optional<shared_ptr<functions::function>> {
             return func;
         },
-        [&] (const functions::function_name& name) {
-            auto fun = functions::instance().get(db, keyspace, name, partially_prepared_args, keyspace, cf_name, receiver.get());
-            if (!fun) {
-                throw exceptions::invalid_request_exception(format("Unknown function {} called", name));
+        [&] (const functions::function_name& name) -> std::optional<shared_ptr<functions::function>> {
+            auto resolution = functions::instance().try_get(db, keyspace, name,
+                    partially_prepared_args
+                            | std::views::transform(&partially_prepared_arg::testable)
+                            | std::ranges::to<std::vector>(),
+                    keyspace, cf_name, receiver.get());
+            // try_get yields the function (null if the name isn't declared) or the resolution
+            // error. When this call is an argument being probed for inference (allow_unresolved),
+            // an unresolved call is an expected hole; otherwise (a direct/top-level prepare) it is
+            // a real error to surface.
+            if (resolution.has_value() && resolution.value()) {
+                return std::move(resolution).value();
             }
-            return fun;
+            if (allow_unresolved) {
+                return std::nullopt;
+            }
+            if (resolution.has_error()) {
+                resolution.error().throw_me();
+            }
+            throw exceptions::invalid_request_exception(format("Unknown function {} called", name));
         },
     }, fc.func);
+    if (!fun_opt) {
+        return std::nullopt;
+    }
+    auto fun = std::move(*fun_opt);
 
     // Functions.get() will complain if no function "name" type check with the provided arguments.
     // Still validate the return type: accepted if value-compatible with the receiver or
@@ -1230,8 +1277,17 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     parameters.reserve(partially_prepared_args.size());
     bool all_terminal = true;
     for (size_t i = 0; i < partially_prepared_args.size(); ++i) {
-        expr::expression e = prepare_expression(fc.args[i], db, keyspace, schema_opt,
-                                                functions::instance().make_arg_spec(keyspace, cf_name, *fun, i));
+        auto arg_spec = functions::instance().make_arg_spec(keyspace, cf_name, *fun, i);
+        // Both paths must yield arg_spec->type: prepare_expression tail-coerces; the
+        // reuse path coerces explicitly.
+        expr::expression e = [&] () -> expr::expression {
+            if (!partially_prepared_args[i].prepared) {
+                return prepare_expression(fc.args[i], db, keyspace, schema_opt, arg_spec);
+            } else {
+                expr::expression prepared = std::move(*partially_prepared_args[i].prepared);
+                return coerce_to(std::move(prepared), arg_spec->type, db, keyspace);
+            }
+        }();
         if (!expr::is<expr::constant>(e)) {
             all_terminal = false;
         }
@@ -1262,7 +1318,11 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
         auto&& fun = std::visit(overloaded_functor{
             [&] (const functions::function_name& name) {
                 auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt);
-                return functions::instance().get(db, keyspace, name, args, receiver.ks_name, receiver.cf_name, &receiver);
+                return functions::instance().get(db, keyspace, name,
+                        args
+                                | std::views::transform(&partially_prepared_arg::testable)
+                                | std::ranges::to<std::vector>(),
+                        receiver.ks_name, receiver.cf_name, &receiver);
             },
             [] (const shared_ptr<functions::function>& func) {
                 return func;
@@ -1408,7 +1468,7 @@ prepare_column_mutation_attribute(
 }
 
 std::optional<expression>
-try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved) {
     return expr::visit(overloaded_functor{
         [&] (const constant& value) -> std::optional<expression> {
             if (receiver && !is_assignable(expression_test_assignment(value.type, *receiver))) {
@@ -1503,7 +1563,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return prepare_column_mutation_attribute(cma, db, keyspace, schema_opt, std::move(receiver));
         },
         [&] (const function_call& fc) -> std::optional<expression> {
-            return prepare_function_call(fc, db, keyspace, schema_opt, std::move(receiver));
+            return prepare_function_call(fc, db, keyspace, schema_opt, std::move(receiver), allow_unresolved);
         },
         [&] (const cast& c) -> std::optional<expression> {
             return cast_prepare_expression(c, db, keyspace, schema_opt, receiver);

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -36,6 +36,10 @@ static const column_value resolve_column(const unresolved_identifier& col_ident,
 static assignment_testable::test_result expression_test_assignment(const data_type& expr_type,
                                                                    const column_specification& receiver);
 
+static expression coerce_to(expression e, const data_type& target, data_dictionary::database db, const sstring& keyspace);
+
+static bool is_widenable_to(const data_type& from, const data_type& to);
+
 
 static
 lw_shared_ptr<column_specification>
@@ -653,7 +657,13 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
         if (!value_opt) {
             return std::nullopt;
         }
-        auto& value = *value_opt;
+        auto value = std::move(*value_opt);
+        // A prepared component can carry a type narrower than the declared component
+        // type (e.g. a widening C-cast); coerce it so the serialized tuple matches
+        // the receiver's layout.
+        if (component_receiver) {
+            value = coerce_to(std::move(value), component_receiver->type, db, keyspace);
+        }
         if (!is<constant>(value)) {
             all_terminal = false;
         }
@@ -871,7 +881,8 @@ cast_test_assignment(const cast& c, data_dictionary::database db, const sstring&
         data_type casted_type = cast_get_prepared_type(c, db, keyspace);
         if (receiver.type == casted_type) {
             return assignment_testable::test_result::EXACT_MATCH;
-        } else if (receiver.type->is_value_compatible_with(*casted_type)) {
+        } else if (receiver.type->is_value_compatible_with(*casted_type)
+                   || is_widenable_to(casted_type, receiver.type)) {
             return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
         } else {
             return assignment_testable::test_result::NOT_ASSIGNABLE;
@@ -883,10 +894,9 @@ cast_test_assignment(const cast& c, data_dictionary::database db, const sstring&
 
 // expr::cast shows up when the user uses a C-style cast with destination type in parenthesis.
 // For example: `(int)1242` or `(blob)(int)1337`.
-// Currently such casts are very limited. Casting using this syntax is only allowed when the
-// binary representation doesn't change during the cast. This means that it's legal to cast
-// an int to blob (the bytes don't change), but it's illegal to cast an int to bigint (4 bytes -> 8 bytes).
-// This limitation simplifies things - we can just reinterpret the value as the destination type.
+// A C-style cast represents its argument's value as the destination type when that is
+// lossless: a byte-compatible reinterpret (e.g. int -> blob, the bytes don't change) or a
+// numeric widening (e.g. int -> bigint, converted like CAST).
 static
 std::optional<expression>
 c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
@@ -902,30 +912,30 @@ c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sst
     lw_shared_ptr<column_specification> cast_type_receiver = casted_spec_of(c, db, keyspace, *receiver);
 
     // First check if the casted expression can be assigned(converted) to the type specified in the cast.
-    // test_assignment uses is_value_compatible_with to check if the binary representation is compatible
-    // between the two types.
+    // test_assignment accepts a value-compatible binary representation or a lossless widening to c.type.
     if (!is_assignable(test_assignment(c.arg, db, keyspace, schema_opt, *cast_type_receiver))) {
         throw exceptions::invalid_request_exception(format("Cannot cast value {:user} to type {}", c.arg, cast_type->as_cql3_type()));
     }
-
-    // Then check if a value of type c.type can be assigned(converted) to the receiver type.
-    // cast_test_assignment also uses is_value_compatible_with to check binary representation compatibility.
-    if (!is_assignable(cast_test_assignment(c, db, keyspace, schema_opt, *receiver))) {
-        throw exceptions::invalid_request_exception(format("Cannot assign value {:user} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
-    }
-
-    // Now we know that c.arg is compatible with c.type, and c.type is compatible with receiver->type.
-    // This means that the cast is correct - we can take the binary representation of c.arg value and
-    // reinterpret it as a value of type receiver->type without any problems.
 
     // Prepare the argument using cast_type_receiver.
     // Using this receiver makes it possible to write things like: (blob)(int)1234
     // Using the original receiver wouldn't work in such cases - it would complain
     // that untyped_constant(1234) isn't a valid blob constant.
+    expression prepared_arg = prepare_expression(c.arg, db, keyspace, schema_opt, cast_type_receiver);
+
+    // Then check if a value of type c.type can be assigned(converted) to the receiver type.
+    // cast_test_assignment accepts a value-compatible representation or a lossless widening to it.
+    if (!is_assignable(cast_test_assignment(c, db, keyspace, schema_opt, *receiver))) {
+        throw exceptions::invalid_request_exception(format("Cannot assign value {:user} to {} of type {}", c, receiver->name, receiver->type->as_cql3_type()));
+    }
+
+    // Now we know c.arg is compatible with c.type, and c.type with receiver->type - by a binary
+    // reinterpret or a lossless widening. The cast node carries c.type; if receiver->type is wider,
+    // the consuming prepare_expression coerces the result to it.
     return cast{
         .style = cast::cast_style::c,
-        .arg = prepare_expression(c.arg, db, keyspace, schema_opt, cast_type_receiver),
-        .type = receiver->type,
+        .arg = std::move(prepared_arg),
+        .type = cast_type,
     };
 }
 
@@ -1034,6 +1044,88 @@ field_selection_test_assignment(const field_selection& fs, data_dictionary::data
     return expression_test_assignment(field_type, receiver);
 }
 
+// Widen two types within a shared lossless numeric chain, returning the wider one
+// (nullopt if they share none). Chains: byte < short < int32 < int64 < varint, and
+// float < double; cross-chain (e.g. int32 -> double) is not widenable.
+static
+std::optional<data_type>
+try_widen(const data_type& a, const data_type& b) {
+    using kind = abstract_type::kind;
+    static constexpr kind integer_chain[] = {
+        kind::byte, kind::short_kind, kind::int32, kind::long_kind, kind::varint
+    };
+    static constexpr kind float_chain[] = {
+        kind::float_kind, kind::double_kind
+    };
+    auto rank_in = [] (const kind chain[], size_t len, const data_type& t) -> std::optional<size_t> {
+        for (size_t i = 0; i < len; ++i) {
+            if (chain[i] == t->without_reversed().get_kind()) {
+                return i;
+            }
+        }
+        return std::nullopt;
+    };
+    auto kind_to_type = [] (kind k) -> data_type {
+        switch (k) {
+            case kind::byte: return byte_type;
+            case kind::short_kind: return short_type;
+            case kind::int32: return int32_type;
+            case kind::long_kind: return long_type;
+            case kind::varint: return varint_type;
+            case kind::float_kind: return float_type;
+            case kind::double_kind: return double_type;
+            default: on_internal_error(expr_logger, format("unexpected kind in numeric widening: {}", static_cast<int>(k)));
+        }
+    };
+    auto ra = rank_in(integer_chain, std::size(integer_chain), a);
+    auto rb = rank_in(integer_chain, std::size(integer_chain), b);
+    if (ra && rb) {
+        return kind_to_type(integer_chain[std::max(*ra, *rb)]);
+    }
+    ra = rank_in(float_chain, std::size(float_chain), a);
+    rb = rank_in(float_chain, std::size(float_chain), b);
+    if (ra && rb) {
+        return kind_to_type(float_chain[std::max(*ra, *rb)]);
+    }
+    return std::nullopt;
+}
+
+static
+bool is_widenable_to(const data_type& from, const data_type& to) {
+    auto widened = try_widen(from, to);
+    return widened && **widened == to->without_reversed();
+}
+
+// Give `e` target's representation. Precondition: `e` is assignable to `target`.
+// Value-compatible types share bytes, so only a constant's label is updated; a
+// width-changing widening (e.g. int -> bigint) needs a real castas conversion,
+// folded immediately for a terminal constant.
+static
+expression
+coerce_to(expression e, const data_type& target, data_dictionary::database db, const sstring& keyspace) {
+    const data_type src = type_of(e);
+    if (src == target) {
+        return e;
+    }
+    // Only a width-changing widening needs conversion; every other assignable pair
+    // (value-compatible, widening to varint, counter -> bigint, reversed) is byte-safe.
+    if (is_widenable_to(src, target) && !target->is_value_compatible_with(*src)) {
+        const bool terminal = expr::is<constant>(e);
+        function_call conversion {
+            .func = functions::get_castas_fctn_as_cql3_function(target->underlying_type(), src),
+            .args = {std::move(e)},
+        };
+        if (terminal) {
+            return constant(expr::evaluate(conversion, query_options::DEFAULT), target);
+        }
+        return conversion;
+    }
+    if (auto* c = expr::as_if<constant>(&e)) {
+        c->type = target;
+    }
+    return e;
+}
+
 static
 std::vector<::shared_ptr<assignment_testable>>
 prepare_function_args_for_type_inference(std::span<const expression> args, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt) {
@@ -1120,8 +1212,10 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
     }, fc.func);
 
     // Functions.get() will complain if no function "name" type check with the provided arguments.
-    // We still have to validate that the return type matches however
-    if (receiver && !receiver->type->is_value_compatible_with(*fun->return_type())) {
+    // Still validate the return type: accepted if value-compatible with the receiver or
+    // widenable to it (the caller then wraps the call via coerce_to).
+    if (receiver && !receiver->type->is_value_compatible_with(*fun->return_type())
+            && !is_widenable_to(fun->return_type(), receiver->type)) {
         throw exceptions::invalid_request_exception(format("Type error: cannot assign result of function {} (type {}) to {} (type {})",
                                                     fun->name(), fun->return_type()->as_cql3_type(),
                                                     receiver->name, receiver->type->as_cql3_type()));
@@ -1176,7 +1270,8 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
         }, fc.func);
         if (fun && receiver.type == fun->return_type()) {
             return assignment_testable::test_result::EXACT_MATCH;
-        } else if (!fun || receiver.type->is_value_compatible_with(*fun->return_type())) {
+        } else if (!fun || receiver.type->is_value_compatible_with(*fun->return_type())
+                        || is_widenable_to(fun->return_type(), receiver.type)) {
             return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
         } else {
             return assignment_testable::test_result::NOT_ASSIGNABLE;
@@ -1191,6 +1286,8 @@ static assignment_testable::test_result expression_test_assignment(const data_ty
     if (receiver.type->underlying_type() == expr_type->underlying_type() || (receiver.type == long_type && expr_type->is_counter())) {
         return assignment_testable::test_result::EXACT_MATCH;
     } else if (receiver.type->is_value_compatible_with(*expr_type)) {
+        return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
+    } else if (is_widenable_to(expr_type, receiver.type)) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     } else {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
@@ -1320,13 +1417,10 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
                            value.type->as_cql3_type(), receiver->name, receiver->type->as_cql3_type()));
             }
 
-            constant result = value;
             if (receiver) {
-                // The receiver might have a different type from the constant, but this is allowed if the types are compatible.
-                // In such case the type is implicitly converted to receiver type.
-                result.type = receiver->type;
+                return coerce_to(value, receiver->type, db, keyspace);
             }
-            return result;
+            return value;
         },
         [&] (const binary_operator& binop) -> std::optional<expression> {
             if (receiver.get() != nullptr && &receiver->type->without_reversed() != boolean_type.get()) {
@@ -1636,11 +1730,15 @@ test_assignment_any_size_float_vector(const expression& expr) {
 
 expression
 prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver));
+    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver);
     if (!e_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
     }
-    return std::move(*e_opt);
+    expression result = std::move(*e_opt);
+    if (receiver) {
+        result = coerce_to(std::move(result), receiver->type, db, keyspace);
+    }
+    return result;
 }
 
 assignment_testable::test_result

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -26,6 +26,7 @@
 #include "exceptions/unrecognized_entity_exception.hh"
 #include "utils/like_matcher.hh"
 #include "utils/chunked_string.hh"
+#include "utils/hash.hh"
 
 #include <ranges>
 
@@ -39,6 +40,61 @@ static assignment_testable::test_result expression_test_assignment(const data_ty
 static expression coerce_to(expression e, const data_type& target, data_dictionary::database db, const sstring& keyspace);
 
 static bool is_widenable_to(const data_type& from, const data_type& to);
+
+// Memoization that is active only for the duration of a single top-level prepare.
+//
+// Resolving an unresolved nested function call against a candidate parameter type
+// is recursive. When a multi-overload function has an argument that is itself an
+// unresolved hole (e.g. an ambiguous nested call), overload resolution probes that
+// hole once per candidate parameter type, at every nesting level - which is
+// exponential in the nesting depth. Caching the result of such a probe for a given
+// (call, receiver type) collapses that back to linear.
+//
+// A prepare_memo is created on the stack by the public prepare entry points and
+// threaded by reference through the recursive prepare; it is freed when that entry
+// point returns, so nothing is retained between independent prepare calls. Being a
+// parameter rather than a global, its lifetime is exactly the prepare it belongs to,
+// with no dependence on preparation staying synchronous.
+//
+// keyspace/schema/cf are constant within a prepare, so the key is just (call, receiver type).
+struct call_probe_key {
+    function_call call;
+    data_type receiver_type;
+    bool operator==(const call_probe_key&) const = default;
+};
+
+// Shallow hash: (qualified name, arity, receiver type) only - args aren't hashed; operator== separates them.
+struct call_probe_key_hash {
+    size_t operator()(const call_probe_key& k) const {
+        const auto fn = std::visit(overloaded_functor{
+            [] (const functions::function_name& name) { return name; },
+            [] (const shared_ptr<functions::function>& f) { return f->name(); },
+        }, k.call.func);
+        size_t h = std::hash<functions::function_name>{}(fn);
+        h = utils::hash_combine(h, k.call.args.size());
+        h = utils::hash_combine(h, std::hash<sstring>{}(k.receiver_type->name()));
+        return h;
+    }
+};
+
+struct prepare_memo {
+    // Test-only: when false, probes are neither looked up nor stored, so a test can
+    // observe the un-memoized (exponential) probing cost for comparison. The constructor
+    // seeds it from the test switch (always true in release).
+    bool enabled = true;
+    std::unordered_map<call_probe_key, assignment_testable::test_result, call_probe_key_hash> test_assignment_function_call;
+
+    prepare_memo();
+};
+
+// Memo-threaded overloads of the public entry points. The public (memo-less) functions
+// create a prepare_memo on the stack and delegate here; the recursive prepare passes the
+// same memo by reference, so it is never global.
+static std::optional<expression> try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved = false);
+static assignment_testable::test_result test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
+static expression prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo);
+static assignment_testable::test_result test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo);
+static ::shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt, prepare_memo& memo);
 
 
 static
@@ -91,7 +147,7 @@ usertype_field_spec_of(const column_specification& column, size_t field) {
 
 static
 void
-usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!receiver.type->is_user_type()) {
         throw exceptions::invalid_request_exception(format("Invalid user type literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
@@ -104,7 +160,7 @@ usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_
         }
         const expression& value = u.elements.at(field);
         auto&& field_spec = usertype_field_spec_of(receiver, i);
-        if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, schema_opt, *field_spec))) {
+        if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, schema_opt, *field_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid user type literal for {}: field {} is not of type {}", *receiver.name, field, field_spec->type->as_cql3_type()));
         }
     }
@@ -112,9 +168,9 @@ usertype_constructor_validate_assignable_to(const usertype_constructor& u, data_
 
 static
 assignment_testable::test_result
-usertype_constructor_test_assignment(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+usertype_constructor_test_assignment(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     try {
-        usertype_constructor_validate_assignable_to(u, db, keyspace, schema_opt, receiver);
+        usertype_constructor_validate_assignable_to(u, db, keyspace, schema_opt, receiver, memo);
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     } catch (exceptions::invalid_request_exception& e) {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
@@ -123,11 +179,11 @@ usertype_constructor_test_assignment(const usertype_constructor& u, data_diction
 
 static
 std::optional<expression>
-usertype_constructor_prepare_expression(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+usertype_constructor_prepare_expression(const usertype_constructor& u, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     if (!receiver) {
         return std::nullopt; // cannot infer type from {field: value}
     }
-    usertype_constructor_validate_assignable_to(u, db, keyspace, schema_opt, *receiver);
+    usertype_constructor_validate_assignable_to(u, db, keyspace, schema_opt, *receiver, memo);
     auto&& ut = static_pointer_cast<const user_type_impl>(receiver->type);
     bool all_terminal = true;
 
@@ -141,7 +197,7 @@ usertype_constructor_prepare_expression(const usertype_constructor& u, data_dict
             raw = iraw->second;
             ++found_values;
         }
-        expression value = prepare_expression(raw, db, keyspace, schema_opt, usertype_field_spec_of(*receiver, i));
+        expression value = prepare_expression(raw, db, keyspace, schema_opt, usertype_field_spec_of(*receiver, i), memo);
 
         if (!is<constant>(value)) {
             all_terminal = false;
@@ -199,7 +255,7 @@ map_value_spec_of(const column_specification& column) {
 
 static
 void
-map_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+map_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!receiver.type->without_reversed().is_map()) {
         throw exceptions::invalid_request_exception(format("Invalid map literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
     }
@@ -210,10 +266,10 @@ map_validate_assignable_to(const collection_constructor& c, data_dictionary::dat
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }
-        if (!is_assignable(test_assignment(entry_tuple.elements[0], db, keyspace, schema_opt, *key_spec))) {
+        if (!is_assignable(test_assignment(entry_tuple.elements[0], db, keyspace, schema_opt, *key_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid map literal for {}: key {} is not of type {}", *receiver.name, entry_tuple.elements[0], key_spec->type->as_cql3_type()));
         }
-        if (!is_assignable(test_assignment(entry_tuple.elements[1], db, keyspace, schema_opt, *value_spec))) {
+        if (!is_assignable(test_assignment(entry_tuple.elements[1], db, keyspace, schema_opt, *value_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid map literal for {}: value {} is not of type {}", *receiver.name, entry_tuple.elements[1], value_spec->type->as_cql3_type()));
         }
     }
@@ -221,7 +277,7 @@ map_validate_assignable_to(const collection_constructor& c, data_dictionary::dat
 
 static
 assignment_testable::test_result
-map_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+map_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!dynamic_pointer_cast<const map_type_impl>(receiver.type)) {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
     }
@@ -238,8 +294,8 @@ map_test_assignment(const collection_constructor& c, data_dictionary::database d
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }
-        auto t1 = test_assignment(entry_tuple.elements[0], db, keyspace, schema_opt, *key_spec);
-        auto t2 = test_assignment(entry_tuple.elements[1], db, keyspace, schema_opt, *value_spec);
+        auto t1 = test_assignment(entry_tuple.elements[0], db, keyspace, schema_opt, *key_spec, memo);
+        auto t2 = test_assignment(entry_tuple.elements[1], db, keyspace, schema_opt, *value_spec, memo);
         if (t1 == assignment_testable::test_result::NOT_ASSIGNABLE || t2 == assignment_testable::test_result::NOT_ASSIGNABLE)
             return assignment_testable::test_result::NOT_ASSIGNABLE;
         if (t1 != assignment_testable::test_result::EXACT_MATCH || t2 != assignment_testable::test_result::EXACT_MATCH)
@@ -250,12 +306,12 @@ map_test_assignment(const collection_constructor& c, data_dictionary::database d
 
 static
 std::optional<expression>
-map_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+map_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     if (!receiver) {
         // TODO: It is possible to infer the type of a map from the types of the key/value pairs
         return std::nullopt;
     }
-    map_validate_assignable_to(c, db, keyspace, schema_opt, *receiver);
+    map_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
     auto key_spec = maps::key_spec_of(*receiver);
     auto value_spec = maps::value_spec_of(*receiver);
@@ -282,8 +338,8 @@ map_prepare_expression(const collection_constructor& c, data_dictionary::databas
         if (entry_tuple.elements.size() != 2) {
             on_internal_error(expr_logger, "map element is not a tuple of arity 2");
         }
-        expression k = prepare_expression(entry_tuple.elements[0], db, keyspace, schema_opt, key_spec);
-        expression v = prepare_expression(entry_tuple.elements[1], db, keyspace, schema_opt, value_spec);
+        expression k = prepare_expression(entry_tuple.elements[0], db, keyspace, schema_opt, key_spec, memo);
+        expression v = prepare_expression(entry_tuple.elements[1], db, keyspace, schema_opt, value_spec, memo);
 
         // Check if one of values contains a nonpure function
         if (!is<constant>(k) || !is<constant>(v)) {
@@ -318,7 +374,7 @@ set_value_spec_of(const column_specification& column) {
 
 static
 void
-set_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+set_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!receiver.type->without_reversed().is_set()) {
         // We've parsed empty maps as a set literal to break the ambiguity so
         // handle that case now
@@ -331,7 +387,7 @@ set_validate_assignable_to(const collection_constructor& c, data_dictionary::dat
 
     auto&& value_spec = set_value_spec_of(receiver);
     for (auto& e: c.elements) {
-        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec))) {
+        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid set literal for {}: value {} is not of type {}", *receiver.name, e, value_spec->type->as_cql3_type()));
         }
     }
@@ -339,7 +395,7 @@ set_validate_assignable_to(const collection_constructor& c, data_dictionary::dat
 
 static
 assignment_testable::test_result
-set_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+set_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!receiver.type->without_reversed().is_set()) {
         // We've parsed empty maps as a set literal to break the ambiguity so handle that case now
         if (dynamic_pointer_cast<const map_type_impl>(receiver.type) && c.elements.empty()) {
@@ -355,17 +411,17 @@ set_test_assignment(const collection_constructor& c, data_dictionary::database d
     }
 
     auto&& value_spec = set_value_spec_of(receiver);
-    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec);
+    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec, memo);
 }
 
 static
 std::optional<expression>
-set_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+set_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     if (!receiver) {
         // TODO: It is possible to infer the type of a set from the types of the values
         return std::nullopt;
     }
-    set_validate_assignable_to(c, db, keyspace, schema_opt, *receiver);
+    set_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
     if (c.elements.empty()) {
 
@@ -395,7 +451,7 @@ set_prepare_expression(const collection_constructor& c, data_dictionary::databas
     bool all_terminal = true;
     for (auto& e : c.elements)
     {
-        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec);
+        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec, memo);
 
         if (!is<constant>(elem)) {
             all_terminal = false;
@@ -427,14 +483,14 @@ list_value_spec_of(const column_specification& column) {
 
 static
 void
-list_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring keyspace, const schema* schema_opt, const column_specification& receiver) {
+list_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (!receiver.type->without_reversed().is_list()) {
         throw exceptions::invalid_request_exception(format("Invalid list literal for {} of type {}",
                 *receiver.name, receiver.type->as_cql3_type()));
     }
     auto&& value_spec = list_value_spec_of(receiver);
     for (auto& e : c.elements) {
-        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec))) {
+        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid list literal for {}: value {} is not of type {}",
                     *receiver.name, e, value_spec->type->as_cql3_type()));
         }
@@ -443,21 +499,21 @@ list_validate_assignable_to(const collection_constructor& c, data_dictionary::da
 
 static
 assignment_testable::test_result
-list_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+list_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     // If there is no elements, we can't say it's an exact match (an empty list if fundamentally polymorphic).
     if (c.elements.empty()) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     }
 
     auto&& value_spec = list_value_spec_of(receiver);
-    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec);
+    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec, memo);
 }
 
 
 static
 std::optional<expression>
-list_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    list_validate_assignable_to(c, db, keyspace, schema_opt, *receiver);
+list_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+    list_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
     // In Cassandra, an empty (unfrozen) map/set/list is equivalent to the column being null. In
     // other words a non-frozen collection only exists if it has elements. Return nullptr right
@@ -472,7 +528,7 @@ list_prepare_expression(const collection_constructor& c, data_dictionary::databa
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto& e : c.elements) {
-        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec);
+        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec, memo);
 
         if (!is<constant>(elem)) {
             all_terminal = false;
@@ -501,7 +557,7 @@ vector_value_spec_of(const column_specification& column) {
 
 static
 void
-vector_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring keyspace, const schema* schema_opt, const column_specification& receiver) {
+vector_validate_assignable_to(const collection_constructor& c, data_dictionary::database db, const sstring keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     auto vt = dynamic_pointer_cast<const vector_type_impl>(receiver.type->underlying_type());
     if (!vt) {
         throw exceptions::invalid_request_exception(format("Invalid vector type literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
@@ -520,7 +576,7 @@ vector_validate_assignable_to(const collection_constructor& c, data_dictionary::
 
     auto&& value_spec = vector_value_spec_of(receiver);
     for (auto& e : c.elements) {
-        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec))) {
+        if (!is_assignable(test_assignment(e, db, keyspace, schema_opt, *value_spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid vector literal for {}: value {} is not of type {}",
                     *receiver.name, e, value_spec->type->as_cql3_type()));
         }
@@ -529,27 +585,27 @@ vector_validate_assignable_to(const collection_constructor& c, data_dictionary::
 
 static
 assignment_testable::test_result
-vector_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+vector_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     // If there is no elements, we can't say it's an exact match (an empty vector if fundamentally polymorphic).
     if (c.elements.empty()) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     }
 
     auto&& value_spec = vector_value_spec_of(receiver);
-    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec);
+    return test_assignment_all(c.elements, db, keyspace, schema_opt, *value_spec, memo);
 }
 
 static
 std::optional<expression>
-vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    vector_validate_assignable_to(c, db, keyspace, schema_opt, *receiver);
+vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+    vector_validate_assignable_to(c, db, keyspace, schema_opt, *receiver, memo);
 
     auto&& value_spec = vector_value_spec_of(*receiver);
     std::vector<expression> values;
     values.reserve(c.elements.size());
     bool all_terminal = true;
     for (auto& e : c.elements) {
-        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec);
+        expression elem = prepare_expression(e, db, keyspace, schema_opt, value_spec, memo);
 
         if (!is<constant>(elem)) {
             all_terminal = false;
@@ -572,11 +628,11 @@ vector_prepare_expression(const collection_constructor& c, data_dictionary::data
 
 static
 assignment_testable::test_result
-list_or_vector_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+list_or_vector_test_assignment(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     if (dynamic_pointer_cast<const vector_type_impl>(receiver.type)) {
-        return vector_test_assignment(c, db, keyspace, schema_opt, receiver);
+        return vector_test_assignment(c, db, keyspace, schema_opt, receiver, memo);
     } else if (dynamic_pointer_cast<const list_type_impl>(receiver.type)) {
-        return list_test_assignment(c, db, keyspace, schema_opt, receiver);
+        return list_test_assignment(c, db, keyspace, schema_opt, receiver, memo);
     } else {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
     }
@@ -584,7 +640,7 @@ list_or_vector_test_assignment(const collection_constructor& c, data_dictionary:
 
 static
 std::optional<expression>
-list_or_vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+list_or_vector_prepare_expression(const collection_constructor& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     if (!receiver) {
         // TODO: It is possible to infer the type of a list or vector from the types of the key/value pairs
         return std::nullopt;
@@ -592,9 +648,9 @@ list_or_vector_prepare_expression(const collection_constructor& c, data_dictiona
 
     // We do not check if the receiver is a list because it is checked later in the list_prepare_expression.
     if (receiver->type->is_vector()) {
-        return vector_prepare_expression(c, db, keyspace, schema_opt, receiver);
+        return vector_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
     } else {
-        return list_prepare_expression(c, db, keyspace, schema_opt, receiver);
+        return list_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
     }
 }
 
@@ -610,7 +666,7 @@ component_spec_of(const column_specification& column, size_t component) {
 
 static
 void
-tuple_constructor_validate_assignable_to(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+tuple_constructor_validate_assignable_to(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     auto tt = dynamic_pointer_cast<const tuple_type_impl>(receiver.type->underlying_type());
     if (!tt) {
         throw exceptions::invalid_request_exception(format("Invalid tuple type literal for {} of type {}", *receiver.name, receiver.type->as_cql3_type()));
@@ -623,7 +679,7 @@ tuple_constructor_validate_assignable_to(const tuple_constructor& tc, data_dicti
 
         auto&& value = tc.elements[i];
         auto&& spec = component_spec_of(receiver, i);
-        if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, schema_opt, *spec))) {
+        if (!assignment_testable::is_assignable(test_assignment(value, db, keyspace, schema_opt, *spec, memo))) {
             throw exceptions::invalid_request_exception(format("Invalid tuple literal for {}: component {:d} is not of type {}", *receiver.name, i, spec->type->as_cql3_type()));
         }
     }
@@ -631,9 +687,9 @@ tuple_constructor_validate_assignable_to(const tuple_constructor& tc, data_dicti
 
 static
 assignment_testable::test_result
-tuple_constructor_test_assignment(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+tuple_constructor_test_assignment(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     try {
-        tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, receiver);
+        tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, receiver, memo);
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     } catch (exceptions::invalid_request_exception& e) {
         return assignment_testable::test_result::NOT_ASSIGNABLE;
@@ -642,9 +698,9 @@ tuple_constructor_test_assignment(const tuple_constructor& tc, data_dictionary::
 
 static
 std::optional<expression>
-tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     if (receiver) {
-        tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, *receiver);
+        tuple_constructor_validate_assignable_to(tc, db, keyspace, schema_opt, *receiver, memo);
     }
     std::vector<expression> values;
     bool all_terminal = true;
@@ -653,7 +709,7 @@ tuple_constructor_prepare_nontuple(const tuple_constructor& tc, data_dictionary:
         if (receiver) {
             component_receiver = component_spec_of(*receiver, i);
         }
-        std::optional<expression> value_opt = try_prepare_expression(tc.elements[i], db, keyspace, schema_opt, component_receiver);
+        std::optional<expression> value_opt = try_prepare_expression(tc.elements[i], db, keyspace, schema_opt, component_receiver, memo);
         if (!value_opt) {
             return std::nullopt;
         }
@@ -899,7 +955,7 @@ cast_test_assignment(const cast& c, data_dictionary::database db, const sstring&
 // numeric widening (e.g. int -> bigint, converted like CAST).
 static
 std::optional<expression>
-c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     data_type cast_type = cast_get_prepared_type(c, db, keyspace);
 
     if (!receiver) {
@@ -913,7 +969,7 @@ c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sst
 
     // First check if the casted expression can be assigned(converted) to the type specified in the cast.
     // test_assignment accepts a value-compatible binary representation or a lossless widening to c.type.
-    if (!is_assignable(test_assignment(c.arg, db, keyspace, schema_opt, *cast_type_receiver))) {
+    if (!is_assignable(test_assignment(c.arg, db, keyspace, schema_opt, *cast_type_receiver, memo))) {
         throw exceptions::invalid_request_exception(format("Cannot cast value {:user} to type {}", c.arg, cast_type->as_cql3_type()));
     }
 
@@ -921,7 +977,7 @@ c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sst
     // Using this receiver makes it possible to write things like: (blob)(int)1234
     // Using the original receiver wouldn't work in such cases - it would complain
     // that untyped_constant(1234) isn't a valid blob constant.
-    expression prepared_arg = prepare_expression(c.arg, db, keyspace, schema_opt, cast_type_receiver);
+    expression prepared_arg = prepare_expression(c.arg, db, keyspace, schema_opt, cast_type_receiver, memo);
 
     // Then check if a value of type c.type can be assigned(converted) to the receiver type.
     // cast_test_assignment accepts a value-compatible representation or a lossless widening to it.
@@ -941,7 +997,7 @@ c_cast_prepare_expression(const cast& c, data_dictionary::database db, const sst
 
 static
 std::optional<expression>
-sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     data_type cast_type = cast_get_prepared_type(c, db, keyspace);
 
     if (!receiver) {
@@ -950,7 +1006,7 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
             keyspace, "unknown_cf", ::make_shared<column_identifier>(receiver_name, true), cast_type);
     }
 
-    auto prepared_arg = try_prepare_expression(c.arg, db, keyspace, schema_opt, nullptr);
+    auto prepared_arg = try_prepare_expression(c.arg, db, keyspace, schema_opt, nullptr, memo);
     if (!prepared_arg) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of cast argument {}", c.arg));
     }
@@ -971,20 +1027,20 @@ sql_cast_prepare_expression(const cast& c, data_dictionary::database db, const s
 }
 
 std::optional<expression>
-cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+cast_prepare_expression(const cast& c, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     switch (c.style) {
     case cast::cast_style::c:
-        return c_cast_prepare_expression(c, db, keyspace, schema_opt, std::move(receiver));
+        return c_cast_prepare_expression(c, db, keyspace, schema_opt, std::move(receiver), memo);
     case cast::cast_style::sql:
-        return sql_cast_prepare_expression(c, db, keyspace, schema_opt, std::move(receiver));
+        return sql_cast_prepare_expression(c, db, keyspace, schema_opt, std::move(receiver), memo);
     }
     on_internal_error(expr_logger, "Illegal cast style");
 }
 
 std::optional<expression>
-field_selection_prepare_expression(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+field_selection_prepare_expression(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
     // We can't infer the type of the user defined type from the field being selected
-    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr);
+    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, memo);
     if (!prepared_structure) {
         throw exceptions::invalid_request_exception(fmt::format("Cannot infer type of {}", fs.structure));
     }
@@ -1016,9 +1072,9 @@ field_selection_prepare_expression(const field_selection& fs, data_dictionary::d
 }
 
 assignment_testable::test_result
-field_selection_test_assignment(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+field_selection_test_assignment(const field_selection& fs, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     // We can't infer the type of the user defined type from the field being selected
-    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr);
+    auto prepared_structure = try_prepare_expression(fs.structure, db, keyspace, schema_opt, nullptr, memo);
     if (!prepared_structure) {
         throw exceptions::invalid_request_exception(fmt::format("Cannot infer type of {}", fs.structure));
     }
@@ -1137,7 +1193,7 @@ struct partially_prepared_arg {
 
 static
 std::vector<partially_prepared_arg>
-prepare_function_args_for_type_inference(std::span<const expression> args, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt) {
+prepare_function_args_for_type_inference(std::span<const expression> args, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, prepare_memo& memo) {
     // Prepare the arguments that can be prepared without a receiver.
     // Prepared expressions have a known type, which helps with finding the right function.
     std::vector<partially_prepared_arg> partially_prepared_args;
@@ -1146,11 +1202,11 @@ prepare_function_args_for_type_inference(std::span<const expression> args, data_
         // A nullopt means the argument can't be resolved without a receiver (e.g. a nested
         // call that is ambiguous until the parameter type is known) - it stays a hole, to be
         // probed against each candidate parameter type and re-prepared once one is chosen.
-        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, /*allow_unresolved=*/true);
+        std::optional<expression> prepared_arg_opt = try_prepare_expression(argument, db, keyspace, schema_opt, nullptr, memo, /*allow_unresolved=*/true);
         std::optional<data_type> type = prepared_arg_opt ? std::optional(type_of(*prepared_arg_opt)) : std::nullopt;
         expression testable_expr = prepared_arg_opt ? *prepared_arg_opt : argument;
         partially_prepared_args.push_back(partially_prepared_arg{
-            .testable = as_assignment_testable(std::move(testable_expr), std::move(type)),
+            .testable = as_assignment_testable(std::move(testable_expr), std::move(type), memo),
             .prepared = std::move(prepared_arg_opt),
         });
     }
@@ -1193,8 +1249,8 @@ try_prepare_count_rows(const expr::function_call& fc, data_dictionary::database 
     }, fc.func);
 }
 
-// Counts entries to prepare_function_call. Used by tests to guard against
-// re-introducing exponential preparation of nested function calls.
+// Counts entries to prepare_function_call and test_assignment_function_call. Used by
+// tests to guard against re-introducing exponential preparation of nested function calls.
 static thread_local uint64_t g_prepare_function_call_count = 0;
 
 uint64_t prepare_function_call_count() {
@@ -1205,8 +1261,30 @@ void reset_prepare_function_call_count() {
     g_prepare_function_call_count = 0;
 }
 
+static thread_local uint64_t g_test_assignment_function_call_count = 0;
+
+uint64_t test_assignment_function_call_count() {
+    return g_test_assignment_function_call_count;
+}
+
+void reset_test_assignment_function_call_count() {
+    g_test_assignment_function_call_count = 0;
+}
+
+// Test-only switch to disable memoization, so tests can observe the un-memoized
+// (exponential) probing cost for comparison. Read once when a top-level prepare entry
+// point creates its prepare_memo; a stale value across a yield only affects whether a
+// cache is used, never correctness.
+static thread_local bool g_prepare_memo_enabled = true;
+
+void set_prepare_memo_enabled(bool enabled) {
+    g_prepare_memo_enabled = enabled;
+}
+
+prepare_memo::prepare_memo() : enabled(g_prepare_memo_enabled) {}
+
 std::optional<expression>
-prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved) {
+prepare_function_call(const expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved) {
     ++g_prepare_function_call_count;
     if (auto prepared = try_prepare_count_rows(fc, db, keyspace, schema_opt, receiver)) {
         return prepared;
@@ -1225,7 +1303,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
 
     // Prepare the arguments that can be prepared without a receiver.
     // Prepared expressions have a known type, which helps with finding the right function.
-    auto partially_prepared_args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt);
+    auto partially_prepared_args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt, memo);
 
     auto fun_opt = std::visit(overloaded_functor{
         [] (const shared_ptr<functions::function>& func) -> std::optional<shared_ptr<functions::function>> {
@@ -1282,7 +1360,7 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
         // reuse path coerces explicitly.
         expr::expression e = [&] () -> expr::expression {
             if (!partially_prepared_args[i].prepared) {
-                return prepare_expression(fc.args[i], db, keyspace, schema_opt, arg_spec);
+                return prepare_expression(fc.args[i], db, keyspace, schema_opt, arg_spec, memo);
             } else {
                 expr::expression prepared = std::move(*partially_prepared_args[i].prepared);
                 return coerce_to(std::move(prepared), arg_spec->type, db, keyspace);
@@ -1309,15 +1387,27 @@ prepare_function_call(const expr::function_call& fc, data_dictionary::database d
 }
 
 assignment_testable::test_result
-test_assignment_function_call(const cql3::expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+test_assignment_function_call(const cql3::expr::function_call& fc, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
+    std::optional<call_probe_key> memo_key;
+    if (memo.enabled) {
+        memo_key = call_probe_key{fc, receiver.type};
+        auto it = memo.test_assignment_function_call.find(*memo_key);
+        if (it != memo.test_assignment_function_call.end()) {
+            return it->second;
+        }
+    }
+
+    ++g_test_assignment_function_call_count;
+
     // Note: Functions.get() will return null if the function doesn't exist, or throw is no function matching
     // the arguments can be found. We may get one of those if an undefined/wrong function is used as argument
     // of another, existing, function. In that case, we return true here because we'll throw a proper exception
     // later with a more helpful error message that if we were to return false here.
+    auto result = [&] () -> assignment_testable::test_result {
     try {
         auto&& fun = std::visit(overloaded_functor{
             [&] (const functions::function_name& name) {
-                auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt);
+                auto args = prepare_function_args_for_type_inference(fc.args, db, keyspace, schema_opt, memo);
                 return functions::instance().get(db, keyspace, name,
                         args
                                 | std::views::transform(&partially_prepared_arg::testable)
@@ -1339,6 +1429,12 @@ test_assignment_function_call(const cql3::expr::function_call& fc, data_dictiona
     } catch (exceptions::invalid_request_exception& e) {
         return assignment_testable::test_result::WEAKLY_ASSIGNABLE;
     }
+    }();
+
+    if (memo_key) {
+        memo.test_assignment_function_call.emplace(std::move(*memo_key), result);
+    }
+    return result;
 }
 
 static assignment_testable::test_result expression_test_assignment(const data_type& expr_type,
@@ -1358,7 +1454,8 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
                                               data_dictionary::database db,
                                               const sstring& keyspace,
                                               const schema* schema_opt,
-                                              lw_shared_ptr<column_specification> receiver) {
+                                              lw_shared_ptr<column_specification> receiver,
+                                              prepare_memo& memo) {
     if (receiver.get() != nullptr && receiver->type->without_reversed().get_kind() != abstract_type::kind::boolean) {
         throw exceptions::invalid_request_exception(
             format("AND conjunction produces a boolean value, which doesn't match the type: {} of {}",
@@ -1384,7 +1481,7 @@ std::optional<expression> prepare_conjunction(const conjunction& conj,
     bool all_terminal = true;
     for (const expression& child : conj.children) {
         std::optional<expression> prepared_child =
-            try_prepare_expression(child, db, keyspace, schema_opt, child_receiver);
+            try_prepare_expression(child, db, keyspace, schema_opt, child_receiver, memo);
         if (!prepared_child.has_value()) {
             throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", child));
         }
@@ -1408,7 +1505,8 @@ prepare_column_mutation_attribute(
         data_dictionary::database db,
         const sstring& keyspace,
         const schema* schema_opt,
-        lw_shared_ptr<column_specification> receiver) {
+        lw_shared_ptr<column_specification> receiver,
+        prepare_memo& memo) {
     auto result_type = expr::column_mutation_attribute_type(cma);
     if (receiver.get() != nullptr && receiver->type->without_reversed().get_kind() != result_type->get_kind()) {
         throw exceptions::invalid_request_exception(
@@ -1416,7 +1514,7 @@ prepare_column_mutation_attribute(
                     cma.kind, result_type->name(),
                     receiver->type->name(), receiver->name->text()));
     }
-    auto column = prepare_expression(cma.column, db, keyspace, schema_opt, nullptr);
+    auto column = prepare_expression(cma.column, db, keyspace, schema_opt, nullptr, memo);
     // Helper for the subscript and field-selection cases below: validates that
     // inner_expr is a column, not a primary key column, that its type satisfies
     // type_allowed, and that the cluster feature flag is on.
@@ -1468,7 +1566,13 @@ prepare_column_mutation_attribute(
 }
 
 std::optional<expression>
-try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, bool allow_unresolved) {
+try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
+    prepare_memo memo;
+    return try_prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), memo);
+}
+
+static std::optional<expression>
+try_prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo, bool allow_unresolved) {
     return expr::visit(overloaded_functor{
         [&] (const constant& value) -> std::optional<expression> {
             if (receiver && !is_assignable(expression_test_assignment(value.type, *receiver))) {
@@ -1513,7 +1617,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return result;
         },
         [&] (const conjunction& conj) -> std::optional<expression> {
-            return prepare_conjunction(conj, db, keyspace, schema_opt, receiver);
+            return prepare_conjunction(conj, db, keyspace, schema_opt, receiver, memo);
         },
         [] (const column_value& cv) -> std::optional<expression> {
             return cv;
@@ -1524,7 +1628,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             }
             auto& schema = *schema_opt;
 
-            auto sub_col_opt = try_prepare_expression(sub.val, db, keyspace, schema_opt, receiver);
+            auto sub_col_opt = try_prepare_expression(sub.val, db, keyspace, schema_opt, receiver, memo);
             if (!sub_col_opt) {
                 return std::nullopt;
             }
@@ -1549,7 +1653,7 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
 
             return subscript {
                 .val = sub_col,
-                .sub = prepare_expression(sub.sub, db, schema.ks_name(), &schema, std::move(subscript_column_spec)),
+                .sub = prepare_expression(sub.sub, db, schema.ks_name(), &schema, std::move(subscript_column_spec), memo),
                 .type = value_cmp,
             };
         },
@@ -1560,16 +1664,16 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return resolve_column(unin, *schema_opt);
         },
         [&] (const column_mutation_attribute& cma) -> std::optional<expression> {
-            return prepare_column_mutation_attribute(cma, db, keyspace, schema_opt, std::move(receiver));
+            return prepare_column_mutation_attribute(cma, db, keyspace, schema_opt, std::move(receiver), memo);
         },
         [&] (const function_call& fc) -> std::optional<expression> {
-            return prepare_function_call(fc, db, keyspace, schema_opt, std::move(receiver), allow_unresolved);
+            return prepare_function_call(fc, db, keyspace, schema_opt, std::move(receiver), memo, allow_unresolved);
         },
         [&] (const cast& c) -> std::optional<expression> {
-            return cast_prepare_expression(c, db, keyspace, schema_opt, receiver);
+            return cast_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const field_selection& fs) -> std::optional<expression> {
-            return field_selection_prepare_expression(fs, db, keyspace, schema_opt, receiver);
+            return field_selection_prepare_expression(fs, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const bind_variable& bv) -> std::optional<expression> {
             return bind_variable_prepare_expression(bv, db, keyspace, receiver);
@@ -1578,20 +1682,20 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
             return untyped_constant_prepare_expression(uc, db, keyspace, receiver);
         },
         [&] (const tuple_constructor& tc) -> std::optional<expression> {
-            return tuple_constructor_prepare_nontuple(tc, db, keyspace, schema_opt, receiver);
+            return tuple_constructor_prepare_nontuple(tc, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const collection_constructor& c) -> std::optional<expression> {
             switch (c.style) {
-            case collection_constructor::style_type::list_or_vector: return list_or_vector_prepare_expression(c, db, keyspace, schema_opt, receiver);
-            case collection_constructor::style_type::set: return set_prepare_expression(c, db, keyspace, schema_opt, receiver);
-            case collection_constructor::style_type::map: return map_prepare_expression(c, db, keyspace, schema_opt, receiver);
+            case collection_constructor::style_type::list_or_vector: return list_or_vector_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
+            case collection_constructor::style_type::set: return set_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
+            case collection_constructor::style_type::map: return map_prepare_expression(c, db, keyspace, schema_opt, receiver, memo);
             case collection_constructor::style_type::vector:
                 on_internal_error(expr_logger, "vector style type found during prepare, should have been introduced post-prepare");
             }
             on_internal_error(expr_logger, fmt::format("unexpected collection_constructor style {}", static_cast<unsigned>(c.style)));
         },
         [&] (const usertype_constructor& uc) -> std::optional<expression> {
-            return usertype_constructor_prepare_expression(uc, db, keyspace, schema_opt, receiver);
+            return usertype_constructor_prepare_expression(uc, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const temporary& t) -> std::optional<expression> {
             on_internal_error(expr_logger, "temporary found during prepare, should have been introduced post-prepare");
@@ -1601,9 +1705,9 @@ try_prepare_expression(const expression& expr, data_dictionary::database db, con
 
 static
 assignment_testable::test_result
-unresolved_identifier_test_assignment(const unresolved_identifier& ui, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
-    auto prepared = prepare_expression(ui, db, keyspace, schema_opt, make_lw_shared<column_specification>(receiver));
-    return test_assignment(prepared, db, keyspace, schema_opt, receiver);
+unresolved_identifier_test_assignment(const unresolved_identifier& ui, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
+    auto prepared = prepare_expression(ui, db, keyspace, schema_opt, make_lw_shared<column_specification>(receiver), memo);
+    return test_assignment(prepared, db, keyspace, schema_opt, receiver, memo);
 }
 
 static
@@ -1615,6 +1719,12 @@ column_mutation_attribute_test_assignment(const column_mutation_attribute& cma, 
 
 assignment_testable::test_result
 test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+    prepare_memo memo;
+    return test_assignment(expr, db, keyspace, schema_opt, receiver, memo);
+}
+
+static assignment_testable::test_result
+test_assignment(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     using test_result = assignment_testable::test_result;
     return expr::visit(overloaded_functor{
         [&] (const constant& value) -> test_result {
@@ -1637,19 +1747,19 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
             return assignment_testable::test_result::NOT_ASSIGNABLE;
         },
         [&] (const unresolved_identifier& ui) -> test_result {
-            return unresolved_identifier_test_assignment(ui, db, keyspace, schema_opt, receiver);
+            return unresolved_identifier_test_assignment(ui, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const column_mutation_attribute& cma) -> test_result {
             return column_mutation_attribute_test_assignment(cma, db, keyspace, schema_opt, receiver);
         },
         [&] (const function_call& fc) -> test_result {
-            return test_assignment_function_call(fc, db, keyspace, schema_opt, receiver);
+            return test_assignment_function_call(fc, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const cast& c) -> test_result {
             return cast_test_assignment(c, db, keyspace, schema_opt, receiver);
         },
         [&] (const field_selection& fs) -> test_result {
-            return field_selection_test_assignment(fs, db, keyspace, schema_opt, receiver);
+            return field_selection_test_assignment(fs, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const bind_variable& bv) -> test_result {
             return bind_variable_test_assignment(bv, db, keyspace, receiver);
@@ -1658,20 +1768,20 @@ test_assignment(const expression& expr, data_dictionary::database db, const sstr
             return untyped_constant_test_assignment(uc, db, keyspace, receiver);
         },
         [&] (const tuple_constructor& tc) -> test_result {
-            return tuple_constructor_test_assignment(tc, db, keyspace, schema_opt, receiver);
+            return tuple_constructor_test_assignment(tc, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const collection_constructor& c) -> test_result {
             switch (c.style) {
-            case collection_constructor::style_type::list_or_vector: return list_or_vector_test_assignment(c, db, keyspace, schema_opt, receiver);
-            case collection_constructor::style_type::set: return set_test_assignment(c, db, keyspace, schema_opt, receiver);
-            case collection_constructor::style_type::map: return map_test_assignment(c, db, keyspace, schema_opt, receiver);
+            case collection_constructor::style_type::list_or_vector: return list_or_vector_test_assignment(c, db, keyspace, schema_opt, receiver, memo);
+            case collection_constructor::style_type::set: return set_test_assignment(c, db, keyspace, schema_opt, receiver, memo);
+            case collection_constructor::style_type::map: return map_test_assignment(c, db, keyspace, schema_opt, receiver, memo);
             case collection_constructor::style_type::vector:
                 on_internal_error(expr_logger, "vector style type found in test_assignment, should have been introduced post-prepare");
             }
             on_internal_error(expr_logger, fmt::format("unexpected collection_constructor style {}", static_cast<unsigned>(c.style)));
         },
         [&] (const usertype_constructor& uc) -> test_result {
-            return usertype_constructor_test_assignment(uc, db, keyspace, schema_opt, receiver);
+            return usertype_constructor_test_assignment(uc, db, keyspace, schema_opt, receiver, memo);
         },
         [&] (const temporary& t) -> test_result {
             on_internal_error(expr_logger, "temporary found in test_assignment, should have been introduced post-prepare");
@@ -1790,7 +1900,13 @@ test_assignment_any_size_float_vector(const expression& expr) {
 
 expression
 prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver) {
-    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver);
+    prepare_memo memo;
+    return prepare_expression(expr, db, keyspace, schema_opt, std::move(receiver), memo);
+}
+
+static expression
+prepare_expression(const expression& expr, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, lw_shared_ptr<column_specification> receiver, prepare_memo& memo) {
+    auto e_opt = try_prepare_expression(expr, db, keyspace, schema_opt, receiver, memo);
     if (!e_opt) {
         throw exceptions::invalid_request_exception(fmt::format("Could not infer type of {}", expr));
     }
@@ -1803,10 +1919,16 @@ prepare_expression(const expression& expr, data_dictionary::database db, const s
 
 assignment_testable::test_result
 test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) {
+    prepare_memo memo;
+    return test_assignment_all(to_test, db, keyspace, schema_opt, receiver, memo);
+}
+
+static assignment_testable::test_result
+test_assignment_all(const std::vector<expression>& to_test, data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver, prepare_memo& memo) {
     using test_result = assignment_testable::test_result;
     test_result res = test_result::EXACT_MATCH;
     for (auto&& e : to_test) {
-        test_result t = test_assignment(e, db, keyspace, schema_opt, receiver);
+        test_result t = test_assignment(e, db, keyspace, schema_opt, receiver, memo);
         if (t == test_result::NOT_ASSIGNABLE) {
             return test_result::NOT_ASSIGNABLE;
         }
@@ -1820,9 +1942,13 @@ test_assignment_all(const std::vector<expression>& to_test, data_dictionary::dat
 class assignment_testable_expression : public assignment_testable {
     expression _e;
     std::optional<data_type> _type_opt;
+    prepare_memo* _memo;
 public:
-    explicit assignment_testable_expression(expression e, std::optional<data_type> type_opt) : _e(std::move(e)), _type_opt(std::move(type_opt)) {}
+    explicit assignment_testable_expression(expression e, std::optional<data_type> type_opt, prepare_memo* memo) : _e(std::move(e)), _type_opt(std::move(type_opt)), _memo(memo) {}
     virtual test_result test_assignment(data_dictionary::database db, const sstring& keyspace, const schema* schema_opt, const column_specification& receiver) const override {
+        if (_memo) {
+            return expr::test_assignment(_e, db, keyspace, schema_opt, receiver, *_memo);
+        }
         return expr::test_assignment(_e, db, keyspace, schema_opt, receiver);
     }
     virtual vector_test_result test_assignment_any_size_float_vector() const override {
@@ -1837,7 +1963,11 @@ public:
 };
 
 ::shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt) {
-    return ::make_shared<assignment_testable_expression>(std::move(e), std::move(type_opt));
+    return ::make_shared<assignment_testable_expression>(std::move(e), std::move(type_opt), nullptr);
+}
+
+static ::shared_ptr<assignment_testable> as_assignment_testable(expression e, std::optional<data_type> type_opt, prepare_memo& memo) {
+    return ::make_shared<assignment_testable_expression>(std::move(e), std::move(type_opt), &memo);
 }
 
 // Finds column_defintion for given column name in the schema.

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -389,6 +389,22 @@ functions::get(data_dictionary::database db,
         const sstring& receiver_ks,
         std::optional<const std::string_view> receiver_cf,
         const column_specification* receiver) const {
+    return try_get(db, keyspace, name, provided_args, receiver_ks, receiver_cf, receiver).value();
+}
+
+static function_resolution resolution_failed(sstring message) {
+    return utils::exception_container<exceptions::invalid_request_exception>(
+            exceptions::invalid_request_exception(std::move(message)));
+}
+
+function_resolution
+functions::try_get(data_dictionary::database db,
+        const sstring& keyspace,
+        const function_name& name,
+        const std::vector<shared_ptr<assignment_testable>>& provided_args,
+        const sstring& receiver_ks,
+        std::optional<const std::string_view> receiver_cf,
+        const column_specification* receiver) const {
 
     static const function_name TOKEN_FUNCTION_NAME = function_name::native_function("token");
     static const function_name TO_JSON_FUNCTION_NAME = function_name::native_function("tojson");
@@ -406,7 +422,9 @@ functions::get(data_dictionary::database db,
     if (SIMILARITY_FUNCTIONS.contains(func_name)) {
         auto arg_types = retrieve_vector_arg_types(func_name, provided_args);
         auto fun = ::make_shared<vector_similarity_fct>(func_name.name, arg_types);
-        validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
+        if (auto err = check_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf)) {
+            return resolution_failed(std::move(*err));
+        }
         return fun;
     }
 
@@ -415,13 +433,15 @@ functions::get(data_dictionary::database db,
                 : name.name == TOKEN_FUNCTION_NAME.name) {
 
         if (!receiver_cf.has_value()) {
-            throw exceptions::invalid_request_exception("functions::get for token doesn't have a known column family");
+            return resolution_failed("functions::get for token doesn't have a known column family");
         }
         if (schema == nullptr) {
-            throw exceptions::invalid_request_exception(seastar::format("functions::get for token cannot find {} table", *receiver_cf));
+            return resolution_failed(seastar::format("functions::get for token cannot find {} table", *receiver_cf));
         }
         auto fun = ::make_shared<token_fct>(schema);
-        validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
+        if (auto err = check_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf)) {
+            return resolution_failed(std::move(*err));
+        }
         return fun;
     }
 
@@ -429,11 +449,11 @@ functions::get(data_dictionary::database db,
                 ? name == TO_JSON_FUNCTION_NAME
                 : name.name == TO_JSON_FUNCTION_NAME.name) {
         if (provided_args.size() != 1) {
-            throw exceptions::invalid_request_exception("toJson() accepts 1 argument only");
+            return resolution_failed("toJson() accepts 1 argument only");
         }
         auto arg_type_opt = provided_args[0]->assignment_testable_type_opt();
         if (!arg_type_opt) {
-            throw exceptions::invalid_request_exception("toJson() is only valid when its argument type is known");
+            return resolution_failed("toJson() is only valid when its argument type is known");
         }
         return make_to_json_function(*arg_type_opt);
     }
@@ -442,10 +462,10 @@ functions::get(data_dictionary::database db,
                 ? name == FROM_JSON_FUNCTION_NAME
                 : name.name == FROM_JSON_FUNCTION_NAME.name) {
         if (provided_args.size() != 1) {
-            throw exceptions::invalid_request_exception("fromJson() accepts 1 argument only");
+            return resolution_failed("fromJson() accepts 1 argument only");
         }
         if (!receiver) {
-            throw exceptions::invalid_request_exception("fromJson() can only be called if receiver type is known");
+            return resolution_failed("fromJson() can only be called if receiver type is known");
         }
         return make_from_json_function(db, keyspace, receiver->type);
     }
@@ -486,13 +506,15 @@ functions::get(data_dictionary::database db,
     }
 
     if (candidates.empty()) {
-        return {};
+        return shared_ptr<function>{};
     }
 
     // Fast path if there is only one choice
     if (candidates.size() == 1) {
         auto fun = std::move(candidates[0]);
-        validate_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf);
+        if (auto err = check_types(db, keyspace, schema.get(), fun, provided_args, receiver_ks, receiver_cf)) {
+            return resolution_failed(std::move(*err));
+        }
         return fun;
     }
 
@@ -512,13 +534,13 @@ functions::get(data_dictionary::database db,
     }
 
     if (compatibles.empty()) {
-        throw exceptions::invalid_request_exception(
+        return resolution_failed(
                 seastar::format("Invalid call to function {}, none of its type signatures match (known type signatures: {})",
                                                         name, fmt::join(candidates, ", ")));
     }
 
     if (compatibles.size() > 1) {
-        throw exceptions::invalid_request_exception(
+        return resolution_failed(
                 seastar::format("Ambiguous call to function {} (can be matched by following signatures: {}): use type casts to disambiguate",
                     name, fmt::join(compatibles, ", ")));
     }
@@ -599,8 +621,8 @@ functions::mock_get(const function_name &name, const std::vector<data_type>& arg
 
 // This method and matchArguments are somewhat duplicate, but this method allows us to provide more precise errors in the common
 // case where there is no override for a given function. This is thus probably worth the minor code duplication.
-void
-functions::validate_types(data_dictionary::database db,
+std::optional<sstring>
+functions::check_types(data_dictionary::database db,
                           const sstring& keyspace,
                           const schema* schema_opt,
                           shared_ptr<function> fun,
@@ -608,9 +630,8 @@ functions::validate_types(data_dictionary::database db,
                           const sstring& receiver_ks,
                           std::optional<const std::string_view> receiver_cf) const {
     if (provided_args.size() != fun->arg_types().size()) {
-        throw exceptions::invalid_request_exception(
-                format("Invalid number of arguments in call to function {}: {:d} required but {:d} provided",
-                        fun->name(), fun->arg_types().size(), provided_args.size()));
+        return format("Invalid number of arguments in call to function {}: {:d} required but {:d} provided",
+                        fun->name(), fun->arg_types().size(), provided_args.size());
     }
 
     for (size_t i = 0; i < provided_args.size(); ++i) {
@@ -624,10 +645,23 @@ functions::validate_types(data_dictionary::database db,
 
         auto&& expected = make_arg_spec(receiver_ks, receiver_cf, *fun, i);
         if (!is_assignable(provided->test_assignment(db, keyspace, schema_opt, *expected))) {
-            throw exceptions::invalid_request_exception(
-                    format("Type error: {} cannot be passed as argument {:d} of function {} of type {}",
-                            provided, i, fun->name(), expected->type->as_cql3_type()));
+            return format("Type error: {} cannot be passed as argument {:d} of function {} of type {}",
+                            provided, i, fun->name(), expected->type->as_cql3_type());
         }
+    }
+    return std::nullopt;
+}
+
+void
+functions::validate_types(data_dictionary::database db,
+                          const sstring& keyspace,
+                          const schema* schema_opt,
+                          shared_ptr<function> fun,
+                          const std::vector<shared_ptr<assignment_testable>>& provided_args,
+                          const sstring& receiver_ks,
+                          std::optional<const std::string_view> receiver_cf) const {
+    if (auto err = check_types(db, keyspace, schema_opt, fun, provided_args, receiver_ks, receiver_cf)) {
+        throw exceptions::invalid_request_exception(std::move(*err));
     }
 }
 

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -518,13 +518,14 @@ functions::try_get(data_dictionary::database db,
         return fun;
     }
 
+    std::vector<shared_ptr<function>> exact_matches;
     std::vector<shared_ptr<function>> compatibles;
     for (auto&& to_test : candidates) {
         auto r = match_arguments(db, keyspace, schema.get(), to_test, provided_args, receiver_ks, receiver_cf);
         switch (r) {
             case assignment_testable::test_result::EXACT_MATCH:
-                // We always favor exact matches
-                return to_test;
+                exact_matches.push_back(std::move(to_test));
+                break;
             case assignment_testable::test_result::WEAKLY_ASSIGNABLE:
                 compatibles.push_back(std::move(to_test));
                 break;
@@ -533,19 +534,24 @@ functions::try_get(data_dictionary::database db,
         };
     }
 
-    if (compatibles.empty()) {
+    // We favor exact matches over merely-assignable ones, but several exact matches - for
+    // example a native function and a user function of the same signature - are just as
+    // ambiguous as several assignable ones.
+    auto& matches = !exact_matches.empty() ? exact_matches : compatibles;
+
+    if (matches.empty()) {
         return resolution_failed(
                 seastar::format("Invalid call to function {}, none of its type signatures match (known type signatures: {})",
                                                         name, fmt::join(candidates, ", ")));
     }
 
-    if (compatibles.size() > 1) {
+    if (matches.size() > 1) {
         return resolution_failed(
                 seastar::format("Ambiguous call to function {} (can be matched by following signatures: {}): use type casts to disambiguate",
-                    name, fmt::join(compatibles, ", ")));
+                    name, fmt::join(matches, ", ")));
     }
 
-    return std::move(compatibles[0]);
+    return std::move(matches[0]);
 }
 
 template<typename F>

--- a/cql3/functions/functions.hh
+++ b/cql3/functions/functions.hh
@@ -17,6 +17,8 @@
 #include "schema/schema.hh"
 #include <unordered_map>
 #include "data_dictionary/user_types_metadata.hh"
+#include "utils/result.hh"
+#include "exceptions/exceptions.hh"
 
 namespace cql3 {
 
@@ -28,6 +30,8 @@ namespace functions {
 
     using declared_t = std::unordered_multimap<function_name, shared_ptr<function>>;
     void add_agg_functions(declared_t& funcs);
+
+using function_resolution = utils::result_with_exception<shared_ptr<function>, exceptions::invalid_request_exception>;
 
 class functions {
     friend class change_batch;
@@ -45,6 +49,13 @@ public:
     functions() : _declared(init()) {}
 
     shared_ptr<function> get(data_dictionary::database db,
+                                    const sstring& keyspace,
+                                    const function_name& name,
+                                    const std::vector<shared_ptr<assignment_testable>>& provided_args,
+                                    const sstring& receiver_ks,
+                                    std::optional<const std::string_view> receiver_cf,
+                                    const column_specification* receiver = nullptr) const;
+    function_resolution try_get(data_dictionary::database db,
                                     const sstring& keyspace,
                                     const function_name& name,
                                     const std::vector<shared_ptr<assignment_testable>>& provided_args,
@@ -88,6 +99,13 @@ private:
                               const std::vector<shared_ptr<assignment_testable>>& provided_args,
                               const sstring& receiver_ks,
                               std::optional<const std::string_view> receiver_cf) const;
+    std::optional<sstring> check_types(data_dictionary::database db,
+                                       const sstring& keyspace,
+                                       const schema* schema_opt,
+                                       shared_ptr<function> fun,
+                                       const std::vector<shared_ptr<assignment_testable>>& provided_args,
+                                       const sstring& receiver_ks,
+                                       std::optional<const std::string_view> receiver_cf) const;
     assignment_testable::test_result match_arguments(data_dictionary::database db, const sstring& keyspace,
             const schema* schema_opt,
             shared_ptr<function> fun,

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -68,10 +68,10 @@ selectable_processes_selection(const expr::expression& selectable) {
             on_internal_error(slogger, "untyped_constant found its way to selector context");
         },
         [&] (const expr::tuple_constructor&) -> bool {
-            on_internal_error(slogger, "tuple_constructor found its way to selector context");
+            return true;
         },
         [&] (const expr::collection_constructor&) -> bool {
-            on_internal_error(slogger, "collection_constructor found its way to selector context");
+            return true;
         },
         [&] (const expr::usertype_constructor&) -> bool {
             on_internal_error(slogger, "collection_constructor found its way to selector context");

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -74,7 +74,7 @@ selectable_processes_selection(const expr::expression& selectable) {
             return true;
         },
         [&] (const expr::usertype_constructor&) -> bool {
-            on_internal_error(slogger, "collection_constructor found its way to selector context");
+            on_internal_error(slogger, "usertype_constructor found its way to selector context");
         },
         [&] (const expr::temporary& t) -> bool {
             // Well it doesn't process the selection, but it's not bypasses the selection completely

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -71,10 +71,10 @@ selectable_processes_selection(const expr::expression& selectable) {
             on_internal_error(slogger, "untyped_constant found its way to selector context");
         },
         [&] (const expr::tuple_constructor&) -> bool {
-            on_internal_error(slogger, "tuple_constructor found its way to selector context");
+            return true;
         },
         [&] (const expr::collection_constructor&) -> bool {
-            on_internal_error(slogger, "collection_constructor found its way to selector context");
+            return true;
         },
         [&] (const expr::usertype_constructor&) -> bool {
             on_internal_error(slogger, "usertype_constructor found its way to selector context");

--- a/cql3/selection/selectable.cc
+++ b/cql3/selection/selectable.cc
@@ -77,7 +77,7 @@ selectable_processes_selection(const expr::expression& selectable) {
             on_internal_error(slogger, "collection_constructor found its way to selector context");
         },
         [&] (const expr::usertype_constructor&) -> bool {
-            on_internal_error(slogger, "collection_constructor found its way to selector context");
+            on_internal_error(slogger, "usertype_constructor found its way to selector context");
         },
         [&] (const expr::temporary& t) -> bool {
             // Well it doesn't process the selection, but it's not bypasses the selection completely

--- a/cql3/selection/selection.cc
+++ b/cql3/selection/selection.cc
@@ -200,6 +200,24 @@ contains_ttl(const expr::expression& e) {
     return contains_column_mutation_attribute(expr::column_mutation_attribute::attribute_kind::ttl, e);
 }
 
+// A call that counts every row: countRows(), or count(<non-null constant>). A
+// constant argument is never null, so counting its non-null occurrences yields
+// the row count, exactly like countRows(). count(<column>) does not qualify: it
+// counts only the rows where the column is non-null.
+static
+bool
+is_count_rows_call(const expr::function_call& fc) {
+    auto& func = std::get<shared_ptr<cql3::functions::function>>(fc.func);
+    if (func->name() == functions::function_name::native_function(functions::aggregate_fcts::COUNT_ROWS_FUNCTION_NAME)) {
+        return true;
+    }
+    if (func->name() != functions::function_name::native_function("count") || fc.args.size() != 1) {
+        return false;
+    }
+    auto* c = expr::as_if<expr::constant>(&fc.args[0]);
+    return c && !c->is_null();
+}
+
 class selection_with_processing : public selection {
 private:
     std::vector<expr::expression> _selectors;
@@ -267,10 +285,7 @@ public:
 
     virtual bool is_count() const override {
         return _selectors.size() == 1
-            && expr::find_in_expression<expr::function_call>(_selectors[0], [] (const expr::function_call& fc) {
-                auto& func = std::get<shared_ptr<cql3::functions::function>>(fc.func);
-                return func->name() == functions::function_name::native_function(functions::aggregate_fcts::COUNT_ROWS_FUNCTION_NAME);
-            });
+            && expr::find_in_expression<expr::function_call>(_selectors[0], is_count_rows_call);
     }
 
     virtual bool is_reducible() const override {
@@ -315,19 +330,27 @@ public:
             }
             auto agg_func = dynamic_pointer_cast<functions::aggregate_function>(std::move(func));
 
-            auto type = (agg_func->name().name == "countRows") ? query::mapreduce_request::reduction_type::count : query::mapreduce_request::reduction_type::aggregate;
+            auto type = is_count_rows_call(*fc) ? query::mapreduce_request::reduction_type::count : query::mapreduce_request::reduction_type::aggregate;
 
             std::vector<sstring> column_names;
-            for (auto& arg : fc->args) {
-                auto col = expr::as_if<expr::column_value>(&arg);
-                if (!col) {
-                    bad();
+            if (type == query::mapreduce_request::reduction_type::aggregate) {
+                for (auto& arg : fc->args) {
+                    auto col = expr::as_if<expr::column_value>(&arg);
+                    if (!col) {
+                        bad();
+                    }
+                    column_names.push_back(col->col->name_as_text());
                 }
-                column_names.push_back(col->col->name_as_text());
             }
 
             auto info = query::mapreduce_request::aggregation_info {
-                .name = agg_func->name(),
+                // For a count reduction the executed plan is the canonical countRows()
+                // regardless of how the selector spelled it; replicas mock the aggregate
+                // from this name. A constant argument could not be shipped anyway (the
+                // request carries column names only), but the count reduction needs none.
+                .name = type == query::mapreduce_request::reduction_type::count
+                        ? functions::function_name::native_function(functions::aggregate_fcts::COUNT_ROWS_FUNCTION_NAME)
+                        : agg_func->name(),
                 .column_names = std::move(column_names),
             };
 

--- a/docs/cql/definitions.rst
+++ b/docs/cql/definitions.rst
@@ -147,8 +147,11 @@ A term is thus one of:
 - A :ref:`constant <constants>`.
 - A literal for either :ref:`a collection <collections>` (including usage of list_or_vector_literal 
   for :ref:`a vector <vectors>`), a user-defined type or a tuple (see the linked sections for details).
-- An arithmetic operation between terms. 
-- A *type hint*
+- An arithmetic operation between terms.
+- A *type hint* ``(T)x``, which represents ``x`` as type ``T`` when that is lossless — a
+  reinterpret between byte-compatible types (e.g. ``(blob)int_value``) or a numeric widening
+  (e.g. ``(bigint)int_value``). A lossy (narrowing), cross-family, or unrelated conversion is
+  rejected; use ``CAST(x AS T)`` for those.
 - A bind marker, which denotes a variable to be bound at execution time. See the section on :ref:`prepared-statements`
   for details. A bind marker can be either anonymous (``?``) or named (``:some_name``). The latter form provides a more
   convenient way to refer to the variable for binding it and should generally be preferred.

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -88,10 +88,41 @@ A :token:`selector` can be one of the following:
 - A literal value (constant).
 - A bind variable (`?` or `:name`).
 
-Note that due to a quirk of the type system, literals and bind markers cannot be
-used as top-level selectors, as the parser cannot infer their type. However, they can be used
-when nested inside functions, as the function formal parameter types provide the
-necessary context.
+Literals can be used as top-level selectors. Their type is inferred automatically.
+The default inferred type depends on the literal kind:
+
+- Whole numbers: the smallest of ``int``, ``bigint``, or ``varint`` that fits the
+  value. For example, ``1`` is inferred as ``int``, ``10000000000`` as ``bigint``,
+  and very large integers as ``varint``. Note that ``tinyint`` and ``smallint`` are
+  never inferred — use ``CAST`` to obtain them.
+- Decimal or scientific-notation numbers (e.g. ``3.14``, ``1e6``): always ``double``.
+  ``float`` and ``decimal`` are never inferred.
+- Strings: ``text``.
+- Booleans: ``boolean``.
+- UUIDs: ``uuid``.
+- Hex literals (e.g. ``0xCAFE``): ``blob``.
+- Durations: ``duration``.
+
+Collection and tuple literals are supported, with element types inferred recursively.
+When collection elements have different sizes within the same numeric family, they are
+widened to the largest type within two lossless chains:
+
+- Integer: ``tinyint`` < ``smallint`` < ``int`` < ``bigint`` < ``varint``
+- Floating-point: ``float`` < ``double``
+
+Cross-family widening (e.g. ``int`` and ``double``) is not supported and requires an
+explicit ``CAST``.
+
+Bind markers (``?`` and ``:name``) cannot be used as top-level selectors, as their
+type cannot be determined without context.
+
+Examples::
+
+    SELECT 1, 'hello', true FROM t;            -- int, text, boolean
+    SELECT [1, 2, 3] FROM t;                   -- frozen<list<int>>
+    SELECT {'a': 1, 'b': 2} FROM t;            -- frozen<map<text, int>>
+    SELECT [1, 10000000000] FROM t;            -- frozen<list<bigint>>, widened from int + bigint
+    SELECT CAST(1 AS bigint) FROM t;           -- bigint via explicit cast
 
 Aliases
 ```````

--- a/docs/cql/dml/select.rst
+++ b/docs/cql/dml/select.rst
@@ -85,13 +85,46 @@ A :token:`selector` can be one of the following:
 - A casting, which allows you to convert a nested selector to a (compatible) type.
 - A function call, where the arguments are selector themselves.
 - A call to the :ref:`COUNT function <count-function>`, which counts all non-null results.
-- A literal value (constant).
+- A literal value: a constant, or a collection or tuple literal.
 - A bind variable (`?` or `:name`).
 
-Note that due to a quirk of the type system, literals and bind markers cannot be
-used as top-level selectors, as the parser cannot infer their type. However, they can be used
-when nested inside functions, as the function formal parameter types provide the
-necessary context.
+Literals can be used as top-level selectors. Their type is inferred automatically.
+The default inferred type depends on the literal kind:
+
+- Whole numbers: the smallest of ``int``, ``bigint``, or ``varint`` that fits the
+  value. For example, ``1`` is inferred as ``int``, ``10000000000`` as ``bigint``,
+  and very large integers as ``varint``. Note that ``tinyint`` and ``smallint`` are
+  never inferred — use a cast (``CAST(1 AS tinyint)`` or the ``(tinyint)1`` type hint)
+  to obtain them.
+- Decimal or scientific-notation numbers (e.g. ``3.14``, ``1e6``): always ``double``.
+  ``float`` and ``decimal`` are never inferred.
+- Strings: ``text``.
+- Booleans: ``boolean``.
+- UUIDs: ``uuid``.
+- Hex literals (e.g. ``0xCAFE``): ``blob``.
+- Durations: ``duration``.
+
+Collection and tuple literals are supported, with element types inferred recursively.
+When collection elements have different sizes within the same numeric family, they are
+widened to the largest type within two lossless chains:
+
+- Integer: ``tinyint`` < ``smallint`` < ``int`` < ``bigint`` < ``varint``
+- Floating-point: ``float`` < ``double``
+
+Cross-family widening (e.g. ``int`` and ``double``) is not supported and requires an
+explicit ``CAST``.
+
+Bind markers (``?`` and ``:name``) cannot be used as *top-level* selectors, since their
+type cannot be inferred without context; they can be used nested inside a function
+call, where the parameter type provides it.
+
+Examples::
+
+    SELECT 1, 'hello', true FROM t;            -- int, text, boolean
+    SELECT [1, 2, 3] FROM t;                   -- frozen<list<int>>
+    SELECT {'a': 1, 'b': 2} FROM t;            -- frozen<map<text, int>>
+    SELECT [1, 10000000000] FROM t;            -- frozen<list<bigint>>, widened from int + bigint
+    SELECT CAST(1 AS bigint) FROM t;           -- bigint via explicit cast
 
 Aliases
 ```````

--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -353,10 +353,18 @@ Native aggregates
 Count
 `````
 
-The ``count`` function can be used to count the rows returned by a query. Example::
+The ``COUNT`` function counts all non-null values of its argument.
+The argument can be a column, a literal, or any expression (including function calls).
+
+``COUNT(*)`` is a special form that counts all rows, regardless of null values::
 
     SELECT COUNT (*) FROM plays;
+
+Since a literal is never null, ``COUNT`` with a literal argument is equivalent to
+``COUNT(*)``::
+
     SELECT COUNT (1) FROM plays;
+    SELECT COUNT ('any') FROM plays;
 
 It also can be used to count the non-null value of a given column::
 

--- a/docs/cql/functions.rst
+++ b/docs/cql/functions.rst
@@ -353,10 +353,18 @@ Native aggregates
 Count
 `````
 
-The ``count`` function can be used to count the rows returned by a query. Example::
+The ``count`` function counts all non-null values of its argument.
+The argument can be a column, a literal, or any expression (including function calls).
+
+``count(*)`` is a special form that counts all rows, regardless of null values::
 
     SELECT COUNT (*) FROM plays;
+
+Since a literal is never null, ``count`` with a literal argument is equivalent to
+``count(*)``::
+
     SELECT COUNT (1) FROM plays;
+    SELECT COUNT ('any') FROM plays;
 
 It also can be used to count the non-null value of a given column::
 

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -6282,12 +6282,59 @@ SEASTAR_TEST_CASE(test_select_collection_literal_type_inference) {
             .with_size(1)
             .with_column_types({expected_nested_list});
 
-        // Different element types in collection should fail (strict matching)
-        BOOST_REQUIRE_THROW(
-            e.execute_cql("SELECT [1, 10000000000] FROM system.local").get(),
-            exceptions::invalid_request_exception);
+        // Type widening within integer chain
+        msg = e.execute_cql("SELECT [1, 10000000000] FROM system.local").get();
+        auto expected_bigint_list = list_type_impl::get_instance(long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_bigint_list});
+
+        msg = e.execute_cql("SELECT {1, 10000000000} FROM system.local").get();
+        auto expected_bigint_set = set_type_impl::get_instance(long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_bigint_set});
+
+        msg = e.execute_cql("SELECT {'a': 1, 'b': 10000000000} FROM system.local").get();
+        auto expected_text_bigint_map = map_type_impl::get_instance(utf8_type, long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_text_bigint_map});
+
+        // Integer widening: int32 + int64 + varint (from literal values)
+        msg = e.execute_cql("SELECT [1, 10000000000, 99999999999999999999] FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({list_type_impl::get_instance(varint_type, false)});
+
+        // Full integer widening chain with C-style type hints
+        msg = e.execute_cql("SELECT [(tinyint)1, (smallint)2, 3, 10000000000, 99999999999999999999] FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({list_type_impl::get_instance(varint_type, false)});
+
+        // Float chain: float + double → double
+        msg = e.execute_cql("SELECT [(float)1.0, 3.14] FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({list_type_impl::get_instance(double_type, false)});
+
+        // Cross-chain widening (int + double) should fail
         BOOST_REQUIRE_THROW(
             e.execute_cql("SELECT [1, 3.14] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, 3.14} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 'b': 3.14} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1: 'a', 3.14: 'b'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        // Cross-chain: float + int
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [(float)1.0, 1] FROM system.local").get(),
             exceptions::invalid_request_exception);
 
         // Mixed types in collection should fail
@@ -6316,12 +6363,38 @@ SEASTAR_TEST_CASE(test_select_collection_literal_type_inference) {
         BOOST_REQUIRE_THROW(
             e.execute_cql("SELECT {} FROM system.local").get(),
             exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [] FROM system.local").get(),
+            exceptions::invalid_request_exception);
 
         // Null has no inherent type. As a top-level selector there is no
         // column or function parameter to provide type context, so type
         // inference fails.
         BOOST_REQUIRE_THROW(
             e.execute_cql("SELECT null FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Null cannot self-type, so collections containing null fail
+        // at type inference time ("Could not infer type of ...").
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, null] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, null} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': null} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {null: 1} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // All nulls in collection — no consensus possible
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [null, null] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {null: null} FROM system.local").get(),
             exceptions::invalid_request_exception);
 
         // Function calls inside collections — infer_type resolves return types

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -6185,4 +6185,167 @@ SEASTAR_TEST_CASE(test_sstable_load_mixed_generation_type) {
     });
 }
 
+SEASTAR_TEST_CASE(test_select_constant_type_inference) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // Integer constant — small value fits int32
+        auto msg = e.execute_cql("SELECT 1 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type})
+            .with_row({{int32_type->decompose(1)}});
+
+        // Integer constant — large value requires bigint
+        msg = e.execute_cql("SELECT 10000000000 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({long_type})
+            .with_row({{long_type->decompose(int64_t(10000000000))}});
+
+        // String constant
+        msg = e.execute_cql("SELECT 'hello' FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({utf8_type})
+            .with_row({{utf8_type->decompose(sstring("hello"))}});
+
+        // Boolean constant
+        msg = e.execute_cql("SELECT true FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({boolean_type})
+            .with_row({{boolean_type->decompose(true)}});
+
+        // Floating-point constant
+        msg = e.execute_cql("SELECT 3.14 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({double_type});
+
+        // Negative integer constant
+        msg = e.execute_cql("SELECT -1 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type});
+
+        // Scientific notation is inferred as double
+        msg = e.execute_cql("SELECT 1e6 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({double_type});
+
+        // Multiple constants
+        msg = e.execute_cql("SELECT 1, 'hello', true FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type, utf8_type, boolean_type});
+
+        // Function call as a top-level selector — type inferred from return type
+        msg = e.execute_cql("SELECT now() FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1);
+
+        // count(1) works
+        msg = e.execute_cql("SELECT count(1) FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_collection_literal_type_inference) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // List literal
+        auto msg = e.execute_cql("SELECT [1, 2, 3] FROM system.local").get();
+        auto expected_list_type = list_type_impl::get_instance(int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_list_type});
+
+        // Set literal
+        msg = e.execute_cql("SELECT {1, 2, 3} FROM system.local").get();
+        auto expected_set_type = set_type_impl::get_instance(int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_set_type});
+
+        // Map literal
+        msg = e.execute_cql("SELECT {'a': 1, 'b': 2} FROM system.local").get();
+        auto expected_map_type = map_type_impl::get_instance(utf8_type, int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_map_type});
+
+        // Nested collection literal
+        msg = e.execute_cql("SELECT [[1, 2], [3, 4]] FROM system.local").get();
+        auto expected_nested_list = list_type_impl::get_instance(
+                list_type_impl::get_instance(int32_type, false), false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_nested_list});
+
+        // Different element types in collection should fail (strict matching)
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, 10000000000] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, 3.14] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Mixed types in collection should fail
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, 'hello'] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, 'hello'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 'b': 'hello'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 2: 3} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, true] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Nested collection type mismatch
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [[1, 2], [3, 'a']] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Empty collection should fail (can't infer type)
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Null has no inherent type. As a top-level selector there is no
+        // column or function parameter to provide type context, so type
+        // inference fails.
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT null FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Function calls inside collections — infer_type resolves return types
+        // via functions::get() without producing prepared expressions
+        msg = e.execute_cql("SELECT [now(), now()] FROM system.local").get();
+        auto expected_timeuuid_list = list_type_impl::get_instance(timeuuid_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_timeuuid_list});
+
+        // Tuple literal
+        msg = e.execute_cql("SELECT (1, 'hello', true) FROM system.local").get();
+        auto expected_tuple_type = tuple_type_impl::get_instance({int32_type, utf8_type, boolean_type});
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_tuple_type});
+
+        // SQL CAST in SELECT clause
+        msg = e.execute_cql("SELECT CAST(1 AS bigint) FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({long_type})
+            .with_row({{long_type->decompose(int64_t(1))}});
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -6835,6 +6835,254 @@ SEASTAR_TEST_CASE(test_tablets_routing_strong_consistency) {
     }, tablet_v2_cql_test_config());
 }
 
+SEASTAR_TEST_CASE(test_select_constant_type_inference) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // Integer constant — small value fits int32
+        auto msg = e.execute_cql("SELECT 1 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type})
+            .with_row({{int32_type->decompose(1)}});
+
+        // Integer constant — large value requires bigint
+        msg = e.execute_cql("SELECT 10000000000 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({long_type})
+            .with_row({{long_type->decompose(int64_t(10000000000))}});
+
+        // String constant
+        msg = e.execute_cql("SELECT 'hello' FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({utf8_type})
+            .with_row({{utf8_type->decompose(sstring("hello"))}});
+
+        // Boolean constant
+        msg = e.execute_cql("SELECT true FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({boolean_type})
+            .with_row({{boolean_type->decompose(true)}});
+
+        // Floating-point constant
+        msg = e.execute_cql("SELECT 3.14 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({double_type});
+
+        // Negative integer constant
+        msg = e.execute_cql("SELECT -1 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type});
+
+        // Scientific notation is inferred as double
+        msg = e.execute_cql("SELECT 1e6 FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({double_type});
+
+        // Multiple constants
+        msg = e.execute_cql("SELECT 1, 'hello', true FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({int32_type, utf8_type, boolean_type});
+
+        // Function call as a top-level selector — type inferred from return type
+        msg = e.execute_cql("SELECT now() FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({timeuuid_type});
+
+        // count(1) works
+        msg = e.execute_cql("SELECT count(1) FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1);
+    });
+}
+
+SEASTAR_TEST_CASE(test_select_collection_literal_type_inference) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        // List literal
+        auto msg = e.execute_cql("SELECT [1, 2, 3] FROM system.local").get();
+        auto expected_list_type = list_type_impl::get_instance(int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_list_type});
+
+        // Set literal
+        msg = e.execute_cql("SELECT {1, 2, 3} FROM system.local").get();
+        auto expected_set_type = set_type_impl::get_instance(int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_set_type});
+
+        // Map literal
+        msg = e.execute_cql("SELECT {'a': 1, 'b': 2} FROM system.local").get();
+        auto expected_map_type = map_type_impl::get_instance(utf8_type, int32_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_map_type});
+
+        // Nested collection literal
+        msg = e.execute_cql("SELECT [[1, 2], [3, 4]] FROM system.local").get();
+        auto expected_nested_list = list_type_impl::get_instance(
+                list_type_impl::get_instance(int32_type, false), false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_nested_list});
+
+        // Type widening within integer chain. The int literal 1 must be converted to
+        // the 8-byte bigint representation, not just relabelled.
+        msg = e.execute_cql("SELECT [1, 10000000000] FROM system.local").get();
+        auto expected_bigint_list = list_type_impl::get_instance(long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_bigint_list})
+            .with_rows({{
+                expected_bigint_list->decompose(
+                    make_list_value(expected_bigint_list, list_type_impl::native_type({int64_t(1), int64_t(10000000000)})))
+            }});
+
+        msg = e.execute_cql("SELECT {1, 10000000000} FROM system.local").get();
+        auto expected_bigint_set = set_type_impl::get_instance(long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_bigint_set});
+
+        msg = e.execute_cql("SELECT {'a': 1, 'b': 10000000000} FROM system.local").get();
+        auto expected_text_bigint_map = map_type_impl::get_instance(utf8_type, long_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_text_bigint_map});
+
+        // Integer widening: int32 + int64 + varint (from literal values)
+        msg = e.execute_cql("SELECT [1, 10000000000, 99999999999999999999] FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({list_type_impl::get_instance(varint_type, false)});
+
+        // Full integer widening chain with C-style type hints
+        msg = e.execute_cql("SELECT [(tinyint)1, (smallint)2, 3, 10000000000, 99999999999999999999] FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({list_type_impl::get_instance(varint_type, false)});
+
+        // Float chain: float + double → double. The (float)1.0 element must be
+        // converted to a double value, not reinterpreted as 4 bytes.
+        msg = e.execute_cql("SELECT [(float)1.0, 3.14] FROM system.local").get();
+        auto expected_double_list = list_type_impl::get_instance(double_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_double_list})
+            .with_rows({{
+                expected_double_list->decompose(
+                    make_list_value(expected_double_list, list_type_impl::native_type({double(1.0), double(3.14)})))
+            }});
+
+        // Cross-chain widening (int + double) should fail
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, 3.14] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, 3.14} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 'b': 3.14} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1: 'a', 3.14: 'b'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        // Cross-chain: float + int
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [(float)1.0, 1] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Mixed types in collection should fail
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, 'hello'] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, 'hello'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 'b': 'hello'} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': 1, 2: 3} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, true] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Nested collection type mismatch
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [[1, 2], [3, 'a']] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Empty collection should fail (can't infer type)
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Null has no inherent type. As a top-level selector there is no
+        // column or function parameter to provide type context, so type
+        // inference fails.
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT null FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Null cannot self-type, so collections containing null fail
+        // at type inference time ("Could not infer type of ...").
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [1, null] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {1, null} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {'a': null} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {null: 1} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // All nulls in collection — no consensus possible
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT [null, null] FROM system.local").get(),
+            exceptions::invalid_request_exception);
+        BOOST_REQUIRE_THROW(
+            e.execute_cql("SELECT {null: null} FROM system.local").get(),
+            exceptions::invalid_request_exception);
+
+        // Function calls inside collections — infer_type resolves return types
+        // via functions::get() without producing prepared expressions
+        msg = e.execute_cql("SELECT [now(), now()] FROM system.local").get();
+        auto expected_timeuuid_list = list_type_impl::get_instance(timeuuid_type, false);
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_timeuuid_list});
+
+        // Tuple literal
+        msg = e.execute_cql("SELECT (1, 'hello', true) FROM system.local").get();
+        auto expected_tuple_type = tuple_type_impl::get_instance({int32_type, utf8_type, boolean_type});
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({expected_tuple_type});
+
+        // SQL CAST in SELECT clause
+        msg = e.execute_cql("SELECT CAST(1 AS bigint) FROM system.local").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_column_types({long_type})
+            .with_row({{long_type->decompose(int64_t(1))}});
+    });
+}
+
 // A narrower (T) cast widening into a wider sink (clustering key, column, WHERE RHS) must be
 // converted to the sink's representation, not just relabelled.
 SEASTAR_TEST_CASE(test_widening_value_into_wider_sink) {

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -6835,4 +6835,35 @@ SEASTAR_TEST_CASE(test_tablets_routing_strong_consistency) {
     }, tablet_v2_cql_test_config());
 }
 
+// A narrower (T) cast widening into a wider sink (clustering key, column, WHERE RHS) must be
+// converted to the sink's representation, not just relabelled.
+SEASTAR_TEST_CASE(test_widening_value_into_wider_sink) {
+    return do_with_cql_env_thread([] (cql_test_env& e) {
+        e.execute_cql("CREATE TABLE wide (pk int, ck bigint, d double, PRIMARY KEY (pk, ck))").get();
+
+        // INSERT sink: (int)5 widens to the bigint clustering key, (float)2.5 widens to
+        // the double column. A relabel would store 4 bytes; we require real conversion.
+        e.execute_cql("INSERT INTO wide (pk, ck, d) VALUES (1, (int)5, (float)2.5)").get();
+
+        auto msg = e.execute_cql("SELECT ck, d FROM wide WHERE pk = 1").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_row({long_type->decompose(int64_t(5)), double_type->decompose(double(2.5))});
+
+        // WHERE RHS sink: (int)5 must be converted to bigint to match the clustering key.
+        // An unconverted 4-byte value would never compare equal to the stored bigint.
+        msg = e.execute_cql("SELECT ck, d FROM wide WHERE pk = 1 AND ck = (int)5").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_row({long_type->decompose(int64_t(5)), double_type->decompose(double(2.5))});
+
+        // UPDATE sink + WHERE-key widening together.
+        e.execute_cql("UPDATE wide SET d = (float)3.5 WHERE pk = 1 AND ck = (int)5").get();
+        msg = e.execute_cql("SELECT d FROM wide WHERE pk = 1").get();
+        assert_that(msg).is_rows()
+            .with_size(1)
+            .with_row({double_type->decompose(double(3.5))});
+    });
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -2607,9 +2607,10 @@ BOOST_AUTO_TEST_CASE(prepare_constant_with_receiver) {
 
     BOOST_REQUIRE_EQUAL(int_const, prepared_int_const);
 
-    // Preparing an int32 with int64 receiver fails
-    BOOST_REQUIRE_THROW(prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(long_type)),
-                        exceptions::invalid_request_exception);
+    // Preparing an int32 with int64 receiver succeeds — int32 is widenable to int64
+    expression prepared_int_long =
+        prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(long_type));
+    BOOST_REQUIRE(expr::type_of(prepared_int_long) == long_type);
 
     // Preparing an int32 with text receiver fails
     BOOST_REQUIRE_THROW(prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(utf8_type)),

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1605,9 +1605,9 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_no_receiver) {
 
     expression untyped = make_int_untyped("1337");
 
-    // Can't infer type
-    BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE(expr::type_of(prepared) == int32_type);
+    BOOST_REQUIRE_EQUAL(prepared, make_int_const(1337));
 }
 
 BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bool) {
@@ -1696,7 +1696,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bad_int) {
                         exceptions::invalid_request_exception);
 }
 
-BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver_fails) {
+BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
@@ -1709,8 +1709,9 @@ BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver_fails) {
             },
         .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(tup, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(tup, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = tuple_type_impl::get_instance({int32_type, int32_type, utf8_type});
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_tuple_constructor) {
@@ -1850,10 +1851,9 @@ BOOST_AUTO_TEST_CASE(prepare_list_or_vector_collection_constructor_no_receiver) 
             },
         .type = nullptr};
 
-    data_type list_type = list_type_impl::get_instance(long_type, true);
-
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = list_type_impl::get_instance(int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_bind_var) {
@@ -2029,8 +2029,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_no_receiver) {
             },
         .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = set_type_impl::get_instance(int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_bind_var) {
@@ -2185,8 +2186,9 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_no_receiver) {
                 },
             .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = map_type_impl::get_instance(int32_type, int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_with_bind_var_key) {

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1478,6 +1478,94 @@ BOOST_AUTO_TEST_CASE(count_of_constant_is_a_count_reduction) {
     BOOST_REQUIRE_EQUAL(reductions.infos[0].column_names.size(), 1);
 }
 
+// An integer literal prefers its default type (int) when choosing between overloads,
+// so f(1) resolves to f(int) instead of being ambiguous between f(int) and f(bigint).
+// This also resolves the otherwise-ambiguous sibling case [f(1), <bigint literal>]:
+// f(1) becomes int, and the list widens int and bigint to list<bigint>.
+BOOST_AUTO_TEST_CASE(integer_literal_prefers_int_overload) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    auto make_overload = [] (data_type t) {
+        return functions::make_native_scalar_function<true>(
+                "expr_test_int_or_bigint", t, std::vector<data_type>{t},
+                [] (std::span<const bytes_opt> args) -> bytes_opt { return args[0]; });
+    };
+    auto restore = functions::change_batch();
+    {
+        auto batch = functions::change_batch();
+        batch.add_function(make_overload(int32_type));
+        batch.add_function(make_overload(long_type));
+        batch.commit();
+    }
+    auto cleanup = seastar::defer([&] () noexcept { restore.commit(); });
+
+    auto call_with = [&] (const char* literal) {
+        return function_call{
+            .func = functions::function_name::native_function("expr_test_int_or_bigint"),
+            .args = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = literal}},
+        };
+    };
+
+    // f(1): no longer ambiguous - resolves the int overload.
+    expression f1 = prepare_expression(call_with("1"), db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(type_of(f1)->as_cql3_type().to_string(), "int");
+
+    // A literal that does not fit int defaults to bigint, so f(10000000000) -> bigint.
+    expression fbig = prepare_expression(call_with("10000000000"), db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(type_of(fbig)->as_cql3_type().to_string(), "bigint");
+
+    // A collection of such calls is no longer ambiguous either: each f(<int literal>)
+    // resolves to the int overload, so [f(1), f(2)] infers list<int>.
+    expression list_literal = collection_constructor{
+        .style = collection_constructor::style_type::list_or_vector,
+        .elements = {call_with("1"), call_with("2")},
+    };
+    expression prepared = prepare_expression(list_literal, db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(type_of(prepared)->as_cql3_type().to_string(), "frozen<list<int>>");
+}
+
+// A numeric widening must convert the value, not just relabel its type: an int
+// widened to bigint must produce the 8-byte bigint representation, and a function
+// result widened inside a collection must be converted too. (Before the conversion
+// was wired up, these produced a value whose bytes did not match the declared type.)
+BOOST_AUTO_TEST_CASE(widening_converts_value) {
+    schema_ptr s = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(s);
+
+    // int constant against a bigint receiver -> the value is the 8-byte bigint.
+    expression p = prepare_expression(make_int_const(1234), db, "test_ks", s.get(), make_receiver(long_type));
+    BOOST_REQUIRE(type_of(p) == long_type);
+    BOOST_REQUIRE_EQUAL(evaluate(p, query_options::DEFAULT), make_bigint_raw(1234));
+
+    // A list mixing an int-returning function call and a bigint literal infers
+    // list<bigint>; the int result must be converted to bigint, not left as 4 bytes.
+    auto make_overload = [] (data_type t) {
+        return functions::make_native_scalar_function<true>(
+                "expr_test_iob", t, std::vector<data_type>{t},
+                [] (std::span<const bytes_opt> a) -> bytes_opt { return a[0]; });
+    };
+    auto restore = functions::change_batch();
+    {
+        auto b = functions::change_batch();
+        b.add_function(make_overload(int32_type));
+        b.add_function(make_overload(long_type));
+        b.commit();
+    }
+    auto cleanup = seastar::defer([&] () noexcept { restore.commit(); });
+    auto iob = [&] (const char* lit) {
+        return function_call{.func = functions::function_name::native_function("expr_test_iob"),
+            .args = {untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = lit}}};
+    };
+    expression lst = collection_constructor{.style = collection_constructor::style_type::list_or_vector,
+        .elements = {iob("1"),
+                     untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "10000000000"}}};
+    expression plst = prepare_expression(lst, db, "test_ks", s.get(), nullptr);
+    BOOST_REQUIRE_EQUAL(type_of(plst)->as_cql3_type().to_string(), "frozen<list<bigint>>");
+    BOOST_REQUIRE_EQUAL(evaluate(plst, query_options::DEFAULT),
+                        make_list_raw({make_bigint_raw(1), make_bigint_raw(10000000000)}));
+}
+
 // prepare_expression for a column_value should do nothing
 BOOST_AUTO_TEST_CASE(prepare_column_value) {
     schema_ptr table_schema = make_simple_test_schema();

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -20,6 +20,9 @@
 #include "utils/chunked_string.hh"
 #include <cassert>
 #include "cql3/query_options.hh"
+#include "cql3/functions/aggregate_fcts.hh"
+#include "cql3/selection/selection.hh"
+#include "cql3/selection/selector.hh"
 #include "types/set.hh"
 #include "types/user.hh"
 #include "test/lib/expr_test_utils.hh"
@@ -1431,6 +1434,48 @@ BOOST_AUTO_TEST_CASE(infer_collection_of_function_calls_keeps_narrow_overload) {
     // Inferred collections are frozen; the key point is the element type is tinyint
     // (the narrow overload), not int (the literal default).
     BOOST_REQUIRE_EQUAL(type_of(prepared)->as_cql3_type().to_string(), "frozen<list<tinyint>>");
+}
+
+// count(<non-null constant>) counts every row, exactly like countRows(), and must keep
+// the parallelized (mapreduce) count execution path: is_count() recognizes it and
+// get_reductions() ships the canonical countRows reduction (the constant could not be
+// shipped to replicas anyway - the request carries column names only - but the count
+// reduction needs no argument). count(<column>) counts non-null values and stays on
+// the aggregate reduction path instead.
+BOOST_AUTO_TEST_CASE(count_of_constant_is_a_count_reduction) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    auto count_call = [] (expression arg) {
+        return function_call{
+            .func = functions::function_name::native_function("count"),
+            .args = {std::move(arg)},
+        };
+    };
+    auto make_selection = [&] (expression call) {
+        expression prepared = prepare_expression(call, db, "test_ks", table_schema.get(), nullptr);
+        std::vector<selection::prepared_selector> selectors{
+            selection::prepared_selector{.expr = std::move(prepared), .alias = nullptr}};
+        return selection::selection::from_selectors(db, table_schema, "test_ks", selectors);
+    };
+
+    for (expression arg : {expression(make_int_untyped("0")), expression(make_int_untyped("1")),
+                           expression(make_string_untyped("abc"))}) {
+        auto sel = make_selection(count_call(std::move(arg)));
+        BOOST_REQUIRE(sel->is_count());
+        auto reductions = sel->get_reductions();
+        BOOST_REQUIRE_EQUAL(reductions.types.size(), 1);
+        BOOST_REQUIRE(reductions.types[0] == query::mapreduce_request::reduction_type::count);
+        BOOST_REQUIRE_EQUAL(reductions.infos[0].name.name, functions::aggregate_fcts::COUNT_ROWS_FUNCTION_NAME);
+        BOOST_REQUIRE(reductions.infos[0].column_names.empty());
+    }
+
+    auto sel = make_selection(count_call(column_value(table_schema->get_column_definition("r"))));
+    BOOST_REQUIRE(!sel->is_count());
+    BOOST_REQUIRE(sel->is_reducible());
+    auto reductions = sel->get_reductions();
+    BOOST_REQUIRE(reductions.types[0] == query::mapreduce_request::reduction_type::aggregate);
+    BOOST_REQUIRE_EQUAL(reductions.infos[0].column_names.size(), 1);
 }
 
 // prepare_expression for a column_value should do nothing

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1411,6 +1411,95 @@ BOOST_AUTO_TEST_CASE(prepare_token_no_args) {
                         exceptions::invalid_request_exception);
 }
 
+BOOST_AUTO_TEST_CASE(cast_type_hint_lossless_widening) {
+    auto s = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(s);
+    auto raw = [] (data_type t) {
+        return cql3_type::raw::from(t);
+    };
+    auto cc = [&] (data_type t, expression arg) -> expression {
+        return cast{.arg = std::move(arg), .type = raw(t)};
+    };
+    auto i = [] (const char* x) {
+        return make_int_untyped(x);
+    };
+    auto f = [] (const char* x) -> expression {
+        return untyped_constant{.partial_type = untyped_constant::type_class::floating_point, .raw_text = x};
+    };
+    auto ok = [&] (expression e) {
+        BOOST_CHECK_NO_THROW(prepare_expression(e, db, "test_ks", s.get(), nullptr));
+    };
+    auto rej = [&] (expression e) {
+        BOOST_CHECK_THROW(prepare_expression(e, db, "test_ks", s.get(), nullptr), exceptions::invalid_request_exception);
+    };
+
+    // Integer-chain widenings (lossless) - accepted
+    ok(cc(short_type,  cc(byte_type,  i("1"))));    // (smallint)(tinyint)1
+    ok(cc(int32_type,  cc(byte_type,  i("1"))));    // (int)(tinyint)1
+    ok(cc(long_type,   cc(byte_type,  i("1"))));    // (bigint)(tinyint)1
+    ok(cc(int32_type,  cc(short_type, i("1"))));    // (int)(smallint)1
+    ok(cc(long_type,   cc(int32_type, i("1"))));    // (bigint)(int)1
+    ok(cc(varint_type, cc(int32_type, i("1"))));    // (varint)(int)1
+    ok(cc(varint_type, cc(long_type,  i("1"))));    // (varint)(bigint)1
+    // Float-chain widening - accepted
+    ok(cc(double_type, cc(float_type, f("1.5"))));  // (double)(float)1.5
+    // Value-compatible reinterpret - accepted
+    ok(cc(bytes_type,  cc(int32_type, i("1"))));    // (blob)(int)1
+
+    // Narrowing - rejected
+    rej(cc(byte_type,  cc(int32_type, i("1"))));    // (tinyint)(int)1
+    rej(cc(short_type, cc(int32_type, i("1"))));    // (smallint)(int)1
+    rej(cc(int32_type, cc(long_type,  i("1"))));    // (int)(bigint)1
+    rej(cc(float_type, cc(double_type, f("1.5")))); // (float)(double)1.5
+    // Cross-chain - rejected
+    rej(cc(double_type, cc(int32_type, i("1"))));   // (double)(int)1
+    rej(cc(int32_type,  cc(float_type, f("1.5")))); // (int)(float)1.5
+
+    // The hint's result, in turn, widens to a wider receiver (consumer coerces) ...
+    BOOST_CHECK_NO_THROW(prepare_expression(
+        cc(byte_type, i("1")), db, "test_ks", s.get(), make_receiver(long_type)));   // (tinyint)1 -> bigint
+    // ... but is not assignable to a narrower receiver.
+    BOOST_CHECK_THROW(prepare_expression(
+        cc(long_type, i("1")), db, "test_ks", s.get(), make_receiver(byte_type)),    // (bigint)1 -> tinyint
+        exceptions::invalid_request_exception);
+}
+
+// A widening C-cast inside a tuple literal must be coerced to the declared component
+// type, so the serialized tuple matches the receiver's layout: ((int)5, 'x') assigned
+// to tuple<bigint, text> must store an 8-byte bigint, not the 4-byte int.
+BOOST_AUTO_TEST_CASE(cast_type_hint_widening_inside_tuple) {
+    auto s = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(s);
+
+    expression tup = tuple_constructor{.elements = {
+        cast{.arg = make_int_untyped("5"), .type = cql3_type::raw::from(int32_type)},
+        make_string_untyped("x"),
+    }};
+    data_type tup_type = tuple_type_impl::get_instance({long_type, utf8_type});
+    expression prepared = prepare_expression(tup, db, "test_ks", s.get(), make_receiver(tup_type));
+
+    cql3::raw_value val = evaluate(prepared, query_options::DEFAULT);
+    bytes b = std::move(val).to_bytes();
+    BOOST_REQUIRE_NO_THROW(tup_type->validate(bytes_view(b)));
+    auto fields = value_cast<tuple_type_impl::native_type>(tup_type->deserialize(bytes_view(b)));
+    BOOST_REQUIRE_EQUAL(value_cast<int64_t>(fields[0]), 5);
+}
+
+// Widening applies to a reversed (DESC clustering) receiver the same way it does to
+// the plain type: `WHERE desc_int_ck = (smallint)5` must behave like the ASC column.
+BOOST_AUTO_TEST_CASE(cast_type_hint_widening_reversed_receiver) {
+    auto s = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(s);
+
+    expression e = cast{.arg = make_int_untyped("5"), .type = cql3_type::raw::from(short_type)};
+    data_type reversed_int = reversed_type_impl::get_instance(int32_type);
+    expression prepared = prepare_expression(e, db, "test_ks", s.get(), make_receiver(reversed_int));
+
+    cql3::raw_value val = evaluate(prepared, query_options::DEFAULT);
+    bytes b = std::move(val).to_bytes();
+    BOOST_REQUIRE_EQUAL(value_cast<int32_t>(int32_type->deserialize(bytes_view(b))), 5);
+}
+
 BOOST_AUTO_TEST_CASE(prepare_cast_int_int) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
@@ -2608,9 +2697,12 @@ BOOST_AUTO_TEST_CASE(prepare_constant_with_receiver) {
 
     BOOST_REQUIRE_EQUAL(int_const, prepared_int_const);
 
-    // Preparing an int32 with int64 receiver fails
-    BOOST_REQUIRE_THROW(prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(long_type)),
-                        exceptions::invalid_request_exception);
+    // Preparing an int32 with an int64 receiver succeeds - int32 widens to int64.
+    // The value must be converted to the 8-byte bigint representation, not relabelled.
+    expression prepared_int_long =
+        prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(long_type));
+    BOOST_REQUIRE(expr::type_of(prepared_int_long) == long_type);
+    BOOST_REQUIRE_EQUAL(evaluate(prepared_int_long, query_options::DEFAULT), make_bigint_raw(1234));
 
     // Preparing an int32 with text receiver fails
     BOOST_REQUIRE_THROW(prepare_expression(int_const, db, "test_ks", table_schema.get(), make_receiver(utf8_type)),

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -28,6 +28,7 @@
 #include "cql3/expr/expr-utils.hh"
 #include "utils/big_decimal.hh"
 #include "utils/multiprecision_int.hh"
+#include "cql3/functions/functions.hh"
 
 using namespace cql3;
 using namespace cql3::expr;
@@ -1271,6 +1272,47 @@ BOOST_AUTO_TEST_CASE(prepare_static_column_unresolved_identifier) {
     expression expected = column_value(table_schema->get_column_definition("s"));
 
     BOOST_REQUIRE_EQUAL(prepared, expected);
+}
+
+namespace cql3::expr {
+extern uint64_t prepare_function_call_count();
+extern void reset_prepare_function_call_count();
+}
+
+// Builds intasblob(blobasint(intasblob(... r ...))) of the given nesting depth.
+// Both are single-overload native functions, so every level resolves
+// unambiguously and bottom-up from a concrete (int) column reference.
+static expression make_nested_blob_conversions(const schema& s, unsigned depth) {
+    expression e = column_value(s.get_column_definition("r")); // int column
+    for (unsigned i = 0; i < depth; ++i) {
+        // Even levels wrap an int (intasblob); odd levels wrap a blob (blobasint).
+        const char* fname = (i % 2 == 0) ? "intasblob" : "blobasint";
+        e = function_call{
+            .func = functions::function_name::native_function(fname),
+            .args = {std::move(e)},
+        };
+    }
+    return e;
+}
+
+// Preparing a chain of N nested function calls must invoke prepare_function_call
+// O(N) times, not O(2^N). Before the pass-A reuse fix this count doubles with each
+// extra level (exponential); after it the count is linear.
+BOOST_AUTO_TEST_CASE(prepare_nested_function_calls_is_not_exponential) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    for (unsigned depth : {1u, 2u, 4u, 8u, 12u, 16u}) {
+        cql3::expr::reset_prepare_function_call_count();
+        expression nested = make_nested_blob_conversions(*table_schema, depth);
+        prepare_expression(nested, db, "test_ks", table_schema.get(), nullptr);
+        uint64_t count = cql3::expr::prepare_function_call_count();
+        BOOST_TEST_MESSAGE(seastar::format("nested function depth={} prepare_function_call_count={}", depth, count));
+        // Linear bound: each level should cost a small constant number of
+        // prepare_function_call invocations. A generous ceiling of 8*depth still
+        // fails loudly for any exponential (2^depth) regression.
+        BOOST_CHECK_LE(count, uint64_t(8) * depth + 8);
+    }
 }
 
 // prepare_expression for a column_value should do nothing

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -29,6 +29,9 @@
 #include "utils/big_decimal.hh"
 #include "utils/multiprecision_int.hh"
 #include "cql3/functions/functions.hh"
+#include "cql3/functions/native_scalar_function.hh"
+#include "exceptions/exceptions.hh"
+#include <seastar/util/defer.hh>
 
 using namespace cql3;
 using namespace cql3::expr;
@@ -1277,6 +1280,9 @@ BOOST_AUTO_TEST_CASE(prepare_static_column_unresolved_identifier) {
 namespace cql3::expr {
 extern uint64_t prepare_function_call_count();
 extern void reset_prepare_function_call_count();
+extern uint64_t test_assignment_function_call_count();
+extern void reset_test_assignment_function_call_count();
+extern void set_prepare_memo_enabled(bool enabled);
 }
 
 // Builds intasblob(blobasint(intasblob(... r ...))) of the given nesting depth.
@@ -1313,6 +1319,79 @@ BOOST_AUTO_TEST_CASE(prepare_nested_function_calls_is_not_exponential) {
         // fails loudly for any exponential (2^depth) regression.
         BOOST_CHECK_LE(count, uint64_t(8) * depth + 8);
     }
+}
+
+// Builds f(f(f(... ? ...))) of the given depth, where f is a function with both
+// f(int) and f(bigint) overloads. A bind marker is assignable to both and never gets a
+// default type, so every nested call stays ambiguous - an unresolved "hole" - and
+// overload resolution must probe it against both candidate parameter types at each level.
+static expression make_nested_overloaded_calls(const char* fname, unsigned depth) {
+    expression e = bind_variable{
+        .bind_index = 0,
+        .receiver = nullptr,
+    };
+    for (unsigned i = 0; i < depth; ++i) {
+        e = function_call{
+            .func = functions::function_name::native_function(fname),
+            .args = {std::move(e)},
+        };
+    }
+    return e;
+}
+
+// Probing a nested hole under a multi-overload function is recursive: without
+// memoization it re-resolves each nested hole once per candidate parameter type at
+// every level, which is exponential in the nesting depth. The per-prepare memo
+// collapses that to linear. This test measures both, to confirm the difference.
+BOOST_AUTO_TEST_CASE(prepare_nested_overloaded_function_probing_is_not_exponential) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    const char* overloaded_test_fn = "expr_test_overloaded_identity";
+    auto make_overload = [&] (data_type t) {
+        return functions::make_native_scalar_function<true>(
+                overloaded_test_fn, t, std::vector<data_type>{t},
+                [] (std::span<const bytes_opt> args) -> bytes_opt { return args[0]; });
+    };
+    // Snapshot the original registry, then install our two overloads. On scope exit we
+    // commit the original snapshot back, so we do not leak them into other tests sharing
+    // this binary.
+    auto original_batch = functions::change_batch();
+    {
+        auto custom_batch = functions::change_batch();
+        custom_batch.add_function(make_overload(int32_type));
+        custom_batch.add_function(make_overload(long_type));
+        custom_batch.commit();
+    }
+    auto cleanup = seastar::defer([&] () noexcept { original_batch.commit(); });
+
+    auto count_probes = [&] (const expression& e, bool memo_enabled) -> uint64_t {
+        cql3::expr::set_prepare_memo_enabled(memo_enabled);
+        cql3::expr::reset_test_assignment_function_call_count();
+        try {
+            // The expression is intentionally ambiguous, so preparation throws; we
+            // only care about how much probing happened on the way to the failure.
+            prepare_expression(e, db, "test_ks", table_schema.get(), nullptr);
+        } catch (const exceptions::invalid_request_exception&) {
+        }
+        return cql3::expr::test_assignment_function_call_count();
+    };
+
+    for (unsigned depth : {2u, 4u, 6u, 8u}) {
+        expression nested = make_nested_overloaded_calls(overloaded_test_fn, depth);
+        uint64_t without_memo = count_probes(nested, false);
+        uint64_t with_memo = count_probes(nested, true);
+        BOOST_TEST_MESSAGE(seastar::format(
+                "overloaded depth={} test_assignment_function_call_count without_memo={} with_memo={}",
+                depth, without_memo, with_memo));
+        // Linear in nesting depth: ~2 probes per level (one per candidate overload),
+        // with headroom so a benign change to that per-level constant won't fail here.
+        BOOST_CHECK_LE(with_memo, uint64_t(4) * depth);
+        if (depth >= 4) {
+            BOOST_CHECK_LT(with_memo, without_memo);
+        }
+    }
+    cql3::expr::set_prepare_memo_enabled(true);
 }
 
 // prepare_expression for a column_value should do nothing

--- a/test/boost/expr_test.cc
+++ b/test/boost/expr_test.cc
@@ -1394,6 +1394,45 @@ BOOST_AUTO_TEST_CASE(prepare_nested_overloaded_function_probing_is_not_exponenti
     cql3::expr::set_prepare_memo_enabled(true);
 }
 
+// Default-type inference for a receiver-less collection must keep integer literals
+// untyped through overload resolution, so a function whose only overload takes tinyint
+// stays reachable: the raw literals are fit-checked against the parameter type rather
+// than pinned to their default int type first (int is not assignable to tinyint).
+BOOST_AUTO_TEST_CASE(infer_collection_of_function_calls_keeps_narrow_overload) {
+    schema_ptr table_schema = make_simple_test_schema();
+    auto [db, db_data] = make_data_dictionary_database(table_schema);
+
+    auto narrow_fn = functions::make_native_scalar_function<true>(
+            "expr_test_narrow_identity", byte_type, std::vector<data_type>{byte_type, byte_type},
+            [] (std::span<const bytes_opt> args) -> bytes_opt { return args[0]; });
+    auto restore = functions::change_batch();
+    {
+        auto batch = functions::change_batch();
+        batch.add_function(narrow_fn);
+        batch.commit();
+    }
+    auto cleanup = seastar::defer([&] () noexcept { restore.commit(); });
+
+    // [f(1, 2)] with no receiver. f has only a tinyint overload, so the literals must
+    // be typed as tinyint and the inferred list element type must be tinyint.
+    expression call = function_call{
+        .func = functions::function_name::native_function("expr_test_narrow_identity"),
+        .args = {
+            untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "1"},
+            untyped_constant{.partial_type = untyped_constant::type_class::integer, .raw_text = "2"},
+        },
+    };
+    expression list_literal = collection_constructor{
+        .style = collection_constructor::style_type::list_or_vector,
+        .elements = {std::move(call)},
+    };
+
+    expression prepared = prepare_expression(list_literal, db, "test_ks", table_schema.get(), nullptr);
+    // Inferred collections are frozen; the key point is the element type is tinyint
+    // (the narrow overload), not int (the literal default).
+    BOOST_REQUIRE_EQUAL(type_of(prepared)->as_cql3_type().to_string(), "frozen<list<tinyint>>");
+}
+
 // prepare_expression for a column_value should do nothing
 BOOST_AUTO_TEST_CASE(prepare_column_value) {
     schema_ptr table_schema = make_simple_test_schema();
@@ -1818,9 +1857,9 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_no_receiver) {
 
     expression untyped = make_int_untyped("1337");
 
-    // Can't infer type
-    BOOST_REQUIRE_THROW(prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(untyped, db, "test_ks", table_schema.get(), nullptr);
+    BOOST_REQUIRE(expr::type_of(prepared) == int32_type);
+    BOOST_REQUIRE_EQUAL(prepared, make_int_const(1337));
 }
 
 BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bool) {
@@ -1909,7 +1948,7 @@ BOOST_AUTO_TEST_CASE(prepare_untyped_constant_bad_int) {
                         exceptions::invalid_request_exception);
 }
 
-BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver_fails) {
+BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver) {
     schema_ptr table_schema = make_simple_test_schema();
     auto [db, db_data] = make_data_dictionary_database(table_schema);
 
@@ -1922,8 +1961,9 @@ BOOST_AUTO_TEST_CASE(prepare_tuple_constructor_no_receiver_fails) {
             },
         .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(tup, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(tup, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = tuple_type_impl::get_instance({int32_type, int32_type, utf8_type});
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_tuple_constructor) {
@@ -2063,10 +2103,9 @@ BOOST_AUTO_TEST_CASE(prepare_list_or_vector_collection_constructor_no_receiver) 
             },
         .type = nullptr};
 
-    data_type list_type = list_type_impl::get_instance(long_type, true);
-
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = list_type_impl::get_instance(int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_list_collection_constructor_with_bind_var) {
@@ -2242,8 +2281,9 @@ BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_no_receiver) {
             },
         .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = set_type_impl::get_instance(int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_set_collection_constructor_with_bind_var) {
@@ -2398,8 +2438,9 @@ BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_no_receiver) {
                 },
             .type = nullptr};
 
-    BOOST_REQUIRE_THROW(prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr),
-                        exceptions::invalid_request_exception);
+    expression prepared = prepare_expression(constructor, db, "test_ks", table_schema.get(), nullptr);
+    data_type expected_type = map_type_impl::get_instance(int32_type, int32_type, false);
+    BOOST_REQUIRE(expr::type_of(prepared) == expected_type);
 }
 
 BOOST_AUTO_TEST_CASE(prepare_map_collection_constructor_with_bind_var_key) {

--- a/test/cqlpy/test_cast.py
+++ b/test/cqlpy/test_cast.py
@@ -87,13 +87,17 @@ def test_cast_int_func_result_to_blob_implicit(cql, table1):
     cql.execute(f"INSERT INTO {table1} (pk, blob_col) VALUES ({pk}, blobasint(0xdeadbeef))")
     assert list(cql.execute(f"SELECT pk, blob_col FROM {table1} WHERE pk = {pk}")) == [(pk, 0xdeadbeef.to_bytes(4, 'big'))]
 
-# An int can't be cast to bigint because the binary representation is different.
-def test_cast_int_to_bigint(cql, table1):
+# An int widens losslessly to bigint - the value is converted, not reinterpreted - so an
+# int can be stored in a bigint column, both implicitly and via a (bigint) type hint.
+# scylla_only: Cassandra rejects assigning an int where a bigint is expected.
+def test_cast_int_to_bigint(cql, table1, scylla_only):
+    expected = int.from_bytes((0xbeefdead).to_bytes(4, 'big'), 'big', signed=True)
     pk = unique_key_int()
-    with pytest.raises(InvalidRequest, match='bigint'):
-        cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, blobasint(0xbeefdead))")
-    with pytest.raises(InvalidRequest, match='bigint'):
-        cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, (bigint)blobasint(0xbeefdead))")
+    cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, blobasint(0xbeefdead))")
+    assert list(cql.execute(f"SELECT bigint_col FROM {table1} WHERE pk = {pk}")) == [(expected,)]
+    pk = unique_key_int()
+    cql.execute(f"INSERT INTO {table1} (pk, bigint_col) VALUES ({pk}, (bigint)blobasint(0xbeefdead))")
+    assert list(cql.execute(f"SELECT bigint_col FROM {table1} WHERE pk = {pk}")) == [(expected,)]
 
 # The function token() returns a bigint, which can be converted to blob.
 def test_cast_bigint_token_to_blobl(cql, table1):

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -63,18 +63,14 @@ def test_set_literal_selector(cql, test_keyspace, scylla_only):
     rows = cql.execute(f"SELECT set_intersection(vals2, {{ {{ 'cc': 3, 'dd': 4 }}, {{ 'cc': 3, 'dd': 5 }} }}) AS intersection FROM {test_keyspace}.sets WHERE id=1")
     assert rows.one().intersection == {frozenset([('cc', 3), ('dd', 4)])}
 
-# Test that simple literals without type hints fail as expected due to type inference failure.
-def test_simple_literal_type_inference_failure(cql, test_keyspace):
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT 1 AS one FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT 'hello' AS greeting FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT [1, 2, 3] AS lst FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT { 'a': 1, 'b': 2 } AS mp FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT (1, 'a', 3.0) AS tpl FROM system.local")
+# Test that simple literals without type hints succeed with type inference,
+# and bind variables fail because they cannot self-type.
+def test_simple_literal_type_inference(cql, test_keyspace, scylla_only):
+    assert cql.execute("SELECT 1 AS one FROM system.local").one().one == 1
+    assert cql.execute("SELECT 'hello' AS greeting FROM system.local").one().greeting == 'hello'
+    assert cql.execute("SELECT [1, 2, 3] AS lst FROM system.local").one().lst == [1, 2, 3]
+    assert cql.execute("SELECT { 'a': 1, 'b': 2 } AS mp FROM system.local").one().mp == {'a': 1, 'b': 2}
+    assert cql.execute("SELECT (1, 'a', 3.0) AS tpl FROM system.local").one().tpl == (1, 'a', 3.0)
     with pytest.raises(InvalidRequest, match="infer type"):
         cql.execute("SELECT ? AS qm FROM system.local")
     with pytest.raises(InvalidRequest, match="infer type"):
@@ -89,3 +85,6 @@ def test_count_literal_only_1(cql, test_keyspace, scylla_only):
     # here is quite a hassle and we plan to relax the restriction later anyway.
     with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
         cql.execute("SELECT count(?) AS cnt FROM system.local")
+    with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
+        stmt = cql.prepare("SELECT count(:bindvar) AS cnt FROM system.local")
+        cql.execute(stmt, {'bindvar': 1})

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -18,7 +18,7 @@
 
 from contextlib import contextmanager
 import pytest
-from .util import unique_name, new_function
+from .util import unique_name, new_function, new_test_table
 from .conftest import scylla_only
 from cassandra.protocol import InvalidRequest
 
@@ -76,15 +76,27 @@ def test_simple_literal_type_inference(cql, test_keyspace, scylla_only):
     with pytest.raises(InvalidRequest, match="infer type"):
         cql.execute("SELECT :bindvar AS bv FROM system.local")
 
-# Test that count(2) fails as expected. We're likely to relax this restriction later
-# as it is quite artificial. scylla_only because Cassandra does allow it.
-def test_count_literal_only_1(cql, test_keyspace, scylla_only):
-    with pytest.raises(InvalidRequest, match="expects a column or the literal 1 as an argument"):
-        cql.execute("SELECT count(2) AS cnt FROM system.local")
-    # Error message here is not the best, but tightening error messages
-    # here is quite a hassle and we plan to relax the restriction later anyway.
+# Test that count with a literal argument works with types that can be inferred,
+# and fails when the argument is a bind variable (which cannot self-type).
+def test_count_literal_args(cql, test_keyspace, scylla_only):
+    assert cql.execute("SELECT count(*) AS cnt FROM system.local").one().cnt == 1
+    assert cql.execute("SELECT count(1) AS cnt FROM system.local").one().cnt == 1
+    assert cql.execute("SELECT count('abc') AS cnt FROM system.local").one().cnt == 1
     with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
         cql.execute("SELECT count(?) AS cnt FROM system.local")
     with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
         stmt = cql.prepare("SELECT count(:bindvar) AS cnt FROM system.local")
         cql.execute(stmt, {'bindvar': 1})
+
+# Test that count(fn(col)) correctly counts only non-null results.
+# The UDF returns NULL for inputs divisible by 7, so out of 14 rows
+# (values 1-14), only values 7 and 14 produce NULL, giving count = 12.
+def test_count_function_with_nulls(cql, test_keyspace, scylla_only):
+    body = "(i int) CALLED ON NULL INPUT RETURNS int LANGUAGE lua AS 'if i % 7 == 0 then return nil else return i end;'"
+    with new_function(cql, test_keyspace, body, args="int") as fn:
+        with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int") as table:
+            for i in range(1, 15):
+                cql.execute(f"INSERT INTO {table} (pk, v) VALUES ({i}, {i})")
+            ksfn = f"{test_keyspace}.{fn}"
+            row = cql.execute(f"SELECT count({ksfn}(v)) AS cnt FROM {table}").one()
+            assert row.cnt == 12

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -76,6 +76,18 @@ def test_simple_literal_type_inference(cql, test_keyspace, scylla_only):
     with pytest.raises(InvalidRequest, match="infer type"):
         cql.execute("SELECT :bindvar AS bv FROM system.local")
 
+# Test that count with a literal argument works with types that can be inferred,
+# and fails when the argument is a bind variable (which cannot self-type).
+def test_count_literal_args(cql, test_keyspace, scylla_only):
+    assert cql.execute("SELECT count(*) AS cnt FROM system.local").one().cnt == 1
+    assert cql.execute("SELECT count(1) AS cnt FROM system.local").one().cnt == 1
+    assert cql.execute("SELECT count('abc') AS cnt FROM system.local").one().cnt == 1
+    with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
+        cql.execute("SELECT count(?) AS cnt FROM system.local")
+    with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
+        stmt = cql.prepare("SELECT count(:bindvar) AS cnt FROM system.local")
+        cql.execute(stmt, {'bindvar': 1})
+
 # Map literal {'a': 1} (inferred as map<text, int>) passed to a function
 # expecting map<text, bigint>.
 def test_map_literal_widening_direct_function_arg(cql, test_keyspace, scylla_only):

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -18,7 +18,7 @@
 
 from contextlib import contextmanager
 import pytest
-from .util import unique_name, new_function
+from .util import unique_name, new_function, new_test_table
 from .conftest import scylla_only
 from cassandra.protocol import InvalidRequest
 
@@ -63,29 +63,49 @@ def test_set_literal_selector(cql, test_keyspace, scylla_only):
     rows = cql.execute(f"SELECT set_intersection(vals2, {{ {{ 'cc': 3, 'dd': 4 }}, {{ 'cc': 3, 'dd': 5 }} }}) AS intersection FROM {test_keyspace}.sets WHERE id=1")
     assert rows.one().intersection == {frozenset([('cc', 3), ('dd', 4)])}
 
-# Test that simple literals without type hints fail as expected due to type inference failure.
-def test_simple_literal_type_inference_failure(cql, test_keyspace):
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT 1 AS one FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT 'hello' AS greeting FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT [1, 2, 3] AS lst FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT { 'a': 1, 'b': 2 } AS mp FROM system.local")
-    with pytest.raises(InvalidRequest, match="infer type"):
-        cql.execute("SELECT (1, 'a', 3.0) AS tpl FROM system.local")
+# Test that simple literals without type hints succeed with type inference,
+# and bind variables fail because they cannot self-type.
+def test_simple_literal_type_inference(cql, test_keyspace, scylla_only):
+    assert cql.execute("SELECT 1 AS one FROM system.local").one().one == 1
+    assert cql.execute("SELECT 'hello' AS greeting FROM system.local").one().greeting == 'hello'
+    assert cql.execute("SELECT [1, 2, 3] AS lst FROM system.local").one().lst == [1, 2, 3]
+    assert cql.execute("SELECT { 'a': 1, 'b': 2 } AS mp FROM system.local").one().mp == {'a': 1, 'b': 2}
+    assert cql.execute("SELECT (1, 'a', 3.0) AS tpl FROM system.local").one().tpl == (1, 'a', 3.0)
     with pytest.raises(InvalidRequest, match="infer type"):
         cql.execute("SELECT ? AS qm FROM system.local")
     with pytest.raises(InvalidRequest, match="infer type"):
         cql.execute("SELECT :bindvar AS bv FROM system.local")
 
-# Test that count(2) fails as expected. We're likely to relax this restriction later
-# as it is quite artificial. scylla_only because Cassandra does allow it.
-def test_count_literal_only_1(cql, test_keyspace, scylla_only):
-    with pytest.raises(InvalidRequest, match="expects a column or the literal 1 as an argument"):
-        cql.execute("SELECT count(2) AS cnt FROM system.local")
-    # Error message here is not the best, but tightening error messages
-    # here is quite a hassle and we plan to relax the restriction later anyway.
-    with pytest.raises(InvalidRequest, match="only valid when argument types are known"):
-        cql.execute("SELECT count(?) AS cnt FROM system.local")
+# Map literal {'a': 1} (inferred as map<text, int>) passed to a function
+# expecting map<text, bigint>.
+def test_map_literal_widening_direct_function_arg(cql, test_keyspace, scylla_only):
+    body = "(m map<text, bigint>) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return 42;'"
+    with new_function(cql, test_keyspace, body, args="map<text, bigint>") as fn:
+        ksfn = f"{test_keyspace}.{fn}"
+        row = cql.execute(f"SELECT {ksfn}({{'a': 1, 'b': 2}}) AS result FROM system.local").one()
+        assert row.result == 42
+
+# Map literal nested inside a collection that is a function arg: the inner {'a': 1}
+# (map<text, int>) must widen to the inner function's map<text, bigint> parameter.
+def test_map_literal_widening_nested_in_collection_arg(cql, test_keyspace, scylla_only):
+    inner_body = "(m map<text, bigint>) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return 42;'"
+    with new_function(cql, test_keyspace, inner_body, args="map<text, bigint>") as inner_fn:
+        outer_body = f"(lst list<bigint>) RETURNS NULL ON NULL INPUT RETURNS bigint LANGUAGE lua AS 'return lst[1];'"
+        with new_function(cql, test_keyspace, outer_body, args="list<bigint>") as outer_fn:
+            ksouter = f"{test_keyspace}.{outer_fn}"
+            ksinner = f"{test_keyspace}.{inner_fn}"
+            row = cql.execute(f"SELECT {ksouter}([{ksinner}({{'a': 1}}), 2]) AS result FROM system.local").one()
+            assert row.result == 42
+
+# Test that count(fn(col)) correctly counts only non-null results.
+# The UDF returns NULL for inputs divisible by 7, so out of 14 rows
+# (values 1-14), only values 7 and 14 produce NULL, giving count = 12.
+def test_count_function_with_nulls(cql, test_keyspace, scylla_only):
+    body = "(i int) CALLED ON NULL INPUT RETURNS int LANGUAGE lua AS 'if i % 7 == 0 then return nil else return i end;'"
+    with new_function(cql, test_keyspace, body, args="int") as fn:
+        with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v int") as table:
+            for i in range(1, 15):
+                cql.execute(f"INSERT INTO {table} (pk, v) VALUES ({i}, {i})")
+            ksfn = f"{test_keyspace}.{fn}"
+            row = cql.execute(f"SELECT count({ksfn}(v)) AS cnt FROM {table}").one()
+            assert row.cnt == 12

--- a/test/cqlpy/test_selector_literals.py
+++ b/test/cqlpy/test_selector_literals.py
@@ -88,6 +88,23 @@ def test_count_literal_args(cql, test_keyspace, scylla_only):
         stmt = cql.prepare("SELECT count(:bindvar) AS cnt FROM system.local")
         cql.execute(stmt, {'bindvar': 1})
 
+# sum() and avg() each have several numeric overloads, so a literal argument used
+# to match an overload was rejected as "Ambiguous call". Inferring the literal's
+# default type lets overload resolution pick a single signature. system.local has
+# exactly one row, so the aggregate of a literal is just that literal.
+def test_select_aggregates_with_literal_args(cql, test_keyspace, scylla_only):
+    assert cql.execute("SELECT sum(5) AS v FROM system.local").one().v == 5
+    assert cql.execute("SELECT avg(5) AS v FROM system.local").one().v == 5
+    assert cql.execute("SELECT min(5) AS v FROM system.local").one().v == 5
+    assert cql.execute("SELECT max(5) AS v FROM system.local").one().v == 5
+    assert cql.execute("SELECT min('hello') AS v FROM system.local").one().v == 'hello'
+    assert cql.execute("SELECT max('hello') AS v FROM system.local").one().v == 'hello'
+    # Aggregates and scalar literals mixed in the same SELECT.
+    row = cql.execute("SELECT count(1) AS cnt, 42 AS num, min(10) AS mn FROM system.local").one()
+    assert row.cnt == 1
+    assert row.num == 42
+    assert row.mn == 10
+
 # Map literal {'a': 1} (inferred as map<text, int>) passed to a function
 # expecting map<text, bigint>.
 def test_map_literal_widening_direct_function_arg(cql, test_keyspace, scylla_only):


### PR DESCRIPTION
This series improves how CQL types literals. A literal's type is taken from its context where there is one, and inferred from the literal itself where there isn't. A bare `SELECT 1` becomes an int, `SELECT [1, 2, 3]` a list<int>, `SELECT {'a': 1}` a map<text, int>. As part of the same typing, a numeric value is accepted where a wider type is expected and widened losslessly  (converted, not reinterpreted) on its way to the receiver, so `[1, 9999999999]` settles on a common element type and an int flows into a bigint column.

It also makes overload resolution prefer a literal's natural type (`f(1)` resolves to `f(int)`), lets `count()` take any expression (removing the old `count(1)` special case), and documents and tightens the `(T)x` type hint to a lossless "represent as T".

Fixes SCYLLADB-1229

This is an improvement. No need for backport.