### PR TITLE
sstables: introduce --abort-on-malformed-sstable-error

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1429,6 +1429,13 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , enable_shard_aware_drivers(this, "enable_shard_aware_drivers", value_status::Used, true, "Enable native transport drivers to use connection-per-shard for better performance.")
     , enable_ipv6_dns_lookup(this, "enable_ipv6_dns_lookup", value_status::Used, false, "Use IPv6 address resolution")
     , abort_on_internal_error(this, "abort_on_internal_error", liveness::LiveUpdate, value_status::Used, false, "Abort the server instead of throwing exception when internal invariants are violated.")
+    , abort_on_malformed_sstable_error(this, "abort_on_malformed_sstable_error", liveness::LiveUpdate, value_status::Used,
+#if defined(DEBUG) || defined(DEVEL)
+            true,
+#else
+            false,
+#endif
+            "Abort the server and generate a coredump instead of throwing an exception when any sstable parse error is detected (malformed_sstable_exception, bufsize_mismatch_exception, parse_assert() failures, or BTI parse errors). Intended for debugging memory corruption that may manifest as sstable corruption. Defaults to true in debug and dev builds.")
     , max_partition_key_restrictions_per_query(this, "max_partition_key_restrictions_per_query", liveness::LiveUpdate, value_status::Used, 100,
             "Maximum number of distinct partition keys restrictions per query. This limit places a bound on the size of IN tuples, "
             "especially when multiple partition key columns have IN restrictions. Increasing this value can result in server instability.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -456,6 +456,7 @@ public:
     named_value<bool> enable_shard_aware_drivers;
     named_value<bool> enable_ipv6_dns_lookup;
     named_value<bool> abort_on_internal_error;
+    named_value<bool> abort_on_malformed_sstable_error;
     named_value<uint32_t> max_partition_key_restrictions_per_query;
     named_value<uint32_t> max_clustering_key_restrictions_per_query;
     named_value<uint64_t> max_memory_for_unlimited_query_soft_limit;

--- a/db/snapshot/backup_task.cc
+++ b/db/snapshot/backup_task.cc
@@ -17,7 +17,6 @@
 #include "db/snapshot-ctl.hh"
 #include "db/snapshot/backup_task.hh"
 #include "schema/schema_fwd.hh"
-#include "sstables/exceptions.hh"
 #include "sstables/sstables.hh"
 #include "sstables/sstable_directory.hh"
 #include "sstables/sstables_manager.hh"
@@ -164,22 +163,23 @@ future<> backup_task_impl::process_snapshot_dir() {
             auto file_path = _snapshot_dir / name;
             auto st = co_await file_stat(directory, name);
             total += st.size;
-            try {
-                auto desc = sstables::parse_path(file_path, "", "");
-                const auto& gen = desc.generation;
-                _sstable_comps[gen].emplace_back(name);
-                _sstables_in_snapshot.insert(desc.generation);
-                ++num_sstable_comps;
-
-                // When the SSTable is only linked-to by the snapshot directory,
-                // it is already deleted from the table's base directory, and
-                // therefore it better be uploaded earlier to free-up its capacity.
-                if (desc.component == sstables::component_type::Data && st.number_of_links == 1) {
-                    snap_log.debug("backup_task: SSTable with generation {} is already deleted from the table", gen);
-                    _deleted_sstables.push_back(gen);
-                }
-            } catch (const sstables::malformed_sstable_exception&) {
+            auto result = sstables::parse_path(file_path, "", "");
+            if (!result) {
                 _files.emplace_back(name);
+                continue;
+            }
+            auto desc = std::move(*result);
+            const auto& gen = desc.generation;
+            _sstable_comps[gen].emplace_back(name);
+            _sstables_in_snapshot.insert(desc.generation);
+            ++num_sstable_comps;
+
+            // When the SSTable is only linked-to by the snapshot directory,
+            // it is already deleted from the table's base directory, and
+            // therefore it better be uploaded earlier to free-up its capacity.
+            if (desc.component == sstables::component_type::Data && st.number_of_links == 1) {
+                snap_log.debug("backup_task: SSTable with generation {} is already deleted from the table", gen);
+                _deleted_sstables.push_back(gen);
             }
         }
         _total_progress.total = total;

--- a/main.cc
+++ b/main.cc
@@ -86,6 +86,7 @@
 #include "service/cache_hitrate_calculator.hh"
 #include "compaction/compaction_manager.hh"
 #include "sstables/sstables.hh"
+#include "sstables/exceptions.hh"
 #include "gms/feature_service.hh"
 #include "replica/distributed_loader.hh"
 #include "sstables_loader.hh"
@@ -1041,6 +1042,11 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 set_abort_on_internal_error(val);
             });
             set_abort_on_internal_error(cfg->abort_on_internal_error());
+
+            auto abort_on_malformed_sstable_error_observer = cfg->abort_on_malformed_sstable_error.observe([] (bool val) {
+                sstables::set_abort_on_malformed_sstable_error(val);
+            });
+            sstables::set_abort_on_malformed_sstable_error(cfg->abort_on_malformed_sstable_error());
 
             checkpoint(stop_signal, "creating snitch");
             debug::the_snitch = &snitch;

