### PR TITLE
service: fix shard selection in tablet rack-list colocation plan

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1469,9 +1469,8 @@ public:
 
         const locator::topology& topo = _tm->get_topology();
 
-        auto migration_tablet_ids = co_await mplan.get_migration_tablet_ids();
         auto colocation_state = co_await find_required_rack_list_colocations(_db, _tm, _sys_ks,
-            _topology->paused_rf_change_requests, std::move(migration_tablet_ids));
+            _topology->paused_rf_change_requests, _scheduled_tablets);
 
         node_load_map nodes;
         topo.for_each_node([&] (const locator::node& node) {
@@ -1486,7 +1485,6 @@ public:
         // Consider load that is about to be scheduled.
         co_await consider_planned_load(nodes, mplan);
 
-        std::unordered_set<global_tablet_id> colocation_tablet_ids;
         for (auto& [dc_rack, colocation_sources] : colocation_state.dst_dc_rack_to_tablets) {
             auto nodes_by_load_dst = nodes | std::views::filter([&] (const auto& host_load) {
                 auto& [host, load] = host_load;
@@ -1512,7 +1510,8 @@ public:
 
             const tablet_metadata& tmeta = _tm->tablets();
             for (colocation_source& source : colocation_sources) {
-                if (colocation_tablet_ids.contains(source.gid)) {
+                co_await coroutine::maybe_yield();
+                if (_scheduled_tablets.contains(source.gid)) {
                     lblogger.debug("Skipped colocation of replica {} of tablet={}, another replica of which is about to be colocated", source.replica, source.gid);
                     continue;
                 }
@@ -1551,7 +1550,6 @@ public:
                     mark_as_scheduled(mig);
                     for (auto& m : mig) {
                         plan.add(std::move(m));
-                        colocation_tablet_ids.insert(m.tablet);
                     }
                 }
                 update_node_load_on_migration(nodes, src, dst, source_tablets);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1457,23 +1457,17 @@ public:
         return tablet_group_size;
     }
 
-    future<migration_plan> make_rack_list_colocation_plan(const migration_plan& mplan) {
-        lblogger.debug("In make_rack_list_colocation_plan");
-
+    future<migration_plan> make_rack_list_colocation_plan_for_dc(
+            const sstring& dc,
+            const std::map<sstring, colocation_source_set>& racks,
+            const std::unordered_map<sstring, std::unordered_set<utils::UUID>>& requests_for_dc,
+            const migration_plan& mplan) {
         migration_plan plan;
-        tablet_rack_list_colocation_plan rack_list_plan;
-        if (!ongoing_rack_list_colocation() || utils::get_local_injector().enter("wait_with_rack_list_colocation")) {
-            co_return plan;
-        }
-
         const locator::topology& topo = _tm->get_topology();
-
-        auto colocation_state = co_await find_required_rack_list_colocations(_db, _tm, _sys_ks,
-            _topology->paused_rf_change_requests, _scheduled_tablets);
 
         node_load_map nodes;
         topo.for_each_node([&] (const locator::node& node) {
-            if (node.get_state() == locator::node::state::normal && !node.is_excluded()) {
+            if (node.get_state() == locator::node::state::normal && !node.is_excluded() && node.dc_rack().dc == dc) {
                 ensure_node(nodes, node.host_id());
             }
         });
@@ -1484,7 +1478,6 @@ public:
         // Consider load that is about to be scheduled.
         co_await consider_planned_load(nodes, mplan);
 
-        for (auto& [dc, racks] : colocation_state.dst_dc_rack_to_tablets) {
         for (auto& [rack, colocation_sources] : racks) {
             auto dc_rack = locator::endpoint_dc_rack{dc, rack};
             auto nodes_by_load_dst = nodes | std::views::filter([&] (const auto& host_load) {
@@ -1495,10 +1488,8 @@ public:
 
             if (nodes_by_load_dst.empty()) {
                 lblogger.warn("No target nodes available for RF change colocation plan in dc {}, rack {}", dc, rack);
-                if (auto dc_it = colocation_state.dst_to_requests.find(dc); dc_it != colocation_state.dst_to_requests.end()) {
-                    if (auto rack_it = dc_it->second.find(rack); rack_it != dc_it->second.end()) {
-                        rack_list_plan.maybe_add_request_to_resume(*rack_it->second.begin());
-                    }
+                if (auto rack_it = requests_for_dc.find(rack); rack_it != requests_for_dc.end()) {
+                    plan.maybe_add_rack_list_request_to_resume(*rack_it->second.begin());
                 }
                 continue;
             }
@@ -1512,7 +1503,7 @@ public:
             std::make_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
 
             const tablet_metadata& tmeta = _tm->tablets();
-            for (colocation_source& source : colocation_sources) {
+            for (const colocation_source& source : colocation_sources) {
                 co_await coroutine::maybe_yield();
                 if (_scheduled_tablets.contains(source.gid)) {
                     lblogger.debug("Skipped colocation of replica {} of tablet={}, another replica of which is about to be colocated", source.replica, source.gid);
@@ -1558,11 +1549,28 @@ public:
                 update_node_load_on_migration(nodes, src, dst, source_tablets);
             }
         }
+        co_return plan;
+    }
+
+    future<migration_plan> make_rack_list_colocation_plan(const migration_plan& mplan) {
+        lblogger.debug("In make_rack_list_colocation_plan");
+
+        migration_plan plan;
+        if (!ongoing_rack_list_colocation() || utils::get_local_injector().enter("wait_with_rack_list_colocation")) {
+            co_return plan;
         }
+
+        auto colocation_state = co_await find_required_rack_list_colocations(_db, _tm, _sys_ks,
+            _topology->paused_rf_change_requests, _scheduled_tablets);
+
+        for (auto& [dc, racks] : colocation_state.dst_dc_rack_to_tablets) {
+            auto requests_it = colocation_state.dst_to_requests.find(dc);
+            plan.merge(co_await make_rack_list_colocation_plan_for_dc(dc, racks, requests_it != colocation_state.dst_to_requests.end() ? requests_it->second : std::unordered_map<sstring, std::unordered_set<utils::UUID>>{}, mplan));
+        }
+
         if (colocation_state.request_to_resume) {
-            rack_list_plan.maybe_add_request_to_resume(colocation_state.request_to_resume);
+            plan.maybe_add_rack_list_request_to_resume(colocation_state.request_to_resume);
         }
-        plan.set_rack_list_colocation_plan(std::move(rack_list_plan));
         co_return std::move(plan);
     }
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -301,11 +301,11 @@ struct colocation_source {
 };
 
 using colocation_source_set = utils::chunked_vector<colocation_source>;
-using colocation_sources_by_destination_rack = std::unordered_map<endpoint_dc_rack, colocation_source_set>;
+using colocation_sources_by_dc_rack = std::map<sstring, std::map<sstring, colocation_source_set>>;
 
 struct rack_list_colocation_state {
-    colocation_sources_by_destination_rack dst_dc_rack_to_tablets;
-    std::unordered_map<endpoint_dc_rack, std::unordered_set<utils::UUID>> dst_to_requests;
+    colocation_sources_by_dc_rack dst_dc_rack_to_tablets;
+    std::unordered_map<sstring, std::unordered_map<sstring, std::unordered_set<utils::UUID>>> dst_to_requests;
     utils::UUID request_to_resume;
 
     void maybe_set_request_to_resume(const utils::UUID& id) {
@@ -416,11 +416,10 @@ future<rack_list_colocation_state> find_required_rack_list_colocations(
 
                     for (auto src_dst : zipped) {
                         auto src = std::get<0>(src_dst);
-                        auto dst = std::get<1>(src_dst);
-                        auto endpoint = locator::endpoint_dc_rack{dc, dst};
+                        auto dst_rack = std::get<1>(src_dst);
 
-                        state.dst_dc_rack_to_tablets[endpoint].emplace_back(colocation_source{{table_or_mv->id(), tid}, src});
-                        state.dst_to_requests[endpoint].insert(request_id);
+                        state.dst_dc_rack_to_tablets[dc][dst_rack].emplace_back(colocation_source{{table_or_mv->id(), tid}, src});
+                        state.dst_to_requests[dc][dst_rack].insert(request_id);
                     }
                     return make_ready_future<>();
                 });
@@ -1485,7 +1484,9 @@ public:
         // Consider load that is about to be scheduled.
         co_await consider_planned_load(nodes, mplan);
 
-        for (auto& [dc_rack, colocation_sources] : colocation_state.dst_dc_rack_to_tablets) {
+        for (auto& [dc, racks] : colocation_state.dst_dc_rack_to_tablets) {
+        for (auto& [rack, colocation_sources] : racks) {
+            auto dc_rack = locator::endpoint_dc_rack{dc, rack};
             auto nodes_by_load_dst = nodes | std::views::filter([&] (const auto& host_load) {
                 auto& [host, load] = host_load;
                 auto& node = *load.node;
@@ -1493,9 +1494,11 @@ public:
             }) | std::views::keys | std::ranges::to<std::vector<host_id>>();
 
             if (nodes_by_load_dst.empty()) {
-                lblogger.warn("No target nodes available for RF change colocation plan in dc {}, rack {}", dc_rack.dc, dc_rack.rack);
-                if (auto it = colocation_state.dst_to_requests.find(dc_rack); it != colocation_state.dst_to_requests.end()) {
-                    rack_list_plan.maybe_add_request_to_resume(*it->second.begin());
+                lblogger.warn("No target nodes available for RF change colocation plan in dc {}, rack {}", dc, rack);
+                if (auto dc_it = colocation_state.dst_to_requests.find(dc); dc_it != colocation_state.dst_to_requests.end()) {
+                    if (auto rack_it = dc_it->second.find(rack); rack_it != dc_it->second.end()) {
+                        rack_list_plan.maybe_add_request_to_resume(*rack_it->second.begin());
+                    }
                 }
                 continue;
             }
@@ -1554,6 +1557,7 @@ public:
                 }
                 update_node_load_on_migration(nodes, src, dst, source_tablets);
             }
+        }
         }
         if (colocation_state.request_to_resume) {
             rack_list_plan.maybe_add_request_to_resume(colocation_state.request_to_resume);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1478,6 +1478,15 @@ public:
         // Consider load that is about to be scheduled.
         co_await consider_planned_load(nodes, mplan);
 
+        // Rebuild the load sketch for this DC so that get_least_loaded_shard()
+        // returns accurate results for nodes in this DC. Without this, the sketch
+        // may contain stale data from the last DC processed by make_plan(), causing
+        // shard 0 to always be selected for nodes in other DCs.
+        _load_sketch = locator::load_sketch(_tm, _table_load_stats, _force_capacity_based_balancing ? _target_tablet_size : 0);
+        _load_sketch->set_minimal_tablet_size(_minimal_tablet_size);
+        _load_sketch->set_force_capacity_based_load(_force_capacity_based_balancing);
+        co_await _load_sketch->populate_dc(dc);
+
         for (auto& [rack, colocation_sources] : racks) {
             auto dc_rack = locator::endpoint_dc_rack{dc, rack};
             auto nodes_by_load_dst = nodes | std::views::filter([&] (const auto& host_load) {

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -320,6 +320,10 @@ public:
         _restore_completions.emplace_back(std::move(info));
     }
 
+    void maybe_add_rack_list_request_to_resume(const utils::UUID& id) {
+        _rack_list_colocation_plan.maybe_add_request_to_resume(id);
+    }
+
     future<std::unordered_set<locator::global_tablet_id>> get_migration_tablet_ids() const;
 };
 

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2828,6 +2828,82 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_map_layout) {
     }, std::move(cfg)).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion_shard_distribution) {
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        auto dc1 = topo.dc();
+        auto rack1 = topo.rack();
+        [[maybe_unused]] auto host1 = topo.add_node(node_state::normal, shard_count);
+        [[maybe_unused]] auto rack2 = topo.start_new_rack();
+        [[maybe_unused]] auto host2 = topo.add_node(node_state::normal, shard_count);
+        auto rack3 = topo.start_new_rack();
+        [[maybe_unused]] auto host3 = topo.add_node(node_state::normal, shard_count);
+
+        auto ks_name = add_keyspace(e, {{dc1, 2}}, 2);
+        auto table1 = add_table(e, ks_name).get();
+
+        // shard         0 1
+        // rack1: host1:
+        // rack2: host2: A B
+        // rack3: host3: B A
+        tablet_id A{0}, B{0};
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
+            tablet_map tmap(2);
+            auto tid = tmap.first_tablet();
+            A = tid;
+            tmap.set_tablet(tid, tablet_info {  // A
+                tablet_replica_set {
+                    tablet_replica{host2, 0},
+                    tablet_replica{host3, 1},
+                }
+            });
+            tid = *tmap.next_tablet(tid);
+            B = tid;
+            tmap.set_tablet(tid, tablet_info {  // B
+                tablet_replica_set {
+                    tablet_replica{host2, 1},
+                    tablet_replica{host3, 0},
+                }
+            });
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            co_return;
+        });
+
+        auto id = utils::UUID_gen::get_time_UUID();
+        // Build the map literal for CQL
+        auto rf_change_data_cql = format("{{'replication:class': 'NetworkTopologyStrategy', 'replication:{}:0': '{}', 'replication:{}:1': '{}'}}",
+            dc1, rack1.rack, dc1, rack3.rack);
+
+        e.execute_cql(format("INSERT INTO system.topology_requests (id, request_type, done, new_keyspace_rf_change_ks_name, new_keyspace_rf_change_data) VALUES ({}, 'keyspace_rf_change', False, '{}', {})",
+            id, ks_name, rf_change_data_cql)).get();
+        auto& stm = e.shared_token_metadata().local();
+        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
+        auto& talloc = e.get_tablet_allocator().local();
+        talloc.set_load_stats(topo.get_load_stats());
+        auto& sys_ks = e.get_system_keyspace().local();
+        auto& topology = e.get_topology_state_machine().local()._topology;
+        topology.paused_rf_change_requests.insert(id);
+        migration_plan plan = talloc.balance_tablets(stm.get(), &topology, &sys_ks).get();
+
+        BOOST_REQUIRE_EQUAL(plan.migrations().size(), 2);
+        // A and B both move host2 -> host1. They must land on different shards
+        // so that host1's shards are loaded evenly. Count migrations per shard.
+        std::unordered_map<shard_id, unsigned> shard_migrations;
+        for (auto& mig : plan.migrations()) {
+            testlog.info("Rack list colocation migration: {}", mig);
+            BOOST_REQUIRE(mig.kind == locator::tablet_transition_kind::migration);
+            BOOST_REQUIRE(mig.src->host == host2);
+            BOOST_REQUIRE(mig.dst->host == host1);
+            shard_migrations[mig.dst->shard] += 1;
+        }
+        // Each of host1's two shards receives exactly one tablet.
+        BOOST_REQUIRE_EQUAL(shard_migrations[0], 1);
+        BOOST_REQUIRE_EQUAL(shard_migrations[1], 1);
+    }).get();
+}
+
 SEASTAR_THREAD_TEST_CASE(test_colocation_skipped_on_excluded_nodes) {
     do_with_cql_env_thread([] (auto& e) {
         topology_builder topo(e);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2764,6 +2764,7 @@ SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion) {
         e.execute_cql(format("INSERT INTO system.topology_requests (id, request_type, done, new_keyspace_rf_change_ks_name, new_keyspace_rf_change_data) VALUES ({}, 'keyspace_rf_change', False, '{}', {})",
             id, ks_name, rf_change_data_cql)).get();
         auto& stm = e.shared_token_metadata().local();
+        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
         auto& talloc = e.get_tablet_allocator().local();
         talloc.set_load_stats(topo.get_load_stats());
         auto& sys_ks = e.get_system_keyspace().local();
@@ -3016,9 +3017,10 @@ SEASTAR_THREAD_TEST_CASE(test_rack_list_conversion_with_two_replicas_in_rack) {
         e.execute_cql(format("INSERT INTO system.topology_requests (id, request_type, done, new_keyspace_rf_change_ks_name, new_keyspace_rf_change_data) VALUES ({}, 'keyspace_rf_change', False, '{}', {})",
             id, ks_name, rf_change_data_cql)).get();
         auto& stm = e.shared_token_metadata().local();
+        topo.get_shared_load_stats().set_default_tablet_sizes(stm.get());
         auto& topology = e.get_topology_state_machine().local()._topology;
         topology.paused_rf_change_requests.insert(id);
-        rebalance_tablets(e);
+        rebalance_tablets(e, &topo.get_shared_load_stats());
         check_rack_list(stm.get()->get_topology(), stm.get()->tablets().get_tablet_map(table1), dc1, {rack1.rack, rack2.rack});
     }).get();
 }


### PR DESCRIPTION
During a rack-list RF change, the load balancer placed all new replicas on a
target node onto shard 0 instead of spreading them across the node's shards.

The cluster self-heals (the balancer later moves tablets off the overloaded
shard 0), so this isn't a correctness bug. But it slows RF changes by roughly
nr_shards, since new-replica data streams into one shard instead of all shards
in parallel, and it triggers a wave of needless intra-node migrations to undo
the skew.

Root cause: `_load_sketch` is per-DC and rebuilt inside `make_plan()`, so after
the balancing loop it only holds data for the last DC. `make_rack_list_colocation_plan()`
runs afterwards, so for nodes in other DCs it sees zero load and always picks
shard 0. 

Fix: rebuild the sketch via `populate_dc(dc)` per DC before selecting
shards. The earlier patches are preparatory refactors.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1345.

Needs backport to 2026.1 that introduces the colocation and 2026.2