### PR TITLE
cdc: use before_drop_column_family_in_notification for nested notification calls

### DIFF
--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -281,7 +281,7 @@ public:
                 auto log_mut = db::schema_tables::make_drop_table_mutations(keyspace.metadata(), log_schema, timestamp);
                 mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
 
-                db.get_notifier().before_drop_column_family(*log_schema, mutations, timestamp);
+                db.get_notifier().before_drop_column_family_in_notification(*log_schema, mutations, timestamp);
             }
         }
 

--- a/cdc/log.cc
+++ b/cdc/log.cc
@@ -265,7 +265,7 @@ public:
             mutations.insert(mutations.end(), std::make_move_iterator(log_mut.begin()), std::make_move_iterator(log_mut.end()));
 
             if (!log_schema) {
-                db.get_notifier().before_create_column_family(*keyspace.metadata(), *new_log_schema, mutations, timestamp);
+                db.get_notifier().before_create_column_family_in_notification(*keyspace.metadata(), *new_log_schema, mutations, timestamp);
             }
         }
     }

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -158,6 +158,9 @@ public:
     void pre_create_column_families(const keyspace_metadata& ksm, std::vector<schema_ptr>&, api::timestamp_type);
 
     void before_create_column_family(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    // When in the context of a notification callback, call `before_create_column_family_in_notification`,
+    // and otherwise call 'before_create_column_family'.
+    void before_create_column_family_in_notification(const keyspace_metadata& ksm, const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);

--- a/service/migration_listener.hh
+++ b/service/migration_listener.hh
@@ -161,6 +161,9 @@ public:
     void before_create_column_families(const keyspace_metadata& ksm, const std::vector<schema_ptr>&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_update_column_family(const schema& new_schema, const schema& old_schema, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_column_family(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
+    // When in the context of a notification callback, call `before_drop_column_family_in_notification`,
+    // and otherwise call 'before_drop_column_family'.
+    void before_drop_column_family_in_notification(const schema&, utils::chunked_vector<mutation>&, api::timestamp_type);
     void before_drop_keyspace(const sstring& keyspace_name, utils::chunked_vector<mutation>&, api::timestamp_type);
 
     // Called when creating a tablet map for a new table.

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -443,6 +443,14 @@ void migration_notifier::before_create_column_family(const keyspace_metadata& ks
     });
 }
 
+void migration_notifier::before_create_column_family_in_notification(const keyspace_metadata& ksm,
+        const schema& schema, utils::chunked_vector<mutation>& mutations, api::timestamp_type timestamp) {
+    _listeners.thread_for_each_nested([&ksm, &schema, &mutations, timestamp] (migration_listener* listener) {
+        // allow exceptions. so a listener can effectively kill a create-table
+        listener->on_before_create_column_family(ksm, schema, mutations, timestamp);
+    });
+}
+
 void migration_notifier::pre_create_column_families(const keyspace_metadata& ksm, std::vector<schema_ptr>& cfms, api::timestamp_type timestamp) {
     _listeners.thread_for_each([&ksm, &cfms, timestamp] (migration_listener* listener) {
         // allow exceptions. so a listener can effectively kill a create-table
@@ -733,7 +741,7 @@ future<utils::chunked_vector<mutation>> prepare_keyspace_drop_announcement(stora
 }
 
 future<utils::chunked_vector<mutation>> prepare_column_family_drop_announcement(storage_proxy& sp,
-        const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts, drop_views drop_views) {
+        const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts, drop_views drop_views, bool in_notification) {
     try {
         auto& db = sp.local_db();
         auto& old_cfm = db.find_column_family(ks_name, cf_name);
@@ -775,10 +783,15 @@ future<utils::chunked_vector<mutation>> prepare_column_family_drop_announcement(
 
         // notifiers must run in seastar thread
         co_await seastar::async([&] {
+            auto&& notify_drop = [&] (const ::schema& s) {
+                in_notification
+                    ? db.get_notifier().before_drop_column_family_in_notification(s, mutations, ts)
+                    : db.get_notifier().before_drop_column_family(s, mutations, ts);
+            };
             for (auto& view : views) {
-                db.get_notifier().before_drop_column_family(*view, mutations, ts);
+                notify_drop(*view);
             }
-            db.get_notifier().before_drop_column_family(*schema, mutations, ts);
+            notify_drop(*schema);
         });
         co_return co_await include_keyspace(sp, *keyspace, std::move(mutations));
     } catch (const replica::no_such_column_family& e) {

--- a/service/migration_manager.cc
+++ b/service/migration_manager.cc
@@ -474,6 +474,14 @@ void migration_notifier::before_drop_column_family(const schema& schema,
     });
 }
 
+void migration_notifier::before_drop_column_family_in_notification(const schema& schema,
+        utils::chunked_vector<mutation>& mutations, api::timestamp_type ts) {
+    _listeners.thread_for_each_nested([&mutations, &schema, ts] (migration_listener* listener) {
+        // allow exceptions. so a listener can effectively kill a drop-column
+        listener->on_before_drop_column_family(schema, mutations, ts);
+    });
+}
+
 void migration_notifier::before_drop_keyspace(const sstring& keyspace_name,
         utils::chunked_vector<mutation>& mutations, api::timestamp_type ts) {
     _listeners.thread_for_each([&mutations, &keyspace_name, ts] (migration_listener* listener) {

--- a/service/migration_manager.hh
+++ b/service/migration_manager.hh
@@ -218,7 +218,8 @@ future<utils::chunked_vector<mutation>> prepare_keyspace_drop_announcement(stora
 class drop_views_tag;
 using drop_views = bool_class<drop_views_tag>;
 future<utils::chunked_vector<mutation>> prepare_column_family_drop_announcement(storage_proxy& sp,
-        const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts, drop_views drop_views = drop_views::no);
+        const sstring& ks_name, const sstring& cf_name, api::timestamp_type ts, drop_views drop_views = drop_views::no,
+        bool in_notification = false);
 
 future<utils::chunked_vector<mutation>> prepare_type_drop_announcement(storage_proxy& sp, user_type dropped_type, api::timestamp_type ts);
 

--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -411,7 +411,8 @@ void paxos_store::on_before_drop_column_family(const schema& schema, utils::chun
             state_schema->ks_name(),
             state_schema->cf_name(),
             timestamp,
-            drop_views::yes).get();
+            drop_views::yes,
+            true).get();
         mutations.insert(mutations.end(), std::make_move_iterator(muts.begin()), std::make_move_iterator(muts.end()));
     }
 }


### PR DESCRIPTION
`cdc_service::on_before_drop_column_family()` calls `db.get_notifier().before_drop_column_family()` to notify other listeners about dropping the CDC log table. However, `on_before_drop_column_family` is itself invoked from within a `thread_for_each()` iteration over listeners. Calling `before_drop_column_family()` (which also uses `thread_for_each()`) from inside that callback violates the `atomic_vector` contract, which states: *"The callback function must not call remove or thread_for_each."*

The first patch adds `before_drop_column_family_in_notification()` (using `thread_for_each_nested`) and switches the CDC log drop notification to use it — following the same pattern already used by `before_allocate_tablet_map_in_notification`.

The second patch fixes the same class of bug in two more places found during review:

- **`cdc/log.cc` — `on_before_update_column_family`**: calls `before_create_column_family()` when CDC is first enabled on a table via ALTER TABLE. Fixed by adding `before_create_column_family_in_notification()` and switching to it.

- **`service/paxos/paxos_state.cc` — `on_before_drop_column_family`**: calls `prepare_column_family_drop_announcement()`, which internally calls `before_drop_column_family()` for views and the table itself. Fixed by adding a `bool in_notification` parameter to `prepare_column_family_drop_announcement` that selects the `_in_notification` variant.