### PR TITLE
sstables: fix segfault in parse_assert() when message is nullptr

### DIFF
--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -38,7 +38,7 @@ public:
 // The exception will include a complete backtrace, so no need to add call-site identifiers to the message.
 inline void parse_assert(bool condition, std::optional<component_name> filename = {}, const char* message = nullptr) {
     if (!condition) [[unlikely]] {
-        on_parse_error(message, filename);
+        on_parse_error(message ? message : sstring(), filename);
     }
 }
 


### PR DESCRIPTION
parse_assert() accepts an optional `message` parameter that defaults
to nullptr. When the assertion fails and message is nullptr, it is
implicitly converted to sstring via the sstring(const char*) constructor,
which calls strlen(nullptr) -- undefined behavior that manifests as a
segfault in __strlen_evex.

This turns what should be a graceful malformed_sstable_exception into a
fatal crash. In the case of CUSTOMER-279, a corrupt SSTable triggered
parse_assert() during streaming (in continuous_data_consumer::
fast_forward_to()), causing a crash loop on the affected node.

Fix by guarding the nullptr case with a ternary, passing an empty
sstring() when message is null. on_parse_error() already handles
the empty-message case by substituting "parse_assert() failed".

Fixes: SCYLLADB-1329

Backport: bug was introduced in 27e26ed93f ("sstables/exceptions: introduce parse_assert()"), so needs backport to 2025.1, 2025.3, 2025.4, 2026.1