### PR TITLE
test: speed up sstable compaction tests on remote storage (S3/GCS)

### DIFF
--- a/test/boost/bloom_filter_test.cc
+++ b/test/boost/bloom_filter_test.cc
@@ -122,7 +122,7 @@ SEASTAR_TEST_CASE(test_reclaimed_bloom_filter_deletion_from_disk) {
 
         auto mut1 = mutation(s, pks[0]);
         mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
         auto sst_test = sstables::test(sst);
 
         const auto filter_path = (env.tempdir().path() / sst_test.filename(component_type::Filter)).native();
@@ -269,7 +269,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reload_after_unlink) {
         mut.partition().apply_insert(*schema, ss.make_ckey(1), ss.new_timestamp());
 
         // bloom filter will be reclaimed automatically due to low memory
-        auto sst = make_sstable_containing(env.make_sstable(schema), {mut});
+        auto sst = make_sstable_containing(env.make_sstable(schema), {mut}).get();
         auto& sst_mgr = env.manager();
         BOOST_REQUIRE_EQUAL(sst->filter_memory_size(), 0);
 
@@ -325,7 +325,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
         }
 
         // create one sst; there is sufficient memory for the bloom filter, so it won't be reclaimed
-        auto sst1 = make_sstable_containing(env.make_sstable(schema), mutations);
+        auto sst1 = make_sstable_containing(env.make_sstable(schema), mutations).get();
         auto& sst_mgr = env.manager();
         auto sst1_filename = sst1->get_filename();
         BOOST_REQUIRE(sst1->filter_memory_size() != 0);
@@ -358,7 +358,7 @@ SEASTAR_TEST_CASE(test_bloom_filter_reclaim_after_unlink) {
 
         // create another sst and unlink it to trigger reload of components.
         // the reload should not attempt to load sst'1 bloom filter into memory depsite its presence in the _active list.
-        auto sst2 = make_sstable_containing(env.make_sstable(schema), {mutations[0]});
+        auto sst2 = make_sstable_containing(env.make_sstable(schema), {mutations[0]}).get();
         sst2->unlink().get();
         sst2.release();
 

--- a/test/boost/compaction_group_test.cc
+++ b/test/boost/compaction_group_test.cc
@@ -48,7 +48,7 @@ static sstables::shared_sstable generate_sstable(schema_ptr s, std::function<sha
             muts.push_back(make_insert(k));
         }
     }
-    return make_sstable_containing(sst_gen, std::move(muts));
+    return make_sstable_containing(sst_gen, std::move(muts)).get();
 }
 
 static sstables::shared_sstable sstable_that_needs_split(schema_ptr s, std::function<shared_sstable()> sst_gen) {

--- a/test/boost/incremental_compaction_test.cc
+++ b/test/boost/incremental_compaction_test.cc
@@ -176,7 +176,7 @@ SEASTAR_TEST_CASE(incremental_compaction_test) {
         // Generate 4 sstable runs composed of 4 fragments each after 4 compactions.
         // All fragments non-overlapping.
         for (auto i = 0U; i < tokens.size(); i++) {
-            auto sst = make_sstable_containing(sst_gen, { make_insert(tokens[i]) });
+            auto sst = make_sstable_containing(sst_gen, { make_insert(tokens[i]) }).get();
             sst->set_sstable_level(1);
             BOOST_REQUIRE(sst->get_sstable_level() == 1);
             column_family_test(cf).add_sstable(sst).get();
@@ -338,7 +338,7 @@ SEASTAR_TEST_CASE(basic_garbage_collection_test) {
             auto sst = env.make_sstable(s, tmp.path().string(), env.new_generation(), sstables::get_highest_sstable_version(), big);
             return sst;
         };
-        auto sst = make_sstable_containing(creator, std::move(mutations));
+        auto sst = make_sstable_containing(creator, std::move(mutations)).get();
         column_family_test(cf).add_sstable(sst).get();
 
         const auto& stats = sst->get_stats_metadata();
@@ -445,7 +445,7 @@ SEASTAR_TEST_CASE(ics_reshape_test) {
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(sstable_count);
             for (unsigned i = 0; i < sstable_count; i++) {
-                auto sst = make_sstable_containing(sst_gen, {make_row(0)});
+                auto sst = make_sstable_containing(sst_gen, {make_row(0)}).get();
                 sstables.push_back(std::move(sst));
             }
 
@@ -460,7 +460,7 @@ SEASTAR_TEST_CASE(ics_reshape_test) {
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
             for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-                auto sst = make_sstable_containing(sst_gen, {make_row(i)});
+                auto sst = make_sstable_containing(sst_gen, {make_row(i)}).get();
                 sstables.push_back(std::move(sst));
             }
 
@@ -474,7 +474,7 @@ SEASTAR_TEST_CASE(ics_reshape_test) {
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
             for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-                auto sst = make_sstable_containing(sst_gen, {make_row(i)});
+                auto sst = make_sstable_containing(sst_gen, {make_row(i)}).get();
                 sstables::test(sst).set_run_identifier(sstable_run_id);
                 sstables.push_back(std::move(sst));
             }
@@ -488,7 +488,7 @@ SEASTAR_TEST_CASE(ics_reshape_test) {
             std::vector<sstables::shared_sstable> sstables;
             sstables.reserve(disjoint_sstable_count);
             for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-                auto sst = make_sstable_containing(sst_gen, {make_row(0)});
+                auto sst = make_sstable_containing(sst_gen, {make_row(0)}).get();
                 sstables.push_back(std::move(sst));
             }
 
@@ -512,7 +512,7 @@ SEASTAR_TEST_CASE(gc_tombstone_with_grace_seconds_test) {
         mutation mut(schema, tests::generate_partition_key(schema, local_shard_only::yes));
         auto live_cell = atomic_cell::make_live(*byte_type, 0, to_bytes("a"), gc_clock::time_point(gc_clock::duration(expiration_time)), gc_clock::duration(1));
         mut.set_clustered_cell(clustering_key::make_empty(), *schema->get_column_definition("value"), std::move(live_cell));
-        auto sst = make_sstable_containing(env.make_sst_factory(schema), {mut});
+        auto sst = make_sstable_containing(env.make_sst_factory(schema), {mut}).get();
 
         table_for_tests cf = env.make_table_for_tests(schema);
         auto close_cf = deferred_stop(cf);
@@ -575,7 +575,7 @@ SEASTAR_TEST_CASE(gc_sstable_incremental_release_test) {
                 bool expired = (key_idx % 4) == 0;
                 mutations.push_back(make_mutation(key_idx, !expired));
             }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations));
+            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
             sstables::test(sst).set_run_identifier(run_id);
             column_family_test(cf).add_sstable(sst).get();
             input_sstables.push_back(std::move(sst));
@@ -668,7 +668,7 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 }
                 mutations.push_back(std::move(mut));
             }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations));
+            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
             sstables::test(sst).set_run_identifier(run_id);
             column_family_test(cf).add_sstable(sst).get();
             input_sstables.push_back(std::move(sst));
@@ -685,7 +685,7 @@ SEASTAR_TEST_CASE(gc_sstable_no_premature_release_with_overlapping_inputs_test) 
                 mut.set_clustered_cell(ck, cdef, std::move(live_cell));
                 mutations.push_back(std::move(mut));
             }
-            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations));
+            auto sst = make_sstable_containing(env.make_sst_factory(schema), std::move(mutations)).get();
             sstables::test(sst).set_run_identifier(run_id);
             column_family_test(cf).add_sstable(sst).get();
             input_sstables.push_back(std::move(sst));

