### PR TITLE
topology: propagate error messages through raft_topology_cmd_result

### DIFF
--- a/idl/storage_service.idl.hh
+++ b/idl/storage_service.idl.hh
@@ -72,6 +72,7 @@ struct raft_topology_cmd_result {
         success
     };
     service::raft_topology_cmd_result::command_status status;
+    sstring error_message [[version 2026.2]];
 };
 
 struct raft_snapshot {

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -4792,8 +4792,13 @@ future<raft_topology_cmd_result> storage_service::raft_topology_cmd_handler(raft
         }
     } catch (const raft::request_aborted& e) {
         rtlogger.warn("raft_topology_cmd {} failed with: {}", cmd.cmd, e);
+        result.error_message = e.what();
+    } catch (const std::exception& e) {
+        rtlogger.error("raft_topology_cmd {} failed with: {}", cmd.cmd, e);
+        result.error_message = e.what();
     } catch (...) {
         rtlogger.error("raft_topology_cmd {} failed with: {}", cmd.cmd, std::current_exception());
+        result.error_message = "unknown error";
     }
 
     rtlogger.info("topology cmd rpc {} completed with status={} index={}",

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -443,8 +443,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     co_await ser::storage_service_rpc_verbs::send_raft_topology_cmd(
                             &_messaging, to_host_id(id), id, _term, cmd_index, cmd);
         if (result.status == raft_topology_cmd_result::command_status::fail) {
+            auto msg = result.error_message.empty()
+                ? ::format("failed status returned from {}", id)
+                : ::format("failed status returned from {}: {}", id, result.error_message);
             co_await coroutine::exception(std::make_exception_ptr(
-                    std::runtime_error(::format("failed status returned from {}", id))));
+                    std::runtime_error(std::move(msg))));
         }
     };
 
@@ -3909,10 +3912,15 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     throw;
                 } catch (seastar::abort_requested_exception&) {
                     throw;
+                } catch (const std::exception& e) {
+                    rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
+                                    " (node state is rebuilding): {}", e);
+                    rtbuilder.done(e.what());
+                    retake = true;
                 } catch (...) {
                     rtlogger.error("send_raft_topology_cmd(stream_ranges) failed with exception"
                                     " (node state is rebuilding): {}", std::current_exception());
-                    rtbuilder.done("streaming failed");
+                    rtbuilder.done("unknown error");
                     retake = true;
                 }
                 if (retake) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -318,6 +318,9 @@ struct raft_topology_cmd_result {
         success
     };
     command_status status = command_status::fail;
+    // Carries the error description back to the topology coordinator
+    // when the command fails.
+    sstring error_message;
 };
 
 // This class is used in RPC's signatures to hold the topology_version of the caller.


### PR DESCRIPTION
## Summary

When a topology command (e.g., rebuild) fails on a target node, the exception message is swallowed at multiple levels in the Raft topology error propagation chain, causing users to see only a generic "rebuild failed: streaming failed" instead of the actionable error message from the handler (e.g., the rebuild safety check added in #16827).

This PR fixes the error propagation by:
- Adding an `error_message` field to `raft_topology_cmd_result` (with `[[version 2026.2]]` for wire compatibility)
- Populating it with the exception text in the handler's catch blocks
- Including it in the exception thrown by `exec_direct_command_helper`
- Passing the actual error through to `rtbuilder.done()` instead of the hardcoded "streaming failed"

The IDL change uses size-prefix serialization with a version guard, so old nodes that don't know about the field simply skip the extra bytes, and new nodes receiving from old nodes get an empty string default. No feature flag is needed.

Fixes: SCYLLADB-1404

## Files changed
- `idl/storage_service.idl.hh` — added `error_message` field with `[[version 2026.2]]`
- `service/topology_state_machine.hh` — added `error_message` to the C++ struct
- `service/storage_service.cc` — populate `error_message` in catch blocks of `raft_topology_cmd_handler`
- `service/topology_coordinator.cc` — include `error_message` in thrown exceptions; pass actual error to `rtbuilder.done()`

## Testing
- Compiled and linked successfully in dev mode
- System tests (`test/cluster/test_rebuild_safety.py`) pass with this fix — the safety check error message now propagates to the client