### PR TITLE
tablet_allocator: fix livelock in rack_list colocation when target rack has no available nodes

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -432,7 +432,26 @@ future<bool> requires_rack_list_colocation(
         db::system_keyspace* sys_ks,
         utils::UUID request_id) {
     auto res = co_await find_required_rack_list_colocations(db, tmptr, sys_ks, {request_id}, {});
-    co_return res.request_to_resume != request_id;
+    if (res.request_to_resume == request_id) {
+        co_return false;
+    }
+    // Colocation is still needed. Check that every target rack has at least one
+    // available node, otherwise the request can never complete and would livelock
+    // bouncing between paused and resumed states.
+    const auto& topo = tmptr->get_topology();
+    for (const auto& [dc_rack, _] : res.dst_dc_rack_to_tablets) {
+        bool has_node = false;
+        topo.for_each_node([&] (const locator::node& node) {
+            if (!has_node && node.dc_rack() == dc_rack && node.get_state() == locator::node::state::normal && !node.is_excluded()) {
+                has_node = true;
+            }
+        });
+        if (!has_node) {
+            throw std::runtime_error(format("No available nodes in dc={}, rack={} for rack_list colocation", dc_rack.dc, dc_rack.rack));
+        }
+        co_await coroutine::maybe_yield();
+    }
+    co_return true;
 }
 
 }

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -505,8 +505,11 @@ struct fmt::formatter<service::plan_summary> : fmt::formatter<std::string_view> 
         if (plan.resize_plan().finalize_resize.size()) {
             fmt::format_to(ctx.out(), "{}resize-ready: {}", get_delim(), plan.resize_plan().finalize_resize.size());
         }