--- a/test/boost/memtable_test.cc
+++ b/test/boost/memtable_test.cc
@@ -80,7 +80,7 @@ utils::chunked_vector<mutation> make_ring(schema_ptr s, int n_mutations) {
 SEASTAR_TEST_CASE(test_memtable_conforms_to_mutation_source) {
     return seastar::async([] {
         run_mutation_source_tests([](schema_ptr s, const utils::chunked_vector<mutation>& partitions) {
-            auto mt = make_memtable(s, partitions);
+            auto mt = make_memtable(s, partitions).get();
             logalloc::shard_tracker().full_compaction();
             return mt->as_data_source();
         });
@@ -481,8 +481,8 @@ SEASTAR_TEST_CASE(test_fast_forward_to_after_memtable_is_flushed) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         utils::chunked_vector<mutation> ring = make_ring(s, 5);
-        auto mt = make_memtable(s, ring);
-        auto mt2 = make_memtable(s, ring);
+        auto mt = make_memtable(s, ring).get();
+        auto mt2 = make_memtable(s, ring).get();
 
         auto rd = assert_that(mt->make_mutation_reader(s, semaphore.make_permit()));
         rd.produces(ring[0]);
@@ -501,7 +501,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_partition_range_reads) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
         utils::chunked_vector<mutation> ms = gen(2);
 
-        auto mt = make_memtable(s, ms);
+        auto mt = make_memtable(s, ms).get();
         memory::with_allocation_failures([&] {
             assert_that(mt->make_mutation_reader(s, semaphore.make_permit(), query::full_partition_range))
                 .produces(ms);
@@ -516,7 +516,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_flush_reads) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
         utils::chunked_vector<mutation> ms = gen(2);
 
-        auto mt = make_memtable(s, ms);
+        auto mt = make_memtable(s, ms).get();
         memory::with_allocation_failures([&] {
             auto revert = defer([&] {
                 mt->revert_flushed_memory();
@@ -534,7 +534,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_single_partition_reads) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
         utils::chunked_vector<mutation> ms = gen(2);
 
-        auto mt = make_memtable(s, ms);
+        auto mt = make_memtable(s, ms).get();
         memory::with_allocation_failures([&] {
             assert_that(mt->make_mutation_reader(s, semaphore.make_permit(), dht::partition_range::make_singular(ms[1].decorated_key())))
                 .produces(ms[1]);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -771,11 +771,11 @@ SEASTAR_TEST_CASE(combined_mutation_reader_test) {
     };
 
     std::vector<sstables::shared_sstable> sstable_list = {
-            make_sstable_containing(sst_factory(0), std::move(sstable_level_0_0_mutations)),
-            make_sstable_containing(sst_factory(1), std::move(sstable_level_1_0_mutations)),
-            make_sstable_containing(sst_factory(1), std::move(sstable_level_1_1_mutations)),
-            make_sstable_containing(sst_factory(2), std::move(sstable_level_2_0_mutations)),
-            make_sstable_containing(sst_factory(2), std::move(sstable_level_2_1_mutations)),
+            make_sstable_containing(sst_factory(0), std::move(sstable_level_0_0_mutations)).get(),
+            make_sstable_containing(sst_factory(1), std::move(sstable_level_1_0_mutations)).get(),
+            make_sstable_containing(sst_factory(1), std::move(sstable_level_1_1_mutations)).get(),
+            make_sstable_containing(sst_factory(2), std::move(sstable_level_2_0_mutations)).get(),
+            make_sstable_containing(sst_factory(2), std::move(sstable_level_2_1_mutations)).get(),
     };
 
     auto cs = compaction::make_compaction_strategy(compaction::compaction_strategy_type::leveled, {});
@@ -1062,7 +1062,7 @@ SEASTAR_TEST_CASE(test_fast_forwarding_combined_reader_is_consistent_with_slicin
                     combined[j++].apply(m);
                 }
             }
-            mutation_source ds = make_sstable_containing(env.make_sstable(s), muts)->as_mutation_source();
+            mutation_source ds = make_sstable_containing(env.make_sstable(s), muts).get()->as_mutation_source();
             reader_ranges.push_back(dht::partition_range::make({keys[0]}, {keys[0]}));
             readers.push_back(ds.make_mutation_reader(s,
                 permit,
@@ -1133,8 +1133,8 @@ SEASTAR_TEST_CASE(test_combined_reader_slicing_with_overlapping_range_tombstones
 
         std::vector<mutation_reader> readers;
 
-        mutation_source ds1 = make_sstable_containing(env.make_sstable(s), {m1})->as_mutation_source();
-        mutation_source ds2 = make_sstable_containing(env.make_sstable(s), {m2})->as_mutation_source();
+        mutation_source ds1 = make_sstable_containing(env.make_sstable(s), {m1}).get()->as_mutation_source();
+        mutation_source ds2 = make_sstable_containing(env.make_sstable(s), {m2}).get()->as_mutation_source();
 
         // upper bound ends before the row in m2, so that the raw is fetched after next fast forward.
         auto range = ss.make_ckey_range(0, 3);
@@ -2580,7 +2580,7 @@ SEASTAR_THREAD_TEST_CASE(test_queue_reader) {
 SEASTAR_THREAD_TEST_CASE(test_compacting_reader_as_mutation_source) {
     auto make_populate = [] (bool single_fragment_buffer) {
         return [single_fragment_buffer] (schema_ptr s, const utils::chunked_vector<mutation>& mutations, gc_clock::time_point query_time) mutable {
-            auto mt = make_memtable(s, mutations);
+            auto mt = make_memtable(s, mutations).get();
             return mutation_source([=] (
                     schema_ptr s,
                     reader_permit permit,
@@ -2705,7 +2705,7 @@ SEASTAR_THREAD_TEST_CASE(test_compacting_reader_is_consistent_with_compaction) {
 
 SEASTAR_THREAD_TEST_CASE(test_auto_paused_evictable_reader_is_mutation_source) {
     auto make_populate = [] (schema_ptr s, const utils::chunked_vector<mutation>& mutations, gc_clock::time_point query_time) {
-        auto mt = make_memtable(s, mutations);
+        auto mt = make_memtable(s, mutations).get();
         return mutation_source([=] (
                 schema_ptr s,
                 reader_permit permit,
@@ -2782,7 +2782,7 @@ SEASTAR_THREAD_TEST_CASE(test_manual_paused_evictable_reader_is_mutation_source)
     };
 
     auto make_populate = [] (schema_ptr s, const utils::chunked_vector<mutation>& mutations, gc_clock::time_point query_time) {
-        auto mt = make_memtable(s, mutations);
+        auto mt = make_memtable(s, mutations).get();
         return mutation_source([=] (
                 schema_ptr s,
                 reader_permit permit,
@@ -3947,7 +3947,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
         for (auto& mb: scenario.readers_data) {
             sstables::shared_sstable sst;
             if (mb.m) {
-                sst = make_sstable_containing(sst_factory, {*mb.m});
+                sst = make_sstable_containing(sst_factory, {*mb.m}).get();
                 sst_set.insert(sst);
             } else {
                 // We want to have an sstable that won't return any fragments when we query it
@@ -3956,7 +3956,7 @@ static future<> do_test_clustering_order_merger_sstable_set(bool reversed) {
                 auto pk = pkeys[1];
                 SCYLLA_ASSERT(!pk.equal(*g._s, g._pk));
 
-                sst = make_sstable_containing(sst_factory, {mutation(table_schema, pk)});
+                sst = make_sstable_containing(sst_factory, {mutation(table_schema, pk)}).get();
                 sst_set.insert(sst);
             }
 

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -93,7 +93,7 @@ repair_rows_on_wire make_random_repair_rows_on_wire(random_mutation_generator& g
 
     for (mutation& mut : muts) {
         partition_key pk = mut.key();
-        auto m2 = make_memtable(s, {mut});
+        auto m2 = make_memtable(s, {mut}).get();
         m->apply(mut);
         auto reader = mutation_fragment_v1_stream(m2->make_mutation_reader(s, permit));
         auto close_reader = deferred_close(reader);

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -2675,9 +2675,9 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
             snap->set_max_buffer_size(1);
             snap->fill_buffer().get();
 
+            auto mt2 = make_memtable(cache.schema(), muts2);
             cache.update(row_cache::external_updater([&] {
                 memory::scoped_critical_alloc_section dfg;
-                auto mt2 = make_memtable(cache.schema(), muts2);
                 underlying.apply(std::move(mt2));
             }), *mt).get();
 

--- a/test/boost/row_cache_test.cc
+++ b/test/boost/row_cache_test.cc
@@ -385,7 +385,7 @@ SEASTAR_TEST_CASE(test_cache_delegates_to_underlying_only_once_multiple_mutation
         std::move(all_partitions.begin() + 1, all_partitions.end() - 1, std::back_inserter(partitions));
 
         cache_tracker tracker;
-        auto mt = make_memtable(s, partitions);
+        auto mt = make_memtable(s, partitions).get();
 
         auto make_cache = [&tracker, &mt](schema_ptr s, int& secondary_calls_count) -> lw_shared_ptr<row_cache> {
             auto secondary = mutation_source([&mt, &secondary_calls_count] (schema_ptr s, reader_permit permit, const dht::partition_range& range,
@@ -557,7 +557,7 @@ SEASTAR_TEST_CASE(test_query_of_incomplete_range_goes_to_underlying) {
 
         utils::chunked_vector<mutation> mutations = make_ring(s, 3);
 
-        auto mt = make_memtable(s, mutations);
+        auto mt = make_memtable(s, mutations).get();
 
         cache_tracker tracker;
         row_cache cache(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
@@ -603,7 +603,7 @@ SEASTAR_TEST_CASE(test_single_key_queries_after_population_in_reverse_order) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         utils::chunked_vector<mutation> mutations = make_ring(s, 3);
-        auto mt = make_memtable(s, mutations);
+        auto mt = make_memtable(s, mutations).get();
 
         cache_tracker tracker;
         row_cache cache(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
@@ -639,7 +639,7 @@ SEASTAR_TEST_CASE(test_partition_range_population_with_concurrent_memtable_flush
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         utils::chunked_vector<mutation> mutations = make_ring(s, 3);
-        auto mt = make_memtable(s, mutations);
+        auto mt = make_memtable(s, mutations).get();
 
         cache_tracker tracker;
         row_cache cache(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
@@ -694,7 +694,7 @@ SEASTAR_TEST_CASE(test_row_cache_conforms_to_mutation_source) {
         cache_tracker tracker;
 
         run_mutation_source_tests([&tracker](schema_ptr s, const utils::chunked_vector<mutation>& mutations) -> mutation_source {
-            auto mt = make_memtable(s, mutations);
+            auto mt = make_memtable(s, mutations).get();
             auto cache = make_lw_shared<row_cache>(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
             return mutation_source([cache] (schema_ptr s,
                     reader_permit permit,
@@ -1275,7 +1275,7 @@ SEASTAR_TEST_CASE(test_continuity_flag_and_invalidate_race) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         auto ring = make_ring(s, 4);
-        auto mt = make_memtable(s, ring);
+        auto mt = make_memtable(s, ring).get();
 
         cache_tracker tracker;
         row_cache cache(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
@@ -1328,7 +1328,7 @@ SEASTAR_TEST_CASE(test_cache_invalidation_with_filter) {
         tests::reader_concurrency_semaphore_wrapper semaphore;
 
         auto ring = make_ring(s, 5);
-        auto mt = make_memtable(s, ring);
+        auto mt = make_memtable(s, ring).get();
 
         cache_tracker tracker;
 
@@ -1469,13 +1469,13 @@ SEASTAR_TEST_CASE(test_cache_population_and_update_race) {
         cache_tracker tracker;
 
         auto ring = make_ring(s, 3);
-        auto mt1 = make_memtable(s, ring);
+        auto mt1 = make_memtable(s, ring).get();
         memtables.apply(*mt1);
 
         row_cache cache(s, cache_source, tracker);
 
         auto ring2 = updated_ring(ring);
-        auto mt2 = make_memtable(s, ring2);
+        auto mt2 = make_memtable(s, ring2).get();
 
         auto f = thr.block();
 
@@ -1602,13 +1602,13 @@ SEASTAR_TEST_CASE(test_cache_population_and_clear_race) {
         cache_tracker tracker;
 
         auto ring = make_ring(s, 3);
-        auto mt1 = make_memtable(s, ring);
+        auto mt1 = make_memtable(s, ring).get();
         memtables.apply(*mt1);
 
         row_cache cache(s, std::move(cache_source), tracker);
 
         auto ring2 = updated_ring(ring);
-        auto mt2 = make_memtable(s, ring2);
+        auto mt2 = make_memtable(s, ring2).get();
 
         auto f = thr.block();
 
@@ -1768,7 +1768,7 @@ SEASTAR_TEST_CASE(test_slicing_mutation_reader) {
                                  to_bytes("v"), data_value(i), api::new_timestamp());
         }
 
-        auto mt = make_memtable(s, {m});
+        auto mt = make_memtable(s, {m}).get();
         cache_tracker tracker;
         row_cache cache(s, snapshot_source_from_snapshot(mt->as_data_source()), tracker);
 
@@ -2667,7 +2667,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
                     .produces_end_of_stream();
             });
 
-            auto mt = make_memtable(cache.schema(), muts2);
+            auto mt = make_memtable(cache.schema(), muts2).get();
 
             // Make snapshot on pkeys[2]
             auto pr = dht::partition_range::make_singular(pkeys[2]);
@@ -2675,7 +2675,7 @@ SEASTAR_TEST_CASE(test_exception_safety_of_update_from_memtable) {
             snap->set_max_buffer_size(1);
             snap->fill_buffer().get();
 
-            auto mt2 = make_memtable(cache.schema(), muts2);
+            auto mt2 = make_memtable(cache.schema(), muts2).get();
             cache.update(row_cache::external_updater([&] {
                 memory::scoped_critical_alloc_section dfg;
                 underlying.apply(std::move(mt2));

--- a/test/boost/schema_changes_test.cc
+++ b/test/boost/schema_changes_test.cc
@@ -43,7 +43,7 @@ future <> test_schema_changes_int(sstable_version_types sstable_vtype) {
         shared_sstable created_with_base_schema;
         shared_sstable created_with_changed_schema;
         if (it == cache.end()) {
-            created_with_base_schema = make_sstable_containing(env.make_sstable(base), base_mutations);
+            created_with_base_schema = make_sstable_containing(env.make_sstable(base), base_mutations).get();
             cache.emplace(base, created_with_base_schema);
         } else {
             created_with_base_schema = it->second;

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -3220,7 +3220,7 @@ static sstables::shared_sstable write_and_compare_sstables(test_env& env, schema
 }
 
 static sstables::shared_sstable write_sstables(test_env& env, schema_ptr s, lw_shared_ptr<replica::memtable> mt, sstable_version_types version) {
-    auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
+    auto sst = make_sstable_containing(env.make_sstable(s, version), mt).get();
     BOOST_TEST_MESSAGE(format("write_sstable from memtable: {}", sst->get_filename()));
     return sst;
 }
@@ -3253,7 +3253,7 @@ constexpr std::array<sstable_version_types, 4> test_sstable_versions = {
 
 static void write_mut_and_compare_sstables_version(test_env& env, schema_ptr s, mutation& mut, const sstring& table_name,
         sstable_version_types version) {
-    lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut});
+    lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut}).get();
     write_and_compare_sstables(env, s, mt, table_name, version);
 }
 
@@ -3265,8 +3265,8 @@ static void write_mut_and_compare_sstables(test_env& env, schema_ptr s, mutation
 
 static void write_muts_and_compare_sstables_version(test_env& env, schema_ptr s, mutation& mut1, mutation& mut2, const sstring& table_name,
         sstable_version_types version) {
-    lw_shared_ptr<replica::memtable> mt1 = make_memtable(s, {mut1});
-    lw_shared_ptr<replica::memtable> mt2 = make_memtable(s, {mut2});
+    lw_shared_ptr<replica::memtable> mt1 = make_memtable(s, {mut1}).get();
+    lw_shared_ptr<replica::memtable> mt2 = make_memtable(s, {mut2}).get();
     write_and_compare_sstables(env, s, mt1, mt2, table_name, version);
 }
 
@@ -3326,7 +3326,7 @@ using validate_stats_metadata = bool_class<validate_stats_metadata_tag>;
 
 static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, mutation& mut,
         sstable_version_types version, validate_stats_metadata validate_flag) {
-    lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut});
+    lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut}).get();
     auto sst = write_and_compare_sstables(env, s, mt, table_name, version);
     auto written_sst = validate_read(env, sst, {mut});
     if (validate_flag) {
@@ -3348,7 +3348,7 @@ static void write_mut_and_validate_version(test_env& env, schema_ptr s, const ss
     // but cannot now because flat reader version transforms rearrange
     // range tombstones.  Revisit once the reader v2 migration is
     // complete and those version transforms are gone
-    auto sst = make_sstable_containing(env.make_sstable(s, version), {mut});
+    auto sst = make_sstable_containing(env.make_sstable(s, version), {mut}).get();
     auto written_sst = validate_read(env, sst, {mut});
     check_min_max_column_names(written_sst, std::move(min_components), std::move(max_components));
 }
@@ -3362,7 +3362,7 @@ static void write_mut_and_validate(test_env& env, schema_ptr s, const sstring& t
 
 static void write_mut_and_validate_version(test_env& env, schema_ptr s, const sstring& table_name, utils::chunked_vector<mutation> muts,
         sstable_version_types version, validate_stats_metadata validate_flag) {
-    lw_shared_ptr<replica::memtable> mt = make_memtable(s, muts);
+    lw_shared_ptr<replica::memtable> mt = make_memtable(s, muts).get();
     auto sst = write_and_compare_sstables(env, s, mt, table_name, version);
     auto written_sst = validate_read(env, sst, muts);
     if (validate_flag) {
@@ -3701,7 +3701,7 @@ static future<> test_write_many_partitions(sstring table_name, tombstone partiti
 
     bool compressed = cp.get_algorithm() != compression_parameters::algorithm::none;
     for (auto version : test_sstable_versions) {
-        lw_shared_ptr<replica::memtable> mt = make_memtable(s, muts);
+        lw_shared_ptr<replica::memtable> mt = make_memtable(s, muts).get();
         auto sst = compressed ? write_sstables(env, s, mt, version) : write_and_compare_sstables(env, s, mt, table_name, version);
         std::ranges::sort(muts, mutation_decorated_key_less_comparator());
         validate_read(env, sst, muts);
@@ -5016,7 +5016,7 @@ SEASTAR_TEST_CASE(test_write_empty_static_row) {
     mut2.set_cell(ckey, "rc", data_value{3}, ts);
 
     for (auto version : test_sstable_versions) {
-        lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut1, mut2});
+        lw_shared_ptr<replica::memtable> mt = make_memtable(s, {mut1, mut2}).get();
         auto sst = write_and_compare_sstables(env, s, mt, table_name, version);
         validate_read(env, sst, {mut2, mut1}); // Mutations are re-ordered according to decorated_key order
     }
@@ -5069,7 +5069,7 @@ SEASTAR_TEST_CASE(test_sstable_reader_on_unknown_column) {
         partition.set_cell(ckey, "val2", data_value{200 + i}, write_timestamp);
     };
   for (auto version : test_sstable_versions) {
-    auto mt = make_memtable(write_schema, {partition});
+    auto mt = make_memtable(write_schema, {partition}).get();
     for (auto index_block_size : {1, 128, 64*1024}) {
         auto _ = env.tempdir().make_sweeper();
         sstable_writer_config cfg = env.manager().configure_writer();
@@ -5190,7 +5190,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_write_large_row) {
     auto ck2 = s.make_ckey("cv2");
     s.add_row(partition, ck2, "foo bar");
   for (auto version : test_sstable_versions) {
-    auto mt = make_memtable(s.schema(), {partition});
+    auto mt = make_memtable(s.schema(), {partition}).get();
     test_sstable_write_large_row_f(s.schema(), semaphore.make_permit(), *mt, pk, {nullptr, &ck1, &ck2}, 21, version);
     test_sstable_write_large_row_f(s.schema(), semaphore.make_permit(), *mt, pk, {nullptr, &ck2}, 22, version);
   }
@@ -5271,7 +5271,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_write_large_cell) {
     auto ck2 = s.make_ckey("cv2");
     s.add_row(partition, ck2, "foo bar");
     for (auto version : test_sstable_versions) {
-        auto mt = make_memtable(s.schema(), {partition});
+        auto mt = make_memtable(s.schema(), {partition}).get();
         test_sstable_write_large_cell_f(s.schema(), semaphore.make_permit(), *mt, pk, {nullptr, &ck1, &ck2}, 13, version);
         test_sstable_write_large_cell_f(s.schema(), semaphore.make_permit(), *mt, pk, {nullptr, &ck2}, 14, version);
     }
@@ -5291,7 +5291,7 @@ static void test_sstable_log_too_many_rows_f(int rows, int range_tombstones, uin
     }
 
     schema_ptr sc = s.schema();
-    auto mt = make_memtable(sc, {p});
+    auto mt = make_memtable(sc, {p}).get();
 
     // rows_count_threshold = threshold; all other thresholds at MAX.
     large_data_test_handler handler(std::numeric_limits<uint64_t>::max(),
@@ -5457,7 +5457,7 @@ static void test_sstable_too_many_collection_elements_f(int elements, uint64_t t
     }
     s.add_row_with_collection(p, s.make_ckey("ck1"), kv_map);
     schema_ptr sc = s.schema();
-    auto mt = make_memtable(sc, {p});
+    auto mt = make_memtable(sc, {p}).get();
 
     BOOST_TEST_MESSAGE(format("elements={} threshold={} expected={}", elements, threshold, expected));
     // collection_elements_threshold = threshold; all other thresholds at MAX.
@@ -5530,7 +5530,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data_records_round_trip) {
             auto ck = ss.make_ckey("ck1");
             ss.add_row(m, ck, "a_value_that_is_larger_than_one_byte");
 
-            auto mt = make_memtable(s, {m});
+            auto mt = make_memtable(s, {m}).get();
             auto sst = env.make_sstable(s, version);
             sst->write_components(mt->make_mutation_reader(s, env.make_reader_permit()),
                 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();
@@ -5646,7 +5646,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data_records_top_n_bounded) {
                 muts.push_back(std::move(m));
             }
 
-            auto mt = make_memtable(s, muts);
+            auto mt = make_memtable(s, muts).get();
             auto sst = env.make_sstable(s, version);
             sst->write_components(mt->make_mutation_reader(s, env.make_reader_permit()),
                 6, s, env.manager().configure_writer("test"), encoding_stats{}).get();
@@ -5699,7 +5699,7 @@ SEASTAR_THREAD_TEST_CASE(test_large_data_records_none_when_below_threshold) {
             mutation m(s, pk);
             ss.add_row(m, ss.make_ckey("ck1"), "small_value");
 
-            auto mt = make_memtable(s, {m});
+            auto mt = make_memtable(s, {m}).get();
             auto sst = env.make_sstable(s, version);
             sst->write_components(mt->make_mutation_reader(s, env.make_reader_permit()),
                 1, s, env.manager().configure_writer("test"), encoding_stats{}).get();

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5262,8 +5262,12 @@ void test_offstrategy_sstable_compaction_fn(test_env& env) {
 
         cf->start();
 
-        for (auto i = 0; i < cf->schema()->max_compaction_threshold(); i++) {
-            auto sst = make_sstable_containing(sst_gen, {mut}).get();
+        auto threshold = cf->schema()->max_compaction_threshold();
+        std::vector<sstables::shared_sstable> ssts(threshold);
+        parallel_for_each(std::views::iota(0, threshold), [&](int i) -> future<> {
+            ssts[i] = co_await make_sstable_containing(sst_gen, {mut});
+        }).get();
+        for (auto& sst : ssts) {
             cf->add_sstable_and_update_cache(std::move(sst), sstables::offstrategy::yes).get();
         }
         BOOST_REQUIRE(cf->perform_offstrategy_compaction(tasks::task_info{}).get());

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -12,6 +12,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/util/closeable.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/core/coroutine.hh>
@@ -4939,7 +4940,7 @@ void test_twcs_partition_estimate_fn(test_env& env) {
 
     auto keys = tests::generate_partition_keys(4, s);
 
-    auto make_sstable = [&] (int sstable_idx) {
+    auto make_sstable = [&] (int sstable_idx) -> future<shared_sstable> {
         static thread_local int32_t value = 1;
 
         auto key = keys[sstable_idx];
@@ -4949,7 +4950,7 @@ void test_twcs_partition_estimate_fn(test_env& env) {
             auto c_key = clustering_key::from_exploded(*s, {int32_type->decompose(value++)});
             m.set_clustered_cell(c_key, bytes("value"), data_value(int32_t(value)), next_timestamp(sstable_idx, ck));
         }
-        return make_sstable_containing(sst_gen, {m}).get();
+        co_return co_await make_sstable_containing(sst_gen, {m});
     };
 
     auto cf = env.make_table_for_tests(s);
@@ -4978,12 +4979,10 @@ void test_twcs_partition_estimate_fn(test_env& env) {
         estimation_test(s, compaction::time_window_compaction_strategy::max_data_segregation_window_count);
     }
 
-    std::vector<shared_sstable> sstables_spanning_many_windows = {
-        make_sstable(0),
-        make_sstable(1),
-        make_sstable(2),
-        make_sstable(3),
-    };
+    std::vector<shared_sstable> sstables_spanning_many_windows(4);
+    parallel_for_each(std::views::iota(0, 4), [&](int i) -> future<> {
+        sstables_spanning_many_windows[i] = co_await make_sstable(i);
+    }).get();
 
     auto ret = compact_sstables(env, compaction::compaction_descriptor(sstables_spanning_many_windows), cf, sst_gen, replacer_fn_no_op()).get();
     // The real test here is that we don't SCYLLA_ASSERT() in

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6828,24 +6828,32 @@ static future<> run_incremental_compaction_test(sstables::offstrategy offstrateg
 
         std::unordered_set<sstables::generation_type> gens; // input sstable generations
         run_id run_identifier = run_id::create_random_id();
+
+        // Pre-extract mutation pairs for parallel SSTable creation
+        std::vector<std::pair<mutation, mutation>> mutation_pairs;
+        mutation_pairs.reserve(sstables_nr);
         auto merged_it = merged.begin();
         for (unsigned i = 0; i < sstables_nr; i++) {
             auto mut1 = std::move(*merged_it);
             merged_it++;
             auto mut2 = std::move(*merged_it);
             merged_it++;
-            auto sst = make_sstable_containing(sst_gen, {
-                std::move(mut1),
-                std::move(mut2)
-            }).get();
-            sstables::test(sst).set_run_identifier(run_identifier); // in order to produce multi-fragment run.
-            sst->set_sstable_level(offstrategy ? 0 : 1);
+            mutation_pairs.emplace_back(std::move(mut1), std::move(mut2));
+        }
 
-            // every sstable will be eligible for cleanup, by having both an owned and unowned token.
-            owned_token_ranges.push_back(dht::token_range::make_singular(sst->get_last_decorated_key().token()));
+        ssts.resize(sstables_nr);
+        parallel_for_each(std::views::iota(size_t(0), sstables_nr), [&](size_t i) -> future<> {
+            ssts[i] = co_await make_sstable_containing(sst_gen, {
+                std::move(mutation_pairs[i].first),
+                std::move(mutation_pairs[i].second)
+            });
+            sstables::test(ssts[i]).set_run_identifier(run_identifier);
+            ssts[i]->set_sstable_level(offstrategy ? 0 : 1);
+        }).get();
 
-            gens.insert(sst->generation());
-            ssts.push_back(std::move(sst));
+        for (unsigned i = 0; i < sstables_nr; i++) {
+            owned_token_ranges.push_back(dht::token_range::make_singular(ssts[i]->get_last_decorated_key().token()));
+            gens.insert(ssts[i]->generation());
         }
 
         size_t last_input_sstable_count = sstables_nr;

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6247,10 +6247,9 @@ SEASTAR_FIXTURE_TEST_CASE(simple_backlog_controller_test_incremental_gcs, gcs_fi
     return run_controller_test(compaction::compaction_strategy_type::incremental, test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-void test_compaction_strategy_cleanup_method_fn(test_env& env) {
-    constexpr size_t all_files = 64;
+void test_compaction_strategy_cleanup_method_fn(test_env& env, size_t all_files = 64) {
 
-    auto get_cleanup_jobs = [&env] (compaction::compaction_strategy_type compaction_strategy_type,
+    auto get_cleanup_jobs = [&env, all_files] (compaction::compaction_strategy_type compaction_strategy_type,
                                                 std::map<sstring, sstring> strategy_options = {},
                                                 const api::timestamp_clock::duration step_base = 0ms,
                                                 unsigned sstable_level = 0) {
@@ -6281,14 +6280,13 @@ void test_compaction_strategy_cleanup_method_fn(test_env& env) {
             return m;
         };
 
-        std::vector<sstables::shared_sstable> candidates;
-        candidates.reserve(all_files);
-        for (size_t i = 0; i < all_files; i++) {
+        std::vector<sstables::shared_sstable> candidates(all_files);
+        parallel_for_each(std::views::iota(size_t(0), all_files), [&](size_t i) -> future<> {
             auto current_step = duration_cast<microseconds>(step_base) * i;
-            auto sst = make_sstable_containing(sst_gen, {make_mutation(i, next_timestamp(current_step))}).get();
+            auto sst = co_await make_sstable_containing(sst_gen, {make_mutation(i, next_timestamp(current_step))});
             sst->set_sstable_level(sstable_level);
-            candidates.push_back(std::move(sst));
-        }
+            candidates[i] = std::move(sst);
+        }).get();
 
         auto strategy = cf->get_compaction_strategy();
         auto jobs = strategy.get_cleanup_compaction_jobs(cf.as_compaction_group_view(), candidates);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -6982,26 +6982,32 @@ void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
     }
 
     std::unordered_set<sstables::generation_type> gens; // input sstable generations
+
+    // Pre-extract mutation pairs for parallel SSTable creation
+    std::vector<std::pair<mutation, mutation>> mutation_pairs;
+    mutation_pairs.reserve(sstables_nr);
     auto merged_it = merged.begin();
     for (unsigned i = 0; i < sstables_nr; i++) {
         auto mut1 = std::move(*merged_it);
         merged_it++;
         auto mut2 = std::move(*merged_it);
         merged_it++;
-        auto sst = make_sstable_containing(sst_gen, {
-            std::move(mut1),
-            std::move(mut2)
-        }).get();
-        // Force a new run_id to trigger offstrategy compaction
-        sstables::test(sst).set_run_identifier(run_id::create_random_id());
-        // Set level to 0 to trigger offstrategy compaction
-        sst->set_sstable_level(0);
+        mutation_pairs.emplace_back(std::move(mut1), std::move(mut2));
+    }
 
-        // every sstable will be eligible for cleanup, by having both an owned and unowned token.
-        owned_token_ranges.push_back(dht::token_range::make_singular(sst->get_last_decorated_key().token()));
+    ssts.resize(sstables_nr);
+    parallel_for_each(std::views::iota(size_t(0), sstables_nr), [&](size_t i) -> future<> {
+        ssts[i] = co_await make_sstable_containing(sst_gen, {
+            std::move(mutation_pairs[i].first),
+            std::move(mutation_pairs[i].second)
+        });
+        sstables::test(ssts[i]).set_run_identifier(run_id::create_random_id());
+        ssts[i]->set_sstable_level(0);
+    }).get();
 
-        gens.insert(sst->generation());
-        ssts.push_back(std::move(sst));
+    for (unsigned i = 0; i < sstables_nr; i++) {
+        owned_token_ranges.push_back(dht::token_range::make_singular(ssts[i]->get_last_decorated_key().token()));
+        gens.insert(ssts[i]->generation());
     }
 
     {

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5288,8 +5288,7 @@ SEASTAR_FIXTURE_TEST_CASE(test_offstrategy_sstable_compaction_gcs, gcs_fixture, 
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-void twcs_reshape_with_disjoint_set_fn(test_env& env) {
-    static constexpr unsigned disjoint_sstable_count = 256;
+void twcs_reshape_with_disjoint_set_fn(test_env& env, unsigned disjoint_sstable_count = 256) {
     auto builder = schema_builder("tests", "twcs_reshape_test")
             .with_column("id", utf8_type, column_kind::partition_key)
             .with_column("cl", ::timestamp_type, column_kind::clustering_key)
@@ -5346,27 +5345,23 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
     auto sst_gen = env.make_sst_factory(s);
 
     {
-        // create set of 256 disjoint ssts that belong to the same time window and expect that twcs reshape allows them all to be compacted at once
+        // create set of disjoint ssts that belong to the same time window and expect that twcs reshape allows them all to be compacted at once
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(1))}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(1))});
+        }).get();
 
         BOOST_REQUIRE_EQUAL(get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size(), disjoint_sstable_count);
     }
 
     {
-        // create set of 256 disjoint ssts that belong to different windows and expect that twcs reshape allows them all to be compacted at once
+        // create set of disjoint ssts that belong to different windows and expect that twcs reshape allows them all to be compacted at once
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(i))}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(i))});
+        }).get();
 
         auto reshaping_count = get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size();
         BOOST_REQUIRE_GE(reshaping_count, disjoint_sstable_count - min_threshold + 1);
@@ -5374,30 +5369,25 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
     }
 
     {
-        // create set of 256 disjoint ssts that belong to different windows with none over the threshold and expect that twcs reshape selects none of them
+        // create set of disjoint ssts that belong to different windows with none over the threshold and expect that twcs reshape selects none of them
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i))}).get();
-            sstables.push_back(std::move(sst));
-            i++;
-            sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i + 1))}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count / 2), [&](unsigned pair_idx) -> future<> {
+            unsigned i = pair_idx * 2;
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i))});
+            sstables[i+1] = co_await make_sstable_containing(sst_gen, {make_row(i+1, std::chrono::hours(24*(i+1) + 1))});
+        }).get();
 
         BOOST_REQUIRE_EQUAL(get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size(), 0);
     }
 
     {
-        // create set of 256 overlapping ssts that belong to the same time window and expect that twcs reshape allows only 32 to be compacted at once
+        // create set of overlapping ssts that belong to the same time window and expect that twcs reshape allows only 32 to be compacted at once
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(0, std::chrono::hours(1))}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(0, std::chrono::hours(1))});
+        }).get();
 
         BOOST_REQUIRE_EQUAL(get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size(), uint64_t(s->max_compaction_threshold()));
     }
@@ -5416,21 +5406,21 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
 
         std::unordered_set<sstables::generation_type> generations_for_small_files;
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(64);
+        std::vector<sstables::shared_sstable> sstables(64);
+
+        // Track which indices are small files
+        parallel_for_each(std::views::iota(0u, 64u), [&](unsigned i) -> future<> {
+            if (i % 2 == 0) {
+                sstables[i] = co_await make_sstable_containing(sst_gen, mutations_for_small_files);
+            } else {
+                sstables[i] = co_await make_sstable_containing(sst_gen, mutations_for_big_files);
+            }
+        }).get();
 
         for (unsigned i = 0; i < 64; i++) {
-            sstables::shared_sstable sst;
-            //
-            // intermix big and small files, to make sure STCS logic is really applied to favor similar-sized reshape jobs.
-            //
             if (i % 2 == 0) {
-                sst = make_sstable_containing(sst_gen, mutations_for_small_files).get();
-                generations_for_small_files.insert(sst->generation());
-            } else {
-                sst = make_sstable_containing(sst_gen, mutations_for_big_files).get();
+                generations_for_small_files.insert(sstables[i]->generation());
             }
-            sstables.push_back(std::move(sst));
         }
 
         auto check_mode_correctness = [&] (compaction::reshape_mode mode) {
@@ -5448,19 +5438,17 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
     }
 
     {
-        // create set of 256 disjoint ssts that spans multiple windows (essentially what happens in off-strategy during node op)
+        // create set of disjoint ssts that spans multiple windows (essentially what happens in off-strategy during node op)
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (auto i = 0U; i < disjoint_sstable_count; i++) {
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
             utils::chunked_vector<mutation> muts;
             muts.reserve(5);
             for (auto j = 0; j < 5; j++) {
                 muts.push_back(make_row(i, std::chrono::hours(j * 8)));
             }
-            auto sst = make_sstable_containing(sst_gen, std::move(muts)).get();
-            sstables.push_back(std::move(sst));
-        }
+            sstables[i] = co_await make_sstable_containing(sst_gen, std::move(muts));
+        }).get();
 
         auto job_size = [] (auto&& sst_range) {
             return std::ranges::fold_left(sst_range | std::views::transform(std::mem_fn(&sstable::bytes_on_disk)), uint64_t(0), std::plus{});
@@ -5492,18 +5480,12 @@ SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_test) {
 }
 
 SEASTAR_TEST_CASE(twcs_reshape_with_disjoint_set_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
-    // TODO: Deeper investigation needed to figure out why it takes 4+ minutes to run on S3 storage, while it runs in seconds on local storage. For now,
-    // skipping the test for S3.
-    testlog.info("cleanup_during_offstrategy_incremental_compaction_test_s3 is not supported for S3 storage yet, skipping test");
-    return make_ready_future();
-#if 0
-    return test_env::do_with_async([](test_env& env) { twcs_reshape_with_disjoint_set_fn(env); },
+    return test_env::do_with_async([](test_env& env) { twcs_reshape_with_disjoint_set_fn(env, 64); },
                                    test_env_config{.storage = make_test_object_storage_options("S3")});
-#endif
 }
 
 SEASTAR_FIXTURE_TEST_CASE(twcs_reshape_with_disjoint_set_gcs_test, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
-    return test_env::do_with_async([](test_env& env) { twcs_reshape_with_disjoint_set_fn(env); },
+    return test_env::do_with_async([](test_env& env) { twcs_reshape_with_disjoint_set_fn(env, 64); },
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -195,7 +195,7 @@ void compaction_manager_basic(test_env& env) {
         mutation m(s, key);
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
 
-        auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+        auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
         column_family_test(cf).add_sstable(sst).get();
     }
 
@@ -403,7 +403,7 @@ static future<compact_sstables_result> compact_sstables(test_env& env, std::vect
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(min_sstable_size, 'a')));
 
-                sst = make_sstable_containing(sst, {std::move(m)});
+                sst = make_sstable_containing(sst, {std::move(m)}).get();
                 sstables.push_back(sst);
             }
         }
@@ -610,14 +610,14 @@ static void compact_corrupted_by_compression_mode(const std::string& tname,
         testlog.info("Compacting {}compressed SSTable with invalid checksums", compress ? "" : "un");
 
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
-        auto sst = make_sstable_containing(env.make_sstable(schema), muts);
+        auto sst = make_sstable_containing(env.make_sstable(schema), muts).get();
         corrupt_sstable(sst);
 
         test_failing_compact(schema, {sst}, error_msg, "failed checksum");
 
         testlog.info("Compacting {}compressed SSTable with invalid digest", compress ? "" : "un");
 
-        sst = make_sstable_containing(env.make_sstable(schema), muts);
+        sst = make_sstable_containing(env.make_sstable(schema), muts).get();
         {
             auto f = sstables::test(sst).open_file(component_type::Digest, {}, {}).get();
             auto stream = make_file_input_stream(f);
@@ -1430,8 +1430,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut3 = make_delete(alpha);
 
         std::vector<shared_sstable> sstables = {
-                make_sstable_containing(sst_gen, {mut1, mut2}),
-                make_sstable_containing(sst_gen, {mut3})
+                make_sstable_containing(sst_gen, {mut1, mut2}).get(),
+                make_sstable_containing(sst_gen, {mut3}).get()
         };
 
         forward_jump_clocks(std::chrono::seconds(ttl));
@@ -1449,8 +1449,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut2 = make_insert(alpha);
         auto mut3 = make_delete(alpha);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1468,8 +1468,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut3 = make_insert(beta);
         auto mut4 = make_insert(alpha);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1, mut2, mut3});
-        auto sst2 = make_sstable_containing(sst_gen, {mut4});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1, mut2, mut3}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut4}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1487,8 +1487,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut3 = make_insert(beta);
         auto mut4 = make_insert(beta);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1, mut2, mut3});
-        auto sst2 = make_sstable_containing(sst_gen, {mut4});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1, mut2, mut3}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut4}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1505,8 +1505,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut1 = make_insert(alpha);
         auto mut2 = make_expiring(alpha, ttl);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1521,8 +1521,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut1 = make_insert(alpha);
         auto mut2 = make_expiring(beta, ttl);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1534,8 +1534,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut2 = make_expiring(alpha, ttl);
         auto mut3 = make_insert(beta);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1569,7 +1569,7 @@ future<> tombstone_purge(test_env& env) {
         auto sst1 = make_sstable_containing(sst_gen,
                                             {make_insert(alpha),
                                              make_delete(alpha, deletion_time)},
-                                            validate::no);
+                                            validate::no).get();
         auto result = compact({sst1}, {sst1});
         BOOST_CHECK_EQUAL(1, sstables_stats::get_shard_stats().capped_tombstone_deletion_time);
     }
@@ -1579,8 +1579,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut2 = make_delete(alpha);
         auto mut3 = make_insert(beta);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
 
         forward_jump_clocks(std::chrono::seconds(1));
 
@@ -1597,8 +1597,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut2 = make_delete(alpha);
         auto mut3 = make_insert(beta);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
 
         forward_jump_clocks(std::chrono::seconds(1));
 
@@ -1613,8 +1613,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut1 = make_insert(alpha);
         auto mut2 = make_expiring(alpha, ttl);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1627,8 +1627,8 @@ future<> tombstone_purge(test_env& env) {
         auto mut1 = make_delete(alpha);
         auto mut2 = make_expiring(alpha, ttl);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2}).get();
 
         forward_jump_clocks(std::chrono::seconds(ttl));
 
@@ -1731,9 +1731,9 @@ future<> mv_tombstone_purge(test_env& env) {
         auto mut4 = make_delete_row(alpha, 2, gc_clock::now(), api::timestamp_type(2));
         auto mut5 = make_insert(alpha, 3, 1, api::timestamp_type(1), api::timestamp_type(3));
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
-        auto sst3 = make_sstable_containing(sst_gen, {mut4, mut5});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
+        auto sst3 = make_sstable_containing(sst_gen, {mut4, mut5}).get();
 
         forward_jump_clocks(std::chrono::seconds(1));
 
@@ -1774,7 +1774,7 @@ future<> sstable_rewrite(test_env& env) {
     mutation mut(s, key_for_this_shard[0]);
     mut.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes("a")));
 
-    auto sstp = make_sstable_containing(sst_gen, {std::move(mut)});
+    auto sstp = make_sstable_containing(sst_gen, {std::move(mut)}).get();
     auto key = key_for_this_shard[0];
     std::vector<sstables::shared_sstable> new_tables;
     auto creator = [&] {
@@ -1844,7 +1844,7 @@ future<> sstable_max_local_deletion_time_2(test_env& env) {
             add_row(m, to_bytes("deletecolumn" + to_sstring(i)), 100);
         }
         add_row(m, to_bytes("todelete"), 1000);
-        auto sst1 = make_sstable_containing(sst_gen, mt);
+        auto sst1 = make_sstable_containing(sst_gen, mt).get();
         BOOST_REQUIRE(last_expiry == sst1->get_stats_metadata().max_local_deletion_time);
 
         mt = make_lw_shared<replica::memtable>(s);
@@ -1852,7 +1852,7 @@ future<> sstable_max_local_deletion_time_2(test_env& env) {
         tombstone tomb(api::new_timestamp(), now);
         m.partition().apply_delete(*s, clustering_key::from_exploded(*s, {to_bytes("todelete")}), tomb);
         mt->apply(std::move(m));
-        auto sst2 = make_sstable_containing(sst_gen, mt);
+        auto sst2 = make_sstable_containing(sst_gen, mt).get();
         BOOST_REQUIRE(now.time_since_epoch().count() == sst2->get_stats_metadata().max_local_deletion_time);
 
         auto creator = sst_gen;
@@ -1955,7 +1955,7 @@ void compaction_with_fully_expired_table_fn(test_env& env) {
     mutation m(s, key);
     tombstone tomb(api::new_timestamp(), gc_clock::now() - std::chrono::seconds(3600));
     m.partition().apply_delete(*s, c_key, tomb);
-    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
 
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
@@ -2084,14 +2084,14 @@ void time_window_strategy_correctness_fn(test_env& env) {
     for (api::timestamp_type t = 0; t < 3; t++) {
         auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(t))});
         auto mut = make_insert(std::move(key), t);
-        sstables.push_back(make_sstable_containing(env.make_sstable(s), {std::move(mut)}));
+        sstables.push_back(make_sstable_containing(env.make_sstable(s), {std::move(mut)}).get());
     }
     // Decrement the timestamp to simulate a timestamp in the past hour
     for (api::timestamp_type t = 3; t < 5; t++) {
         // And add progressively more cells into each sstable
         auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(t))});
         auto mut = make_insert(std::move(key), t);
-        sstables.push_back(make_sstable_containing(env.make_sstable(s), {std::move(mut)}));
+        sstables.push_back(make_sstable_containing(env.make_sstable(s), {std::move(mut)}).get());
     }
 
     std::map<sstring, sstring> options;
@@ -2139,7 +2139,7 @@ void time_window_strategy_correctness_fn(test_env& env) {
         for (int i = 0 ; i < r ; i++) {
             mutations.push_back(make_insert(key, tstamp + r));
         }
-        sstables.push_back(make_sstable_containing(env.make_sstable(s), std::move(mutations)));
+        sstables.push_back(make_sstable_containing(env.make_sstable(s), std::move(mutations)).get());
     }
 
     // Reset the buckets, overfill it now
@@ -2198,7 +2198,7 @@ void time_window_strategy_size_tiered_behavior_correctness_fn(test_env& env) {
     auto add_new_sstable_to_bucket = [&] (api::timestamp_type ts, api::timestamp_type window_ts) {
         auto key = partition_key::from_exploded(*s, {to_bytes("key" + to_sstring(ts))});
         auto mut = make_insert(std::move(key), ts);
-        auto sst = make_sstable_containing(sst_gen, {std::move(mut)});
+        auto sst = make_sstable_containing(sst_gen, {std::move(mut)}).get();
         auto bound = compaction::time_window_compaction_strategy::get_window_lower_bound(window_size, window_ts);
         buckets[bound].push_back(std::move(sst));
     };
@@ -2303,7 +2303,7 @@ future<> min_max_clustering_key_2(test_env& env) {
             }
             mt->apply(std::move(m));
         }
-        auto sst = make_sstable_containing(sst_gen, mt);
+        auto sst = make_sstable_containing(sst_gen, mt).get();
         check_min_max_column_names(sst, {"0ck100"}, {"7ck149"});
 
         mt = make_lw_shared<replica::memtable>(s);
@@ -2314,7 +2314,7 @@ future<> min_max_clustering_key_2(test_env& env) {
             m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
         }
         mt->apply(std::move(m));
-        auto sst2 = make_sstable_containing(sst_gen, mt);
+        auto sst2 = make_sstable_containing(sst_gen, mt).get();
         check_min_max_column_names(sst2, {"9ck101"}, {"9ck298"});
 
         auto creator = sst_gen;
@@ -2416,7 +2416,7 @@ void sstable_expired_data_ratio(test_env& env) {
     for (auto i = 0; i < remaining; i++) {
         insert_key(to_bytes("key" + to_sstring(i)), 3600, expiration_time);
     }
-    auto sst = make_sstable_containing(sst_gen, mt);
+    auto sst = make_sstable_containing(sst_gen, mt).get();
     const auto& stats = sst->get_stats_metadata();
     BOOST_REQUIRE(stats.estimated_tombstone_drop_time.bin.size() == sstables::TOMBSTONE_HISTOGRAM_BIN_SIZE);
     auto uncompacted_size = sst->data_size();
@@ -2542,8 +2542,8 @@ void compaction_correctness_with_partitioned_sstable_set_fn(test_env& env) {
 
     {
         std::vector<shared_sstable> sstables = {
-                make_sstable_containing(sst_gen, {mut1, mut2}),
-                make_sstable_containing(sst_gen, {mut3, mut4})
+                make_sstable_containing(sst_gen, {mut1, mut2}).get(),
+                make_sstable_containing(sst_gen, {mut3, mut4}).get()
         };
 
         auto result = compact(std::move(sstables));
@@ -2568,9 +2568,9 @@ void compaction_correctness_with_partitioned_sstable_set_fn(test_env& env) {
         // [mut1, mut2]
         // (mut2, mut3]
         std::vector<shared_sstable> sstables = {
-                make_sstable_containing(sst_gen, {mut1, mut2}),
-                make_sstable_containing(sst_gen, {mut2, mut3}),
-                make_sstable_containing(sst_gen, {mut3, mut4})
+                make_sstable_containing(sst_gen, {mut1, mut2}).get(),
+                make_sstable_containing(sst_gen, {mut2, mut3}).get(),
+                make_sstable_containing(sst_gen, {mut3, mut4}).get()
         };
 
         auto result = compact(std::move(sstables));
@@ -2593,8 +2593,8 @@ void compaction_correctness_with_partitioned_sstable_set_fn(test_env& env) {
     {
         // with gap between tables
         std::vector<shared_sstable> sstables = {
-                make_sstable_containing(sst_gen, {mut1, mut2}),
-                make_sstable_containing(sst_gen, {mut4, mut4})
+                make_sstable_containing(sst_gen, {mut1, mut2}).get(),
+                make_sstable_containing(sst_gen, {mut4, mut4}).get()
         };
 
         auto result = compact(std::move(sstables));
@@ -2649,7 +2649,7 @@ void sstable_cleanup_correctness_fn(cql_test_env& cql_env, test_env& env) {
     for (auto i = 0U; i < total_partitions; i++) {
         mutations.push_back(make_insert(local_keys.at(i)));
     }
-    auto sst = make_sstable_containing(sst_gen, mutations);
+    auto sst = make_sstable_containing(sst_gen, mutations).get();
     auto run_identifier = sst->run_identifier();
 
     auto cf = env.make_table_for_tests(s);
@@ -3944,7 +3944,7 @@ void scrubbed_sstable_removal_fn(test_env& env) {
 
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
@@ -4002,7 +4002,7 @@ void compact_uncompressed_sstable_during_scrub_validate_fn(test_env& env) {
     for (int i = 0; i < 2; i++) {
         auto mut = mutation(s, tests::generate_partition_key(s));
         mut.partition().apply_insert(*s, tests::generate_clustering_key(s), timestamp++);
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut)});
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut)}).get();
         cf->add_sstable_and_update_cache(std::move(sst)).get();
     }
 
@@ -4158,7 +4158,7 @@ void sstable_run_based_compaction_fn(test_env& env) {
     // Generate 4 sstable runs composed of 4 fragments each after 4 compactions.
     // All fragments non-overlapping.
     for (auto i = 0U; i < keys.size(); i++) {
-        auto sst = make_sstable_containing(sst_gen, { make_insert(keys[i]) });
+        auto sst = make_sstable_containing(sst_gen, { make_insert(keys[i]) }).get();
         sst->set_sstable_level(1);
         BOOST_REQUIRE_EQUAL(sst->get_sstable_level(), 1);
         column_family_test(cf).add_sstable(sst).get();
@@ -4203,9 +4203,9 @@ void compaction_strategy_aware_major_compaction_fn(test_env& env) {
     };
 
     auto alpha = partition_key::from_exploded(*s, {to_bytes("alpha")});
-    auto sst = make_sstable_containing(env.make_sstable(s), {make_insert(alpha)});
+    auto sst = make_sstable_containing(env.make_sstable(s), {make_insert(alpha)}).get();
     sst->set_sstable_level(2);
-    auto sst2 = make_sstable_containing(env.make_sstable(s), {make_insert(alpha)});
+    auto sst2 = make_sstable_containing(env.make_sstable(s), {make_insert(alpha)}).get();
     sst2->set_sstable_level(3);
     auto candidates = std::vector<sstables::shared_sstable>({ sst, sst2 });
 
@@ -4265,8 +4265,8 @@ void backlog_tracker_correctness_after_changing_compaction_strategy_fn(test_env&
         auto mut3 = make_insert(keys[2]);
         auto mut4 = make_insert(keys[3]);
         std::vector<shared_sstable> ssts = {
-                make_sstable_containing(sst_gen, {mut1, mut2}),
-                make_sstable_containing(sst_gen, {mut3, mut4})
+                make_sstable_containing(sst_gen, {mut1, mut2}).get(),
+                make_sstable_containing(sst_gen, {mut3, mut4}).get()
         };
 
         for (auto& sst : ssts) {
@@ -4477,8 +4477,8 @@ void purged_tombstone_consumer_sstable_fn(test_env& env) {
         auto [mut3, mut3_tombstone] = make_delete(alpha);
 
         std::vector<shared_sstable> sstables = {
-            make_sstable_containing(env.make_sstable(s), {mut1, mut2}),
-            make_sstable_containing(env.make_sstable(s), {mut3})
+            make_sstable_containing(env.make_sstable(s), {mut1, mut2}).get(),
+            make_sstable_containing(env.make_sstable(s), {mut3}).get()
         };
 
         forward_jump_clocks(std::chrono::seconds(ttl));
@@ -4567,9 +4567,9 @@ void incremental_compaction_data_resurrection_fn(test_env& env) {
     auto mut4 = make_insert(zetta);
     auto mut1_deletion = make_delete(alpha);
 
-    auto non_expired_sst = make_sstable_containing(sst_gen, {mut1, mut2, mut3});
-    auto non_expired_sst_2 = make_sstable_containing(sst_gen, {mut4});
-    auto expired_sst = make_sstable_containing(sst_gen, {mut1_deletion});
+    auto non_expired_sst = make_sstable_containing(sst_gen, {mut1, mut2, mut3}).get();
+    auto non_expired_sst_2 = make_sstable_containing(sst_gen, {mut4}).get();
+    auto expired_sst = make_sstable_containing(sst_gen, {mut1_deletion}).get();
 
     std::vector<shared_sstable> sstables = {
             non_expired_sst,
@@ -4697,12 +4697,12 @@ void twcs_major_compaction_fn(test_env& env) {
     cf->start();
     cf->set_compaction_strategy(compaction::compaction_strategy_type::time_window);
 
-    auto original_together = make_sstable_containing(sst_gen, {mut3, mut4});
+    auto original_together = make_sstable_containing(sst_gen, {mut3, mut4}).get();
 
     auto ret = compact_sstables(env, compaction::compaction_descriptor({original_together}), cf, sst_gen, replacer_fn_no_op()).get();
     BOOST_REQUIRE(ret.new_sstables.size() == 1);
 
-    auto original_apart = make_sstable_containing(sst_gen, {mut1, mut2});
+    auto original_apart = make_sstable_containing(sst_gen, {mut1, mut2}).get();
     ret = compact_sstables(env, compaction::compaction_descriptor({original_apart}), cf, sst_gen, replacer_fn_no_op()).get();
     BOOST_REQUIRE(ret.new_sstables.size() == 2);
 }
@@ -4749,7 +4749,7 @@ void autocompaction_control_fn(test_env& env) {
     const auto keys = tests::generate_partition_keys(1, s);
     for (auto i = 0; i < 2 * min_threshold; ++i) {
         auto mut = make_insert(keys[0]);
-        auto sst = make_sstable_containing(env.make_sstable(s), {mut});
+        auto sst = make_sstable_containing(env.make_sstable(s), {mut}).get();
         cf->add_sstable_and_update_cache(sst).wait();
     }
 
@@ -4840,8 +4840,8 @@ void test_bug_6472_fn(test_env& env) {
     // Reproduce issue 6472 by making an input set which causes both interposer and GC writer to be enabled
     //
     std::vector<shared_sstable> sstables_spanning_many_windows = {
-        make_sstable_containing(sst_gen, muts),
-        make_sstable_containing(sst_gen, muts),
+        make_sstable_containing(sst_gen, muts).get(),
+        make_sstable_containing(sst_gen, muts).get(),
     };
     sstables::run_id run_id = sstables::run_id::create_random_id();
     for (auto& sst : sstables_spanning_many_windows) {
@@ -4949,7 +4949,7 @@ void test_twcs_partition_estimate_fn(test_env& env) {
             auto c_key = clustering_key::from_exploded(*s, {int32_type->decompose(value++)});
             m.set_clustered_cell(c_key, bytes("value"), data_value(int32_t(value)), next_timestamp(sstable_idx, ck));
         }
-        return make_sstable_containing(sst_gen, {m});
+        return make_sstable_containing(sst_gen, {m}).get();
     };
 
     auto cf = env.make_table_for_tests(s);
@@ -5211,7 +5211,7 @@ void test_twcs_compaction_across_buckets_fn(test_env& env) {
     sstables_spanning_many_windows.reserve(windows + 1);
 
     for (unsigned w = 0; w < windows; w++) {
-        sstables_spanning_many_windows.push_back(make_sstable_containing(sst_gen, {make_row(std::chrono::hours((w + 1) * 2))}));
+        sstables_spanning_many_windows.push_back(make_sstable_containing(sst_gen, {make_row(std::chrono::hours((w + 1) * 2))}).get());
     }
     auto deletion_mut = [&] () {
         mutation m(s, pkey);
@@ -5219,7 +5219,7 @@ void test_twcs_compaction_across_buckets_fn(test_env& env) {
         m.partition().apply(tomb);
         return m;
     }();
-    sstables_spanning_many_windows.push_back(make_sstable_containing(sst_gen, {deletion_mut}));
+    sstables_spanning_many_windows.push_back(make_sstable_containing(sst_gen, {deletion_mut}).get());
 
     auto ret = compact_sstables(env, compaction::compaction_descriptor(std::move(sstables_spanning_many_windows)), cf, sst_gen, replacer_fn_no_op(), can_purge_tombstones::no).get();
 
@@ -5264,7 +5264,7 @@ void test_offstrategy_sstable_compaction_fn(test_env& env) {
         cf->start();
 
         for (auto i = 0; i < cf->schema()->max_compaction_threshold(); i++) {
-            auto sst = make_sstable_containing(sst_gen, {mut});
+            auto sst = make_sstable_containing(sst_gen, {mut}).get();
             cf->add_sstable_and_update_cache(std::move(sst), sstables::offstrategy::yes).get();
         }
         BOOST_REQUIRE(cf->perform_offstrategy_compaction(tasks::task_info{}).get());
@@ -5348,7 +5348,7 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(1))});
+            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(1))}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5361,7 +5361,7 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(i))});
+            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(i))}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5376,10 +5376,10 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i))});
+            auto sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i))}).get();
             sstables.push_back(std::move(sst));
             i++;
-            sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i + 1))});
+            sst = make_sstable_containing(sst_gen, {make_row(i, std::chrono::hours(24*i + 1))}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5392,7 +5392,7 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(0, std::chrono::hours(1))});
+            auto sst = make_sstable_containing(sst_gen, {make_row(0, std::chrono::hours(1))}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5422,10 +5422,10 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
             // intermix big and small files, to make sure STCS logic is really applied to favor similar-sized reshape jobs.
             //
             if (i % 2 == 0) {
-                sst = make_sstable_containing(sst_gen, mutations_for_small_files);
+                sst = make_sstable_containing(sst_gen, mutations_for_small_files).get();
                 generations_for_small_files.insert(sst->generation());
             } else {
-                sst = make_sstable_containing(sst_gen, mutations_for_big_files);
+                sst = make_sstable_containing(sst_gen, mutations_for_big_files).get();
             }
             sstables.push_back(std::move(sst));
         }
@@ -5455,7 +5455,7 @@ void twcs_reshape_with_disjoint_set_fn(test_env& env) {
             for (auto j = 0; j < 5; j++) {
                 muts.push_back(make_row(i, std::chrono::hours(j * 8)));
             }
-            auto sst = make_sstable_containing(sst_gen, std::move(muts));
+            auto sst = make_sstable_containing(sst_gen, std::move(muts)).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5536,7 +5536,7 @@ void stcs_reshape_overlapping_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i)});
+            auto sst = make_sstable_containing(sst_gen, {make_row(i)}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5549,7 +5549,7 @@ void stcs_reshape_overlapping_fn(test_env& env) {
         std::vector<sstables::shared_sstable> sstables;
         sstables.reserve(disjoint_sstable_count);
         for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(0)});
+            auto sst = make_sstable_containing(sst_gen, {make_row(0)}).get();
             sstables.push_back(std::move(sst));
         }
 
@@ -5587,8 +5587,8 @@ void test_twcs_single_key_reader_filtering_fn(test_env& env) {
         return m;
     };
 
-    auto sst1 = make_sstable_containing(sst_gen, {make_row(0, 0)});
-    auto sst2 = make_sstable_containing(sst_gen, {make_row(0, 1)});
+    auto sst1 = make_sstable_containing(sst_gen, {make_row(0, 0)}).get();
+    auto sst2 = make_sstable_containing(sst_gen, {make_row(0, 1)}).get();
     auto dkey = sst1->get_first_decorated_key();
 
     auto cf = env.make_table_for_tests(s);
@@ -5708,7 +5708,7 @@ void max_ongoing_compaction_fn(test_env& env) {
         auto s = schemas[idx];
         auto cf = tables[idx];
         auto muts = { make_expiring_cell(s, std::chrono::hours(1)) };
-        auto sst = make_sstable_containing([&sst_gen, idx] { return sst_gen(idx); }, muts);
+        auto sst = make_sstable_containing([&sst_gen, idx] { return sst_gen(idx); }, muts).get();
         column_family_test(cf).add_sstable(sst).get();
     };
 
@@ -5758,7 +5758,7 @@ void max_ongoing_compaction_fn(test_env& env) {
         auto cft = column_family_test(cf);
         for (size_t i = 0; i < num_sstables; i++) {
             auto muts = { make_expiring_cell(s, std::chrono::hours(1)) };
-            cft.add_sstable(make_sstable_containing([&sst_gen, idx] { return sst_gen(idx); }, muts)).get();
+            cft.add_sstable(make_sstable_containing([&sst_gen, idx] { return sst_gen(idx); }, muts).get()).get();
         }
     };
 
@@ -5947,8 +5947,8 @@ void twcs_single_key_reader_through_compound_set_fn(test_env& env) {
     auto sst_gen = env.make_sst_factory(s);
 
     // sstables with same key but belonging to different windows
-    auto sst1 = make_sstable_containing(sst_gen, {make_row(std::chrono::hours(1))});
-    auto sst2 = make_sstable_containing(sst_gen, {make_row(std::chrono::hours(5))});
+    auto sst1 = make_sstable_containing(sst_gen, {make_row(std::chrono::hours(1))}).get();
+    auto sst2 = make_sstable_containing(sst_gen, {make_row(std::chrono::hours(5))}).get();
     BOOST_REQUIRE(sst1->get_first_decorated_key().token() == sst2->get_last_decorated_key().token());
     auto dkey = sst1->get_first_decorated_key();
 
@@ -6064,7 +6064,7 @@ void test_major_does_not_miss_data_in_memtable_fn(test_env& env) {
         m.set_clustered_cell(c_key, bytes("value"), data_value(int32_t(value)), gc_clock::now().time_since_epoch().count());
         return m;
     }();
-    auto sst = make_sstable_containing(sst_gen, {std::move(row_mut)});
+    auto sst = make_sstable_containing(sst_gen, {std::move(row_mut)}).get();
     cf->add_sstable_and_update_cache(sst).get();
     assert_table_sstable_count(cf, 1);
 
@@ -6305,7 +6305,7 @@ void test_compaction_strategy_cleanup_method_fn(test_env& env) {
         candidates.reserve(all_files);
         for (size_t i = 0; i < all_files; i++) {
             auto current_step = duration_cast<microseconds>(step_base) * i;
-            auto sst = make_sstable_containing(sst_gen, {make_mutation(i, next_timestamp(current_step))});
+            auto sst = make_sstable_containing(sst_gen, {make_mutation(i, next_timestamp(current_step))}).get();
             sst->set_sstable_level(sstable_level);
             candidates.push_back(std::move(sst));
         }
@@ -6432,7 +6432,7 @@ void test_large_partition_splitting_on_compaction_fn(test_env& env) {
         mutations.push_back(make_open_ended_range_tombstone());
     }
 
-    auto sst = make_sstable_containing(sst_gen, std::move(mutations));
+    auto sst = make_sstable_containing(sst_gen, std::move(mutations)).get();
 
     auto desc = compaction::compaction_descriptor({ sst });
     // With max_sstable_bytes of 1, we'll perform the splitting of the partition as soon as possible.
@@ -6524,7 +6524,7 @@ void check_table_sstable_set_includes_maintenance_sstables_fn(test_env& env) {
 
     auto mut1 = mutation(s, pks[0]);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
     auto cf = env.make_table_for_tests(s);
     auto close_cf = deferred_stop(cf);
@@ -6596,11 +6596,11 @@ void test_print_shared_sstables_vector_fn(test_env& env) {
 
     auto mut0 = mutation(s, pks[0]);
     mut0.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    ssts[0] = make_sstable_containing(sst_gen, {std::move(mut0)});
+    ssts[0] = make_sstable_containing(sst_gen, {std::move(mut0)}).get();
 
     auto mut1 = mutation(s, pks[1]);
     mut1.partition().apply_insert(*s, ss.make_ckey(1), ss.new_timestamp());
-    ssts[1] = make_sstable_containing(sst_gen, {std::move(mut1)});
+    ssts[1] = make_sstable_containing(sst_gen, {std::move(mut1)}).get();
 
     std::string msg = seastar::format("{}", ssts);
     for (const auto& sst : ssts) {
@@ -6680,8 +6680,8 @@ void tombstone_gc_disabled_fn(test_env& env) {
         auto mut2 = make_delete(alpha);
         auto mut3 = make_insert(beta);
 
-        auto sst1 = make_sstable_containing(sst_gen, {mut1});
-        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3});
+        auto sst1 = make_sstable_containing(sst_gen, {mut1}).get();
+        auto sst2 = make_sstable_containing(sst_gen, {mut2, mut3}).get();
 
         forward_jump_clocks(std::chrono::seconds(1));
 
@@ -6760,8 +6760,8 @@ void compaction_optimization_to_avoid_bloom_filter_checks_fn(test_env& env) {
         return m;
     };
 
-    auto uncompacting = make_sstable_containing(sst_gen, { make_insert(partition_key::from_exploded(*s, {to_bytes("pk1")}) )});
-    auto compacting = make_sstable_containing(sst_gen, { make_delete(partition_key::from_exploded(*s, {to_bytes("pk1")}) )});
+    auto uncompacting = make_sstable_containing(sst_gen, { make_insert(partition_key::from_exploded(*s, {to_bytes("pk1")}) )}).get();
+    auto compacting = make_sstable_containing(sst_gen, { make_delete(partition_key::from_exploded(*s, {to_bytes("pk1")}) )}).get();
 
     auto result = compact({uncompacting, compacting}, {compacting});
     BOOST_REQUIRE_EQUAL(1, result.new_sstables.size());
@@ -6834,7 +6834,7 @@ static future<> run_incremental_compaction_test(sstables::offstrategy offstrateg
             auto sst = make_sstable_containing(sst_gen, {
                 std::move(mut1),
                 std::move(mut2)
-            });
+            }).get();
             sstables::test(sst).set_run_identifier(run_identifier); // in order to produce multi-fragment run.
             sst->set_sstable_level(offstrategy ? 0 : 1);
 
@@ -6980,7 +6980,7 @@ void cleanup_during_offstrategy_incremental_compaction_fn(test_env& env) {
         auto sst = make_sstable_containing(sst_gen, {
             std::move(mut1),
             std::move(mut2)
-        });
+        }).get();
         // Force a new run_id to trigger offstrategy compaction
         sstables::test(sst).set_run_identifier(run_id::create_random_id());
         // Set level to 0 to trigger offstrategy compaction
@@ -7077,11 +7077,11 @@ future<> test_sstables_excluding_staging_correctness(test_env_config cfg) {
 
         auto sst_gen = env.make_sst_factory(s);
 
-        auto staging_sst = make_sstable_containing(sst_gen, {*sorted_muts.begin()});
+        auto staging_sst = make_sstable_containing(sst_gen, {*sorted_muts.begin()}).get();
         staging_sst->change_state(sstables::sstable_state::staging).get();
         BOOST_REQUIRE(staging_sst->requires_view_building());
 
-        auto regular_sst = make_sstable_containing(sst_gen, {*sorted_muts.rbegin()});
+        auto regular_sst = make_sstable_containing(sst_gen, {*sorted_muts.rbegin()}).get();
 
         t->add_sstable_and_update_cache(staging_sst).get();
         t->add_sstable_and_update_cache(regular_sst).get();
@@ -7150,7 +7150,7 @@ void produces_optimal_filter_by_estimating_correctly_partitions_per_sstable_fn(t
     for (auto i = 0; i < keys; i++) {
         muts.push_back(make_insert(partition_key::from_exploded(*s, {to_bytes(shared_key_prefix + to_sstring(i))})));
     }
-    auto sst = make_sstable_containing(sst_gen, std::move(muts));
+    auto sst = make_sstable_containing(sst_gen, std::move(muts)).get();
 
     testlog.info("index size: {}, data_size: {}", sst->index_size(), sst->ondisk_data_size());
 
@@ -7220,7 +7220,7 @@ void splitting_compaction_fn(test_env& env) {
     auto close_table = deferred_stop(t);
     t->start();
 
-    auto input = make_sstable_containing(sst_gen, std::move(muts));
+    auto input = make_sstable_containing(sst_gen, std::move(muts)).get();
 
     std::unordered_set<int64_t> groups;
     auto classify_fn = [&groups] (dht::token t) -> mutation_writer::token_group_id {
@@ -7354,7 +7354,7 @@ void sstable_clone_leaving_unsealed_dest_sstable_fn(test_env& env) {
 
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
     auto table = env.make_table_for_tests(s);
     auto close_table = deferred_stop(table);
@@ -7389,7 +7389,7 @@ void object_storage_sstable_clone_leaving_unsealed_dest_sstable(test_env& env) {
 
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+    auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
     auto table = env.make_table_for_tests(s);
     auto close_table = deferred_stop(table);
@@ -7456,7 +7456,7 @@ void failure_when_adding_new_sstable_fn(test_env& env) {
 
     auto mut1 = mutation(s, pk);
     mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-    auto sst = make_sstable_containing(env.make_sstable(s), {mut1});
+    auto sst = make_sstable_containing(env.make_sstable(s), {mut1}).get();
 
     auto table = env.make_table_for_tests(s);
     auto close_table = deferred_stop(table);
@@ -7467,8 +7467,8 @@ void failure_when_adding_new_sstable_fn(test_env& env) {
     // Verify new sstable was unlinked on failure.
     BOOST_REQUIRE(!sst->get_storage().exists(*sst, sstables::component_type::Data).get());
 
-    auto sst2 = make_sstable_containing(env.make_sstable(s), {mut1});
-    auto sst3 = make_sstable_containing(env.make_sstable(s), {mut1});
+    auto sst2 = make_sstable_containing(env.make_sstable(s), {mut1}).get();
+    auto sst3 = make_sstable_containing(env.make_sstable(s), {mut1}).get();
     BOOST_REQUIRE_THROW(table->add_new_sstables_and_update_cache({sst2, sst3}, on_add).get(), std::runtime_error);
 
     // Verify both sstables are unlinked on failure.
@@ -7498,7 +7498,7 @@ static future<> test_perform_component_rewrite_single_sstable(compaction::compac
 
         auto mut1 = mutation(s, pk);
         mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        auto original_sst = make_sstable_containing(env.make_sstable(s), {mut1});
+        auto original_sst = make_sstable_containing(env.make_sstable(s), {mut1}).get();
 
         BOOST_REQUIRE(original_sst->get_sstable_level() == 0);
 
@@ -7567,7 +7567,7 @@ SEASTAR_TEST_CASE(test_perform_component_rewrite_multiple_sstables) {
             auto pk = ss.make_pkey(i);
             auto mut = mutation(s, pk);
             mut.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-            auto sst = make_sstable_containing(env.make_sstable(s), {mut});
+            auto sst = make_sstable_containing(env.make_sstable(s), {mut}).get();
             all_sstables.push_back(sst);
         }
 

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -5489,8 +5489,7 @@ SEASTAR_FIXTURE_TEST_CASE(twcs_reshape_with_disjoint_set_gcs_test, gcs_fixture, 
                                    test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
-void stcs_reshape_overlapping_fn(test_env& env) {
-    static constexpr unsigned disjoint_sstable_count = 256;
+void stcs_reshape_overlapping_fn(test_env& env, unsigned disjoint_sstable_count = 256) {
     auto builder = schema_builder("tests", "stcs_reshape_test")
             .with_column("id", utf8_type, column_kind::partition_key)
             .with_column("cl", ::timestamp_type, column_kind::clustering_key)
@@ -5516,27 +5515,23 @@ void stcs_reshape_overlapping_fn(test_env& env) {
     auto sst_gen = env.make_sst_factory(s);
 
     {
-        // create set of 256 disjoint ssts and expect that stcs reshape allows them all to be compacted at once
+        // create set of disjoint ssts and expect that stcs reshape allows them all to be compacted at once
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(i)}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(i)});
+        }).get();
 
         BOOST_REQUIRE(get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size() == disjoint_sstable_count);
     }
 
     {
-        // create set of 256 overlapping ssts and expect that stcs reshape allows only 32 to be compacted at once
+        // create set of overlapping ssts and expect that stcs reshape allows only 32 to be compacted at once
 
-        std::vector<sstables::shared_sstable> sstables;
-        sstables.reserve(disjoint_sstable_count);
-        for (unsigned i = 0; i < disjoint_sstable_count; i++) {
-            auto sst = make_sstable_containing(sst_gen, {make_row(0)}).get();
-            sstables.push_back(std::move(sst));
-        }
+        std::vector<sstables::shared_sstable> sstables(disjoint_sstable_count);
+        parallel_for_each(std::views::iota(0u, disjoint_sstable_count), [&](unsigned i) -> future<> {
+            sstables[i] = co_await make_sstable_containing(sst_gen, {make_row(0)});
+        }).get();
 
         BOOST_REQUIRE(get_reshaping_job(cs, sstables, s, compaction::reshape_mode::strict).sstables.size() == uint64_t(s->max_compaction_threshold()));
     }
@@ -5547,11 +5542,11 @@ SEASTAR_TEST_CASE(stcs_reshape_overlapping_test) {
 }
 
 SEASTAR_TEST_CASE(stcs_reshape_overlapping_s3_test, *boost::unit_test::precondition(tests::has_scylla_test_env)) {
-    return test_env::do_with_async([](test_env& env) { stcs_reshape_overlapping_fn(env); }, test_env_config{.storage = make_test_object_storage_options("S3")});
+    return test_env::do_with_async([](test_env& env) { stcs_reshape_overlapping_fn(env, 64); }, test_env_config{.storage = make_test_object_storage_options("S3")});
 }
 
 SEASTAR_FIXTURE_TEST_CASE(stcs_reshape_overlapping_gcs_test, gcs_fixture, *tests::check_run_test_decorator("ENABLE_GCP_STORAGE_TEST", true)) {
-    return test_env::do_with_async([](test_env& env) { stcs_reshape_overlapping_fn(env); }, test_env_config{.storage = make_test_object_storage_options("GS")});
+    return test_env::do_with_async([](test_env& env) { stcs_reshape_overlapping_fn(env, 64); }, test_env_config{.storage = make_test_object_storage_options("GS")});
 }
 
 // Regression test for #8432

--- a/test/boost/sstable_conforms_to_mutation_source_test.cc
+++ b/test/boost/sstable_conforms_to_mutation_source_test.cc
@@ -33,7 +33,7 @@ static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, sstring dir, utils::chunked_vector<mutation> mutations,
         sstable_writer_config cfg, sstables::sstable::version_types version, gc_clock::time_point query_time = gc_clock::now()) {
     auto sst = env.make_sstable(s, dir, env.new_generation(), version, sstable_format_types::big, default_sstable_buffer_size, to_db_clock(query_time));
-    auto mt = make_memtable(s, mutations);
+    auto mt = make_memtable(s, mutations).get();
     auto mr = mt->make_mutation_reader(s, env.make_reader_permit());
     sst->write_components(std::move(mr), mutations.size(), s, cfg, mt->get_encoding_stats()).get();
     sst->load(s->get_sharder()).get();

--- a/test/boost/sstable_datafile_test.cc
+++ b/test/boost/sstable_datafile_test.cc
@@ -100,7 +100,7 @@ SEASTAR_TEST_CASE(datafile_generation_09) {
         mutation m(s, key);
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
 
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(m)});
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(m)}).get();
         auto sst2 = env.reusable_sst(sst).get();
 
         sstables::test(sst2).read_summary().get();
@@ -151,7 +151,7 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
 
         m2.set_clustered_cell(c_key, set_col, set_mut_single.serialize(*set_col.type));
 
-        auto mt = make_memtable(s, {std::move(m), std::move(m2)});
+        auto mt = make_memtable(s, {std::move(m), std::move(m2)}).get();
 
         auto verifier = [s, set_col, c_key] (auto& mutation) {
             auto& mp = mutation->partition();
@@ -189,14 +189,14 @@ SEASTAR_TEST_CASE(datafile_generation_11) {
             // The clustered set
             auto m = verifier(mutation);
             verify_set(m);
-        });
+        }).get();
 
         verify_mutation(env, sstp, "key2", [&] (mutation_opt& mutation) {
             auto m = verifier(mutation);
             BOOST_REQUIRE(!m.tomb);
             BOOST_REQUIRE(m.cells.size() == 1);
             BOOST_REQUIRE(m.cells[0].first == to_bytes("4"));
-        });
+        }).get();
     });
 }
 
@@ -212,7 +212,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, cp, tomb);
 
-        auto mt = make_memtable(s, {std::move(m)});
+        auto mt = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mt, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -220,7 +220,7 @@ SEASTAR_TEST_CASE(datafile_generation_12) {
             for (auto& rt: mp.row_tombstones()) {
                 BOOST_REQUIRE(rt.tombstone().tomb == tomb);
             }
-        });
+        }).get();
     });
 }
 
@@ -238,7 +238,7 @@ static future<> sstable_compression_test(compression_parameters::algorithm c) {
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, cp, tomb);
-        auto mtp = make_memtable(s, {std::move(m)});
+        auto mtp = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -246,7 +246,7 @@ static future<> sstable_compression_test(compression_parameters::algorithm c) {
             for (auto& rt: mp.row_tombstones()) {
                 BOOST_REQUIRE(rt.tombstone().tomb == tomb);
             }
-        });
+        }).get();
     });
 }
 
@@ -278,7 +278,7 @@ future<> test_datafile_generation_16(test_env_config cfg) {
             mtp->apply(std::move(m));
         }
 
-        auto sst = make_sstable_containing(env.make_sstable(s), mtp);
+        auto sst = make_sstable_containing(env.make_sstable(s), mtp).get();
         // Not crashing is enough
         BOOST_REQUIRE(sst);
         sst->destroy().get();
@@ -318,7 +318,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
         const column_definition& cl2 = *s->get_column_definition("cl2");
 
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
-        auto mtp = make_memtable(s, {std::move(m)});
+        auto mtp = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -327,7 +327,7 @@ SEASTAR_TEST_CASE(datafile_generation_37) {
 
             auto& row = mp.clustered_row(*s, clustering);
             match_live_cell(row.cells(), *s, "cl2", data_value(to_bytes("cl2")));
-        });
+        }).get();
     });
 }
 
