### PR TITLE
test: use exclusive driver connection in test_limited_concurrency_of_…

### DIFF
--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -100,7 +100,7 @@ async def test_limited_concurrency_of_writes(manager: ManagerClient):
     })
     node2 = await manager.server_add()
 
-    cql = manager.get_cql()
+    cql = await manager.get_cql_exclusive(node1)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 2}") as ks:
         table = f"{ks}.t"
         await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")


### PR DESCRIPTION
…writes

Use get_cql_exclusive(node1) so the driver only connects to node1 and never attempts to contact the stopped node2. The test was flaky because the driver received `Host has been marked down or removed` from node2.

Fixes: SCYLLADB-1227

Backport to prevent flakiness on older branches.