### PR TITLE
build: add -ftime-trace support for compilation profiling

### DIFF
--- a/cmake/mode.common.cmake
+++ b/cmake/mode.common.cmake
@@ -137,6 +137,24 @@ endfunction()
 
 option(Scylla_WITH_DEBUG_INFO "Enable debug info" OFF)
 
+# Time trace profiling: adds -ftime-trace to all C++ compilations (Clang only).
+# Each .o produces a companion .json file in the build directory that can be
+# analyzed with ClangBuildAnalyzer or loaded in chrome://tracing.
+#
+# Usage:
+#   cmake -DScylla_TIME_TRACE=ON ...
+#   ninja
+#   # Analyze results (requires ClangBuildAnalyzer):
+#   ClangBuildAnalyzer --all <build-dir> capture.bin
+#   ClangBuildAnalyzer --analyze capture.bin
+option(Scylla_TIME_TRACE "Enable Clang -ftime-trace for build profiling" OFF)
+if(Scylla_TIME_TRACE)
+  if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR "Scylla_TIME_TRACE requires Clang (found ${CMAKE_CXX_COMPILER_ID})")
+  endif()
+  add_compile_options(-ftime-trace)
+endif()
+
 macro(update_build_flags config)
   cmake_parse_arguments (
     parsed_args

--- a/configure.py
+++ b/configure.py
@@ -853,6 +853,10 @@ arg_parser.add_argument('--coverage', action = 'store_true', help = 'Compile scy
 arg_parser.add_argument('--build-dir', action='store', default='build',
                         help='Build directory path')
 arg_parser.add_argument('--disable-precompiled-header', action='store_true', default=False, help='Disable precompiled header for scylla binary')
+arg_parser.add_argument('--time-trace', action='store_true', default=False,
+                        help='Enable Clang -ftime-trace for build profiling. '
+                             'Each .o produces a .json file analyzable with '
+                             'ClangBuildAnalyzer or chrome://tracing')
 arg_parser.add_argument('-h', '--help', action='store_true', help='show this help message and exit')
 args = arg_parser.parse_args()
 if args.help:
@@ -1961,6 +1965,9 @@ user_cflags += ' -fextend-variable-liveness=none'
 
 if args.target != '':
     user_cflags += ' -march=' + args.target
+
+if args.time_trace:
+    user_cflags += ' -ftime-trace'
 
 for mode in modes:
     # Those flags are passed not only to Scylla objects, but also to libraries


### PR DESCRIPTION
## Summary

- Add `--time-trace` flag to `configure.py` and `Scylla_TIME_TRACE` CMake option to enable Clang's `-ftime-trace` on all C++ compilations
- When enabled, each `.o` produces a companion `.json` trace file for analysis with [ClangBuildAnalyzer](https://github.com/ArasLabs/ClangBuildAnalyzer) or `chrome://tracing`
- Foundation for data-driven build speed improvements

## Usage

**configure.py:**
```bash
./configure.py --time-trace --mode dev
ninja build/dev/scylla
```

**CMake:**
```bash
cmake -DScylla_TIME_TRACE=ON -DCMAKE_BUILD_TYPE=Dev ..
ninja
```

**Analysis:**
```bash
ClangBuildAnalyzer --all build/dev capture.bin
ClangBuildAnalyzer --analyze capture.bin
```

Refs #1