### PR TITLE
gms/gossiper: fix use-after-move in do_send_ack2_msg

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -399,9 +399,10 @@ future<> gossiper::do_send_ack2_msg(locator::host_id from, utils::chunked_vector
         }
     }
     gms::gossip_digest_ack2 ack2_msg(std::move(delta_ep_state_map));
-    logger.debug("Calling do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
+    auto ack2_msg_str = fmt::format("{}", ack2_msg);
+    logger.debug("Calling do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg_str);
     co_await ser::gossip_rpc_verbs::send_gossip_digest_ack2(&_messaging, from, std::move(ack2_msg));
-    logger.debug("finished do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg);
+    logger.debug("finished do_send_ack2_msg to node {}, ack_msg_digest={}, ack2_msg={}", from, ack_msg_digest, ack2_msg_str);
 }
 
 // Depends on


### PR DESCRIPTION
## Summary

- **Fix use-after-move bug**: In `do_send_ack2_msg()`, `ack2_msg` was read after being `std::move()`-d into `send_gossip_digest_ack2()`. The second `logger.debug()` call accessed a moved-from `gossip_digest_ack2` object, which is undefined behavior.
- **Guard expensive formatting**: Wrap both debug log calls with `logger.is_enabled()` to avoid eagerly formatting the gossip message when debug logging is disabled.
- **Fix whitespace**: Minor whitespace fix in `ack_msg_digest` assignment.

Cherry-picked from #29203 (commit cd517ab) as a standalone fix since the use-after-move is a correctness bug.

## What was changed

In `gms/gossiper.cc`, function `do_send_ack2_msg()`:
- `ack2_msg` is now formatted to a string *before* being moved, and both log calls use the cached string
- Both debug log calls are guarded with `logger.is_enabled(logging::log_level::debug)`

## How it was tested

Cherry-picked cleanly from a PR that was built successfully in dev, release, and debug modes.

FIXES: https://scylladb.atlassian.net/browse/SCYLLADB-1778
Backport - yes, Ithink we should backport use-after-move, even if it's in a debug-only log.