### PR TITLE
view_building_worker: fix race during draining procedure

### DIFF
--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -166,7 +166,7 @@ future<> view_building_worker::do_drain() {
     }
     co_await _state._mutex.wait();
     _state._mutex.broken();
-    co_await _state.clear();
+    co_await _state.drain();
     co_await uninit_messaging_service();
 }
 
@@ -495,6 +495,10 @@ future<> view_building_worker::state::clean_up_after_batch() {
 
 // Flush base table, set is as currently processing base table and save which views exist at the time of flush
 future<> view_building_worker::state::flush_base_table(replica::database& db, table_id base_table_id, abort_source& as) {
+    if (_drained) {
+        on_internal_error(vbw_logger, "view_building_worker::state was already drained");
+    }
+
     auto cf = db.find_column_family(base_table_id).shared_from_this();
     co_await when_all(cf->await_pending_writes(), cf->await_pending_streams());
     co_await flush_base(cf, as);
@@ -511,6 +515,11 @@ future<> view_building_worker::state::clear() {
     processing_base_table.reset();
     completed_tasks.clear();
     flushed_views.clear();
+}
+
+future<> view_building_worker::state::drain() {
+    _drained = true;
+    co_await clear();
 }
 
 view_building_worker::batch::batch(sharded<view_building_worker>& vbw, std::unordered_map<utils::UUID, view_building_task> tasks, table_id base_id, locator::tablet_replica replica)

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -154,7 +154,7 @@ future<> view_building_worker::do_drain() {
     if (!_as.abort_requested()) {
         _as.request_abort();
     }
-    _state._mutex.broken();
+    co_await _staging_sstables_mutex.wait();
     _staging_sstables_mutex.broken();
     _sstables_to_register_event.broken();
     if (this_shard_id() == 0) {
@@ -164,6 +164,8 @@ future<> view_building_worker::do_drain() {
         co_await std::move(state_observer);
         co_await _mnotifier.unregister_listener(this);
     }
+    co_await _state._mutex.wait();
+    _state._mutex.broken();
     co_await _state.clear();
     co_await uninit_messaging_service();
 }

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -470,6 +470,16 @@ static std::unordered_set<table_id> get_ids_of_all_views(replica::database& db, 
     }) | std::ranges::to<std::unordered_set>();;
 }
 
+void view_building_worker::state::start_batch(std::unique_ptr<batch> batch) {
+    if (_drained) {
+        on_internal_error(vbw_logger, "view_building_worker::state was already drained");
+    } else if (_batch) {
+        on_internal_error(vbw_logger, fmt::format("view_building_worker::state::start_batch(): some batch (tasks: {}) is already running", _batch->tasks | std::views::keys));
+    }
+    _batch = std::move(batch);
+    _batch->start();
+}
+
 // If `state::processing_base_table` is different that the `view_building_state::currently_processed_base_table`,
 // clear the state, save and flush new base table
 future<> view_building_worker::state::update_processing_base_table(replica::database& db, const view_building_state& building_state, abort_source& as) {
@@ -818,8 +828,8 @@ future<std::vector<utils::UUID>> view_building_worker::work_on_tasks(raft::term_
         }
 
         // Create and start the batch
-        _state._batch = std::make_unique<batch>(container(), std::move(tasks), *building_state.currently_processed_base_table, my_replica);
-        _state._batch->start();
+        auto batch = std::make_unique<view_building_worker::batch>(container(), std::move(tasks), *building_state.currently_processed_base_table, my_replica);
+        _state.start_batch(std::move(batch));
     }
 
     if (std::ranges::all_of(ids, [&] (auto& id) { return !_state._batch->tasks.contains(id); })) {

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -143,6 +143,14 @@ dht::token_range view_building_worker::get_tablet_token_range(table_id table_id,
 }
 
 future<> view_building_worker::drain() {
+    auto drain_started = std::exchange(_drain_started, started_drain::yes);
+    if (drain_started == started_drain::no) {
+        _drain_finished = shared_future(do_drain());
+    }
+    return _drain_finished.get_future();
+}
+
+future<> view_building_worker::do_drain() {
     if (!_as.abort_requested()) {
         _as.request_abort();
     }

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -100,6 +100,7 @@ class view_building_worker : public seastar::peering_sharded_service<view_buildi
         semaphore _mutex = semaphore(1);
         bool _drained = false;
         // All of the methods below should be executed while holding `_mutex` unit!
+        void start_batch(std::unique_ptr<batch> batch);
         future<> update_processing_base_table(replica::database& db, const view_building_state& building_state, abort_source& as);
         future<> flush_base_table(replica::database& db, table_id base_table_id, abort_source& as);
         future<> clean_up_after_batch();

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -98,11 +98,13 @@ class view_building_worker : public seastar::peering_sharded_service<view_buildi
         std::unordered_set<table_id> flushed_views;
 
         semaphore _mutex = semaphore(1);
+        bool _drained = false;
         // All of the methods below should be executed while holding `_mutex` unit!
         future<> update_processing_base_table(replica::database& db, const view_building_state& building_state, abort_source& as);
         future<> flush_base_table(replica::database& db, table_id base_table_id, abort_source& as);
         future<> clean_up_after_batch();
         future<> clear();
+        future<> drain();
     };
 
     // Wrapper which represents information needed to create

--- a/db/view/view_building_worker.hh
+++ b/db/view/view_building_worker.hh
@@ -177,6 +177,11 @@ private:
     void init_messaging_service();
     future<> uninit_messaging_service();
     future<std::vector<utils::UUID>> work_on_tasks(raft::term_t term, std::vector<utils::UUID> ids);
+
+    using started_drain = bool_class<struct started_drain_tag>;
+    started_drain _drain_started = started_drain::no;
+    shared_future<> _drain_finished;
+    future<> do_drain();
 };
 
 }


### PR DESCRIPTION
View building worker was breaking semaphores without holding their locks.
This lead to races like SCYLLADB-844 and SCYLLADB-543,
where a new batch was started after `view_building_worker::state` was cleared in the `drain()` process.

This patch fix the race by:
- taking a lock of the mutex before breaking it
- distinguishing between `state::clear()`(can happen multiple times) and `state::drain()`(can be called only once during shutdown)
- asserting that the state is not doing any new work after it was drained

Fixes SCYLLADB-844
Fixes SCYLLADB-543

This PR should be backported to all versions containing view building coordinator (2025.4 and newer).