### PR TITLE
sstables: use chunked_managed_vector for promoted indexes in partition_index_page

### DIFF
--- a/sstables/index_entry.hh
+++ b/sstables/index_entry.hh
@@ -239,11 +239,9 @@ public:
     // The i-th element corresponds to the i-th entry in _entries.
     // Can be smaller than _entries. If _entries[i] doesn't have a matching element in _promoted_indexes then
     // that entry doesn't have a promoted index.
-    // It's not chunked, because promoted index is present only when there are large partitions in the page,
-    // which also means the page will have typically only 1 entry due to summary:data_file size ratio.
     // Kept separately to avoid paying for storage cost in pages where no entry has a promoted index,
     // which is typical in workloads with small partitions.
-    managed_vector<promoted_index> _promoted_indexes;
+    lsa::chunked_managed_vector<promoted_index> _promoted_indexes;
 public:
     partition_index_page() = default;
     partition_index_page(partition_index_page&&) noexcept = default;


### PR DESCRIPTION
Switch _promoted_indexes storage in partition_index_page from managed_vector to chunked_managed_vector to avoid large contiguous allocations.

Avoid allocation failure (or crashes with --abort-on-internal-error) when large partitions have enough promoted index entries to trigger a large allocation with managed_vector.

Fixes: SCYLLADB-1315

Backport: problem introduced by https://github.com/scylladb/scylladb/commit/50dc7c6dd82fdce3bb8053438819c43e18e5416f, no backport needed.