### PR TITLE
guardrails: Add coordinator-side large data guardrails

### DIFF
--- a/conf/scylla.yaml
+++ b/conf/scylla.yaml
@@ -439,6 +439,10 @@ large_row_fail_threshold_mb: 20
 # Log a warning when writing cells larger than this value
 # compaction_large_cell_warning_threshold_mb: 1
 
+# Reject writes with cell value size exceeding this threshold (MB).
+# Set to 0 to disable.
+large_cell_fail_threshold_mb: 2
+
 # Log a warning when row number is larger than this value
 # compaction_rows_count_warning_threshold: 100000
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -842,6 +842,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Log a warning when writing rows larger than this value.")
     , compaction_large_cell_warning_threshold_mb(this, "compaction_large_cell_warning_threshold_mb", liveness::LiveUpdate, value_status::Used, 1,
         "Log a warning when writing cells larger than this value.")
+    , large_cell_fail_threshold_mb(this, "large_cell_fail_threshold_mb", liveness::LiveUpdate, value_status::Used, 0,
+        "Reject writes with cell value size exceeding this threshold in MB. Set to 0 to disable.")
     , large_partition_fail_threshold_mb(this, "large_partition_fail_threshold_mb", liveness::LiveUpdate, value_status::Used, 0,
         "Reject writes targeting a partition whose on-disk size already exceeds this threshold in MB, as recorded in any SSTable's large data records. "
         "Set to 0 to disable.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -233,6 +233,7 @@ public:
     named_value<uint32_t> compaction_large_partition_warning_threshold_mb;
     named_value<uint32_t> compaction_large_row_warning_threshold_mb;
     named_value<uint32_t> compaction_large_cell_warning_threshold_mb;
+    named_value<uint32_t> large_cell_fail_threshold_mb;
     named_value<uint32_t> large_partition_fail_threshold_mb;
     named_value<uint32_t> rows_count_fail_threshold;
     named_value<uint32_t> large_row_fail_threshold_mb;

--- a/db/large_data_handler.cc
+++ b/db/large_data_handler.cc
@@ -14,7 +14,10 @@
 #include "db/large_data_handler.hh"
 #include "keys/keys.hh"
 #include "mutation/mutation_partition.hh"
+#include "mutation/atomic_cell.hh"
+#include "mutation/collection_mutation.hh"
 #include "replica/exceptions.hh"
+#include "exceptions/exceptions.hh"
 #include "sstables/sstables.hh"
 #include "gms/feature_service.hh"
 #include "cql3/untyped_result_set.hh"
@@ -25,7 +28,31 @@ namespace db {
 
 namespace {
 constexpr uint64_t MB = 1024 * 1024;
+
+enum class guardrail_source { replica, coordinator };
+
+template <guardrail_source Source, typename ContextFn>
+void enforce_threshold(const schema& s, uint64_t value,
+        uint64_t fail_threshold, uint64_t warn_threshold,
+        std::string_view metric, ContextFn&& make_context) {
+    if (fail_threshold > 0 && value > fail_threshold) [[unlikely]] {
+        auto msg = seastar::format(
+            "Large data guardrail: {} {} exceeds hard limit {} "
+            "(keyspace={}, table={}, {})",
+            metric, value, fail_threshold, s.ks_name(), s.cf_name(), make_context());
+        if constexpr (Source == guardrail_source::replica) {
+            throw replica::large_data_exception(s.ks_name(), s.cf_name(), std::move(msg));
+        } else {
+            throw exceptions::invalid_request_exception(std::move(msg));
+        }
+    }
+    if (warn_threshold > 0 && value > warn_threshold) [[unlikely]] {
+        large_data_logger.warn("Large data guardrail: {} {} exceeds soft limit {} "
+            "(keyspace={}, table={}, {})",
+            metric, value, warn_threshold, s.ks_name(), s.cf_name(), make_context());
+    }
 }
+} // anonymous namespace
 
 nop_large_data_handler::nop_large_data_handler()
     : large_data_handler(std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(),
@@ -175,37 +202,19 @@ void large_data_guardrail::check(const schema& s, const mutation_partition& mp,
 }
 
 void large_data_guardrail::check_partition(const schema& s, bytes_view pk_bytes, partition_key_view pk) const {
-    const uint64_t size_fail = uint64_t(_cfg.partition_size_fail_threshold_mb()) * MB;
-    const uint64_t size_warn = uint64_t(_cfg.partition_size_warn_threshold_mb()) * MB;
-    const uint64_t rows_fail = uint64_t(_cfg.rows_count_fail_threshold());
-    const uint64_t rows_warn = uint64_t(_cfg.rows_count_warn_threshold());
-
     auto entry = _index.lookup_partition(pk_bytes);
     if (!entry) [[likely]] {
         return;
     }
-    if (size_fail > 0 && entry->partition_size >= size_fail) {
-        throw replica::large_data_exception(s.ks_name(), s.cf_name(), format(
-            "Large data guardrail: partition size {} exceeds hard limit {} "
-            "(keyspace={}, table={}, partition_key={})",
-            entry->partition_size, size_fail, s.ks_name(), s.cf_name(), pk));
-    }
-    if (entry->partition_size >= size_warn) {
-        large_data_logger.warn("Large data guardrail: partition size {} exceeds soft limit {} "
-            "(keyspace={}, table={}, partition_key={})",
-            entry->partition_size, size_warn, s.ks_name(), s.cf_name(), pk);
-    }
-    if (rows_fail > 0 && entry->rows >= rows_fail) {
-        throw replica::large_data_exception(s.ks_name(), s.cf_name(), format(
-            "Large data guardrail: partition row count {} exceeds hard limit {} "
-            "(keyspace={}, table={}, partition_key={})",
-            entry->rows, rows_fail, s.ks_name(), s.cf_name(), pk));
-    }
-    if (entry->rows >= rows_warn) {
-        large_data_logger.warn("Large data guardrail: partition row count {} exceeds soft limit {} "
-            "(keyspace={}, table={}, partition_key={})",
-            entry->rows, rows_warn, s.ks_name(), s.cf_name(), pk);
-    }
+    auto context = [&] { return seastar::format("partition_key={}", pk); };
+    enforce_threshold<guardrail_source::replica>(s, entry->partition_size,
+        uint64_t(_cfg.partition_size_fail_threshold_mb()) * MB,
+        uint64_t(_cfg.partition_size_warn_threshold_mb()) * MB,
+        "partition size", context);
+    enforce_threshold<guardrail_source::replica>(s, entry->rows,
+        uint64_t(_cfg.rows_count_fail_threshold()),
+        uint64_t(_cfg.rows_count_warn_threshold()),
+        "partition row count", context);
 }
 
 void large_data_guardrail::check_rows_and_collections(const schema& s, bytes_view pk_bytes,
@@ -230,25 +239,16 @@ void large_data_guardrail::check_rows_and_collections(const schema& s, bytes_vie
 
 void large_data_guardrail::check_row_size(const schema& s, bytes_view pk_bytes, partition_key_view pk,
         bytes_view ck_bytes, const clustering_key_prefix* ck) const {
-    const uint64_t fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
-    const uint64_t warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
     auto row_size = _index.lookup_row(pk_bytes, ck_bytes);
     if (!row_size) [[likely]] {
         return;
     }
-    if (fail > 0 && *row_size >= fail) {
-        throw replica::large_data_exception(s.ks_name(), s.cf_name(), format(
-            "Large data guardrail: row size {} exceeds hard limit {} "
-            "(keyspace={}, table={}, clustering_key={})",
-            *row_size, fail, s.ks_name(), s.cf_name(),
-            ck ? format("{}", ck->with_schema(s)) : sstring()));
-    }
-    if (*row_size >= warn) {
-        large_data_logger.warn("Large data guardrail: row size {} exceeds soft limit {} "
-            "(keyspace={}, table={}, clustering_key={})",
-            *row_size, warn, s.ks_name(), s.cf_name(),
-            ck ? format("{}", ck->with_schema(s)) : sstring());
-    }
+    enforce_threshold<guardrail_source::replica>(s, *row_size,
+        uint64_t(_cfg.row_size_fail_threshold_mb()) * MB,
+        uint64_t(_cfg.row_size_warn_threshold_mb()) * MB,
+        "row size",
+        [&] { return seastar::format("clustering_key={}",
+            ck ? seastar::format("{}", ck->with_schema(s)) : sstring()); });
 }
 
 void large_data_guardrail::check_collection_element_count(const schema& s, bytes_view pk_bytes, partition_key_view pk,
@@ -257,25 +257,75 @@ void large_data_guardrail::check_collection_element_count(const schema& s, bytes
     if (cdef.is_atomic()) {
         return;
     }
-    const uint64_t fail = uint64_t(_cfg.collection_elements_fail_threshold());
-    const uint64_t warn = uint64_t(_cfg.collection_elements_warn_threshold());
     auto col_bytes = to_bytes(cdef.name_as_text());
     auto count = _index.lookup_collection(pk_bytes, ck_bytes, bytes_view(col_bytes));
     if (!count) [[likely]] {
         return;
     }
-    if (fail > 0 && *count >= fail) {
-        throw replica::large_data_exception(s.ks_name(), s.cf_name(), format(
-            "Large data guardrail: collection element count {} exceeds hard limit {} "
-            "(keyspace={}, table={}, column={}, clustering_key={})",
-            *count, fail, s.ks_name(), s.cf_name(), cdef.name_as_text(),
-            ck ? format("{}", ck->with_schema(s)) : sstring()));
+    enforce_threshold<guardrail_source::replica>(s, *count,
+        uint64_t(_cfg.collection_elements_fail_threshold()),
+        uint64_t(_cfg.collection_elements_warn_threshold()),
+        "collection element count",
+        [&] { return seastar::format("column={}, clustering_key={}",
+            cdef.name_as_text(),
+            ck ? seastar::format("{}", ck->with_schema(s)) : sstring()); });
+}
+
+void large_data_guardrail::check_coordinator(const schema& s, const mutation_partition& mp,
+        partition_key_view pk) const {
+    const uint64_t cell_fail = uint64_t(_cfg.cell_size_fail_threshold_mb()) * MB;
+    const uint64_t cell_warn = uint64_t(_cfg.cell_size_warn_threshold_mb()) * MB;
+    const uint64_t row_fail = uint64_t(_cfg.row_size_fail_threshold_mb()) * MB;
+    const uint64_t row_warn = uint64_t(_cfg.row_size_warn_threshold_mb()) * MB;
+    const uint64_t coll_fail = uint64_t(_cfg.collection_elements_fail_threshold());
+    const uint64_t coll_warn = uint64_t(_cfg.collection_elements_warn_threshold());
+
+    auto check_cell = [&](const column_definition& cdef, const atomic_cell_or_collection& cell) {
+        if (!cdef.is_atomic()) {
+            return;
+        }
+        auto acv = cell.as_atomic_cell(cdef);
+        if (!acv.is_live()) {
+            return;
+        }
+        enforce_threshold<guardrail_source::coordinator>(s, acv.value_size(),
+            cell_fail, cell_warn, "cell value size",
+            [&] { return seastar::format("column={}", cdef.name_as_text()); });
+    };
+
+    auto check_collection = [&](const column_definition& cdef, const atomic_cell_or_collection& cell) {
+        if (cdef.is_atomic()) {
+            return;
+        }
+        enforce_threshold<guardrail_source::coordinator>(s, cell.as_collection_mutation().size(),
+            coll_fail, coll_warn, "collection element count",
+            [&] { return seastar::format("column={}", cdef.name_as_text()); });
+    };
+
+    if (!mp.static_row().empty()) {
+        auto static_size = mp.static_row().external_memory_usage(s, column_kind::static_column);
+        enforce_threshold<guardrail_source::coordinator>(s, static_size,
+            row_fail, row_warn, "static row size",
+            [&] { return seastar::format("partition_key={}", pk); });
+        mp.static_row().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
+            const column_definition& cdef = s.static_column_at(id);
+            check_cell(cdef, cell);
+            check_collection(cdef, cell);
+        });
     }
-    if (*count >= warn) {
-        large_data_logger.warn("Large data guardrail: collection element count {} exceeds soft limit {} "
-            "(keyspace={}, table={}, column={}, clustering_key={})",
-            *count, warn, s.ks_name(), s.cf_name(), cdef.name_as_text(),
-            ck ? format("{}", ck->with_schema(s)) : sstring());
+
+    for (const rows_entry& e : mp.clustered_rows()) {
+        if (e.dummy()) {
+            continue;
+        }
+        enforce_threshold<guardrail_source::coordinator>(s, e.memory_usage(s),
+            row_fail, row_warn, "row size",
+            [&] { return seastar::format("clustering_key={}", e.key().with_schema(s)); });
+        e.row().cells().for_each_cell([&](column_id id, const atomic_cell_or_collection& cell) {
+            const column_definition& cdef = s.regular_column_at(id);
+            check_cell(cdef, cell);
+            check_collection(cdef, cell);
+        });
     }
 }
 

--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <optional>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/future.hh>
 #include <boost/intrusive/set.hpp>
 #include "bytes.hh"
 #include "schema/schema_fwd.hh"
@@ -114,24 +115,40 @@ private:
 };
 
 struct guardrail_config {
+    // Partition thresholds (replica-side only — checked via SSTable metadata index)
     utils::updateable_value<uint32_t> partition_size_fail_threshold_mb;
     utils::updateable_value<uint32_t> partition_size_warn_threshold_mb;
     utils::updateable_value<uint32_t> rows_count_fail_threshold;
     utils::updateable_value<uint32_t> rows_count_warn_threshold;
+    // Row thresholds (shared: replica checks on-disk size, coordinator checks mutation memory)
     utils::updateable_value<uint32_t> row_size_fail_threshold_mb;
     utils::updateable_value<uint32_t> row_size_warn_threshold_mb;
+    // Collection thresholds (shared: replica checks SSTable metadata, coordinator checks mutation)
     utils::updateable_value<uint32_t> collection_elements_fail_threshold;
     utils::updateable_value<uint32_t> collection_elements_warn_threshold;
+    // Cell thresholds (coordinator-side only — checked from mutation content)
+    utils::updateable_value<uint32_t> cell_size_fail_threshold_mb;
+    utils::updateable_value<uint32_t> cell_size_warn_threshold_mb;
 };
 
-// Each replica::table holds a unique_ptr to either a real guardrail or a
+// Each replica::table holds a shared_ptr to either a real guardrail or a
 // noop.  The guardrail owns the per-table large_data_record_index, so
 // noop tables pay no index-maintenance cost.
+//
+// The guardrail provides two check methods:
+//   check()              — replica-side, uses SSTable metadata index
+//   check_coordinator()  — coordinator-side, checks mutation content directly
 class large_data_guardrail_base {
 public:
     virtual ~large_data_guardrail_base() = default;
+    // Replica-side check: looks up partition/row/collection in the SSTable
+    // metadata index and rejects or warns based on recorded on-disk sizes.
     virtual void check(const schema& s, const mutation_partition& mp,
-                       partition_key_view pk) const = 0;
+            partition_key_view pk) const = 0;
+    // Coordinator-side check: inspects the mutation content directly
+    // (cell value sizes, row memory usage, collection element counts).
+    virtual void check_coordinator(const schema& s, const mutation_partition& mp,
+            partition_key_view pk) const = 0;
     virtual void register_sstable(sstables::shared_sstable sst) = 0;
     virtual void rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) = 0;
 };
@@ -143,7 +160,9 @@ public:
         return inst;
     }
     void check(const schema&, const mutation_partition&,
-               partition_key_view) const override {}
+            partition_key_view) const override {}
+    void check_coordinator(const schema&, const mutation_partition&,
+            partition_key_view) const override {}
     void register_sstable(sstables::shared_sstable) override {}
     void rebuild(const std::unordered_set<sstables::shared_sstable>&) override {}
 };