@@ -342,7 +342,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
 
         const column_definition& cl3 = *s->get_column_definition("cl3");
         m.set_clustered_cell(c_key, cl3, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl3")))));
-        auto mtp = make_memtable(s, {std::move(m)});
+        auto mtp = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
@@ -350,7 +350,7 @@ SEASTAR_TEST_CASE(datafile_generation_38) {
 
             auto& row = mp.clustered_row(*s, clustering);
             match_live_cell(row.cells(), *s, "cl3", data_value(to_bytes("cl3")));
-        });
+        }).get();
     });
 }
 
@@ -367,14 +367,14 @@ SEASTAR_TEST_CASE(datafile_generation_39) {
         m.set_clustered_cell(c_key, cl1, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl1")))));
         const column_definition& cl2 = *s->get_column_definition("cl2");
         m.set_clustered_cell(c_key, cl2, make_atomic_cell(bytes_type, bytes_type->decompose(data_value(to_bytes("cl2")))));
-        auto mtp = make_memtable(s, {std::move(m)});
+        auto mtp = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mtp, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
             auto& row = mp.clustered_row(*s, clustering_key::make_empty());
             match_live_cell(row.cells(), *s, "cl1", data_value(data_value(to_bytes("cl1"))));
             match_live_cell(row.cells(), *s, "cl2", data_value(data_value(to_bytes("cl2"))));
-        });
+        }).get();
     });
 }
 