--- a/sstables/checksummed_data_source.cc
+++ b/sstables/checksummed_data_source.cc
@@ -115,7 +115,7 @@ public:
         if (buf.size() != chunk_size) {
             auto actual_end = _underlying_pos + buf.size();
             if (chunk_index + 1 < _checksum.checksums.size()) {
-                throw malformed_sstable_exception(seastar::format("Checksummed reader hit premature end-of-file at file offset {}: expected {} chunks of size {} but data file has {}",
+                throw_malformed_sstable_exception(seastar::format("Checksummed reader hit premature end-of-file at file offset {}: expected {} chunks of size {} but data file has {}",
                         actual_end, _checksum.checksums.size(), chunk_size, chunk_index + 1));
             } else if (actual_end < _file_len) {
                 // Truncation on last chunk. Update _end_pos so that future
@@ -124,7 +124,7 @@ public:
             }
         }
         if (chunk_index >= _checksum.checksums.size()) {
-            throw malformed_sstable_exception(seastar::format("Chunk count mismatch between CRC and Data.db: expected {} but data file has more", _checksum.checksums.size()));
+            throw_malformed_sstable_exception(seastar::format("Chunk count mismatch between CRC and Data.db: expected {} but data file has more", _checksum.checksums.size()));
         }
         auto expected_checksum = _checksum.checksums[chunk_index];
         auto actual_checksum = ChecksumType::checksum(buf.get(), buf.size());
@@ -231,7 +231,7 @@ input_stream<char> make_checksummed_file_m_format_input_stream(
 }
 
 void throwing_integrity_error_handler(sstring msg) {
-        throw sstables::malformed_sstable_exception(msg);
+        throw_malformed_sstable_exception(msg);
 };
 
 }

--- a/sstables/compress.cc
+++ b/sstables/compress.cc
@@ -158,7 +158,7 @@ void compression::segmented_offsets::state::update_position_trackers(std::size_t
 
 void compression::segmented_offsets::init(uint32_t chunk_size) {
     if (chunk_size == 0) {
-        throw sstables::malformed_sstable_exception("Segmented offsets chunk size is zero.");
+        throw_malformed_sstable_exception("Segmented offsets chunk size is zero.");
     }
 
     _chunk_size = chunk_size;
@@ -373,11 +373,11 @@ public:
             throw std::runtime_error(format("compressed reader not aligned to chunk boundary: pos={} offset={}", _pos, addr.offset));
         }
         if (!addr.chunk_len) {
-            throw sstables::malformed_sstable_exception(format("compressed chunk_len must be greater than zero, chunk_start={}", addr.chunk_start));
+            sstables::throw_malformed_sstable_exception(format("compressed chunk_len must be greater than zero, chunk_start={}", addr.chunk_start));
         }
         auto buf = co_await _input_stream->read_exactly(addr.chunk_len);
         if (buf.size() != addr.chunk_len) {
-            throw sstables::malformed_sstable_exception(format("compressed reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", _underlying_pos, addr.chunk_len, buf.size()));
+            sstables::throw_malformed_sstable_exception(format("compressed reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", _underlying_pos, addr.chunk_len, buf.size()));
         }
         auto res_units = co_await _permit.request_memory(_compression_metadata->uncompressed_chunk_length());
         // The last 4 bytes of the chunk are the adler32/crc32 checksum
@@ -388,7 +388,7 @@ public:
         auto expected_checksum = read_be<uint32_t>(buf.get() + compressed_len);
         auto actual_checksum = ChecksumType::checksum(buf.get(), compressed_len);
         if (expected_checksum != actual_checksum) {
-            throw sstables::malformed_sstable_exception(format("compressed chunk of size {} at file offset {} failed checksum, expected={}, actual={}", addr.chunk_len, _underlying_pos, expected_checksum, actual_checksum));
+            sstables::throw_malformed_sstable_exception(format("compressed chunk of size {} at file offset {} failed checksum, expected={}, actual={}", addr.chunk_len, _underlying_pos, expected_checksum, actual_checksum));
         }
 
         if constexpr (check_digest) {
@@ -420,7 +420,7 @@ public:
             if (_digests.can_calculate_digest
                     && _pos == _compression_metadata->uncompressed_file_length()
                     && _digests.expected_digest != _digests.actual_digest) {
-                throw sstables::malformed_sstable_exception(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
+                sstables::throw_malformed_sstable_exception(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
             }
         }
         co_return make_tracked_temporary_buffer(std::move(out), std::move(res_units));
@@ -511,20 +511,20 @@ public:
 
         auto chunk_len = get_chunk_len(_current_chunk_index);
         if (!chunk_len) {
-            throw sstables::malformed_sstable_exception(format("compressed raw reader chunk_len must be greater than zero, pos={}", _pos));
+            sstables::throw_malformed_sstable_exception(format("compressed raw reader chunk_len must be greater than zero, pos={}", _pos));
         }
 
         auto res_units = co_await _permit.request_memory(chunk_len);
         auto buf = co_await _input_stream->read_exactly(chunk_len);
         if (buf.size() != chunk_len) {
-            throw sstables::malformed_sstable_exception(format("compressed raw reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", _pos, chunk_len, buf.size()));
+            sstables::throw_malformed_sstable_exception(format("compressed raw reader hit premature end-of-file at file offset {}, expected chunk_len={}, actual={}", _pos, chunk_len, buf.size()));
         }
 
         auto compressed_len = chunk_len - 4;
         auto expected_checksum = read_be<uint32_t>(buf.get() + compressed_len);
         auto actual_checksum = crc32_utils::checksum(buf.get(), compressed_len);
         if (expected_checksum != actual_checksum) {
-            throw sstables::malformed_sstable_exception(format("compressed chunk of size {} at file offset {} failed checksum, expected={}, actual={}", chunk_len, _pos, expected_checksum, actual_checksum));
+            sstables::throw_malformed_sstable_exception(format("compressed chunk of size {} at file offset {} failed checksum, expected={}, actual={}", chunk_len, _pos, expected_checksum, actual_checksum));
         }
 
         if constexpr (check_digest) {
@@ -543,7 +543,7 @@ public:
             if (_digests.can_calculate_digest
                     && _current_chunk_index == _compression_metadata->offsets.size()
                     && _digests.expected_digest != _digests.actual_digest) {
-                throw sstables::malformed_sstable_exception(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
+                sstables::throw_malformed_sstable_exception(seastar::format("Digest mismatch: expected={}, actual={}", _digests.expected_digest, _digests.actual_digest));
             }
         }
 

--- a/sstables/compressor.cc
+++ b/sstables/compressor.cc
@@ -363,7 +363,7 @@ static std::optional<std::vector<std::byte>> dict_from_options(const sstables::c
                 auto i = std::stoi(k_str.substr(DICTIONARY_OPTION.size()));
                 parts.emplace(i, v.value);
             } catch (const std::exception& e) {
-                throw sstables::malformed_sstable_exception(fmt::format("Corrupted dictionary option: {}", k_str));
+                sstables::throw_malformed_sstable_exception(fmt::format("Corrupted dictionary option: {}", k_str));
             }
         }
         auto v_str = sstring(v.value.begin(), v.value.end());
@@ -372,7 +372,7 @@ static std::optional<std::vector<std::byte>> dict_from_options(const sstables::c
     int i = 0;
     for (const auto& [k, v] : parts) {
         if (k != i) {
-            throw sstables::malformed_sstable_exception(fmt::format("Missing dictionary part: expected {}, got {}", i, k));
+            sstables::throw_malformed_sstable_exception(fmt::format("Missing dictionary part: expected {}, got {}", i, k));
         }
         ++i;
         auto s = std::as_bytes(std::span(v));

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -63,4 +63,15 @@ bool abort_on_malformed_sstable_error() noexcept;
 [[noreturn]] void throw_malformed_sstable_exception(sstring msg, component_name filename);
 [[noreturn]] void throw_bufsize_mismatch_exception(size_t size, size_t expected);
 
+// Disables aborting on malformed sstable errors for a scope.
+//
+// Intended for tests which intentionally corrupt sstables and expect
+// malformed_sstable_exception to be thrown rather than the process aborting.
+class scoped_no_abort_on_malformed_sstable_error {
+    bool _prev;
+public:
+    scoped_no_abort_on_malformed_sstable_error() noexcept;
+    ~scoped_no_abort_on_malformed_sstable_error();
+};
+
 }

--- a/sstables/exceptions.hh
+++ b/sstables/exceptions.hh
@@ -48,4 +48,19 @@ struct bufsize_mismatch_exception : malformed_sstable_exception {
     {}
 };
 
+// Controls whether malformed sstable errors abort the process (generating a coredump) or throw an
+// exception. Aborting is useful when the malformed sstable error is caused by memory corruption
+// rather than actual sstable corruption, as it allows post-mortem analysis of the coredump.
+// Controlled by the --abort-on-malformed-sstable-error command-line option.
+// Returns the previous value of the flag.
+bool set_abort_on_malformed_sstable_error(bool value) noexcept;
+bool abort_on_malformed_sstable_error() noexcept;
+
+// Use these helpers instead of directly throwing malformed_sstable_exception or
+// bufsize_mismatch_exception. They check the abort_on_malformed_sstable_error flag and either
+// abort the process (with logging) or throw the appropriate exception.
+[[noreturn]] void throw_malformed_sstable_exception(sstring msg);
+[[noreturn]] void throw_malformed_sstable_exception(sstring msg, component_name filename);
+[[noreturn]] void throw_bufsize_mismatch_exception(size_t size, size_t expected);
+
 }

--- a/sstables/index_reader.hh
+++ b/sstables/index_reader.hh
@@ -191,10 +191,10 @@ private:
 public:
     void verify_end_state() const {
         if (this->_remain > 0) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), _sst.index_filename());
+            throw_malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): parsing ended but there is unconsumed data", _state), _sst.index_filename());
         }
         if (_state != state::KEY_SIZE && _state != state::START) {
-            throw malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), _sst.index_filename());
+            throw_malformed_sstable_exception(fmt::format("index_consume_entry_context (state={}): cannot finish parsing current entry, no more data", _state), _sst.index_filename());
         }
     }
 
@@ -544,7 +544,7 @@ private:
             bound.current_index_idx = 0;
             bound.current_pi_idx = 0;
             if (bound.current_list->empty()) {
-                throw malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->index_filename());
+                throw_malformed_sstable_exception(format("missing index entry for summary index {} (bound {})", summary_idx, fmt::ptr(&bound)), _sstable->index_filename());
             }
             bound.data_file_position = bound.current_list->_entries[0].position();
             bound.element = indexable_element::partition;

--- a/sstables/kl/reader.cc
+++ b/sstables/kl/reader.cc
@@ -176,7 +176,7 @@ public:
             } else if (clustering.size() == (expected_normal + 1)) {
                 return true;
             }
-            throw malformed_sstable_exception(format("Found {:d} clustering elements in column name. Was not expecting that!", clustering.size()));
+            throw_malformed_sstable_exception(format("Found {:d} clustering elements in column name. Was not expecting that!", clustering.size()));
         }
 
         static bool check_static(const schema& schema, bytes_view col) {
@@ -210,12 +210,12 @@ public:
             if (is_static) {
                 for (auto& e: clustering) {
                     if (e.size() != 0) {
-                        throw malformed_sstable_exception("Static row has clustering key information. I didn't expect that!");
+                        throw_malformed_sstable_exception("Static row has clustering key information. I didn't expect that!");
                     }
                 }
             }
             if (is_present && is_static != cdef->is_static()) {
-                throw malformed_sstable_exception(seastar::format("Mismatch between {} cell and {} column definition",
+                throw_malformed_sstable_exception(seastar::format("Mismatch between {} cell and {} column definition",
                                                                   is_static ? "static" : "non-static", cdef->is_static() ? "static" : "non-static"));
             }
         }
@@ -577,20 +577,20 @@ public:
                     [] (const collection_type_impl& ctype) -> const abstract_type& { return *ctype.value_comparator(); },
                     [&] (const user_type_impl& utype) -> const abstract_type& {
                         if (col.collection_extra_data.size() != sizeof(int16_t)) {
-                            throw malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
+                            throw_malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
                                         sizeof(int16_t), col.collection_extra_data.size()));
                         }
 
                         auto field_idx = deserialize_field_index(col.collection_extra_data);
                         if (field_idx >= utype.size()) {
-                            throw malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
+                            throw_malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
                                         utype.size(), field_idx));
                         }
 
                         return *utype.type(field_idx);
                     },
                     [] (const abstract_type& o) -> const abstract_type& {
-                        throw malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
+                        throw_malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
                     }
                 ));
                 auto ac = make_atomic_cell(value_type,
@@ -708,7 +708,7 @@ public:
             case composite::eoc::end:
                 return bound_kind::excl_start;
         }
