### PR TITLE
index, vector_index: limit primary key columns to 255

### DIFF
--- a/index/vector_index.cc
+++ b/index/vector_index.cc
@@ -442,6 +442,16 @@ void vector_index::check_uses_tablets(const schema& schema, const data_dictionar
     }
 }
 
+void vector_index::check_key_column_count(const schema& schema) const {
+    // The vector-store InvariantKey supports at most 255 key columns (VECTOR-553).
+    static constexpr column_count_type max_key_columns = 255;
+    auto key_column_count = schema.partition_key_size() + schema.clustering_key_size();
+    if (key_column_count > max_key_columns) {
+        throw exceptions::invalid_request_exception(
+            format("Vector index requires at most {:d} primary key columns, but {:d} were found", max_key_columns, key_column_count));
+    }
+}
+
 void vector_index::validate(const schema &schema, const cql3::statements::index_specific_prop_defs &properties,
         const std::vector<::shared_ptr<cql3::statements::index_target>> &targets,
         const gms::feature_service& fs,
@@ -449,6 +459,7 @@ void vector_index::validate(const schema &schema, const cql3::statements::index_
 {
     check_uses_tablets(schema, db);
     check_target(schema, targets);
+    check_key_column_count(schema);
     check_cdc_not_explicitly_disabled(schema);
     check_cdc_options(schema);
     check_index_options(properties);

--- a/index/vector_index.hh
+++ b/index/vector_index.hh
@@ -47,6 +47,7 @@ private:
     void check_uses_tablets(const schema& schema, const data_dictionary::database& db) const;
     void check_cdc_not_explicitly_disabled(const schema& schema) const;
     void check_target(const schema& schema, const std::vector<::shared_ptr<cql3::statements::index_target>>& targets) const;
+    void check_key_column_count(const schema& schema) const;
     void check_index_options(const cql3::statements::index_specific_prop_defs& properties) const;
 };
 

--- a/test/cqlpy/test_vector_index.py
+++ b/test/cqlpy/test_vector_index.py
@@ -858,3 +858,31 @@ def test_ann_query_with_pk_restriction(cql, test_keyspace, skip_without_tablets)
     schema = 'p int primary key, q int, v vector<float, 3>'
     with new_test_table(cql, test_keyspace, schema) as table:
         cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
+
+# Test that vector index creation is rejected when the primary key has
+# more than 255 columns, which is the limit of the vector-store InvariantKey
+# (VECTOR-553).
+def test_create_vector_index_rejects_too_many_partition_key_columns(cql, test_keyspace, scylla_only, skip_without_tablets):
+    pk_cols = ', '.join([f'p{i} int' for i in range(256)])
+    pk_names = ', '.join([f'p{i}' for i in range(256)])
+    schema = f'{pk_cols}, v vector<float, 3>, PRIMARY KEY (({pk_names}))'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="Vector index requires at most 255 primary key columns"):
+            cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
+
+def test_create_vector_index_rejects_too_many_pk_and_ck_columns(cql, test_keyspace, scylla_only, skip_without_tablets):
+    pk_cols = ', '.join([f'p{i} int' for i in range(128)])
+    pk_names = ', '.join([f'p{i}' for i in range(128)])
+    ck_cols = ', '.join([f'c{i} int' for i in range(128)])
+    ck_names = ', '.join([f'c{i}' for i in range(128)])
+    schema = f'{pk_cols}, {ck_cols}, v vector<float, 3>, PRIMARY KEY (({pk_names}), {ck_names})'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        with pytest.raises(InvalidRequest, match="Vector index requires at most 255 primary key columns"):
+            cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")
+
+def test_create_vector_index_accepts_255_key_columns(cql, test_keyspace, scylla_only, skip_without_tablets):
+    pk_cols = ', '.join([f'p{i} int' for i in range(255)])
+    pk_names = ', '.join([f'p{i}' for i in range(255)])
+    schema = f'{pk_cols}, v vector<float, 3>, PRIMARY KEY (({pk_names}))'
+    with new_test_table(cql, test_keyspace, schema) as table:
+        cql.execute(f"CREATE CUSTOM INDEX ON {table}(v) USING 'vector_index'")


### PR DESCRIPTION
The vector-store's InvariantKey type supports at most 255 key components. Reject vector index creation when the base table's primary key (partition + clustering columns) exceeds this limit.

Fixes: VECTOR-553

