### PR TITLE
Remove legacy tables creation code

### DIFF
--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -118,10 +118,6 @@ std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
     return {view_build_status(), cdc_desc(), cdc_timestamps()};
 }
 
-std::vector<schema_ptr> system_distributed_keyspace::all_everywhere_tables() {
-    return {};
-}
-
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
         : _qp(qp)
         , _mm(mm)
@@ -138,7 +134,7 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
 
     while (true) {
         // Check if there is any work to do before taking the group 0 guard.
-        bool keyspaces_setup = db.has_keyspace(NAME) && db.has_keyspace(NAME_EVERYWHERE);
+        bool keyspaces_setup = db.has_keyspace(NAME);
         bool tables_setup = std::all_of(tables.begin(), tables.end(), [db] (schema_ptr t) { return db.has_schema(t->ks_name(), t->cf_name()); } );
         if (keyspaces_setup && tables_setup) {
             dlogger.info("system_distributed(_everywhere) keyspaces and tables are up-to-date. Not creating");
@@ -151,37 +147,22 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
         utils::chunked_vector<mutation> mutations;
         sstring description;
 
-        auto sd_ksm = keyspace_metadata::new_keyspace(
+        auto ksm = keyspace_metadata::new_keyspace(
                 NAME,
                 "org.apache.cassandra.locator.SimpleStrategy",
                 {{"replication_factor", "3"}},
                 std::nullopt, std::nullopt);
         if (!db.has_keyspace(NAME)) {
-            mutations = service::prepare_new_keyspace_announcement(db.real_database(), sd_ksm, ts);
+            mutations = service::prepare_new_keyspace_announcement(db.real_database(), ksm, ts);
             description += format(" create {} keyspace;", NAME);
         } else {
             dlogger.info("{} keyspace is already present. Not creating", NAME);
         }
 
-        auto sde_ksm = keyspace_metadata::new_keyspace(
-                NAME_EVERYWHERE,
-                "org.apache.cassandra.locator.EverywhereStrategy",
-                {},
-                std::nullopt, std::nullopt);
-        if (!db.has_keyspace(NAME_EVERYWHERE)) {
-            auto sde_mutations = service::prepare_new_keyspace_announcement(db.real_database(), sde_ksm, ts);
-            std::move(sde_mutations.begin(), sde_mutations.end(), std::back_inserter(mutations));
-            description += format(" create {} keyspace;", NAME_EVERYWHERE);
-        } else {
-            dlogger.info("{} keyspace is already present. Not creating", NAME_EVERYWHERE);
-        }
-
         // Get mutations for creating tables.
         auto num_keyspace_mutations = mutations.size();
         co_await coroutine::parallel_for_each(ensured_tables(),
-                [this, &mutations, db, ts, sd_ksm, sde_ksm] (auto&& table) -> future<> {
-            auto ksm = table->ks_name() == NAME ? sd_ksm : sde_ksm;
-
+                [this, &mutations, db, ts, ksm] (auto&& table) -> future<> {
             if (!db.has_schema(table->ks_name(), table->cf_name())) {
                 co_return co_await service::prepare_new_column_family_announcement(mutations, _sp, *ksm, std::move(table), ts);
             }

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -40,8 +40,7 @@ extern logging::logger cdc_log;
 namespace db {
 namespace {
     const auto set_wait_for_sync_to_commitlog = schema_builder::register_schema_initializer([](schema_builder& builder) {
-        if ((builder.ks_name() == system_distributed_keyspace::NAME_EVERYWHERE && builder.cf_name() == system_distributed_keyspace::CDC_GENERATIONS_V2) ||
-            (builder.ks_name() == system_distributed_keyspace::NAME && builder.cf_name() == system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION))
+        if (builder.ks_name() == system_distributed_keyspace::NAME && builder.cf_name() == system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION)
         {
             builder.set_wait_for_sync_to_commitlog(true);
         }
@@ -51,14 +50,6 @@ namespace {
 extern thread_local data_type cdc_streams_set_type;
 thread_local data_type cdc_streams_set_type = set_type_impl::get_instance(bytes_type, false);
 
-/* See `token_range_description` struct */
-thread_local data_type cdc_streams_list_type = list_type_impl::get_instance(bytes_type, false);
-thread_local data_type cdc_token_range_description_type = tuple_type_impl::get_instance(
-        { long_type             // dht::token token_range_end;
-        , cdc_streams_list_type // std::vector<stream_id> streams;
-        , byte_type             // uint8_t sharding_ignore_msb;
-        });
-thread_local data_type cdc_generation_description_type = list_type_impl::get_instance(cdc_token_range_description_type, false);
 
 schema_ptr view_build_status() {
     static thread_local auto schema = [] {
@@ -74,42 +65,6 @@ schema_ptr view_build_status() {
     return schema;
 }
 
-/* An internal table used by nodes to exchange CDC generation data. */
-schema_ptr cdc_generations_v2() {
-    thread_local auto schema = [] {
-        auto id = generate_legacy_id(system_distributed_keyspace::NAME_EVERYWHERE, system_distributed_keyspace::CDC_GENERATIONS_V2);
-        return schema_builder(system_distributed_keyspace::NAME_EVERYWHERE, system_distributed_keyspace::CDC_GENERATIONS_V2, {id})
-                /* The unique identifier of this generation. */
-                .with_column("id", uuid_type, column_kind::partition_key)
-                /* The generation describes a mapping from all tokens in the token ring to a set of stream IDs.
-                 * This mapping is built from a bunch of smaller mappings, each describing how tokens in a subrange
-                 * of the token ring are mapped to stream IDs; these subranges together cover the entire token ring.
-                 * Each such range-local mapping is represented by a row of this table.
-                 * The clustering key of the row is the end of the range being described by this row.
-                 * The start of this range is the range_end of the previous row (in the clustering order, which is the integer order)
-                 * or of the last row of this partition if this is the first the first row. */
-                .with_column("range_end", long_type, column_kind::clustering_key)
-                /* The set of streams mapped to in this range.
-                 * The number of streams mapped to a single range in a CDC generation is bounded from above by the number
-                 * of shards on the owner of that range in the token ring.
-                 * In other words, the number of elements of this set is bounded by the maximum of the number of shards
-                 * over all nodes. The serialized size is obtained by counting about 20B for each stream.
-                 * For example, if all nodes in the cluster have at most 128 shards,
-                 * the serialized size of this set will be bounded by ~2.5 KB. */
-                .with_column("streams", cdc_streams_set_type)
-                /* The value of the `ignore_msb` sharding parameter of the node which was the owner of this token range
-                 * when the generation was first created. Together with the set of streams above it fully describes
-                 * the mapping for this particular range. */
-                .with_column("ignore_msb", byte_type)
-                /* Column used for sanity checking.
-                 * For a given generation it's equal to the number of ranges in this generation;
-                 * thus, after the generation is fully inserted, it must be equal to the number of rows in the partition. */
-                .with_column("num_ranges", int32_type, column_kind::static_column)
-                .with_hash_version()
-                .build();
-    }();
-    return schema;
-}
 
 /* A user-facing table providing identifiers of the streams used in CDC generations. */
 schema_ptr cdc_desc() {
@@ -162,7 +117,6 @@ static const sstring CDC_TIMESTAMPS_KEY = "timestamps";
 static std::vector<schema_ptr> ensured_tables() {
     return {
         view_build_status(),
-        cdc_generations_v2(),
         cdc_desc(),
         cdc_timestamps(),
     };
@@ -173,7 +127,7 @@ std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_everywhere_tables() {
-    return {cdc_generations_v2()};
+    return {};
 }
 
 system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& qp, service::migration_manager& mm, service::storage_proxy& sp)
@@ -300,90 +254,6 @@ static service::query_state& internal_distributed_query_state() {
  */
 static db::consistency_level quorum_if_many(size_t num_token_owners) {
     return num_token_owners > 1 ? db::consistency_level::QUORUM : db::consistency_level::ONE;
-}
-
-future<>
-system_distributed_keyspace::insert_cdc_generation(
-        utils::UUID id,
-        const cdc::topology_description& desc,
-        context ctx) {
-    using namespace std::chrono_literals;
-
-    const size_t concurrency = 10;
-    const size_t num_replicas = ctx.num_token_owners;
-
-    // To insert the data quickly and efficiently we send it in batches of multiple rows
-    // (each batch represented by a single mutation). We also send multiple such batches concurrently.
-    // However, we need to limit the memory consumption of the operation.
-    // I assume that the memory consumption grows linearly with the number of replicas
-    // (we send to all replicas ``at the same time''), with the batch size (the data must
-    // be copied for each replica?) and with concurrency. These assumptions may be too conservative
-    // but that won't hurt in a significant way (it may hurt the efficiency of the operation a little).
-    // Thus, if we want to limit the memory consumption to L, it should be true that
-    // mutation_size * num_replicas * concurrency <= L, hence
-    // mutation_size <= L / (num_replicas * concurrency).
-    // For example, say L = 10MB, concurrency = 10, num_replicas = 100; we get
-    // mutation_size <= 10MB / 1000 = 10KB.
-    // On the other hand we must have mutation_size >= size of a single row,
-    // so we will use mutation_size <= max(size of single row, L/(num_replicas*concurrency)).
-
-    // It has been tested that sending 1MB batches to 3 replicas with concurrency 20 works OK,
-    // which would correspond to L ~= 60MB. Hence that's the limit we use here.
-    const size_t L = 60'000'000;
-    const auto mutation_size_threshold = std::max(size_t(1), L / (num_replicas * concurrency));
-
-    auto s = _qp.db().real_database().find_schema(
-        system_distributed_keyspace::NAME_EVERYWHERE, system_distributed_keyspace::CDC_GENERATIONS_V2);
-    auto ms = co_await cdc::get_cdc_generation_mutations_v2(s, id, desc, mutation_size_threshold, api::new_timestamp());
-    co_await max_concurrent_for_each(ms, concurrency, [&] (mutation& m) -> future<> {
-        co_await _sp.mutate(
-            { std::move(m) },
-            db::consistency_level::ALL,
-            db::timeout_clock::now() + 60s,
-            nullptr, // trace_state
-            empty_service_permit(),
-            db::allow_per_partition_rate_limit::no,
-            false // raw_counters
-        );
-    });
-}
-
-future<std::optional<cdc::topology_description>>
-system_distributed_keyspace::read_cdc_generation(utils::UUID id) {
-    utils::chunked_vector<cdc::token_range_description> entries;
-    size_t num_ranges = 0;
-    co_await _qp.query_internal(
-            // This should be a local read so 20s should be more than enough
-            format("SELECT range_end, streams, ignore_msb, num_ranges FROM {}.{} WHERE id = ? USING TIMEOUT 20s", NAME_EVERYWHERE, CDC_GENERATIONS_V2),
-            db::consistency_level::ONE, // we wrote the generation with ALL so ONE must see it (or there's something really wrong)
-            { id },
-            1000, // for ~1KB rows, ~1MB page size
-            [&] (const cql3::untyped_result_set_row& row) {
-
-        std::vector<cdc::stream_id> streams;
-        row.get_list_data<bytes>("streams", std::back_inserter(streams));
-        entries.push_back(cdc::token_range_description{
-                dht::token::from_int64(row.get_as<int64_t>("range_end")),
-                std::move(streams),
-                uint8_t(row.get_as<int8_t>("ignore_msb"))});
-        num_ranges = row.get_as<int32_t>("num_ranges");
-        return make_ready_future<stop_iteration>(stop_iteration::no);
-    });
-
-    if (entries.empty()) {
-        co_return std::nullopt;
-    }
-
-    // Paranoic sanity check. Partial reads should not happen since generations should be retrieved only after they
-    // were written successfully with CL=ALL. But nobody uses EverywhereStrategy tables so they weren't ever properly
-    // tested, so just in case...
-    if (entries.size() != num_ranges) {
-        throw std::runtime_error(format(
-                "read_cdc_generation: wrong number of rows. The `num_ranges` column claimed {} rows,"
-                " but reading the partition returned {}.", num_ranges, entries.size()));
-    }
-
-    co_return std::optional{cdc::topology_description(std::move(entries))};
 }
 
 static future<utils::chunked_vector<mutation>> get_cdc_streams_descriptions_v2_mutation(

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -38,14 +38,6 @@ static logging::logger dlogger("system_distributed_keyspace");
 extern logging::logger cdc_log;
 
 namespace db {
-namespace {
-    const auto set_wait_for_sync_to_commitlog = schema_builder::register_schema_initializer([](schema_builder& builder) {
-        if (builder.ks_name() == system_distributed_keyspace::NAME && builder.cf_name() == system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION)
-        {
-            builder.set_wait_for_sync_to_commitlog(true);
-        }
-    });
-}
 
 extern thread_local data_type cdc_streams_set_type;
 thread_local data_type cdc_streams_set_type = set_type_impl::get_instance(bytes_type, false);

--- a/db/system_distributed_keyspace.cc
+++ b/db/system_distributed_keyspace.cc
@@ -13,7 +13,6 @@
 #include "replica/database.hh"
 #include "db/consistency_level_type.hh"
 #include "db/system_keyspace.hh"
-#include "db/config.hh"
 #include "schema/schema_builder.hh"
 #include "timeout_config.hh"
 #include "types/types.hh"
@@ -22,8 +21,6 @@
 #include "cdc/generation.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_proxy.hh"
-#include "gms/feature_service.hh"
-
 #include "service/migration_manager.hh"
 #include "locator/host_id.hh"
 
@@ -152,23 +149,6 @@ schema_ptr cdc_timestamps() {
 
 static const sstring CDC_TIMESTAMPS_KEY = "timestamps";
 
-schema_ptr service_levels() {
-    static thread_local auto schema = [] {
-        auto id = generate_legacy_id(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS);
-        auto builder = schema_builder(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS, std::make_optional(id))
-                .with_column("service_level", utf8_type, column_kind::partition_key)
-                .with_column("shares", int32_type);
-        if (utils::get_local_injector().is_enabled("service_levels_v1_table_without_shares")) {
-            builder.remove_column("shares");
-        }
-
-        return builder
-                .with_hash_version()
-                .build();
-    }();
-    return schema;
-}
-
 // This is the set of tables which this node ensures to exist in the cluster.
 // It does that by announcing the creation of these schemas on initialization
 // of the `system_distributed_keyspace` service (see `start()`), unless it first
@@ -185,12 +165,11 @@ static std::vector<schema_ptr> ensured_tables() {
         cdc_generations_v2(),
         cdc_desc(),
         cdc_timestamps(),
-        service_levels(),
     };
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_distributed_tables() {
-    return {view_build_status(), cdc_desc(), cdc_timestamps(), service_levels()};
+    return {view_build_status(), cdc_desc(), cdc_timestamps()};
 }
 
 std::vector<schema_ptr> system_distributed_keyspace::all_everywhere_tables() {
@@ -203,36 +182,6 @@ system_distributed_keyspace::system_distributed_keyspace(cql3::query_processor& 
         , _sp(sp) {
 }
 
-static std::vector<std::pair<std::string_view, data_type>> new_service_levels_columns(bool workload_prioritization_enabled) {
-    std::vector<std::pair<std::string_view, data_type>> new_columns {{"timeout", duration_type}, {"workload_type", utf8_type}};
-    if (workload_prioritization_enabled) {
-        new_columns.push_back({"shares", int32_type});
-    }
-    return new_columns;
-};
-
-static schema_ptr get_current_service_levels(data_dictionary::database db) {
-    return db.has_schema(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS)
-            ? db.find_schema(system_distributed_keyspace::NAME, system_distributed_keyspace::SERVICE_LEVELS)
-            : service_levels();
-}
-
-static schema_ptr get_updated_service_levels(data_dictionary::database db, bool workload_prioritization_enabled) {
-    SCYLLA_ASSERT(this_shard_id() == 0);
-    auto schema = get_current_service_levels(db);
-    schema_builder b(schema);
-    for (const auto& col : new_service_levels_columns(workload_prioritization_enabled)) {
-        auto& [col_name, col_type] = col;
-        bytes options_name = to_bytes(col_name.data());
-        if (schema->get_column_definition(options_name)) {
-            continue;
-        }
-        b.with_column(options_name, col_type, column_kind::regular_column);
-    }
-    b.with_hash_version();
-    return b.build();
-}
-
 future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tables) {
     if (this_shard_id() != 0) {
         _started = true;
@@ -243,11 +192,9 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
 
     while (true) {
         // Check if there is any work to do before taking the group 0 guard.
-        bool workload_prioritization_enabled = _sp.features().workload_prioritization;
         bool keyspaces_setup = db.has_keyspace(NAME) && db.has_keyspace(NAME_EVERYWHERE);
         bool tables_setup = std::all_of(tables.begin(), tables.end(), [db] (schema_ptr t) { return db.has_schema(t->ks_name(), t->cf_name()); } );
-        bool service_levels_up_to_date = get_current_service_levels(db)->equal_columns(*get_updated_service_levels(db, workload_prioritization_enabled));
-        if (keyspaces_setup && tables_setup && service_levels_up_to_date) {
+        if (keyspaces_setup && tables_setup) {
             dlogger.info("system_distributed(_everywhere) keyspaces and tables are up-to-date. Not creating");
             _started = true;
             co_return;
@@ -283,25 +230,14 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
             dlogger.info("{} keyspace is already present. Not creating", NAME_EVERYWHERE);
         }
 
-        // Get mutations for creating and updating tables.
+        // Get mutations for creating tables.
         auto num_keyspace_mutations = mutations.size();
         co_await coroutine::parallel_for_each(ensured_tables(),
-                [this, &mutations, db, ts, sd_ksm, sde_ksm, workload_prioritization_enabled] (auto&& table) -> future<> {
+                [this, &mutations, db, ts, sd_ksm, sde_ksm] (auto&& table) -> future<> {
             auto ksm = table->ks_name() == NAME ? sd_ksm : sde_ksm;
-
-            // Ensure that the service_levels table contains new columns.
-            if (table->cf_name() == SERVICE_LEVELS) {
-                table = get_updated_service_levels(db, workload_prioritization_enabled);
-            }
 
             if (!db.has_schema(table->ks_name(), table->cf_name())) {
                 co_return co_await service::prepare_new_column_family_announcement(mutations, _sp, *ksm, std::move(table), ts);
-            }
-
-            // The service_levels table exists. Update it if it lacks new columns.
-            if (table->cf_name() == SERVICE_LEVELS && !get_current_service_levels(db)->equal_columns(*table)) {
-                auto update_mutations = co_await service::prepare_column_family_update_announcement(_sp, table, std::vector<view_ptr>(), ts);
-                std::move(update_mutations.begin(), update_mutations.end(), std::back_inserter(mutations));
             }
         });
         if (mutations.size() > num_keyspace_mutations) {
@@ -321,15 +257,6 @@ future<> system_distributed_keyspace::create_tables(std::vector<schema_ptr> tabl
 
         _started = true;
         co_return;
-    }
-}
-
- future<> system_distributed_keyspace::start_workload_prioritization() {
-    if (this_shard_id() != 0) {
-        co_return;
-    }
-    if (_qp.db().features().workload_prioritization) {
-       co_await create_tables({get_updated_service_levels(_qp.db(), true)});
     }
 }
 
@@ -628,67 +555,6 @@ system_distributed_keyspace::cdc_current_generation_timestamp(context ctx) {
             cql3::query_processor::cache_internal::no);
 
     co_return timestamp_cql->one().get_as<db_clock::time_point>("time");
-}
-
-future<qos::service_levels_info> system_distributed_keyspace::get_service_levels(qos::query_context ctx) const {
-    return qos::get_service_levels(_qp, NAME, SERVICE_LEVELS, db::consistency_level::ONE, ctx);
-}
-
-future<qos::service_levels_info> system_distributed_keyspace::get_service_level(sstring service_level_name) const {
-    return qos::get_service_level(_qp, NAME, SERVICE_LEVELS, service_level_name, db::consistency_level::ONE);
-}
-
-future<> system_distributed_keyspace::set_service_level(sstring service_level_name, qos::service_level_options slo) const {
-    static sstring prepared_query = format("INSERT INTO {}.{} (service_level) VALUES (?);", NAME, SERVICE_LEVELS);
-    co_await _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}, cql3::query_processor::cache_internal::no);
-    auto to_data_value = [&] (const qos::service_level_options::timeout_type& tv) {
-        return std::visit(overloaded_functor {
-            [&] (const qos::service_level_options::unset_marker&) {
-                return data_value::make_null(duration_type);
-            },
-            [&] (const qos::service_level_options::delete_marker&) {
-                return data_value::make_null(duration_type);
-            },
-            [&] (const lowres_clock::duration& d) {
-                return data_value(cql_duration(months_counter{0},
-                        days_counter{0},
-                        nanoseconds_counter{std::chrono::duration_cast<std::chrono::nanoseconds>(d).count()}));
-            },
-        }, tv);
-    };
-    auto to_data_value_g = [&] <typename T> (const std::variant<qos::service_level_options::unset_marker, qos::service_level_options::delete_marker, T>& v) {
-        return std::visit(overloaded_functor {
-            [&] (const qos::service_level_options::unset_marker&) {
-                return data_value::make_null(data_type_for<T>());
-            },
-            [&] (const qos::service_level_options::delete_marker&) {
-                return data_value::make_null(data_type_for<T>());
-            },
-            [&] (const T& v) {
-                return data_value(v);
-            },
-        }, v);
-    };
-    data_value workload = slo.workload == qos::service_level_options::workload_type::unspecified
-            ? data_value::make_null(utf8_type)
-            : data_value(qos::service_level_options::to_string(slo.workload));
-    co_await _qp.execute_internal(format("UPDATE {}.{} SET timeout = ?, workload_type = ? WHERE service_level = ?;", NAME, SERVICE_LEVELS),
-                db::consistency_level::ONE,
-                internal_distributed_query_state(),
-                {to_data_value(slo.timeout),
-                    workload,
-                    service_level_name},
-                cql3::query_processor::cache_internal::no);
-    co_await _qp.execute_internal(format("UPDATE {}.{} SET shares = ? WHERE service_level = ?;", NAME, SERVICE_LEVELS),
-                db::consistency_level::ONE,
-                internal_distributed_query_state(),
-                {to_data_value_g(slo.shares), service_level_name},
-                cql3::query_processor::cache_internal::no);
-}
-
-future<> system_distributed_keyspace::drop_service_level(sstring service_level_name) const {
-    static sstring prepared_query = format("DELETE FROM {}.{} WHERE service_level= ?;", NAME, SERVICE_LEVELS);
-    return _qp.execute_internal(prepared_query, db::consistency_level::ONE, internal_distributed_query_state(), {service_level_name}, cql3::query_processor::cache_internal::no).discard_result();
 }
 
 }

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -35,7 +35,6 @@ namespace db {
 class system_distributed_keyspace {
 public:
     static constexpr auto NAME = "system_distributed";
-    static constexpr auto NAME_EVERYWHERE = "system_distributed_everywhere";
 
     static constexpr auto VIEW_BUILD_STATUS = "view_build_status";
 
@@ -65,7 +64,6 @@ private:
 
 public:
     static std::vector<schema_ptr> all_distributed_tables();
-    static std::vector<schema_ptr> all_everywhere_tables();
 
     system_distributed_keyspace(cql3::query_processor&, service::migration_manager&, service::storage_proxy&);
 

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -39,13 +39,6 @@ public:
 
     static constexpr auto VIEW_BUILD_STATUS = "view_build_status";
 
-    /* Nodes use this table to communicate new CDC stream generations to other nodes. */
-    static constexpr auto CDC_TOPOLOGY_DESCRIPTION = "cdc_generation_descriptions";
-
-    /* Nodes use this table to communicate new CDC stream generations to other nodes.
-     * Resides in system_distributed_everywhere. */
-    static constexpr auto CDC_GENERATIONS_V2 = "cdc_generation_descriptions_v2";
-
     /* This table is used by CDC clients to learn about available CDC streams. */
     static constexpr auto CDC_DESC_V2 = "cdc_streams_descriptions_v2";
 

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "schema/schema_fwd.hh"
-#include "service/qos/qos_common.hh"
 #include "utils/UUID.hh"
 #include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
@@ -42,7 +41,6 @@ public:
     static constexpr auto NAME_EVERYWHERE = "system_distributed_everywhere";
 
     static constexpr auto VIEW_BUILD_STATUS = "view_build_status";
-    static constexpr auto SERVICE_LEVELS = "service_levels";
 
     /* Nodes use this table to communicate new CDC stream generations to other nodes. */
     static constexpr auto CDC_TOPOLOGY_DESCRIPTION = "cdc_generation_descriptions";
@@ -82,7 +80,6 @@ public:
     system_distributed_keyspace(cql3::query_processor&, service::migration_manager&, service::storage_proxy&);
 
     future<> start();
-    future<> start_workload_prioritization();
     future<> stop();
 
     bool started() const { return _started; }
@@ -96,11 +93,6 @@ public:
     future<std::map<db_clock::time_point, cdc::streams_version>> cdc_get_versioned_streams(db_clock::time_point not_older_than, context);
 
     future<db_clock::time_point> cdc_current_generation_timestamp(context);
-
-    future<qos::service_levels_info> get_service_levels(qos::query_context ctx) const;
-    future<qos::service_levels_info> get_service_level(sstring service_level_name) const;
-    future<> set_service_level(sstring service_level_name, qos::service_level_options slo) const;
-    future<> drop_service_level(sstring service_level_name) const;
 
 private:
     future<> create_tables(std::vector<schema_ptr> tables);

--- a/db/system_distributed_keyspace.hh
+++ b/db/system_distributed_keyspace.hh
@@ -9,8 +9,6 @@
 #pragma once
 
 #include "schema/schema_fwd.hh"
-#include "utils/UUID.hh"
-#include "cdc/generation_id.hh"
 #include "locator/host_id.hh"
 
 #include <seastar/core/future.hh>
@@ -23,7 +21,6 @@ class query_processor;
 }
 
 namespace cdc {
-    class stream_id;
     class topology_description;
     class streams_version;
 } // namespace cdc
@@ -83,9 +80,6 @@ public:
     future<> stop();
 
     bool started() const { return _started; }
-
-    future<> insert_cdc_generation(utils::UUID, const cdc::topology_description&, context);
-    future<std::optional<cdc::topology_description>> read_cdc_generation(utils::UUID);
 
     future<> create_cdc_desc(db_clock::time_point, const cdc::topology_description&, context);
     future<bool> cdc_desc_exists(db_clock::time_point, context);

--- a/gms/feature_service.cc
+++ b/gms/feature_service.cc
@@ -108,6 +108,7 @@ std::set<std::string_view> feature_service::supported_feature_set() const {
         "UUID_SSTABLE_IDENTIFIERS"sv,
         "GROUP0_SCHEMA_VERSIONING"sv,
         "VIEW_BUILD_STATUS_ON_GROUP0"sv,
+        "CDC_GENERATIONS_V2"sv,
     };
 
     if (is_test_only_feature_deprecated()) {

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -83,7 +83,6 @@ public:
     gms::feature alternator_ttl { *this, "ALTERNATOR_TTL"sv };
     gms::feature cql_row_ttl { *this, "CQL_ROW_TTL"sv };
     gms::feature range_scan_data_variant { *this, "RANGE_SCAN_DATA_VARIANT"sv };
-    gms::feature cdc_generations_v2 { *this, "CDC_GENERATIONS_V2"sv };
     gms::feature user_defined_aggregates { *this, "UDA"sv };
     // Historically max_result_size contained only two fields: soft_limit and
     // hard_limit. It was somehow obscure because for normal paged queries both

--- a/main.cc
+++ b/main.cc
@@ -2288,10 +2288,12 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                ss.local().wait_for_group0_stop().get();
             });
 
-            // Setup group0 early in case the node is bootstrapped already and the group exists.
-            // Need to do it before allowing incoming messaging service connections since
-            // storage proxy's and migration manager's verbs may access group0.
-            group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+            if (!group0_service.maintenance_mode() && sys_ks.local().bootstrap_complete()) {
+                // Setup group0 early in case the node is bootstrapped already and the group exists.
+                // Need to do it before allowing incoming messaging service connections since
+                // storage proxy's and migration manager's verbs may access group0.
+                group0_service.setup_group0_if_exist(sys_ks.local(), ss.local(), qp.local(), mm.local()).get();
+            }
 
             // The call to setup_group0_if_exists() above guarantees that, if group0 is
             // created and started, the locally persisted group0 state has been applied

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -1020,8 +1020,7 @@ void database::drop_keyspace(const sstring& name) {
 static bool is_system_table(const schema& s) {
     auto& k = s.ks_name();
     return k == db::system_keyspace::NAME ||
-        k == db::system_distributed_keyspace::NAME ||
-        k == db::system_distributed_keyspace::NAME_EVERYWHERE;
+        k == db::system_distributed_keyspace::NAME;
 }
 
 sstables::sstables_manager& database::get_sstables_manager(const schema& s) const {

--- a/replica/distributed_loader.cc
+++ b/replica/distributed_loader.cc
@@ -47,7 +47,6 @@ bool is_system_keyspace(std::string_view name) {
 
 static const std::unordered_set<std::string_view> internal_keyspaces = {
         db::system_distributed_keyspace::NAME,
-        db::system_distributed_keyspace::NAME_EVERYWHERE,
         db::system_keyspace::NAME,
         db::schema_tables::NAME,
         auth::meta::legacy::AUTH_KS,

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -124,9 +124,7 @@ future<> service::client_state::check_internal_table_permissions(std::string_vie
     if (forbidden_permissions.contains(cmd.permission)) {
         if ((ks == db::system_distributed_keyspace::NAME || ks == db::system_distributed_keyspace::NAME_EVERYWHERE)
                 && (table_name == db::system_distributed_keyspace::CDC_DESC_V2
-                || table_name == db::system_distributed_keyspace::CDC_TOPOLOGY_DESCRIPTION
-                || table_name == db::system_distributed_keyspace::CDC_TIMESTAMPS
-                || table_name == db::system_distributed_keyspace::CDC_GENERATIONS_V2)) {
+                || table_name == db::system_distributed_keyspace::CDC_TIMESTAMPS)) {
             return make_exception_future(exceptions::unauthorized_exception(
                     format("Cannot {} {}", auth::permissions::to_string(cmd.permission), cmd.resource)));
         }

--- a/service/client_state.cc
+++ b/service/client_state.cc
@@ -122,7 +122,7 @@ future<> service::client_state::check_internal_table_permissions(std::string_vie
                     auth::permission::ALTER, auth::permission::DROP>();
 
     if (forbidden_permissions.contains(cmd.permission)) {
-        if ((ks == db::system_distributed_keyspace::NAME || ks == db::system_distributed_keyspace::NAME_EVERYWHERE)
+        if (ks == db::system_distributed_keyspace::NAME
                 && (table_name == db::system_distributed_keyspace::CDC_DESC_V2
                 || table_name == db::system_distributed_keyspace::CDC_TIMESTAMPS)) {
             return make_exception_future(exceptions::unauthorized_exception(

--- a/service/qos/service_level_controller.cc
+++ b/service/qos/service_level_controller.cc
@@ -26,7 +26,6 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include "service/qos/raft_service_level_distributed_data_accessor.hh"
 #include "service_level_controller.hh"
-#include "db/system_distributed_keyspace.hh"
 #include "cql3/query_processor.hh"
 #include "service/storage_service.hh"
 #include "service/topology_state_machine.hh"

--- a/service/qos/service_level_controller.hh
+++ b/service/qos/service_level_controller.hh
@@ -31,7 +31,6 @@
 
 namespace db {
     class system_keyspace;
-    class system_distributed_keyspace;
 }
 namespace cql3 {
     class query_processor;

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -681,16 +681,6 @@ bool raft_group0::maintenance_mode() {
 }
 
 future<> raft_group0::setup_group0_if_exist(db::system_keyspace& sys_ks, service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm) {
-    if (maintenance_mode()) {
-        co_return;
-    }
-
-    if (!sys_ks.bootstrap_complete()) {
-        // If bootstrap did not complete yet, there is no group 0 to setup at this point
-        // -- it will be done after we start gossiping, in `setup_group0`.
-        co_return;
-    }
-
     auto group0_id = raft::group_id{co_await sys_ks.get_raft_group0_id()};
     if (group0_id) {
         // Group 0 ID is present => we've already joined group 0 earlier.
@@ -711,15 +701,6 @@ future<> raft_group0::setup_group0(
         db::system_keyspace& sys_ks, const std::unordered_set<gms::inet_address>& initial_contact_nodes, shared_ptr<group0_handshaker> handshaker,
         service::storage_service& ss, cql3::query_processor& qp, service::migration_manager& mm,
         const join_node_request_params& params) {
-    if (maintenance_mode()) {
-        // The node is in maintenance mode.
-        co_return;
-    }
-
-    if (joined_group0()) {
-        // Group 0 is already set up, there is nothing to do.
-        co_return;
-    }
     // Reaching this point is possible only in two cases:
     // - the node is bootstrapping,
     // - the node is restarting in the Raft-based recovery procedure and has not joined the new group 0 yet.

--- a/service/raft/raft_group0.hh
+++ b/service/raft/raft_group0.hh
@@ -271,6 +271,10 @@ public:
     seastar::scheduling_group get_scheduling_group() {
         return _sg;
     }
+
+    // Returns true if in maintenance mode
+    bool maintenance_mode();
+
 private:
     static void init_rpc_verbs(raft_group0& shard0_this);
     static future<> uninit_rpc_verbs(netw::messaging_service& ms);
@@ -332,9 +336,6 @@ private:
     // Does not affect non-members. This behavior is only guaranteed if no concurrent membership changes are happening.
     future<> modify_raft_voter_status(const std::unordered_set<raft::server_id>& voters_add, const std::unordered_set<raft::server_id>& voters_del,
             abort_source& as, std::optional<raft_timeout> timeout = std::nullopt);
-
-    // Returns true if in maintenance mode
-    bool maintenance_mode();
 };
 
 } // end of namespace service

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1606,6 +1606,8 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
 
     SCYLLA_ASSERT(_group0);
 
+    auto request_id = utils::UUID_gen::get_time_UUID();
+    if (!_group0->maintenance_mode() && !_group0->joined_group0()) {
     join_node_request_params join_params {
         .host_id = _group0->load_my_id(),
         .cluster_name = _db.local().get_config().cluster_name(),
@@ -1618,7 +1620,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
         .shard_count = smp::count,
         .ignore_msb =  _db.local().get_config().murmur3_partitioner_ignore_msb_bits(),
         .supported_features = _feature_service.supported_feature_set() | std::ranges::to<std::vector<sstring>>(),
-        .request_id = utils::UUID_gen::get_time_UUID(),
+        .request_id = request_id,
     };
 
     if (raft_replace_info) {
@@ -1631,10 +1633,6 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
         }
     }
 
-    // setup_group0 will do nothing if the node has already set up group 0 in setup_group0_if_exist in main.cc, which
-    // happens when the node is restarting and not joining the new group 0 in the Raft-based recovery procedure.
-    // It does not matter which handshaker we choose in this case since it will not be used.
-    //
     // We use the legacy handshaker in the Raft-based recovery procedure to join the new group 0 without involving
     // the topology coordinator. We can assume this node has already been accepted by the topology coordinator once
     // and joined topology.
@@ -1644,6 +1642,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
             : _group0->make_legacy_handshaker(raft::is_voter::no);
     co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
             *this, _qp, _migration_manager.local(), join_params);
+    }
 
     raft::server& raft_server = _group0->group0_server();
 
@@ -1692,7 +1691,7 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
             throw std::runtime_error("Crashed in crash_before_topology_request_completion");
         });
 
-        auto err = co_await wait_for_topology_request_completion(join_params.request_id);
+        auto err = co_await wait_for_topology_request_completion(request_id);
         if (!err.empty()) {
             throw std::runtime_error(fmt::format("{} failed. See earlier errors ({})", raft_replace_info ? "Replace" : "Bootstrap", err));
         }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1608,40 +1608,40 @@ future<> storage_service::join_topology(sharded<service::storage_proxy>& proxy,
 
     auto request_id = utils::UUID_gen::get_time_UUID();
     if (!_group0->maintenance_mode() && !_group0->joined_group0()) {
-    join_node_request_params join_params {
-        .host_id = _group0->load_my_id(),
-        .cluster_name = _db.local().get_config().cluster_name(),
-        .snitch_name = _db.local().get_snitch_name(),
-        .datacenter = _snitch.local()->get_datacenter(),
-        .rack = _snitch.local()->get_rack(),
-        .release_version = version::release(),
-        .num_tokens = _db.local().get_config().join_ring() ? _db.local().get_config().num_tokens() : 0,
-        .tokens_string = _db.local().get_config().join_ring() ? _db.local().get_config().initial_token() : sstring(),
-        .shard_count = smp::count,
-        .ignore_msb =  _db.local().get_config().murmur3_partitioner_ignore_msb_bits(),
-        .supported_features = _feature_service.supported_feature_set() | std::ranges::to<std::vector<sstring>>(),
-        .request_id = request_id,
-    };
+        join_node_request_params join_params {
+            .host_id = _group0->load_my_id(),
+            .cluster_name = _db.local().get_config().cluster_name(),
+            .snitch_name = _db.local().get_snitch_name(),
+            .datacenter = _snitch.local()->get_datacenter(),
+            .rack = _snitch.local()->get_rack(),
+            .release_version = version::release(),
+            .num_tokens = _db.local().get_config().join_ring() ? _db.local().get_config().num_tokens() : 0,
+            .tokens_string = _db.local().get_config().join_ring() ? _db.local().get_config().initial_token() : sstring(),
+            .shard_count = smp::count,
+            .ignore_msb =  _db.local().get_config().murmur3_partitioner_ignore_msb_bits(),
+            .supported_features = _feature_service.supported_feature_set() | std::ranges::to<std::vector<sstring>>(),
+            .request_id = request_id,
+        };
 
-    if (raft_replace_info) {
-        join_params.replaced_id = raft_replace_info->raft_id;
-        join_params.ignore_nodes = utils::split_comma_separated_list(_db.local().get_config().ignore_dead_nodes_for_replace());
-        if (!locator::check_host_ids_contain_only_uuid(join_params.ignore_nodes)) {
-            slogger.warn("Warning: Using IP addresses for '--ignore-dead-nodes-for-replace' is deprecated and will"
-                         " be disabled in a future release. Please use host IDs instead. Provided values: {}",
-                         _db.local().get_config().ignore_dead_nodes_for_replace());
+        if (raft_replace_info) {
+            join_params.replaced_id = raft_replace_info->raft_id;
+            join_params.ignore_nodes = utils::split_comma_separated_list(_db.local().get_config().ignore_dead_nodes_for_replace());
+            if (!locator::check_host_ids_contain_only_uuid(join_params.ignore_nodes)) {
+                slogger.warn("Warning: Using IP addresses for '--ignore-dead-nodes-for-replace' is deprecated and will"
+                            " be disabled in a future release. Please use host IDs instead. Provided values: {}",
+                            _db.local().get_config().ignore_dead_nodes_for_replace());
+            }
         }
-    }
 
-    // We use the legacy handshaker in the Raft-based recovery procedure to join the new group 0 without involving
-    // the topology coordinator. We can assume this node has already been accepted by the topology coordinator once
-    // and joined topology.
-    ::shared_ptr<group0_handshaker> handshaker =
-            !_db.local().get_config().recovery_leader.is_set()
-            ? ::make_shared<join_node_rpc_handshaker>(*this, join_params)
-            : _group0->make_legacy_handshaker(raft::is_voter::no);
-    co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
-            *this, _qp, _migration_manager.local(), join_params);
+        // We use the legacy handshaker in the Raft-based recovery procedure to join the new group 0 without involving
+        // the topology coordinator. We can assume this node has already been accepted by the topology coordinator once
+        // and joined topology.
+        ::shared_ptr<group0_handshaker> handshaker =
+                !_db.local().get_config().recovery_leader.is_set()
+                ? ::make_shared<join_node_rpc_handshaker>(*this, join_params)
+                : _group0->make_legacy_handshaker(raft::is_voter::no);
+        co_await _group0->setup_group0(_sys_ks.local(), initial_contact_nodes, std::move(handshaker),
+                *this, _qp, _migration_manager.local(), join_params);
     }
 
     raft::server& raft_server = _group0->group0_server();

--- a/test/boost/cdc_test.cc
+++ b/test/boost/cdc_test.cc
@@ -297,11 +297,10 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_description) {
             BOOST_REQUIRE_THROW(e.execute_cql(stmt).get(), exceptions::unauthorized_exception);
         };
 
-        const std::string generations_v2 = "system_distributed_everywhere.cdc_generation_descriptions_v2";
         const std::string streams = "system_distributed.cdc_streams_descriptions_v2";
         const std::string timestamps = "system_distributed.cdc_generation_timestamps";
 
-        for (auto& t : {generations_v2, streams, timestamps}) {
+        for (auto& t : {streams, timestamps}) {
             auto dot_pos = t.find_first_of('.');
             SCYLLA_ASSERT(dot_pos != std::string_view::npos && dot_pos != 0 && dot_pos != t.size() - 1);
             BOOST_REQUIRE(e.local_db().has_schema(t.substr(0, dot_pos), t.substr(dot_pos + 1)));
@@ -317,18 +316,15 @@ SEASTAR_THREAD_TEST_CASE(test_permissions_of_cdc_description) {
         for (auto& t : {streams}) {
             assert_unauthorized(seastar::format("ALTER TABLE {} ALTER time TYPE blob", t));
         }
-        assert_unauthorized(seastar::format("ALTER TABLE {} ALTER id TYPE blob", generations_v2));
         assert_unauthorized(seastar::format("ALTER TABLE {} ALTER key TYPE blob", timestamps));
 
         // Allow DELETE
         for (auto& t : {streams}) {
             e.execute_cql(seastar::format("DELETE FROM {} WHERE time = toTimeStamp(now())", t)).get();
         }
-        e.execute_cql(seastar::format("DELETE FROM {} WHERE id = uuid()", generations_v2)).get();
         e.execute_cql(seastar::format("DELETE FROM {} WHERE key = 'timestamps'", timestamps)).get();
 
         // Allow UPDATE, INSERT
-        e.execute_cql(seastar::format("INSERT INTO {} (id, range_end) VALUES (uuid(), 0)", generations_v2)).get();
         e.execute_cql(seastar::format("INSERT INTO {} (time, range_end) VALUES (toTimeStamp(now()), 0)", streams)).get();
         e.execute_cql(seastar::format("UPDATE {} SET expired = toTimeStamp(now()) WHERE key = 'timestamps' AND time = toTimeStamp(now())", timestamps)).get();
     }).get();

--- a/test/lib/cql_test_env.cc
+++ b/test/lib/cql_test_env.cc
@@ -1115,8 +1115,9 @@ private:
                 _ss.local().wait_for_group0_stop().get();
             });
 
-            group0_service.setup_group0_if_exist(_sys_ks.local(), _ss.local(), _qp.local(), _mm.local()).get();
-
+            if (!group0_service.maintenance_mode() && _sys_ks.local().bootstrap_complete()) {
+                group0_service.setup_group0_if_exist(_sys_ks.local(), _ss.local(), _qp.local(), _mm.local()).get();
+            }
             _groups_manager.invoke_on_all([](service::strong_consistency::groups_manager& m) {
                 return m.start();
             }).get();

--- a/tools/schema_loader.cc
+++ b/tools/schema_loader.cc
@@ -661,7 +661,6 @@ schema_ptr load_system_schema(const db::config& cfg, std::string_view keyspace, 
         {db::schema_tables::NAME, db::schema_tables::all_tables(db::schema_features::full())},
         {db::system_keyspace::NAME, db::system_keyspace::all_tables(cfg)},
         {db::system_distributed_keyspace::NAME, db::system_distributed_keyspace::all_distributed_tables()},
-        {db::system_distributed_keyspace::NAME_EVERYWHERE, db::system_distributed_keyspace::all_everywhere_tables()},
     };
     auto ks_it = schemas.find(keyspace);
     if (ks_it == schemas.end()) {


### PR DESCRIPTION
Drop creation of `service_levels` and `cdc_generation_descriptions_v2` table creation code since they are no longer needed. Old clusters will still have it because they were created earlier. Also the series contains a small improvement around group0 creation.

No backport needed since this removes functionality.