### PR TITLE
docker: fix coredump collection when host uses pipe-based core_pattern

### DIFF
--- a/dist/common/supervisor/scylla-server.sh
+++ b/dist/common/supervisor/scylla-server.sh
@@ -9,6 +9,22 @@ for f in "$etcdir"/scylla.d/*.conf; do
 done
 
 if is_privileged; then
+    # Override pipe-based core_pattern that may not work inside a container
+    # (e.g. Ubuntu host's apport).  File-based patterns resolve inside the
+    # container's mount namespace, so coredumps land in the right place.
+    # Derive workdir from scylla.yaml, matching the Python entrypoint logic.
+    _workdir=$(python3 -c "import yaml; cfg=yaml.safe_load(open('/etc/scylla/scylla.yaml')); print(cfg.get('workdir') or '/var/lib/scylla')" 2>/dev/null || echo "/var/lib/scylla")
+    _coredump_dir="${_workdir}/coredump"
+    core_pattern=$(cat /proc/sys/kernel/core_pattern 2>/dev/null || true)
+    if [[ "$core_pattern" == "|"* ]]; then
+        if ! mkdir -p "$_coredump_dir" 2>/dev/null; then
+            echo "WARNING: could not create coredump directory $_coredump_dir" >&2
+        elif echo "${_coredump_dir}/core.%e.%p.%t" > /proc/sys/kernel/core_pattern 2>/dev/null; then
+            echo "kernel.core_pattern overridden to file-based pattern: ${_coredump_dir}/core.%e.%p.%t" >&2
+        else
+            echo "WARNING: pipe-based core_pattern detected but could not override. Coredumps may be lost." >&2
+        fi
+    fi
     "$scriptsdir"/scylla_prepare
 fi
 execsudo /usr/bin/env SCYLLA_HOME=$SCYLLA_HOME SCYLLA_CONF=$SCYLLA_CONF "$bindir"/scylla $SCYLLA_ARGS $SEASTAR_IO $DEV_MODE $CPUSET $SCYLLA_DOCKER_ARGS

--- a/dist/docker/docker-entrypoint.py
+++ b/dist/docker/docker-entrypoint.py
@@ -24,6 +24,7 @@ try:
     setup.developerMode()
     setup.cpuSet()
     setup.io()
+    setup.coredumpSetup()
     setup.cqlshrc()
     setup.write_rackdc_properties()
     setup.arguments()

--- a/dist/docker/scyllasetup.py
+++ b/dist/docker/scyllasetup.py
@@ -3,6 +3,7 @@ import logging
 import yaml
 import os
 import socket
+import errno
 
 def is_bind_mount(path):
     # Check if the file or its parent is a mount point (bind mount or otherwise)
@@ -47,6 +48,7 @@ class ScyllaSetup:
         self._dc = arguments.dc
         self._rack = arguments.rack
         self._blocked_reactor_notify_ms = arguments.blocked_reactor_notify_ms
+        self._coredump_dir = None
 
     def _run(self, *args, **kwargs):
         logging.info('running: {}'.format(args))
@@ -131,6 +133,70 @@ class ScyllaSetup:
         with open(rackdc_path, "w") as f:
             f.write(f"dc={dc}\n")
             f.write(f"rack={rack}\n")
+
+    CORE_PATTERN_PATH = '/proc/sys/kernel/core_pattern'
+
+    def _get_coredump_dir(self):
+        """Return the coredump directory, deriving it from scylla.yaml workdir if needed."""
+        if self._coredump_dir is not None:
+            return self._coredump_dir
+        conf_dir = "/etc/scylla"
+        try:
+            with open(os.path.join(conf_dir, "scylla.yaml")) as f:
+                cfg = yaml.safe_load(f) or {}
+        except Exception:
+            cfg = {}
+        workdir = cfg.get('workdir') or '/var/lib/scylla'
+        self._coredump_dir = os.path.join(workdir, 'coredump')
+        return self._coredump_dir
+
+    def coredumpSetup(self):
+        """Configure coredump handling for containers.
+
+        The host's kernel.core_pattern may pipe core dumps to a handler
+        (e.g. Ubuntu's apport) that does not exist or work correctly
+        inside the container.  This method tries to switch to a file-based
+        core_pattern so that coredumps are written directly to disk.
+
+        Writing to /proc/sys/kernel/core_pattern requires privileges
+        (root with CAP_SYS_ADMIN).  When the container lacks permission
+        a warning is logged with guidance for the operator.
+        """
+        coredump_dir = self._get_coredump_dir()
+
+        try:
+            os.makedirs(coredump_dir, exist_ok=True)
+        except OSError as e:
+            logging.warning('Could not create coredump directory %s: %s',
+                            coredump_dir, e)
+            return
+
+        try:
+            with open(self.CORE_PATTERN_PATH) as f:
+                current = f.read().strip()
+        except Exception as e:
+            logging.debug('Could not read %s: %s', self.CORE_PATTERN_PATH, e)
+            return
+
+        if not current.startswith('|'):
+            return
+
+        desired = f'{coredump_dir}/core.%e.%p.%t'
+        try:
+            with open(self.CORE_PATTERN_PATH, 'w') as f:
+                f.write(desired + '\n')
+            logging.info('kernel.core_pattern set to %s', desired)
+        except OSError as e:
+            if e.errno in (errno.EACCES, errno.EPERM, errno.EROFS):
+                logging.warning(
+                    'kernel.core_pattern pipes to a program that may not work '
+                    'inside the container, and we lack permission to override it. '
+                    'To fix this, either run with --privileged or set on the host: '
+                    'sysctl -w kernel.core_pattern="%s"', desired)
+            else:
+                logging.debug('Unexpected OSError setting core_pattern: %s', e)
+        except Exception as e:
+            logging.debug('Unexpected error in coredumpSetup: %s', e)
 
     def arguments(self):
         args = []

--- a/test.py
+++ b/test.py
@@ -433,7 +433,7 @@ async def process_coverage(options):
     logger.debug(f"Binary ids map is: {files_to_ids_map}")
     logger.info("Done getting binary ids for coverage conversion")
     # get the suits that have actually been ran
-    suits_to_exclude = ["pylib_test", "nodetool"]
+    suits_to_exclude = ["pylib_test", "dist_test", "nodetool"]
     sources_to_exclude = [line for line in open("coverage_excludes.txt", 'r').read().split('\n') if line and not line.startswith('#')]
     ran_suites = list({test.suite for test in TestSuite.all_tests() if test.suite.need_coverage()})
 

--- a/test/dist_test/__init__.py
+++ b/test/dist_test/__init__.py
@@ -1,0 +1,5 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#

--- a/test/dist_test/test_coredump_setup.py
+++ b/test/dist_test/test_coredump_setup.py
@@ -1,0 +1,188 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+import builtins
+import errno
+import importlib.util
+import logging
+import os
+
+
+# ---------------------------------------------------------------------------
+# Load scyllasetup from dist/docker/ using importlib so we test the real
+# production code rather than a duplicated copy of the logic.
+# ---------------------------------------------------------------------------
+
+_SCYLLASETUP_PATH = os.path.join(
+    os.path.dirname(__file__), '..', '..', 'dist', 'docker', 'scyllasetup.py',
+)
+
+def _load_scyllasetup():
+    spec = importlib.util.spec_from_file_location('scyllasetup', _SCYLLASETUP_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+scyllasetup = _load_scyllasetup()
+
+
+def _make_setup(tmp_path, core_pattern_content):
+    """Create a ScyllaSetup-like object with paths redirected to tmp_path.
+
+    Returns (setup_obj, core_pattern_file, coredump_dir).
+    """
+    core_pattern_file = tmp_path / "core_pattern"
+    core_pattern_file.write_text(core_pattern_content)
+
+    coredump_dir = tmp_path / "coredump"
+    # coredump_dir is intentionally NOT pre-created; the method should create it.
+
+    # Build a minimal object that has coredumpSetup bound to it,
+    # with the class-level path constants overridden for testing.
+    setup = object.__new__(scyllasetup.ScyllaSetup)
+    setup.CORE_PATTERN_PATH = str(core_pattern_file)
+    setup._coredump_dir = str(coredump_dir)
+
+    return setup, core_pattern_file, coredump_dir
+
+
+class TestCoredumpSetup:
+    """Unit tests for ScyllaSetup.coredumpSetup()."""
+
+    def test_pipe_pattern_is_overridden(self, tmp_path):
+        """A pipe-based pattern is replaced with a file-based one."""
+        setup, core_file, coredump_dir = _make_setup(
+            tmp_path,
+            "|/usr/share/apport/apport -p%p -s%s -c%c -d%d -P%P -u%u -g%g -- %E\n",
+        )
+        setup.coredumpSetup()
+        result = core_file.read_text().strip()
+        assert result == f"{coredump_dir}/core.%e.%p.%t"
+        assert coredump_dir.is_dir()
+
+    def test_file_pattern_is_left_alone(self, tmp_path):
+        """A file-based pattern is not modified."""
+        original = "core.%e.%p.%t"
+        setup, core_file, _ = _make_setup(tmp_path, original)
+        setup.coredumpSetup()
+        assert core_file.read_text().strip() == original
+
+    def test_systemd_coredump_pattern_is_overridden(self, tmp_path):
+        """systemd-coredump pipe pattern is replaced."""
+        setup, core_file, coredump_dir = _make_setup(
+            tmp_path,
+            "|/usr/lib/systemd/systemd-coredump %p %u %g %s %t %e\n",
+        )
+        setup.coredumpSetup()
+        result = core_file.read_text().strip()
+        assert result == f"{coredump_dir}/core.%e.%p.%t"
+
+    def test_readonly_pattern_file_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """When the pattern file is not writable, a warning is logged."""
+        setup, core_file, _ = _make_setup(
+            tmp_path,
+            "|/usr/share/apport/apport -p%p\n",
+        )
+        real_open = builtins.open
+
+        def raising_open(path, mode="r", *args, **kwargs):
+            if path == str(core_file) and mode == "w":
+                raise OSError(errno.EACCES, "Permission denied")
+            return real_open(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", raising_open)
+
+        with caplog.at_level(logging.WARNING):
+            setup.coredumpSetup()
+        assert "permission" in caplog.text.lower()
+        # Original content is preserved.
+        assert core_file.read_text().startswith("|")
+
+    def test_readonly_filesystem_logs_warning(self, tmp_path, monkeypatch, caplog):
+        """A read-only filesystem error logs the same host-side guidance."""
+        setup, core_file, _ = _make_setup(
+            tmp_path,
+            "|/usr/share/apport/apport -p%p\n",
+        )
+        real_open = builtins.open
+
+        def raising_open(path, mode="r", *args, **kwargs):
+            if path == str(core_file) and mode == "w":
+                raise OSError(errno.EROFS, "Read-only file system")
+            return real_open(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", raising_open)
+
+        with caplog.at_level(logging.WARNING):
+            setup.coredumpSetup()
+
+        assert "permission" in caplog.text.lower()
+        assert "kernel.core_pattern" in caplog.text
+        assert core_file.read_text().startswith("|")
+
+    def test_unexpected_oserror_logs_debug(self, tmp_path, monkeypatch, caplog):
+        """An unexpected OSError errno is logged at DEBUG, not propagated."""
+        setup, core_file, _ = _make_setup(
+            tmp_path,
+            "|/usr/share/apport/apport -p%p\n",
+        )
+        real_open = builtins.open
+
+        def raising_open(path, mode="r", *args, **kwargs):
+            if path == str(core_file) and mode == "w":
+                raise OSError(errno.ENOSPC, "No space left on device")
+            return real_open(path, mode, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", raising_open)
+
+        with caplog.at_level(logging.DEBUG):
+            setup.coredumpSetup()  # should not raise
+
+        assert "Unexpected OSError" in caplog.text
+        assert core_file.read_text().startswith("|")
+
+    def test_coredump_dir_is_created(self, tmp_path):
+        """The coredump directory is created even when no override happens."""
+        setup, _, coredump_dir = _make_setup(tmp_path, "core")
+        assert not coredump_dir.exists()
+        setup.coredumpSetup()
+        assert coredump_dir.is_dir()
+
+    def test_missing_pattern_file(self, tmp_path):
+        """If the pattern file doesn't exist, the method returns silently."""
+        setup, core_file, coredump_dir = _make_setup(tmp_path, "dummy")
+        core_file.unlink()  # remove it
+        setup.coredumpSetup()  # should not raise
+        assert coredump_dir.is_dir()
+
+    def test_empty_pattern(self, tmp_path):
+        """An empty pattern is not pipe-based, so no override."""
+        setup, core_file, _ = _make_setup(tmp_path, "")
+        setup.coredumpSetup()
+        assert core_file.read_text() == ""
+
+    def test_makedirs_failure_does_not_override_pattern(self, tmp_path, monkeypatch, caplog):
+        """If coredump dir creation fails, core_pattern is not modified."""
+        setup, core_file, coredump_dir = _make_setup(
+            tmp_path,
+            "|/usr/share/apport/apport -p%p\n",
+        )
+        real_makedirs = os.makedirs
+
+        def failing_makedirs(path, *args, **kwargs):
+            if path == str(coredump_dir):
+                raise OSError(errno.EACCES, "Permission denied")
+            return real_makedirs(path, *args, **kwargs)
+
+        monkeypatch.setattr(os, "makedirs", failing_makedirs)
+
+        with caplog.at_level(logging.WARNING):
+            setup.coredumpSetup()
+
+        assert "Could not create coredump directory" in caplog.text
+        # core_pattern must NOT have been modified
+        assert core_file.read_text().startswith("|")


### PR DESCRIPTION
## Summary

- Fix silent coredump loss in Docker containers when the host OS uses a pipe-based `kernel.core_pattern` (e.g. Ubuntu's apport: `|/usr/share/apport/apport ...`). The pipe target doesn't exist inside the container, so coredumps are silently discarded.
- When a pipe-based pattern is detected, override it with a file-based pattern (`/var/lib/scylla/coredump/core.%e.%p.%t`). If the container lacks permission to write to `/proc/sys/kernel/core_pattern`, log a warning with the exact `sysctl` command the user should run on the host.
- Add unit tests for the coredump setup logic (9 test cases covering pipe override, file-pattern passthrough, systemd-coredump, read-only fallback, directory creation, missing pattern file, empty pattern, and unexpected OSError).

## Changes

| File | Description |
|---|---|
| `dist/docker/scyllasetup.py` | New `coredumpSetup()` method on `ScyllaSetup` |
| `dist/docker/docker-entrypoint.py` | Call `setup.coredumpSetup()` at startup |
| `dist/common/supervisor/scylla-server.sh` | Equivalent bash logic in the privileged (`EUID == 0`) block |
| `test/pylib_test/test_coredump_setup.py` | Unit tests for the coredump setup logic |

## Notes

- `kernel.core_pattern` is a global (non-namespaced) kernel sysctl — it cannot be changed from inside an unprivileged container. The fix gracefully degrades to a warning in that case.
- The Docker entrypoint runs as user `scylla`, so the Python path will typically log the warning. The bash path in `scylla-server.sh` fires when running as root with `--privileged`.

Fixes: SCYLLADB-1366

---

## V2

- **Fix silent exception swallowing** in `coredumpSetup()`: added `else` branch to the `OSError` handler so unexpected errno values (e.g. `EIO`) are logged at DEBUG level instead of silently discarded. Changed bare `except Exception: pass` to log at DEBUG as well.
- **Add logging to bash script**: replaced silent `|| true` on the `core_pattern` write with an `if/else` that logs success or emits a warning to stderr on failure.
- **Refactor tests to use real production code**: replaced the duplicated copy of `coredumpSetup` logic in the test helper with `importlib.util` loading of the actual `scyllasetup` module from `dist/docker/`. Tests now exercise the real code via `ScyllaSetup` instances with overridden class-level path attributes (`CORE_PATTERN_PATH`, `COREDUMP_DIR`).
- **Reorder `coredumpSetup()` call**: moved from after `set_housekeeping()` to after `io()` in `docker-entrypoint.py`, grouping it with other system-level setup calls.

---

## V3

- **Wrap `os.makedirs` in try/except** so a failure to create the coredump directory does not abort container startup.
- **Derive coredump directory from `workdir`** in `scylla.yaml` instead of hardcoding `/var/lib/scylla/coredump`, matching how `io()` resolves paths. Falls back to the default when yaml is unavailable.
- **Add trailing newline** to the Python `f.write()` call for consistency with the bash `echo` path.
- **Fix docstring**: "silently skipped" → "a warning is logged with guidance for the operator".
- **Move `import logging` / `import builtins`** to top-level imports in the test file.
- **Replace filesystem-dependent `EACCES` test** with `monkeypatch` injection, removing `@pytest.mark.skipif(os.geteuid() == 0)` so the test runs reliably under root-based CI.
- **Add test for unexpected `OSError` errno** (e.g. `ENOSPC`) to cover the `else` branch added in V2.