-        if (plan.rack_list_colocation_plan().size()) {
+        if (plan.rack_list_colocation_plan().request_to_resume()) {
             fmt::format_to(ctx.out(), "{}rack-list colocation ready: {}", get_delim(), plan.rack_list_colocation_plan().request_to_resume());
+        }
+        if (const auto& failure = plan.rack_list_colocation_plan().request_to_fail(); failure) {
+            fmt::format_to(ctx.out(), "{}rack-list colocation failed: {} ({})", get_delim(), failure->request_id, failure->error);
         }
         if (!plan.restore_completions().empty()) {
             fmt::format_to(ctx.out(), "{}restore completed for: {}", get_delim(), plan.restore_completions() | std::views::transform(&service::restore_completion_info::table));
@@ -1466,7 +1469,7 @@ public:
         const locator::topology& topo = _tm->get_topology();
 
         node_load_map nodes;
-        topo.for_each_node([&] (const locator::node& node) {
+        _tm->for_each_token_owner([&] (const locator::node& node) {
             if (node.get_state() == locator::node::state::normal && !node.is_excluded() && node.dc_rack().dc == dc) {
                 ensure_node(nodes, node.host_id());
             }
@@ -1496,9 +1499,10 @@ public:
             }) | std::views::keys | std::ranges::to<std::vector<host_id>>();
 
             if (nodes_by_load_dst.empty()) {
-                lblogger.warn("No target nodes available for RF change colocation plan in dc {}, rack {}", dc, rack);
+                auto error = format("No target nodes available for RF change colocation plan in dc {}, rack {}", dc, rack);
+                lblogger.warn("{}", error);
                 if (auto rack_it = requests_for_dc.find(rack); rack_it != requests_for_dc.end()) {
-                    plan.maybe_add_rack_list_request_to_resume(*rack_it->second.begin());
+                    plan.maybe_add_rack_list_request_to_fail(*rack_it->second.begin(), std::move(error));
                 }
                 continue;
             }

--- a/service/tablet_allocator.hh
+++ b/service/tablet_allocator.hh
@@ -173,22 +173,41 @@ struct tablet_repair_plan {
     }
 };
 
+struct rack_list_colocation_failure {
+    utils::UUID request_id;
+    sstring error;
+};
+
 struct tablet_rack_list_colocation_plan {
     utils::UUID _request_to_resume;
+    std::optional<rack_list_colocation_failure> _request_to_fail;
 
     const utils::UUID& request_to_resume() const noexcept {
         return _request_to_resume;
     }
 
-    size_t size() const { return _request_to_resume ? 1 : 0; };
+    const std::optional<rack_list_colocation_failure>& request_to_fail() const noexcept {
+        return _request_to_fail;
+    }
+
+    size_t size() const { return (_request_to_resume ? 1 : 0) + (_request_to_fail ? 1 : 0); };
 
     void merge(tablet_rack_list_colocation_plan&& other) {
         _request_to_resume = _request_to_resume ? _request_to_resume : other._request_to_resume;
+        if (!_request_to_fail) {
+            _request_to_fail = std::move(other._request_to_fail);
+        }
     }
 
     void maybe_add_request_to_resume(const utils::UUID& id) {
         if (!_request_to_resume) {
             _request_to_resume = id;
+        }
+    }
+
+    void maybe_add_request_to_fail(const utils::UUID& id, sstring error) {
+        if (!_request_to_fail) {
+            _request_to_fail = rack_list_colocation_failure{id, std::move(error)};
         }
     }
 };
@@ -322,6 +341,10 @@ public:
 
     void maybe_add_rack_list_request_to_resume(const utils::UUID& id) {
         _rack_list_colocation_plan.maybe_add_request_to_resume(id);
+    }
+
+    void maybe_add_rack_list_request_to_fail(const utils::UUID& id, sstring error) {
+        _rack_list_colocation_plan.maybe_add_request_to_fail(id, std::move(error));
     }
 
     future<std::unordered_set<locator::global_tablet_id>> get_migration_tablet_ids() const;

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1814,6 +1814,19 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
                 .build());
     }
 
+    // Drops the request paused for rack_list colocation without queueing it again
+    // and reports the error to the client.
+    // The keyspace metadata is not touched, as it is not modified before the colocation is done.
+    void generate_rack_list_colocation_failure_update(group0_update_collector& out, const group0_guard& guard, const rack_list_colocation_failure& failure) {
+        rtlogger.warn("Failing request {} paused for rack_list colocation: {}", failure.request_id, failure.error);
+        out.emplace_back(topology_mutation_builder(guard.write_timestamp())
+                .resume_rf_change_request(_topo_sm._topology.paused_rf_change_requests, failure.request_id)
+                .build());
+        out.emplace_back(topology_request_tracking_mutation_builder(failure.request_id)
+                .done(failure.error)
+                .build());
+    }
+
     // Updates keyspace properties; removes system_schema.keyspaces::next_replication;
     // finishes RF change request; Removes request from system.topology::ongoing_rf_changes.
     void generate_rf_change_completion_update(group0_update_collector& out, const group0_guard& guard, const rf_change_completion_info& completion) {
@@ -1914,6 +1927,10 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
 
             if (auto request_to_resume = plan.rack_list_colocation_plan().request_to_resume(); request_to_resume) {
                 generate_rf_change_resume_update(out, guard, request_to_resume);
+            }
+
+            if (const auto& request_to_fail = plan.rack_list_colocation_plan().request_to_fail(); request_to_fail) {
+                generate_rack_list_colocation_failure_update(out, guard, *request_to_fail);
             }
 
             co_await generate_rf_change_updates(out, guard, plan.rf_change_plan());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -2124,6 +2124,9 @@ future<> apply_plan(token_metadata& tm, const migration_plan& plan, service::top
     if (auto request_id = plan.rack_list_colocation_plan().request_to_resume(); request_id) {
         topology.paused_rf_change_requests.erase(request_id);
     }
+    if (const auto& failure = plan.rack_list_colocation_plan().request_to_fail(); failure) {
+        topology.paused_rf_change_requests.erase(failure->request_id);
+    }
     co_await apply_repair_transitions(tm, plan);
 }
 

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -751,6 +751,109 @@ async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient)
     for r in tablet_replicas:
         assert len(r.replicas) == 2
 
+# Regression test: when the target rack in a rack_list colocation has no
+# available nodes (all excluded), the ALTER KEYSPACE must fail promptly
+# instead of livelocking with the request endlessly bouncing between
+# paused and resumed states.
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_rack_list_colocation_livelock_no_target_nodes(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    async def get_replication_options(ks: str, host=None):
+        res = await cql.run_async(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks}'", host=host)
+        repl = parse_replication_options(res[0].replication_v2 or res[0].replication)
+        return repl
+
+    numeric_injection = "create_with_numeric"
+    colocation_injection = "wait_with_rack_list_colocation"
+    config = {
+        "tablets_mode_for_new_keyspaces": "enabled",
+        "error_injections_at_startup": [numeric_injection, colocation_injection],
+        "failure_detector_timeout_in_ms": 2000,
+        "tablet_load_stats_refresh_interval_in_seconds": 1,
+    }
+    cmdline = ['--logger-log-level', 'load_balancer=debug', '--smp=2']
+
+    servers = [
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+    ]
+
+    host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    live_host = hosts[0]
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} AND tablets = {'initial': 8}", host=live_host) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY);", host=live_host)
+        repl = await get_replication_options(ks, host=live_host)
+        assert repl['dc1'] == '1'
+
+        # Verify at least one tablet is on rack1a so colocation is triggered
+        # when we ALTER to ['rack1b'].
+        tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, "t")
+        rack1a_tablets = [r for r in tablet_replicas if r.replicas[0][0] in (host_ids[0], host_ids[1])]
+        assert len(rack1a_tablets) > 0, "Need at least one tablet on rack1a for colocation to trigger"
+
+        # Disable the numeric injection so ALTER produces rack_list format.
+        for s in servers:
+            await manager.api.disable_injection(s.ip_addr, numeric_injection)
+
+        # Find topology coordinator and open its log.
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await find_server_by_host_id(manager, servers, coord)
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+        mark = await coord_log.mark()
+
+        # ALTER KEYSPACE in background: convert numeric RF=1 to rack_list ['rack1b'].
+        # Tablets on rack1a need colocation to rack1b first. The injection prevents
+        # colocation from progressing.
+        async def alter_keyspace():
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1b']}};", host=live_host)
+        alter_task = asyncio.create_task(alter_keyspace())
+
+        # Wait for the request to be paused for colocation.
+        await coord_log.wait_for(f'keyspace_rf_change for keyspace {ks} postponed for colocation', from_mark=mark)
+
+        # Stop the rack1b node and mark it as excluded. The node remains in the
+        # topology with state=normal but is_excluded()=true, so
+        # make_rack_list_colocation_plan skips it when building nodes_by_load_dst.
+        await manager.server_stop(servers[2].server_id)
+        await manager.others_not_see_server(servers[2].ip_addr)
+        await manager.api.exclude_node(servers[0].ip_addr, hosts=[host_ids[2]])
+        live_servers = servers[:2]
+
+        # Re-detect coordinator (may have changed if servers[2] was the coordinator).
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await find_server_by_host_id(manager, live_servers, coord)
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+
+        # Disable the colocation injection on live nodes so the real colocation
+        # plan runs. rack1b has no non-excluded nodes, so the system must detect
+        # the situation and fail the ALTER rather than looping forever.
+        for s in live_servers:
+            await manager.api.disable_injection(s.ip_addr, colocation_injection)
+
+        # The ALTER must complete (with an error) within a reasonable time.
+        # If the livelock bug is present, this times out.
+        try:
+            await asyncio.wait_for(alter_task, timeout=60)
+        except asyncio.TimeoutError:
+            alter_task.cancel()
+            try:
+                await alter_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            pytest.fail("ALTER KEYSPACE livelocked: request kept bouncing between paused and resumed states")
+        except Exception:
+            pass  # Expected: ALTER should fail when target rack has no available nodes
+
+        # The ALTER should not have succeeded — the keyspace must still have
+        # its original numeric RF.
+        repl = await get_replication_options(ks, host=live_host)
+        assert repl['dc1'] == '1'
+
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads
 # from is migrated away.

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1335,6 +1335,109 @@ async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient)
     for r in tablet_replicas:
         assert len(r.replicas) == 2
 