@@ -154,7 +173,9 @@ public:
         : _cfg(std::move(cfg)) {}
 
     void check(const schema& s, const mutation_partition& mp,
-               partition_key_view pk) const override;
+            partition_key_view pk) const override;
+    void check_coordinator(const schema& s, const mutation_partition& mp,
+            partition_key_view pk) const override;
     void register_sstable(sstables::shared_sstable sst) override;
     void rebuild(const std::unordered_set<sstables::shared_sstable>& sstables) override;
 

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1635,6 +1635,8 @@ keyspace::make_column_family_config(const schema& s, const database& db) const {
         .row_size_warn_threshold_mb = db_config.compaction_large_row_warning_threshold_mb,
         .collection_elements_fail_threshold = db_config.large_collection_elements_fail_threshold,
         .collection_elements_warn_threshold = db_config.compaction_collection_elements_count_warning_threshold,
+        .cell_size_fail_threshold_mb = db_config.large_cell_fail_threshold_mb,
+        .cell_size_warn_threshold_mb = db_config.compaction_large_cell_warning_threshold_mb,
     };
 
     return cfg;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -65,6 +65,7 @@
 #include "service/migration_manager.hh"
 #include "service/client_state.hh"
 #include "service/paxos/proposal.hh"
+#include "db/large_data_handler.hh"
 #include "service/topology_mutation.hh"
 #include "locator/token_metadata.hh"
 #include <seastar/core/coroutine.hh>
