### PR TITLE
commitlog: fix inverted set_with_schema in add_entries oversized path

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -3147,7 +3147,7 @@ db::commitlog::add_entries(utils::chunked_vector<commitlog_entry_writer> entry_w
         size_t size(segment& seg, size_t i) override {
             auto& w = _writers.at(i);
             if (_sizes_computed != &seg) {
-                w.set_with_schema(seg.is_schema_version_known(w.schema())); 
+                w.set_with_schema(!seg.is_schema_version_known(w.schema()));
             }
             return w.size();
         }

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1836,7 +1836,7 @@ SEASTAR_TEST_CASE(test_commitlog_update_max_data_lifetime) {
 /**
  * Test allocating oversized multi-entry
 */
-static future<> do_test_oversized_entry(size_t max_size_mb) {
+static future<> do_test_oversized_entry(size_t max_size_mb, noncopyable_function<void(const commitlog_entry_reader&)> entry_check = {}) {
     commitlog::config cfg;
 
     cfg.commitlog_segment_size_in_mb = max_size_mb;
@@ -1904,6 +1904,9 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
                 auto m2 = rp2mut.at(rp).unfreeze(gen.schema());
 
                 BOOST_CHECK_EQUAL(m1, m2);
+                if (entry_check) {
+                    entry_check(cer);
+                }
                 ++n;
                 co_return;
             });
@@ -2337,7 +2340,6 @@ SEASTAR_TEST_CASE(test_segment_end_on_entry_end) {
     });
 }
 
-
 // Verify that commitlog segments are replayed in ascending segment ID
 // order within each shard. The replayer distributes segments by shard and
 // iterates them per-shard; this test captures the "Replaying" debug log
@@ -2405,6 +2407,33 @@ SEASTAR_TEST_CASE(test_commitlog_replay_segment_order) {
             BOOST_CHECK_GT(replayed_ids[i], replayed_ids[i - 1]);
         }
     });
+}
+
+/**
+ * Test that add_entries() in the oversized allocation path correctly includes
+ * column mappings in commitlog entries when the schema is not known to the
+ * segment.
+ *
+ * Reproduces a bug where cl_entries_writer::size(segment&, size_t) used the
+ * wrong polarity for set_with_schema (missing negation of
+ * is_schema_version_known), causing column mappings to be omitted when the
+ * schema was unknown to the segment. This happens specifically in the
+ * oversized_allocation() code path, where size(segment&, size_t) is called
+ * without a preceding size(segment&) on the same segment, so the defensive
+ * guard (_sizes_computed != &seg) fires and the buggy line executes.
+ */
+SEASTAR_TEST_CASE(test_commitlog_add_entries_oversized_includes_schema_mapping) {
+    size_t with_mapping = 0;
+    co_await do_test_oversized_entry(1, [&with_mapping](const commitlog_entry_reader& cer) {
+        if (cer.get_column_mapping().has_value()) {
+            ++with_mapping;
+        }
+    });
+    // At least one entry per segment must have the column mapping embedded,
+    // since the schema version is new to each segment. With the bug (missing
+    // negation), no entries would have column mappings because set_with_schema
+    // is passed the wrong value in the oversized path.
+    BOOST_CHECK_GT(with_mapping, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -1893,6 +1893,7 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
     commitlog::replay_state state;
     for (auto& f : replay_set) {
         try {
+            bool first = true;
             co_await commitlog::read_log_file(state, f, cfg.fname_prefix, [&](commitlog::buffer_and_replay_position buf_rp) -> future<> {
                 auto&& buf = buf_rp.buffer;
                 auto&& rp = buf_rp.position;
@@ -1904,6 +1905,16 @@ static future<> do_test_oversized_entry(size_t max_size_mb) {
                 auto m2 = rp2mut.at(rp).unfreeze(gen.schema());
 
                 BOOST_CHECK_EQUAL(m1, m2);
+                // Schema mappings must be written at least once per segment
+                // (in the first entry when the schema is new). Additional
+                // entries may also carry the mapping because
+                // forget_schema_versions() is called on each chunk flush,
+                // so the invariant is: first entry must have it, others may.
+                bool has_mapping = cer.get_column_mapping().has_value();
+                if (first) {
+                    BOOST_CHECK(has_mapping);
+                    first = false;
+                }
                 ++n;
                 co_return;
             });
@@ -2336,7 +2347,6 @@ SEASTAR_TEST_CASE(test_segment_end_on_entry_end) {
         co_await replay_segment(segment_path);
     });
 }
-
 
 // Verify that commitlog segments are replayed in ascending segment ID
 // order within each shard. The replayer distributes segments by shard and


### PR DESCRIPTION
## Summary

- Fix inverted `set_with_schema` polarity in `cl_entries_writer::size(segment&, size_t)` that caused column mappings to be omitted from commitlog entries when the schema was unknown to the segment
- Add a regression test that verifies column mappings are correctly embedded when `add_entries()` takes the `oversized_allocation()` code path

## Bug Description

In `commitlog::add_entries()`, the `cl_entries_writer::size(segment&, size_t)` method (line 3150) sets:

```cpp
w.set_with_schema(seg.is_schema_version_known(w.schema()));
```

This is missing the `!` negation used in the correct logic at lines 3086 and 3141:

```cpp
w.set_with_schema(!seg.is_schema_version_known(w.schema()));
```

The inverted polarity means `with_schema=true` when the schema IS known (useless) and `with_schema=false` when the schema is NOT known (harmful — column mapping is omitted, making replay unable to resolve the schema).

## When it triggers

The `_sizes_computed != &seg` guard that gates this code fires specifically in the `oversized_allocation()` code path. In this path, `writer.size(segment&, size_t)` is called per-entry (line 1720) without a preceding `writer.size(segment&)` call on the same segment, so `_sizes_computed` is either `nullptr` or stale from a different segment.
Potentially this can lead to missing schema mappings, which could prevent commit log replay, or redundant schema copies that would unnecessarily consume disk space.

Fixes: SCYLLADB-2421

Backport: since the fix is trivial, all currently supported versions. 