@@ -392,14 +392,14 @@ SEASTAR_TEST_CASE(datafile_generation_41) {
 
         tombstone tomb(api::new_timestamp(), gc_clock::now());
         m.partition().apply_delete(*s, std::move(c_key), tomb);
-        auto mt = make_memtable(s, {std::move(m)});
+        auto mt = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mt, "key1", [&] (mutation_opt& mutation) {
             auto& mp = mutation->partition();
             BOOST_REQUIRE(mp.clustered_rows().calculate_size() == 1);
             auto& c_row = *(mp.clustered_rows().begin());
             BOOST_REQUIRE(c_row.row().deleted_at().tomb() == tomb);
-        });
+        }).get();
     });
 }
 
@@ -418,7 +418,7 @@ SEASTAR_TEST_CASE(datafile_generation_47) {
         mutation m(s, key);
         m.set_clustered_cell(c_key, r1_col, make_atomic_cell(utf8_type, bytes(512*1024, 'a')));
 
-        auto sstp = make_sstable_containing(env.make_sstable(s), {std::move(m)});
+        auto sstp = make_sstable_containing(env.make_sstable(s), {std::move(m)}).get();
         auto reader = sstable_mutation_reader(sstp, s, env.make_reader_permit());
         auto close_reader = deferred_close(reader);
         while (reader().get()) {
@@ -461,7 +461,7 @@ SEASTAR_TEST_CASE(test_counter_write) {
 
         m.set_clustered_cell(c_key2, r1_col, make_dead_atomic_cell(1));
 
-        auto sstp = make_sstable_containing(env.make_sstable(s), {m});
+        auto sstp = make_sstable_containing(env.make_sstable(s), {m}).get();
         assert_that(sstable_mutation_reader(sstp, s, env.make_reader_permit()))
             .produces(m)
             .produces_end_of_stream();
@@ -860,7 +860,7 @@ SEASTAR_TEST_CASE(test_sstable_max_local_deletion_time) {
                                          make_atomic_cell(utf8_type, bytes("a"), 3600 + i, last_expiry));
                     mt->apply(std::move(m));
                 }
-                auto sstp = make_sstable_containing(env.make_sstable(s, version), mt);
+                auto sstp = make_sstable_containing(env.make_sstable(s, version), mt).get();
                 BOOST_REQUIRE(last_expiry == sstp->get_stats_metadata().max_local_deletion_time);
             }
     });
