### PR TITLE
tablets: fix rebuild skipping repair/streaming during RF reduction

### DIFF
--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -170,10 +170,6 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
 
             return result;
         case tablet_transition_kind::rebuild_v2: {
-            if (!trinfo.pending_replica.has_value()) {
-                return result; // No nodes to stream to -> no nodes to stream from
-            }
-
             auto s = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end());
             erase_if(s, [&] (const tablet_replica& r) {
                 auto* n = topo.find_node(r.host);
@@ -182,7 +178,9 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
             result.stream_weight = locator::tablet_migration_stream_weight_repair;
             result.read_from = s;
             result.written_to = std::move(s);
-            result.written_to.insert(*trinfo.pending_replica);
+            if (trinfo.pending_replica) {
+                result.written_to.insert(*trinfo.pending_replica);
+            }
 
             return result;
         }

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -217,10 +217,6 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
 
             return result;
         case tablet_transition_kind::rebuild_v2: {
-            if (!trinfo.pending_replica.has_value()) {
-                return result; // No nodes to stream to -> no nodes to stream from
-            }
-
             auto s = std::unordered_set<tablet_replica>(tinfo.replicas.begin(), tinfo.replicas.end());
             erase_if(s, [&] (const tablet_replica& r) {
                 auto* n = topo.find_node(r.host);
@@ -229,7 +225,9 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
             result.stream_weight = locator::tablet_migration_stream_weight_repair;
             result.read_from = s;
             result.written_to = std::move(s);
-            result.written_to.insert(*trinfo.pending_replica);
+            if (trinfo.pending_replica) {
+                result.written_to.insert(*trinfo.pending_replica);
+            }
 
             return result;
         }

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1992,10 +1992,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     if (advance_in_background(gid, tablet_state.rebuild_repair, "rebuild_repair", [&] {
                         utils::get_local_injector().inject("rebuild_repair_stage_fail",
                             [] { throw std::runtime_error("rebuild_repair failed due to error injection"); });
-                        if (!trinfo.pending_replica) {
-                            rtlogger.info("Skipped tablet rebuild repair of {} as no pending replica found", gid);
-                            return make_ready_future<>();
-                        }
                         auto tsi = get_migration_streaming_info(get_token_metadata().get_topology(), tmap.get_tablet_info(gid.tablet), trinfo);
                         if (tsi.read_from.empty()) {
                             rtlogger.info("Skipped tablet rebuild repair of {} as no tablet replica was found", gid);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -2178,10 +2178,6 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                     if (advance_in_background(gid, tablet_state.rebuild_repair, "rebuild_repair", [&] {
                         utils::get_local_injector().inject("rebuild_repair_stage_fail",
                             [] { throw std::runtime_error("rebuild_repair failed due to error injection"); });
-                        if (!trinfo.pending_replica) {
-                            rtlogger.info("Skipped tablet rebuild repair of {} as no pending replica found", gid);
-                            return make_ready_future<>();
-                        }
                         auto tsi = get_migration_streaming_info(get_token_metadata().get_topology(), tmap.get_tablet_info(gid.tablet), trinfo);
                         if (tsi.read_from.empty()) {
                             rtlogger.info("Skipped tablet rebuild repair of {} as no tablet replica was found", gid);

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -2474,3 +2474,92 @@ async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, ma
         for t in replicas:
             assert len(t.replicas) == 1
             assert t.replicas[0][0] == dc1_host_id
+
+@pytest.mark.asyncio
+async def test_rf_reduction_preserves_quorum_writes(manager: ManagerClient) -> None:
+    """RF reduction must preserve QUORUM-acknowledged writes even when surviving replicas missed them.
+
+    With RF=5 on 5 nodes (5 racks), write pk=2 at QUORUM while r1/r2 are down, so only r3/r4/r5
+    have it. After restart, reduce RF to 2 keeping only r1/r2. The RF reduction must stream/repair
+    data from removed replicas to surviving ones so that pk=2 remains readable.
+    """
+    # Disable hinted handoff so hints don't replay the writes to r1/r2 after restart,
+    # which would mask the bug by delivering the data before ALTER KEYSPACE runs.
+    cfg = {'hinted_handoff_enabled': False}
+    servers = await manager.servers_add(5, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"},
+        {"dc": "dc1", "rack": "r4"},
+        {"dc": "dc1", "rack": "r5"},
+    ])
+
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r3', 'r4', 'r5']} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+        # Verify all 5 nodes are replicas for the single tablet.
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 't')
+        assert len(replicas) == 1, f"Expected 1 tablet, got {len(replicas)}"
+        assert len(replicas[0].replicas) == 5, f"Expected 5 replicas, got {len(replicas[0].replicas)}"
+
+        # Insert baseline row visible to all nodes.
+        logger.info("Inserting pk=1 at CL=ALL")
+        await cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk, v) VALUES (1, 100)", consistency_level=ConsistencyLevel.ALL))
+        rows = await cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 1", consistency_level=ConsistencyLevel.ALL))
+        assert len(rows) == 1 and rows[0].v == 100
+
+        # Stop r1 and r2 so they miss the next write.
+        logger.info("Stopping r1 and r2")
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_stop_gracefully(servers[1].server_id)
+
+        # Write pk=2 at QUORUM. With 3 live nodes, all 3 (r3/r4/r5) respond. r1/r2 never see it.
+        logger.info("Inserting pk=2 at CL=QUORUM (only r3, r4, r5 have it)")
+        await cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk, v) VALUES (2, 200)", consistency_level=ConsistencyLevel.QUORUM))
+        rows = await cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 2", consistency_level=ConsistencyLevel.QUORUM))
+        assert len(rows) == 1 and rows[0].v == 200
+
+        # Restart the stopped nodes.
+        logger.info("Restarting r1 and r2")
+        await manager.server_start(servers[0].server_id)
+        await manager.server_start(servers[1].server_id)
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        # Reduce RF from 5 to 2, each step removing one rack that had pk=2.
+        logger.info("Reducing RF: 5 -> 4 -> 3 -> 2, keeping only r1 and r2")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r4', 'r5']}}")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r5']}}")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2']}}")
+
+        for s in servers:
+            await read_barrier(manager.api, s.ip_addr)
+
+        # Verify only r1 and r2 remain as replicas.
+        replicas_after = await get_all_tablet_replicas(manager, servers[0], ks, 't')
+        assert len(replicas_after) == 1
+        assert len(replicas_after[0].replicas) == 2, f"Expected 2 replicas after RF reduction, got {len(replicas_after[0].replicas)}"
+
+        remaining_host_ids = {host_id for host_id, _ in replicas_after[0].replicas}
+        r1_host_id = await manager.get_host_id(servers[0].server_id)
+        r2_host_id = await manager.get_host_id(servers[1].server_id)
+        assert remaining_host_ids == {r1_host_id, r2_host_id}, f"Expected replicas on r1 and r2, got {remaining_host_ids}"
+
+        # Read directly from r1 and r2 to avoid driver routing to former replicas.
+        logger.info("Verifying data on surviving replicas r1 and r2")
+        cql_r1 = await manager.get_cql_exclusive(servers[0])
+        cql_r2 = await manager.get_cql_exclusive(servers[1])
+
+        for label, excl_cql in [("r1", cql_r1), ("r2", cql_r2)]:
+            # pk=1 (written at ALL) should still be present.
+            rows = await excl_cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 1", consistency_level=ConsistencyLevel.ONE))
+            assert len(rows) == 1 and rows[0].v == 100, f"pk=1 should be present on {label}, got {rows}"
+
+            # pk=2 (written at QUORUM while r1/r2 were down) must still be present.
+            # RF reduction should stream data from removed replicas to surviving ones.
+            rows = await excl_cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 2", consistency_level=ConsistencyLevel.ONE))
+            assert len(rows) == 1 and rows[0].v == 200, f"pk=2 should be present on {label}, got {rows}"
+            logger.info(f"Confirmed: pk=2 is present on {label}")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -2610,3 +2610,92 @@ async def test_split_completion_with_data_in_main_cg(manager: ManagerClient):
         # Release the split monitor hold for clean shutdown.
         await manager.api.message_injection(target.ip_addr, "tablet_split_monitor_wait")
         await manager.server_update_config(target.server_id, "error_injections_at_startup", [])
+
+@pytest.mark.asyncio
+async def test_rf_reduction_preserves_quorum_writes(manager: ManagerClient) -> None:
+    """RF reduction must preserve QUORUM-acknowledged writes even when surviving replicas missed them.
+
+    With RF=5 on 5 nodes (5 racks), write pk=2 at QUORUM while r1/r2 are down, so only r3/r4/r5
+    have it. After restart, reduce RF to 2 keeping only r1/r2. The RF reduction must stream/repair
+    data from removed replicas to surviving ones so that pk=2 remains readable.
+    """
+    # Disable hinted handoff so hints don't replay the writes to r1/r2 after restart,
+    # which would mask the bug by delivering the data before ALTER KEYSPACE runs.
+    cfg = {'hinted_handoff_enabled': False}
+    servers = await manager.servers_add(5, config=cfg, property_file=[
+        {"dc": "dc1", "rack": "r1"},
+        {"dc": "dc1", "rack": "r2"},
+        {"dc": "dc1", "rack": "r3"},
+        {"dc": "dc1", "rack": "r4"},
+        {"dc": "dc1", "rack": "r5"},
+    ])
+
+    cql = manager.get_cql()
+    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r3', 'r4', 'r5']} AND tablets = {'initial': 1}") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+        # Verify all 5 nodes are replicas for the single tablet.
+        replicas = await get_all_tablet_replicas(manager, servers[0], ks, 't')
+        assert len(replicas) == 1, f"Expected 1 tablet, got {len(replicas)}"
+        assert len(replicas[0].replicas) == 5, f"Expected 5 replicas, got {len(replicas[0].replicas)}"
+
+        # Insert baseline row visible to all nodes.
+        logger.info("Inserting pk=1 at CL=ALL")
+        await cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk, v) VALUES (1, 100)", consistency_level=ConsistencyLevel.ALL))
+        rows = await cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 1", consistency_level=ConsistencyLevel.ALL))
+        assert len(rows) == 1 and rows[0].v == 100
+
+        # Stop r1 and r2 so they miss the next write.
+        logger.info("Stopping r1 and r2")
+        await manager.server_stop_gracefully(servers[0].server_id)
+        await manager.server_stop_gracefully(servers[1].server_id)
+
+        # Write pk=2 at QUORUM. With 3 live nodes, all 3 (r3/r4/r5) respond. r1/r2 never see it.
+        logger.info("Inserting pk=2 at CL=QUORUM (only r3, r4, r5 have it)")
+        await cql.run_async(SimpleStatement(f"INSERT INTO {ks}.t (pk, v) VALUES (2, 200)", consistency_level=ConsistencyLevel.QUORUM))
+        rows = await cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 2", consistency_level=ConsistencyLevel.QUORUM))
+        assert len(rows) == 1 and rows[0].v == 200
+
+        # Restart the stopped nodes.
+        logger.info("Restarting r1 and r2")
+        await manager.server_start(servers[0].server_id)
+        await manager.server_start(servers[1].server_id)
+        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+        # Reduce RF from 5 to 2, each step removing one rack that had pk=2.
+        logger.info("Reducing RF: 5 -> 4 -> 3 -> 2, keeping only r1 and r2")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r4', 'r5']}}")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r5']}}")
+        await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2']}}")
+
+        for s in servers:
+            await read_barrier(manager.api, s.ip_addr)
+
+        # Verify only r1 and r2 remain as replicas.
+        replicas_after = await get_all_tablet_replicas(manager, servers[0], ks, 't')
+        assert len(replicas_after) == 1
+        assert len(replicas_after[0].replicas) == 2, f"Expected 2 replicas after RF reduction, got {len(replicas_after[0].replicas)}"
+
+        remaining_host_ids = {host_id for host_id, _ in replicas_after[0].replicas}
+        r1_host_id = await manager.get_host_id(servers[0].server_id)
+        r2_host_id = await manager.get_host_id(servers[1].server_id)
+        assert remaining_host_ids == {r1_host_id, r2_host_id}, f"Expected replicas on r1 and r2, got {remaining_host_ids}"
+
+        # Read directly from r1 and r2 to avoid driver routing to former replicas.
+        logger.info("Verifying data on surviving replicas r1 and r2")
+        cql_r1 = await manager.get_cql_exclusive(servers[0])
+        cql_r2 = await manager.get_cql_exclusive(servers[1])
+
+        for label, excl_cql in [("r1", cql_r1), ("r2", cql_r2)]:
+            # pk=1 (written at ALL) should still be present.
+            rows = await excl_cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 1", consistency_level=ConsistencyLevel.ONE))
+            assert len(rows) == 1 and rows[0].v == 100, f"pk=1 should be present on {label}, got {rows}"
+
+            # pk=2 (written at QUORUM while r1/r2 were down) must still be present.
+            # RF reduction should stream data from removed replicas to surviving ones.
+            rows = await excl_cql.run_async(SimpleStatement(f"SELECT v FROM {ks}.t WHERE pk = 2", consistency_level=ConsistencyLevel.ONE))
+            assert len(rows) == 1 and rows[0].v == 200, f"pk=2 should be present on {label}, got {rows}"
+            logger.info(f"Confirmed: pk=2 is present on {label}")


### PR DESCRIPTION
When reducing tablet RF via ALTER KEYSPACE, the rebuild repair and streaming stages were skipped when no pending replica existed (only replicas being removed). This caused QUORUM-acknowledged writes to be silently lost if the surviving replicas had missed them.

Repair tablet during rebuild even without a pending replica.

Add a regression test.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1418.

All live versions affected