@@ -4287,6 +4288,11 @@ storage_proxy::mutate_with_triggers(utils::chunked_vector<mutation> mutations, d
     clock_type::time_point timeout,
     bool should_mutate_atomically, tracing::trace_state_ptr tr_state, service_permit permit, db::allow_per_partition_rate_limit allow_limit, bool raw_counters, coordinator_mutate_options options) {
     warn(unimplemented::cause::TRIGGERS);
+
+    for (const mutation& m : mutations) {
+        m.schema()->table().get_large_data_guardrail()->check_coordinator(*m.schema(), m.partition(), m.key());
+    }
+
     if (should_mutate_atomically) {
         SCYLLA_ASSERT(!raw_counters);
         return mutate_atomically_result(std::move(mutations), cl, timeout, std::move(tr_state), std::move(permit), std::move(options));

--- a/test/boost/large_data_guardrail_test.cc
+++ b/test/boost/large_data_guardrail_test.cc
@@ -517,4 +517,50 @@ SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_frozen_not_checked_by_eleme
     BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
 }
 
+// Mixed guardrail tests
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_limit_independent_of_row_limit) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_limit_independent_of_cell_limit) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+// Per-table toggle and noop tests
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_noop_allows_everything) {
+    auto s = make_simple_schema();
+    auto m = make_mutation_with_cell(s, 2 * MB);
+    BOOST_REQUIRE_NO_THROW(
+        db::noop_large_data_guardrail::instance()->check(*m.schema(), m.partition(), m.key()));
+}
+
+BOOST_AUTO_TEST_CASE(test_per_table_guardrails_enabled_by_extension) {
+    auto s = schema_builder(1, "ks", "tbl_guardrails")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("v", bytes_type)
+        .set_large_data_guardrails_enabled(true)
+        .build();
+    BOOST_REQUIRE(s->large_data_guardrails_enabled());
+}
+
+BOOST_AUTO_TEST_CASE(test_per_table_guardrails_disabled_by_default) {
+    auto s = schema_builder(1, "ks", "tbl_no_guardrails")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("v", bytes_type)
+        .build();
+    BOOST_REQUIRE(!s->large_data_guardrails_enabled());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/large_data_guardrail_test.cc
+++ b/test/boost/large_data_guardrail_test.cc
@@ -366,4 +366,46 @@ SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_rejects_large_static_c
     BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
 }
 
+// Row guardrail tests
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_rejects_large_row) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_allows_small_row) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, 100);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_disabled_when_zero) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config();
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, 2 * MB);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_rejects_large_static_row) {
+    auto s = make_static_schema();
+    auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_static_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_allows_tombstone) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_tombstone(s);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/large_data_guardrail_test.cc
+++ b/test/boost/large_data_guardrail_test.cc
@@ -314,6 +314,53 @@ void coordinator_check(const db::large_data_guardrail& g, const mutation& m) {
     g.check_coordinator(*m.schema(), m.partition(), m.key());
 }
 
+schema_ptr make_set_schema() {
+    auto set_type = set_type_impl::get_instance(int32_type, true);
+    return schema_builder(1, "ks", "tbl")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("s", set_type)
+        .build();
+}
+
+schema_ptr make_static_set_schema() {
+    auto set_type = set_type_impl::get_instance(int32_type, true);
+    return schema_builder(1, "ks", "tbl")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("s", set_type, column_kind::static_column)
+        .build();
+}
+
+schema_ptr make_frozen_set_schema() {
+    auto set_type = set_type_impl::get_instance(int32_type, false);
+    return schema_builder(1, "ks", "tbl")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("v", set_type)
+        .build();
+}
+
+mutation make_mutation_with_set(schema_ptr s, size_t element_count, bool is_static = false) {
+    auto key = partition_key::from_exploded(*s, {to_bytes("pk1")});
+    auto c_key = clustering_key::from_exploded(*s, {to_bytes("ck1")});
+    mutation m(s, key);
+    collection_mutation_writer w({});
+    for (size_t i = 0; i < element_count; ++i) {
+        auto key = int32_type->decompose(int(i));
+        w.push_back(
+            managed_bytes_view(bytes_view(key)),
+            atomic_cell::make_live(*bytes_type, 0, bytes_view(), atomic_cell::collection_member::yes));
+    }
+    const column_definition& col = *s->get_column_definition("s");
+    auto serialized = std::move(w).finish();
+    if (is_static) {
+        m.set_static_cell(col, std::move(serialized));
+    } else {
+        m.set_clustered_cell(c_key, col, std::move(serialized));
+    }
+    return m;
+}
+
 } // anonymous namespace
 
 // Cell guardrail tests