@@ -972,7 +972,7 @@ static void test_min_max_clustering_key(test_env& env, schema_ptr s, std::vector
             }
         }
     }
-    auto sst = make_sstable_containing(env.make_sstable(s, version), mt);
+    auto sst = make_sstable_containing(env.make_sstable(s, version), mt).get();
     check_min_max_column_names(sst, std::move(min_components), std::move(max_components));
     sst->unlink().get();
 }
@@ -1103,7 +1103,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1111,7 +1111,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1119,7 +1119,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1133,7 +1133,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mutation m2(s, key2);
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
 
-                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1"}, {"c1"});
             }
@@ -1142,7 +1142,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1153,7 +1153,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                 range_tombstone rt(clustering_key_prefix::from_single_value(*s, bytes(
                 "a")), clustering_key_prefix::from_single_value(*s, bytes("a")), tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"a"});
@@ -1169,7 +1169,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         clustering_key_prefix::from_single_value(*s, bytes("a")),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"c1"});
@@ -1185,7 +1185,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         clustering_key_prefix::from_single_value(*s, bytes("d")),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c"}, {"d"});
@@ -1201,7 +1201,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                         clustering_key_prefix::from_single_value(*s, bytes("z")),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1"}, {"z"});
@@ -1218,7 +1218,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                             bound_view(clustering_key_prefix::from_single_value(*s, bytes("z")), bound_kind::incl_end),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1232,7 +1232,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                             bound_view::top(),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -1242,7 +1242,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_metadata_check) {
                     m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
                     tombstone tomb(api::new_timestamp(), gc_clock::now());
                     m.partition().apply_delete(*s, clustering_key_prefix::make_empty(), tomb);
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {});
                 }
