### PR TITLE
tools: add compression advisor current config 

### DIFF
--- a/docs/operating-scylla/_common/tools_index.rst
+++ b/docs/operating-scylla/_common/tools_index.rst
@@ -14,6 +14,7 @@
 * :doc:`Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>` - a Unix domain socket for full-permission CQL connection.
 * :doc:`Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>` - a mode for performing maintenance tasks on an offline ScyllaDB node.
 * :doc:`Task manager </operating-scylla/admin-tools/task-manager/>` - a tool for tracking long-running background operations.
+* :doc:`Compression Advisor </operating-scylla/admin-tools/compression-advisor/>` - analyzes a table's compression configuration and recommends LZ4/ZSTD settings that reduce on-disk size.
 
 
 Run each tool with ``-h``, ``--help`` for full options description.

--- a/docs/operating-scylla/admin-tools/compression-advisor.rst
+++ b/docs/operating-scylla/admin-tools/compression-advisor.rst
@@ -1,0 +1,139 @@
+Compression Advisor
+====================
+
+The Compression Advisor (``tools/compression_advisor.py``) analyzes the
+compression configuration of a single table and recommends whether a different
+compressor, compression level, or chunk length would meaningfully reduce its
+on-disk size.
+
+It reads the table's current compression settings over CQL, asks the node to
+estimate compression ratios for a range of candidate configurations through the
+``estimate_compression_ratios`` REST API, and prints a color-coded heatmap grid,
+a summary table comparing the current configuration against the best LZ4 and
+ZSTD candidates, and a single ready-to-run ``ALTER TABLE`` statement for the
+best overall recommendation.
+
+The advisor only recommends a change when it improves the estimated compression
+ratio by at least 5%, and it prefers the default 4 KB chunk length unless a
+larger chunk is more than 5% better. This avoids churning table settings for
+negligible gains.
+
+Prerequisites
+-------------
+
+* Python 3.
+* *(Optional)* The `ScyllaDB Python driver
+  <https://pypi.org/project/scylla-driver/>`_ (``scylla-driver``), used to read
+  the current compression configuration over CQL. Install it with:
+
+  .. code-block:: console
+
+     pip install scylla-driver
+
+  If the driver is not installed, the tool still runs and prints the full
+  estimation heatmap and recommendations — it simply cannot highlight or
+  compare against the table's current compression settings.
+
+* Network access from where you run the tool to:
+
+  * the ScyllaDB CQL native transport port (``9042`` by default), and
+  * the ScyllaDB Admin REST API port (``10000`` by default).
+
+* The ``SSTABLE_COMPRESSION_DICTS`` cluster feature must be enabled on all
+  nodes. The ``estimate_compression_ratios`` REST API depends on it; without it
+  the endpoint returns an error and the tool reports that the API returned
+  invalid JSON.
+
+Usage
+-----
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host <node-ip> --keyspace <ks> --table <tbl> [options]
+
+For example:
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace myks --table mytbl
+
+To disable the ANSI color output (for example when redirecting to a file):
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace myks --table mytbl --no-color
+
+Options
+-------
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Option
+     - Default
+     - Description
+   * - ``--host``
+     - *(required)*
+     - IP address of a ScyllaDB node to query.
+   * - ``--keyspace``
+     - *(required)*
+     - Keyspace name of the table to analyze.
+   * - ``--table``
+     - *(required)*
+     - Table name to analyze.
+   * - ``--api-port``
+     - ``10000``
+     - ScyllaDB Admin REST API port.
+   * - ``--cql-port``
+     - ``9042``
+     - ScyllaDB CQL native transport port.
+   * - ``--no-color``
+     - *off*
+     - Disable ANSI color output. Color is also disabled automatically when the
+       output is not a terminal.
+
+Run the tool with ``-h`` / ``--help`` for the full list of options.
+
+Output
+------
+
+The advisor prints three sections:
+
+* **Heatmap grid** — the estimated compression ratio for every candidate
+  compressor / chunk length / level combination, color-coded so the most
+  effective configurations stand out. The current configuration is highlighted.
+* **Summary table** — the current configuration alongside the best LZ4 and best
+  ZSTD candidates, with the estimated size reduction relative to the current
+  setting.
+* **Recommended change** — a single ``ALTER TABLE`` statement for the best
+  overall recommendation (chosen between the best LZ4 and best ZSTD candidate).
+  When a dictionary-aware compressor with a retrained dictionary is recommended,
+  the tool also prints the corresponding ``retrain_dict`` REST call needed to
+  train the compression dictionary.
+
+The recommended ``ALTER TABLE`` statement always quotes the keyspace and table
+identifiers, uses the dictionary-capable compressor names returned by the
+estimator (for example ``ZstdWithDictsCompressor``), and includes
+``compression_level`` for ZSTD. For example:
+
+.. code-block:: cql
+
+   ALTER TABLE "myks"."mytbl" WITH compression = {'sstable_compression': 'ZstdWithDictsCompressor', 'chunk_length_in_kb': '4', 'compression_level': '5'};
+
+If the recommendation uses a retrained dictionary, the tool also prints, as
+comments, the REST call to train it:
+
+.. code-block:: console
+
+   -- Then retrain the dictionary (requires SSTABLE_COMPRESSION_DICTS feature):
+   -- POST /storage_service/retrain_dict?keyspace=myks&cf=mytbl
+
+When no change improves the estimated ratio by more than 5%, the tool reports
+that the current configuration is already optimal instead of printing an
+``ALTER TABLE`` statement.
+
+.. note::
+
+   The advisor only estimates and recommends; it never modifies the table.
+   Apply any recommended ``ALTER TABLE`` statement yourself after reviewing it.

--- a/docs/operating-scylla/admin-tools/compression-advisor.rst
+++ b/docs/operating-scylla/admin-tools/compression-advisor.rst
@@ -1,0 +1,151 @@
+Compression Advisor
+====================
+
+The Compression Advisor (``tools/compression_advisor.py``) analyzes the
+compression configuration of a single table and recommends whether a different
+compressor, compression level, or chunk length would meaningfully reduce its
+on-disk size.
+
+It reads the table's current compression settings over CQL, asks the node to
+estimate compression ratios for a range of candidate configurations through the
+``estimate_compression_ratios`` REST API, and prints a color-coded heatmap grid,
+a summary table comparing the current configuration against the best LZ4 and
+ZSTD candidates, and a single ready-to-run ``ALTER TABLE`` statement for the
+best overall recommendation.
+
+The advisor only recommends a change when it improves the estimated compression
+ratio by at least 5%, and it prefers the default 4 KB chunk length unless a
+larger chunk is more than 5% better. This avoids churning table settings for
+negligible gains.
+
+Prerequisites
+-------------
+
+* Python 3.
+* The `ScyllaDB Python driver
+  <https://python-driver.docs.scylladb.com/>`_ (``scylla-driver``), used to
+  read the current compression configuration over CQL. Install it with:
+
+  .. code-block:: console
+
+     pip install scylla-driver
+
+  Without the driver, the tool still runs and prints the heatmap and
+  recommendations, but cannot compare against the current configuration.
+
+* Network access from where you run the tool to:
+
+  * the ScyllaDB CQL native transport port (``9042`` by default), and
+  * the ScyllaDB Admin REST API port (``10000`` by default).
+
+* The ``SSTABLE_COMPRESSION_DICTS`` cluster feature must be enabled on all
+  nodes. If not enabled, the ``estimate_compression_ratios`` REST API is
+  unavailable and Compression Advisor reports that the API returned invalid
+  JSON.
+
+Usage
+-----
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host <node-ip> --keyspace <ks> --table <tbl> [options]
+
+For example:
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace myks --table mytbl
+
+To disable the ANSI color output (for example when redirecting to a file):
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace myks --table mytbl --no-color
+
+If the cluster uses ``PasswordAuthenticator``, pass CQL credentials so the tool
+can read the current compression configuration:
+
+.. code-block:: console
+
+   python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace myks --table mytbl --username scylla --password mypassword
+
+Options
+-------
+
+.. list-table::
+   :widths: 20 15 65
+   :header-rows: 1
+
+   * - Option
+     - Default
+     - Description
+   * - ``--host``
+     - *(required)*
+     - IP address of a ScyllaDB node to query.
+   * - ``--keyspace``
+     - *(required)*
+     - Keyspace name of the table to analyze.
+   * - ``--table``
+     - *(required)*
+     - Table name to analyze.
+   * - ``--api-port``
+     - ``10000``
+     - ScyllaDB Admin REST API port.
+   * - ``--cql-port``
+     - ``9042``
+     - ScyllaDB CQL native transport port.
+   * - ``--username``
+     - *(none)*
+     - CQL username, required if the cluster uses ``PasswordAuthenticator``.
+   * - ``--password``
+     - *(none)*
+     - CQL password, required if the cluster uses ``PasswordAuthenticator``.
+   * - ``--no-color``
+     - *off*
+     - Disable ANSI color output. Color is also disabled automatically when the
+       output is not a terminal.
+
+Run the tool with ``-h`` / ``--help`` for the full list of options.
+
+Output
+------
+
+The advisor prints three sections:
+
+* **Heatmap grid** — the estimated compression ratio for every candidate
+  compressor / chunk length / level combination, color-coded so the most
+  effective configurations stand out. The current configuration is highlighted.
+* **Summary table** — the current configuration alongside the best LZ4 and best
+  ZSTD candidates, with the estimated size reduction relative to the current
+  setting.
+* **Recommended change** — a single ``ALTER TABLE`` statement for the best
+  overall recommendation (chosen between the best LZ4 and best ZSTD candidate).
+  When a dictionary-aware compressor with a retrained dictionary is recommended,
+  the tool also prints the corresponding ``retrain_dict`` REST call needed to
+  train the compression dictionary.
+
+The recommended ``ALTER TABLE`` statement always quotes the keyspace and table
+identifiers, uses the dictionary-capable compressor names returned by the
+estimator (for example ``ZstdWithDictsCompressor``), and includes
+``compression_level`` for ZSTD. For example:
+
+.. code-block:: cql
+
+   ALTER TABLE "myks"."mytbl" WITH compression = {'sstable_compression': 'ZstdWithDictsCompressor', 'chunk_length_in_kb': '4', 'compression_level': '5'};
+
+If the recommendation uses a retrained dictionary, the tool also prints, as
+comments, the REST call to train it:
+
+.. code-block:: console
+
+   -- Then retrain the dictionary (requires SSTABLE_COMPRESSION_DICTS feature):
+   -- POST /storage_service/retrain_dict?keyspace=myks&cf=mytbl
+
+When no change improves the estimated ratio by more than 5%, the tool reports
+that the current configuration is already optimal instead of printing an
+``ALTER TABLE`` statement.
+
+.. note::
+
+   The advisor only estimates and recommends; it never modifies the table.
+   Apply any recommended ``ALTER TABLE`` statement yourself after reviewing it.

--- a/docs/operating-scylla/admin-tools/index.rst
+++ b/docs/operating-scylla/admin-tools/index.rst
@@ -21,6 +21,7 @@ Admin Tools
    Maintenance socket </operating-scylla/admin-tools/maintenance-socket/>
    Maintenance mode </operating-scylla/admin-tools/maintenance-mode/>
    Task manager </operating-scylla/admin-tools/task-manager/>
+   Compression Advisor </operating-scylla/admin-tools/compression-advisor/>
 
 .. panel-box::
   :title: Admin Tools

--- a/test/tools/__init__.py
+++ b/test/tools/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1

