### PR TITLE
alternator/streams: keep disabled streams usable and purge on re-enable

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1860,7 +1860,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
             if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
-                if (add_stream_options(*stream_specification, builder, p.local())) {
+                if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
                     validate_cdc_log_name_length(builder.cf_name());
                     // On tablet tables, defer stream enablement and block
                     // tablet merges (see defer_enabling_streams_block_tablet_merges).
@@ -1874,6 +1874,26 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                     if (stream_enabled->GetBool()) {
                         if (tab->cdc_options().enabled() || tab->cdc_options().enable_requested()) {
                             co_return api_error::validation("Table already has an enabled stream: TableName: " + tab->cf_name());
+                        }
+                        // When re-enabling streams on an Alternator table, drop the old
+                        // CDC log table first as a separate schema change, so the
+                        // subsequent UpdateTable creates a fresh one with a new UUID
+                        // (= new StreamArn). See #7239.
+                        auto logname = cdc::log_name(tab->cf_name());
+                        auto& local_db = p.local().local_db();
+                        if (local_db.has_schema(tab->ks_name(), logname)
+                                && cdc::is_log_schema(*local_db.find_schema(tab->ks_name(), logname))) {
+                            auto drop_m = co_await service::prepare_column_family_drop_announcement(
+                                p.local(), tab->ks_name(), logname,
+                                group0_guard.write_timestamp());
+                            co_await mm.announce(std::move(drop_m), std::move(group0_guard),
+                                format("alternator-executor: drop old CDC log for {}", tab->cf_name()));
+                            co_await mm.wait_for_schema_agreement(
+                                p.local().local_db(), db::timeout_clock::now() + 10s, nullptr);
+                            group0_guard = co_await mm.start_group0_operation();
+                            tab = get_table(p.local(), request);
+                            builder = schema_builder(tab);
+                            add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options());
                         }
                     }
                     else if (!tab->cdc_options().enabled() && !tab->cdc_options().enable_requested()) {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -1860,7 +1860,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
             rjson::value* stream_specification = rjson::find(request, "StreamSpecification");
             if (stream_specification && stream_specification->IsObject()) {
                 empty_request = false;
-                if (add_stream_options(*stream_specification, builder, p.local())) {
+                if (add_stream_options(*stream_specification, builder, p.local(), tab->cdc_options())) {
                     validate_cdc_log_name_length(builder.cf_name());
                     // On tablet tables, defer stream enablement and block
                     // tablet merges (see defer_enabling_streams_block_tablet_merges).
@@ -1874,6 +1874,23 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                     if (stream_enabled->GetBool()) {
                         if (tab->cdc_options().enabled() || tab->cdc_options().enable_requested()) {
                             co_return api_error::validation("Table already has an enabled stream: TableName: " + tab->cf_name());
+                        }
+                        // When re-enabling streams on an Alternator table, drop the old
+                        // CDC log table first as a separate schema change, so the
+                        // subsequent UpdateTable creates a fresh one with a new UUID
+                        // (= new StreamArn). See #7239.
+                        auto logname = cdc::log_name(tab->cf_name());
+                        auto& local_db = p.local().local_db();
+                        if (local_db.has_schema(tab->ks_name(), logname)
+                                && cdc::is_log_schema(*local_db.find_schema(tab->ks_name(), logname))) {
+                            auto drop_m = co_await service::prepare_column_family_drop_announcement(
+                                p.local(), tab->ks_name(), logname,
+                                group0_guard.write_timestamp());
+                            co_await mm.announce(std::move(drop_m), std::move(group0_guard),
+                                format("alternator-executor: drop old CDC log for {}", tab->cf_name()));
+                            co_await mm.wait_for_schema_agreement(
+                                p.local().local_db(), db::timeout_clock::now() + 10s, nullptr);
+                            continue;
                         }
                     }
                     else if (!tab->cdc_options().enabled() && !tab->cdc_options().enable_requested()) {

--- a/alternator/executor.hh
+++ b/alternator/executor.hh
@@ -30,6 +30,7 @@
 #include "utils/updateable_value.hh"
 
 #include "tracing/trace_state.hh"
+#include "cdc/cdc_options.hh"
 
 
 namespace db {
@@ -199,7 +200,7 @@ private:
         tracing::trace_state_ptr trace_state, service_permit permit);
 
 public:
-    static bool add_stream_options(const rjson::value& stream_spec, schema_builder&, service::storage_proxy& sp);
+    static bool add_stream_options(const rjson::value& stream_spec, schema_builder&, service::storage_proxy& sp, const cdc::options& existing_cdc_opts = {});
     static void supplement_table_info(rjson::value& descr, const schema& schema, service::storage_proxy& sp);
     static void supplement_table_stream_info(rjson::value& descr, const schema& schema, const service::storage_proxy& sp);
 };

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1587,6 +1587,8 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
         // false. See issue #7239.
         cdc::options opts = existing_cdc_opts;
         opts.enabled(false);
+        opts.enable_requested(false);
+        opts.tablet_merge_blocked(false);
         builder.with_cdc_options(opts);
         return false;
     }

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -280,7 +280,10 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
         if (!is_alternator_keyspace(ks_name)) {
             continue;
         }
-        if (cdc::is_log_for_some_table(db.real_database(), ks_name, cf_name)) {
+        // Use get_base_table instead of is_log_for_some_table because the
+        // latter requires CDC to be enabled, but we want to list streams
+        // that have been disabled but whose log table still exists (#7239).
+        if (cdc::get_base_table(db.real_database(), ks_name, cf_name)) {
             rjson::value new_entry = rjson::empty_object();
             last = i->schema()->id();
             auto arn = stream_arn{ i->schema(), cdc::get_base_table(db.real_database(), *i->schema()) };
@@ -424,7 +427,7 @@ std::istream& operator>>(std::istream& is, stream_view_type& type) {
     return is;
 }
 
-static stream_view_type cdc_options_to_steam_view_type(const cdc::options& opts) {
+static stream_view_type cdc_options_to_stream_view_type(const cdc::options& opts) {
     stream_view_type type = stream_view_type::KEYS_ONLY;
     if (opts.preimage() && opts.postimage()) {
         type = stream_view_type::NEW_AND_OLD_IMAGES;
@@ -870,6 +873,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     auto& opts = bs->cdc_options();
 
     auto status = "DISABLED";
+    bool stream_disabled = !opts.enabled();
 
     if (opts.enabled()) {
         if (!_cdc_metadata.streams_available()) {
@@ -885,7 +889,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     rjson::add(stream_desc, "StreamStatus", rjson::from_string(status));
 
-    stream_view_type type = cdc_options_to_steam_view_type(opts);
+    stream_view_type type = cdc_options_to_stream_view_type(opts);
 
     rjson::add(stream_desc, "StreamArn", stream_arn);
     rjson::add(stream_desc, "StreamViewType", type);
@@ -893,10 +897,9 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     describe_key_schema(stream_desc, *bs);
 
-    if (!opts.enabled()) {
-        rjson::add(ret, "StreamDescription", std::move(stream_desc));
-        co_return rjson::print(std::move(ret));
-    }
+    // For disabled streams, we still fall through to enumerate shards
+    // below. All shards will have EndingSequenceNumber set, indicating
+    // they are closed. See issue #7239.
 
     // TODO: label
     // TODO: creation time
@@ -979,6 +982,12 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
         auto expired = [&]() -> std::optional<db_clock::time_point> {
             auto j = std::next(i);
             if (j == e) {
+                // For a disabled stream, all shards are closed (#7239).
+                // Use "now" as the ending sequence number for the last
+                // generation's shards.
+                if (stream_disabled) {
+                    return db_clock::now();
+                }
                 return std::nullopt;
             }
             // add this so we sort of match potential 
@@ -1329,7 +1338,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         | std::ranges::to<query::column_id_vector>()
     ;
 
-    stream_view_type type = cdc_options_to_steam_view_type(base->cdc_options());
+    stream_view_type type = cdc_options_to_stream_view_type(base->cdc_options());
 
     auto selection = cql3::selection::selection::for_columns(schema, std::move(columns));
     auto partition_slice = query::partition_slice(
@@ -1513,7 +1522,10 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     auto& shard = iter.shard;
 
-    if (shard.time < ts && ts < high_ts) {
+    if (!base->cdc_options().enabled()) {
+        // Stream is disabled -- all shards are closed (#7239).
+        // Don't return NextShardIterator.
+    } else if (shard.time < ts && ts < high_ts) {
         // The DynamoDB documentation states that when a shard is
         // closed, reading it until the end has NextShardIterator
         // "set to null". Our test test_streams_closed_read
@@ -1533,7 +1545,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     co_return rjson::print(std::move(ret));
 }
 
-bool executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp) {
+bool executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp, const cdc::options& existing_cdc_opts) {
     auto stream_enabled = rjson::find(stream_specification, "StreamEnabled");
     if (!stream_enabled || !stream_enabled->IsBool()) {
         throw api_error::validation("StreamSpecification needs boolean StreamEnabled");
@@ -1569,7 +1581,11 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
         builder.with_cdc_options(opts);
         return true;
     } else {
-        cdc::options opts;
+        // When disabling, preserve the existing CDC options (preimage,
+        // postimage, ttl, etc.) so that DescribeStream can still report the
+        // correct StreamViewType on a disabled stream. Only flip enabled to
+        // false. See issue #7239.
+        cdc::options opts = existing_cdc_opts;
         opts.enabled(false);
         builder.with_cdc_options(opts);
         return false;
@@ -1578,33 +1594,42 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
 
 void executor::supplement_table_stream_info(rjson::value& descr, const schema& schema, const service::storage_proxy& sp) {
     auto& opts = schema.cdc_options();
-    if (opts.enabled()) {
-        auto db = sp.data_dictionary();
-        auto cf = db.find_table(schema.ks_name(), cdc::log_name(schema.cf_name()));
-        stream_arn arn(cf.schema(), cdc::get_base_table(db.real_database(), *cf.schema()));
-        rjson::add(descr, "LatestStreamArn", arn);
-        rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*cf.schema())));
-    } else if (!opts.enable_requested()) {
-        return;
+    // Show stream info when CDC is enabled, or when it was disabled but the
+    // log table still exists (the stream is usable for reads). See #7239.
+    auto db = sp.data_dictionary();
+    auto log_name = cdc::log_name(schema.cf_name());
+    bool has_log = false;
+    schema_ptr log_schema;
+    try {
+        auto cf = db.find_table(schema.ks_name(), log_name);
+        log_schema = cf.schema();
+        has_log = true;
+    } catch (data_dictionary::no_such_column_family&) {
     }
-    // For both enabled() and enable_requested():
-    // DynamoDB returns StreamEnabled=true in StreamSpecification even when
-    // the stream status is ENABLING (not yet fully active). We mirror this
-    // behavior: enable_requested means the user asked for streams but CDC
-    // is not yet finalized, so we still report StreamEnabled=true.
-    auto stream_desc = rjson::empty_object();
-    rjson::add(stream_desc, "StreamEnabled", true);
 
-    auto mode = stream_view_type::KEYS_ONLY;
-    if (opts.preimage() && opts.postimage()) {
-        mode = stream_view_type::NEW_AND_OLD_IMAGES;
-    } else if (opts.preimage()) {
-        mode = stream_view_type::OLD_IMAGE;
-    } else if (opts.postimage()) {
-        mode = stream_view_type::NEW_IMAGE;
+    if (has_log) {
+        stream_arn arn(log_schema, cdc::get_base_table(db.real_database(), *log_schema));
+        rjson::add(descr, "LatestStreamArn", arn);
+        rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*log_schema)));
+
+        auto stream_desc = rjson::empty_object();
+        rjson::add(stream_desc, "StreamEnabled", opts.enabled());
+
+        stream_view_type mode = cdc_options_to_stream_view_type(opts);
+        rjson::add(stream_desc, "StreamViewType", mode);
+        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
+    } else if (opts.enable_requested()) {
+        // DynamoDB returns StreamEnabled=true in StreamSpecification even when
+        // the stream status is ENABLING (not yet fully active). We mirror this
+        // behavior: enable_requested means the user asked for streams but CDC
+        // is not yet finalized, so we still report StreamEnabled=true.
+        auto stream_desc = rjson::empty_object();
+        rjson::add(stream_desc, "StreamEnabled", true);
+
+        stream_view_type mode = cdc_options_to_stream_view_type(opts);
+        rjson::add(stream_desc, "StreamViewType", mode);
+        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
     }
-    rjson::add(stream_desc, "StreamViewType", mode);
-    rjson::add(descr, "StreamSpecification", std::move(stream_desc));
 }
 
 } // namespace alternator

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -280,7 +280,10 @@ future<alternator::executor::request_return_type> alternator::executor::list_str
         if (!is_alternator_keyspace(ks_name)) {
             continue;
         }
-        if (cdc::is_log_for_some_table(db.real_database(), ks_name, cf_name)) {
+        // Use get_base_table instead of is_log_for_some_table because the
+        // latter requires CDC to be enabled, but we want to list streams
+        // that have been disabled but whose log table still exists (#7239).
+        if (cdc::get_base_table(db.real_database(), ks_name, cf_name)) {
             rjson::value new_entry = rjson::empty_object();
             last = i->schema()->id();
             auto arn = stream_arn{ i->schema(), cdc::get_base_table(db.real_database(), *i->schema()) };
@@ -424,7 +427,7 @@ std::istream& operator>>(std::istream& is, stream_view_type& type) {
     return is;
 }
 
-static stream_view_type cdc_options_to_steam_view_type(const cdc::options& opts) {
+static stream_view_type cdc_options_to_stream_view_type(const cdc::options& opts) {
     stream_view_type type = stream_view_type::KEYS_ONLY;
     if (opts.preimage() && opts.postimage()) {
         type = stream_view_type::NEW_AND_OLD_IMAGES;
@@ -870,6 +873,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
     auto& opts = bs->cdc_options();
 
     auto status = "DISABLED";
+    bool stream_disabled = !opts.enabled();
 
     if (opts.enabled()) {
         if (!_cdc_metadata.streams_available()) {
@@ -885,7 +889,7 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     rjson::add(stream_desc, "StreamStatus", rjson::from_string(status));
 
-    stream_view_type type = cdc_options_to_steam_view_type(opts);
+    stream_view_type type = cdc_options_to_stream_view_type(opts);
 
     rjson::add(stream_desc, "StreamArn", stream_arn);
     rjson::add(stream_desc, "StreamViewType", type);
@@ -893,10 +897,9 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
 
     describe_key_schema(stream_desc, *bs);
 
-    if (!opts.enabled()) {
-        rjson::add(ret, "StreamDescription", std::move(stream_desc));
-        co_return rjson::print(std::move(ret));
-    }
+    // For disabled streams, we still fall through to enumerate shards
+    // below. All shards will have EndingSequenceNumber set, indicating
+    // they are closed. See issue #7239.
 
     // TODO: label
     // TODO: creation time
@@ -979,6 +982,12 @@ future<executor::request_return_type> executor::describe_stream(client_state& cl
         auto expired = [&]() -> std::optional<db_clock::time_point> {
             auto j = std::next(i);
             if (j == e) {
+                // For a disabled stream, all shards are closed (#7239).
+                // Use "now" as the ending sequence number for the last
+                // generation's shards.
+                if (stream_disabled) {
+                    return db_clock::now();
+                }
                 return std::nullopt;
             }
             // add this so we sort of match potential 
@@ -1329,7 +1338,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
         | std::ranges::to<query::column_id_vector>()
     ;
 
-    stream_view_type type = cdc_options_to_steam_view_type(base->cdc_options());
+    stream_view_type type = cdc_options_to_stream_view_type(base->cdc_options());
 
     auto selection = cql3::selection::selection::for_columns(schema, std::move(columns));
     auto partition_slice = query::partition_slice(
@@ -1513,7 +1522,10 @@ future<executor::request_return_type> executor::get_records(client_state& client
 
     auto& shard = iter.shard;
 
-    if (shard.time < ts && ts < high_ts) {
+    if (!base->cdc_options().enabled()) {
+        // Stream is disabled -- all shards are closed (#7239).
+        // Don't return NextShardIterator.
+    } else if (shard.time < ts && ts < high_ts) {
         // The DynamoDB documentation states that when a shard is
         // closed, reading it until the end has NextShardIterator
         // "set to null". Our test test_streams_closed_read
@@ -1533,7 +1545,7 @@ future<executor::request_return_type> executor::get_records(client_state& client
     co_return rjson::print(std::move(ret));
 }
 
-bool executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp) {
+bool executor::add_stream_options(const rjson::value& stream_specification, schema_builder& builder, service::storage_proxy& sp, const cdc::options& existing_cdc_opts) {
     auto stream_enabled = rjson::find(stream_specification, "StreamEnabled");
     if (!stream_enabled || !stream_enabled->IsBool()) {
         throw api_error::validation("StreamSpecification needs boolean StreamEnabled");
@@ -1569,8 +1581,13 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
         builder.with_cdc_options(opts);
         return true;
     } else {
-        cdc::options opts;
+        // When disabling, preserve the existing CDC options (preimage,
+        // postimage, ttl, etc.) so that DescribeStream can still report
+        // the correct StreamViewType on a disabled stream.
+        cdc::options opts = existing_cdc_opts;
         opts.enabled(false);
+        opts.enable_requested(false);
+        opts.tablet_merge_blocked(false);
         builder.with_cdc_options(opts);
         return false;
     }
@@ -1578,33 +1595,36 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
 
 void executor::supplement_table_stream_info(rjson::value& descr, const schema& schema, const service::storage_proxy& sp) {
     auto& opts = schema.cdc_options();
-    if (opts.enabled()) {
-        auto db = sp.data_dictionary();
-        auto cf = db.find_table(schema.ks_name(), cdc::log_name(schema.cf_name()));
-        stream_arn arn(cf.schema(), cdc::get_base_table(db.real_database(), *cf.schema()));
+    // Report stream info when:
+    //   1. Log table exists (covers both enabled and disabled-but-readable).
+    //   2. enable_requested (ENABLING state, log not yet created).
+    auto db = sp.data_dictionary();
+    auto log_name = cdc::log_name(schema.cf_name());
+    auto log_cf = db.try_find_table(schema.ks_name(), log_name);
+    if (log_cf) {
+        auto log_schema = log_cf->schema();
+        stream_arn arn(log_schema, cdc::get_base_table(db.real_database(), *log_schema));
         rjson::add(descr, "LatestStreamArn", arn);
-        rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*cf.schema())));
-    } else if (!opts.enable_requested()) {
-        return;
-    }
-    // For both enabled() and enable_requested():
-    // DynamoDB returns StreamEnabled=true in StreamSpecification even when
-    // the stream status is ENABLING (not yet fully active). We mirror this
-    // behavior: enable_requested means the user asked for streams but CDC
-    // is not yet finalized, so we still report StreamEnabled=true.
-    auto stream_desc = rjson::empty_object();
-    rjson::add(stream_desc, "StreamEnabled", true);
+        rjson::add(descr, "LatestStreamLabel", rjson::from_string(stream_label(*log_schema)));
 
-    auto mode = stream_view_type::KEYS_ONLY;
-    if (opts.preimage() && opts.postimage()) {
-        mode = stream_view_type::NEW_AND_OLD_IMAGES;
-    } else if (opts.preimage()) {
-        mode = stream_view_type::OLD_IMAGE;
-    } else if (opts.postimage()) {
-        mode = stream_view_type::NEW_IMAGE;
+        auto stream_desc = rjson::empty_object();
+        rjson::add(stream_desc, "StreamEnabled", opts.enabled());
+
+        stream_view_type mode = cdc_options_to_stream_view_type(opts);
+        rjson::add(stream_desc, "StreamViewType", mode);
+        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
+    } else if (opts.enable_requested()) {
+        // DynamoDB returns StreamEnabled=true in StreamSpecification even when
+        // the stream status is ENABLING (not yet fully active). We mirror this
+        // behavior: enable_requested means the user asked for streams but CDC
+        // is not yet finalized, so we still report StreamEnabled=true.
+        auto stream_desc = rjson::empty_object();
+        rjson::add(stream_desc, "StreamEnabled", true);
+
+        stream_view_type mode = cdc_options_to_stream_view_type(opts);
+        rjson::add(stream_desc, "StreamViewType", mode);
+        rjson::add(descr, "StreamSpecification", std::move(stream_desc));
     }
-    rjson::add(stream_desc, "StreamViewType", mode);
-    rjson::add(descr, "StreamSpecification", std::move(stream_desc));
 }
 
 } // namespace alternator

--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1531,11 +1531,8 @@ future<executor::request_return_type> executor::get_records(client_state& client
         // "set to null". Our test test_streams_closed_read
         // confirms that by "null" they meant not set at all.
     } else {
-        // We could have return the same iterator again, but we did
-        // a search from it until high_ts and found nothing, so we
-        // can also start the next search from high_ts.
-        // TODO: but why? It's simpler just to leave the iterator be.
-        shard_iterator next_iter(iter.table, iter.shard, utils::UUID_gen::min_time_UUID(high_ts.time_since_epoch()), true);
+        // Shard is still open with no records in the scanned window.
+        // Return the original iterator so the client can poll again.
         rjson::add(ret, "NextShardIterator", iter);
     }
     _stats.api_operations.get_records_latency.mark(std::chrono::steady_clock::now() - start_time);

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -324,6 +324,13 @@ experimental:
     stream events. Without this option, such no-op operations may still
     generate spurious stream events.
     <https://github.com/scylladb/scylladb/issues/28368>
+  * When a stream is disabled, no new records are written but the existing
+    stream data is preserved and remains readable through its original
+    StreamArn. The data expires via TTL after 24 hours. Re-enabling the
+    stream purges the old data immediately and produces a new StreamArn.
+    In contrast, DynamoDB keeps the old stream and its data readable for
+    24 hours through the old StreamArn even after re-enabling.
+    <https://github.com/scylladb/scylla/issues/7239>
 
 ## Unimplemented API features
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -324,6 +324,13 @@ experimental:
     stream events. Without this option, such no-op operations may still
     generate spurious stream events.
     <https://github.com/scylladb/scylladb/issues/28368>
+  * When a stream is disabled, no new records are written but the existing
+    stream data is preserved and remains readable through its original
+    StreamArn. The data expires via TTL after 24 hours. Re-enabling the
+    stream purges the old data immediately and produces a new StreamArn.
+    In contrast, DynamoDB keeps the old stream and its data readable for
+    24 hours through the old StreamArn even after re-enabling.
+    <https://scylladb.atlassian.net/browse/SCYLLADB-1873>
 
 ## Unimplemented API features
 

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -47,8 +47,8 @@ def disable_stream(dynamodbstreams, table):
     # Wait for the stream to really be disabled. A table may have multiple
     # historic streams - we need all of them to become DISABLED. One of
     # them (the current one) may remain DISABLING for some time.
-    exp = time.process_time() + 60
-    while time.process_time() < exp:
+    exp = time.time() + 60
+    while time.time() < exp:
         streams = dynamodbstreams.list_streams(TableName=table.name)
         disabled = True
         for stream in streams['Streams']:
@@ -104,8 +104,8 @@ def create_stream_test_table(dynamodb, StreamViewType=None, Tags=None):
                 raise
 
 def wait_for_active_stream(dynamodbstreams, table, timeout=60):
-    exp = time.process_time() + timeout
-    while time.process_time() < exp:
+    exp = time.time() + timeout
+    while time.time() < exp:
         streams = dynamodbstreams.list_streams(TableName=table.name)
         for stream in streams['Streams']:
             arn = stream['StreamArn']

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -59,7 +59,7 @@ def disable_stream(dynamodbstreams, table):
         if disabled:
             print('disabled stream on {}'.format(table.name))
             return
-        time.sleep(0.5)
+        time.sleep(0.1)
     pytest.fail("timed out")
             
 # Cannot use fixtures. Because real dynamodb cannot _remove_ a stream
@@ -2044,7 +2044,6 @@ def test_stream_specification(test_table_stream_with_result, dynamodbstreams):
 # be missing? Or a "null" JSON type? Or an empty string? This test verifies
 # that the right answer is that NextShardIterator should be *missing*
 # (reproduces issue #7237).
-@pytest.mark.xfail(reason="disabled stream is deleted - issue #7239")
 def test_streams_closed_read(dynamodb, dynamodbstreams):
     # This test can't use the shared table test_table_ss_keys_only,
     # because it wants to disable streaming, so let's create a new table:
@@ -2097,7 +2096,6 @@ def test_streams_closed_read(dynamodb, dynamodbstreams):
 # listed for the table, this ARN should continue to work, listing the
 # stream's shards should give an indication that they are all closed - but
 # all these shards should still be readable.
-@pytest.mark.xfail(reason="disabled stream is deleted - issue #7239")
 def test_streams_disabled_stream(dynamodb, dynamodbstreams):
     # This test can't use the shared table test_table_ss_keys_only,
     # because it wants to disable streaming, so let's create a new table:
@@ -2419,3 +2417,69 @@ def test_stream_shard_filtering_missing_shard_id(test_table_ss_keys_only, dynamo
 # TODO: Can we test shard splitting? (shard splitting
 #   requires the user to - periodically or following shards ending - to call
 #   DescribeStream again. We don't do this in any of our tests.
+
+# Count the total number of records currently visible on a stream by reading
+# all shards from the beginning (TRIM_HORIZON).
+def _count_stream_records(dynamodbstreams, arn):
+    desc = dynamodbstreams.describe_stream(StreamArn=arn)['StreamDescription']
+    nrecords = 0
+    for shard in desc['Shards']:
+        iter = dynamodbstreams.get_shard_iterator(StreamArn=arn,
+            ShardId=shard['ShardId'], ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+        response = dynamodbstreams.get_records(ShardIterator=iter)
+        if 'Records' in response:
+            nrecords += len(response['Records'])
+    return nrecords
+
+# Test that disabling a stream does not destroy the old stream data.
+# The data should remain readable via the stream ARN after disabling.
+# Reproduces issue #7239.
+def test_streams_disable_data_survives(dynamodb, dynamodbstreams):
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+        (arn, label) = wait_for_active_stream(dynamodbstreams, table)
+
+        # Write some data while the stream is active
+        p = random_string()
+        table.update_item(Key={'p': p, 'c': random_string()},
+            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+
+        assert _count_stream_records(dynamodbstreams, arn) > 0
+
+        disable_stream(dynamodbstreams, table)
+
+        # After disabling, the old stream data should still be readable.
+        assert _count_stream_records(dynamodbstreams, arn) > 0
+
+# Test that after disabling and re-enabling a stream on a table, the old
+# stream data remains readable through the old ARN. In DynamoDB, it
+# remains readable for 24 hours. In Scylla, it is currently purged upon
+# re-enabling (issue #7239).
+def test_streams_reenable(request, dynamodb, dynamodbstreams):
+    if not is_aws(dynamodb):
+        request.node.add_marker(pytest.mark.xfail(
+            reason="Scylla purges old stream data on re-enable "
+                   "instead of keeping it readable - issue #7239"))
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+        (arn1, label1) = wait_for_active_stream(dynamodbstreams, table)
+
+        # Write some data while the first stream is active
+        p = random_string()
+        table.update_item(Key={'p': p, 'c': random_string()},
+            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+
+        assert _count_stream_records(dynamodbstreams, arn1) > 0
+
+        disable_stream(dynamodbstreams, table)
+
+        # Re-enable the stream
+        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'})
+        (arn2, label2) = wait_for_active_stream(dynamodbstreams, table)
+
+        # The new ARN must differ from the old one
+        assert arn1 != arn2
+
+        # The new stream should have no old data.
+        assert _count_stream_records(dynamodbstreams, arn2) == 0
+
+        # The old stream data should still be readable via the old ARN.
+        assert _count_stream_records(dynamodbstreams, arn1) > 0

--- a/test/alternator/test_streams.py
+++ b/test/alternator/test_streams.py
@@ -59,7 +59,7 @@ def disable_stream(dynamodbstreams, table):
         if disabled:
             print('disabled stream on {}'.format(table.name))
             return
-        time.sleep(0.5)
+        time.sleep(0.1)
     pytest.fail("timed out")
             
 # Cannot use fixtures. Because real dynamodb cannot _remove_ a stream
@@ -2044,7 +2044,6 @@ def test_stream_specification(test_table_stream_with_result, dynamodbstreams):
 # be missing? Or a "null" JSON type? Or an empty string? This test verifies
 # that the right answer is that NextShardIterator should be *missing*
 # (reproduces issue #7237).
-@pytest.mark.xfail(reason="disabled stream is deleted - issue #7239")
 def test_streams_closed_read(dynamodb, dynamodbstreams):
     # This test can't use the shared table test_table_ss_keys_only,
     # because it wants to disable streaming, so let's create a new table:
@@ -2097,7 +2096,6 @@ def test_streams_closed_read(dynamodb, dynamodbstreams):
 # listed for the table, this ARN should continue to work, listing the
 # stream's shards should give an indication that they are all closed - but
 # all these shards should still be readable.
-@pytest.mark.xfail(reason="disabled stream is deleted - issue #7239")
 def test_streams_disabled_stream(dynamodb, dynamodbstreams):
     # This test can't use the shared table test_table_ss_keys_only,
     # because it wants to disable streaming, so let's create a new table:
@@ -2419,3 +2417,70 @@ def test_stream_shard_filtering_missing_shard_id(test_table_ss_keys_only, dynamo
 # TODO: Can we test shard splitting? (shard splitting
 #   requires the user to - periodically or following shards ending - to call
 #   DescribeStream again. We don't do this in any of our tests.
+
+# Count the total number of records currently visible on a stream by reading
+# all shards from the beginning (TRIM_HORIZON).
+def _count_stream_records(dynamodbstreams, arn):
+    shards = []
+    last_shard_id = None
+    while True:
+        kwargs = {'StreamArn': arn}
+        if last_shard_id:
+            kwargs['ExclusiveStartShardId'] = last_shard_id
+        desc = dynamodbstreams.describe_stream(**kwargs)['StreamDescription']
+        shards.extend(desc['Shards'])
+        last_shard_id = desc.get('LastEvaluatedShardId')
+        if not last_shard_id:
+            break
+    nrecords = 0
+    for shard in shards:
+        it = dynamodbstreams.get_shard_iterator(StreamArn=arn,
+            ShardId=shard['ShardId'], ShardIteratorType='TRIM_HORIZON')['ShardIterator']
+        while it:
+            response = dynamodbstreams.get_records(ShardIterator=it)
+            nrecords += len(response.get('Records', []))
+            it = response.get('NextShardIterator')
+            if not response.get('Records'):
+                break
+    return nrecords
+
+def _wait_for_stream_records(dynamodbstreams, arn, timeout=15):
+    """Poll until at least one stream record is visible."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _count_stream_records(dynamodbstreams, arn) > 0:
+            return
+        time.sleep(0.1)
+    pytest.fail(f"Timed out waiting for stream records on {arn}")
+
+# Test that after disabling and re-enabling a stream on a table, the old
+# stream data remains readable through the old ARN. In DynamoDB, it
+# remains readable for 24 hours. In Scylla, it is currently purged upon
+# re-enabling.
+@pytest.mark.xfail(reason="Scylla purges old stream data on re-enable "
+        "instead of keeping it readable for 24h - SCYLLADB-1873")
+def test_streams_reenable(dynamodb, dynamodbstreams):
+    with create_stream_test_table(dynamodb, StreamViewType='KEYS_ONLY') as table:
+        (arn1, label1) = wait_for_active_stream(dynamodbstreams, table)
+
+        # Write some data while the first stream is active
+        p = random_string()
+        table.update_item(Key={'p': p, 'c': random_string()},
+            UpdateExpression='SET x = :val1', ExpressionAttributeValues={':val1': 5})
+
+        _wait_for_stream_records(dynamodbstreams, arn1)
+
+        disable_stream(dynamodbstreams, table)
+
+        # Re-enable the stream
+        table.update(StreamSpecification={'StreamEnabled': True, 'StreamViewType': 'KEYS_ONLY'})
+        (arn2, label2) = wait_for_active_stream(dynamodbstreams, table)
+
+        # The new ARN must differ from the old one
+        assert arn1 != arn2
+
+        # The new stream should have no old data.
+        assert _count_stream_records(dynamodbstreams, arn2) == 0
+
+        # The old stream data should still be readable via the old ARN.
+        assert _count_stream_records(dynamodbstreams, arn1) > 0


### PR DESCRIPTION
When an Alternator stream is disabled, the data should continue to be accessible so that consumers can finish reading. When the stream is later re-enabled, a new StreamArn is produced and only then the old data is purged.

On disable, the existing CDC options (including preimage and postimage) are preserved so that DescribeStream can still report StreamViewType. All stream APIs continue to work on the disabled stream, with all shards reported as closed (EndingSequenceNumber set). No new CDC records are written; existing data expires via TTL after 24 hours.

On re-enable, the old CDC log table is dropped as a separate Raft group0 schema change and a fresh one is created with a new UUID, giving a new StreamArn. This is Alternator-specific — CQL CDC keeps reusing the log table. Re-enabling is the only way to immediately purge old stream data.

Old stream data is removed immediately upon re-enable (a discrepancy with DynamoDB, which keeps it readable for 24 hours through the old StreamArn).

Tests updated to cover the new disable and re-enable behavior.

Fixes #7239
Fixes SCYLLADB-523