+# Regression test: when the target rack in a rack_list colocation has no
+# available nodes (all excluded), the ALTER KEYSPACE must fail promptly
+# instead of livelocking with the request endlessly bouncing between
+# paused and resumed states.
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_rack_list_colocation_livelock_no_target_nodes(request: pytest.FixtureRequest, manager: ManagerClient) -> None:
+    async def get_replication_options(ks: str, host=None):
+        res = await cql.run_async(f"SELECT * FROM system_schema.keyspaces WHERE keyspace_name = '{ks}'", host=host)
+        repl = parse_replication_options(res[0].replication_v2 or res[0].replication)
+        return repl
+
+    numeric_injection = "create_with_numeric"
+    colocation_injection = "wait_with_rack_list_colocation"
+    config = {
+        "tablets_mode_for_new_keyspaces": "enabled",
+        "error_injections_at_startup": [numeric_injection, colocation_injection],
+        "failure_detector_timeout_in_ms": 2000,
+        "tablet_load_stats_refresh_interval_in_seconds": 1,
+    }
+    cmdline = ['--logger-log-level', 'load_balancer=debug', '--smp=2']
+
+    servers = [
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1a'}),
+        await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
+    ]
+
+    host_ids = [await manager.get_host_id(s.server_id) for s in servers]
+
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    live_host = hosts[0]
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} AND tablets = {'initial': 8}", host=live_host) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY);", host=live_host)
+        repl = await get_replication_options(ks, host=live_host)
+        assert repl['dc1'] == '1'
+
+        # Verify at least one tablet is on rack1a so colocation is triggered
+        # when we ALTER to ['rack1b'].
+        tablet_replicas = await get_all_tablet_replicas(manager, servers[0], ks, "t")
+        rack1a_tablets = [r for r in tablet_replicas if r.replicas[0][0] in (host_ids[0], host_ids[1])]
+        assert len(rack1a_tablets) > 0, "Need at least one tablet on rack1a for colocation to trigger"
+
+        # Disable the numeric injection so ALTER produces rack_list format.
+        for s in servers:
+            await manager.api.disable_injection(s.ip_addr, numeric_injection)
+
+        # Find topology coordinator and open its log.
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await manager.find_server_by_host_id(servers, coord)
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+        mark = await coord_log.mark()
+
+        # ALTER KEYSPACE in background: convert numeric RF=1 to rack_list ['rack1b'].
+        # Tablets on rack1a need colocation to rack1b first. The injection prevents
+        # colocation from progressing.
+        async def alter_keyspace():
+            await cql.run_async(f"ALTER KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1b']}};", host=live_host)
+        alter_task = asyncio.create_task(alter_keyspace())
+
+        # Wait for the request to be paused for colocation.
+        await coord_log.wait_for(f'keyspace_rf_change for keyspace {ks} postponed for colocation', from_mark=mark)
+
+        # Stop the rack1b node and mark it as excluded. The node remains in the
+        # topology with state=normal but is_excluded()=true, so
+        # make_rack_list_colocation_plan skips it when building nodes_by_load_dst.
+        await manager.server_stop(servers[2].server_id, convict=True)
+        await manager.others_not_see_server(servers[2].ip_addr)
+        await manager.api.exclude_node(servers[0].ip_addr, hosts=[host_ids[2]])
+        live_servers = servers[:2]
+
+        # Re-detect coordinator (may have changed if servers[2] was the coordinator).
+        coord = await get_topology_coordinator(manager)
+        coord_serv = await manager.find_server_by_host_id(live_servers, coord)
+        coord_log = await manager.server_open_log(coord_serv.server_id)
+
+        # Disable the colocation injection on live nodes so the real colocation
+        # plan runs. rack1b has no non-excluded nodes, so the system must detect
+        # the situation and fail the ALTER rather than looping forever.
+        for s in live_servers:
+            await manager.api.disable_injection(s.ip_addr, colocation_injection)
+
+        # The ALTER must complete (with an error) within a reasonable time.
+        # If the livelock bug is present, this times out.
+        try:
+            await asyncio.wait_for(alter_task, timeout=60)
+        except asyncio.TimeoutError:
+            alter_task.cancel()
+            try:
+                await alter_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            pytest.fail("ALTER KEYSPACE livelocked: request kept bouncing between paused and resumed states")
+        except Exception:
+            pass  # Expected: ALTER should fail when target rack has no available nodes
+
+        # The ALTER should not have succeeded — the keyspace must still have
+        # its original numeric RF.
+        repl = await get_replication_options(ks, host=live_host)
+        assert repl['dc1'] == '1'
+
 # Reproducer for https://github.com/scylladb/scylladb/issues/18110
 # Check that an existing cached read, will be cleaned up when the tablet it reads
 # from is migrated away.


### PR DESCRIPTION
When altering a keyspace to use rack_list replication and the target rack has no available nodes (e.g. stopped and excluded), the RF change request livelocks, endlessly bouncing between paused and resumed states.

The root cause is that make_rack_list_colocation_plan finds no nodes in the target rack and resumes the paused request without generating any migrations. The topology coordinator re-processes the resumed request, sees tablets still need moving, and pauses it again, ad infinitum.

Fix requires_rack_list_colocation to check that every target rack has at least one normal, non-excluded node after determining colocation is still needed. If any target rack has no available nodes, throw an exception which propagates to the keyspace_rf_change handler's existing catch block, failing the request with an error returned to the client.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1526.

Needs backport to 2026.1 that introduces rack list colocation