### PR TITLE
Fix missing format string placeholders across the codebase (33 bugs across 14 modules )

### DIFF
--- a/alternator/conditions.cc
+++ b/alternator/conditions.cc
@@ -681,7 +681,7 @@ static bool calculate_primitive_condition(const parsed::primitive_condition& con
     case parsed::primitive_condition::type::VALUE:
         if (calculated_values.size() != 1) {
             // Shouldn't happen unless we have a bug in the parser
-            throw std::logic_error(format("Unexpected values in primitive_condition", cond._values.size()));
+            throw std::logic_error(format("Unexpected values {} in primitive_condition", cond._values.size()));
         }
         // Unwrap the boolean wrapped as the value (if it is a boolean)
         if (calculated_values[0].IsObject() && calculated_values[0].MemberCount() == 1) {

--- a/cdc/split.cc
+++ b/cdc/split.cc
@@ -267,7 +267,7 @@ struct extract_row_visitor {
             visit_collection(v);
         },
         [&] (const abstract_type& o) {
-            throw std::runtime_error(format("extract_changes: unknown collection type:", o.name()));
+            throw std::runtime_error(format("extract_changes: unknown collection type: {}", o.name()));
         }
         ));
     }

--- a/cql3/expr/prepare_expr.cc
+++ b/cql3/expr/prepare_expr.cc
@@ -1070,7 +1070,7 @@ try_prepare_count_rows(const expr::function_call& fc, data_dictionary::database 
                                 .args = {},
                             };
                         } else {
-                            throw exceptions::invalid_request_exception(format("count() expects a column or the literal 1 as an argument", fc.args[0]));
+                            throw exceptions::invalid_request_exception(format("count() expects a column or the literal 1 as an argument, got {}", fc.args[0]));
                         }
                     }
                 }

--- a/data_dictionary/data_dictionary.cc
+++ b/data_dictionary/data_dictionary.cc
@@ -339,7 +339,7 @@ static storage_options::object_storage object_storage_from_map(std::string_view 
     }
     if (values.size() > allowed_options.size()) {
         throw std::runtime_error(fmt::format("Extraneous options for {}: {}; allowed: {}",
-            fmt::join(values | std::views::keys, ","), type,
+            type, fmt::join(values | std::views::keys, ","),
             fmt::join(allowed_options | std::views::keys, ",")));
     }
     options.type = std::string(type);