@@ -405,6 +452,68 @@ SEASTAR_THREAD_TEST_CASE(test_coordinator_row_hard_limit_allows_tombstone) {
     auto cfg = make_coordinator_config(0, 0, 1 /* row_fail_mb */);
     db::large_data_guardrail g(std::move(cfg));
     auto m = make_mutation_with_tombstone(s);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+// Collection guardrail tests
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_hard_limit_rejects_large_set) {
+    auto s = make_set_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 100 /* collection_fail */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 101);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_hard_limit_allows_small_set) {
+    auto s = make_set_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 100 /* collection_fail */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 10);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_hard_limit_allows_at_threshold) {
+    auto s = make_set_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 100 /* collection_fail */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 100);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_hard_limit_disabled_when_zero) {
+    auto s = make_set_schema();
+    auto cfg = make_coordinator_config();
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 10000);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_hard_limit_rejects_large_static_set) {
+    auto s = make_static_set_schema();
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 100 /* collection_fail */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_set(s, 101, true /* is_static */);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_collection_frozen_not_checked_by_element_count) {
+    auto s = make_frozen_set_schema();
+    auto set_type = set_type_impl::get_instance(int32_type, false);
+    auto key = partition_key::from_exploded(*s, {to_bytes("pk1")});
+    mutation m(s, key);
+
+    set_type_impl::native_type elements;
+    for (int i = 0; i < 200; ++i) {
+        elements.push_back(data_value(i));
+    }
+    auto frozen_value = make_set_value(set_type, std::move(elements));
+    const column_definition& v_col = *s->get_column_definition("v");
+    auto cell = atomic_cell::make_live(*set_type, 0, frozen_value.serialize_nonnull());
+    m.set_clustered_cell(clustering_key::make_empty(), v_col, std::move(cell));
+
+    auto cfg = make_coordinator_config(0, 0, 0, 0, 100 /* collection_fail */);
+    db::large_data_guardrail g(std::move(cfg));
     BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
 }
 

--- a/test/boost/large_data_guardrail_test.cc
+++ b/test/boost/large_data_guardrail_test.cc
@@ -8,7 +8,15 @@
 
 #include <boost/test/unit_test.hpp>
 #include <deque>
+#undef SEASTAR_TESTING_MAIN
+#include <seastar/testing/thread_test_case.hh>
 #include "db/large_data_handler.hh"
+#include "mutation/mutation.hh"
+#include "mutation/atomic_cell.hh"
+#include "mutation/collection_mutation.hh"
+#include "schema/schema_builder.hh"
+#include "exceptions/exceptions.hh"
+#include "types/set.hh"
 
 using sstables::large_data_record;
 using sstables::large_data_type;
@@ -228,6 +236,134 @@ BOOST_AUTO_TEST_CASE(test_auto_unlink_on_record_destruction) {
     }
     // store destroyed → records destroyed → auto_unlink fires
     BOOST_REQUIRE(set.empty());