-        throw malformed_sstable_exception(format("Unexpected start composite marker {:d}", uint16_t(uint8_t(found))));
+        throw_malformed_sstable_exception(format("Unexpected start composite marker {:d}", uint16_t(uint8_t(found))));
     }
 
     static bound_kind end_marker_to_bound_kind(bytes_view component) {
@@ -723,7 +723,7 @@ public:
             case composite::eoc::end:
                 return bound_kind::incl_end;
         }
-        throw malformed_sstable_exception(format("Unexpected end composite marker {:d}", uint16_t(uint8_t(found))));
+        throw_malformed_sstable_exception(format("Unexpected end composite marker {:d}", uint16_t(uint8_t(found))));
     }
 
     // Consume one range tombstone.
@@ -1050,7 +1050,7 @@ private:
                 } else {
                     // FIXME: see ColumnSerializer.java:deserializeColumnBody
                     if ((mask & column_mask::counter_update) != column_mask::none) {
-                        throw malformed_sstable_exception("FIXME COUNTER_UPDATE_MASK");
+                        throw_malformed_sstable_exception("FIXME COUNTER_UPDATE_MASK");
                     }
                     _ttl = _expiration = 0;
                     _deleted = (mask & column_mask::deletion) != column_mask::none;
@@ -1062,7 +1062,7 @@ private:
                 mp_row_consumer_k_l::proceed ret;
                 if (_deleted) {
                     if (_val_fragmented.size_bytes() != 4) {
-                        throw malformed_sstable_exception("deleted cell expects local_deletion_time value");
+                        throw_malformed_sstable_exception("deleted cell expects local_deletion_time value");
                     }
                     _val = temporary_buffer<char>(4);
                     auto v = fragmented_temporary_buffer::view(_val_fragmented);
@@ -1110,7 +1110,7 @@ public:
             return;
         }
         if (_state != state::ROW_START || data_consumer::primitive_consumer::active()) {
-            throw malformed_sstable_exception("end of input, but not end of row");
+            throw_malformed_sstable_exception("end of input, but not end of row");
         }
     }
 
@@ -1249,7 +1249,7 @@ private:
         }
 
         if (!_consumer.is_mutation_end()) {
-            throw malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
+            throw_malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
                                                      position_in_partition_view::printer(*_schema, _consumer.position())), _sst->get_filename());
         }
 
@@ -1442,7 +1442,7 @@ public:
             try {
                 f.get();
             } catch(sstables::malformed_sstable_exception& e) {
-                throw sstables::malformed_sstable_exception(format("Failed to read partition from SSTable {} due to {}", _sst->get_filename(), e.what()));
+                throw_malformed_sstable_exception(format("Failed to read partition from SSTable {} due to {}", _sst->get_filename(), e.what()));
             }
         });
     }

--- a/sstables/m_format_read_helpers.cc
+++ b/sstables/m_format_read_helpers.cc
@@ -17,7 +17,7 @@ namespace sstables {
 
 static void check_buf_size(temporary_buffer<char>& buf, size_t expected) {
     if (buf.size() < expected) {
-        throw bufsize_mismatch_exception(buf.size(), expected);
+        throw_bufsize_mismatch_exception(buf.size(), expected);
     }
 }
 

--- a/sstables/m_format_read_helpers.hh
+++ b/sstables/m_format_read_helpers.hh
@@ -46,10 +46,10 @@ inline api::timestamp_type parse_timestamp(const serialization_header& header,
 inline gc_clock::duration parse_ttl(int64_t value) {
     if (!is_expired_liveness_ttl(value)) {
         if (value < 0) {
-            throw malformed_sstable_exception(format("Negative ttl: {}", value));
+            throw_malformed_sstable_exception(format("Negative ttl: {}", value));
         }
         if (value > max_ttl.count()) {
-            throw malformed_sstable_exception(format("Too big ttl: {}", value));
+            throw_malformed_sstable_exception(format("Too big ttl: {}", value));
         }
     }
     return gc_clock::duration(value);

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -79,7 +79,7 @@ public:
     data_consumer::proceed consume_range_tombstone_start(clustering_key_prefix ck, bound_kind k, tombstone t) {
         sstlog.trace("mp_row_consumer_m {}: consume_range_tombstone_start(ck={}, k={}, t={})", fmt::ptr(this), ck, k, t);
         if (_mf_filter->current_tombstone()) {
-            throw sstables::malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("Range tombstones have to be disjoint: current opened range tombstone {}, new tombstone {}",
                            _mf_filter->current_tombstone(), t));
         }
@@ -90,12 +90,12 @@ public:
     data_consumer::proceed consume_range_tombstone_end(clustering_key_prefix ck, bound_kind k, tombstone t) {
         sstlog.trace("mp_row_consumer_m {}: consume_range_tombstone_end(ck={}, k={}, t={})", fmt::ptr(this), ck, k, t);
         if (!_mf_filter->current_tombstone()) {
-            throw sstables::malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("Closing range tombstone that wasn't opened: clustering {}, kind {}, tombstone {}",
                            ck, k, t));
         }
         if (_mf_filter->current_tombstone() != t) {
-            throw sstables::malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("Range tombstone with ck {} and two different tombstones at ends: {}, {}",
                            ck, _mf_filter->current_tombstone(), t));
         }
@@ -106,11 +106,11 @@ public:
     data_consumer::proceed consume_range_tombstone_boundary(position_in_partition pos, tombstone left, tombstone right) {
         sstlog.trace("mp_row_consumer_m {}: consume_range_tombstone_boundary(pos={}, left={}, right={})", fmt::ptr(this), pos, left, right);
         if (!_mf_filter->current_tombstone()) {
-            throw sstables::malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("Closing range tombstone that wasn't opened: pos {}, tombstone {}", pos, left));
         }
         if (_mf_filter->current_tombstone() != left) {
-            throw sstables::malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("Range tombstone at {} and two different tombstones at ends: {}, {}",
                            pos, _mf_filter->current_tombstone(), left));
         }
@@ -166,7 +166,7 @@ public:
 
     void check_schema_mismatch(const column_translation::column_info& column_info, const column_definition& column_def) const {
         if (column_info.schema_mismatch) {
-            throw malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                     format("{} definition in serialization header does not match schema. Expected {} but got {}",
                         column_def.name_as_text(),
                         column_def.type->name(),
@@ -180,7 +180,7 @@ public:
             sstring name = sstring(to_string_view(*column_info.name));
             auto it = _schema->dropped_columns().find(name);
             if (it == _schema->dropped_columns().end() || timestamp > it->second.timestamp) {
-                throw malformed_sstable_exception(format("Column {} missing in current schema", name));
+                throw_malformed_sstable_exception(format("Column {} missing in current schema", name));
             }
         }
     }
@@ -399,20 +399,20 @@ public:
                 [] (const collection_type_impl& ctype) -> const abstract_type& { return *ctype.value_comparator(); },
                 [&] (const user_type_impl& utype) -> const abstract_type& {
                     if (cell_path.size() != sizeof(int16_t)) {
-                        throw malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
+                        throw_malformed_sstable_exception(format("wrong size of field index while reading UDT column: expected {}, got {}",
                                     sizeof(int16_t), cell_path.size()));
                     }
 
                     auto field_idx = deserialize_field_index(cell_path);
                     if (field_idx >= utype.size()) {
-                        throw malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
+                        throw_malformed_sstable_exception(format("field index too big while reading UDT column: type has {} fields, got {}",
                                     utype.size(), field_idx));
                     }
 
                     return *utype.type(field_idx);
                 },
                 [] (const abstract_type& o) -> const abstract_type& {
-                    throw malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
+                    throw_malformed_sstable_exception(format("attempted to read multi-cell column, but expected type was {}", o.name()));
                 }
             ));
             auto ac = is_deleted ? atomic_cell::make_dead(timestamp, local_deletion_time)