--- a/db/commitlog/commitlog_replayer.cc
+++ b/db/commitlog/commitlog_replayer.cc
@@ -217,7 +217,7 @@ future<> db::commitlog_replayer::impl::process(stats* s, commitlog::buffer_and_r
         if (cm_it == local_cm.end()) {
             if (!cer.get_column_mapping()) {
                 rlogger.debug("replaying at {} v={} at {}", fm.column_family_id(), fm.schema_version(), rp);
-                throw std::runtime_error(format("unknown schema version {}, table=", fm.schema_version(), fm.column_family_id()));
+                throw std::runtime_error(format("unknown schema version {}, table={}", fm.schema_version(), fm.column_family_id()));
             }
             rlogger.debug("new schema version {} in entry {}", fm.schema_version(), rp);
             cm_it = local_cm.emplace(fm.schema_version(), *cer.get_column_mapping()).first;

--- a/db/heat_load_balance.cc
+++ b/db/heat_load_balance.cc
@@ -327,7 +327,7 @@ redistribute(const std::vector<float>& p, unsigned me, unsigned k) {
                 }
             }
 
-            hr_logger.trace("     pp after1=", pp);
+            hr_logger.trace("     pp after1={}", pp);
             if (d.first == me) {
                 // We only care what "me" sends, and only the elements in
                 // the sorted list earlier than me could have forced it to

--- a/db/view/row_locking.cc
+++ b/db/view/row_locking.cc
@@ -150,14 +150,14 @@ row_locker::unlock(const dht::decorated_key* pk, bool partition_exclusive,
         auto pli = _two_level_locks.find(*pk);
         if (pli == _two_level_locks.end()) {
             // This shouldn't happen... We can't unlock this lock if we can't find it...
-            mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for partition", *pk);
+            mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for partition {}", *pk);
             return;
         }
         SCYLLA_ASSERT(&pli->first == pk);
         if (cpk) {
             auto rli = pli->second._row_locks.find(*cpk);
             if (rli == pli->second._row_locks.end()) {
-                mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for row", *cpk);
+                mylog.error("column_family::local_base_lock_holder::~local_base_lock_holder() can't find lock for row {}", *cpk);
                 return;
             }
             SCYLLA_ASSERT(&rli->first == cpk);

--- a/db/view/view_building_worker.cc
+++ b/db/view/view_building_worker.cc
@@ -715,7 +715,7 @@ future<> view_building_worker::do_build_range(table_id base_id, std::vector<tabl
             vbw_logger.info("Building range {} for base table {} and views {} was aborted.", range, base_id, views_ids);
         } catch (...) {
             eptr = std::current_exception();
-            vbw_logger.warn("Error during processing range {} for base table {} and views {}: ", range, base_id, views_ids, eptr);
+            vbw_logger.warn("Error during processing range {} for base table {} and views {}: {}", range, base_id, views_ids, eptr);
         }
         reader.close().get();
 

--- a/db/view/view_update_generator.cc
+++ b/db/view/view_update_generator.cc
@@ -112,7 +112,7 @@ future<> view_update_generator::start() {
     _started = seastar::async([this]() mutable {
         auto drop_sstable_references = defer([&] () noexcept {
             // Clear sstable references so sstables_manager::stop() doesn't hang.
-            vug_logger.info("leaving {} unstaged sstables unprocessed",
+            vug_logger.info("leaving {} unstaged sstables and {} sstables with tables unprocessed",
                     _sstables_to_move.size(), _sstables_with_tables.size());
             _sstables_to_move.clear();
             _sstables_with_tables.clear();

--- a/ent/encryption/kmip_host.cc
+++ b/ent/encryption/kmip_host.cc
@@ -598,7 +598,7 @@ future<int> kmip_host::impl::do_cmd(KMIP_CMD* cmd, con_ptr cp, Func& f, bool ret
 
 template<typename Func>
 future<kmip_host::impl::kmip_cmd> kmip_host::impl::do_cmd(kmip_cmd cmd_in, Func && f) {
-    kmip_log.trace("{}: begin do_cmd", *this, cmd_in);
+    kmip_log.trace("{}: begin do_cmd {}", *this, cmd_in);
     KMIP_CMD* cmd = cmd_in;
 
     // #998 Need to do retry loop, because we can have either timed out connection,

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -616,7 +616,7 @@ future<rjson::value> encryption::kms_host::impl::do_post(std::string_view target
             static auto get_xml_node = [](node_type* node, const char* what) {
                 auto res = node->first_node(what);
                 if (!res) {
-                    throw malformed_response_error(fmt::format("XML parse error", what));
+                    throw malformed_response_error(fmt::format("XML parse error: {}", what));
                 }
                 return res;
             };

--- a/mutation/mutation_partition.hh
+++ b/mutation/mutation_partition.hh
@@ -707,9 +707,10 @@ struct fmt::formatter<shadowable_tombstone> : fmt::formatter<string_view> {
     template <typename FormatContext>
     auto format(const shadowable_tombstone& t, FormatContext& ctx) const {
         if (t) {
+            auto& tomb = t.tomb();
             return fmt::format_to(ctx.out(),
                                   "{{shadowable tombstone: timestamp={}, deletion_time={}}}",
-                                  t.tomb().timestamp, t.tomb(), t.tomb().deletion_time.time_since_epoch().count());
+                                  tomb.timestamp, tomb.deletion_time.time_since_epoch().count());
         } else {
             return fmt::format_to(ctx.out(),
                                   "{{shadowable tombstone: none}}");

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -1936,7 +1936,7 @@ std::unique_ptr<server> create_server(server_id uuid, std::unique_ptr<rpc> rpc,
 }
 
 std::ostream& operator<<(std::ostream& os, const server_impl& s) {
-    fmt::print(os, "[id: {}, fsm ()]\n", s._id, *s._fsm);
+    fmt::print(os, "[id: {}, fsm ({})]\n", s._id, *s._fsm);
     return os;
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -5609,7 +5609,7 @@ future<> compaction_group::cleanup() {
     auto updater = row_cache::external_updater(std::make_unique<compaction_group_cleaner>(*this));
 
     auto p_range = to_partition_range(token_range());
-    tlogger.debug("Invalidating range {} for compaction group {} of table {} during cleanup.",
+    tlogger.debug("Invalidating range {} for compaction group {} of table {}.{} during cleanup.",
                   p_range, group_id(), _t.schema()->ks_name(), _t.schema()->cf_name());
     // Since permit is still held, all actions below will be executed atomically:
     co_await _t._cache.invalidate(std::move(updater), p_range);

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -1038,7 +1038,7 @@ with_timeout(abort_source& as, db::timeout_clock::duration d, F&& fun) {
         } catch (...) {
             // There should be no other exceptions, but just in case, catch and discard.
             // we want to propagate exceptions from `f`, not from sleep.
-            group0_log.error("unexpected exception from sleep_and_abort", std::current_exception());
+            group0_log.error("unexpected exception from sleep_and_abort: {}", std::current_exception());
         }
 
         // Translate aborts caused by timeout to `timed_out_error`.

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -496,7 +496,7 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
     };
 
     auto process_normal_node = [&] (raft::server_id id, locator::host_id host_id, std::optional<gms::inet_address> ip, const replica_state& rs) -> future<> {
-        rtlogger.trace("loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={} shards={}",
+        rtlogger.trace("loading topology: raft id={} ip={} node state={} dc={} rack={} tokens state={} tokens={} shards={} cleanup={}",
                       id, ip, rs.state, rs.datacenter, rs.rack, _topology_state_machine._topology.tstate, rs.ring.value().tokens, rs.shard_count, rs.cleanup);
         // Save tokens, not needed for raft topology management, but needed by legacy
         // Also ip -> id mapping is needed for address map recreation on reboot
@@ -5961,18 +5961,12 @@ future<join_node_request_result> storage_service::join_node_request_handler(join
         if (const auto *p = _topology_state_machine._topology.find(params.host_id)) {
             const auto& rs = p->second;
             if (rs.state == node_state::left) {
-                rtlogger.warn("the node {} attempted to join",
-                        " but it was removed from the cluster. Rejecting"
-                        " the node",
-                        params.host_id);
+                rtlogger.warn("the node {} attempted to join but it was removed from the cluster. Rejecting the node", params.host_id);
                 result.result = join_node_request_result::rejected{
                     .reason = "The node has already been removed from the cluster",
                 };
             } else {
-                rtlogger.warn("the node {} attempted to join",
-                        " again after an unfinished attempt but it is no longer"
-                        " allowed to do so. Rejecting the node",
-                        params.host_id);
+                rtlogger.warn("the node {} attempted to join again after an unfinished attempt but it is no longer allowed to do so. Rejecting the node", params.host_id);
                 result.result = join_node_request_result::rejected{
                     .reason = "The node requested to join before but didn't finish the procedure. "
                               "Please clear the data directory and restart.",

--- a/sstables/mx/partition_reversing_data_source.cc
+++ b/sstables/mx/partition_reversing_data_source.cc
@@ -502,7 +502,7 @@ public:
                 }
                 if (_row_start != _partition_end) {
                     on_internal_error(sstlog, format(
-                        "partition_reversing_data_source: invariant broken: _row_start == _row_end({}), but"
+                        "partition_reversing_data_source: invariant broken: _row_start({}) == _row_end({}), but"
                         " != _partition_end({})", _row_start, _row_end, _partition_end));
                 }
                 look_in_last_block = true;

--- a/sstables/mx/reader.cc
+++ b/sstables/mx/reader.cc
@@ -505,7 +505,7 @@ public:
             return consume_range_tombstone_boundary(std::move(pos), end_tombstone, start_tombstone);
         }
         default:
-            on_parse_error(format("Invalid boundary type", static_cast<std::underlying_type<sstables::bound_kind_m>::type>(kind)), _sst->get_filename());
+            on_parse_error(format("Invalid boundary type {}", static_cast<std::underlying_type<sstables::bound_kind_m>::type>(kind)), _sst->get_filename());
         }
     }
 
@@ -2221,7 +2221,7 @@ public:
         case bound_kind_m::excl_end_incl_start:
             return consume_range_tombstone(ecp, bound_kind::incl_start, start_tombstone);
         default:
-            on_parse_error(format("Invalid boundary type", static_cast<std::underlying_type_t<bound_kind_m>>(kind)), {});
+            on_parse_error(format("Invalid boundary type {}", static_cast<std::underlying_type_t<bound_kind_m>>(kind)), {});
         }
     }
 

--- a/transport/event_notifier.cc
+++ b/transport/event_notifier.cc
@@ -151,12 +151,12 @@ void cql_server::event_notifier::on_update_view(const sstring& ks_name, const ss
 
 void cql_server::event_notifier::on_update_function(const sstring& ks_name, const sstring& function_name)
 {
-    elogger.warn("%s event ignored", __func__);
+    elogger.warn("{} event ignored", __func__);
 }
 
 void cql_server::event_notifier::on_update_aggregate(const sstring& ks_name, const sstring& aggregate_name)
 {
-    elogger.warn("%s event ignored", __func__);
+    elogger.warn("{} event ignored", __func__);
 }
 
 void cql_server::event_notifier::on_drop_keyspace(const sstring& ks_name)
@@ -210,12 +210,12 @@ void cql_server::event_notifier::on_drop_view(const sstring& ks_name, const sstr
 
 void cql_server::event_notifier::on_drop_function(const sstring& ks_name, const sstring& function_name)
 {
-    elogger.warn("%s event ignored", __func__);
+    elogger.warn("{} event ignored", __func__);
 }
 
 void cql_server::event_notifier::on_drop_aggregate(const sstring& ks_name, const sstring& aggregate_name)
 {
-    elogger.warn("%s event ignored", __func__);
+    elogger.warn("{} event ignored", __func__);
 }
 
 future<> cql_server::event_notifier::on_before_service_level_add(qos::service_level_options, qos::service_level_info sl_info) {

--- a/types/map.hh
+++ b/types/map.hh
@@ -84,12 +84,12 @@ bytes map_type_impl::serialize_to_bytes(const Range& map_range) {
     for (const std::pair<const bytes, bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
-                fmt::format("Map key size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
+                fmt::format("Map key size too large: {} bytes > {}", elem.first.size(), std::numeric_limits<int32_t>::max()));
         }
 
         if (elem.second.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
-                fmt::format("Map value size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
+                fmt::format("Map value size too large: {} bytes > {}", elem.second.size(), std::numeric_limits<int32_t>::max()));
         }
 
         write_collection_value(out, elem.first);
@@ -121,12 +121,12 @@ managed_bytes map_type_impl::serialize_to_managed_bytes(const Range& map_range) 
     for (const std::pair<const managed_bytes, managed_bytes>& elem : map_range) {
         if (elem.first.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
-                fmt::format("Map key size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
+                fmt::format("Map key size too large: {} bytes > {}", elem.first.size(), std::numeric_limits<int32_t>::max()));
         }
 
         if (elem.second.size() > std::numeric_limits<int32_t>::max()) {
             throw exceptions::invalid_request_exception(
-                fmt::format("Map value size too large: {} bytes > {}", map_size, std::numeric_limits<int32_t>::max()));
+                fmt::format("Map value size too large: {} bytes > {}", elem.second.size(), std::numeric_limits<int32_t>::max()));
         }
 
         write_collection_value(out, elem.first);

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -629,7 +629,7 @@ future<> utils::gcp::storage::client::object_data_sink::remove_upload() {
         co_return;
     }
 
-    gcp_storage.debug("Removing incomplete upload {}:{} ()", _bucket, _object_name, _session_path);
+    gcp_storage.debug("Removing incomplete upload {}:{} ({})", _bucket, _object_name, _session_path);
 
     auto res = co_await _impl->send_with_retry(_session_path
         , GCP_OBJECT_SCOPE_READ_WRITE

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -795,7 +795,7 @@ private:
             if (etag.empty()) {
                 throw std::runtime_error("Cannot parse ETag");
             }
-            s3l.trace("Part data -> etag = {} (upload id {})", part_number, etag, _upload_id);
+            s3l.trace("Part {} data -> etag = {} (upload id {})", part_number, etag, _upload_id);
             _part_etags[part_number] = std::move(etag);
         },http::reply::status_type::ok, _as)
         .handle_exception([this, part_number](auto ex) {


### PR DESCRIPTION
## Summary

Fix 28 format string bugs plus 5 related format argument bugs across 14 modules
where `{}` placeholders were missing or arguments were wrong, causing arguments to
be silently dropped or misleading output from the `{fmt}` library.

Inspired by https://github.com/scylladb/scylladb/pull/29143 (which fixed a single
instance in `replica/table.cc`), a comprehensive audit of the entire codebase was
performed to find all similar issues.

## Bug categories

### Missing/wrong format placeholders (28 instances)
- **Missing `{}` placeholder** (21 instances): format string simply lacks `{}` for a
  passed argument, e.g. `format("msg for table {}", group_id, table_id)` -- `group_id`
  is silently dropped
- **Spurious comma breaking C++ string literal concatenation** (2 instances): a comma
  after a string literal prevents adjacent-literal concatenation, turning the
  continuation into a format argument instead of part of the format string
- **Printf-style `%s` in fmtlib context** (4 instances): `%s` has no meaning in fmtlib
  and appears as literal text while the argument is silently ignored
- **Extra spurious argument** (1 instance): an extraneous `t.tomb()` argument inserted
  between correct arguments, causing wrong values in the wrong slots

### Related format argument bugs (5 instances)
- **Wrong variable in error message** (4 instances in `types/map.hh`): error messages
  for oversized map keys/values reported `map_size` (total entry count) instead of the
  actual `elem.first.size()` or `elem.second.size()` that exceeded the limit
- **Swapped argument order** (1 instance in `data_dictionary/data_dictionary.cc`):
  format string says `"Extraneous options for {type}: {values}"` but the values and
  type arguments were passed in reverse order

## Modules affected (one commit per module)

| Module | Bugs Fixed | Files |
|--------|:---------:|-------|
| `replica/` | 1 | `table.cc` |
| `service/` | 4 | `raft_group0.cc`, `storage_service.cc` |
| `db/` | 6 | `heat_load_balance.cc`, `commitlog_replayer.cc`, `view_update_generator.cc`, `view_building_worker.cc`, `row_locking.cc` |
| `cql3/` | 2 | `prepare_expr.cc`, `statement_restrictions.cc` |
| `transport/` | 4 | `event_notifier.cc` |
| `sstables/` | 3 | `partition_reversing_data_source.cc`, `reader.cc` |
| `alternator/` | 1 | `conditions.cc` |
| `cdc/` | 1 | `split.cc` |
| `raft/` | 1 | `server.cc` |
| `utils/` | 2 | `gcp/object_storage.cc`, `s3/client.cc` |
| `mutation/` | 1 | `mutation_partition.hh` |
| `ent/` | 2 | `kmip_host.cc`, `kms_host.cc` |
| `types/` | 4 | `map.hh` |
| `data_dictionary/` | 1 | `data_dictionary.cc` |

## Root cause

The `{fmt}` library's compile-time checker validates that each `{}` placeholder
references a valid argument, but does **not** verify the reverse -- that every
argument has a corresponding placeholder. Extra arguments are silently ignored
at both compile time and runtime.

## Testing

Build verified with `dbuild ninja build/dev/scylla` -- compiles cleanly.

---

**Note:** Commits were amended to fix the author name from "Yaniv Michael Kaul" to "Yaniv Kaul".