### PR TITLE
[WIP, checking CI, don't review] raft: throw maybe_applied_via_snapshot instead of commit_status_unknown where possible

### DIFF
--- a/db/view/view_building_coordinator.cc
+++ b/db/view/view_building_coordinator.cc
@@ -88,6 +88,8 @@ void view_building_coordinator::handle_coordinator_error(std::exception_ptr eptr
         vbc_logger.debug("view building coordinator got raft::request_aborted");
     } catch (service::term_changed_error&) {
         vbc_logger.debug("view building coordinator notices term change {} -> {}", _term, _raft.get_current_term());
+    } catch (raft::maybe_applied_via_snapshot&) {
+        vbc_logger.debug("view building coordinator got raft::maybe_applied_via_snapshot");
     } catch (raft::commit_status_unknown&) {
         vbc_logger.warn("view building coordinator got raft::commit_status_unknown");
     } catch (...) {
@@ -158,6 +160,8 @@ future<> view_building_coordinator::finished_task_gc_fiber() {
             vbc_logger.debug("view_building_coordinator::finished_task_gc_fiber got raft::request_aborted");
         } catch (service::term_changed_error&) {
             vbc_logger.debug("view_building_coordinator::finished_task_gc_fiber notices term change {} -> {}", _term, _raft.get_current_term());
+        } catch (raft::maybe_applied_via_snapshot&) {
+            vbc_logger.debug("view_building_coordinator::finished_task_gc_fiber got raft::maybe_applied_via_snapshot");
         } catch (raft::commit_status_unknown&) {
             vbc_logger.warn("view_building_coordinator::finished_task_gc_fiber got raft::commit_status_unknown");
         } catch (...) {

--- a/raft/raft.hh
+++ b/raft/raft.hh
@@ -269,6 +269,20 @@ struct commit_status_unknown : public error {
     commit_status_unknown() : error("Commit status of the entry is unknown") {}
 };
 
+// Thrown by `add_entry` when the entry is known to be committed but we cannot
+// guarantee that `state_machine::apply` was called locally for this entry.
+// This happens when a snapshot is loaded that includes the entry, so the state
+// machine's state already contains the entry's effects (either via a prior
+// `apply()` call or via `load_snapshot()`). At least one node in the
+// configuration must have applied the entry via `apply()` (the one that
+// produced the snapshot).
+//
+// Callers that only need to know "the entry was applied to the state machine"
+// can treat this exception as success.
+struct maybe_applied_via_snapshot : public error {
+    maybe_applied_via_snapshot() : error("Entry was committed but may have been applied via snapshot rather than apply()") {}
+};
+
 struct stopped_error : public error {
     explicit stopped_error(const sstring& reason = "")
             : error(!reason.empty()

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -239,7 +239,11 @@ private:
 
     // Drop waiter that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
-    void drop_waiters(std::optional<index_t> idx = {});
+    // When `snap_term` is provided (snapshot case), waiters whose term matches the
+    // snapshot term are resolved with `maybe_applied_via_snapshot` instead of
+    // `commit_status_unknown`, since the snapshot-term match proves they were committed
+    // and included in the snapshot.
+    void drop_waiters(std::optional<index_t> idx = {}, std::optional<term_t> snap_term = {});
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
     // to be applied.
@@ -556,12 +560,20 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
                 auto snap_term = _fsm->log_term_for(snap_idx);
                 SCYLLA_ASSERT(snap_term);
                 SCYLLA_ASSERT(snap_idx >= eid.idx);
-                if (type == wait_type::committed && snap_term == eid.term) {
+                if (snap_term == eid.term) {
+                    if (type == wait_type::committed) {
+                        logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away, but has the snapshot's term"
+                                     " (snapshot index: {})", id(), eid.term, eid.idx, snap_idx);
+                        co_return;
+                    }
+                    // wait_type::applied: the entry was committed and included in a snapshot
+                    // that has been applied to the state machine (either via apply() or via
+                    // load_snapshot()). We can't guarantee that state_machine::apply() was
+                    // called locally for this specific entry, but the state machine's state
+                    // includes its effects.
                     logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away, but has the snapshot's term"
-                                 " (snapshot index: {})", id(), eid.term, eid.idx, snap_idx);
-                    co_return;
-
-                    // We don't do this for `wait_type::applied` - see below why.
+                                 " (snapshot index: {}), throwing maybe_applied_via_snapshot", id(), eid.term, eid.idx, snap_idx);
+                    throw maybe_applied_via_snapshot();
                 }
 
                 logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away", id(), eid.term, eid.idx);
@@ -573,17 +585,14 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
             }
 
             if (type == wait_type::applied && _fsm->log_last_snapshot_idx() >= eid.idx) {
-                // We know the entry was committed but the wait type is `applied`
-                // and we don't know if the entry was applied with `state_machine::apply`
-                // (we may've loaded a snapshot before we managed to apply the entry).
-                // As specified by `add_entry`, throw `commit_status_unknown` in this case.
-                //
-                // FIXME: replace this with a different exception type - `commit_status_unknown`
-                // gives too much uncertainty while we know that the entry was committed
-                // and had to be applied on at least one server. Some callers of `add_entry`
-                // need to know only that the current state includes that entry, whether it was done
-                // through `apply` on this server or through receiving a snapshot.
-                throw commit_status_unknown();
+                // We know the entry was committed (term matches) but the wait type
+                // is `applied` and a snapshot has been loaded past this entry's index.
+                // We can't guarantee that state_machine::apply() was called locally
+                // for this specific entry — it may have been subsumed by a
+                // load_snapshot() call. However, the entry's effects are included
+                // in the state machine's state, and at least one node must have
+                // applied it via apply() (the one that produced the snapshot).
+                throw maybe_applied_via_snapshot();
             }
 
             co_return;
@@ -995,7 +1004,7 @@ void server_impl::notify_waiters(std::map<index_t, op_status>& waiters,
     }
 }
 
-void server_impl::drop_waiters(std::optional<index_t> idx) {
+void server_impl::drop_waiters(std::optional<index_t> idx, std::optional<term_t> snap_term) {
     auto drop = [&] (std::map<index_t, op_status>& waiters) {
         while (waiters.size() != 0) {
             auto it = waiters.begin();
@@ -1004,7 +1013,14 @@ void server_impl::drop_waiters(std::optional<index_t> idx) {
             }
             auto [entry_idx, status] = std::move(*it);
             waiters.erase(it);
-            status.done.set_exception(commit_status_unknown());
+            if (snap_term && status.term == *snap_term) {
+                // The waiter's term matches the snapshot term. By the Log Matching
+                // Property (same reasoning as in wait_for_entry), the entry was
+                // committed and included in the snapshot.
+                status.done.set_exception(maybe_applied_via_snapshot());
+            } else {
+                status.done.set_exception(commit_status_unknown());
+            }
             _stats.waiters_dropped++;
         }
     };
@@ -1431,7 +1447,7 @@ future<> server_impl::applier_fiber() {
                 // Apply snapshot it to the state machine
                 logger.trace("[{}] apply_fiber applying snapshot {}", _id, snp.id);
                 co_await _state_machine->load_snapshot(snp.id);
-                drop_waiters(snp.idx);
+                drop_waiters(snp.idx, snp.term);
                 _applied_idx = snp.idx;
                 _applied_index_changed.broadcast();
                 _stats.sm_load_snapshot++;

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -95,6 +95,10 @@ public:
     //     Thrown if the leader has changed and the log entry has either
     //     been replaced by the new leader or the server has lost track of it.
     //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.
+    // raft::maybe_applied_via_snapshot
+    //     Thrown if the entry was committed but may have been applied via a snapshot load rather than
+    //     a local `state_machine::apply()` call. The entry's effects are in the state machine's state.
+    //     Callers can treat this as success if they don't need a guarantee of local `apply()`.
     // raft::dropped_entry
     //     Thrown if the entry was replaced because of a leader change.
     // raft::request_aborted

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -82,15 +82,19 @@ public:
     // Successful `add_entry` with `wait_type::committed` does not guarantee that `state_machine::apply` will be called
     // locally for this entry. Between the commit and the application we may receive a snapshot containing this entry,
     // so the state machine's state 'jumps' forward in time, skipping the entry application.
-    // However, for `wait_type::applied`, we guarantee that the entry will be applied locally with `state_machine::apply`.
-    // If a snapshot causes the state machine to jump over the entry, `add_entry` will return `commit_status_unknown`
-    // (even if the snapshot included that entry).
+    // For `wait_type::applied`, we normally guarantee that the entry will be applied locally with `state_machine::apply`.
+    // However, if a snapshot causes the state machine to jump over the entry, `add_entry` will throw
+    // `maybe_applied_via_snapshot` instead of resolving successfully. This means the entry was committed and its
+    // effects are included in the state machine's state (via the snapshot), but `state_machine::apply` may not have
+    // been called locally for this specific entry. At least one node in the configuration applied it via `apply()`
+    // (the one that produced the snapshot). Callers that only need to know "the entry was applied to the state
+    // machine" can treat this exception as success.
     //
     // Exceptions:
     // raft::commit_status_unknown
     //     Thrown if the leader has changed and the log entry has either
     //     been replaced by the new leader or the server has lost track of it.
-    //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.L
+    //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.
     // raft::dropped_entry
     //     Thrown if the entry was replaced because of a leader change.
     // raft::request_aborted

--- a/service/raft/raft_group0_client.cc
+++ b/service/raft/raft_group0_client.cc
@@ -182,6 +182,11 @@ future<> raft_group0_client::add_entry(group0_command group0_cmd, group0_guard g
                 logger.warn("add_entry: returned \"{}\". Retrying the command (prev_state_id: {}, new_state_id: {})",
                         e, group0_cmd.prev_state_id, group0_cmd.new_state_id);
                 retry = true;
+            } catch (const raft::maybe_applied_via_snapshot& e) {
+                // The entry was committed and applied (either via apply() or via snapshot).
+                // This is equivalent to success — no need to retry.
+                logger.info("add_entry: returned \"{}\". Treating as success (prev_state_id: {}, new_state_id: {})",
+                        e, group0_cmd.prev_state_id, group0_cmd.new_state_id);
             } catch (const raft::commit_status_unknown& e) {
                 logger.warn("add_entry: returned \"{}\". Retrying the command (prev_state_id: {}, new_state_id: {})",
                         e, group0_cmd.prev_state_id, group0_cmd.new_state_id);

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -241,6 +241,12 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
                         ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
 
                     continue;
+                } else if (try_catch<raft::maybe_applied_via_snapshot>(ex)) {
+                    // The entry was committed and applied (either via apply() or via snapshot).
+                    // This is equivalent to success for our purposes.
+                    logger.debug("mutate(): add_entry, got maybe_applied_via_snapshot {}, table {}.{}, tablet {}, term {}",
+                        ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);
+                    co_return std::monostate{};
                 } else if (try_catch<raft::commit_status_unknown>(ex)) {
                     logger.debug("mutate(): add_entry, got commit_status_unknown {}, table {}.{}, tablet {}, term {}",
                         ex, schema->ks_name(), schema->cf_name(), op.tablet_id, term);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4350,6 +4350,8 @@ bool topology_coordinator::handle_topology_coordinator_error(std::exception_ptr 
         rtlogger.debug("topology change coordinator fiber aborted");
     } catch (seastar::abort_requested_exception&) {
         rtlogger.debug("topology change coordinator fiber aborted");
+    } catch (raft::maybe_applied_via_snapshot&) {
+        rtlogger.debug("topology change coordinator fiber got maybe_applied_via_snapshot");
     } catch (raft::commit_status_unknown&) {
         rtlogger.warn("topology change coordinator fiber got commit_status_unknown");
     } catch (group0_concurrent_modification&) {

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -223,7 +223,7 @@ raft::command make_command(const cmd_id_t& cmd_id, const Input& input) {
 
 // TODO: handle other errors?
 template <PureStateMachine M>
-using call_result_t = std::variant<typename M::output_t, timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::stopped_error, raft::not_a_member>;
+using call_result_t = std::variant<typename M::output_t, timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::maybe_applied_via_snapshot, raft::stopped_error, raft::not_a_member>;
 
 // Wait for a future `f` to finish, but keep the result inside a `future`.
 // Works for `future<void>` as well as for `future<T>`.
@@ -334,6 +334,8 @@ future<call_result_t<M>> call(
         } catch (raft::dropped_entry& e) {
             return make_ready_future<call_result_t<M>>(e);
         } catch (raft::commit_status_unknown& e) {
+            return make_ready_future<call_result_t<M>>(e);
+        } catch (raft::maybe_applied_via_snapshot& e) {
             return make_ready_future<call_result_t<M>>(e);
         } catch (raft::stopped_error& e) {
             return make_ready_future<call_result_t<M>>(e);
@@ -1251,7 +1253,7 @@ private:
 };
 
 using reconfigure_result_t = std::variant<std::monostate,
-    timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::conf_change_in_progress, raft::stopped_error, raft::not_a_member>;
+    timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::maybe_applied_via_snapshot, raft::conf_change_in_progress, raft::stopped_error, raft::not_a_member>;
 
 future<reconfigure_result_t> reconfigure(
         const std::vector<std::pair<raft::server_id, raft::is_voter>>& ids,
@@ -1273,6 +1275,8 @@ future<reconfigure_result_t> reconfigure(
     } catch (raft::dropped_entry e) {
         co_return e;
     } catch (raft::commit_status_unknown e) {
+        co_return e;
+    } catch (raft::maybe_applied_via_snapshot e) {
         co_return e;
     } catch (raft::conf_change_in_progress e) {
         co_return e;
@@ -1312,6 +1316,8 @@ future<reconfigure_result_t> modify_config(
     } catch (raft::dropped_entry e) {
         co_return e;
     } catch (raft::commit_status_unknown e) {
+        co_return e;
+    } catch (raft::maybe_applied_via_snapshot e) {
         co_return e;
     } catch (raft::conf_change_in_progress e) {
         co_return e;
@@ -3513,6 +3519,10 @@ SEASTAR_TEST_CASE(basic_generator_test) {
                     [this] (raft::commit_status_unknown& e) {
                         // TODO SCYLLA_ASSERT: only allowed if reconfigurations happen?
                         // SCYLLA_ASSERT(false); TODO debug this
+                        ++_stats.failures;
+                    },
+                    [this] (raft::maybe_applied_via_snapshot& e) {
+                        // The entry was applied (via snapshot) but we don't have the output.
                         ++_stats.failures;
                     },
                     [this] (auto&) {

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -1832,6 +1832,12 @@ public:
         return n._server->is_leader();
     }
 
+    const state_t& state(raft::server_id id) {
+        auto& n = _routes.at(id);
+        SCYLLA_ASSERT(n._server);
+        return n._server->state();
+    }
+
     future<call_result_t<M>> call(
             raft::server_id id,
             typename M::input_t input,
@@ -2253,7 +2259,15 @@ SEASTAR_TEST_CASE(test_frequent_snapshotting) {
 
         co_await call(ExReg::exchange{0}, 100_t);
         for (int i = 1; i <= 100; ++i) {
-            SCYLLA_ASSERT(eq(co_await call(ExReg::exchange{i}, 100_t), ExReg::ret{i - 1}));
+            auto r = co_await call(ExReg::exchange{i}, 100_t);
+            if (std::holds_alternative<raft::maybe_applied_via_snapshot>(r)) {
+                // The entry was applied via snapshot — apply() wasn't called
+                // locally so the output channel wasn't filled.
+                // We need to look at the state directly instead.
+                SCYLLA_ASSERT(env.state(leader_id) == i);
+            } else {
+                SCYLLA_ASSERT(eq(r, ExReg::ret{i - 1}));
+            }
         }
 
         tlogger.debug("100 exchanges - three servers - passed");
@@ -2265,7 +2279,13 @@ SEASTAR_TEST_CASE(test_frequent_snapshotting) {
             co_await timer.sleep(2_t);
         }
         for (int i = 0; i < 100; ++i) {
-            SCYLLA_ASSERT(eq(co_await std::move(futs[i]), ExReg::ret{100}));
+            auto r = co_await std::move(futs[i]);
+            if (std::holds_alternative<raft::maybe_applied_via_snapshot>(r)) {
+                // Same as above.
+                SCYLLA_ASSERT(env.state(leader_id) == 100);
+            } else {
+                SCYLLA_ASSERT(eq(r, ExReg::ret{100}));
+            }
         }
 
         tlogger.debug("100 concurrent reads - three servers - passed");

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -957,6 +957,11 @@ future<> raft_cluster<Clock>::add_entry(size_t val, std::optional<size_t> server
             auto& at = _servers[server ? *server : _leader].server;
             co_await at->add_entry(create_command(val), raft::wait_type::committed, nullptr);
             break;
+        } catch (raft::maybe_applied_via_snapshot& e) {
+            // The entry was committed and applied (via snapshot). Treat as success.
+            tlogger.info("replication_test: got `maybe_applied_via_snapshot` from `add_entry`"
+                    ", val: {}, server: {}", val, server);
+            break;
         } catch (raft::commit_status_unknown& e) {
             // FIXME: in some cases when we get `commit_status_unknown` the entry may have been applied.
             // Retrying it could lead to double application which causes hard to debug failures, e.g. #14029.
@@ -1218,6 +1223,8 @@ future<> raft_cluster<Clock>::change_configuration(set_config sc) {
                 raft::wait_type::committed, nullptr);
     } catch (raft::not_a_leader& e) {
         // leader stepped down, implying config fully changed
+    } catch (raft::maybe_applied_via_snapshot& e) {
+        // The entry was committed and applied. Treat as success.
     } catch (raft::commit_status_unknown& e) {}
 
     // Stop nodes no longer in configuration


### PR DESCRIPTION
When `add_entry` encounters a snapshot that has jumped past the entry,
in some cases, the raft library threw `commit_status_unknown` even when
it could deduce (via the Log Matching Property) that the entry was committed
and included in the snapshot. For strongly consistent tables,
`commit_status_unknown` is propagated to the user, so we want to avoid it
whenever possible.

This series introduces a new exception, `maybe_applied_via_snapshot`, for
such cases. It means: the entry was committed and its effects are in the
state machine (via the snapshot), but `state_machine::apply()` may not have
been called locally for this specific entry. Callers that only need to know
that the entry was applied can treat it as success. That's what all callers
in Scylla (strongly consistent tables and group0) currently do. For group0,
this results in avoiding some unnecessary retries, which is a minor
improvement.

Note that we want to throw a new exception instead of not throwing any
exception at all because some `add_entry` callers could require `apply()`
being called. One example is in the nemesis test, where `apply()` fills the
output channel.

`maybe_applied_via_snapshot` is thrown in 3 sites. 2 out of 3 sites apply
only to `wait_type::applied`, and the remaining site applies to both
`wait_type::committed` and `wait_type::applied`. We use
`wait_type::committed` for strongly consistent tables, so this PR doesn't
have that much impact on the strongly consistent tables.

The new exception is also used to deflake `test_frequent_snapshotting` and
fix SCYLLADB-1264. This change is in the last commit.

Fixes SCYLLADB-430
Fixes SCYLLADB-1264

No backport:
- improvements relevant mostly for strongly consistent tables (experimental),
- quite risky changes,
- `test_frequent_snapshotting` fails very rarely, so we don't have to deflake
  it in older branches.