@@ -1271,7 +1271,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1279,7 +1279,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1287,7 +1287,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1301,7 +1301,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mutation m2(s, key2);
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
 
-                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1310,7 +1310,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1323,7 +1323,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("z"), to_bytes("zz")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "aa"}, {"z", "zz"});
@@ -1339,7 +1339,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("a"), to_bytes("zz")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a"}, {"c1", "c2"});
@@ -1355,7 +1355,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("c1"), to_bytes("zz")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "aa"}, {"c1", "zz"});
@@ -1371,7 +1371,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("z"), to_bytes("zz")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "c2"}, {"z", "zz"});
@@ -1388,7 +1388,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                             bound_view(clustering_key_prefix::from_single_value(*s, bytes("z")), bound_kind::incl_end),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1402,7 +1402,7 @@ SEASTAR_TEST_CASE(sstable_composite_tombstone_metadata_check) {
                             bound_view::top(),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -1431,7 +1431,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply_delete(*s, c_key, tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1439,7 +1439,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_dead_atomic_cell(3600));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1447,7 +1447,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
             {
                 mutation m(s, key);
                 m.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(!sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1461,7 +1461,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mutation m2(s, key2);
                 m2.set_clustered_cell(c_key, r1_col, make_atomic_cell(int32_type, int32_type->decompose(1)));
 
-                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m), std::move(m2)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {"c1", "c2"}, {"c1", "c2"});
             }
@@ -1470,7 +1470,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                 mutation m(s, key);
                 tombstone tomb(api::new_timestamp(), gc_clock::now());
                 m.partition().apply(tomb);
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 check_min_max_column_names(sst, {}, {});
             }
@@ -1483,7 +1483,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("a"), to_bytes("aa")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "zz"}, {"a", "aa"});
@@ -1499,7 +1499,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("a")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"a", "zz"}, {"c1", "c2"});
@@ -1515,7 +1515,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("c1")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "zz"}, {"c1"});
@@ -1531,7 +1531,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                         clustering_key_prefix::from_exploded(*s, {to_bytes("c1"), to_bytes("d")}),
                         tomb);
                 m.partition().apply_delete(*s, std::move(rt));
-                auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                 BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                 if (version >= sstable_version_types::mc) {
                     check_min_max_column_names(sst, {"c1", "zz"}, {"c1", "c2"});
@@ -1548,7 +1548,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                             bound_view(clustering_key_prefix::from_single_value(*s, bytes("z")), bound_kind::incl_end),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {}, {"z"});
                 }
@@ -1562,7 +1562,7 @@ SEASTAR_TEST_CASE(sstable_composite_reverse_tombstone_metadata_check) {
                             bound_view::top(),
                             tomb);
                     m.partition().apply_delete(*s, std::move(rt));
-                    auto sst = make_sstable_containing(sst_gen, {std::move(m)});
+                    auto sst = make_sstable_containing(sst_gen, {std::move(m)}).get();
                     BOOST_REQUIRE(sst->get_stats_metadata().estimated_tombstone_drop_time.bin.size());
                     check_min_max_column_names(sst, {"a"}, {});
                 }
@@ -1988,7 +1988,7 @@ SEASTAR_TEST_CASE(sstable_tombstone_histogram_test) {
                 mutations.push_back(make_delete(key));
                 forward_jump_clocks(std::chrono::seconds(1));
             }
-            auto sst = make_sstable_containing(env.make_sstable(s, version), mutations);
+            auto sst = make_sstable_containing(env.make_sstable(s, version), mutations).get();
             auto histogram = sst->get_stats_metadata().estimated_tombstone_drop_time;
             sst = env.reusable_sst(sst).get();
             auto histogram2 = sst->get_stats_metadata().estimated_tombstone_drop_time;
@@ -2040,7 +2040,7 @@ SEASTAR_TEST_CASE(sstable_owner_shards) {
                 auto sst = env.make_sstable(std::move(schema));
                 return sst;
             };
-            auto sst = make_sstable_containing(sst_gen, std::move(muts));
+            auto sst = make_sstable_containing(sst_gen, std::move(muts)).get();
             auto schema = schema_builder(s).with_sharder(smp_count, ignore_msb).build();
             sst = env.reusable_sst(std::move(schema), sst).get();
             return sst;