--- a/test/tools/test_compression_advisor.py
+++ b/test/tools/test_compression_advisor.py
@@ -1,0 +1,1484 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""Unit tests for tools/compression_advisor.py.
+
+These are pure-Python tests that require no running ScyllaDB cluster.
+Run with:  python -m pytest test/tools/test_compression_advisor.py -v
+"""
+
+import re
+import pytest
+import sys
+import os
+import types
+import json
+import urllib.error
+
+# Make tools/ importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tools"))
+import compression_advisor as ca
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_result(
+    algo: str, chunk_kb: int, level: int, dict_mode: str, ratio: float
+) -> dict:
+    """Build one estimation result entry."""
+    return {
+        "sstable_compression": algo,
+        "chunk_length_in_kb": chunk_kb,
+        "level": level,
+        "dict": dict_mode,
+        "ratio": ratio,
+    }
+
+
+def _lz4(chunk_kb, dict_mode, ratio):
+    return make_result("LZ4WithDictsCompressor", chunk_kb, 1, dict_mode, ratio)
+
+
+def _zstd(chunk_kb, level, dict_mode, ratio):
+    return make_result("ZstdWithDictsCompressor", chunk_kb, level, dict_mode, ratio)
+
+
+def make_full_result_set(
+    *,
+    # Base ratios for LZ4, no dict, per chunk size
+    lz4_none_1k=0.82,
+    lz4_none_4k=0.78,
+    lz4_none_16k=0.67,
+    # LZ4 with future dict
+    lz4_future_1k=0.45,
+    lz4_future_4k=0.41,
+    lz4_future_16k=0.38,
+    # LZ4 with past dict
+    lz4_past_1k=0.55,
+    lz4_past_4k=0.52,
+    lz4_past_16k=0.48,
+    # ZSTD base ratio scale: each level improves by this factor
+    zstd_level_factors=None,
+    # ZSTD no-dict base (4K level 1)
+    zstd_none_base=0.76,
+    # ZSTD future-dict base (4K level 1)
+    zstd_future_base=0.38,
+    # ZSTD past-dict base (4K level 1)
+    zstd_past_base=0.50,
+    # Chunk size factors relative to 4K
+    chunk_1k_factor=1.05,  # 1K is 5% worse than 4K
+    chunk_16k_factor=0.92,  # 16K is 8% better than 4K
+):
+    """Build a complete 54-entry result set with configurable parameters."""
+    if zstd_level_factors is None:
+        # Default: diminishing returns — levels 1-3 meaningful, 4-5 marginal
+        zstd_level_factors = {1: 1.0, 2: 0.96, 3: 0.93, 4: 0.925, 5: 0.92}
+
+    results = []
+
+    # LZ4 entries (1 level × 3 chunks × 3 dicts = 9)
+    for chunk_kb, none_r, past_r, future_r in [
+        (1, lz4_none_1k, lz4_past_1k, lz4_future_1k),
+        (4, lz4_none_4k, lz4_past_4k, lz4_future_4k),
+        (16, lz4_none_16k, lz4_past_16k, lz4_future_16k),
+    ]:
+        results.append(_lz4(chunk_kb, "none", none_r))
+        results.append(_lz4(chunk_kb, "past", past_r))
+        results.append(_lz4(chunk_kb, "future", future_r))
+
+    # ZSTD entries (5 levels × 3 chunks × 3 dicts = 45)
+    for level in range(1, 6):
+        lf = zstd_level_factors[level]
+        for chunk_kb, chunk_f in [
+            (1, chunk_1k_factor),
+            (4, 1.0),
+            (16, chunk_16k_factor),
+        ]:
+            none_r = zstd_none_base * lf * chunk_f
+            past_r = zstd_past_base * lf * chunk_f
+            future_r = zstd_future_base * lf * chunk_f
+            results.append(_zstd(chunk_kb, level, "none", round(none_r, 4)))
+            results.append(_zstd(chunk_kb, level, "past", round(past_r, 4)))
+            results.append(_zstd(chunk_kb, level, "future", round(future_r, 4)))
+
+    assert len(results) == 54
+    return results
+
+
+# ---------------------------------------------------------------------------
+# TestParseCurrentConfig
+# ---------------------------------------------------------------------------
+
+
+class TestParseCurrentConfig:
+    def test_lz4_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4Compressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["chunk_length_kb"] == 4
+        assert cfg["level"] == 1
+        assert cfg["dict_aware"] is False
+
+    def test_lz4_with_dicts(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "16",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["chunk_length_kb"] == 16
+
+    def test_zstd_with_level(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+                "chunk_length_in_kb": "4",
+                "compression_level": "3",
+            }
+        )
+        assert cfg["algorithm"] == "ZstdWithDictsCompressor"
+        assert cfg["level"] == 3
+
+    def test_fully_qualified_java_name(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "org.apache.cassandra.io.compress.LZ4Compressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["dict_aware"] is False
+
+    def test_dict_capable_compressor_is_dict_aware(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["dict_aware"] is True
+
+    def test_default_chunk_length(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+            }
+        )
+        assert cfg["chunk_length_kb"] == 4
+
+    def test_default_level(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+            }
+        )
+        assert cfg["level"] == 1
+
+    def test_snappy_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "SnappyCompressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        # Snappy is recognized but not dict-aware (not in _TO_DICT_AWARE)
+        assert cfg["dict_aware"] is False
+        assert cfg["algorithm"] == "SnappyCompressor"
+
+    def test_unknown_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "SomeFutureCompressor",
+            }
+        )
+        assert cfg["algorithm"] == "SomeFutureCompressor"
+        assert cfg["dict_aware"] is False
+
+    def test_invalid_chunk_length_defaults_to_4(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "banana",
+            }
+        )
+        assert cfg["chunk_length_kb"] == 4
+
+    def test_invalid_level_defaults_to_1(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+                "compression_level": "high",
+            }
+        )
+        assert cfg["level"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestFindCurrentRatio
+# ---------------------------------------------------------------------------
+
+
+class TestFindCurrentRatio:
+    def test_exact_match_with_past_dict(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+            _lz4(4, "future", 0.41),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+    def test_prefers_past_over_none(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+    def test_fallback_to_none_when_no_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "future", 0.41),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.78
+
+    def test_returns_zero_when_no_match(self):
+        results = [
+            _lz4(1, "none", 0.82),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.0
+
+    def test_zstd_match(self):
+        results = [
+            _zstd(4, 3, "past", 0.35),
+            _zstd(4, 3, "none", 0.50),
+        ]
+        cfg = {"algorithm": "ZstdWithDictsCompressor", "chunk_length_kb": 4, "level": 3}
+        assert ca.find_current_ratio(results, cfg) == 0.35
+
+    def test_plain_compressor_prefers_none_over_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": False,
+        }
+        assert ca.find_current_ratio(results, cfg) == 0.78
+
+    def test_dict_capable_compressor_prefers_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+
+# ---------------------------------------------------------------------------
+# TestSelectBestForFamily
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestForFamily:
+    # --- Chunk size preferences ---
+
+    def test_prefers_4k_when_1k_marginally_better(self):
+        """1K is only ~2% better than 4K -> prefer 4K."""
+        results = [
+            _lz4(1, "future", 0.40),  # absolute best, but only 2.4% better than 4K
+            _lz4(4, "future", 0.41),  # within 5% of best
+            _lz4(16, "future", 0.45),  # worse than 4K
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.82),
+            _lz4(16, "none", 0.85),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["chunk_length_kb"] == 4
+
+    def test_picks_1k_when_significantly_better(self):
+        """1K is 20% better than 4K -> pick 1K."""
+        results = [
+            _lz4(1, "future", 0.30),
+            _lz4(4, "future", 0.50),  # 67% worse
+            _lz4(16, "future", 0.48),
+            _lz4(1, "none", 0.60),
+            _lz4(4, "none", 0.80),
+            _lz4(16, "none", 0.75),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        # absolute best is 1K=0.30, 4K=0.50 is not within 5%
+        assert best["config"]["chunk_length_kb"] != 4
+
+    def test_prefers_4k_over_16k_when_close(self):
+        """16K is only 3% better than 4K -> prefer 4K."""
+        results = [
+            _lz4(1, "future", 0.50),
+            _lz4(4, "future", 0.41),
+            _lz4(16, "future", 0.40),  # 2.4% better than 4K
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.70),
+            _lz4(16, "none", 0.68),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["chunk_length_kb"] == 4
+
+    # --- Dictionary preferences ---
+
+    def test_prefers_no_dict_when_marginal_improvement(self):
+        """Dict provides only 3% improvement -> prefer no dict."""
+        results = [
+            _lz4(4, "none", 0.42),
+            _lz4(4, "future", 0.41),  # 2.4% better
+            _lz4(1, "none", 0.50),
+            _lz4(1, "future", 0.48),
+            _lz4(16, "none", 0.40),
+            _lz4(16, "future", 0.39),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["dict"] == "none"
+
+    def test_recommends_dict_when_significant(self):
+        """Dict provides 33% improvement -> recommend dict."""
+        results = [
+            _lz4(4, "none", 0.60),
+            _lz4(4, "future", 0.40),  # 33% better
+            _lz4(1, "none", 0.65),
+            _lz4(1, "future", 0.42),
+            _lz4(16, "none", 0.55),
+            _lz4(16, "future", 0.38),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["dict"] == "future"
+
+    # --- Level preferences (ZSTD) ---
+
+    def test_prefers_level1_when_level5_marginally_better(self):
+        """ZSTD level 5 is only 2% better than level 1 -> pick level 1."""
+        results = []
+        for level, ratio in [(1, 0.40), (2, 0.395), (3, 0.393), (4, 0.392), (5, 0.391)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.2))
+        # Add other chunks to avoid issues
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.50))
+                results.append(_zstd(ck, level, "none", 0.70))
+        best = ca.select_best_for_family(results, "Zstd")
+        assert best["config"]["level"] == 1
+
+    def test_picks_level3_when_diminishing_returns(self):
+        """Levels 1-3 have meaningful improvement, 4-5 are marginal."""
+        results = []
+        for level, ratio in [(1, 0.50), (2, 0.45), (3, 0.42), (4, 0.415), (5, 0.41)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.15))
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.60))
+                results.append(_zstd(ck, level, "none", 0.80))
+        best = ca.select_best_for_family(results, "Zstd")
+        # Level 3 at 0.42 vs best 0.41: within 5%. Level 1 at 0.50 vs 0.41: not within 5%
+        # Level 2 at 0.45 vs 0.41: 9.7% — not within 5%
+        # Level 3 at 0.42 vs 0.41: 2.4% — within 5%!
+        assert best["config"]["level"] == 3
+
+    def test_picks_level5_when_each_level_significant(self):
+        """Each level has >5% improvement over the previous."""
+        results = []
+        for level, ratio in [(1, 0.60), (2, 0.50), (3, 0.40), (4, 0.30), (5, 0.20)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.15))
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.70))
+                results.append(_zstd(ck, level, "none", 0.85))
+        best = ca.select_best_for_family(results, "Zstd")
+        # Each level far apart from best=0.20. Only level 5 is within 5% of 0.20
+        assert best["config"]["level"] == 5
+
+    # --- LZ4 always level 1 ---
+
+    def test_lz4_always_level_1(self):
+        results = [
+            _lz4(4, "future", 0.40),
+            _lz4(4, "none", 0.70),
+            _lz4(1, "future", 0.42),
+            _lz4(1, "none", 0.75),
+            _lz4(16, "future", 0.38),
+            _lz4(16, "none", 0.65),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["level"] == 1
+
+    # --- Edge cases ---
+
+    def test_all_ratios_identical_picks_simplest(self):
+        """When all ratios are the same, pick the simplest config."""
+        results = []
+        for ck in [1, 4, 16]:
+            results.append(_lz4(ck, "none", 0.50))
+            results.append(_lz4(ck, "future", 0.50))
+        best = ca.select_best_for_family(results, "LZ4")
+        # Should prefer 4K and no dict (simplest)
+        assert best["config"]["chunk_length_kb"] == 4
+        assert best["config"]["dict"] == "none"
+
+    def test_generates_notes(self):
+        """Check that notes are generated for preference decisions."""
+        results = [
+            _lz4(1, "future", 0.39),
+            _lz4(4, "future", 0.41),
+            _lz4(16, "future", 0.38),
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.82),
+            _lz4(16, "none", 0.75),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert len(best["notes"]) > 0
+
+    def test_no_results_returns_none_config(self):
+        """If no results match the family, config is None."""
+        results = [
+            _lz4(4, "future", 0.40),
+        ]
+        best = ca.select_best_for_family(results, "Zstd")
+        assert best["config"] is None
+
+    def test_no_4k_entries_picks_best_available_chunk(self):
+        """If no 4K entries exist, pick the best available chunk size."""
+        results = [
+            _lz4(1, "future", 0.45),
+            _lz4(16, "future", 0.38),
+            _lz4(1, "none", 0.80),
+            _lz4(16, "none", 0.65),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"] is not None
+        # Should pick the best chunk (16K with 0.38)
+        assert best["config"]["chunk_length_kb"] in (1, 16)
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_parse_current_config_empty_dict(self):
+        """parse_current_config({}) should return sensible defaults."""
+        cfg = ca.parse_current_config({})
+        assert cfg["chunk_length_kb"] == 4
+        assert cfg["level"] == 1
+        assert cfg["algorithm"] == ""
+        assert cfg["dict_aware"] is False
+
+    def test_find_current_ratio_empty_results(self):
+        """find_current_ratio([], cfg) should return 0.0."""
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio([], cfg) == 0.0
+
+    def test_select_best_empty_results(self):
+        """select_best_for_family([], ...) should return None config."""
+        best = ca.select_best_for_family([], "LZ4")
+        assert best["config"] is None
+
+    def test_visible_len_no_ansi(self):
+        """_visible_len on plain text returns normal length."""
+        assert ca._visible_len("hello") == 5
+
+    def test_visible_len_with_ansi(self):
+        """_visible_len strips ANSI codes."""
+        s = "\033[1;32m-15.3%\033[0m"
+        assert ca._visible_len(s) == 6  # "-15.3%"
+
+    def test_ratio_zero_shown_as_zero(self):
+        """Ratio 0.0 should be shown as '0.00', not as a dash."""
+        # This tests fix #2: cur["ratio"] == 0.0 should not be treated as falsy
+        results = [_lz4(4, "none", 0.0), _lz4(4, "past", 0.0)]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        table = ca.format_summary_table(summary, use_color=False)
+        # The ratio for current should be "0.000", not "—"
+        assert "0.000" in table
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateSummary
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummary:
+    def test_summary_has_all_keys(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert "current" in summary
+        assert "best_lz4" in summary
+        assert "best_zstd" in summary
+
+    def test_current_ratio_matches(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["ratio"] == 0.52  # lz4_past_4k default
+
+    def test_improvement_pct_calculation(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Both recommendations should be better (positive improvement)
+        assert summary["best_lz4"]["improvement_pct"] > 0
+        assert summary["best_zstd"]["improvement_pct"] > 0
+
+    def test_recommendations_not_worse_than_current(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        cur_ratio = summary["current"]["ratio"]
+        if summary["best_lz4"]["config"]:
+            assert summary["best_lz4"]["config"]["ratio"] <= cur_ratio
+        if summary["best_zstd"]["config"]:
+            assert summary["best_zstd"]["config"]["ratio"] <= cur_ratio
+
+    def test_negative_improvement_when_current_is_optimal(self):
+        """If current config is better than recommendations, improvement is negative."""
+        # Make current config very good: past dict at 4K is 0.10
+        results = make_full_result_set(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Current ratio is very low (0.10), recommendations are higher
+        assert summary["best_lz4"]["improvement_pct"] < 0
+
+    def test_with_full_54_entry_dataset(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["algorithm"] == "ZstdWithDictsCompressor"
+        assert summary["best_lz4"]["config"] is not None
+        assert summary["best_zstd"]["config"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TestFormatHeatmapGrid
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHeatmapGrid:
+    def _make_grid(self, use_color=False):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        return ca.format_heatmap_grid(results, cfg, summary, use_color)
+
+    def test_grid_has_header_row(self):
+        grid = self._make_grid(use_color=False)
+        assert "no dict" in grid
+        assert "future dict" in grid
+
+    def test_grid_has_chunk_size_columns(self):
+        grid = self._make_grid(use_color=False)
+        assert "1K" in grid
+        assert "4K" in grid
+        assert "16K" in grid
+
+    def test_grid_has_algorithm_rows(self):
+        grid = self._make_grid(use_color=False)
+        assert "LZ4" in grid
+        assert "ZSTD" in grid
+
+    def test_grid_has_all_zstd_levels(self):
+        grid = self._make_grid(use_color=False)
+        for lvl in range(1, 6):
+            assert f"level {lvl}" in grid
+
+    def test_grid_has_6_data_rows(self):
+        """1 LZ4 row + 5 ZSTD rows = 6 data rows."""
+        grid = self._make_grid(use_color=False)
+        lvl_count = sum(
+            1
+            for line in grid.split("\n")
+            if "level " in line
+            and any(c.isdigit() for c in line.split("level ")[-1][:1])
+        )
+        assert lvl_count == 6
+
+    def test_current_config_marked(self):
+        grid = self._make_grid(use_color=False)
+        assert "*" in grid
+
+    def test_recommended_config_marked(self):
+        grid = self._make_grid(use_color=False)
+        assert "\u25c4" in grid  # ◄
+
+    def test_no_recommended_marker_on_regression(self):
+        """If a family's best is worse than current, no ◄ for that family."""
+        # Current is ZSTD with very good past-dict ratio;
+        # LZ4 recommendations will all be worse -> no ◄ on LZ4 cells
+        results = make_full_result_set(
+            lz4_future_4k=0.60,
+            lz4_future_1k=0.65,
+            lz4_future_16k=0.58,
+            zstd_past_base=0.20,  # current ratio is very good
+            zstd_future_base=0.15,  # ZSTD still gets ◄
+        )
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        lines = grid.split("\n")
+        lz4_lines = [l for l in lines if l.strip().startswith("LZ4")]
+        # No ◄ on LZ4 lines (it's a regression)
+        for line in lz4_lines:
+            assert "\u25c4" not in line, f"LZ4 regression should not have ◄: {line}"
+        # But ZSTD should still have ◄
+        zstd_lines = [l for l in lines if l.strip().startswith("ZSTD")]
+        assert any("\u25c4" in l for l in zstd_lines), "ZSTD improvement should have ◄"
+
+    def test_no_color_mode_no_ansi(self):
+        grid = self._make_grid(use_color=False)
+        assert "\033[" not in grid
+
+    def test_color_mode_has_ansi(self):
+        grid = self._make_grid(use_color=True)
+        assert "\033[" in grid
+
+    def test_legend_present(self):
+        grid = self._make_grid(use_color=False)
+        assert "current" in grid.lower()
+        assert "recommended" in grid.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestFormatSummaryTable
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummaryTable:
+    def _make_table(self, use_color=False):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        return ca.format_summary_table(summary, use_color)
+
+    def test_three_columns(self):
+        tbl = self._make_table(use_color=False)
+        assert "Current" in tbl
+        assert "Best LZ4" in tbl
+        assert "Best ZSTD" in tbl
+
+    def test_contains_algorithm_names(self):
+        tbl = self._make_table(use_color=False)
+        assert "LZ4WithDicts" in tbl
+        assert "ZstdWithDicts" in tbl
+
+    def test_contains_ratio_values(self):
+        tbl = self._make_table(use_color=False)
+        # Should contain some decimal ratios
+        assert re.search(r"0\.\d{3}", tbl)
+
+    def test_contains_improvement_pct(self):
+        tbl = self._make_table(use_color=False)
+        assert "%" in tbl
+
+    def test_small_improvement_uses_size_change_sign(self):
+        results = make_full_result_set(
+            lz4_past_4k=0.50,
+            lz4_none_4k=0.485,
+            lz4_none_1k=0.60,
+            lz4_none_16k=0.60,
+            lz4_future_1k=0.60,
+            lz4_future_4k=0.60,
+            lz4_future_16k=0.60,
+            zstd_future_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        tbl = ca.format_summary_table(summary, use_color=False)
+
+        assert 0 < summary["best_lz4"]["improvement_pct"] < 5
+        assert "-3.0%" in tbl
+
+    def test_small_regression_uses_size_change_sign(self):
+        results = make_full_result_set(
+            lz4_past_4k=0.50,
+            lz4_none_4k=0.515,
+            lz4_none_1k=0.60,
+            lz4_none_16k=0.60,
+            lz4_future_1k=0.60,
+            lz4_future_4k=0.60,
+            lz4_future_16k=0.60,
+            zstd_future_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        tbl = ca.format_summary_table(summary, use_color=False)
+
+        assert -5 < summary["best_lz4"]["improvement_pct"] < 0
+        assert "+3.0%" in tbl
+
+    def test_notes_section(self):
+        tbl = self._make_table(use_color=False)
+        assert "Notes" in tbl
+
+    def test_no_color_mode(self):
+        tbl = self._make_table(use_color=False)
+        assert "\033[" not in tbl
+
+    def test_color_mode(self):
+        tbl = self._make_table(use_color=True)
+        assert "\033[" in tbl
+
+
+# ---------------------------------------------------------------------------
+# TestFormatAlterTable
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAlterTable:
+    def _make_summary(self, **kwargs):
+        results = make_full_result_set(**kwargs)
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        return ca.generate_summary(results, cfg)
+
+    def test_contains_alter_table(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "myks", "mytbl", use_color=False)
+        assert 'ALTER TABLE "myks"."mytbl"' in output
+
+    def test_contains_compression_map(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "myks", "mytbl", use_color=False)
+        assert "sstable_compression" in output
+        assert "chunk_length_in_kb" in output
+
+    def test_zstd_recommendation_includes_level(self):
+        """When ZSTD is recommended at level > 1, include compression_level."""
+        # Make ZSTD dramatically better so it's picked, and ensure higher levels win
+        summary = self._make_summary(
+            zstd_future_base=0.20,
+            zstd_none_base=0.80,
+            zstd_level_factors={1: 1.0, 2: 0.80, 3: 0.60, 4: 0.40, 5: 0.30},
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ZstdWithDictsCompressor" in output, "ZSTD should be recommended"
+        assert "compression_level" in output
+
+    def test_zstd_level1_recommendation_includes_level(self):
+        """When ZSTD level 1 is recommended, include compression_level explicitly."""
+        summary = self._make_summary(
+            lz4_none_1k=0.82,
+            lz4_none_4k=0.81,
+            lz4_none_16k=0.80,
+            lz4_future_1k=0.79,
+            lz4_future_4k=0.78,
+            lz4_future_16k=0.77,
+            lz4_past_1k=0.82,
+            lz4_past_4k=0.80,
+            lz4_past_16k=0.79,
+            zstd_future_base=0.60,
+            zstd_none_base=0.95,
+            zstd_level_factors={1: 1.0, 2: 0.98, 3: 0.97, 4: 0.965, 5: 0.96},
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ZstdWithDictsCompressor" in output, "ZSTD should be recommended"
+        assert "'compression_level': '1'" in output
+
+    def test_lz4_recommendation_no_level(self):
+        """LZ4 is always level 1, so no compression_level in the ALTER."""
+        # Make LZ4 the best option by making it very good and ZSTD worse
+        summary = self._make_summary(
+            lz4_future_4k=0.10,
+            lz4_past_4k=0.80,
+            zstd_future_base=0.90,
+            zstd_none_base=0.95,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "LZ4WithDictsCompressor" in output, "LZ4 should be recommended"
+        assert "compression_level" not in output
+
+    def test_prefers_lz4_when_both_improve_but_lz4_improves_more(self):
+        summary = self._make_summary(
+            lz4_future_4k=0.20,
+            lz4_past_4k=0.50,
+            zstd_future_base=0.47,
+            zstd_past_base=0.55,
+            zstd_none_base=0.80,
+            zstd_level_factors={1: 1.0, 2: 0.99, 3: 0.98, 4: 0.97, 5: 0.96},
+        )
+        assert (
+            summary["best_lz4"]["improvement_pct"]
+            > summary["best_zstd"]["improvement_pct"]
+        )
+
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "LZ4WithDictsCompressor" in output
+        assert "ZstdWithDictsCompressor" not in output
+
+    def test_dict_retrain_hint_when_future(self):
+        """When future dict is recommended, show the retrain hint."""
+        summary = self._make_summary(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.30,
+            lz4_past_4k=0.78,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        # With these params, the best recommendation should use a future dict
+        best_lz4_dict = summary["best_lz4"]["config"].get("dict", "")
+        best_zstd_dict = (
+            summary["best_zstd"]["config"].get("dict", "")
+            if summary["best_zstd"]["config"]
+            else ""
+        )
+        assert best_lz4_dict == "future" or best_zstd_dict == "future", (
+            "At least one recommendation should use future dict"
+        )
+        assert "retrain" in output.lower()
+
+    def test_quotes_identifiers(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "select", "table-name", use_color=False)
+        assert 'ALTER TABLE "select"."table-name"' in output
+
+    def test_retrain_hint_urlencodes_identifiers(self):
+        summary = self._make_summary(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.30,
+            lz4_past_4k=0.78,
+        )
+        output = ca.format_alter_table(summary, "my ks", "tbl/name", use_color=False)
+        assert "keyspace=my+ks" in output
+        assert "cf=tbl%2Fname" in output
+
+    def test_no_change_when_already_optimal(self):
+        """When current is already best, say so."""
+        summary = self._make_summary(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "optimal" in output.lower() or "no change" in output.lower()
+
+    def test_no_color_mode(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "\033[" not in output
+
+    def test_color_mode(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=True)
+        assert "\033[" in output
+
+
+# ---------------------------------------------------------------------------
+# TestFormatOutput (full pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatOutput:
+    def test_full_output_structure(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        output = ca.format_output(results, cfg, "myks", "mytbl", use_color=False)
+        assert "myks.mytbl" in output
+        assert "lower is better" in output
+        assert "Recommendation Summary" in output
+        assert "no dict" in output
+        assert "future dict" in output
+        assert "ALTER TABLE" in output
+
+    def test_full_output_no_crash_with_all_zeros(self):
+        """Degenerate case: all ratios are 0."""
+        results = []
+        for ck in [1, 4, 16]:
+            results.append(_lz4(ck, "none", 0.0))
+            results.append(_lz4(ck, "past", 0.0))
+            results.append(_lz4(ck, "future", 0.0))
+        for ck in [1, 4, 16]:
+            for lvl in range(1, 6):
+                results.append(_zstd(ck, lvl, "none", 0.0))
+                results.append(_zstd(ck, lvl, "past", 0.0))
+                results.append(_zstd(ck, lvl, "future", 0.0))
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        # Should not crash
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+
+
+# ---------------------------------------------------------------------------
+# TestI/OHelpers
+# ---------------------------------------------------------------------------
+
+
+class TestIOHelpers:
+    def test_call_estimate_api_exits_on_non_list_json(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"message": "table not found"}'
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "unexpected JSON structure" in capsys.readouterr().err
+
+    def test_call_estimate_api_returns_list_json(self, monkeypatch):
+        entry = make_result("LZ4WithDictsCompressor", 4, 1, "none", 0.5)
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps([entry]).encode()
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        assert ca.call_estimate_api("127.0.0.1", "ks", "tbl") == [entry]
+
+    def test_call_estimate_api_exits_on_malformed_entry(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                # Missing the required keys (only "ratio" present).
+                return b'[{"ratio": 0.5}]'
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "malformed entry at index 0" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_non_utf8(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b"\xff\xfe not valid utf-8"
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_read_timeout(self, monkeypatch, capsys):
+        # A read timeout raises TimeoutError (an OSError), which is *not* a
+        # URLError subclass; it must still be handled gracefully.
+        def raise_timeout(*args, **kwargs):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(ca.urllib.request, "urlopen", raise_timeout)
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "Error calling estimation API" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_invalid_json(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b"<html>Server Error</html>"
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_url_error(self, monkeypatch, capsys):
+        def raise_urlerror(*args, **kwargs):
+            raise urllib.error.URLError("boom")
+
+        monkeypatch.setattr(ca.urllib.request, "urlopen", raise_urlerror)
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "Error calling estimation API" in capsys.readouterr().err
+
+    def test_get_current_config_shuts_down_cluster_on_connect_error(self, monkeypatch):
+        class FakeCluster:
+            last_instance = None
+
+            def __init__(self, hosts, port):
+                self.hosts = hosts
+                self.port = port
+                self.shutdown_called = False
+                FakeCluster.last_instance = self
+
+            def connect(self):
+                raise RuntimeError("connect failed")
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        with pytest.raises(SystemExit) as exc:
+            ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert FakeCluster.last_instance is not None
+        assert FakeCluster.last_instance.shutdown_called is True
+
+    def test_get_current_config_handles_empty_compression_map(self, monkeypatch):
+        """An uncompressed table (compression is None) must not crash."""
+
+        class FakeRow:
+            compression = None
+
+        class FakeResult:
+            def one(self):
+                return FakeRow()
+
+        class FakeSession:
+            def execute(self, *args, **kwargs):
+                return FakeResult()
+
+        class FakeCluster:
+            def __init__(self, hosts, port):
+                self.shutdown_called = False
+
+            def connect(self):
+                return FakeSession()
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+        assert result == {}
+
+    def test_full_output_no_crash_zstd_current(self):
+        """Current config is ZSTD."""
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 3,
+            "dict_aware": True,
+        }
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+
+    def test_get_current_config_returns_none_without_driver(self, monkeypatch, capsys):
+        """If the ScyllaDB driver is missing, return None instead of exiting."""
+        # Ensure importing cassandra.cluster raises ImportError.
+        monkeypatch.setitem(sys.modules, "cassandra", None)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", None)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "scylla-driver" in err
+        assert "continuing without" in err
+
+
+class TestUnknownCurrentConfig:
+    """Behavior when the current compression config cannot be determined."""
+
+    def test_generate_summary_handles_none(self):
+        results = make_full_result_set()
+        summary = ca.generate_summary(results, None)
+        assert summary["current"]["ratio"] is None
+        assert summary["current"]["algorithm"] is None
+        # Recommendations are still produced, but improvement is unknown.
+        assert summary["best_lz4"]["config"] is not None
+        assert summary["best_lz4"]["improvement_pct"] is None
+        assert summary["best_zstd"]["improvement_pct"] is None
+
+    def test_format_output_no_crash_with_none(self):
+        results = make_full_result_set()
+        output = ca.format_output(results, None, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+        # Unknown current values are rendered as a dash, not "None".
+        assert "None" not in output
+        # The best absolute config is still recommended via ALTER TABLE.
+        assert "ALTER TABLE" in output
+
+    def test_format_heatmap_grid_no_crash_with_none(self):
+        results = make_full_result_set()
+        summary = ca.generate_summary(results, None)
+        grid = ca.format_heatmap_grid(results, None, summary, use_color=False)
+        assert "no dict" in grid
+
+
+# ---------------------------------------------------------------------------
+# TestEndToEnd: scenario-based integration tests (no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_dictionary_helps_significantly(self):
+        """Scenario: dictionary provides huge improvement."""
+        results = make_full_result_set(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.40,
+            lz4_past_4k=0.78,
+            zstd_none_base=0.78,
+            zstd_future_base=0.35,
+            zstd_past_base=0.75,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Dictionary should be recommended for both
+        assert summary["best_lz4"]["config"]["dict"] == "future"
+        assert summary["best_zstd"]["config"]["dict"] == "future"
+        # Large improvements expected
+        assert summary["best_lz4"]["improvement_pct"] > 40
+        assert summary["best_zstd"]["improvement_pct"] > 40
+
+    def test_dictionary_not_worth_it(self):
+        """Scenario: dictionary provides negligible improvement."""
+        results = make_full_result_set(
+            lz4_none_4k=0.40,
+            lz4_future_4k=0.39,
+            lz4_past_4k=0.40,
+            zstd_none_base=0.38,
+            zstd_future_base=0.37,
+            zstd_past_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # No-dict should be preferred (dict is < 5% better)
+        assert summary["best_lz4"]["config"]["dict"] == "none"
+
+    def test_already_optimal(self):
+        """Scenario: current config has the best ratio of all."""
+        # Make past dict extraordinarily good
+        results = make_full_result_set(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Recommendations should have negative improvement
+        assert summary["best_lz4"]["improvement_pct"] < 0
+
+    def test_zstd_much_better_than_lz4(self):
+        """Scenario: ZSTD provides dramatically better compression."""
+        results = make_full_result_set(
+            lz4_future_4k=0.60,
+            zstd_future_base=0.25,
+            lz4_past_4k=0.65,
+            zstd_past_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # ZSTD should show much more improvement than LZ4
+        assert (
+            summary["best_zstd"]["improvement_pct"]
+            > summary["best_lz4"]["improvement_pct"]
+        )
+
+    def test_small_chunk_big_win(self):
+        """Scenario: 1K chunk is dramatically better (e.g. very small rows)."""
+        results = make_full_result_set(
+            lz4_future_1k=0.20,
+            lz4_future_4k=0.50,
+            lz4_future_16k=0.48,
+            lz4_past_4k=0.55,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # 1K should be chosen despite 4K preference (>5% better)
+        assert summary["best_lz4"]["config"]["chunk_length_kb"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestUncompressedTable: an uncompressed table must still get recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestUncompressedTable:
+    """An uncompressed table is treated as ratio 1.0 (raw) so it still gets
+    recommendations."""
+
+    def test_parse_marks_uncompressed(self):
+        cfg = ca.parse_current_config({})
+        assert cfg["uncompressed"] is True
+        assert cfg["algorithm"] == ""
+
+    def test_parse_compressed_not_marked_uncompressed(self):
+        cfg = ca.parse_current_config(
+            {"sstable_compression": "LZ4Compressor", "chunk_length_in_kb": "4"}
+        )
+        assert cfg["uncompressed"] is False
+
+    def test_find_current_ratio_is_one_for_uncompressed(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        assert ca.find_current_ratio(results, cfg) == 1.0
+
+    def test_summary_reports_uncompressed_current(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["ratio"] == 1.0
+        assert summary["current"]["algorithm"] == "uncompressed"
+        assert summary["best_lz4"]["improvement_pct"] > 0
+        assert summary["best_zstd"]["improvement_pct"] > 0
+
+    def test_uncompressed_recommends_a_change(self):
+        # Regression: an uncompressed table must not be reported as optimal.
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ALTER TABLE" in output
+        assert "optimal" not in output.lower()
+
+    def test_full_output_no_crash_for_uncompressed(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+        assert "uncompressed" in output
+        assert "None" not in output
+
+    def test_heatmap_no_star_for_uncompressed(self):
+        # The table uses none of the listed compressors, so no cell is current.
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        data_rows = [
+            l for l in grid.split("\n")
+            if l.strip().startswith("LZ4") or l.strip().startswith("ZSTD")
+        ]
+        assert all("*" not in row for row in data_rows)
+
+
+# ---------------------------------------------------------------------------
+# TestHeatmapCurrentCellRatio: starred cell agrees with the summary
+# ---------------------------------------------------------------------------
+
+
+class TestHeatmapCurrentCellRatio:
+    """For a dict-capable current compressor, the starred cell shows the active
+    (``past``) ratio that the summary reports, not the no-dict ratio."""
+
+    def _setup(self):
+        # past (0.52) differs from none (0.78) at 4K so a mismatch would show.
+        results = make_full_result_set(
+            lz4_none_4k=0.78,
+            lz4_past_4k=0.52,
+            lz4_future_4k=0.41,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        return summary, grid
+
+    def test_starred_cell_shows_past_ratio_not_none_ratio(self):
+        summary, grid = self._setup()
+        assert summary["current"]["ratio"] == 0.52
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert "0.520*" in star_line
+        assert "0.780*" not in star_line
+
+    def test_summary_and_starred_cell_agree(self):
+        summary, grid = self._setup()
+        cur = f"{summary['current']['ratio']:.3f}"
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert f"{cur}*" in star_line
+
+    def test_plain_current_cell_unchanged(self):
+        # A non-dict-aware current compressor still shows its no-dict ratio.
+        results = make_full_result_set(lz4_none_4k=0.78, lz4_past_4k=0.52)
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": False,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert "0.780*" in star_line

--- a/test/tools/test_compression_advisor.py
+++ b/test/tools/test_compression_advisor.py
@@ -1,0 +1,1624 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""Unit tests for tools/compression_advisor.py.
+
+These are pure-Python tests that require no running ScyllaDB cluster.
+Run with:  python -m pytest test/tools/test_compression_advisor.py -v
+"""
+
+import re
+import pytest
+import sys
+import os
+import types
+import json
+import urllib.error
+
+# Make tools/ importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "tools"))
+import compression_advisor as ca
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_result(
+    algo: str, chunk_kb: int, level: int, dict_mode: str, ratio: float
+) -> dict:
+    """Build one estimation result entry."""
+    return {
+        "sstable_compression": algo,
+        "chunk_length_in_kb": chunk_kb,
+        "level": level,
+        "dict": dict_mode,
+        "ratio": ratio,
+    }
+
+
+def _lz4(chunk_kb, dict_mode, ratio):
+    return make_result("LZ4WithDictsCompressor", chunk_kb, 1, dict_mode, ratio)
+
+
+def _zstd(chunk_kb, level, dict_mode, ratio):
+    return make_result("ZstdWithDictsCompressor", chunk_kb, level, dict_mode, ratio)
+
+
+def make_full_result_set(
+    *,
+    # Base ratios for LZ4, no dict, per chunk size
+    lz4_none_1k=0.82,
+    lz4_none_4k=0.78,
+    lz4_none_16k=0.67,
+    # LZ4 with future dict
+    lz4_future_1k=0.45,
+    lz4_future_4k=0.41,
+    lz4_future_16k=0.38,
+    # LZ4 with past dict
+    lz4_past_1k=0.55,
+    lz4_past_4k=0.52,
+    lz4_past_16k=0.48,
+    # ZSTD base ratio scale: each level improves by this factor
+    zstd_level_factors=None,
+    # ZSTD no-dict base (4K level 1)
+    zstd_none_base=0.76,
+    # ZSTD future-dict base (4K level 1)
+    zstd_future_base=0.38,
+    # ZSTD past-dict base (4K level 1)
+    zstd_past_base=0.50,
+    # Chunk size factors relative to 4K
+    chunk_1k_factor=1.05,  # 1K is 5% worse than 4K
+    chunk_16k_factor=0.92,  # 16K is 8% better than 4K
+):
+    """Build a complete 54-entry result set with configurable parameters."""
+    if zstd_level_factors is None:
+        # Default: diminishing returns — levels 1-3 meaningful, 4-5 marginal
+        zstd_level_factors = {1: 1.0, 2: 0.96, 3: 0.93, 4: 0.925, 5: 0.92}
+
+    results = []
+
+    # LZ4 entries (1 level × 3 chunks × 3 dicts = 9)
+    for chunk_kb, none_r, past_r, future_r in [
+        (1, lz4_none_1k, lz4_past_1k, lz4_future_1k),
+        (4, lz4_none_4k, lz4_past_4k, lz4_future_4k),
+        (16, lz4_none_16k, lz4_past_16k, lz4_future_16k),
+    ]:
+        results.append(_lz4(chunk_kb, "none", none_r))
+        results.append(_lz4(chunk_kb, "past", past_r))
+        results.append(_lz4(chunk_kb, "future", future_r))
+
+    # ZSTD entries (5 levels × 3 chunks × 3 dicts = 45)
+    for level in range(1, 6):
+        lf = zstd_level_factors[level]
+        for chunk_kb, chunk_f in [
+            (1, chunk_1k_factor),
+            (4, 1.0),
+            (16, chunk_16k_factor),
+        ]:
+            none_r = zstd_none_base * lf * chunk_f
+            past_r = zstd_past_base * lf * chunk_f
+            future_r = zstd_future_base * lf * chunk_f
+            results.append(_zstd(chunk_kb, level, "none", round(none_r, 4)))
+            results.append(_zstd(chunk_kb, level, "past", round(past_r, 4)))
+            results.append(_zstd(chunk_kb, level, "future", round(future_r, 4)))
+
+    assert len(results) == 54
+    return results
+
+
+# ---------------------------------------------------------------------------
+# TestParseCurrentConfig
+# ---------------------------------------------------------------------------
+
+
+class TestParseCurrentConfig:
+    def test_lz4_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4Compressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["chunk_length_kb"] == 4
+        assert cfg["level"] == 1
+        assert cfg["dict_aware"] is False
+
+    def test_lz4_with_dicts(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "16",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["chunk_length_kb"] == 16
+
+    def test_zstd_with_level(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+                "chunk_length_in_kb": "4",
+                "compression_level": "3",
+            }
+        )
+        assert cfg["algorithm"] == "ZstdWithDictsCompressor"
+        assert cfg["level"] == 3
+
+    def test_fully_qualified_java_name(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "org.apache.cassandra.io.compress.LZ4Compressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["algorithm"] == "LZ4WithDictsCompressor"
+        assert cfg["dict_aware"] is False
+
+    def test_dict_capable_compressor_is_dict_aware(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        assert cfg["dict_aware"] is True
+
+    def test_default_chunk_length(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+            }
+        )
+        assert cfg["chunk_length_kb"] == 4
+
+    def test_default_level(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+            }
+        )
+        assert cfg["level"] == 1
+
+    def test_snappy_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "SnappyCompressor",
+                "chunk_length_in_kb": "4",
+            }
+        )
+        # Snappy is recognized but not dict-aware (not in _TO_DICT_AWARE)
+        assert cfg["dict_aware"] is False
+        assert cfg["algorithm"] == "SnappyCompressor"
+
+    def test_unknown_compressor(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "SomeFutureCompressor",
+            }
+        )
+        assert cfg["algorithm"] == "SomeFutureCompressor"
+        assert cfg["dict_aware"] is False
+
+    def test_invalid_chunk_length_defaults_to_4(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "LZ4WithDictsCompressor",
+                "chunk_length_in_kb": "banana",
+            }
+        )
+        assert cfg["chunk_length_kb"] == 4
+
+    def test_invalid_level_defaults_to_1(self):
+        cfg = ca.parse_current_config(
+            {
+                "sstable_compression": "ZstdWithDictsCompressor",
+                "compression_level": "high",
+            }
+        )
+        assert cfg["level"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestFindCurrentRatio
+# ---------------------------------------------------------------------------
+
+
+class TestFindCurrentRatio:
+    def test_exact_match_with_past_dict(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+            _lz4(4, "future", 0.41),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+    def test_prefers_past_over_none(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+    def test_fallback_to_none_when_no_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "future", 0.41),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) == 0.78
+
+    def test_returns_none_when_no_match(self):
+        results = [
+            _lz4(1, "none", 0.82),
+        ]
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio(results, cfg) is None
+
+    def test_zstd_match(self):
+        results = [
+            _zstd(4, 3, "past", 0.35),
+            _zstd(4, 3, "none", 0.50),
+        ]
+        cfg = {"algorithm": "ZstdWithDictsCompressor", "chunk_length_kb": 4, "level": 3}
+        assert ca.find_current_ratio(results, cfg) == 0.35
+
+    def test_plain_compressor_prefers_none_over_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": False,
+        }
+        assert ca.find_current_ratio(results, cfg) == 0.78
+
+    def test_dict_capable_compressor_prefers_past(self):
+        results = [
+            _lz4(4, "none", 0.78),
+            _lz4(4, "past", 0.52),
+        ]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        assert ca.find_current_ratio(results, cfg) == 0.52
+
+
+# ---------------------------------------------------------------------------
+# TestUnmatchedCurrentConfig
+# ---------------------------------------------------------------------------
+
+
+class TestUnmatchedCurrentConfig:
+    def test_improvement_pct_is_none_when_current_unmatched(self):
+        """A current config with no estimation entry must yield None improvement,
+        not 0.0, so the tool still recommends candidates instead of 'already optimal'.
+        """
+        results = make_full_result_set()
+        # Snappy is not in the estimator's dictionary-aware set and has no entry.
+        cfg = {"algorithm": "SnappyCompressor", "chunk_length_kb": 4, "level": 1}
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["ratio"] is None
+        assert summary["best_lz4"]["improvement_pct"] is None
+        assert summary["best_zstd"]["improvement_pct"] is None
+
+    def test_alter_table_recommends_when_current_unmatched(self):
+        results = make_full_result_set()
+        cfg = {"algorithm": "SnappyCompressor", "chunk_length_kb": 4, "level": 1}
+        summary = ca.generate_summary(results, cfg)
+        alter = ca.format_alter_table(summary, "ks", "tbl")
+        assert "already optimal" not in alter
+        assert "ALTER TABLE" in alter
+
+
+# ---------------------------------------------------------------------------
+# TestSelectBestForFamily
+# ---------------------------------------------------------------------------
+
+
+class TestSelectBestForFamily:
+    # --- Chunk size preferences ---
+
+    def test_prefers_4k_when_1k_marginally_better(self):
+        """1K is only ~2% better than 4K -> prefer 4K."""
+        results = [
+            _lz4(1, "future", 0.40),  # absolute best, but only 2.4% better than 4K
+            _lz4(4, "future", 0.41),  # within 5% of best
+            _lz4(16, "future", 0.45),  # worse than 4K
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.82),
+            _lz4(16, "none", 0.85),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["chunk_length_kb"] == 4
+
+    def test_picks_1k_when_significantly_better(self):
+        """1K is 20% better than 4K -> pick 1K."""
+        results = [
+            _lz4(1, "future", 0.30),
+            _lz4(4, "future", 0.50),  # 67% worse
+            _lz4(16, "future", 0.48),
+            _lz4(1, "none", 0.60),
+            _lz4(4, "none", 0.80),
+            _lz4(16, "none", 0.75),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        # absolute best is 1K=0.30, 4K=0.50 is not within 5%
+        assert best["config"]["chunk_length_kb"] != 4
+
+    def test_prefers_4k_over_16k_when_close(self):
+        """16K is only 3% better than 4K -> prefer 4K."""
+        results = [
+            _lz4(1, "future", 0.50),
+            _lz4(4, "future", 0.41),
+            _lz4(16, "future", 0.40),  # 2.4% better than 4K
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.70),
+            _lz4(16, "none", 0.68),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["chunk_length_kb"] == 4
+
+    # --- Dictionary preferences ---
+
+    def test_prefers_no_dict_when_marginal_improvement(self):
+        """Dict provides only 3% improvement -> prefer no dict."""
+        results = [
+            _lz4(4, "none", 0.42),
+            _lz4(4, "future", 0.41),  # 2.4% better
+            _lz4(1, "none", 0.50),
+            _lz4(1, "future", 0.48),
+            _lz4(16, "none", 0.40),
+            _lz4(16, "future", 0.39),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["dict"] == "none"
+
+    def test_recommends_dict_when_significant(self):
+        """Dict provides 33% improvement -> recommend dict."""
+        results = [
+            _lz4(4, "none", 0.60),
+            _lz4(4, "future", 0.40),  # 33% better
+            _lz4(1, "none", 0.65),
+            _lz4(1, "future", 0.42),
+            _lz4(16, "none", 0.55),
+            _lz4(16, "future", 0.38),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["dict"] == "future"
+
+    # --- Level preferences (ZSTD) ---
+
+    def test_prefers_level1_when_level5_marginally_better(self):
+        """ZSTD level 5 is only 2% better than level 1 -> pick level 1."""
+        results = []
+        for level, ratio in [(1, 0.40), (2, 0.395), (3, 0.393), (4, 0.392), (5, 0.391)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.2))
+        # Add other chunks to avoid issues
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.50))
+                results.append(_zstd(ck, level, "none", 0.70))
+        best = ca.select_best_for_family(results, "Zstd")
+        assert best["config"]["level"] == 1
+
+    def test_picks_level3_when_diminishing_returns(self):
+        """Levels 1-3 have meaningful improvement, 4-5 are marginal."""
+        results = []
+        for level, ratio in [(1, 0.50), (2, 0.45), (3, 0.42), (4, 0.415), (5, 0.41)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.15))
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.60))
+                results.append(_zstd(ck, level, "none", 0.80))
+        best = ca.select_best_for_family(results, "Zstd")
+        # Level 3 at 0.42 vs best 0.41: within 5%. Level 1 at 0.50 vs 0.41: not within 5%
+        # Level 2 at 0.45 vs 0.41: 9.7% — not within 5%
+        # Level 3 at 0.42 vs 0.41: 2.4% — within 5%!
+        assert best["config"]["level"] == 3
+
+    def test_picks_level5_when_each_level_significant(self):
+        """Each level has >5% improvement over the previous."""
+        results = []
+        for level, ratio in [(1, 0.60), (2, 0.50), (3, 0.40), (4, 0.30), (5, 0.20)]:
+            results.append(_zstd(4, level, "future", ratio))
+            results.append(_zstd(4, level, "none", ratio + 0.15))
+        for ck in [1, 16]:
+            for level in range(1, 6):
+                results.append(_zstd(ck, level, "future", 0.70))
+                results.append(_zstd(ck, level, "none", 0.85))
+        best = ca.select_best_for_family(results, "Zstd")
+        # Each level far apart from best=0.20. Only level 5 is within 5% of 0.20
+        assert best["config"]["level"] == 5
+
+    # --- LZ4 always level 1 ---
+
+    def test_lz4_always_level_1(self):
+        results = [
+            _lz4(4, "future", 0.40),
+            _lz4(4, "none", 0.70),
+            _lz4(1, "future", 0.42),
+            _lz4(1, "none", 0.75),
+            _lz4(16, "future", 0.38),
+            _lz4(16, "none", 0.65),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"]["level"] == 1
+
+    # --- Edge cases ---
+
+    def test_all_ratios_identical_picks_simplest(self):
+        """When all ratios are the same, pick the simplest config."""
+        results = []
+        for ck in [1, 4, 16]:
+            results.append(_lz4(ck, "none", 0.50))
+            results.append(_lz4(ck, "future", 0.50))
+        best = ca.select_best_for_family(results, "LZ4")
+        # Should prefer 4K and no dict (simplest)
+        assert best["config"]["chunk_length_kb"] == 4
+        assert best["config"]["dict"] == "none"
+
+    def test_generates_notes(self):
+        """Check that notes are generated for preference decisions."""
+        results = [
+            _lz4(1, "future", 0.39),
+            _lz4(4, "future", 0.41),
+            _lz4(16, "future", 0.38),
+            _lz4(1, "none", 0.80),
+            _lz4(4, "none", 0.82),
+            _lz4(16, "none", 0.75),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert len(best["notes"]) > 0
+
+    def test_no_results_returns_none_config(self):
+        """If no results match the family, config is None."""
+        results = [
+            _lz4(4, "future", 0.40),
+        ]
+        best = ca.select_best_for_family(results, "Zstd")
+        assert best["config"] is None
+
+    def test_no_4k_entries_picks_best_available_chunk(self):
+        """If no 4K entries exist, pick the best available chunk size."""
+        results = [
+            _lz4(1, "future", 0.45),
+            _lz4(16, "future", 0.38),
+            _lz4(1, "none", 0.80),
+            _lz4(16, "none", 0.65),
+        ]
+        best = ca.select_best_for_family(results, "LZ4")
+        assert best["config"] is not None
+        # Should pick the best chunk (16K with 0.38)
+        assert best["config"]["chunk_length_kb"] in (1, 16)
+
+
+# ---------------------------------------------------------------------------
+# TestEdgeCases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_parse_current_config_empty_dict(self):
+        """parse_current_config({}) should return sensible defaults."""
+        cfg = ca.parse_current_config({})
+        assert cfg["chunk_length_kb"] == 4
+        assert cfg["level"] == 1
+        assert cfg["algorithm"] == ""
+        assert cfg["dict_aware"] is False
+
+    def test_find_current_ratio_empty_results(self):
+        """find_current_ratio([], cfg) should return None."""
+        cfg = {"algorithm": "LZ4WithDictsCompressor", "chunk_length_kb": 4, "level": 1}
+        assert ca.find_current_ratio([], cfg) is None
+
+    def test_select_best_empty_results(self):
+        """select_best_for_family([], ...) should return None config."""
+        best = ca.select_best_for_family([], "LZ4")
+        assert best["config"] is None
+
+    def test_visible_len_no_ansi(self):
+        """_visible_len on plain text returns normal length."""
+        assert ca._visible_len("hello") == 5
+
+    def test_visible_len_with_ansi(self):
+        """_visible_len strips ANSI codes."""
+        s = "\033[1;32m-15.3%\033[0m"
+        assert ca._visible_len(s) == 6  # "-15.3%"
+
+    def test_ratio_zero_shown_as_zero(self):
+        """Ratio 0.0 should be shown as '0.00', not as a dash."""
+        # This tests fix #2: cur["ratio"] == 0.0 should not be treated as falsy
+        results = [_lz4(4, "none", 0.0), _lz4(4, "past", 0.0)]
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        table = ca.format_summary_table(summary, use_color=False)
+        # The ratio for current should be "0.000", not "—"
+        assert "0.000" in table
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateSummary
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSummary:
+    def test_summary_has_all_keys(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert "current" in summary
+        assert "best_lz4" in summary
+        assert "best_zstd" in summary
+
+    def test_current_ratio_matches(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["ratio"] == 0.52  # lz4_past_4k default
+
+    def test_improvement_pct_calculation(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Both recommendations should be better (positive improvement)
+        assert summary["best_lz4"]["improvement_pct"] > 0
+        assert summary["best_zstd"]["improvement_pct"] > 0
+
+    def test_recommendations_not_worse_than_current(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        cur_ratio = summary["current"]["ratio"]
+        if summary["best_lz4"]["config"]:
+            assert summary["best_lz4"]["config"]["ratio"] <= cur_ratio
+        if summary["best_zstd"]["config"]:
+            assert summary["best_zstd"]["config"]["ratio"] <= cur_ratio
+
+    def test_negative_improvement_when_current_is_optimal(self):
+        """If current config is better than recommendations, improvement is negative."""
+        # Make current config very good: past dict at 4K is 0.10
+        results = make_full_result_set(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Current ratio is very low (0.10), recommendations are higher
+        assert summary["best_lz4"]["improvement_pct"] < 0
+
+    def test_with_full_54_entry_dataset(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["algorithm"] == "ZstdWithDictsCompressor"
+        assert summary["best_lz4"]["config"] is not None
+        assert summary["best_zstd"]["config"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TestFormatHeatmapGrid
+# ---------------------------------------------------------------------------
+
+
+class TestFormatHeatmapGrid:
+    def _make_grid(self, use_color=False):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        return ca.format_heatmap_grid(results, cfg, summary, use_color)
+
+    def test_grid_has_header_row(self):
+        grid = self._make_grid(use_color=False)
+        assert "no dict" in grid
+        assert "future dict" in grid
+
+    def test_grid_has_chunk_size_columns(self):
+        grid = self._make_grid(use_color=False)
+        assert "1K" in grid
+        assert "4K" in grid
+        assert "16K" in grid
+
+    def test_grid_has_algorithm_rows(self):
+        grid = self._make_grid(use_color=False)
+        assert "LZ4" in grid
+        assert "ZSTD" in grid
+
+    def test_grid_has_all_zstd_levels(self):
+        grid = self._make_grid(use_color=False)
+        for lvl in range(1, 6):
+            assert f"level {lvl}" in grid
+
+    def test_grid_has_6_data_rows(self):
+        """1 LZ4 row + 5 ZSTD rows = 6 data rows."""
+        grid = self._make_grid(use_color=False)
+        lvl_count = sum(
+            1
+            for line in grid.split("\n")
+            if "level " in line
+            and any(c.isdigit() for c in line.split("level ")[-1][:1])
+        )
+        assert lvl_count == 6
+
+    def test_current_config_marked(self):
+        grid = self._make_grid(use_color=False)
+        assert "*" in grid
+
+    def test_recommended_config_marked(self):
+        grid = self._make_grid(use_color=False)
+        assert "\u25c4" in grid  # ◄
+
+    def test_no_recommended_marker_on_regression(self):
+        """If a family's best is worse than current, no ◄ for that family."""
+        # Current is ZSTD with very good past-dict ratio;
+        # LZ4 recommendations will all be worse -> no ◄ on LZ4 cells
+        results = make_full_result_set(
+            lz4_future_4k=0.60,
+            lz4_future_1k=0.65,
+            lz4_future_16k=0.58,
+            zstd_past_base=0.20,  # current ratio is very good
+            zstd_future_base=0.15,  # ZSTD still gets ◄
+        )
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        lines = grid.split("\n")
+        lz4_lines = [l for l in lines if l.strip().startswith("LZ4")]
+        # No ◄ on LZ4 lines (it's a regression)
+        for line in lz4_lines:
+            assert "\u25c4" not in line, f"LZ4 regression should not have ◄: {line}"
+        # But ZSTD should still have ◄
+        zstd_lines = [l for l in lines if l.strip().startswith("ZSTD")]
+        assert any("\u25c4" in l for l in zstd_lines), "ZSTD improvement should have ◄"
+
+    def test_no_color_mode_no_ansi(self):
+        grid = self._make_grid(use_color=False)
+        assert "\033[" not in grid
+
+    def test_color_mode_has_ansi(self):
+        grid = self._make_grid(use_color=True)
+        assert "\033[" in grid
+
+    def test_legend_present(self):
+        grid = self._make_grid(use_color=False)
+        assert "current" in grid.lower()
+        assert "recommended" in grid.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestFormatSummaryTable
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummaryTable:
+    def _make_table(self, use_color=False):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        return ca.format_summary_table(summary, use_color)
+
+    def test_three_columns(self):
+        tbl = self._make_table(use_color=False)
+        assert "Current" in tbl
+        assert "Best LZ4" in tbl
+        assert "Best ZSTD" in tbl
+
+    def test_contains_algorithm_names(self):
+        tbl = self._make_table(use_color=False)
+        assert "LZ4WithDicts" in tbl
+        assert "ZstdWithDicts" in tbl
+
+    def test_contains_ratio_values(self):
+        tbl = self._make_table(use_color=False)
+        # Should contain some decimal ratios
+        assert re.search(r"0\.\d{3}", tbl)
+
+    def test_contains_improvement_pct(self):
+        tbl = self._make_table(use_color=False)
+        assert "%" in tbl
+
+    def test_small_improvement_uses_size_change_sign(self):
+        results = make_full_result_set(
+            lz4_past_4k=0.50,
+            lz4_none_4k=0.485,
+            lz4_none_1k=0.60,
+            lz4_none_16k=0.60,
+            lz4_future_1k=0.60,
+            lz4_future_4k=0.60,
+            lz4_future_16k=0.60,
+            zstd_future_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        tbl = ca.format_summary_table(summary, use_color=False)
+
+        assert 0 < summary["best_lz4"]["improvement_pct"] < 5
+        assert "-3.0%" in tbl
+
+    def test_small_regression_uses_size_change_sign(self):
+        results = make_full_result_set(
+            lz4_past_4k=0.50,
+            lz4_none_4k=0.515,
+            lz4_none_1k=0.60,
+            lz4_none_16k=0.60,
+            lz4_future_1k=0.60,
+            lz4_future_4k=0.60,
+            lz4_future_16k=0.60,
+            zstd_future_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        tbl = ca.format_summary_table(summary, use_color=False)
+
+        assert -5 < summary["best_lz4"]["improvement_pct"] < 0
+        assert "+3.0%" in tbl
+
+    def test_notes_section(self):
+        tbl = self._make_table(use_color=False)
+        assert "Notes" in tbl
+
+    def test_no_color_mode(self):
+        tbl = self._make_table(use_color=False)
+        assert "\033[" not in tbl
+
+    def test_color_mode(self):
+        tbl = self._make_table(use_color=True)
+        assert "\033[" in tbl
+
+
+# ---------------------------------------------------------------------------
+# TestFormatAlterTable
+# ---------------------------------------------------------------------------
+
+
+class TestFormatAlterTable:
+    def _make_summary(self, **kwargs):
+        results = make_full_result_set(**kwargs)
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        return ca.generate_summary(results, cfg)
+
+    def test_contains_alter_table(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "myks", "mytbl", use_color=False)
+        assert 'ALTER TABLE "myks"."mytbl"' in output
+
+    def test_contains_compression_map(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "myks", "mytbl", use_color=False)
+        assert "sstable_compression" in output
+        assert "chunk_length_in_kb" in output
+
+    def test_zstd_recommendation_includes_level(self):
+        """When ZSTD is recommended at level > 1, include compression_level."""
+        # Make ZSTD dramatically better so it's picked, and ensure higher levels win
+        summary = self._make_summary(
+            zstd_future_base=0.20,
+            zstd_none_base=0.80,
+            zstd_level_factors={1: 1.0, 2: 0.80, 3: 0.60, 4: 0.40, 5: 0.30},
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ZstdWithDictsCompressor" in output, "ZSTD should be recommended"
+        assert "compression_level" in output
+
+    def test_zstd_level1_recommendation_includes_level(self):
+        """When ZSTD level 1 is recommended, include compression_level explicitly."""
+        summary = self._make_summary(
+            lz4_none_1k=0.82,
+            lz4_none_4k=0.81,
+            lz4_none_16k=0.80,
+            lz4_future_1k=0.79,
+            lz4_future_4k=0.78,
+            lz4_future_16k=0.77,
+            lz4_past_1k=0.82,
+            lz4_past_4k=0.80,
+            lz4_past_16k=0.79,
+            zstd_future_base=0.60,
+            zstd_none_base=0.95,
+            zstd_level_factors={1: 1.0, 2: 0.98, 3: 0.97, 4: 0.965, 5: 0.96},
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ZstdWithDictsCompressor" in output, "ZSTD should be recommended"
+        assert "'compression_level': '1'" in output
+
+    def test_lz4_recommendation_no_level(self):
+        """LZ4 is always level 1, so no compression_level in the ALTER."""
+        # Make LZ4 the best option by making it very good and ZSTD worse
+        summary = self._make_summary(
+            lz4_future_4k=0.10,
+            lz4_past_4k=0.80,
+            zstd_future_base=0.90,
+            zstd_none_base=0.95,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "LZ4WithDictsCompressor" in output, "LZ4 should be recommended"
+        assert "compression_level" not in output
+
+    def test_prefers_lz4_when_both_improve_but_lz4_improves_more(self):
+        summary = self._make_summary(
+            lz4_future_4k=0.20,
+            lz4_past_4k=0.50,
+            zstd_future_base=0.47,
+            zstd_past_base=0.55,
+            zstd_none_base=0.80,
+            zstd_level_factors={1: 1.0, 2: 0.99, 3: 0.98, 4: 0.97, 5: 0.96},
+        )
+        assert (
+            summary["best_lz4"]["improvement_pct"]
+            > summary["best_zstd"]["improvement_pct"]
+        )
+
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "LZ4WithDictsCompressor" in output
+        assert "ZstdWithDictsCompressor" not in output
+
+    def test_dict_retrain_hint_when_future(self):
+        """When future dict is recommended, show the retrain hint."""
+        summary = self._make_summary(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.30,
+            lz4_past_4k=0.78,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        # With these params, the best recommendation should use a future dict
+        best_lz4_dict = summary["best_lz4"]["config"].get("dict", "")
+        best_zstd_dict = (
+            summary["best_zstd"]["config"].get("dict", "")
+            if summary["best_zstd"]["config"]
+            else ""
+        )
+        assert best_lz4_dict == "future" or best_zstd_dict == "future", (
+            "At least one recommendation should use future dict"
+        )
+        assert "retrain" in output.lower()
+
+    def test_quotes_identifiers(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "select", "table-name", use_color=False)
+        assert 'ALTER TABLE "select"."table-name"' in output
+
+    def test_retrain_hint_urlencodes_identifiers(self):
+        summary = self._make_summary(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.30,
+            lz4_past_4k=0.78,
+        )
+        output = ca.format_alter_table(summary, "my ks", "tbl/name", use_color=False)
+        assert "keyspace=my+ks" in output
+        assert "cf=tbl%2Fname" in output
+
+    def test_no_change_when_already_optimal(self):
+        """When current is already best, say so."""
+        summary = self._make_summary(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "optimal" in output.lower() or "no change" in output.lower()
+
+    def test_no_color_mode(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "\033[" not in output
+
+    def test_color_mode(self):
+        summary = self._make_summary()
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=True)
+        assert "\033[" in output
+
+
+# ---------------------------------------------------------------------------
+# TestFormatOutput (full pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatOutput:
+    def test_full_output_structure(self):
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        output = ca.format_output(results, cfg, "myks", "mytbl", use_color=False)
+        assert "myks.mytbl" in output
+        assert "lower is better" in output
+        assert "Recommendation Summary" in output
+        assert "no dict" in output
+        assert "future dict" in output
+        assert "ALTER TABLE" in output
+
+    def test_full_output_no_crash_with_all_zeros(self):
+        """Degenerate case: all ratios are 0."""
+        results = []
+        for ck in [1, 4, 16]:
+            results.append(_lz4(ck, "none", 0.0))
+            results.append(_lz4(ck, "past", 0.0))
+            results.append(_lz4(ck, "future", 0.0))
+        for ck in [1, 4, 16]:
+            for lvl in range(1, 6):
+                results.append(_zstd(ck, lvl, "none", 0.0))
+                results.append(_zstd(ck, lvl, "past", 0.0))
+                results.append(_zstd(ck, lvl, "future", 0.0))
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        # Should not crash
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+
+
+# ---------------------------------------------------------------------------
+# TestI/OHelpers
+# ---------------------------------------------------------------------------
+
+
+class TestIOHelpers:
+    def test_call_estimate_api_exits_on_non_list_json(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b'{"message": "table not found"}'
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "unexpected JSON structure" in capsys.readouterr().err
+
+    def test_call_estimate_api_returns_list_json(self, monkeypatch):
+        entry = make_result("LZ4WithDictsCompressor", 4, 1, "none", 0.5)
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps([entry]).encode()
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        assert ca.call_estimate_api("127.0.0.1", "ks", "tbl") == [entry]
+
+    def test_get_current_config_passes_auth_provider_when_credentials_given(self, monkeypatch):
+        """--username/--password must be wired into Cluster as a PlainTextAuthProvider."""
+
+        class FakeRow:
+            compression = None
+
+        class FakeResult:
+            def one(self):
+                return FakeRow()
+
+        class FakeSession:
+            def execute(self, *args, **kwargs):
+                return FakeResult()
+
+        captured = {}
+
+        class FakeCluster:
+            def __init__(self, hosts, port, auth_provider=None):
+                captured["auth_provider"] = auth_provider
+                self.shutdown_called = False
+
+            def connect(self):
+                return FakeSession()
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        class FakeAuthProvider:
+            def __init__(self, username, password):
+                self.username = username
+                self.password = password
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        auth_mod = types.ModuleType("cassandra.auth")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+        setattr(auth_mod, "PlainTextAuthProvider", FakeAuthProvider)
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.auth", auth_mod)
+
+        ca.get_current_config_via_cql(
+            "127.0.0.1", "ks", "tbl", username="user", password="pass"
+        )
+        assert isinstance(captured["auth_provider"], FakeAuthProvider)
+
+    def test_get_current_config_no_auth_provider_without_credentials(self, monkeypatch):
+        class FakeRow:
+            compression = None
+
+        class FakeResult:
+            def one(self):
+                return FakeRow()
+
+        class FakeSession:
+            def execute(self, *args, **kwargs):
+                return FakeResult()
+
+        captured = {}
+
+        class FakeCluster:
+            def __init__(self, hosts, port, auth_provider=None):
+                captured["auth_provider"] = auth_provider
+                self.shutdown_called = False
+
+            def connect(self):
+                return FakeSession()
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+        assert captured["auth_provider"] is None
+
+    def test_call_estimate_api_exits_on_malformed_entry(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                # Missing the required keys (only "ratio" present).
+                return b'[{"ratio": 0.5}]'
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "malformed entry at index 0" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_non_utf8(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b"\xff\xfe not valid utf-8"
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_read_timeout(self, monkeypatch, capsys):
+        # A read timeout raises TimeoutError (an OSError), which is *not* a
+        # URLError subclass; it must still be handled gracefully.
+        def raise_timeout(*args, **kwargs):
+            raise TimeoutError("timed out")
+
+        monkeypatch.setattr(ca.urllib.request, "urlopen", raise_timeout)
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "Error calling estimation API" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_invalid_json(self, monkeypatch, capsys):
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return b"<html>Server Error</html>"
+
+        monkeypatch.setattr(
+            ca.urllib.request, "urlopen", lambda *args, **kwargs: FakeResponse()
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_call_estimate_api_exits_on_url_error(self, monkeypatch, capsys):
+        def raise_urlerror(*args, **kwargs):
+            raise urllib.error.URLError("boom")
+
+        monkeypatch.setattr(ca.urllib.request, "urlopen", raise_urlerror)
+
+        with pytest.raises(SystemExit) as exc:
+            ca.call_estimate_api("127.0.0.1", "ks", "tbl")
+
+        assert exc.value.code == 1
+        assert "Error calling estimation API" in capsys.readouterr().err
+
+    def test_get_current_config_shuts_down_cluster_on_connect_error(self, monkeypatch):
+        class FakeCluster:
+            last_instance = None
+
+            def __init__(self, hosts, port):
+                self.hosts = hosts
+                self.port = port
+                self.shutdown_called = False
+                FakeCluster.last_instance = self
+
+            def connect(self):
+                raise RuntimeError("connect failed")
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+        # A connect error must no longer abort the run; the tool continues
+        # without the current configuration so the estimation report still prints.
+        assert result is None
+        assert FakeCluster.last_instance is not None
+        assert FakeCluster.last_instance.shutdown_called is True
+
+    def test_get_current_config_returns_none_when_table_not_found(
+        self, monkeypatch, capsys
+    ):
+        class FakeResult:
+            def one(self):
+                return None
+
+        class FakeSession:
+            def execute(self, *args, **kwargs):
+                return FakeResult()
+
+        class FakeCluster:
+            def __init__(self, hosts, port):
+                self.shutdown_called = False
+
+            def connect(self):
+                return FakeSession()
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+        # A missing table must no longer abort the run; the tool continues
+        # without the current configuration so the estimation report still prints.
+        assert result is None
+        assert "not found" in capsys.readouterr().err
+
+    def test_get_current_config_handles_empty_compression_map(self, monkeypatch):
+        """An uncompressed table (compression is None) must not crash."""
+
+        class FakeRow:
+            compression = None
+
+        class FakeResult:
+            def one(self):
+                return FakeRow()
+
+        class FakeSession:
+            def execute(self, *args, **kwargs):
+                return FakeResult()
+
+        class FakeCluster:
+            def __init__(self, hosts, port):
+                self.shutdown_called = False
+
+            def connect(self):
+                return FakeSession()
+
+            def shutdown(self):
+                self.shutdown_called = True
+
+        cassandra_mod = types.ModuleType("cassandra")
+        cluster_mod = types.ModuleType("cassandra.cluster")
+        setattr(cluster_mod, "Cluster", FakeCluster)
+        monkeypatch.setitem(sys.modules, "cassandra", cassandra_mod)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", cluster_mod)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+        assert result == {}
+
+    def test_full_output_no_crash_zstd_current(self):
+        """Current config is ZSTD."""
+        results = make_full_result_set()
+        cfg = {
+            "algorithm": "ZstdWithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 3,
+            "dict_aware": True,
+        }
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+
+    def test_get_current_config_returns_none_without_driver(self, monkeypatch, capsys):
+        """If the ScyllaDB driver is missing, return None instead of exiting."""
+        # Ensure importing cassandra.cluster raises ImportError.
+        monkeypatch.setitem(sys.modules, "cassandra", None)
+        monkeypatch.setitem(sys.modules, "cassandra.cluster", None)
+
+        result = ca.get_current_config_via_cql("127.0.0.1", "ks", "tbl")
+
+        assert result is None
+        err = capsys.readouterr().err
+        assert "scylla-driver" in err
+        assert "continuing without" in err
+
+
+class TestUnknownCurrentConfig:
+    """Behavior when the current compression config cannot be determined."""
+
+    def test_generate_summary_handles_none(self):
+        results = make_full_result_set()
+        summary = ca.generate_summary(results, None)
+        assert summary["current"]["ratio"] is None
+        assert summary["current"]["algorithm"] is None
+        # Recommendations are still produced, but improvement is unknown.
+        assert summary["best_lz4"]["config"] is not None
+        assert summary["best_lz4"]["improvement_pct"] is None
+        assert summary["best_zstd"]["improvement_pct"] is None
+
+    def test_format_output_no_crash_with_none(self):
+        results = make_full_result_set()
+        output = ca.format_output(results, None, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+        # Unknown current values are rendered as a dash, not "None".
+        assert "None" not in output
+        # The best absolute config is still recommended via ALTER TABLE.
+        assert "ALTER TABLE" in output
+
+    def test_format_heatmap_grid_no_crash_with_none(self):
+        results = make_full_result_set()
+        summary = ca.generate_summary(results, None)
+        grid = ca.format_heatmap_grid(results, None, summary, use_color=False)
+        assert "no dict" in grid
+
+
+# ---------------------------------------------------------------------------
+# TestEndToEnd: scenario-based integration tests (no I/O)
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def test_dictionary_helps_significantly(self):
+        """Scenario: dictionary provides huge improvement."""
+        results = make_full_result_set(
+            lz4_none_4k=0.80,
+            lz4_future_4k=0.40,
+            lz4_past_4k=0.78,
+            zstd_none_base=0.78,
+            zstd_future_base=0.35,
+            zstd_past_base=0.75,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Dictionary should be recommended for both
+        assert summary["best_lz4"]["config"]["dict"] == "future"
+        assert summary["best_zstd"]["config"]["dict"] == "future"
+        # Large improvements expected
+        assert summary["best_lz4"]["improvement_pct"] > 40
+        assert summary["best_zstd"]["improvement_pct"] > 40
+
+    def test_dictionary_not_worth_it(self):
+        """Scenario: dictionary provides negligible improvement."""
+        results = make_full_result_set(
+            lz4_none_4k=0.40,
+            lz4_future_4k=0.39,
+            lz4_past_4k=0.40,
+            zstd_none_base=0.38,
+            zstd_future_base=0.37,
+            zstd_past_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # No-dict should be preferred (dict is < 5% better)
+        assert summary["best_lz4"]["config"]["dict"] == "none"
+
+    def test_already_optimal(self):
+        """Scenario: current config has the best ratio of all."""
+        # Make past dict extraordinarily good
+        results = make_full_result_set(
+            lz4_past_4k=0.10,
+            lz4_future_4k=0.41,
+            zstd_future_base=0.38,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # Recommendations should have negative improvement
+        assert summary["best_lz4"]["improvement_pct"] < 0
+
+    def test_zstd_much_better_than_lz4(self):
+        """Scenario: ZSTD provides dramatically better compression."""
+        results = make_full_result_set(
+            lz4_future_4k=0.60,
+            zstd_future_base=0.25,
+            lz4_past_4k=0.65,
+            zstd_past_base=0.30,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # ZSTD should show much more improvement than LZ4
+        assert (
+            summary["best_zstd"]["improvement_pct"]
+            > summary["best_lz4"]["improvement_pct"]
+        )
+
+    def test_small_chunk_big_win(self):
+        """Scenario: 1K chunk is dramatically better (e.g. very small rows)."""
+        results = make_full_result_set(
+            lz4_future_1k=0.20,
+            lz4_future_4k=0.50,
+            lz4_future_16k=0.48,
+            lz4_past_4k=0.55,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        # 1K should be chosen despite 4K preference (>5% better)
+        assert summary["best_lz4"]["config"]["chunk_length_kb"] == 1
+
+
+# ---------------------------------------------------------------------------
+# TestUncompressedTable: an uncompressed table must still get recommendations
+# ---------------------------------------------------------------------------
+
+
+class TestUncompressedTable:
+    """An uncompressed table is treated as ratio 1.0 (raw) so it still gets
+    recommendations."""
+
+    def test_parse_marks_uncompressed(self):
+        cfg = ca.parse_current_config({})
+        assert cfg["uncompressed"] is True
+        assert cfg["algorithm"] == ""
+
+    def test_parse_compressed_not_marked_uncompressed(self):
+        cfg = ca.parse_current_config(
+            {"sstable_compression": "LZ4Compressor", "chunk_length_in_kb": "4"}
+        )
+        assert cfg["uncompressed"] is False
+
+    def test_find_current_ratio_is_one_for_uncompressed(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        assert ca.find_current_ratio(results, cfg) == 1.0
+
+    def test_summary_reports_uncompressed_current(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        assert summary["current"]["ratio"] == 1.0
+        assert summary["current"]["algorithm"] == "uncompressed"
+        assert summary["best_lz4"]["improvement_pct"] > 0
+        assert summary["best_zstd"]["improvement_pct"] > 0
+
+    def test_uncompressed_recommends_a_change(self):
+        # Regression: an uncompressed table must not be reported as optimal.
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        output = ca.format_alter_table(summary, "ks", "tbl", use_color=False)
+        assert "ALTER TABLE" in output
+        assert "optimal" not in output.lower()
+
+    def test_full_output_no_crash_for_uncompressed(self):
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        output = ca.format_output(results, cfg, "ks", "tbl", use_color=False)
+        assert "ks.tbl" in output
+        assert "uncompressed" in output
+        assert "None" not in output
+
+    def test_heatmap_no_star_for_uncompressed(self):
+        # The table uses none of the listed compressors, so no cell is current.
+        results = make_full_result_set()
+        cfg = ca.parse_current_config({})
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        data_rows = [
+            l for l in grid.split("\n")
+            if l.strip().startswith("LZ4") or l.strip().startswith("ZSTD")
+        ]
+        assert all("*" not in row for row in data_rows)
+
+
+# ---------------------------------------------------------------------------
+# TestHeatmapCurrentCellRatio: starred cell agrees with the summary
+# ---------------------------------------------------------------------------
+
+
+class TestHeatmapCurrentCellRatio:
+    """For a dict-capable current compressor, the starred cell shows the active
+    (``past``) ratio that the summary reports, not the no-dict ratio."""
+
+    def _setup(self):
+        # past (0.52) differs from none (0.78) at 4K so a mismatch would show.
+        results = make_full_result_set(
+            lz4_none_4k=0.78,
+            lz4_past_4k=0.52,
+            lz4_future_4k=0.41,
+        )
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": True,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        return summary, grid
+
+    def test_starred_cell_shows_past_ratio_not_none_ratio(self):
+        summary, grid = self._setup()
+        assert summary["current"]["ratio"] == 0.52
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert "0.520*" in star_line
+        assert "0.780*" not in star_line
+
+    def test_summary_and_starred_cell_agree(self):
+        summary, grid = self._setup()
+        cur = f"{summary['current']['ratio']:.3f}"
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert f"{cur}*" in star_line
+
+    def test_plain_current_cell_unchanged(self):
+        # A non-dict-aware current compressor still shows its no-dict ratio.
+        results = make_full_result_set(lz4_none_4k=0.78, lz4_past_4k=0.52)
+        cfg = {
+            "algorithm": "LZ4WithDictsCompressor",
+            "chunk_length_kb": 4,
+            "level": 1,
+            "dict_aware": False,
+        }
+        summary = ca.generate_summary(results, cfg)
+        grid = ca.format_heatmap_grid(results, cfg, summary, use_color=False)
+        star_line = next(l for l in grid.split("\n") if "*" in l and l.strip().startswith("LZ4"))
+        assert "0.780*" in star_line

--- a/tools/compression_advisor.py
+++ b/tools/compression_advisor.py
@@ -1,0 +1,997 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""ScyllaDB Compression Advisor.
+
+Calls the estimate_compression_ratios REST API and produces a
+color-coded heatmap grid + summary table comparing the current
+compression configuration against recommended LZ4 and ZSTD configs.
+
+Usage:
+    python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace ks --table tbl
+    python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace ks --table tbl --no-color
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+import urllib.error
+import urllib.parse
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+IMPROVEMENT_THRESHOLD = 0.05  # 5% minimum to justify added complexity
+
+# Compressor name normalization: Java fully-qualified names → short names
+_COMPRESSOR_ALIASES = {
+    "org.apache.cassandra.io.compress.LZ4Compressor": "LZ4Compressor",
+    "org.apache.cassandra.io.compress.ZstdCompressor": "ZstdCompressor",
+    "org.apache.cassandra.io.compress.SnappyCompressor": "SnappyCompressor",
+    "org.apache.cassandra.io.compress.DeflateCompressor": "DeflateCompressor",
+    "LZ4Compressor": "LZ4Compressor",
+    "ZstdCompressor": "ZstdCompressor",
+    "SnappyCompressor": "SnappyCompressor",
+    "DeflateCompressor": "DeflateCompressor",
+    "LZ4WithDictsCompressor": "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor": "ZstdWithDictsCompressor",
+}
+
+# Map non-dict compressor names to their dict-aware equivalents
+_TO_DICT_AWARE = {
+    "LZ4Compressor": "LZ4WithDictsCompressor",
+    "ZstdCompressor": "ZstdWithDictsCompressor",
+    "LZ4WithDictsCompressor": "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor": "ZstdWithDictsCompressor",
+}
+
+_DICT_CAPABLE = {
+    "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor",
+}
+
+# Keys every estimation-result entry returned by the REST API must contain.
+_RESULT_KEYS = frozenset(
+    {"sstable_compression", "chunk_length_in_kb", "level", "dict", "ratio"}
+)
+
+
+# ---------------------------------------------------------------------------
+# ANSI color helpers
+# ---------------------------------------------------------------------------
+
+
+class _Colors:
+    """ANSI escape code container.  Codes are empty strings when disabled."""
+
+    def __init__(self, enabled: bool):
+        if enabled:
+            self.RESET = "\033[0m"
+            self.BOLD = "\033[1m"
+            self.DIM = "\033[2m"
+            self.GREEN = "\033[32m"
+            self.RED = "\033[31m"
+            self.YELLOW = "\033[1;33m"
+            self.CYAN = "\033[1;36m"
+            self.BOLD_GREEN = "\033[1;32m"
+            self.BOLD_RED = "\033[1;31m"
+        else:
+            self.RESET = ""
+            self.BOLD = ""
+            self.DIM = ""
+            self.GREEN = ""
+            self.RED = ""
+            self.YELLOW = ""
+            self.CYAN = ""
+            self.BOLD_GREEN = ""
+            self.BOLD_RED = ""
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_current_config(cql_compression_map: dict) -> dict:
+    """Normalize the CQL ``system_schema.tables`` compression map.
+
+    Input example (from CQL)::
+
+        {'chunk_length_in_kb': '4',
+         'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+
+    Returns a dict::
+
+        {'algorithm': 'LZ4WithDictsCompressor',
+         'chunk_length_kb': 4,
+         'level': 1,
+         'dict_aware': False,
+         'uncompressed': False}
+
+    An empty/absent ``sstable_compression`` means the table is uncompressed.
+    This is reported via ``uncompressed: True`` (with ``algorithm: ''``) so the
+    advisor can treat the current ratio as 1.0 (raw size) and still recommend
+    beneficial configurations instead of silently suppressing them.
+    """
+    raw_algo = cql_compression_map.get("sstable_compression", "")
+    raw_algo_str = raw_algo if isinstance(raw_algo, str) else ""
+    algo = _COMPRESSOR_ALIASES.get(raw_algo_str, raw_algo_str)
+
+    uncompressed = algo == ""
+    dict_aware = algo in _DICT_CAPABLE
+    estimation_algo = _TO_DICT_AWARE.get(algo, algo)
+
+    chunk_str = cql_compression_map.get("chunk_length_in_kb", "4")
+    try:
+        chunk_kb = int(chunk_str)
+    except (ValueError, TypeError):
+        chunk_kb = 4
+
+    level_str = cql_compression_map.get("compression_level", "1")
+    try:
+        level = int(level_str)
+    except (ValueError, TypeError):
+        level = 1
+
+    return {
+        "algorithm": estimation_algo,
+        "chunk_length_kb": chunk_kb,
+        "level": level,
+        "dict_aware": dict_aware,
+        "uncompressed": uncompressed,
+    }
+
+
+def find_current_ratio(results: list, current_config: dict) -> float:
+    """Find the compression ratio for the current config in *results*.
+
+    For an uncompressed table, returns 1.0 (compressed size == raw size) so the
+    advisor compares candidate configs against the raw on-disk footprint.
+
+    For dict-aware compressors, looks for the ``past`` dict entry first
+    (= the currently deployed dictionary) and falls back to ``none`` if
+    no ``past`` match exists. For plain compressors, uses the ``none``
+    bucket only.
+
+    Returns 0.0 if the table is compressed but no matching entry is found.
+    """
+    if current_config.get("uncompressed"):
+        return 1.0
+
+    def _match(r, dict_mode):
+        return (
+            r["sstable_compression"] == current_config["algorithm"]
+            and r["chunk_length_in_kb"] == current_config["chunk_length_kb"]
+            and r["level"] == current_config["level"]
+            and r["dict"] == dict_mode
+        )
+
+    current_uses_dict = current_config.get("dict_aware")
+    if current_uses_dict is None:
+        current_uses_dict = current_config.get("algorithm") in _DICT_CAPABLE
+
+    if current_uses_dict:
+        for r in results:
+            if _match(r, "past"):
+                return r["ratio"]
+    for r in results:
+        if _match(r, "none"):
+            return r["ratio"]
+    return 0.0
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: heuristic selection
+# ---------------------------------------------------------------------------
+
+
+def _within_threshold(candidate_ratio: float, best_ratio: float) -> bool:
+    """Return True if *candidate_ratio* is within IMPROVEMENT_THRESHOLD of *best_ratio*."""
+    if best_ratio == 0:
+        return True
+    return candidate_ratio <= best_ratio * (1 + IMPROVEMENT_THRESHOLD)
+
+
+def select_best_for_family(results: list, family_prefix: str) -> dict:
+    """Select the best practical config for one algorithm family.
+
+    *family_prefix* is ``"LZ4"`` or ``"Zstd"``.
+
+    Applies the preference cascade (each override requires >5% improvement):
+
+    1. Start from the absolute best ratio among ``future`` dict entries.
+    2. Prefer 4 KB chunk size if within threshold of best chunk.
+    3. Prefer ``none`` dict if within threshold of ``future`` dict.
+    4. (ZSTD) Prefer the lowest level within threshold of the best level.
+
+    Returns::
+
+        {'config': {algorithm, chunk_length_kb, level, dict, ratio},
+         'notes': [str, ...]}
+    """
+    algo_name = f"{family_prefix}WithDictsCompressor"
+
+    notes: list[str] = []
+
+    # --- Collect future-dict candidates for this family ---
+    future = [
+        r
+        for r in results
+        if r["sstable_compression"] == algo_name and r["dict"] == "future"
+    ]
+    none_entries = [
+        r
+        for r in results
+        if r["sstable_compression"] == algo_name and r["dict"] == "none"
+    ]
+
+    if not future:
+        # Fall back to none-dict if no future entries
+        future = none_entries
+    if not future:
+        return {"config": None, "notes": ["No results for this algorithm family"]}
+
+    # --- 1. Absolute best ratio ---
+    best = min(future, key=lambda r: r["ratio"])
+    best_ratio = best["ratio"]
+
+    # --- 2. Chunk size preference: prefer 4K ---
+    best_at_4k = [r for r in future if r["chunk_length_in_kb"] == 4]
+    if best_at_4k:
+        best_4k = min(best_at_4k, key=lambda r: r["ratio"])
+        if _within_threshold(best_4k["ratio"], best_ratio):
+            if best["chunk_length_in_kb"] != 4:
+                pct = (
+                    (best_4k["ratio"] - best_ratio) / best_ratio * 100
+                    if best_ratio
+                    else 0
+                )
+                notes.append(
+                    f"4K chunk preferred ({best['chunk_length_in_kb']}K only {abs(pct):.1f}% better, below {IMPROVEMENT_THRESHOLD * 100:.0f}% threshold)"
+                )
+            chosen_chunk = 4
+        else:
+            chosen_chunk = best["chunk_length_in_kb"]
+            pct = (
+                (best_4k["ratio"] - best_ratio) / best_ratio * 100 if best_ratio else 0
+            )
+            notes.append(
+                f"{chosen_chunk}K chunk chosen ({abs(pct):.1f}% better than 4K)"
+            )
+    else:
+        chosen_chunk = best["chunk_length_in_kb"]
+
+    # --- 3. Dict preference: prefer none ---
+    future_at_chunk = [r for r in future if r["chunk_length_in_kb"] == chosen_chunk]
+    none_at_chunk = [r for r in none_entries if r["chunk_length_in_kb"] == chosen_chunk]
+
+    if future_at_chunk and none_at_chunk:
+        best_future = min(future_at_chunk, key=lambda r: r["ratio"])
+        best_none = min(none_at_chunk, key=lambda r: r["ratio"])
+        if _within_threshold(best_none["ratio"], best_future["ratio"]):
+            chosen_dict = "none"
+            if best_future["ratio"] < best_none["ratio"]:
+                pct = (
+                    (best_none["ratio"] - best_future["ratio"])
+                    / best_future["ratio"]
+                    * 100
+                    if best_future["ratio"]
+                    else 0
+                )
+                notes.append(
+                    f"No dictionary preferred (dict only {abs(pct):.1f}% better, below {IMPROVEMENT_THRESHOLD * 100:.0f}% threshold)"
+                )
+            else:
+                notes.append("No dictionary preferred (no improvement from dictionary)")
+        else:
+            chosen_dict = "future"
+            pct = (
+                (best_none["ratio"] - best_future["ratio"]) / best_future["ratio"] * 100
+                if best_future["ratio"]
+                else 0
+            )
+            notes.append(
+                f"Dictionary retrain recommended ({abs(pct):.1f}% improvement over no-dict)"
+            )
+    else:
+        chosen_dict = "future" if future_at_chunk else "none"
+
+    # --- 4. Level preference (ZSTD): prefer lowest adequate level ---
+    if family_prefix == "Zstd":
+        pool = future_at_chunk if chosen_dict == "future" else none_at_chunk
+        if not pool:
+            pool = future_at_chunk or none_at_chunk or future
+        # Filter to chosen dict
+        pool = [r for r in pool if r["dict"] == chosen_dict]
+        if pool:
+            best_level_r = min(pool, key=lambda r: r["ratio"])
+            best_level_ratio = best_level_r["ratio"]
+            # Walk from level 1 upward; pick lowest within threshold
+            levels_sorted = sorted(pool, key=lambda r: r["level"])
+            chosen_level = best_level_r["level"]
+            for r in levels_sorted:
+                if _within_threshold(r["ratio"], best_level_ratio):
+                    chosen_level = r["level"]
+                    break
+            if chosen_level < best_level_r["level"]:
+                pct = (
+                    (
+                        dict([(r["level"], r["ratio"]) for r in levels_sorted])[
+                            chosen_level
+                        ]
+                        - best_level_ratio
+                    )
+                    / best_level_ratio
+                    * 100
+                    if best_level_ratio
+                    else 0
+                )
+                notes.append(
+                    f"Level {chosen_level} chosen (levels {chosen_level + 1}-{best_level_r['level']} add only {abs(pct):.1f}% improvement)"
+                )
+            elif chosen_level > 1:
+                lvl1 = [r for r in levels_sorted if r["level"] == 1]
+                if lvl1:
+                    pct = (
+                        (lvl1[0]["ratio"] - best_level_ratio) / best_level_ratio * 100
+                        if best_level_ratio
+                        else 0
+                    )
+                    notes.append(
+                        f"Level {chosen_level} chosen ({abs(pct):.1f}% better than level 1)"
+                    )
+        else:
+            chosen_level = 1
+    else:
+        chosen_level = 1
+
+    # --- Find the exact matching result ---
+    chosen_dict_entries = future_at_chunk if chosen_dict == "future" else none_at_chunk
+    if not chosen_dict_entries:
+        chosen_dict_entries = future
+    match = [
+        r
+        for r in chosen_dict_entries
+        if r["level"] == chosen_level and r["dict"] == chosen_dict
+    ]
+    if not match:
+        # Broader fallback
+        match = [
+            r
+            for r in results
+            if r["sstable_compression"] == algo_name
+            and r["chunk_length_in_kb"] == chosen_chunk
+            and r["level"] == chosen_level
+            and r["dict"] == chosen_dict
+        ]
+    if not match:
+        # Last resort: pick the absolute best
+        match = [best]
+
+    chosen = match[0]
+    return {
+        "config": {
+            "algorithm": chosen["sstable_compression"],
+            "chunk_length_kb": chosen["chunk_length_in_kb"],
+            "level": chosen["level"],
+            "dict": chosen["dict"],
+            "ratio": chosen["ratio"],
+        },
+        "notes": notes,
+    }
+
+
+def generate_summary(results: list, current_config: Optional[dict]) -> dict:
+    """Produce the full summary: current config + two recommendations.
+
+    Returns::
+
+        {'current':   {'algorithm', 'chunk_length_kb', 'level', 'dict', 'ratio'},
+         'best_lz4':  {'config': {..., 'ratio'}, 'improvement_pct': float, 'notes': [str]},
+         'best_zstd': {'config': {..., 'ratio'}, 'improvement_pct': float, 'notes': [str]}}
+
+    When *current_config* is ``None`` (e.g. the ScyllaDB driver is not
+    installed) the current configuration is reported as unknown, improvement
+    percentages cannot be computed (``improvement_pct`` is ``None``), and the
+    recommendations fall back to the best absolute ratio per family.
+
+    When the table is uncompressed the current ratio is 1.0 (raw size) so
+    improvements are measured against the uncompressed footprint.
+    """
+    if current_config is None:
+        current_ratio: Optional[float] = None
+        current = {
+            "algorithm": None,
+            "chunk_length_kb": None,
+            "level": None,
+            "dict": None,
+            "ratio": None,
+        }
+    elif current_config.get("uncompressed"):
+        # Uncompressed table: ratio 1.0 (raw), no algorithm/level/dictionary.
+        current_ratio = find_current_ratio(results, current_config)
+        current = {
+            "algorithm": "uncompressed",
+            "chunk_length_kb": None,
+            "level": None,
+            "dict": None,
+            "ratio": current_ratio,
+        }
+    else:
+        current_ratio = find_current_ratio(results, current_config)
+        current = {
+            "algorithm": current_config["algorithm"],
+            "chunk_length_kb": current_config["chunk_length_kb"],
+            "level": current_config["level"],
+            "dict": "current",
+            "ratio": current_ratio,
+        }
+
+    def _make_recommendation(family_prefix):
+        # ``improvement_pct`` is tri-state:
+        #   float  -> percentage improvement vs the known current config
+        #   None   -> current config is unknown, so it cannot be computed
+        #   0.0    -> no candidate config exists for this family
+        sel = select_best_for_family(results, family_prefix)
+        if sel["config"] is None:
+            return {"config": None, "improvement_pct": 0.0, "notes": sel["notes"]}
+        cfg = sel["config"]
+        if current_ratio is None:
+            improvement = None
+        elif current_ratio > 0:
+            improvement = (current_ratio - cfg["ratio"]) / current_ratio * 100
+        else:
+            improvement = 0.0
+        return {
+            "config": cfg,
+            "improvement_pct": improvement,
+            "notes": sel["notes"],
+        }
+
+    return {
+        "current": current,
+        "best_lz4": _make_recommendation("LZ4"),
+        "best_zstd": _make_recommendation("Zstd"),
+    }
+
+
+def _is_recommended(rec: dict) -> bool:
+    """Whether a recommendation should be highlighted.
+
+    When the current config is known, only highlight if it improves over the
+    current ratio by more than the threshold.  When the current config is
+    unknown (``improvement_pct is None``), always highlight the best absolute
+    config for the family.
+    """
+    if not rec["config"]:
+        return False
+    imp = rec["improvement_pct"]
+    if imp is None:
+        return True
+    return imp > IMPROVEMENT_THRESHOLD * 100
+
+
+def _recommendation_sort_key(rec: dict) -> float:
+    """Sort key for picking the single best recommendation.
+
+    Uses the improvement percentage when the current config is known, and
+    otherwise (unknown current) ranks by absolute compression quality so the
+    lowest-ratio config wins.
+    """
+    imp = rec["improvement_pct"]
+    if imp is not None:
+        return imp
+    return (1.0 - rec["config"]["ratio"]) * 100
+
+
+# ---------------------------------------------------------------------------
+# Formatting: heatmap grid
+# ---------------------------------------------------------------------------
+
+
+def _ratio_cell(
+    ratio: float,
+    current_ratio: float,
+    is_current: bool,
+    is_recommended: bool,
+    C: _Colors,
+) -> str:
+    """Format a single ratio value with optional coloring and markers."""
+    val_str = f"{ratio:5.3f}"
+
+    marker = ""
+    if is_current:
+        marker = f"{C.YELLOW}*{C.RESET}"
+    elif is_recommended:
+        marker = f"{C.CYAN}\u25c4{C.RESET}"
+    else:
+        marker = " "
+
+    if current_ratio > 0:
+        rel = (ratio - current_ratio) / current_ratio
+        if is_current:
+            colored = f"{C.YELLOW}{val_str}{C.RESET}"
+        elif rel < -IMPROVEMENT_THRESHOLD:
+            colored = f"{C.GREEN}{val_str}{C.RESET}"
+        elif rel > IMPROVEMENT_THRESHOLD:
+            colored = f"{C.RED}{val_str}{C.RESET}"
+        else:
+            colored = f"{C.DIM}{val_str}{C.RESET}"
+    else:
+        colored = val_str
+
+    return f"{colored}{marker}"
+
+
+def format_heatmap_grid(
+    results: list, current_config: Optional[dict], summary: dict, use_color: bool = True
+) -> str:
+    """Render the full heatmap grid as a string.
+
+    Layout::
+
+                               no dict              future dict
+                         1K      4K      16K     1K      4K      16K
+        LZ4    lvl1    0.82    0.78*   0.67    0.45    0.41<   0.38
+        ZSTD   lvl1    ...
+        ...
+    """
+    C = _Colors(use_color)
+    lines: list[str] = []
+
+    chunk_sizes = [1, 4, 16]
+    dict_modes = ["none", "future"]
+
+    # Build a lookup: (algo, chunk, level, dict) -> ratio
+    lookup: dict[tuple, float] = {}
+    for r in results:
+        key = (r["sstable_compression"], r["chunk_length_in_kb"], r["level"], r["dict"])
+        lookup[key] = r["ratio"]
+
+    # Determine which entries are recommended (only if they improve over current)
+    rec_lz4_key = None
+    rec_zstd_key = None
+    if _is_recommended(summary["best_lz4"]):
+        c = summary["best_lz4"]["config"]
+        rec_lz4_key = (c["algorithm"], c["chunk_length_kb"], c["level"], c["dict"])
+    if _is_recommended(summary["best_zstd"]):
+        c = summary["best_zstd"]["config"]
+        rec_zstd_key = (c["algorithm"], c["chunk_length_kb"], c["level"], c["dict"])
+
+    # A real ratio is always > 0, so ``or 0.0`` only ever substitutes for an
+    # unknown (None) current config, which disables current-vs-others coloring.
+    current_ratio = summary["current"]["ratio"] or 0.0
+
+    # Header
+    col_w = 8
+    label_w = 15
+    lines.append("")
+    hdr1 = " " * label_w
+    for dm in dict_modes:
+        label = "no dict" if dm == "none" else "future dict"
+        span = col_w * len(chunk_sizes)
+        hdr1 += label.center(span)
+    lines.append(hdr1)
+
+    hdr2 = " " * label_w
+    for _ in dict_modes:
+        for ck in chunk_sizes:
+            hdr2 += f"{ck}K".center(col_w)
+    lines.append(f"{C.BOLD}{hdr2}{C.RESET}")
+    lines.append("")
+
+    # Rows: LZ4 level 1, then ZSTD levels 1-5
+    rows = [("LZ4WithDictsCompressor", "LZ4", 1)]
+    for lvl in range(1, 6):
+        rows.append(("ZstdWithDictsCompressor", "ZSTD", lvl))
+
+    for algo_full, algo_short, level in rows:
+        row_label = f"{algo_short:5s}  level {level}".ljust(label_w)
+        row = row_label
+        for dm in dict_modes:
+            for ck in chunk_sizes:
+                key = (algo_full, ck, level, dm)
+                ratio = lookup.get(key, -1.0)
+                if ratio < 0:
+                    row += "   —   ".center(col_w)
+                    continue
+                # Check current: match on algo/chunk/level, dict=past maps to none column
+                is_cur = (
+                    current_config is not None
+                    and algo_full == current_config["algorithm"]
+                    and ck == current_config["chunk_length_kb"]
+                    and level == current_config["level"]
+                    and dm == "none"
+                )
+                # Dict-capable current: show the active (``past``) ratio so the
+                # starred cell matches the summary.
+                display_ratio = ratio
+                if (
+                    is_cur
+                    and current_config.get("dict_aware")
+                    and summary["current"]["ratio"] is not None
+                ):
+                    display_ratio = summary["current"]["ratio"]
+                is_rec = key == rec_lz4_key or key == rec_zstd_key
+                cell = _ratio_cell(display_ratio, current_ratio, is_cur, is_rec, C)
+                # Pad cell accounting for ANSI codes (they have zero display width)
+                visible_len = len(f"{display_ratio:5.3f}") + 1  # value + marker
+                padding = col_w - visible_len
+                row += cell + " " * max(padding, 1)
+        lines.append(row)
+
+    lines.append("")
+    lines.append(
+        f"  {C.YELLOW}*{C.RESET} = current (shown in no-dict column; dictionary-aware "
+        f"compressors show the active dictionary ratio)    "
+        f"{C.CYAN}\u25c4{C.RESET} = recommended"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Formatting: summary table
+# ---------------------------------------------------------------------------
+
+
+def format_summary_table(summary: dict, use_color: bool = True) -> str:
+    """Render the recommendation summary as a 3-column table."""
+    C = _Colors(use_color)
+    lines: list[str] = []
+
+    cur = summary["current"]
+    lz4 = summary["best_lz4"]
+    zstd = summary["best_zstd"]
+
+    col_w = 18
+    hdr = f"{'':20s}{C.BOLD}{'Current':>{col_w}s}{'Best LZ4':>{col_w}s}{'Best ZSTD':>{col_w}s}{C.RESET}"
+    lines.append(hdr)
+    lines.append("\u2500" * (20 + 3 * col_w))
+
+    def _algo_short(name):
+        if not name:
+            return "—"
+        if "LZ4" in name:
+            return "LZ4WithDicts"
+        if "Zstd" in name or "ZSTD" in name:
+            return "ZstdWithDicts"
+        return name
+
+    def _dict_label(d):
+        if not d:
+            return "—"
+        if d == "current":
+            return "current"
+        if d == "future":
+            return "retrained"
+        return d
+
+    def _row(label, cur_val, lz4_val, zstd_val):
+        return f"{label:20s}{str(cur_val):>{col_w}s}{str(lz4_val):>{col_w}s}{str(zstd_val):>{col_w}s}"
+
+    lz4_cfg = lz4["config"] or {}
+    zstd_cfg = zstd["config"] or {}
+
+    lines.append(
+        _row(
+            "Algorithm",
+            _algo_short(cur.get("algorithm", "—")),
+            _algo_short(lz4_cfg.get("algorithm", "—")),
+            _algo_short(zstd_cfg.get("algorithm", "—")),
+        )
+    )
+    lines.append(
+        _row(
+            "Chunk Size (KB)",
+            cur.get("chunk_length_kb") or "—",
+            lz4_cfg.get("chunk_length_kb", "—"),
+            zstd_cfg.get("chunk_length_kb", "—"),
+        )
+    )
+    lines.append(
+        _row(
+            "Level",
+            cur.get("level") or "—",
+            lz4_cfg.get("level", "—"),
+            zstd_cfg.get("level", "—"),
+        )
+    )
+    lines.append(
+        _row(
+            "Dictionary",
+            _dict_label(cur.get("dict", "—")),
+            _dict_label(lz4_cfg.get("dict", "—")),
+            _dict_label(zstd_cfg.get("dict", "—")),
+        )
+    )
+
+    # Ratio row with color
+    cur_ratio_s = f"{cur['ratio']:.3f}" if cur["ratio"] is not None else "—"
+    lz4_ratio_s = f"{lz4_cfg['ratio']:.3f}" if lz4_cfg.get("ratio") is not None else "—"
+    zstd_ratio_s = (
+        f"{zstd_cfg['ratio']:.3f}" if zstd_cfg.get("ratio") is not None else "—"
+    )
+    lines.append(_row("Ratio", cur_ratio_s, lz4_ratio_s, zstd_ratio_s))
+
+    # Improvement row — signs use "size change" convention:
+    # positive improvement (better compression) → negative display (smaller size),
+    # negative improvement (worse compression) → positive display (larger size).
+    def _improvement_str(rec, C):
+        if not rec["config"]:
+            return "—"
+        pct = rec["improvement_pct"]
+        if pct is None:
+            return f"{C.DIM}n/a{C.RESET}"
+        if pct > IMPROVEMENT_THRESHOLD * 100:
+            return f"{C.BOLD_GREEN}-{pct:.1f}%{C.RESET}"
+        elif pct < -IMPROVEMENT_THRESHOLD * 100:
+            return f"{C.BOLD_RED}+{abs(pct):.1f}%{C.RESET}"
+        else:
+            return f"{C.DIM}{-pct:+.1f}%{C.RESET}"
+
+    imp_cur = "—"
+    imp_lz4 = _improvement_str(lz4, C)
+    imp_zstd = _improvement_str(zstd, C)
+    # For improvement row, we need to handle ANSI codes in alignment
+    # Use raw string building since colors mess up alignment
+    # Pad colored strings manually
+    lines.append(
+        f"{'vs Current':20s}{imp_cur:>{col_w}s}{imp_lz4:>{col_w + len(imp_lz4) - _visible_len(imp_lz4)}s}{imp_zstd:>{col_w + len(imp_zstd) - _visible_len(imp_zstd)}s}"
+    )
+
+    # Notes
+    all_notes = []
+    if lz4.get("notes"):
+        for n in lz4["notes"]:
+            all_notes.append(f"  LZ4: {n}")
+    if zstd.get("notes"):
+        for n in zstd["notes"]:
+            all_notes.append(f"  ZSTD: {n}")
+    if all_notes:
+        lines.append("")
+        lines.append(f"{C.BOLD}Notes:{C.RESET}")
+        lines.extend(all_notes)
+
+    return "\n".join(lines)
+
+
+def _visible_len(s: str) -> int:
+    """Return the visible length of a string, ignoring ANSI escape codes."""
+    return len(re.sub(r"\033\[[0-9;]*m", "", s))
+
+
+# ---------------------------------------------------------------------------
+# Full formatted output
+# ---------------------------------------------------------------------------
+
+
+def format_alter_table(
+    summary: dict, keyspace: str, table: str, use_color: bool = True
+) -> str:
+    """Generate the ALTER TABLE CQL command for the best recommendation.
+
+    Picks the recommendation with the largest improvement above the
+    threshold, otherwise emits a no-change message.
+    """
+    C = _Colors(use_color)
+
+    # Pick the best recommendation
+    best = None
+    zstd = summary["best_zstd"]
+    lz4 = summary["best_lz4"]
+
+    candidates = []
+    if _is_recommended(zstd):
+        candidates.append((_recommendation_sort_key(zstd), "ZSTD", zstd))
+    if _is_recommended(lz4):
+        candidates.append((_recommendation_sort_key(lz4), "LZ4", lz4))
+    if candidates:
+        _, _, best = max(candidates, key=lambda item: item[0])
+
+    if not best:
+        return f"{C.DIM}No change recommended — current config is already optimal.{C.RESET}"
+
+    cfg = best["config"]
+    algo = cfg["algorithm"]
+    chunk = cfg["chunk_length_kb"]
+    level = cfg["level"]
+    needs_dict = cfg["dict"] == "future"
+
+    # Build compression map entries
+    opts = [f"'sstable_compression': '{algo}'", f"'chunk_length_in_kb': '{chunk}'"]
+    if "Zstd" in algo:
+        opts.append(f"'compression_level': '{level}'")
+
+    compression_map = "{" + ", ".join(opts) + "}"
+
+    lines = []
+    lines.append(f"{C.BOLD}Apply with:{C.RESET}")
+    lines.append("")
+    lines.append(
+        f'  {C.CYAN}ALTER TABLE "{keyspace}"."{table}" '
+        f"WITH compression = {compression_map};{C.RESET}"
+    )
+    if needs_dict:
+        retrain_params = urllib.parse.urlencode({"keyspace": keyspace, "cf": table})
+        lines.append("")
+        lines.append(
+            "  -- Then retrain the dictionary (requires SSTABLE_COMPRESSION_DICTS feature):"
+        )
+        lines.append(f"  -- POST /storage_service/retrain_dict?{retrain_params}")
+
+    return "\n".join(lines)
+
+
+def format_output(
+    results: list,
+    current_config: Optional[dict],
+    keyspace: str,
+    table: str,
+    use_color: bool = True,
+) -> str:
+    """Produce the complete formatted output string."""
+    C = _Colors(use_color)
+    summary = generate_summary(results, current_config)
+
+    parts = []
+    parts.append(
+        f"{C.BOLD}Compression Estimation Results for {keyspace}.{table}{C.RESET}"
+    )
+    parts.append("(ratio = compressed/raw, lower is better)")
+    parts.append(format_heatmap_grid(results, current_config, summary, use_color))
+    parts.append("")
+    parts.append(f"{C.BOLD}Recommendation Summary{C.RESET}")
+    parts.append(format_summary_table(summary, use_color))
+    parts.append("")
+    parts.append(format_alter_table(summary, keyspace, table, use_color))
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# I/O: CQL and REST
+# ---------------------------------------------------------------------------
+
+
+def get_current_config_via_cql(
+    host: str, keyspace: str, table: str, port: int = 9042
+) -> Optional[dict]:
+    """Query ``system_schema.tables`` for the current compression config.
+
+    Returns the raw CQL compression map, e.g.::
+
+        {'chunk_length_in_kb': '4',
+         'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+
+    Returns ``None`` (and prints a warning) if the ScyllaDB Python driver is
+    not installed.  In that case the caller can still produce the estimation
+    report, just without highlighting the current configuration.
+    """
+    try:
+        from cassandra.cluster import Cluster
+    except ImportError:
+        print(
+            "Warning: ScyllaDB Python driver not found — continuing without the "
+            "current compression settings.\n"
+            "         Install it with: pip install scylla-driver",
+            file=sys.stderr,
+        )
+        return None
+
+    cluster = Cluster([host], port=port)
+    try:
+        session = cluster.connect()
+        rows = session.execute(
+            "SELECT compression FROM system_schema.tables "
+            "WHERE keyspace_name = %s AND table_name = %s",
+            (keyspace, table),
+        )
+        row = rows.one()
+        if row is None:
+            print(f"Error: table {keyspace}.{table} not found", file=sys.stderr)
+            sys.exit(1)
+        # A table may have an empty/absent compression map (uncompressed);
+        # normalize to {} so the caller falls back to default settings rather
+        # than crashing on dict(None).
+        return dict(row.compression or {})
+    except Exception as e:
+        print(
+            f"Error reading current config from CQL at {host}:{port}: {e}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    finally:
+        cluster.shutdown()
+
+
+def call_estimate_api(host: str, keyspace: str, table: str, port: int = 10000) -> list:
+    """Call ``GET /storage_service/estimate_compression_ratios``."""
+    params = urllib.parse.urlencode({"keyspace": keyspace, "cf": table})
+    url = f"http://{host}:{port}/storage_service/estimate_compression_ratios?{params}"
+    try:
+        with urllib.request.urlopen(url, timeout=300) as resp:
+            raw = resp.read()
+    except OSError as e:
+        # OSError is the common base of urllib.error.URLError (and HTTPError),
+        # socket.timeout/TimeoutError raised mid-read, and connection resets.
+        print(f"Error calling estimation API: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data: Any = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        print(f"Error: estimation API returned invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print(
+            "Error: estimation API returned unexpected JSON structure",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    for index, entry in enumerate(data):
+        if not isinstance(entry, dict) or not _RESULT_KEYS <= entry.keys():
+            print(
+                f"Error: estimation API returned a malformed entry at index "
+                f"{index}: {entry!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ScyllaDB Compression Advisor — analyze compression "
+        "configurations and recommend improvements.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s --host 10.0.0.1 --keyspace myks --table mytbl\n"
+            "  %(prog)s --host 10.0.0.1 --keyspace myks --table mytbl --no-color\n"
+        ),
+    )
+    parser.add_argument("--host", required=True, help="ScyllaDB node IP address")
+    parser.add_argument("--keyspace", required=True, help="Keyspace name")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument(
+        "--api-port", type=int, default=10000, help="REST API port (default: 10000)"
+    )
+    parser.add_argument(
+        "--cql-port",
+        type=int,
+        default=9042,
+        help="CQL native transport port (default: 9042)",
+    )
+    parser.add_argument(
+        "--no-color", action="store_true", help="Disable ANSI color output"
+    )
+    args = parser.parse_args()
+
+    use_color = not args.no_color and sys.stdout.isatty()
+
+    cql_map = get_current_config_via_cql(
+        args.host, args.keyspace, args.table, args.cql_port
+    )
+    current_config = parse_current_config(cql_map) if cql_map is not None else None
+    results = call_estimate_api(args.host, args.keyspace, args.table, args.api_port)
+
+    output = format_output(
+        results, current_config, args.keyspace, args.table, use_color
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/compression_advisor.py
+++ b/tools/compression_advisor.py
@@ -1,0 +1,1039 @@
+#!/usr/bin/env python3
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""ScyllaDB Compression Advisor.
+
+Calls the estimate_compression_ratios REST API and produces a
+color-coded heatmap grid + summary table comparing the current
+compression configuration against recommended LZ4 and ZSTD configs.
+
+Usage:
+    python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace ks --table tbl
+    python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace ks --table tbl --no-color
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+import urllib.error
+import urllib.parse
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+IMPROVEMENT_THRESHOLD = 0.05  # 5% minimum to justify added complexity
+CHUNK_SIZE_PREFERENCE_THRESHOLD = 0.10  # 4K chunks cut read amplification, so tolerate a bigger ratio gap
+
+# Compressor name normalization: Java fully-qualified names → short names
+_COMPRESSOR_ALIASES = {
+    "org.apache.cassandra.io.compress.LZ4Compressor": "LZ4Compressor",
+    "org.apache.cassandra.io.compress.ZstdCompressor": "ZstdCompressor",
+    "org.apache.cassandra.io.compress.SnappyCompressor": "SnappyCompressor",
+    "org.apache.cassandra.io.compress.DeflateCompressor": "DeflateCompressor",
+    "LZ4Compressor": "LZ4Compressor",
+    "ZstdCompressor": "ZstdCompressor",
+    "SnappyCompressor": "SnappyCompressor",
+    "DeflateCompressor": "DeflateCompressor",
+    "LZ4WithDictsCompressor": "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor": "ZstdWithDictsCompressor",
+}
+
+# Map non-dict compressor names to their dict-aware equivalents
+_TO_DICT_AWARE = {
+    "LZ4Compressor": "LZ4WithDictsCompressor",
+    "ZstdCompressor": "ZstdWithDictsCompressor",
+    "LZ4WithDictsCompressor": "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor": "ZstdWithDictsCompressor",
+}
+
+_DICT_CAPABLE = {
+    "LZ4WithDictsCompressor",
+    "ZstdWithDictsCompressor",
+}
+
+# Keys every estimation-result entry returned by the REST API must contain.
+_RESULT_KEYS = frozenset(
+    {"sstable_compression", "chunk_length_in_kb", "level", "dict", "ratio"}
+)
+
+
+# ---------------------------------------------------------------------------
+# ANSI color helpers
+# ---------------------------------------------------------------------------
+
+
+class _Colors:
+    """ANSI escape code container.  Codes are empty strings when disabled."""
+
+    def __init__(self, enabled: bool):
+        if enabled:
+            self.RESET = "\033[0m"
+            self.BOLD = "\033[1m"
+            self.DIM = "\033[2m"
+            self.GREEN = "\033[32m"
+            self.RED = "\033[31m"
+            self.YELLOW = "\033[1;33m"
+            self.CYAN = "\033[1;36m"
+            self.BOLD_GREEN = "\033[1;32m"
+            self.BOLD_RED = "\033[1;31m"
+        else:
+            self.RESET = ""
+            self.BOLD = ""
+            self.DIM = ""
+            self.GREEN = ""
+            self.RED = ""
+            self.YELLOW = ""
+            self.CYAN = ""
+            self.BOLD_GREEN = ""
+            self.BOLD_RED = ""
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_current_config(cql_compression_map: dict) -> dict:
+    """Normalize the CQL ``system_schema.tables`` compression map.
+
+    Input example (from CQL)::
+
+        {'chunk_length_in_kb': '4',
+         'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+
+    Returns a dict::
+
+        {'algorithm': 'LZ4WithDictsCompressor',
+         'chunk_length_kb': 4,
+         'level': 1,
+         'dict_aware': False,
+         'uncompressed': False}
+
+    An empty/absent ``sstable_compression`` means the table is uncompressed.
+    This is reported via ``uncompressed: True`` (with ``algorithm: ''``) so the
+    advisor can treat the current ratio as 1.0 (raw size) and still recommend
+    beneficial configurations instead of silently suppressing them.
+    """
+    raw_algo = cql_compression_map.get("sstable_compression", "")
+    raw_algo_str = raw_algo if isinstance(raw_algo, str) else ""
+    algo = _COMPRESSOR_ALIASES.get(raw_algo_str, raw_algo_str)
+
+    uncompressed = algo == ""
+    dict_aware = algo in _DICT_CAPABLE
+    estimation_algo = _TO_DICT_AWARE.get(algo, algo)
+
+    chunk_str = cql_compression_map.get("chunk_length_in_kb", "4")
+    try:
+        chunk_kb = int(chunk_str)
+    except (ValueError, TypeError):
+        chunk_kb = 4
+
+    level_str = cql_compression_map.get("compression_level", "1")
+    try:
+        level = int(level_str)
+    except (ValueError, TypeError):
+        level = 1
+
+    return {
+        "algorithm": estimation_algo,
+        "chunk_length_kb": chunk_kb,
+        "level": level,
+        "dict_aware": dict_aware,
+        "uncompressed": uncompressed,
+    }
+
+
+def find_current_ratio(results: list, current_config: dict) -> Optional[float]:
+    """Find the compression ratio for the current config in *results*.
+
+    For an uncompressed table, returns 1.0 (compressed size == raw size) so the
+    advisor compares candidate configs against the raw on-disk footprint.
+
+    For dict-aware compressors, looks for the ``past`` dict entry first
+    (= the currently deployed dictionary) and falls back to ``none`` if
+    no ``past`` match exists. For plain compressors, uses the ``none``
+    bucket only.
+
+    Returns ``None`` if the table is compressed but no matching entry is found,
+    so the caller can route it through the unknown-current path instead of
+    falsely reporting "already optimal".
+    """
+    if current_config.get("uncompressed"):
+        return 1.0
+
+    def _match(r, dict_mode) -> bool:
+        return (
+            r["sstable_compression"] == current_config["algorithm"]
+            and r["chunk_length_in_kb"] == current_config["chunk_length_kb"]
+            and r["level"] == current_config["level"]
+            and r["dict"] == dict_mode
+        )
+
+    current_uses_dict = current_config.get("dict_aware")
+    if current_uses_dict is None:
+        current_uses_dict = current_config.get("algorithm") in _DICT_CAPABLE
+
+    if current_uses_dict:
+        for r in results:
+            if _match(r, "past"):
+                return r["ratio"]
+    for r in results:
+        if _match(r, "none"):
+            return r["ratio"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Pure logic: heuristic selection
+# ---------------------------------------------------------------------------
+
+
+def _within_threshold(
+    candidate_ratio: float, best_ratio: float, threshold: float = IMPROVEMENT_THRESHOLD
+) -> bool:
+    """Return True if *candidate_ratio* is within *threshold* of *best_ratio*."""
+    if best_ratio == 0:
+        return True
+    return candidate_ratio <= best_ratio * (1 + threshold)
+
+
+def select_best_for_family(results: list, family_prefix: str) -> dict:
+    """Select the best practical config for one algorithm family.
+
+    *family_prefix* is ``"LZ4"`` or ``"Zstd"``.
+
+    Applies the preference cascade (each override requires a real improvement
+    above its threshold):
+
+    1. Start from the absolute best ratio among ``future`` dict entries.
+    2. Prefer 4 KB chunk size unless a larger chunk beats it by more than
+       ``CHUNK_SIZE_PREFERENCE_THRESHOLD`` (4K has the lowest read
+       amplification, so it gets a wider tolerance than the other axes).
+    3. Prefer ``none`` dict if within ``IMPROVEMENT_THRESHOLD`` of ``future`` dict.
+    4. (ZSTD) Prefer the lowest level within ``IMPROVEMENT_THRESHOLD`` of the
+       best level.
+
+    Returns::
+
+        {'config': {algorithm, chunk_length_kb, level, dict, ratio},
+         'notes': [str, ...]}
+    """
+    algo_name = f"{family_prefix}WithDictsCompressor"
+
+    notes: list[str] = []
+
+    # --- Collect future-dict candidates for this family ---
+    future = [
+        r
+        for r in results
+        if r["sstable_compression"] == algo_name and r["dict"] == "future"
+    ]
+    none_entries = [
+        r
+        for r in results
+        if r["sstable_compression"] == algo_name and r["dict"] == "none"
+    ]
+
+    if not future:
+        # Fall back to none-dict if no future entries
+        future = none_entries
+    if not future:
+        return {"config": None, "notes": ["No results for this algorithm family"]}
+
+    # --- 1. Absolute best ratio ---
+    best = min(future, key=lambda r: r["ratio"])
+    best_ratio = best["ratio"]
+
+    # --- 2. Chunk size preference: prefer 4K ---
+    best_at_4k = [r for r in future if r["chunk_length_in_kb"] == 4]
+    if best_at_4k:
+        best_4k = min(best_at_4k, key=lambda r: r["ratio"])
+        if _within_threshold(
+            best_4k["ratio"], best_ratio, CHUNK_SIZE_PREFERENCE_THRESHOLD
+        ):
+            if best["chunk_length_in_kb"] != 4:
+                pct = (
+                    (best_4k["ratio"] - best_ratio) / best_ratio * 100
+                    if best_ratio
+                    else 0
+                )
+                notes.append(
+                    f"4K chunk preferred ({best['chunk_length_in_kb']}K only {abs(pct):.1f}% better, below {CHUNK_SIZE_PREFERENCE_THRESHOLD * 100:.0f}% threshold)"
+                )
+            chosen_chunk = 4
+        else:
+            chosen_chunk = best["chunk_length_in_kb"]
+            pct = (
+                (best_4k["ratio"] - best_ratio) / best_ratio * 100 if best_ratio else 0
+            )
+            notes.append(
+                f"{chosen_chunk}K chunk chosen ({abs(pct):.1f}% better than 4K)"
+            )
+    else:
+        chosen_chunk = best["chunk_length_in_kb"]
+
+    # --- 3. Dict preference: prefer none ---
+    future_at_chunk = [r for r in future if r["chunk_length_in_kb"] == chosen_chunk]
+    none_at_chunk = [r for r in none_entries if r["chunk_length_in_kb"] == chosen_chunk]
+
+    if future_at_chunk and none_at_chunk:
+        best_future = min(future_at_chunk, key=lambda r: r["ratio"])
+        best_none = min(none_at_chunk, key=lambda r: r["ratio"])
+        if _within_threshold(best_none["ratio"], best_future["ratio"]):
+            chosen_dict = "none"
+            if best_future["ratio"] < best_none["ratio"]:
+                pct = (
+                    (best_none["ratio"] - best_future["ratio"])
+                    / best_future["ratio"]
+                    * 100
+                    if best_future["ratio"]
+                    else 0
+                )
+                notes.append(
+                    f"No dictionary preferred (dict only {abs(pct):.1f}% better, below {IMPROVEMENT_THRESHOLD * 100:.0f}% threshold)"
+                )
+            else:
+                notes.append("No dictionary preferred (no improvement from dictionary)")
+        else:
+            chosen_dict = "future"
+            pct = (
+                (best_none["ratio"] - best_future["ratio"]) / best_future["ratio"] * 100
+                if best_future["ratio"]
+                else 0
+            )
+            notes.append(
+                f"Dictionary retrain recommended ({abs(pct):.1f}% improvement over no-dict)"
+            )
+    else:
+        chosen_dict = "future" if future_at_chunk else "none"
+
+    # --- 4. Level preference (ZSTD): prefer lowest adequate level ---
+    if family_prefix == "Zstd":
+        pool = future_at_chunk if chosen_dict == "future" else none_at_chunk
+        if not pool:
+            pool = future_at_chunk or none_at_chunk or future
+        # Filter to chosen dict
+        pool = [r for r in pool if r["dict"] == chosen_dict]
+        if pool:
+            best_level_r = min(pool, key=lambda r: r["ratio"])
+            best_level_ratio = best_level_r["ratio"]
+            # Walk from level 1 upward; pick lowest within threshold
+            levels_sorted = sorted(pool, key=lambda r: r["level"])
+            chosen_level = best_level_r["level"]
+            for r in levels_sorted:
+                if _within_threshold(r["ratio"], best_level_ratio):
+                    chosen_level = r["level"]
+                    break
+            if chosen_level < best_level_r["level"]:
+                pct = (
+                    (
+                        dict([(r["level"], r["ratio"]) for r in levels_sorted])[
+                            chosen_level
+                        ]
+                        - best_level_ratio
+                    )
+                    / best_level_ratio
+                    * 100
+                    if best_level_ratio
+                    else 0
+                )
+                notes.append(
+                    f"Level {chosen_level} chosen (levels {chosen_level + 1}-{best_level_r['level']} add only {abs(pct):.1f}% improvement)"
+                )
+            elif chosen_level > 1:
+                lvl1 = [r for r in levels_sorted if r["level"] == 1]
+                if lvl1:
+                    pct = (
+                        (lvl1[0]["ratio"] - best_level_ratio) / best_level_ratio * 100
+                        if best_level_ratio
+                        else 0
+                    )
+                    notes.append(
+                        f"Level {chosen_level} chosen ({abs(pct):.1f}% better than level 1)"
+                    )
+        else:
+            chosen_level = 1
+    else:
+        chosen_level = 1
+
+    # --- Find the exact matching result ---
+    chosen_dict_entries = future_at_chunk if chosen_dict == "future" else none_at_chunk
+    if not chosen_dict_entries:
+        chosen_dict_entries = future
+    match = [
+        r
+        for r in chosen_dict_entries
+        if r["level"] == chosen_level and r["dict"] == chosen_dict
+    ]
+    if not match:
+        # Broader fallback
+        match = [
+            r
+            for r in results
+            if r["sstable_compression"] == algo_name
+            and r["chunk_length_in_kb"] == chosen_chunk
+            and r["level"] == chosen_level
+            and r["dict"] == chosen_dict
+        ]
+    if not match:
+        # Last resort: pick the absolute best
+        match = [best]
+
+    chosen = match[0]
+    return {
+        "config": {
+            "algorithm": chosen["sstable_compression"],
+            "chunk_length_kb": chosen["chunk_length_in_kb"],
+            "level": chosen["level"],
+            "dict": chosen["dict"],
+            "ratio": chosen["ratio"],
+        },
+        "notes": notes,
+    }
+
+
+def generate_summary(results: list, current_config: Optional[dict]) -> dict:
+    """Produce the full summary: current config + two recommendations.
+
+    Returns::
+
+        {'current':   {'algorithm', 'chunk_length_kb', 'level', 'dict', 'ratio'},
+         'best_lz4':  {'config': {..., 'ratio'}, 'improvement_pct': float, 'notes': [str]},
+         'best_zstd': {'config': {..., 'ratio'}, 'improvement_pct': float, 'notes': [str]}}
+
+    When *current_config* is ``None`` (e.g. the ScyllaDB driver is not
+    installed) the current configuration is reported as unknown, improvement
+    percentages cannot be computed (``improvement_pct`` is ``None``), and the
+    recommendations fall back to the best absolute ratio per family.
+
+    When the table is uncompressed the current ratio is 1.0 (raw size) so
+    improvements are measured against the uncompressed footprint.
+    """
+    if current_config is None:
+        current_ratio: Optional[float] = None
+        current = {
+            "algorithm": None,
+            "chunk_length_kb": None,
+            "level": None,
+            "dict": None,
+            "ratio": None,
+        }
+    elif current_config.get("uncompressed"):
+        # Uncompressed table: ratio 1.0 (raw), no algorithm/level/dictionary.
+        current_ratio = find_current_ratio(results, current_config)
+        current = {
+            "algorithm": "uncompressed",
+            "chunk_length_kb": None,
+            "level": None,
+            "dict": None,
+            "ratio": current_ratio,
+        }
+    else:
+        current_ratio = find_current_ratio(results, current_config)
+        current = {
+            "algorithm": current_config["algorithm"],
+            "chunk_length_kb": current_config["chunk_length_kb"],
+            "level": current_config["level"],
+            "dict": "current",
+            "ratio": current_ratio,
+        }
+
+    def _make_recommendation(family_prefix):
+        # ``improvement_pct`` is tri-state:
+        #   float  -> percentage improvement vs the known current config
+        #   None   -> current config is unknown, so it cannot be computed
+        #   0.0    -> no candidate config exists for this family
+        sel = select_best_for_family(results, family_prefix)
+        if sel["config"] is None:
+            return {"config": None, "improvement_pct": 0.0, "notes": sel["notes"]}
+        cfg = sel["config"]
+        if current_ratio is None:
+            improvement = None
+        elif current_ratio > 0:
+            improvement = (current_ratio - cfg["ratio"]) / current_ratio * 100
+        else:
+            improvement = 0.0
+        return {
+            "config": cfg,
+            "improvement_pct": improvement,
+            "notes": sel["notes"],
+        }
+
+    return {
+        "current": current,
+        "best_lz4": _make_recommendation("LZ4"),
+        "best_zstd": _make_recommendation("Zstd"),
+    }
+
+
+def _is_recommended(rec: dict) -> bool:
+    """Whether a recommendation should be highlighted.
+
+    When the current config is known, only highlight if it improves over the
+    current ratio by more than the threshold.  When the current config is
+    unknown (``improvement_pct is None``), always highlight the best absolute
+    config for the family.
+    """
+    if not rec["config"]:
+        return False
+    imp = rec["improvement_pct"]
+    if imp is None:
+        return True
+    return imp > IMPROVEMENT_THRESHOLD * 100
+
+
+def _recommendation_sort_key(rec: dict) -> float:
+    """Sort key for picking the single best recommendation.
+
+    Uses the improvement percentage when the current config is known, and
+    otherwise (unknown current) ranks by absolute compression quality so the
+    lowest-ratio config wins.
+    """
+    imp = rec["improvement_pct"]
+    if imp is not None:
+        return imp
+    return (1.0 - rec["config"]["ratio"]) * 100
+
+
+# ---------------------------------------------------------------------------
+# Formatting: heatmap grid
+# ---------------------------------------------------------------------------
+
+
+def _ratio_cell(
+    ratio: float,
+    current_ratio: float,
+    is_current: bool,
+    is_recommended: bool,
+    C: _Colors,
+) -> str:
+    """Format a single ratio value with optional coloring and markers."""
+    val_str = f"{ratio:5.3f}"
+
+    marker = ""
+    if is_current:
+        marker = f"{C.YELLOW}*{C.RESET}"
+    elif is_recommended:
+        marker = f"{C.CYAN}\u25c4{C.RESET}"
+    else:
+        marker = " "
+
+    if current_ratio > 0:
+        rel = (ratio - current_ratio) / current_ratio
+        if is_current:
+            colored = f"{C.YELLOW}{val_str}{C.RESET}"
+        elif rel < -IMPROVEMENT_THRESHOLD:
+            colored = f"{C.GREEN}{val_str}{C.RESET}"
+        elif rel > IMPROVEMENT_THRESHOLD:
+            colored = f"{C.RED}{val_str}{C.RESET}"
+        else:
+            colored = f"{C.DIM}{val_str}{C.RESET}"
+    else:
+        colored = val_str
+
+    return f"{colored}{marker}"
+
+
+def format_heatmap_grid(
+    results: list, current_config: Optional[dict], summary: dict, use_color: bool = True
+) -> str:
+    """Render the full heatmap grid as a string.
+
+    Layout::
+
+                               no dict              future dict
+                         1K      4K      16K     1K      4K      16K
+        LZ4    lvl1    0.82    0.78*   0.67    0.45    0.41<   0.38
+        ZSTD   lvl1    ...
+        ...
+    """
+    C = _Colors(use_color)
+    lines: list[str] = []
+
+    chunk_sizes = [1, 4, 16]
+    dict_modes = ["none", "future"]
+
+    # Build a lookup: (algo, chunk, level, dict) -> ratio
+    lookup: dict[tuple, float] = {}
+    for r in results:
+        key = (r["sstable_compression"], r["chunk_length_in_kb"], r["level"], r["dict"])
+        lookup[key] = r["ratio"]
+
+    # Determine which entries are recommended (only if they improve over current)
+    rec_lz4_key = None
+    rec_zstd_key = None
+    if _is_recommended(summary["best_lz4"]):
+        c = summary["best_lz4"]["config"]
+        rec_lz4_key = (c["algorithm"], c["chunk_length_kb"], c["level"], c["dict"])
+    if _is_recommended(summary["best_zstd"]):
+        c = summary["best_zstd"]["config"]
+        rec_zstd_key = (c["algorithm"], c["chunk_length_kb"], c["level"], c["dict"])
+
+    # A real ratio is always > 0, so ``or 0.0`` only ever substitutes for an
+    # unknown (None) current config, which disables current-vs-others coloring.
+    current_ratio = summary["current"]["ratio"] or 0.0
+
+    # Header
+    col_w = 8
+    label_w = 15
+    lines.append("")
+    hdr1 = " " * label_w
+    for dm in dict_modes:
+        label = "no dict" if dm == "none" else "future dict"
+        span = col_w * len(chunk_sizes)
+        hdr1 += label.center(span)
+    lines.append(hdr1)
+
+    hdr2 = " " * label_w
+    for _ in dict_modes:
+        for ck in chunk_sizes:
+            hdr2 += f"{ck}K".center(col_w)
+    lines.append(f"{C.BOLD}{hdr2}{C.RESET}")
+    lines.append("")
+
+    # Rows: LZ4 level 1, then ZSTD levels 1-5
+    rows = [("LZ4WithDictsCompressor", "LZ4", 1)]
+    for lvl in range(1, 6):
+        rows.append(("ZstdWithDictsCompressor", "ZSTD", lvl))
+
+    for algo_full, algo_short, level in rows:
+        row_label = f"{algo_short:5s}  level {level}".ljust(label_w)
+        row = row_label
+        for dm in dict_modes:
+            for ck in chunk_sizes:
+                key = (algo_full, ck, level, dm)
+                ratio = lookup.get(key, -1.0)
+                if ratio < 0:
+                    row += "   —   ".center(col_w)
+                    continue
+                # Check current: match on algo/chunk/level, dict=past maps to none column
+                is_cur = (
+                    current_config is not None
+                    and algo_full == current_config["algorithm"]
+                    and ck == current_config["chunk_length_kb"]
+                    and level == current_config["level"]
+                    and dm == "none"
+                )
+                # Dict-capable current: show the active (``past``) ratio so the
+                # starred cell matches the summary.
+                display_ratio = ratio
+                if (
+                    is_cur
+                    and current_config.get("dict_aware")
+                    and summary["current"]["ratio"] is not None
+                ):
+                    display_ratio = summary["current"]["ratio"]
+                is_rec = key == rec_lz4_key or key == rec_zstd_key
+                cell = _ratio_cell(display_ratio, current_ratio, is_cur, is_rec, C)
+                # Pad cell accounting for ANSI codes (they have zero display width)
+                visible_len = len(f"{display_ratio:5.3f}") + 1  # value + marker
+                padding = col_w - visible_len
+                row += cell + " " * max(padding, 1)
+        lines.append(row)
+
+    lines.append("")
+    lines.append(
+        f"  {C.YELLOW}*{C.RESET} = current (shown in no-dict column; dictionary-aware "
+        f"compressors show the active dictionary ratio)    "
+        f"{C.CYAN}\u25c4{C.RESET} = recommended"
+    )
+    lines.append(
+        f"  Color = ratio vs. current ({C.GREEN}green{C.RESET} = "
+        f">{IMPROVEMENT_THRESHOLD * 100:.0f}% better, {C.RED}red{C.RESET} = "
+        f">{IMPROVEMENT_THRESHOLD * 100:.0f}% worse, dim = within "
+        f"{IMPROVEMENT_THRESHOLD * 100:.0f}% either way)"
+    )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Formatting: summary table
+# ---------------------------------------------------------------------------
+
+
+def format_summary_table(summary: dict, use_color: bool = True) -> str:
+    """Render the recommendation summary as a 3-column table."""
+    C = _Colors(use_color)
+    lines: list[str] = []
+
+    cur = summary["current"]
+    lz4 = summary["best_lz4"]
+    zstd = summary["best_zstd"]
+
+    col_w = 18
+    hdr = f"{'':20s}{C.BOLD}{'Current':>{col_w}s}{'Best LZ4':>{col_w}s}{'Best ZSTD':>{col_w}s}{C.RESET}"
+    lines.append(hdr)
+    lines.append("\u2500" * (20 + 3 * col_w))
+
+    def _algo_short(name):
+        if not name:
+            return "—"
+        if "LZ4" in name:
+            return "LZ4WithDicts"
+        if "Zstd" in name or "ZSTD" in name:
+            return "ZstdWithDicts"
+        return name
+
+    def _dict_label(d):
+        if not d:
+            return "—"
+        if d == "current":
+            return "current"
+        if d == "future":
+            return "retrained"
+        return d
+
+    def _row(label, cur_val, lz4_val, zstd_val):
+        return f"{label:20s}{str(cur_val):>{col_w}s}{str(lz4_val):>{col_w}s}{str(zstd_val):>{col_w}s}"
+
+    lz4_cfg = lz4["config"] or {}
+    zstd_cfg = zstd["config"] or {}
+
+    lines.append(
+        _row(
+            "Algorithm",
+            _algo_short(cur.get("algorithm", "—")),
+            _algo_short(lz4_cfg.get("algorithm", "—")),
+            _algo_short(zstd_cfg.get("algorithm", "—")),
+        )
+    )
+    lines.append(
+        _row(
+            "Chunk Size (KB)",
+            cur.get("chunk_length_kb") or "—",
+            lz4_cfg.get("chunk_length_kb", "—"),
+            zstd_cfg.get("chunk_length_kb", "—"),
+        )
+    )
+    lines.append(
+        _row(
+            "Level",
+            cur.get("level") or "—",
+            lz4_cfg.get("level", "—"),
+            zstd_cfg.get("level", "—"),
+        )
+    )
+    lines.append(
+        _row(
+            "Dictionary",
+            _dict_label(cur.get("dict", "—")),
+            _dict_label(lz4_cfg.get("dict", "—")),
+            _dict_label(zstd_cfg.get("dict", "—")),
+        )
+    )
+
+    # Ratio row with color
+    cur_ratio_s = f"{cur['ratio']:.3f}" if cur["ratio"] is not None else "—"
+    lz4_ratio_s = f"{lz4_cfg['ratio']:.3f}" if lz4_cfg.get("ratio") is not None else "—"
+    zstd_ratio_s = (
+        f"{zstd_cfg['ratio']:.3f}" if zstd_cfg.get("ratio") is not None else "—"
+    )
+    lines.append(_row("Ratio", cur_ratio_s, lz4_ratio_s, zstd_ratio_s))
+
+    # Improvement row — signs use "size change" convention:
+    # positive improvement (better compression) → negative display (smaller size),
+    # negative improvement (worse compression) → positive display (larger size).
+    def _improvement_str(rec, C):
+        if not rec["config"]:
+            return "—"
+        pct = rec["improvement_pct"]
+        if pct is None:
+            return f"{C.DIM}n/a{C.RESET}"
+        if pct > IMPROVEMENT_THRESHOLD * 100:
+            return f"{C.BOLD_GREEN}-{pct:.1f}%{C.RESET}"
+        elif pct < -IMPROVEMENT_THRESHOLD * 100:
+            return f"{C.BOLD_RED}+{abs(pct):.1f}%{C.RESET}"
+        else:
+            return f"{C.DIM}{-pct:+.1f}%{C.RESET}"
+
+    imp_cur = "—"
+    imp_lz4 = _improvement_str(lz4, C)
+    imp_zstd = _improvement_str(zstd, C)
+    # For improvement row, we need to handle ANSI codes in alignment
+    # Use raw string building since colors mess up alignment
+    # Pad colored strings manually
+    lines.append(
+        f"{'vs Current':20s}{imp_cur:>{col_w}s}{imp_lz4:>{col_w + len(imp_lz4) - _visible_len(imp_lz4)}s}{imp_zstd:>{col_w + len(imp_zstd) - _visible_len(imp_zstd)}s}"
+    )
+
+    # Notes
+    all_notes = []
+    if lz4.get("notes"):
+        for n in lz4["notes"]:
+            all_notes.append(f"  LZ4: {n}")
+    if zstd.get("notes"):
+        for n in zstd["notes"]:
+            all_notes.append(f"  ZSTD: {n}")
+    if all_notes:
+        lines.append("")
+        lines.append(f"{C.BOLD}Notes:{C.RESET}")
+        lines.extend(all_notes)
+
+    return "\n".join(lines)
+
+
+def _visible_len(s: str) -> int:
+    """Return the visible length of a string, ignoring ANSI escape codes."""
+    return len(re.sub(r"\033\[[0-9;]*m", "", s))
+
+
+# ---------------------------------------------------------------------------
+# Full formatted output
+# ---------------------------------------------------------------------------
+
+
+def format_alter_table(
+    summary: dict, keyspace: str, table: str, use_color: bool = True
+) -> str:
+    """Generate the ALTER TABLE CQL command for the best recommendation.
+
+    Picks the recommendation with the largest improvement above the
+    threshold, otherwise emits a no-change message.
+    """
+    C = _Colors(use_color)
+
+    # Pick the best recommendation
+    best = None
+    zstd = summary["best_zstd"]
+    lz4 = summary["best_lz4"]
+
+    candidates = []
+    if _is_recommended(zstd):
+        candidates.append((_recommendation_sort_key(zstd), "ZSTD", zstd))
+    if _is_recommended(lz4):
+        candidates.append((_recommendation_sort_key(lz4), "LZ4", lz4))
+    if candidates:
+        _, _, best = max(candidates, key=lambda item: item[0])
+
+    if not best:
+        return f"{C.DIM}No change recommended — current config is already optimal.{C.RESET}"
+
+    cfg = best["config"]
+    algo = cfg["algorithm"]
+    chunk = cfg["chunk_length_kb"]
+    level = cfg["level"]
+    needs_dict = cfg["dict"] == "future"
+
+    # Build compression map entries
+    opts = [f"'sstable_compression': '{algo}'", f"'chunk_length_in_kb': '{chunk}'"]
+    if "Zstd" in algo:
+        opts.append(f"'compression_level': '{level}'")
+
+    compression_map = "{" + ", ".join(opts) + "}"
+
+    lines = []
+    lines.append(f"{C.BOLD}Apply with:{C.RESET}")
+    lines.append("")
+    lines.append(
+        f'  {C.CYAN}ALTER TABLE "{keyspace}"."{table}" '
+        f"WITH compression = {compression_map};{C.RESET}"
+    )
+    if needs_dict:
+        retrain_params = urllib.parse.urlencode({"keyspace": keyspace, "cf": table})
+        lines.append("")
+        lines.append(
+            "  -- Then retrain the dictionary (requires SSTABLE_COMPRESSION_DICTS feature):"
+        )
+        lines.append(f"  -- POST /storage_service/retrain_dict?{retrain_params}")
+
+    return "\n".join(lines)
+
+
+def format_output(
+    results: list,
+    current_config: Optional[dict],
+    keyspace: str,
+    table: str,
+    use_color: bool = True,
+) -> str:
+    """Produce the complete formatted output string."""
+    C = _Colors(use_color)
+    summary = generate_summary(results, current_config)
+
+    parts = []
+    parts.append(
+        f"{C.BOLD}Compression Estimation Results for {keyspace}.{table}{C.RESET}"
+    )
+    parts.append("(ratio = compressed/raw, lower is better)")
+    parts.append(format_heatmap_grid(results, current_config, summary, use_color))
+    parts.append("")
+    parts.append(f"{C.BOLD}Recommendation Summary{C.RESET}")
+    parts.append(format_summary_table(summary, use_color))
+    parts.append("")
+    parts.append(format_alter_table(summary, keyspace, table, use_color))
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# I/O: CQL and REST
+# ---------------------------------------------------------------------------
+
+
+def get_current_config_via_cql(
+    host: str,
+    keyspace: str,
+    table: str,
+    port: int = 9042,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> Optional[dict]:
+    """Query ``system_schema.tables`` for the current compression config.
+
+    Returns the raw CQL compression map, e.g.::
+
+        {'chunk_length_in_kb': '4',
+         'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
+
+    Returns ``None`` (and prints a warning) if the ScyllaDB Python driver is
+    not installed, if authentication is required but no credentials were
+    supplied, or if the query fails.  In that case the caller can still produce
+    the estimation report, just without highlighting the current configuration.
+    """
+    try:
+        from cassandra.cluster import Cluster
+    except ImportError:
+        print(
+            "Warning: ScyllaDB Python driver not found — continuing without the "
+            "current compression settings.\n"
+            "         Install it with: pip install scylla-driver",
+            file=sys.stderr,
+        )
+        return None
+
+    auth_provider = None
+    if username and password:
+        from cassandra.auth import PlainTextAuthProvider
+
+        auth_provider = PlainTextAuthProvider(username=username, password=password)
+    cluster_kwargs = {"port": port}
+    if auth_provider is not None:
+        cluster_kwargs["auth_provider"] = auth_provider
+    cluster = Cluster([host], **cluster_kwargs)
+    try:
+        session = cluster.connect()
+        rows = session.execute(
+            "SELECT compression FROM system_schema.tables "
+            "WHERE keyspace_name = %s AND table_name = %s",
+            (keyspace, table),
+        )
+        row = rows.one()
+        if row is None:
+            print(
+                f"Warning: table {keyspace}.{table} not found; "
+                "continuing without the current configuration.",
+                file=sys.stderr,
+            )
+            return None
+        # A table may have an empty/absent compression map (uncompressed);
+        # normalize to {} so the caller falls back to default settings rather
+        # than crashing on dict(None).
+        return dict(row.compression or {})
+    except Exception as e:
+        print(
+            f"Warning: could not read current config from CQL at {host}:{port} "
+            f"({e}); continuing without the current configuration.",
+            file=sys.stderr,
+        )
+        return None
+    finally:
+        cluster.shutdown()
+
+
+def call_estimate_api(host: str, keyspace: str, table: str, port: int = 10000) -> list:
+    """Call ``GET /storage_service/estimate_compression_ratios``."""
+    params = urllib.parse.urlencode({"keyspace": keyspace, "cf": table})
+    url = f"http://{host}:{port}/storage_service/estimate_compression_ratios?{params}"
+    try:
+        with urllib.request.urlopen(url, timeout=300) as resp:
+            raw = resp.read()
+    except OSError as e:
+        # OSError is the common base of urllib.error.URLError (and HTTPError),
+        # socket.timeout/TimeoutError raised mid-read, and connection resets.
+        print(f"Error calling estimation API: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        data: Any = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
+        print(f"Error: estimation API returned invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print(
+            "Error: estimation API returned unexpected JSON structure",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    for index, entry in enumerate(data):
+        if not isinstance(entry, dict) or not _RESULT_KEYS <= entry.keys():
+            print(
+                f"Error: estimation API returned a malformed entry at index "
+                f"{index}: {entry!r}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="ScyllaDB Compression Advisor — analyze compression "
+        "configurations and recommend improvements.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  %(prog)s --host 10.0.0.1 --keyspace myks --table mytbl\n"
+            "  %(prog)s --host 10.0.0.1 --keyspace myks --table mytbl --no-color\n"
+        ),
+    )
+    parser.add_argument("--host", required=True, help="ScyllaDB node IP address")
+    parser.add_argument("--keyspace", required=True, help="Keyspace name")
+    parser.add_argument("--table", required=True, help="Table name")
+    parser.add_argument(
+        "--api-port", type=int, default=10000, help="REST API port (default: 10000)"
+    )
+    parser.add_argument(
+        "--cql-port",
+        type=int,
+        default=9042,
+        help="CQL native transport port (default: 9042)",
+    )
+    parser.add_argument(
+        "--no-color", action="store_true", help="Disable ANSI color output"
+    )
+    parser.add_argument(
+        "--username", default=None, help="CQL username (required if the cluster uses PasswordAuthenticator)"
+    )
+    parser.add_argument(
+        "--password", default=None, help="CQL password (required if the cluster uses PasswordAuthenticator)"
+    )
+    args = parser.parse_args()
+
+    use_color = not args.no_color and sys.stdout.isatty()
+
+    cql_map = get_current_config_via_cql(
+        args.host, args.keyspace, args.table, args.cql_port, args.username, args.password
+    )
+    current_config = parse_current_config(cql_map) if cql_map is not None else None
+    results = call_estimate_api(args.host, args.keyspace, args.table, args.api_port)
+
+    output = format_output(
+        results, current_config, args.keyspace, args.table, use_color
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a tool + tests for it that make the ESTIMATE API for storage compression human and lovely (IMHO):

<img width="1317" height="788" alt="image" src="https://github.com/user-attachments/assets/3d3140bf-9749-4e2a-806c-76e27faee01d" />

Usage:
```
python3 tools/compression_advisor.py --host 127.0.0.1 --keyspace ks --table tbl
```

AI-assisted: coded with Opencode/Opus 4.6, reviewed by Opus 4.6 and GTP-5.4 locally.