@@ -559,7 +559,7 @@ public:
         sstlog.trace("mp_row_consumer_m {}: on_end_of_stream()", fmt::ptr(this));
         if (_mf_filter && _mf_filter->current_tombstone()) {
             if (_mf_filter->out_of_range()) {
-                throw sstables::malformed_sstable_exception("Unclosed range tombstone.");
+                throw_malformed_sstable_exception("Unclosed range tombstone.");
             }
             auto result = _mf_filter->apply(position_in_partition_view::after_all_clustered_rows(), {});
             for (auto&& rt : result.rts) {
@@ -904,7 +904,7 @@ private:
                         _is_first_unfiltered = false;
                         goto row_body_label;
                     } else {
-                        throw malformed_sstable_exception("static row should be a first unfiltered in a partition");
+                        throw_malformed_sstable_exception("static row should be a first unfiltered in a partition");
                     }
                 }
                 start_row(_regular_row);
@@ -924,7 +924,7 @@ private:
                     continue;
                 }
                 if (_null_component_occured) {
-                    throw malformed_sstable_exception("non-null component after null component");
+                    throw_malformed_sstable_exception("non-null component after null component");
                 }
                 if (is_block_empty()) {
                     _row_key.push_back({});
@@ -971,7 +971,7 @@ private:
             }
             if (_extended_flags.is_static()) {
                 if (_flags.has_timestamp() || _flags.has_ttl() || _flags.has_deletion()) {
-                    throw malformed_sstable_exception(format("Static row has unexpected flags: timestamp={}, ttl={}, deletion={}",
+                    throw_malformed_sstable_exception(format("Static row has unexpected flags: timestamp={}, ttl={}, deletion={}",
                         _flags.has_timestamp(), _flags.has_ttl(), _flags.has_deletion()));
                 }
             } else {
@@ -994,7 +994,7 @@ private:
                 }
                 if (_extended_flags.has_scylla_shadowable_deletion()) {
                     if (!_has_shadowable_tombstones) {
-                        throw malformed_sstable_exception("Scylla shadowable tombstone flag is set but not supported on this SSTables");
+                        throw_malformed_sstable_exception("Scylla shadowable tombstone flag is set but not supported on this SSTables");
                     }
                     co_yield this->read_unsigned_vint(*_processing_data);
                     _row_shadowable_tombstone.timestamp = parse_timestamp(_header, this->_u64);
@@ -1155,7 +1155,7 @@ private:
             _left_range_tombstone.deletion_time = parse_expiry(_header, this->_u64);
             if (!is_boundary_between_adjacent_intervals(_range_tombstone_kind)) {
                 if (!is_bound_kind(_range_tombstone_kind)) {
-                    throw sstables::malformed_sstable_exception(
+                    throw_malformed_sstable_exception(
                         format("Corrupted range tombstone: invalid boundary type {}", _range_tombstone_kind));
                 }
                 _sst->get_stats().on_range_tombstone_read();
@@ -1219,7 +1219,7 @@ public:
         // is the first state corresponding to the contents of a new partition.
         if (_state != state::DELETION_TIME
                 && (_state != state::PARTITION_START || data_consumer::primitive_consumer::active())) {
-            throw malformed_sstable_exception("end of input, but not end of partition");
+            throw_malformed_sstable_exception("end of input, but not end of partition");
         }
     }
 
@@ -1410,7 +1410,7 @@ private:
         }
 
         if (!_consumer.is_mutation_end()) {
-            throw malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
+            throw_malformed_sstable_exception(format("consumer not at partition boundary, position: {}",
                                                      position_in_partition_view::printer(*_schema, _consumer.position())), _sst->get_filename());
         }
 

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <expected>
 #include <seastar/core/sstring.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/sharded.hh>
@@ -43,11 +44,11 @@ struct entry_descriptor {
 
 // Parses sstable file path extracting entry_descriptor from it. Returns the descriptor
 // and the keyspace.table pair of strings.
-std::tuple<entry_descriptor, sstring, sstring> parse_path(const std::filesystem::path& sst_path);
+std::expected<std::tuple<entry_descriptor, sstring, sstring>, sstring> parse_path(const std::filesystem::path& sst_path);
 
 // Use the given ks and cf and don't attempt to extract it from the dir path.
 // This allows loading sstables from any path, but the filename still has to be valid.
-entry_descriptor parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf);
+std::expected<entry_descriptor, sstring> parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf);
 
 // contains data for loading a sstable using components shared by a single shard;
 // can be moved across shards

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -379,7 +379,10 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
         while (auto de = co_await lister.get()) {
             auto component_path = _directory / de->name;
             auto comps = sstables::parse_path(component_path, directory._schema->ks_name(), directory._schema->cf_name());
-            handle(std::move(comps), component_path);
+            if (!comps) {
+                throw sstables::malformed_sstable_exception(comps.error());
+            }
+            handle(std::move(*comps), component_path);
         }
     }));
 
@@ -448,7 +451,11 @@ future<> sstable_directory::sstables_registry_components_lister::process(sstable
 future<> sstable_directory::restore_components_lister::process(sstable_directory& directory, process_flags flags) {
     co_await coroutine::parallel_for_each(_toc_filenames, [flags, &directory] (sstring toc_filename) -> future<> {
         std::filesystem::path sst_path{toc_filename};
-        entry_descriptor desc = sstables::parse_path(sst_path, "", "");
+        auto result = sstables::parse_path(sst_path, "", "");
+        if (!result) {
+            throw sstables::malformed_sstable_exception(result.error());
+        }
+        entry_descriptor desc = std::move(*result);
         if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {
             co_return;
         }

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -380,7 +380,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
             auto component_path = _directory / de->name;
             auto comps = sstables::parse_path(component_path, directory._schema->ks_name(), directory._schema->cf_name());
             if (!comps) {
-                throw sstables::malformed_sstable_exception(comps.error());
+                throw_malformed_sstable_exception(comps.error());
             }
             handle(std::move(*comps), component_path);
         }
@@ -420,7 +420,7 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
     // log and proceed.
     for (auto& path : _state->generations_found | std::views::values) {
         if (flags.throw_on_missing_toc) {
-            throw sstables::malformed_sstable_exception(seastar::format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _directory.native(), path.native()));
+            throw_malformed_sstable_exception(seastar::format("At directory: {}: no TOC found for SSTable {}!. Refusing to boot", _directory.native(), path.native()));
         } else {
             dirlog.info("Found incomplete SSTable {} at directory {}. Removing", path.native(), _directory.native());
             _state->files_for_removal.insert(path.native());
@@ -453,7 +453,7 @@ future<> sstable_directory::restore_components_lister::process(sstable_directory
         std::filesystem::path sst_path{toc_filename};
         auto result = sstables::parse_path(sst_path, "", "");
         if (!result) {
-            throw sstables::malformed_sstable_exception(result.error());
+            throw_malformed_sstable_exception(result.error());
         }
         entry_descriptor desc = std::move(*result);
         if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -705,20 +705,20 @@ future<> parse(const schema& schema, sstable_version_types v, random_access_read
                 break;
             case metadata_type::Serialization:
                 if (v < sstable_version_types::mc) {
-                    throw malformed_sstable_exception(
+                    throw_malformed_sstable_exception(
                         "Statistics is malformed: SSTable is in 2.x format but contains serialization header.");
                 } else {
                     co_await parse<serialization_header>(schema, v, in, s.contents[type]);
                 }
                 break;
             default:
-                throw malformed_sstable_exception(fmt::format("Invalid metadata type at Statistics file: {} ", int(type)));
+                throw_malformed_sstable_exception(fmt::format("Invalid metadata type at Statistics file: {} ", int(type)));
             }
         }
     } catch (const malformed_sstable_exception&) {
         throw;
     } catch (...) {
-        throw malformed_sstable_exception(fmt::format("Statistics file is malformed: {}", std::current_exception()));
+        throw_malformed_sstable_exception(fmt::format("Statistics file is malformed: {}", std::current_exception()));
     }
 }
 
@@ -854,7 +854,7 @@ future<> parse(const schema& s, sstable_version_types v, random_access_reader& i
 
     co_await parse(s, v, in, c.name, c.options, chunk_len, data_len);
     if (chunk_len == 0) {
-        throw malformed_sstable_exception("CompressionInfo is malformed: zero chunk_len");
+        throw_malformed_sstable_exception("CompressionInfo is malformed: zero chunk_len");
     }
     c.set_uncompressed_chunk_length(chunk_len);
     c.set_uncompressed_file_length(data_len);
@@ -936,12 +936,12 @@ future<> sstable::read_toc(sstable_open_config cfg) noexcept {
                 }
             }
             if (!_recognized_components.size()) {
-                throw malformed_sstable_exception("Empty TOC", toc_filename());
+                throw_malformed_sstable_exception("Empty TOC", toc_filename());
             }
         });
     } catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(fmt::format("{}: file not found", toc_filename()));