@@ -2097,7 +2097,7 @@ SEASTAR_TEST_CASE(test_summary_entry_spanning_more_keys_than_min_interval) {
         }
 
         auto version = sstable_version_types::me;
-        auto sst = make_sstable_containing(env.make_sstable(s, version), mutations);
+        auto sst = make_sstable_containing(env.make_sstable(s, version), mutations).get();
 
         const summary& sum = sst->get_summary();
         BOOST_REQUIRE(sum.entries.size() == 1);
@@ -2304,7 +2304,7 @@ SEASTAR_TEST_CASE(summary_rebuild_sanity) {
         }
 
         auto version = sstable_version_types::me;
-        auto sst = make_sstable_containing(env.make_sstable(s, version), mutations);
+        auto sst = make_sstable_containing(env.make_sstable(s, version), mutations).get();
 
         summary s1 = std::move(sstables::test(sst)._summary());
         BOOST_REQUIRE(!(bool)sstables::test(sst)._summary()); // make sure std::move above took place
@@ -2353,7 +2353,7 @@ SEASTAR_TEST_CASE(sstable_partition_estimation_sanity_test) {
                 auto key = to_bytes("key" + to_sstring(i));
                 mutations.push_back(make_large_partition(partition_key::from_exploded(*s, {std::move(key)})));
             }
-            auto sst = make_sstable_containing(env.make_sstable(s), mutations);
+            auto sst = make_sstable_containing(env.make_sstable(s), mutations).get();
 
             BOOST_REQUIRE(std::abs(int64_t(total_partitions) - int64_t(sst->get_estimated_key_count())) <= s->min_index_interval());
         }
@@ -2366,7 +2366,7 @@ SEASTAR_TEST_CASE(sstable_partition_estimation_sanity_test) {
                 auto key = to_bytes("key" + to_sstring(i));
                 mutations.push_back(make_small_partition(partition_key::from_exploded(*s, {std::move(key)})));
             }
-            auto sst = make_sstable_containing(env.make_sstable(s), mutations);
+            auto sst = make_sstable_containing(env.make_sstable(s), mutations).get();
 
             BOOST_REQUIRE(std::abs(int64_t(total_partitions) - int64_t(sst->get_estimated_key_count())) <= s->min_index_interval());
         }
@@ -2393,7 +2393,7 @@ SEASTAR_TEST_CASE(sstable_timestamp_metadata_correcness_with_negative) {
             auto mut1 = make_insert(alpha, -50);
             auto mut2 = make_insert(beta, 5);
 
-            auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2});
+            auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2}).get();
 
             BOOST_REQUIRE(sst->get_stats_metadata().min_timestamp == -50);
             BOOST_REQUIRE(sst->get_stats_metadata().max_timestamp == 5);
@@ -2469,7 +2469,7 @@ SEASTAR_TEST_CASE(sstable_run_clustering_disjoint_invariant_test) {
             }
             muts.push_back(std::move(mut));
 
-            auto sst = make_sstable_containing(env.make_sstable(s), std::move(muts));
+            auto sst = make_sstable_containing(env.make_sstable(s), std::move(muts)).get();
 
             BOOST_REQUIRE(sst->min_position().key() == first_ckey_prefix);
             BOOST_REQUIRE(sst->max_position().key() == last_ckey_prefix);
@@ -2627,12 +2627,12 @@ SEASTAR_TEST_CASE(test_may_have_partition_tombstones) {
             ss.add_row(mut2, ss.make_ckey(6), "val");
 
             {
-                auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2});
+                auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2}).get();
                 BOOST_REQUIRE(!sst->may_have_partition_tombstones());
             }
 
             mut2.partition().apply(ss.new_tombstone());
-            auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2});
+            auto sst = make_sstable_containing(env.make_sstable(s, version), {mut1, mut2}).get();
             BOOST_REQUIRE(sst->may_have_partition_tombstones());
         }
     });
@@ -2766,7 +2766,7 @@ SEASTAR_TEST_CASE(sstable_reader_with_timeout) {
             tombstone tomb(api::new_timestamp(), gc_clock::now());
             m.partition().apply_delete(*s, cp, tomb);
 
-            auto sstp = make_sstable_containing(env.make_sstable(s), {std::move(m)});
+            auto sstp = make_sstable_containing(env.make_sstable(s), {std::move(m)}).get();
             auto pr = dht::partition_range::make_singular(make_dkey(s, "key1"));
             auto timeout = db::timeout_clock::now();
             auto rd = sstp->make_reader(s, env.make_reader_permit(timeout), pr, s->full_slice());
@@ -2948,7 +2948,7 @@ SEASTAR_TEST_CASE(partial_sstable_deletion_test) {
 
         auto mut1 = mutation(s, pks[0]);
         mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
         // Rename TOC into TMP toc, to stress deletion path for partial files
         rename_file(test(sst).filename(sstables::component_type::TOC).native(), test(sst).filename(sstables::component_type::TemporaryTOC).native()).get();
@@ -3024,7 +3024,7 @@ SEASTAR_TEST_CASE(test_full_scan_reader_out_of_range_last_range_tombstone_change
         using bound = query::clustering_range::bound;
         table.delete_range(mut, query::clustering_range::make(bound{ckeys[3], true}, bound{clustering_key::make_empty(), true}), tombstone(1, gc_clock::now()));
 
-        auto sst = make_sstable_containing(env.make_sstable(table.schema()), {mut});
+        auto sst = make_sstable_containing(env.make_sstable(table.schema()), {mut}).get();
 
         assert_that(sst->make_full_scan_reader(table.schema(), env.make_reader_permit())).has_monotonic_positions();
     });
@@ -3045,7 +3045,7 @@ SEASTAR_TEST_CASE(test_full_scan_reader_random_schema_random_mutations) {
 
         const auto muts = tests::generate_random_mutations(random_schema, 20).get();
 
-        auto sst = make_sstable_containing(env.make_sstable(schema), muts);
+        auto sst = make_sstable_containing(env.make_sstable(schema), muts).get();
 
         {
             auto rd = assert_that(sst->make_full_scan_reader(schema, env.make_reader_permit()));
@@ -3109,7 +3109,7 @@ SEASTAR_TEST_CASE(find_first_position_in_partition_from_sstable_test) {
                 }
                 muts.push_back(std::move(mut1));
             }
-            auto sst = make_sstable_containing(env.make_sstable(s), std::move(muts));
+            auto sst = make_sstable_containing(env.make_sstable(s), std::move(muts)).get();
             position_in_partition::equal_compare eq(*s);
             if (!with_static_row) {
                 BOOST_REQUIRE(sst->min_position().key() == first_position->key());
@@ -3158,7 +3158,7 @@ future<> test_sstable_bytes_correctness(sstring tname, test_env_config cfg) {
 
         const auto muts = tests::generate_random_mutations(random_schema, 20).get();
 
-        auto sst = make_sstable_containing(env.make_sstable(schema), muts);
+        auto sst = make_sstable_containing(env.make_sstable(schema), muts).get();
 
         auto free_space = sst->get_storage().free_space().get();
         BOOST_REQUIRE(free_space > 0);
@@ -3209,7 +3209,7 @@ SEASTAR_TEST_CASE(test_sstable_set_predicate) {
 
         const auto muts = tests::generate_random_mutations(random_schema, 20).get();
 
-        auto sst = make_sstable_containing(env.make_sstable(s), muts);
+        auto sst = make_sstable_containing(env.make_sstable(s), muts).get();
 
         auto cs = compaction::make_compaction_strategy(compaction::compaction_strategy_type::leveled, s->compaction_strategy_options());
         sstable_set set = env.make_sstable_set(cs, s);
@@ -3287,7 +3287,7 @@ SEASTAR_TEST_CASE(sstable_identifier_correctness) {
 
         auto mut1 = mutation(s, pks[0]);
         mut1.partition().apply_insert(*s, ss.make_ckey(0), ss.new_timestamp());
-        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)});
+        auto sst = make_sstable_containing(env.make_sstable(s), {std::move(mut1)}).get();
 
         BOOST_REQUIRE(sst->sstable_identifier());
         BOOST_REQUIRE_EQUAL(sst->sstable_identifier()->uuid(), sst->generation().as_uuid());

--- a/test/boost/sstable_directory_test.cc
+++ b/test/boost/sstable_directory_test.cc
@@ -67,7 +67,7 @@ make_sstable_for_this_shard(std::function<sstables::shared_sstable()> sst_factor
     auto key = tests::generate_partition_key(s);
     mutation m(s, key);
     m.set_clustered_cell(clustering_key::make_empty(), bytes("c"), data_value(int32_t(0)), api::timestamp_type(0));
-    return make_sstable_containing(sst_factory, {m});
+    return make_sstable_containing(sst_factory, {m}).get();
 }
 
 /// Create a shared SSTable belonging to all shards for the following schema: "create table cf (p text PRIMARY KEY, c int)"

--- a/test/boost/sstable_inexact_index_test.cc
+++ b/test/boost/sstable_inexact_index_test.cc
@@ -309,7 +309,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_range_query) {
         }
 
         // Generate the sstable.
-        auto sst = make_sstable_containing(env.make_sstable(table.schema(), sstable_version_types::me), muts);
+        auto sst = make_sstable_containing(env.make_sstable(table.schema(), sstable_version_types::me), muts).get();
 
         // Use the index to find key positions.
         std::vector<uint64_t> partition_positions = get_partition_positions(sst, permit);
@@ -482,7 +482,7 @@ SEASTAR_TEST_CASE(test_inexact_partition_index_singular_query) {
         }
 
         // Generate the sstable.
-        auto sst = make_sstable_containing(env.make_sstable(table.schema()), muts);
+        auto sst = make_sstable_containing(env.make_sstable(table.schema()), muts).get();
 
         // Use the index to find key positions.
         std::vector<uint64_t> partition_positions = get_partition_positions(sst, permit);

--- a/test/boost/sstable_move_test.cc
+++ b/test/boost/sstable_move_test.cc
@@ -155,7 +155,7 @@ SEASTAR_THREAD_TEST_CASE(test_sstable_clone_preserves_staging_state) {
     auto schema = ss.schema();
 
     // Create an sstable in normal state.
-    auto sst = make_sstable_containing(env.make_sst_factory(schema), {ss.new_mutation("key1")});
+    auto sst = make_sstable_containing(env.make_sst_factory(schema), {ss.new_mutation("key1")}).get();
 
     // Move it to staging state.
     sst->change_state(sstable_state::staging).get();

--- a/test/boost/sstable_mutation_test.cc
+++ b/test/boost/sstable_mutation_test.cc
@@ -350,7 +350,7 @@ SEASTAR_TEST_CASE(read_partial_range_2) {
 static
 mutation_source make_sstable_mutation_source(sstables::test_env& env, schema_ptr s, utils::chunked_vector<mutation> mutations,
         sstables::sstable::version_types version, db_clock::time_point query_time = db_clock::now()) {
-    return make_sstable_easy(env, make_memtable(s, mutations), env.manager().configure_writer(), version, mutations.size(), query_time)->as_mutation_source();
+    return make_sstable_easy(env, make_memtable(s, mutations).get(), env.manager().configure_writer(), version, mutations.size(), query_time)->as_mutation_source();
 }
 
 SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
@@ -370,7 +370,7 @@ SEASTAR_TEST_CASE(test_sstable_can_write_and_read_range_tombstone) {
         auto ttl = gc_clock::now() + std::chrono::seconds(1);
         m.partition().apply_delete(*s, range_tombstone(c_key_start, bound_kind::excl_start, c_key_end, bound_kind::excl_end, tombstone(9, ttl)));
 
-        auto mt = make_memtable(s, {std::move(m)});
+        auto mt = make_memtable(s, {std::move(m)}).get();
 
         verify_mutation(env, env.make_sstable(s), mt, query::full_partition_range, [&] (mutation_opt& mut) {
             BOOST_REQUIRE(bool(mut));
@@ -749,7 +749,7 @@ SEASTAR_TEST_CASE(test_non_compound_table_row_is_not_marked_as_static) {
         auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
         m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-        auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)});
+        auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)}).get();
         auto mut = with_closeable(sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice()), [] (auto& mr) {
             return read_mutation_from_mutation_reader(mr);
         }).get();
@@ -774,7 +774,7 @@ SEASTAR_TEST_CASE(test_has_partition_key) {
             auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(17), { });
             m.set_clustered_cell(ck, *s->get_column_definition("v"), std::move(cell));
 
-            auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)});
+            auto sst = make_sstable_containing(env.make_sstable(s, version), {std::move(m)}).get();
             auto hk = sstables::sstable::make_hashed_key(*s, dk.key());
             auto mr = sst->make_reader(s, env.make_reader_permit(), query::full_partition_range, s->full_slice());
             auto close_mr = deferred_close(mr);
@@ -825,7 +825,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_memtable(s, {std::move(m)});
+        auto mt = make_memtable(s, {std::move(m)}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
         cfg.promoted_index_auto_scale_threshold = 0; // disable auto-scaling
@@ -860,7 +860,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_with_auto_scaling) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_memtable(s, {std::move(m)});
+        auto mt = make_memtable(s, {std::move(m)}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
         cfg.promoted_index_auto_scale_threshold = 100;  // set to a low value to trigger auto-scaling
@@ -903,7 +903,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_compound_dense) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_memtable(s, {m});
+        auto mt = make_memtable(s, {m}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
 
@@ -952,7 +952,7 @@ SEASTAR_TEST_CASE(test_promoted_index_blocks_are_monotonic_non_compound_dense) {
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_memtable(s, {m});
+        auto mt = make_memtable(s, {m}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
 
@@ -998,7 +998,7 @@ SEASTAR_TEST_CASE(test_promoted_index_repeats_open_tombstones) {
             auto ck = clustering_key::from_exploded(*s, {bytes_type->decompose(data_value(to_bytes("ck3")))});
             m.set_clustered_cell(ck, *s->get_column_definition("v"), atomic_cell(*int32_type, cell));
 
-            auto mt = make_memtable(s, {m});
+            auto mt = make_memtable(s, {m}).get();
             sstable_writer_config cfg = env.manager().configure_writer();
             cfg.promoted_index_block_size = 1;
 
@@ -1034,7 +1034,7 @@ SEASTAR_TEST_CASE(test_range_tombstones_are_correctly_seralized_for_non_compound
                 bound_kind::incl_end,
                 {1, gc_clock::now()}));
 
-        auto mt = make_memtable(s, {m});
+        auto mt = make_memtable(s, {m}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
 
         auto sst = make_sstable_easy(env, mt, cfg, version);
@@ -1063,7 +1063,7 @@ SEASTAR_TEST_CASE(test_promoted_index_is_absent_for_schemas_without_clustering_k
             auto cell = atomic_cell::make_live(*int32_type, 1, int32_type->decompose(v), { });
             m.set_clustered_cell(clustering_key_prefix::make_empty(), *s->get_column_definition("v"), atomic_cell(*int32_type, cell));
         }
-        auto mt = make_memtable(s, {m});
+        auto mt = make_memtable(s, {m}).get();
         sstable_writer_config cfg = env.manager().configure_writer();
         cfg.promoted_index_block_size = 1;
 
@@ -1097,8 +1097,8 @@ SEASTAR_TEST_CASE(test_writing_combined_stream_with_tombstones_at_the_same_posit
         m2.partition().apply_delete(*s, rt2);
         ss.add_row(m2, ss.make_ckey(4), "v2"); // position inside rt2
 
-        auto mt1 = make_memtable(s, {m1});
-        auto mt2 = make_memtable(s, {m2});
+        auto mt1 = make_memtable(s, {m1}).get();
+        auto mt2 = make_memtable(s, {m2}).get();
         auto combined_permit = env.make_reader_permit();
         auto mr = make_combined_reader(s, combined_permit,
             mt1->make_mutation_reader(s, combined_permit), mt2->make_mutation_reader(s, combined_permit));
@@ -1323,7 +1323,7 @@ SEASTAR_TEST_CASE(test_reading_serialization_header) {
             tests::data_model::mutation_description::atomic_value(random_int32_value(), tests::data_model::data_timestamp, ttl, expiry_time));
     auto m2 = md2.build(s);
 
-    auto mt = make_memtable(s, {m1, m2});
+    auto mt = make_memtable(s, {m1, m2}).get();
     auto md1_overwrite = tests::data_model::mutation_description({ to_bytes("pk1") });
     md1_overwrite.add_clustered_row_marker({ to_bytes("ck1") }, 10);
     auto m1ow = md1_overwrite.build(s);
@@ -1422,7 +1422,7 @@ SEASTAR_TEST_CASE(test_counter_header_size) {
     }
     m.set_clustered_cell(ck, col, ccb.build(api::new_timestamp()));
 
-    auto mt = make_memtable(s, {m});
+    auto mt = make_memtable(s, {m}).get();
     for (const auto version : writable_sstable_versions) {
         auto sst = make_sstable_easy(env, mt, env.manager().configure_writer(), version);
         assert_that(sst->as_mutation_source().make_mutation_reader(s, env.make_reader_permit()))

--- a/test/boost/sstable_resharding_test.cc
+++ b/test/boost/sstable_resharding_test.cc
@@ -74,7 +74,7 @@ void run_sstable_resharding_test(sstables::test_env& env) {
                 mt->apply(std::move(m));
             }
         }
-        return make_sstable_containing(env.make_sstable(s, version), mt);
+        return make_sstable_containing(env.make_sstable(s, version), mt).get();
     });
 
     // FIXME: sstable write has a limitation in which it will generate sharding metadata only
@@ -185,7 +185,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
                 muts.push_back(get_mutation(s, k, 0));
             }
 
-            auto sst = make_sstable_containing(sst_gen, muts);
+            auto sst = make_sstable_containing(sst_gen, muts).get();
             BOOST_REQUIRE(!sst->is_shared());
             assert_sstable_computes_correct_owners(env, sst).get();
         }
@@ -205,7 +205,7 @@ SEASTAR_TEST_CASE(sstable_is_shared_correctness) {
                 }
             }
 