+}
+
+// ---------------------------------------------------------------------------
+// Coordinator guardrail tests
+// ---------------------------------------------------------------------------
+
+namespace {
+
+constexpr uint64_t MB = 1024 * 1024;
+
+schema_ptr make_simple_schema() {
+    return schema_builder(1, "ks", "tbl")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("v", bytes_type)
+        .build();
+}
+
+schema_ptr make_static_schema() {
+    return schema_builder(1, "ks", "tbl")
+        .with_column("pk", utf8_type, column_kind::partition_key)
+        .with_column("ck", utf8_type, column_kind::clustering_key)
+        .with_column("s", bytes_type, column_kind::static_column)
+        .with_column("v", bytes_type)
+        .build();
+}
+
+mutation make_mutation_with_cell(schema_ptr s, size_t value_size) {
+    auto key = partition_key::from_exploded(*s, {to_bytes("pk1")});
+    auto c_key = clustering_key::from_exploded(*s, {to_bytes("ck1")});
+    mutation m(s, key);
+    auto cell = atomic_cell::make_live(*bytes_type, 0, bytes(value_size, 'x'));
+    const column_definition& v_col = *s->get_column_definition("v");
+    m.set_clustered_cell(c_key, v_col, std::move(cell));
+    return m;
+}
+
+mutation make_mutation_with_static_cell(schema_ptr s, size_t value_size) {
+    auto key = partition_key::from_exploded(*s, {to_bytes("pk1")});
+    mutation m(s, key);
+    auto cell = atomic_cell::make_live(*bytes_type, 0, bytes(value_size, 'x'));
+    const column_definition& s_col = *s->get_column_definition("s");
+    m.set_static_cell(s_col, std::move(cell));
+    return m;
+}
+
+mutation make_mutation_with_tombstone(schema_ptr s) {
+    auto key = partition_key::from_exploded(*s, {to_bytes("pk1")});
+    auto c_key = clustering_key::from_exploded(*s, {to_bytes("ck1")});
+    mutation m(s, key);
+    const column_definition& v_col = *s->get_column_definition("v");
+    auto cell = atomic_cell::make_dead(0, gc_clock::now());
+    m.set_clustered_cell(c_key, v_col, std::move(cell));
+    return m;
+}
+
+db::guardrail_config make_coordinator_config(
+        uint32_t cell_fail_mb = 0, uint32_t cell_warn_mb = 0,
+        uint32_t row_fail_mb = 0, uint32_t row_warn_mb = 0,
+        uint32_t collection_fail = 0, uint32_t collection_warn = 0) {
+    return db::guardrail_config{
+        .partition_size_fail_threshold_mb = utils::updateable_value<uint32_t>(0),
+        .partition_size_warn_threshold_mb = utils::updateable_value<uint32_t>(0),
+        .rows_count_fail_threshold = utils::updateable_value<uint32_t>(0),
+        .rows_count_warn_threshold = utils::updateable_value<uint32_t>(0),
+        .row_size_fail_threshold_mb = utils::updateable_value<uint32_t>(row_fail_mb),
+        .row_size_warn_threshold_mb = utils::updateable_value<uint32_t>(row_warn_mb),
+        .collection_elements_fail_threshold = utils::updateable_value<uint32_t>(collection_fail),
+        .collection_elements_warn_threshold = utils::updateable_value<uint32_t>(collection_warn),
+        .cell_size_fail_threshold_mb = utils::updateable_value<uint32_t>(cell_fail_mb),
+        .cell_size_warn_threshold_mb = utils::updateable_value<uint32_t>(cell_warn_mb),
+    };
+}
+
+void coordinator_check(const db::large_data_guardrail& g, const mutation& m) {
+    g.check_coordinator(*m.schema(), m.partition(), m.key());
+}
+
+} // anonymous namespace
+
+// Cell guardrail tests
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_rejects_large_cell) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_allows_small_cell) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, 100);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_allows_at_threshold) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, MB);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_disabled_when_zero) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config();
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_cell(s, 2 * MB);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_allows_tombstone) {
+    auto s = make_simple_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_tombstone(s);
+    BOOST_REQUIRE_NO_THROW(coordinator_check(g, m));
+}
+
+SEASTAR_THREAD_TEST_CASE(test_coordinator_cell_hard_limit_rejects_large_static_cell) {
+    auto s = make_static_schema();
+    auto cfg = make_coordinator_config(1 /* cell_fail_mb */);
+    db::large_data_guardrail g(std::move(cfg));
+    auto m = make_mutation_with_static_cell(s, MB + 1);
+    BOOST_REQUIRE_THROW(coordinator_check(g, m), exceptions::invalid_request_exception);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/cqlpy/test_coordinator_guardrail_large_cell.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_cell.py
@@ -1,0 +1,251 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import io
+import re
+import time
+
+import pytest
+
+from cassandra.protocol import InvalidRequest
+
+from .test_logs import logfile_path, logfile, wait_for_log
+from .util import config_value_context, new_test_table
+
+
+WARN_RE = r"WARN .+large_data - Large data guardrail: cell value size .+ exceeds soft limit"
+
+
+def assert_no_log(logfile, pattern, action, settle=0.5):
+    logfile.seek(0, io.SEEK_END)
+    action()
+    time.sleep(settle)
+    contents = logfile.read()
+    assert not re.search(pattern, contents), \
+        f"Unexpected log message matching {pattern}"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+
+@pytest.fixture(scope="module")
+def test_table(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        yield table
+
+
+@pytest.fixture(scope="module")
+def test_table_with_static(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, s blob STATIC, v blob, PRIMARY KEY (pk, ck)",
+        " WITH large_data_guardrails_enabled = true",
+    ) as table:
+        yield table
+
+
+def make_blob(size_bytes):
+    return bytes(size_bytes)
+
+
+# --- Hard limit tests (rejection) ---
+
+
+def test_hard_limit_rejects_large_insert(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [2, make_blob(1048576 + 1)])
+
+
+def test_hard_limit_rejects_large_update(cql, test_table):
+    update = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ?")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(update, [make_blob(1048576 + 1), 1])
+
+
+def test_hard_limit_rejects_batch(cql, test_table):
+    batch = cql.prepare(f"BEGIN BATCH INSERT INTO {test_table} (pk, v) VALUES (1, ?) APPLY BATCH")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(batch, [make_blob(1048576 + 1)])
+
+
+def test_hard_limit_disabled_when_zero(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "0"):
+        cql.execute(insert, [1, make_blob(2 * 1024 * 1024)])
+
+
+def test_hard_limit_includes_column_info(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)column=") as exc_info:
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+        msg = str(exc_info.value).lower()
+        assert "keyspace=" in msg
+        assert "table=" in msg
+
+
+# --- Soft limit tests ---
+
+
+def test_soft_limit_write_succeeds(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"):
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "0"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_soft_limit_no_rejection_when_below_threshold_default(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    cql.execute(insert, [1, make_blob(100)])
+
+
+def test_soft_limit_logs_warning(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"):
+            with config_value_context(cql, "large_cell_fail_threshold_mb", "0"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+        wait_for_log(logfile, WARN_RE, timeout=5)
+
+
+def test_soft_limit_no_warning_below_threshold(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"):
+            with config_value_context(cql, "large_cell_fail_threshold_mb", "0"):
+                assert_no_log(logfile, WARN_RE,
+                              lambda: cql.execute(insert, [1, b"\x00"]))
+
+
+# --- Static column tests ---
+
+
+def test_hard_limit_rejects_large_static_cell(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [1, 1, make_blob(1048576 + 1)])
+
+
+def test_soft_limit_allows_large_static_cell(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "compaction_large_cell_warning_threshold_mb", "1"):
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "0"):
+            cql.execute(insert, [1, 1, make_blob(1048576 + 1)])
+
+
+# --- DELETE tests ---
+
+
+def test_delete_always_allowed(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        cql.execute(f"DELETE FROM {test_table} WHERE pk = 1")
+
+
+def test_delete_in_batch_always_allowed(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        cql.execute(f"BEGIN BATCH DELETE FROM {test_table} WHERE pk = 1 APPLY BATCH")
+
+
+# --- Edge case tests ---
+
+
+def test_at_hard_limit_succeeds(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, make_blob(1048576)])
+
+
+# --- LWT exemption tests ---
+# LWT (Paxos) writes are exempt from coordinator-side guardrails because
+# the mutation is not available until after the Paxos prepare round, and
+# abandoning mid-round would violate linearizability (see issue #6299).
+
+
+def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table):
+    """LWT INSERT with large cell must not be rejected by coordinator guardrail."""
+    insert_if = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?) IF NOT EXISTS")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert_if, [100, make_blob(1048576 + 1)])
+
+
+def test_lwt_update_exempt_from_coordinator_guardrail(cql, test_table):
+    """LWT UPDATE with large cell must not be rejected by coordinator guardrail."""
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    update_if = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ? IF v != null")
+    with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+        cql.execute(insert, [102, b"\x00"])
+        cql.execute(update_if, [make_blob(1048576 + 1), 102])
+
+
+# --- Per-table guardrail toggle tests ---
+
+
+def test_per_table_guardrails_disabled_allows_large_cell(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = false",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_per_table_guardrails_enabled_rejects_large_cell(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_alter_table_disable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = false")
+            cql.execute(insert, [2, make_blob(1048576 + 1)])
+
+
+def test_alter_table_reenable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_cell_fail_threshold_mb", "1"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = true")
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [2, make_blob(1048576 + 1)])

--- a/test/cqlpy/test_coordinator_guardrail_large_collection.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_collection.py
@@ -1,0 +1,258 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import io
+import re
+import time
+
+import pytest
+
+from cassandra.protocol import InvalidRequest
+
+from .test_logs import logfile_path, logfile, wait_for_log
+from .util import config_value_context, new_test_table
+
+
+WARN_RE = r"WARN .+large_data - Large data guardrail: collection element count .+ exceeds soft limit"
+
+
+def assert_no_log(logfile, pattern, action, settle=0.5):
+    logfile.seek(0, io.SEEK_END)
+    action()
+    time.sleep(settle)
+    contents = logfile.read()
+    assert not re.search(pattern, contents), \
+        f"Unexpected log message matching {pattern}"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+
+@pytest.fixture(scope="module")
+def test_table_set(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        yield table
+
+
+@pytest.fixture(scope="module")
+def test_table_with_static(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, s set<int> STATIC, v int, PRIMARY KEY (pk, ck)",
+        " WITH large_data_guardrails_enabled = true",
+    ) as table:
+        yield table
+
+
+def make_set(n):
+    """Create a set with n elements."""
+    return set(range(n))
+
+
+# --- Hard limit tests (rejection) ---
+
+
+def test_hard_limit_rejects_large_set_insert(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        cql.execute(insert, [1, make_set(3)])
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [2, make_set(6)])
+
+
+def test_hard_limit_rejects_large_list_insert(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v list<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, list(range(6))])
+
+
+def test_hard_limit_rejects_large_map_insert(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v map<int, int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, {i: i for i in range(6)}])
+
+
+def test_hard_limit_rejects_large_collection_update(cql, test_table_set):
+    update = cql.prepare(f"UPDATE {test_table_set} SET v = ? WHERE pk = ?")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(update, [make_set(6), 1])
+
+
+def test_hard_limit_rejects_batch(cql, test_table_set):
+    batch = cql.prepare(f"BEGIN BATCH INSERT INTO {test_table_set} (pk, v) VALUES (1, ?) APPLY BATCH")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(batch, [make_set(6)])
+
+
+def test_hard_limit_disabled_when_zero(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "0"):
+        cql.execute(insert, [1, make_set(100)])
+
+
+def test_hard_limit_includes_column_info(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        with pytest.raises(InvalidRequest, match="(?i)column=") as exc_info:
+            cql.execute(insert, [1, make_set(6)])
+        msg = str(exc_info.value).lower()
+        assert "keyspace=" in msg
+        assert "table=" in msg
+
+
+def test_at_hard_limit_succeeds(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        cql.execute(insert, [1, make_set(5)])
+
+
+# --- Soft limit tests ---
+
+
+def test_soft_limit_write_succeeds(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"):
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "0"):
+            cql.execute(insert, [1, make_set(6)])
+
+
+def test_soft_limit_no_rejection_when_below_threshold_default(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    cql.execute(insert, [1, make_set(3)])
+
+
+def test_soft_limit_logs_warning(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"):
+            with config_value_context(cql, "large_collection_elements_fail_threshold", "0"):
+                cql.execute(insert, [1, make_set(6)])
+        wait_for_log(logfile, WARN_RE, timeout=5)
+
+
+def test_soft_limit_no_warning_below_threshold(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v set<int>",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"):
+            with config_value_context(cql, "large_collection_elements_fail_threshold", "0"):
+                assert_no_log(logfile, WARN_RE,
+                              lambda: cql.execute(insert, [1, make_set(3)]))
+
+
+# --- Static collection tests ---
+
+
+def test_hard_limit_rejects_large_static_collection(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [1, 1, make_set(6)])
+
+
+def test_soft_limit_allows_large_static_collection(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "compaction_collection_elements_count_warning_threshold", "5"):
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "0"):
+            cql.execute(insert, [1, 1, make_set(6)])
+
+
+# --- DELETE tests ---
+
+
+def test_delete_always_allowed(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        cql.execute(insert, [1, make_set(3)])
+        cql.execute(f"DELETE FROM {test_table_set} WHERE pk = 1")
+
+
+def test_delete_in_batch_always_allowed(cql, test_table_set):
+    insert = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        cql.execute(insert, [1, make_set(3)])
+        cql.execute(f"BEGIN BATCH DELETE FROM {test_table_set} WHERE pk = 1 APPLY BATCH")
+
+
+# --- LWT exemption tests ---
+# LWT (Paxos) writes are exempt from coordinator-side guardrails because
+# the mutation is not available until after the Paxos prepare round, and
+# abandoning mid-round would violate linearizability (see issue #6299).
+
+
+def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table_set):
+    """LWT INSERT with large collection must not be rejected by coordinator guardrail."""
+    insert_if = cql.prepare(f"INSERT INTO {test_table_set} (pk, v) VALUES (?, ?) IF NOT EXISTS")
+    with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+        cql.execute(insert_if, [100, make_set(6)])
+
+
+# --- Per-table guardrail toggle tests ---
+
+
+def test_per_table_guardrails_disabled_allows_large_collection(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v set<int>",
+        extra=" WITH large_data_guardrails_enabled = false",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            cql.execute(insert, [1, make_set(6)])
+
+
+def test_per_table_guardrails_enabled_rejects_large_collection(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v set<int>",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_set(6)])
+
+
+def test_alter_table_disable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v set<int>",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_set(6)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = false")
+            cql.execute(insert, [2, make_set(6)])
+
+
+def test_alter_table_reenable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v set<int>",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_collection_elements_fail_threshold", "5"):
+            cql.execute(insert, [1, make_set(6)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = true")
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [2, make_set(6)])

--- a/test/cqlpy/test_coordinator_guardrail_large_row.py
+++ b/test/cqlpy/test_coordinator_guardrail_large_row.py
@@ -1,0 +1,242 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+import io
+import re
+import time
+
+import pytest
+
+from cassandra.protocol import InvalidRequest
+
+from .test_logs import logfile_path, logfile, wait_for_log
+from .util import config_value_context, new_test_table
+
+
+WARN_RE = r"WARN .+large_data - Large data guardrail: (?:static )?row size .+ exceeds soft limit"
+
+
+def assert_no_log(logfile, pattern, action, settle=0.5):
+    logfile.seek(0, io.SEEK_END)
+    action()
+    time.sleep(settle)
+    contents = logfile.read()
+    assert not re.search(pattern, contents), \
+        f"Unexpected log message matching {pattern}"
+
+
+@pytest.fixture(scope="function", autouse=True)
+def all_tests_are_scylla_only(scylla_only):
+    pass
+
+
+@pytest.fixture(scope="module")
+def test_table(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        yield table
+
+
+@pytest.fixture(scope="module")
+def test_table_with_static(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int, ck int, s blob STATIC, v blob, PRIMARY KEY (pk, ck)",
+        " WITH large_data_guardrails_enabled = true",
+    ) as table:
+        yield table
+
+
+def make_blob(size_bytes):
+    return bytes(size_bytes)
+
+
+# --- Hard limit tests (rejection) ---
+
+
+def test_hard_limit_rejects_large_row_insert(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [2, make_blob(1048576 + 1)])
+
+
+def test_hard_limit_rejects_large_row_update(cql, test_table):
+    update = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ?")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(update, [make_blob(1048576 + 1), 1])
+
+
+def test_hard_limit_rejects_batch(cql, test_table):
+    batch = cql.prepare(f"BEGIN BATCH INSERT INTO {test_table} (pk, v) VALUES (1, ?) APPLY BATCH")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(batch, [make_blob(1048576 + 1)])
+
+
+def test_hard_limit_disabled_when_zero(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "0"):
+        cql.execute(insert, [1, make_blob(2 * 1024 * 1024)])
+
+
+def test_hard_limit_includes_table_info(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail") as exc_info:
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+        msg = str(exc_info.value).lower()
+        assert "keyspace=" in msg
+        assert "table=" in msg
+
+
+# --- Soft limit tests ---
+
+
+def test_soft_limit_write_succeeds(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"):
+        with config_value_context(cql, "large_row_fail_threshold_mb", "0"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_soft_limit_no_rejection_when_below_threshold_default(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    cql.execute(insert, [1, make_blob(100)])
+
+
+def test_soft_limit_logs_warning(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"):
+            with config_value_context(cql, "large_row_fail_threshold_mb", "0"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+        wait_for_log(logfile, WARN_RE, timeout=5)
+
+
+def test_soft_limit_no_warning_below_threshold(cql, test_keyspace, logfile):
+    with new_test_table(cql, test_keyspace, "pk int PRIMARY KEY, v blob",
+                        " WITH large_data_guardrails_enabled = true") as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"):
+            with config_value_context(cql, "large_row_fail_threshold_mb", "0"):
+                assert_no_log(logfile, WARN_RE,
+                              lambda: cql.execute(insert, [1, b"\x00"]))
+
+
+# --- Static row tests ---
+
+
+def test_hard_limit_rejects_large_static_row(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+            cql.execute(insert, [1, 1, make_blob(1048576 + 1)])
+
+
+def test_soft_limit_allows_large_static_row(cql, test_table_with_static):
+    insert = cql.prepare(f"INSERT INTO {test_table_with_static} (pk, ck, s) VALUES (?, ?, ?)")
+    with config_value_context(cql, "compaction_large_row_warning_threshold_mb", "1"):
+        with config_value_context(cql, "large_row_fail_threshold_mb", "0"):
+            cql.execute(insert, [1, 1, make_blob(1048576 + 1)])
+
+
+# --- DELETE tests ---
+
+
+def test_delete_always_allowed(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        cql.execute(f"DELETE FROM {test_table} WHERE pk = 1")
+
+
+def test_delete_in_batch_always_allowed(cql, test_table):
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        cql.execute(insert, [1, b"\x00"])
+        cql.execute(f"BEGIN BATCH DELETE FROM {test_table} WHERE pk = 1 APPLY BATCH")
+
+
+# --- LWT exemption tests ---
+# LWT (Paxos) writes are exempt from coordinator-side guardrails because
+# the mutation is not available until after the Paxos prepare round, and
+# abandoning mid-round would violate linearizability (see issue #6299).
+
+
+def test_lwt_insert_exempt_from_coordinator_guardrail(cql, test_table):
+    """LWT INSERT with large row must not be rejected by coordinator guardrail."""
+    insert_if = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?) IF NOT EXISTS")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        cql.execute(insert_if, [100, make_blob(1048576 + 1)])
+
+
+def test_lwt_update_exempt_from_coordinator_guardrail(cql, test_table):
+    """LWT UPDATE with large row must not be rejected by coordinator guardrail."""
+    insert = cql.prepare(f"INSERT INTO {test_table} (pk, v) VALUES (?, ?)")
+    update_if = cql.prepare(f"UPDATE {test_table} SET v = ? WHERE pk = ? IF v != null")
+    with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+        cql.execute(insert, [102, b"\x00"])
+        cql.execute(update_if, [make_blob(1048576 + 1), 102])
+
+
+# --- Per-table guardrail toggle tests ---
+
+
+def test_per_table_guardrails_disabled_allows_large_row(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = false",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_per_table_guardrails_enabled_rejects_large_row(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+
+
+def test_alter_table_disable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+        extra=" WITH large_data_guardrails_enabled = true",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [1, make_blob(1048576 + 1)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = false")
+            cql.execute(insert, [2, make_blob(1048576 + 1)])
+
+
+def test_alter_table_reenable_guardrails(cql, test_keyspace):
+    with new_test_table(
+        cql,
+        test_keyspace,
+        "pk int PRIMARY KEY, v blob",
+    ) as table:
+        insert = cql.prepare(f"INSERT INTO {table} (pk, v) VALUES (?, ?)")
+        with config_value_context(cql, "large_row_fail_threshold_mb", "1"):
+            cql.execute(insert, [1, make_blob(1048576 + 1)])
+            cql.execute(f"ALTER TABLE {table} WITH large_data_guardrails_enabled = true")
+            with pytest.raises(InvalidRequest, match="(?i)large data guardrail"):
+                cql.execute(insert, [2, make_blob(1048576 + 1)])

--- a/test/cqlpy/test_large_data_guardrail.py
+++ b/test/cqlpy/test_large_data_guardrail.py
@@ -36,15 +36,20 @@ WARN_RE = "Large data guardrail"
 
 def make_oversized_partition(cql, tbl, pk, num_rows, value_size_bytes):
     """Insert `num_rows` rows of `value_size_bytes` blobs under partition key `pk`."""
-    insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+    insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
     for ck in range(num_rows):
         cql.execute(insert, [pk, ck, bytes(value_size_bytes)])
 
 
 def make_large_row(cql, tbl, pk, ck, value_size_bytes):
-    """Insert a single row with a blob of `value_size_bytes` under (pk, ck)."""
-    insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
-    cql.execute(insert, [pk, ck, bytes(value_size_bytes)])
+    """Insert a single row whose total size is `value_size_bytes` under (pk, ck),
+    split across v1 and v2 in separate mutations to keep each below coordinator
+    thresholds."""
+    half = value_size_bytes // 2
+    insert_v1 = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
+    insert_v2 = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v2) VALUES (?, ?, ?)")
+    cql.execute(insert_v1, [pk, ck, bytes(half)])
+    cql.execute(insert_v2, [pk, ck, bytes(value_size_bytes - half)])
 
 
 def build_large_collection(cql, tbl, pk, ck, num_elements):
@@ -97,14 +102,14 @@ def test_partition_size_rejects_after_flush(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_PARTITION_RE):
                 cql.execute(insert, [1, 99, b"\x00"])
 
@@ -120,14 +125,14 @@ def test_partition_size_disabled_when_zero(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '0'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 99, b"\x00"])
 
 
@@ -146,14 +151,14 @@ def test_partition_rows_rejects_after_flush(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'rows_count_fail_threshold', '50'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=60,
                                     value_size_bytes=8)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_PARTITION_RE):
                 cql.execute(insert, [1, 999, b"\x00"])
 
@@ -172,14 +177,14 @@ def test_partition_size_soft_limit_logs_warning(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '10'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 99, b"\x00"])
 
             wait_for_log(logfile, WARN_RE, timeout=5)
@@ -196,14 +201,14 @@ def test_partition_rows_soft_limit_logs_warning(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'rows_count_fail_threshold', '1000'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=60,
                                     value_size_bytes=8)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 999, b"\x00"])
 
             wait_for_log(logfile, WARN_RE, timeout=5)
@@ -217,10 +222,10 @@ def test_partition_no_warning_below_soft_limit(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '10'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 0, b"\x00"])
             nodetool.flush(cql, tbl)
 
@@ -241,14 +246,14 @@ def test_row_size_rejects_after_flush(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_row_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_large_row(cql, tbl, pk=1, ck=0,
                            value_size_bytes=1200 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_ROW_RE):
                 cql.execute(insert, [1, 0, b"\x00"])
 
@@ -266,14 +271,14 @@ def test_row_size_disabled_when_zero(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_row_fail_threshold_mb', '0'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_large_row(cql, tbl, pk=1, ck=0,
                            value_size_bytes=1200 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 0, b"\x00"])
 
 
@@ -291,14 +296,14 @@ def test_row_size_soft_limit_logs_warning(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_row_fail_threshold_mb', '10'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_large_row(cql, tbl, pk=1, ck=0,
                            value_size_bytes=1200 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 0, b"\x00"])
 
             wait_for_log(logfile, WARN_RE, timeout=5)
@@ -312,10 +317,10 @@ def test_row_no_warning_below_soft_limit(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_row_fail_threshold_mb', '10'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 0, b"\x00"])
             nodetool.flush(cql, tbl)
 
@@ -436,14 +441,14 @@ def test_per_table_disabled_at_create(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = false") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 99, b"\x00"])
 
 
@@ -456,14 +461,14 @@ def test_per_table_alter_disable(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_PARTITION_RE):
                 cql.execute(insert, [1, 99, b"\x00"])
 
@@ -480,14 +485,14 @@ def test_per_table_alter_reenable(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = false") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
                                     value_size_bytes=600 * 1024)
             nodetool.flush(cql, tbl)
 
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             cql.execute(insert, [1, 99, b"\x00"])
 
             cql.execute(f"ALTER TABLE {tbl} WITH large_data_guardrails_enabled = true")
@@ -508,7 +513,7 @@ def test_lwt_paxos_learn_is_exempt(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_partition_fail_threshold_mb', '1'))
 
-        schema = "pk int, ck int, v blob, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             make_oversized_partition(cql, tbl, pk=1, num_rows=2,
@@ -516,13 +521,13 @@ def test_lwt_paxos_learn_is_exempt(cql, test_keyspace):
             nodetool.flush(cql, tbl)
 
             # Non-LWT write is rejected.
-            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
             with pytest.raises(WriteFailure, match=REJECT_PARTITION_RE):
                 cql.execute(insert, [1, 99, b"\x00"])
 
             # LWT write succeeds (Paxos learn bypasses guardrail).
             lwt = cql.prepare(
-                f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?) IF NOT EXISTS")
+                f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?) IF NOT EXISTS")
             cql.execute(lwt, [1, 100, b"\x00"])
 
 
@@ -550,12 +555,16 @@ def test_all_guardrails_warn_independently(cql, test_keyspace, logfile):
         cfg.enter_context(config_value_context(cql,
             'large_collection_elements_fail_threshold', '0'))
 
-        schema = "pk int, ck int, v blob, s set<int>, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, s set<int>, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
             # Build data large in all three dimensions under pk=1, ck=0.
-            insert_v = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
-            cql.execute(insert_v, [1, 0, bytes(1200 * 1024)])
+            # Split the row across v1/v2 in separate mutations so each
+            # stays below coordinator thresholds.
+            insert_v1 = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
+            insert_v2 = cql.prepare(f"INSERT INTO {tbl} (pk, ck, v2) VALUES (?, ?, ?)")
+            cql.execute(insert_v1, [1, 0, bytes(600 * 1024)])
+            cql.execute(insert_v2, [1, 0, bytes(600 * 1024)])
             update_s = cql.prepare(
                 f"UPDATE {tbl} SET s = s + ? WHERE pk = ? AND ck = ?")
             for i in range(60):
@@ -564,7 +573,7 @@ def test_all_guardrails_warn_independently(cql, test_keyspace, logfile):
             nodetool.flush(cql, tbl)
 
             insert_both = cql.prepare(
-                f"INSERT INTO {tbl} (pk, ck, v, s) VALUES (?, ?, ?, ?)")
+                f"INSERT INTO {tbl} (pk, ck, v1, s) VALUES (?, ?, ?, ?)")
             cql.execute(insert_both, [1, 0, b"\x00", {999}])
 
             wait_for_all_logs(logfile, [
@@ -595,18 +604,22 @@ def test_each_guardrail_rejects_independently(cql, test_keyspace):
         cfg.enter_context(config_value_context(cql,
             'large_collection_elements_fail_threshold', '50'))
 
-        schema = "pk int, ck int, v blob, s set<int>, PRIMARY KEY (pk, ck)"
+        schema = "pk int, ck int, v1 blob, v2 blob, s set<int>, PRIMARY KEY (pk, ck)"
         with new_test_table(cql, test_keyspace, schema,
                 extra=" WITH large_data_guardrails_enabled = true") as tbl:
-            insert_v = cql.prepare(
-                f"INSERT INTO {tbl} (pk, ck, v) VALUES (?, ?, ?)")
+            insert_v1 = cql.prepare(
+                f"INSERT INTO {tbl} (pk, ck, v1) VALUES (?, ?, ?)")
 
             # pk=1: 20 rows x 150 KB ~ 3 MB partition, each row < 1 MB.
             for ck in range(20):
-                cql.execute(insert_v, [1, ck, bytes(150 * 1024)])
+                cql.execute(insert_v1, [1, ck, bytes(150 * 1024)])
 
-            # pk=2: single 1.2 MB row; partition total < 2 MB.
-            cql.execute(insert_v, [2, 0, bytes(1200 * 1024)])
+            # pk=2: single 1.2 MB row split across v1/v2 in separate
+            # mutations so each stays below coordinator thresholds.
+            insert_v2 = cql.prepare(
+                f"INSERT INTO {tbl} (pk, ck, v2) VALUES (?, ?, ?)")
+            cql.execute(insert_v1, [2, 0, bytes(600 * 1024)])
+            cql.execute(insert_v2, [2, 0, bytes(600 * 1024)])
 
             # pk=3: 60-element collection; row and partition tiny.
             update_s = cql.prepare(
@@ -618,13 +631,13 @@ def test_each_guardrail_rejects_independently(cql, test_keyspace):
 
             # Partition rejection.
             with pytest.raises(WriteFailure, match="(?i)partition size.*exceeds"):
-                cql.execute(insert_v, [1, 99, b"\x00"])
+                cql.execute(insert_v1, [1, 99, b"\x00"])
 
             # Row rejection.
             with pytest.raises(WriteFailure, match="(?i)row size.*exceeds"):
-                cql.execute(insert_v, [2, 0, b"\x00"])
+                cql.execute(insert_v1, [2, 0, b"\x00"])
             # Different CK in pk=2 succeeds.
-            cql.execute(insert_v, [2, 99, b"\x00"])
+            cql.execute(insert_v1, [2, 99, b"\x00"])
 
             # Collection rejection.
             insert_s = cql.prepare(
@@ -633,6 +646,6 @@ def test_each_guardrail_rejects_independently(cql, test_keyspace):
                     match="(?i)collection element count.*exceeds"):
                 cql.execute(insert_s, [3, 0, {999}])
             # Writing without the collection column succeeds.
-            cql.execute(insert_v, [3, 0, b"\x00"])
+            cql.execute(insert_v1, [3, 0, b"\x00"])
             # Different CK in pk=3 succeeds.
             cql.execute(insert_s, [3, 99, {999}])


### PR DESCRIPTION
Extends the large data guardrail (merged in #29733) with
coordinator-side mutation validation. While replica-side guardrails check
SSTable metadata after compaction, coordinator-side guardrails inspect
mutation content *before* writes reach replicas, providing earlier
rejection of oversized data.

## Coordinator-side checks
The coordinator inspects three properties of each mutation:
- **Cell value size** — against `large_cell_fail_threshold_mb` /
  `compaction_large_cell_warning_threshold_mb` (new config options)
- **Row memory usage** — against the existing `large_row_fail_threshold_mb` /
  `compaction_large_row_warning_threshold_mb`
- **Collection element count** — against the existing
  `large_collection_elements_fail_threshold` /
  `compaction_large_collection_elements_count_warning_threshold`
Hard-limit violations throw `invalid_request_exception` (client gets an
error). Soft-limit violations log a warning and allow the write.

NOTE: This PR doesn't cover CQL warnings as they will be handled later in separate PR

Backport is not needed, it is a new feature

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1431