+            throw_malformed_sstable_exception(fmt::format("{}: file not found", toc_filename()));
         }
         throw;
     }
@@ -1094,11 +1094,11 @@ future<> sstable::do_read_simple(component_type type,
         _metadata_size_on_disk += size;
     }  catch (std::system_error& e) {
         if (e.code() == std::error_code(ENOENT, std::system_category())) {
-            throw malformed_sstable_exception(fmt::format("{}: file not found", component_name));
+            throw_malformed_sstable_exception(fmt::format("{}: file not found", component_name));
         }
         throw;
     } catch (malformed_sstable_exception& e) {
-        throw malformed_sstable_exception(e.what(), component_name);
+        throw_malformed_sstable_exception(e.what(), component_name);
     }
 }
 
@@ -1289,7 +1289,7 @@ void sstable::validate_component_digest(component_type type, uint32_t computed_d
         if (_ignore_component_digest_mismatch) {
             sstlog.warn("{}", msg);
         } else {
-            throw malformed_sstable_exception(msg);
+            throw_malformed_sstable_exception(msg);
         }
     }
 }
@@ -1302,7 +1302,7 @@ future<> sstable::validate_index_digest() const {
         }
         auto computed_digest = co_await compute_component_file_digest(f, size);
         if (*expected_digest != computed_digest) {
-            throw malformed_sstable_exception(
+            throw_malformed_sstable_exception(
                 fmt::format("{} digest mismatch in {}: expected {}, computed {}",
                             type, get_filename(), *expected_digest, computed_digest));
         }
@@ -1966,7 +1966,7 @@ void sstable::build_delayed_filter(uint64_t num_partitions) {
         }
     }
     if (processed_hashes != num_partitions) {
-        throw malformed_sstable_exception(fmt::format("Temporary hashes file {} was supposed to contain {} hashes, but it contains only {} hashes",
+        throw_malformed_sstable_exception(fmt::format("Temporary hashes file {} was supposed to contain {} hashes, but it contains only {} hashes",
             filename(component_type::TemporaryHashes), num_partitions, processed_hashes));
     }
 
@@ -2168,7 +2168,7 @@ void prepare_summary(summary& s, uint64_t expected_partition_count, uint32_t min
             !!(expected_partition_count % min_index_interval);
     // FIXME: handle case where max_expected_entries is greater than max value stored by uint32_t.
     if (max_expected_entries > std::numeric_limits<uint32_t>::max()) {
-        throw malformed_sstable_exception("Current sampling level (" + to_sstring(downsampling::BASE_SAMPLING_LEVEL) + ") not enough to generate summary.");
+        throw_malformed_sstable_exception("Current sampling level (" + to_sstring(downsampling::BASE_SAMPLING_LEVEL) + ") not enough to generate summary.");
     }
 
     s.header.memory_size = 0;
@@ -3376,10 +3376,10 @@ void sstable::set_first_and_last_keys() {
         first = decorate_key("first", _partitions_db_footer->first_key.get_bytes());
         last = decorate_key("last", _partitions_db_footer->last_key.get_bytes());
     } else {
-        throw malformed_sstable_exception(format("{}: neither Summary.db nor Partitions.db component is present, can't determine first and last partition key", get_filename()));
+        throw_malformed_sstable_exception(format("{}: neither Summary.db nor Partitions.db component is present, can't determine first and last partition key", get_filename()));
     }
     if (first.value().tri_compare(*_schema, last.value()) > 0) {
-        throw malformed_sstable_exception(format("{}: first and last keys of summary are misordered: first={} > last={}", get_filename(), first.value(), last.value()));
+        throw_malformed_sstable_exception(format("{}: first and last keys of summary are misordered: first={} > last={}", get_filename(), first.value(), last.value()));
     }
     _first = std::move(first.value());
     _last = std::move(last.value());
@@ -4350,7 +4350,7 @@ public:
 std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, std::string_view component_filename, sstable_stream_sink_cfg cfg) {
     auto desc_result = parse_path(component_filename, schema->ks_name(), schema->cf_name());
     if (!desc_result) {
-        throw malformed_sstable_exception(desc_result.error());
+        throw_malformed_sstable_exception(desc_result.error());
     }
     auto desc = std::move(*desc_result);
     auto sst = sstm.make_sstable(schema, s_opts, desc.generation, state, desc.version, desc.format);
@@ -4421,7 +4421,7 @@ namespace trie {
 future<bti_partitions_db_footer> read_bti_partitions_db_footer(const schema& s, sstable_version_types v, const seastar::file& f, uint64_t file_size) {
     file_random_access_reader reader(f, file_size, default_sstable_buffer_size);
     if (file_size < 24) {
-        throw malformed_sstable_exception(fmt::format("Partitions.db file is too small: file_size={}", file_size));
+        throw_malformed_sstable_exception(fmt::format("Partitions.db file is too small: file_size={}", file_size));
     }
     co_await reader.seek(file_size - 24);
     uint64_t keys_position;
@@ -4431,10 +4431,10 @@ future<bti_partitions_db_footer> read_bti_partitions_db_footer(const schema& s, 
     co_await parse(s, v, reader, partition_count);
     co_await parse(s, v, reader, trie_root);
     if (trie_root >= file_size) {
-        throw malformed_sstable_exception(fmt::format("Partitions.db malformed: trie_root={}, file_size={}", trie_root, file_size));
+        throw_malformed_sstable_exception(fmt::format("Partitions.db malformed: trie_root={}, file_size={}", trie_root, file_size));
     }
     if (keys_position >= file_size) {
-        throw malformed_sstable_exception(fmt::format("Partitions.db malformed: keys_position={}, file_size={}", keys_position, file_size));
+        throw_malformed_sstable_exception(fmt::format("Partitions.db malformed: keys_position={}, file_size={}", keys_position, file_size));
     }
     co_await reader.seek(keys_position);
     disk_string<uint16_t> first_key;

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -157,11 +157,19 @@ scoped_no_abort_on_malformed_sstable_error::~scoped_no_abort_on_malformed_sstabl
         }
         return malformed_sstable_exception(message);
     };
+    if (abort_on_malformed_sstable_error()) {
+        sstlog.error("malformed sstable error (aborting): {}", make_exception().what());
+        std::abort();
+    }
     auto ex = std::make_exception_ptr(make_exception());
     on_internal_error(sstlog, std::move(ex));
 }
 
 [[noreturn, gnu::noinline]] void on_bti_parse_error(uint64_t pos) {
+    if (abort_on_malformed_sstable_error()) {
+        sstlog.error("malformed sstable error (aborting): BTI parse error for node at pos {}", pos);
+        std::abort();
+    }
     on_internal_error(sstlog, fmt::format("BTI parse error for node at pos {}", pos));
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -287,7 +287,7 @@ static typename Map::key_type reverse_map(const Value& v, const Map& map) {
 // and we need to do something about it.
 static void check_buf_size(temporary_buffer<char>& buf, size_t expected) {
     if (buf.size() < expected) {
-        throw bufsize_mismatch_exception(buf.size(), expected);
+        throw_bufsize_mismatch_exception(buf.size(), expected);
     }
 }
 

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -7,7 +7,9 @@
  */
 
 #include "utils/log.hh"
+#include <atomic>
 #include <concepts>
+#include <cstdlib>
 #include <vector>
 #include <limits>
 #include <algorithm>
@@ -109,6 +111,32 @@ namespace sstables {
 thread_local utils::updateable_value<bool> global_cache_index_pages(true);
 
 logging::logger sstlog("sstable");
+
+static std::atomic<bool> _abort_on_malformed_sstable_error{false};
+
+bool set_abort_on_malformed_sstable_error(bool value) noexcept {
+    return _abort_on_malformed_sstable_error.exchange(value, std::memory_order_relaxed);
+}
+
+bool abort_on_malformed_sstable_error() noexcept {
+    return _abort_on_malformed_sstable_error.load(std::memory_order_relaxed);
+}
+
+[[noreturn]] void throw_malformed_sstable_exception(sstring msg) {
+    if (_abort_on_malformed_sstable_error.load(std::memory_order_relaxed)) {
+        sstlog.error("malformed sstable error (aborting): {}", msg);
+        std::abort();
+    }
+    throw malformed_sstable_exception(std::move(msg));
+}
+
+[[noreturn]] void throw_malformed_sstable_exception(sstring msg, component_name filename) {
+    throw_malformed_sstable_exception(format("{} in sstable {}", msg, filename));
+}
+
+[[noreturn]] void throw_bufsize_mismatch_exception(size_t size, size_t expected) {
+    throw_malformed_sstable_exception(format("Buffer improperly sized to hold requested data. Got: {:d}. Expected: {:d}", size, expected));
+}
 
 [[noreturn]] void on_parse_error(sstring message, std::optional<component_name> filename) {
     auto make_exception = [&] {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -138,6 +138,15 @@ bool abort_on_malformed_sstable_error() noexcept {
     throw_malformed_sstable_exception(format("Buffer improperly sized to hold requested data. Got: {:d}. Expected: {:d}", size, expected));
 }
 
+scoped_no_abort_on_malformed_sstable_error::scoped_no_abort_on_malformed_sstable_error() noexcept
+    : _prev(set_abort_on_malformed_sstable_error(false))
+{
+}
+
+scoped_no_abort_on_malformed_sstable_error::~scoped_no_abort_on_malformed_sstable_error() {
+    set_abort_on_malformed_sstable_error(_prev);
+}
+
 [[noreturn]] void on_parse_error(sstring message, std::optional<component_name> filename) {
     auto make_exception = [&] {
         if (message.empty()) {

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -30,6 +30,7 @@
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/memory-data-source.hh>
 #include <seastar/util/memory-data-sink.hh>
+#include <expected>
 #include <iterator>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -2893,7 +2894,7 @@ sstable::make_full_scan_reader(
     return kl::make_full_scan_reader(shared_from_this(), std::move(schema), std::move(permit), std::move(trace_state), monitor, integrity);
 }
 
-static std::tuple<entry_descriptor, sstring, sstring> make_entry_descriptor(const std::filesystem::path& sst_path, sstring* const provided_ks, sstring* const provided_cf) {
+static std::expected<std::tuple<entry_descriptor, sstring, sstring>, sstring> make_entry_descriptor(const std::filesystem::path& sst_path, sstring* const provided_ks, sstring* const provided_cf) {
     // examples of fname look like
     //   la-42-big-Data.db
     //   ka-42-big-Data.db
@@ -2935,10 +2936,14 @@ static std::tuple<entry_descriptor, sstring, sstring> make_entry_descriptor(cons
                 ks = dirmatch[1].str();
                 cf = dirmatch[2].str();
             } else {
-                throw malformed_sstable_exception(seastar::format("invalid path for file {}: {}. Path doesn't match known pattern.", fname, sstdir));
+                return std::unexpected{seastar::format("invalid path for file {}: {}. Path doesn't match known pattern.", fname, sstdir)};
             }
         }
-        version = version_from_string(match[1].str());
+        try {
+            version = version_from_string(match[1].str());
+        } catch (const std::exception& e) {
+            return std::unexpected{seastar::format("failed to parse version for sstable filename {}: {}", fname, e)};
+        }
         generation = match[2].str();
         format = sstring(match[3].str());
         component = sstring(match[4].str());
@@ -2952,18 +2957,25 @@ static std::tuple<entry_descriptor, sstring, sstring> make_entry_descriptor(cons
         generation = match[3].str();
         component = sstring(match[4].str());
     } else {
-        throw malformed_sstable_exception(seastar::format("invalid version for file {}. Name doesn't match any known version.", fname));
+        return std::unexpected{seastar::format("invalid version for file {}. Name doesn't match any known version.", fname)};
     }
-    return std::make_tuple(entry_descriptor(generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
+    try {
+        return std::make_tuple(entry_descriptor(generation_type::from_string(generation), version, format_from_string(format), sstable::component_from_sstring(version, component)), ks, cf);
+    } catch (const std::exception& e) {
+        return std::unexpected{seastar::format("failed to parse sstable filename {}: {}", fname, e.what())};
+    }
 }
 
-std::tuple<entry_descriptor, sstring, sstring> parse_path(const std::filesystem::path& sst_path) {
+std::expected<std::tuple<entry_descriptor, sstring, sstring>, sstring> parse_path(const std::filesystem::path& sst_path) {
     return make_entry_descriptor(sst_path, nullptr, nullptr);
 }
 
-entry_descriptor parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf) {
+std::expected<entry_descriptor, sstring> parse_path(const std::filesystem::path& sst_path, sstring ks, sstring cf) {
     auto full = make_entry_descriptor(sst_path, &ks, &cf);
-    return std::get<0>(full);
+    if (!full) {
+        return std::unexpected{full.error()};
+    }
+    return std::get<0>(*full);
 }
 
 sstable_version_types version_from_string(std::string_view s) {
@@ -4291,7 +4303,11 @@ public:
 };
 
 std::unique_ptr<sstable_stream_sink> create_stream_sink(schema_ptr schema, sstables_manager& sstm, const data_dictionary::storage_options& s_opts, sstable_state state, std::string_view component_filename, sstable_stream_sink_cfg cfg) {
-    auto desc = parse_path(component_filename, schema->ks_name(), schema->cf_name());
+    auto desc_result = parse_path(component_filename, schema->ks_name(), schema->cf_name());
+    if (!desc_result) {
+        throw malformed_sstable_exception(desc_result.error());
+    }
+    auto desc = std::move(*desc_result);
     auto sst = sstm.make_sstable(schema, s_opts, desc.generation, state, desc.version, desc.format);
 
     auto type = desc.component;

--- a/sstables/trie/bti_index_reader.cc
+++ b/sstables/trie/bti_index_reader.cc
@@ -49,7 +49,7 @@ struct row_index_header_parser : public data_consumer::continuous_data_consumer<
     {}
     void verify_end_state() {
         if (!_finished) {
-            throw sstables::malformed_sstable_exception(fmt::format("row_index_header_parser: verify_end_state: not finished"));
+            throw_malformed_sstable_exception(fmt::format("row_index_header_parser: verify_end_state: not finished"));
         }
     }
     bool non_consuming() const {

--- a/test/boost/broken_sstable_test.cc
+++ b/test/boost/broken_sstable_test.cc
@@ -12,6 +12,7 @@
 
 #include "test/boost/sstable_test.hh"
 #include "test/lib/exception_utils.hh"
+#include "sstables/exceptions.hh"
 
 using namespace sstables;
 
@@ -30,6 +31,7 @@ struct my_consumer {
 static future<> broken_sst(sstring dir, sstables::generation_type::int_t generation, schema_ptr s, sstring msg, std::optional<sstring> sst_name,
     sstable_version_types version = la) {
   return sstables::test_env::do_with_async([=] (sstables::test_env& env) {
+    sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
     try {
         sstable_ptr sstp = env.reusable_sst(s, dir, generation, version).get();
         auto r = sstp->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
@@ -55,6 +57,7 @@ static future<> broken_sst(sstring dir, sstables::generation_type::int_t generat
 
 SEASTAR_TEST_CASE(test_empty_index) {
   return sstables::test_env::do_with_async([&] (sstables::test_env& env) {
+    sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
     auto s = schema_builder("test_ks", "test_table")
                  .with_column("pk", int32_type, column_kind::partition_key)
                  .with_column("ck", int32_type, column_kind::clustering_key)

--- a/test/boost/file_stream_test.cc
+++ b/test/boost/file_stream_test.cc
@@ -11,6 +11,7 @@
 #include "message/messaging_service.hh"
 #include "test/lib/log.hh"
 #include "test/lib/sstable_utils.hh"
+#include "sstables/exceptions.hh"
 
 #include <boost/lexical_cast.hpp>
 #include <seastar/testing/thread_test_case.hh>
@@ -164,6 +165,7 @@ static future<> corrupt_data_component(sstables::shared_sstable sst) {
 using compress_sstable = bool_class<struct compress_sstable_tag>;
 static future<>
 do_test_sstable_stream(cql_test_env& env, compress_sstable compress, std::function<future<>(shared_sstable)> corruption_fn = nullptr, const sstring& expected_error_msg = "") {
+    sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
     bool verb_register = false;
     auto ops_id = file_stream_id::create_random_id();
     auto& db = env.local_db();

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -27,6 +27,7 @@
 #include "schema/schema_registry.hh"
 #include "utils/chunked_vector.hh"
 #include "repair/incremental.hh"
+#include "sstables/exceptions.hh"
 
 BOOST_AUTO_TEST_SUITE(repair_test)
 
@@ -260,6 +261,7 @@ static future<> corrupt_data_component(sstables::shared_sstable sst) {
 
 static future<> run_repair_reader_corruption_test(random_mutation_generator::compress compress, const sstring& expected_error_msg) {
     return do_with_cql_env([=](cql_test_env& e) -> future<> {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         random_mutation_generator gen{random_mutation_generator::generate_counters::no, local_shard_only::no,
             random_mutation_generator::generate_uncompactable::no, std::nullopt, "ks", "cf", compress};
 

--- a/test/boost/schema_loader_test.cc
+++ b/test/boost/schema_loader_test.cc
@@ -331,7 +331,7 @@ void check_sstable_schema(sstables::test_env& env, std::filesystem::path sst_pat
 
     check_schema_columns(*schema, *mutations.front().schema(), has_scylla_metadata);
 
-    const auto ed = sstables::parse_path(sst_path, "ks", "tbl");
+    const auto ed = sstables::parse_path(sst_path, "ks", "tbl").value();
     const auto dir_path = sst_path.parent_path();
     auto sst = env.make_sstable(schema, dir_path.c_str(), ed.generation, ed.version, ed.format);
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -43,8 +43,7 @@
 #include "db/large_data_handler.hh"
 #include "db/config.hh"
 #include "readers/combined.hh"
-
-#include <fmt/ranges.h>
+#include "sstables/exceptions.hh"
 
 using namespace sstables;
 
@@ -5842,6 +5841,7 @@ SEASTAR_TEST_CASE(test_legacy_udt_in_collection_table) {
 
 SEASTAR_TEST_CASE(test_compression_premature_eof) {
     return test_env::do_with_async([] (test_env& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto stable_dir = "./test/resource/sstables/compression-premature-eof";
         sstable_assertions sst(env, ZSTD_MULTIPLE_CHUNKS_SCHEMA, stable_dir);
         sst.load();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -77,6 +77,7 @@
 #include "readers/combined.hh"
 #include "utils/assert.hh"
 #include "utils/pretty_printers.hh"
+#include "sstables/exceptions.hh"
 
 BOOST_AUTO_TEST_SUITE(sstable_compaction_test)
 
@@ -570,6 +571,7 @@ static void compact_corrupted_by_compression_mode(const std::string& tname,
         const sstring& error_msg)
 {
     test_env::do_with_async([&] (test_env& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto compact = [&] (schema_ptr schema, std::vector<shared_sstable> to_compact) {
             auto sst_gen = env.make_sst_factory(schema);
             auto cf = env.make_table_for_tests(schema);
@@ -3472,6 +3474,7 @@ SEASTAR_THREAD_TEST_CASE(sstable_scrub_abort_mode_malformed_sstable_test) {
     auto muts = tests::generate_random_mutations(test.random_schema(), 3).get();
 
     test.run(schema, muts, [] (table_for_tests& table, compaction::compaction_group_view& ts, std::vector<sstables::shared_sstable> sstables) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         BOOST_REQUIRE(sstables.size() == 1);
         auto sst = sstables.front();
         corrupt_sstable(sst);

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -57,6 +57,7 @@
 #include "test/lib/exception_utils.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/gcs_fixture.hh"
+#include "sstables/exceptions.hh"
 
 namespace fs = std::filesystem;
 
@@ -2215,6 +2216,7 @@ SEASTAR_TEST_CASE(test_broken_promoted_index_is_skipped) {
     // insert into ks.test (pk, ck, v) values (1, 3, 1);
     // delete from ks.test where pk = 1 and ck = 2;
     return test_env::do_with_async([] (test_env& env) {
+      sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
       for (const auto version : all_sstable_versions) {
         if (!has_summary_and_index(version)) {
             // This is an old test for some workaround for

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -29,8 +29,7 @@
 #include "test/lib/cql_assertions.hh"
 #include "utils/lister.hh"
 #include "db/config.hh"
-
-#include <fmt/core.h>
+#include "sstables/exceptions.hh"
 #include <fmt/ranges.h>
 #include <boost/algorithm/string/erase.hpp>
 
@@ -189,6 +188,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_simple_empty_directory_scan) {
 // Test unrecoverable SSTable: missing a file that is expected in the TOC.
 SEASTAR_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) {
     return sstables::test_env::do_with_async([] (test_env& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto sst = make_sstable_for_this_shard(std::bind(new_sstable, std::ref(env), generation_type(this_shard_id())));
 
         // Now there is one sstable to the upload directory, but it is incomplete and one component is missing.
@@ -206,6 +206,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_scan_incomplete_sstables) {
 // reproducing https://github.com/scylladb/scylla/issues/10697
 SEASTAR_TEST_CASE(sstable_directory_test_table_scan_invalid_file) {
     return sstables::test_env::do_with_async([] (test_env& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto& dir = env.tempdir();
         auto sst = make_sstable_for_this_shard(std::bind(new_env_sstable, std::ref(env)));
 
@@ -276,6 +277,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_unlink_sstable_leaves_no_orphans) {
 // Test the absence of TOC. Behavior is controllable by a flag
 SEASTAR_TEST_CASE(sstable_directory_test_table_missing_toc) {
     return sstables::test_env::do_with_async([] (test_env& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto sst = make_sstable_for_this_shard(std::bind(new_env_sstable, std::ref(env)));
         remove_file(test(sst).filename(sstables::component_type::TOC).native()).get();
 
@@ -296,6 +298,7 @@ SEASTAR_TEST_CASE(sstable_directory_test_table_missing_toc) {
 // is not around (but mentioned in the TOC), then this is an error.
 SEASTAR_THREAD_TEST_CASE(sstable_directory_test_temporary_statistics) {
     sstables::test_env::do_with_sharded_async([] (sharded<test_env>& env) {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto sst = make_sstable_for_this_shard(std::bind(new_env_sstable, std::ref(env.local())));
         auto tempstr = test(sst).filename(component_type::TemporaryStatistics);
         tests::touch_file(tempstr.native()).get();

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -16,6 +16,7 @@
 #include "test/lib/sstable_utils.hh"
 #include "test/lib/simple_schema.hh"
 #include "sstable_test.hh"
+#include "sstables/exceptions.hh"
 
 using namespace sstables;
 namespace fs = std::filesystem;
@@ -131,6 +132,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_move_exists_failure) {
     auto scf = make_sstable_compressor_factory_for_tests_in_thread();
     auto env = test_env({}, *scf);
     auto stop_env = defer([&env] { env.stop().get(); });
+    sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
 
     // please note, the SSTables used by this test are stored under
     // get_test_dir("uncompressed", "ks", fs::path(uncompressed_dir())), so the

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -37,6 +37,7 @@
 #include "partition_slice_builder.hh"
 #include "sstables/sstable_mutation_reader.hh"
 #include "sstables/binary_search.hh"
+#include "sstables/exceptions.hh"
 
 #include <boost/range/combine.hpp>
 
@@ -1035,6 +1036,7 @@ static void corrupt_sstable(sstables::shared_sstable sst, component_type compone
 
 static future<> test_component_digest_validation(component_type component, sstable::version_types version, sstring expected_message, compress_sstable compress = compress_sstable::no) {
     return test_env::do_with_async([component, version, expected_message = std::move(expected_message), compress] (test_env& env) mutable {
+        sstables::scoped_no_abort_on_malformed_sstable_error no_abort;
         auto random_spec = tests::make_random_schema_specification(
             "ks",
             std::uniform_int_distribution<size_t>(1, 4),

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -869,7 +869,7 @@ BOOST_AUTO_TEST_CASE(test_parse_path_good) {
         }
     };
     for (auto& [path, expected_ks, expected_cf, expected_desc] : sstables) {
-        auto [desc, ks, cf] = parse_path(path);
+        auto [desc, ks, cf] = parse_path(path).value();
         BOOST_CHECK_EQUAL(ks, expected_ks);
         BOOST_CHECK_EQUAL(cf, expected_cf);
         BOOST_CHECK_EQUAL(expected_desc.generation, desc.generation);
@@ -902,7 +902,7 @@ BOOST_AUTO_TEST_CASE(test_parse_path_bad) {
         "/scylla/system/truncated~38c19fd0fb863310a4b70d0cc66628aa/mc-2-grand-Data.db",
     };
     for (auto path : paths) {
-        BOOST_CHECK_THROW(parse_path(path), std::exception);
+        BOOST_CHECK(!parse_path(path).has_value());
     }
 }
 
@@ -927,7 +927,7 @@ static future<> test_component_digest_persistence(component_type component, ssta
         BOOST_REQUIRE(has_component);
 
         auto toc_path = fmt::to_string(sst_original->toc_filename());
-        auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name());
+        auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();
         auto dir_path = std::filesystem::path(toc_path).parent_path().string();
 
         std::optional<uint32_t> original_digest;
@@ -1052,7 +1052,7 @@ static future<> test_component_digest_validation(component_type component, sstab
         BOOST_REQUIRE(digest.has_value());
 
         auto toc_path = fmt::to_string(sst->toc_filename());
-        auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name());
+        auto entry_desc = sstables::parse_path(toc_path, schema->ks_name(), schema->cf_name()).value();
         auto dir_path = std::filesystem::path(toc_path).parent_path().string();
 
         corrupt_sstable(sst, component);

--- a/test/perf/perf_sstable.hh
+++ b/test/perf/perf_sstable.hh
@@ -227,7 +227,7 @@ public:
         auto dir = co_await open_directory(sst_dir_path.native());
         auto h = dir.list_directory([&](directory_entry de) -> future<> {
             std::filesystem::path sst_path = sst_dir_path / de.name.begin();
-            auto entry = parse_path(sst_path, s->ks_name(), s->cf_name());
+            auto entry = parse_path(sst_path, s->ks_name(), s->cf_name()).value();
             if (entry.component == component_type::TOC) {
                 auto sst = _env.make_sstable(s, this->dir(), entry.generation, entry.version);
                 co_await sst->load(s->get_sharder());

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -38,6 +38,7 @@
 #include "replica/database.hh"
 #include "sstables/sstables_manager.hh"
 #include "sstables/sstable_directory.hh"
+#include "sstables/exceptions.hh"
 #include "types/list.hh"
 #include "data_dictionary/impl.hh"
 #include "data_dictionary/data_dictionary.hh"
@@ -614,7 +615,11 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
 
     schema_ptr bootstrap_schema = schema_builder(keyspace, table).with_column("pk", int32_type, column_kind::partition_key).build();
 
-    const auto ed = sstables::parse_path(sstable_path, keyspace, table);
+    auto ed_result = sstables::parse_path(sstable_path, keyspace, table);
+    if (!ed_result) {
+        throw sstables::malformed_sstable_exception(ed_result.error());
+    }
+    const auto ed = std::move(*ed_result);
     const auto dir_path = sstable_path.parent_path();
     auto local = data_dictionary::make_local_options(dir_path);
     auto bootstrap_sst = sst_man.make_sstable(bootstrap_schema, local, ed.generation, sstables::sstable_state::normal, ed.version, ed.format);

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -617,7 +617,7 @@ schema_ptr do_load_schema_from_sstable(const db::config& dbcfg, std::filesystem:
 
     auto ed_result = sstables::parse_path(sstable_path, keyspace, table);
     if (!ed_result) {
-        throw sstables::malformed_sstable_exception(ed_result.error());
+        sstables::throw_malformed_sstable_exception(ed_result.error());
     }
     const auto ed = std::move(*ed_result);
     const auto dir_path = sstable_path.parent_path();

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -345,7 +345,7 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
         data_dictionary::storage_options options;
         auto ed_result = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
         if (!ed_result) {
-            throw sstables::malformed_sstable_exception(ed_result.error());
+            sstables::throw_malformed_sstable_exception(ed_result.error());
         }
         auto ed = std::move(*ed_result);
 

--- a/tools/scylla-sstable.cc
+++ b/tools/scylla-sstable.cc
@@ -156,13 +156,13 @@ sstable_path_info extract_from_sstable_path(const bpo::variables_map& app_config
 
     auto sst_path = std::filesystem::path(app_config["sstables"].as<std::vector<sstring>>().front());
     sstring keyspace, table;
-    try {
-        auto [_, ks, tbl] = sstables::parse_path(sst_path);
-        keyspace = std::move(ks);
-        table = std::move(tbl);
-    } catch (const sstables::malformed_sstable_exception&) {
+    auto result = sstables::parse_path(sst_path);
+    if (!result) {
         throw std::invalid_argument(fmt::format("cannot extract information from sstable path, sstable has invalid path: {}", sst_path));
     }
+    auto [_, ks, tbl] = std::move(*result);
+    keyspace = std::move(ks);
+    table = std::move(tbl);
     const auto sst_dir_path = std::filesystem::path(sst_path).remove_filename();
     std::filesystem::path data_dir_path;
     // Detect whether sstable is in root table directory, or in a sub-directory
@@ -343,7 +343,11 @@ const std::vector<sstables::shared_sstable> load_sstables(schema_ptr schema, sst
 
 
         data_dictionary::storage_options options;
-        auto ed = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
+        auto ed_result = sstables::parse_path(sst_path, schema->ks_name(), schema->cf_name());
+        if (!ed_result) {
+            throw sstables::malformed_sstable_exception(ed_result.error());
+        }
+        auto ed = std::move(*ed_result);
 
         using osp = db::object_storage_endpoint_param;
         static const auto os_types = { osp::s3_type, osp::gs_type };

--- a/utils/directories.cc
+++ b/utils/directories.cc
@@ -14,7 +14,6 @@
 #include "init.hh"
 #include "supervisor.hh"
 #include "directories.hh"
-#include "sstables/exceptions.hh"
 #include "sstables/open_info.hh"
 #include "utils/disk-error-handler.hh"
 #include "utils/lister.hh"
@@ -172,15 +171,14 @@ future<> directories::verify_owner_and_mode_of_data_dir(directories::set dir_set
             return do_verify_owner_and_mode(std::move(path), recursive::yes, 0, [verify_data_and_index_files] (const fs::path& dir, const directory_entry& de) {
                 auto path = dir / de.name;
                 component_type path_component_type;
-                try {
-                    // use parse_path to deduce the component type as using system calls
-                    // like stat/lstat will load the inode/dentry into the cache.
-                    auto descriptor_tuple = sstables::parse_path(path);
-                    path_component_type = std::get<0>(descriptor_tuple).component;
-                } catch (sstables::malformed_sstable_exception&) {
+                // use parse_path to deduce the component type as using system calls
+                // like stat/lstat will load the inode/dentry into the cache.
+                auto result = sstables::parse_path(path);
+                if (!result) {
                     // path is not a SSTable component - do not filter it out
                     return true;
                 }
+                path_component_type = std::get<0>(*result).component;
                 auto data_or_index_file = (path_component_type == component_type::Data || path_component_type == component_type::Index);
                 return verify_data_and_index_files ? data_or_index_file : !data_or_index_file;
             });


### PR DESCRIPTION
When a malformed sstable error occurs, it is usually caused by actual sstable corruption — a cosmic ray, a bad disk write, etc. However, it can also be caused by memory corruption, where a data structure in memory happens to be read as sstable data. In the latter case, having a coredump of the process at the moment of the error is invaluable for post-mortem debugging, since the exception throwing/catching machinery destroys the stack frames that would point to the corruption site.

This patch series introduces `--abort-on-malformed-sstable-error`, a new command-line option (with `LiveUpdate` support) that, when set, causes the server to call `std::abort()` instead of throwing an exception whenever any sstable parse error is detected. This covers all code paths:

- Direct `throw malformed_sstable_exception(...)` sites (migrated to `throw_malformed_sstable_exception()`)
- Direct `throw bufsize_mismatch_exception(...)` sites (migrated to `throw_bufsize_mismatch_exception()`)
- `parse_assert()` failures (via `on_parse_error()`)
- BTI parse errors (via `on_bti_parse_error()`)

The implementation places the flag and helper functions in `sstables/sstables.cc`, next to the existing `on_parse_error()` / `on_bti_parse_error()` infrastructure.

The flag defaults to `false`, preserving current behaviour. It is intended to be enabled temporarily when investigating suspected memory corruption.

**Commit breakdown:**
1. Infrastructure: flag, getter/setter, and throw helpers in `sstables/sstables.cc`; config option wired up in `main.cc`
2. `on_parse_error()` and `on_bti_parse_error()` check the new flag
3. All ~50 `throw malformed_sstable_exception(...)` sites migrated
4. Both `throw bufsize_mismatch_exception(...)` sites migrated

Refs: SCYLLADB-1087
Backport: new feature, no backport