### PR TITLE
strong_consistency: implement basic coordinator metrics

### DIFF
--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -71,7 +71,7 @@ future<shared_ptr<result_message>> modification_statement::execute_without_check
     using namespace service::strong_consistency;
     if (const auto* redirect = get_if<need_redirect>(&mutate_result)) {
         bool is_write = true;
-        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write);
+        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats());
     }
     utils::get_local_injector().inject("sc_modification_statement_timeout", [&] {
         throw exceptions::mutation_write_timeout_exception{"", "", options.get_consistency(), 0, 0, db::write_type::SIMPLE};

--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -47,7 +47,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
     using namespace service::strong_consistency;
     if (const auto* redirect = get_if<need_redirect>(&query_result)) {
         bool is_write = false;
-        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write);
+        co_return co_await redirect_statement(qp, options, redirect->target, timeout, is_write, coordinator.get().get_stats());
     }
 
     co_return co_await process_results(get<lw_shared_ptr<query::result>>(std::move(query_result)),

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -12,19 +12,23 @@
 #include "cql3/query_processor.hh"
 #include "replica/database.hh"
 #include "locator/tablet_replication_strategy.hh"
+#include "service/strong_consistency/coordinator.hh"
 
 namespace cql3::statements::strong_consistency {
 future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement(query_processor& qp,
         const query_options& options,
         const locator::tablet_replica& target,
         db::timeout_clock::time_point timeout,
-        bool is_write)
+        bool is_write,
+        service::strong_consistency::stats& stats)
 {
     auto&& func_values_cache = const_cast<cql3::query_options&>(options).take_cached_pk_function_calls();
     const auto my_host_id = qp.db().real_database().get_token_metadata().get_topology().my_host_id();
     if (target.host != my_host_id) {
+        ++(is_write ? stats.write_node_bounces : stats.read_node_bounces);
         co_return qp.bounce_to_node(target, std::move(func_values_cache), timeout, is_write);
     }
+    ++(is_write ? stats.write_shard_bounces : stats.read_shard_bounces);
     co_return qp.bounce_to_shard(target.shard, std::move(func_values_cache));
 }
 

--- a/cql3/statements/strong_consistency/statement_helpers.hh
+++ b/cql3/statements/strong_consistency/statement_helpers.hh
@@ -11,6 +11,8 @@
 #include "cql3/cql_statement.hh"
 #include "locator/tablets.hh"
 
+namespace service::strong_consistency { struct stats; }
+
 namespace cql3::statements::strong_consistency {
 
 future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement(
@@ -18,7 +20,8 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
     const query_options& options,
     const locator::tablet_replica& target,
     db::timeout_clock::time_point timeout,
-    bool is_write);
+    bool is_write,
+    service::strong_consistency::stats& stats);
 
 bool is_strongly_consistent(data_dictionary::database db, std::string_view ks_name);
 

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -244,6 +244,11 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
     auto aoe = abort_on_expiry<timeout_clock>(timeout);
     [[maybe_unused]] const auto subs = chain_abort_sources(aoe.abort_source(), as);
 
+    utils::latency_counter lc;
+    lc.start();
+    auto mark_write_latency = defer([this, &lc] { _stats.write.mark(lc.stop().latency()); });
+    bool commit_status_unknown_ex = false;
+
     try {
         auto op_result = co_await create_operation_ctx(*schema, token, aoe.abort_source());
         if (const auto* redirect = get_if<need_redirect>(&op_result)) {
@@ -308,7 +313,11 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
                     logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, tablet {}, term {}",
                         ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
 
+                    ++_stats.write_errors_status_unknown;
                     // FIXME: use a dedicated ERROR_CODE instead of SERVER_ERROR
+                    // FIXME: when a dedicated ERROR_CODE will be used,
+                    //        we can get rid of the boolean flag
+                    commit_status_unknown_ex = true;
                     throw exceptions::server_exception(
                         "The outcome of this statement is unknown. It may or may not have been applied. "
                         "Retrying the statement may be necessary.");
@@ -334,8 +343,12 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
                 || try_catch<seastar::timed_out_error>(ex) || try_catch<seastar::condition_variable_timed_out>(ex)) {
             logger.trace("mutate(): request timed out with error {}, table {}.{}, token {}",
                 ex, schema->ks_name(), schema->cf_name(), token);
+            ++_stats.write_errors_timeout;
             co_return coroutine::return_exception(write_timeout(schema->ks_name(), schema->cf_name()));
         } else {
+            if (!commit_status_unknown_ex) {
+                ++_stats.write_errors_other;
+            }
             logger.trace("mutate(): unknown exception {}, table {}.{}, token {}",
                 ex, schema->ks_name(), schema->cf_name(), token);
             // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.
@@ -354,6 +367,10 @@ auto coordinator::query(schema_ptr schema,
 {
     auto aoe = abort_on_expiry<timeout_clock>(timeout);
     [[maybe_unused]] const auto subs = chain_abort_sources(aoe.abort_source(), as);
+
+    utils::latency_counter lc;
+    lc.start();
+    auto mark_read_latency = defer([this, &lc] { _stats.read.mark(lc.stop().latency()); });
 
     try {
         auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source());
@@ -386,10 +403,12 @@ auto coordinator::query(schema_ptr schema,
                 || try_catch<timed_out_error>(ex)) {
             logger.trace("query(): request timed out with error {}, table {}.{}, read cmd {}",
                 ex, schema->ks_name(), schema->cf_name(), cmd);
+            ++_stats.read_errors_timeout;
             co_return coroutine::return_exception(read_timeout(schema->ks_name(), schema->cf_name()));
         } else {
             logger.trace("mutate(): unknown exception {}, table {}.{}, read cmd {}",
                 ex, schema->ks_name(), schema->cf_name(), cmd);
+            ++_stats.read_errors_other;
             // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.
             throw;
         }

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -19,9 +19,9 @@
 #include "idl/strong_consistency/state_machine.dist.hh"
 #include "idl/strong_consistency/state_machine.dist.impl.hh"
 #include "gms/gossiper.hh"
+#include "utils/histogram_metrics_helper.hh"
 
 namespace service::strong_consistency {
-
 
 static logging::logger logger("sc_coordinator");
 
@@ -48,6 +48,68 @@ struct read_timeout : public exceptions::read_timeout_exception {
         )
     {}
 };
+
+void stats::register_stats() {
+    namespace sm = seastar::metrics;
+    sm::label reason_label("reason");
+
+    _metrics.add_group("strong_consistency_coordinator", {
+        sm::make_summary("write_latency_summary", sm::description("Strong consistency write latency summary"),
+            [this] { return to_metrics_summary(write.summary()); }).set_skip_when_empty(),
+
+        sm::make_histogram("write_latency", sm::description("Strong consistency write latency histogram"),
+            {}, [this] { return to_metrics_histogram(write.histogram()); })
+            .aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+
+        sm::make_counter("write_errors", write_errors_timeout,
+            sm::description("number of strong consistency write requests that failed"),
+            {reason_label("timeout")})
+            .set_skip_when_empty(),
+
+        sm::make_counter("write_errors", write_errors_status_unknown,
+            sm::description("number of strong consistency write requests that failed"),
+            {reason_label("status_unknown")})
+            .set_skip_when_empty(),
+
+        sm::make_counter("write_errors", write_errors_other,
+            sm::description("number of strong consistency write requests that failed"),
+            {reason_label("other")})
+            .set_skip_when_empty(),
+
+        sm::make_counter("write_node_bounces", write_node_bounces,
+            sm::description("number of strong consistency write requests bounced to another node"))
+            .set_skip_when_empty(),
+
+        sm::make_counter("write_shard_bounces", write_shard_bounces,
+            sm::description("number of strong consistency write requests bounced to another shard"))
+            .set_skip_when_empty(),
+
+        sm::make_summary("read_latency_summary", sm::description("Strong consistency read latency summary"),
+            [this] { return to_metrics_summary(read.summary()); }).set_skip_when_empty(),
+
+        sm::make_histogram("read_latency", sm::description("Strong consistency read latency histogram"),
+            {}, [this] { return to_metrics_histogram(read.histogram()); })
+            .aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+
+        sm::make_counter("read_errors", read_errors_timeout,
+            sm::description("number of strong consistency read requests that failed"),
+            {reason_label("timeout")})
+            .set_skip_when_empty(),
+
+        sm::make_counter("read_errors", read_errors_other,
+            sm::description("number of strong consistency read requests that failed"),
+            {reason_label("other")})
+            .set_skip_when_empty(),
+
+        sm::make_counter("read_node_bounces", read_node_bounces,
+            sm::description("number of strong consistency read requests bounced to another node"))
+            .set_skip_when_empty(),
+
+        sm::make_counter("read_shard_bounces", read_shard_bounces,
+            sm::description("number of strong consistency read requests bounced to another shard"))
+            .set_skip_when_empty(),
+    });
+}
 
 static const locator::tablet_replica* find_replica(const locator::tablet_info& tinfo, locator::host_id id) {
     const auto it = std::ranges::find_if(tinfo.replicas,
@@ -170,6 +232,7 @@ coordinator::coordinator(groups_manager& groups_manager, replica::database& db, 
     , _db(db)
     , _gossiper(gossiper)
 {
+    _stats.register_stats();
 }
 
 future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -10,6 +10,8 @@
 
 #include "mutation/mutation.hh"
 #include "query/query-result.hh"
+#include "utils/histogram.hh"
+#include <seastar/core/metrics.hh>
 
 namespace gms {
 
@@ -27,6 +29,25 @@ struct need_redirect {
 template <typename T = std::monostate>
 using value_or_redirect = std::variant<T, need_redirect>;
 
+struct stats {
+    utils::timed_rate_moving_average_summary_and_histogram write;
+    uint64_t write_errors_timeout = 0;
+    uint64_t write_errors_status_unknown = 0;
+    uint64_t write_errors_other = 0;
+    uint64_t write_node_bounces = 0;
+    uint64_t write_shard_bounces = 0;
+
+    utils::timed_rate_moving_average_summary_and_histogram read;
+    uint64_t read_errors_timeout = 0;
+    uint64_t read_errors_other = 0;
+    uint64_t read_node_bounces = 0;
+    uint64_t read_shard_bounces = 0;
+
+    seastar::metrics::metric_groups _metrics;
+
+    void register_stats();
+};
+
 class coordinator : public peering_sharded_service<coordinator> {
 public:
     using timeout_clock = typename db::timeout_clock;
@@ -35,6 +56,7 @@ private:
     groups_manager& _groups_manager;
     replica::database& _db;
     gms::gossiper& _gossiper;
+    stats _stats;
 
     struct operation_ctx;
     future<value_or_redirect<operation_ctx>> create_operation_ctx(const schema& schema,
@@ -42,6 +64,8 @@ private:
         abort_source& as);
 public:
     coordinator(groups_manager& groups_manager, replica::database& db, gms::gossiper& gossiper);
+
+    stats& get_stats() { return _stats; }
 
     using mutation_gen = noncopyable_function<mutation(api::timestamp_type)>;
     future<value_or_redirect<>> mutate(schema_ptr schema, 

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -159,6 +159,30 @@ async def test_basic_write_read(manager: ManagerClient):
         non_replica_host_id = [host_id for host_id in host_ids if str(host_id) not in replica_host_ids][0]
         non_replica_host = host_by_host_id(non_replica_host_id)
 
+        async def collect_metrics():
+            leader_metrics_query = await manager.metrics.query(leader_host.address)
+            leader_metrics = {
+                'scylla_strong_consistency_coordinator_write_latency_count': leader_metrics_query.get('scylla_strong_consistency_coordinator_write_latency_count') or 0,
+                'scylla_strong_consistency_coordinator_read_latency_count':  leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count') or 0,
+            }
+            non_leader_metrics_query = await manager.metrics.query(non_leader_replica_host.address)
+            non_leader_metrics = {
+                'scylla_strong_consistency_coordinator_write_node_bounces': non_leader_metrics_query.get('scylla_strong_consistency_coordinator_write_node_bounces') or 0,
+                'scylla_strong_consistency_coordinator_read_latency_count': non_leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count') or 0,
+            }
+            non_replica_metrics_query = await manager.metrics.query(non_replica_host.address)
+            non_replica_metrics = {
+                'scylla_strong_consistency_coordinator_write_node_bounces': non_replica_metrics_query.get('scylla_strong_consistency_coordinator_write_node_bounces') or 0,
+                'scylla_strong_consistency_coordinator_read_node_bounces':  non_replica_metrics_query.get('scylla_strong_consistency_coordinator_read_node_bounces') or 0,
+            }
+
+            return {
+                'leader': leader_metrics,
+                'replica': non_leader_metrics,
+                'non_replica': non_replica_metrics,
+            }     
+        metrics_before = await collect_metrics()
+
         logger.info(f"Run INSERT statement on leader {leader_host}")
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (10, 20)", host=leader_host)
 
@@ -228,6 +252,12 @@ async def test_basic_write_read(manager: ManagerClient):
         row = rows[0]
         assert row.pk == 10
         assert row.c == 70
+
+        metrics_after = await collect_metrics()
+        # Validate that all matrics were increased after read/write operations
+        for host in metrics_after.keys():
+            for metric_name in metrics_after[host].keys():
+                assert metrics_after[host][metric_name] > metrics_before[host][metric_name]
 
         # Check that we can restart a server with an active tablets raft group
         await manager.server_restart(servers[2].server_id)


### PR DESCRIPTION
Add per-shard metrics for strong consistency coordinator operations (latency, timeouts, bounces, status unknown) under the `"strong_consistency_coordinator"` category. These are analogous to the eventual consistency metrics in `storage_proxy_stats`, enabling direct performance comparison between the two consistency modes.

The metrics are simplified compared to `storage_proxy_stats` — no breakdown by table, tablet, scheduling group, or DC, only per-shard.

Fixes SCYLLADB-1343

Strong consistency is still in experimental phase, no need to backport.