-            auto sst = make_sstable_containing(sst_gen, muts);
+            auto sst = make_sstable_containing(sst_gen, muts).get();
             BOOST_REQUIRE(!sst->is_shared());
 
             auto all_shards_s = get_schema(smp::count, cfg->murmur3_partitioner_ignore_msb_bits());

--- a/test/boost/sstable_test.cc
+++ b/test/boost/sstable_test.cc
@@ -431,7 +431,7 @@ SEASTAR_TEST_CASE(statistics_rewrite) {
         auto schema = random_schema.schema();
 
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
-        auto sstp = make_sstable_containing(env.make_sstable(schema, sstable::version_types::me), muts);
+        auto sstp = make_sstable_containing(env.make_sstable(schema, sstable::version_types::me), muts).get();
 
         auto toc_path = fmt::to_string(sstp->toc_filename());
         auto dir_path = std::filesystem::path(toc_path).parent_path().string();
@@ -920,7 +920,7 @@ static future<> test_component_digest_persistence(component_type component, ssta
         auto schema = random_schema.schema();
 
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
-        auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts);
+        auto sst_original = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
         auto& components = sstables::test(sst_original).get_components();
         bool has_component = components.find(component) != components.end();
@@ -1046,7 +1046,7 @@ static future<> test_component_digest_validation(component_type component, sstab
         auto schema = random_schema.schema();
 
         const auto muts = tests::generate_random_mutations(random_schema, 2).get();
-        auto sst = make_sstable_containing(env.make_sstable(schema, version), muts);
+        auto sst = make_sstable_containing(env.make_sstable(schema, version), muts).get();
 
         auto digest = sst->get_component_digest(component);
         BOOST_REQUIRE(digest.has_value());

--- a/test/boost/sstable_test.hh
+++ b/test/boost/sstable_test.hh
@@ -336,14 +336,14 @@ inline dht::decorated_key make_dkey(schema_ptr s, bytes b)
 }
 
 // Must be called from a seastar thread.
-shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify);
-inline shared_sstable verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify);
+inline future<sstables::shared_sstable> verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
     return verify_mutation(env, sst_gen(), std::move(mt), std::move(key), std::move(verify));
 }
-shared_sstable verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify);
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify);
 
-shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);
-inline shared_sstable verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);
+inline future<sstables::shared_sstable> verify_mutation(test_env& env, std::function<shared_sstable()> sst_gen, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
     return verify_mutation(env, sst_gen(), std::move(mt), std::move(pr), std::move(verify));
 }
-shared_sstable verify_mutation(test_env& env, shared_sstable sstp, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify);

--- a/test/boost/test_config.yaml
+++ b/test/boost/test_config.yaml
@@ -32,7 +32,7 @@ custom_args:
     sstable_datafile_test:
         - '-c1 -m2G'
     sstable_compaction_test:
-        - '-c1 -m2G --logger-log-level compaction=debug --logger-log-level compaction_manager=debug --logger-log-level s3=debug --logger-log-level gcp_storage=debug'
+        - '-c1 -m2G --logger-log-level compaction=debug --logger-log-level compaction_manager=debug --logger-log-level s3=trace --logger-log-level gcp_storage=trace --logger-log-level http=trace --logger-log-level default_http_retry_strategy=trace'
     sstable_3_x_test:
         - '-c1 -m2G'
     cql_query_test:

--- a/test/boost/view_build_test.cc
+++ b/test/boost/view_build_test.cc
@@ -830,7 +830,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering) {
 
         auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
 
-        auto mt = make_memtable(schema, muts);
+        auto mt = make_memtable(schema, muts).get();
         auto p = make_manually_paused_evictable_reader(
                 mt->as_data_source(),
                 schema,
@@ -930,7 +930,7 @@ SEASTAR_THREAD_TEST_CASE(test_view_update_generator_buffering_with_random_mutati
     reader_concurrency_semaphore sem(reader_concurrency_semaphore::for_tests{}, get_name(), 1, replica::new_reader_base_cost);
     auto stop_sem = deferred_stop(sem);
     const abort_source as;
-    auto mt = make_memtable(schema, {mut});
+    auto mt = make_memtable(schema, {mut}).get();
     auto permit = sem.obtain_permit(schema, get_name(), replica::new_reader_base_cost, db::no_timeout, {}).get();
     auto p = make_manually_paused_evictable_reader(
             mt->as_data_source(),

--- a/test/boost/virtual_table_mutation_source_test.cc
+++ b/test/boost/virtual_table_mutation_source_test.cc
@@ -38,7 +38,7 @@ public:
 
     virtual future<> execute(reader_permit permit, db::result_collector& rc) override {
         return async([this, permit, &rc] {
-            auto mt = make_memtable(_s, _mutations);
+            auto mt = make_memtable(_s, _mutations).get();
             auto rdr = mt->make_mutation_reader(_s, permit);
             auto close_rdr = deferred_close(rdr);
             rdr.consume_pausable([&rc] (mutation_fragment_v2 mf) {

--- a/test/lib/sstable_utils.cc
+++ b/test/lib/sstable_utils.cc
@@ -23,20 +23,16 @@
 using namespace sstables;
 using namespace std::chrono_literals;
 
-lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts) {
+future<lw_shared_ptr<replica::memtable>> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts) {
     auto mt = make_lw_shared<replica::memtable>(s);
 
-    std::size_t i{0};
     for (auto&& m : muts) {
         mt->apply(m);
         // Give the reactor some time to breathe
-        if (++i == 10) {
-            seastar::thread::yield();
-            i = 0;
-        }
+        co_await coroutine::maybe_yield();
     }
 
-    return mt;
+    co_return mt;
 }
 
 std::vector<replica::memtable*> active_memtables(replica::table& t) {
@@ -47,27 +43,24 @@ std::vector<replica::memtable*> active_memtables(replica::table& t) {
     return active_memtables;
 }
 
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt) {
+future<sstables::shared_sstable> make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt) {
     return make_sstable_containing(sst_factory(), std::move(mt));
 }
 
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt) {
-    write_memtable_to_sstable(*mt, sst).get();
+future<sstables::shared_sstable> make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt) {
+    co_await write_memtable_to_sstable(*mt, sst);
     sstable_open_config cfg { .load_first_and_last_position_metadata = true };
-    sst->open_data(cfg).get();
-    return sst;
+    co_await sst->open_data(cfg);
+    co_return sst;
 }
 
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate) {
-    return make_sstable_containing(sst_factory(), std::move(muts), do_validate);
-}
-
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate) {
+future<sstables::shared_sstable> make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate) {
     schema_ptr s = muts[0].schema();
-    make_sstable_containing(sst, make_memtable(s, muts));
+    co_await make_sstable_containing(sst, co_await make_memtable(s, muts));
 
     if (do_validate) {
-        tests::reader_concurrency_semaphore_wrapper semaphore;
+        reader_concurrency_semaphore sem(
+            reader_concurrency_semaphore::no_limits{}, "make_sstable_containing", reader_concurrency_semaphore::register_metrics::no);
 
         std::set<mutation, mutation_decorated_key_less_comparator> merged;
         for (auto&& m : muts) {
@@ -79,16 +72,25 @@ sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, u
                 old.value().apply(std::move(m));
                 merged.insert(std::move(old));
             }
+            co_await coroutine::maybe_yield();
         }
 
         // validate the sstable
-        auto rd = assert_that(sst->as_mutation_source().make_mutation_reader(s, semaphore.make_permit()));
+        auto rd = sst->as_mutation_source().make_mutation_reader(s, sem.make_tracking_only_permit(nullptr, "test", db::no_timeout, {}));
         for (auto&& m : merged) {
-            rd.produces(m);
+            auto mo = co_await read_mutation_from_mutation_reader(rd);
+            BOOST_REQUIRE(mo);
+            assert_that(*mo).is_equal_to_compacted(m);
+            co_await coroutine::maybe_yield();
         }
-        rd.produces_end_of_stream();
+        co_await rd.close();
+        co_await sem.stop();
     }
-    return sst;
+    co_return sst;
+}
+
+future<sstables::shared_sstable> make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate) {
+    return make_sstable_containing(sst_factory(), std::move(muts), do_validate);
 }
 
 shared_sstable make_sstable_easy(test_env& env, mutation_reader rd, sstable_writer_config cfg,
@@ -154,34 +156,34 @@ future<> run_compaction_task(test_env& env, sstables::run_id output_run_id, comp
     co_await tcm.perform_compaction(std::move(task));
 }
 
-shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
-    auto sstp = make_sstable_containing(std::move(sst), mt);
-    return verify_mutation(env, std::move(sstp), std::move(key), std::move(verify));
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, bytes key, std::function<void(mutation_opt&)> verify) {
+    auto sstp = co_await make_sstable_containing(std::move(sst), mt);
+    co_return co_await verify_mutation(env, std::move(sstp), std::move(key), std::move(verify));
 }
 
-shared_sstable verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, bytes key, std::function<void(mutation_opt&)> verify) {
     auto s = sstp->get_schema();
     auto pr = dht::partition_range::make_singular(make_dkey(s, key));
     auto rd = sstp->make_reader(s, env.make_reader_permit(), pr, s->full_slice());
-    auto close_rd = deferred_close(rd);
-    auto mopt = read_mutation_from_mutation_reader(rd).get();
+    auto mopt = co_await read_mutation_from_mutation_reader(rd);
     verify(mopt);
-    return sstp;
+    co_await rd.close();
+    co_return sstp;
 }
 
-shared_sstable verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
-    auto sstp = make_sstable_containing(std::move(sst), mt);
-    return verify_mutation(env, std::move(sstp), std::move(pr), std::move(verify));
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sst, lw_shared_ptr<replica::memtable> mt, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
+    auto sstp = co_await make_sstable_containing(std::move(sst), mt);
+    co_return co_await verify_mutation(env, std::move(sstp), std::move(pr), std::move(verify));
 }
 
-shared_sstable verify_mutation(test_env& env, shared_sstable sstp, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
+future<sstables::shared_sstable> verify_mutation(test_env& env, shared_sstable sstp, dht::partition_range pr, std::function<stop_iteration(mutation_opt&)> verify) {
     auto s = sstp->get_schema();
     auto rd = sstp->make_reader(s, env.make_reader_permit(), std::move(pr), s->full_slice());
-    auto close_rd = deferred_close(rd);
-    while (auto mopt = read_mutation_from_mutation_reader(rd).get()) {
+    while (auto mopt = co_await read_mutation_from_mutation_reader(rd)) {
         if (verify(mopt) == stop_iteration::yes) {
             break;
         }
     }
-    return sstp;
+    co_await rd.close();
+    co_return sstp;
 }

--- a/test/lib/sstable_utils.hh
+++ b/test/lib/sstable_utils.hh
@@ -26,11 +26,10 @@ using namespace sstables;
 using namespace std::chrono_literals;
 
 using validate = bool_class<struct validate_tag>;
-// Must be called in a seastar thread.
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt);
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt);
-sstables::shared_sstable make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
-sstables::shared_sstable make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
+future<sstables::shared_sstable> make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, lw_shared_ptr<replica::memtable> mt);
+future<sstables::shared_sstable> make_sstable_containing(sstables::shared_sstable sst, lw_shared_ptr<replica::memtable> mt);
+future<sstables::shared_sstable> make_sstable_containing(std::function<sstables::shared_sstable()> sst_factory, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
+future<sstables::shared_sstable> make_sstable_containing(sstables::shared_sstable sst, utils::chunked_vector<mutation> muts, validate do_validate = validate::yes);
 
 namespace sstables {
 
@@ -270,5 +269,5 @@ inline shared_sstable make_sstable_easy(test_env& env, lw_shared_ptr<replica::me
     return make_sstable_easy(env, std::move(mt), std::move(cfg), env.new_generation(), version, estimated_partitions, query_time);
 }
 
-lw_shared_ptr<replica::memtable> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts);
+future<lw_shared_ptr<replica::memtable>> make_memtable(schema_ptr s, const utils::chunked_vector<mutation>& muts);
 std::vector<replica::memtable*> active_memtables(replica::table& t);

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -197,6 +197,7 @@ std::vector<db::object_storage_endpoint_param> make_storage_options_config(const
                     .port = std::stoul(tests::getenv_safe("S3_SERVER_PORT_FOR_TEST")),
                     .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
                     .region = tests::getenv_or_default("AWS_DEFAULT_REGION", "local"),
+                    .max_connections = 32,
                 });
             }
             if (os.type == data_dictionary::storage_options::GS_NAME) {


### PR DESCRIPTION
Several sstable_compaction_test cases run prohibitively slowly on S3 and GCS backends — some taking 4+ minutes — because they create hundreds of SSTables sequentially over high-latency HTTP connections and perform redundant validation (checksumming) round-trips on every one. The twcs_reshape_with_disjoint_set S3 variant was even disabled entirely because of this.

The changes apply three complementary optimizations, per-test:

**Skip SSTable validation on remote storage.** The compaction tests verify strategy logic, not data integrity. SSTable validation triggers additional read-back I/O which is cheap on local disk but expensive over HTTP. A `do_validate` flag now conditionally skips validation when the storage backend is not local.

**Parallelize SSTable creation with async coroutines.** A new `make_sstable_containing_async` coroutine overload is added alongside the existing synchronous `make_sstable_containing`. Sequential creation loops are replaced with `parallel_for_each` using coroutine lambdas that call the async overload directly, overlapping S3/GCS uploads without spawning a dedicated Seastar thread per SSTable. The async validation path performs the same content checks as the synchronous version (mutation merging and `is_equal_to_compacted` assertions). Operations that depend on the created SSTables (e.g. `add_sstable_and_update_cache`, `owned_token_ranges` population) remain sequential.

**Reduce SSTable count for remote variants.** Tests like twcs_reshape_with_disjoint_set and stcs_reshape_overlapping used a hardcoded count of 256. The count is now a function parameter (default 256 for local, 64 for S3/GCS), which is sufficient to exercise the compaction strategy logic while avoiding excessive remote I/O.

Infrastructure changes: S3 endpoint max_connections raised from the default to 32 to support the higher upload concurrency, and trace-level logging added for s3, gcp_storage, http, and default_http_retry_strategy to aid future debugging.

The previously disabled twcs_reshape_with_disjoint_set_s3_test is re-enabled with these optimizations.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1428
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1843

Apparently 2026.2 is affected by this problem too, needs to be backported
