### PR TITLE
test/cqlpy: fix nodetool.compact() utility function on Cassandra

### DIFF
--- a/test/cqlpy/nodetool.py
+++ b/test/cqlpy/nodetool.py
@@ -85,21 +85,21 @@ def run_nodetool(cql, *args, **subprocess_kwargs):
 def flush(cql, table):
     ks, cf = table.split('.')
     if has_rest_api(cql):
-        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_flush/{ks}', params={'cf' : cf})
+        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_flush/{ks}', params={'cf' : cf}).raise_for_status()
     else:
-        run_nodetool(cql, "flush", ks, cf)
+        run_nodetool(cql, "flush", ks, cf, check=True)
 
 def flush_keyspace(cql, ks):
     if has_rest_api(cql):
-        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_flush/{ks}')
+        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_flush/{ks}').raise_for_status()
     else:
-        run_nodetool(cql, "flush", ks)
+        run_nodetool(cql, "flush", ks, check=True)
 
 def flush_all(cql):
     if has_rest_api(cql):
-        requests.post(f'{rest_api_url(cql)}/storage_service/flush')
+        requests.post(f'{rest_api_url(cql)}/storage_service/flush').raise_for_status()
     else:
-        run_nodetool(cql, "flush")
+        run_nodetool(cql, "flush", check=True)
 
 # Note that this function will, by default (flush_memtables=True), perform
 # both a flush (of all tables) and compaction (of just the specified table).
@@ -111,24 +111,24 @@ def compact(cql, table, flush_memtables=True):
         params = {'cf': cf}
         if not flush_memtables:
             params["flush_memtables"] = "false"
-        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params)
+        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params).raise_for_status()
     else:
         if flush_memtables:
             # note that we flush all memtables, not just the specified table
-            run_nodetool(cql, "flush")
-        run_nodetool(cql, "compact", ks, cf)
+            run_nodetool(cql, "flush", check=True)
+        run_nodetool(cql, "compact", ks, cf, check=True)
 
 def compact_keyspace(cql, ks, flush_memtables=True):
     if has_rest_api(cql):
         params = None
         if not flush_memtables:
             params = {"flush_memtables": "false"}
-        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params)
+        requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params).raise_for_status()
     else:
         if flush_memtables:
             # note that we flush all memtables, not just the specified keyspace
-            run_nodetool(cql, "flush")
-        run_nodetool(cql, "compact", ks)
+            run_nodetool(cql, "flush", check=True)
+        run_nodetool(cql, "compact", ks, check=True)
 
 def take_snapshot(cql, table, tag, skip_flush = None, ttl = None):
     ks, cf = table.split('.')

--- a/test/cqlpy/nodetool.py
+++ b/test/cqlpy/nodetool.py
@@ -101,6 +101,10 @@ def flush_all(cql):
     else:
         run_nodetool(cql, "flush")
 
+# Note that this function will, by default (flush_memtables=True), perform
+# both a flush (of all tables) and compaction (of just the specified table).
+# This is *not* the normal behavior of Cassandra's "nodetool compact" -
+# so on Cassandra we need to call two separate nodetool commands.
 def compact(cql, table, flush_memtables=True):
     ks, cf = table.split('.')
     if has_rest_api(cql):
@@ -109,9 +113,10 @@ def compact(cql, table, flush_memtables=True):
             params["flush_memtables"] = "false"
         requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params)
     else:
-        args = [] if not flush_memtables else ["--flush-memtables", "false"]
-        args.extend([ks, cf])
-        run_nodetool(cql, "compact", *args)
+        if flush_memtables:
+            # note that we flush all memtables, not just the specified table
+            run_nodetool(cql, "flush")
+        run_nodetool(cql, "compact", ks, cf)
 
 def compact_keyspace(cql, ks, flush_memtables=True):
     if has_rest_api(cql):
@@ -120,9 +125,10 @@ def compact_keyspace(cql, ks, flush_memtables=True):
             params = {"flush_memtables": "false"}
         requests.post(f'{rest_api_url(cql)}/storage_service/keyspace_compaction/{ks}', params=params)
     else:
-        args = [] if not flush_memtables else ["--flush-memtables", "false"]
-        args.extend([ks])
-        run_nodetool(cql, "compact", *args)
+        if flush_memtables:
+            # note that we flush all memtables, not just the specified keyspace
+            run_nodetool(cql, "flush")
+        run_nodetool(cql, "compact", ks)
 
 def take_snapshot(cql, table, tag, skip_flush = None, ttl = None):
     ks, cf = table.split('.')

--- a/test/cqlpy/nodetool.py
+++ b/test/cqlpy/nodetool.py
@@ -57,7 +57,7 @@ def nodetool_cmd():
     if nodetool_cmd.cmd:
         return nodetool_cmd.cmd
     if not nodetool_cmd.failed:
-        nodetool_cmd.conf = os.getenv('NODETOOL').split() or ['nodetool']
+        nodetool_cmd.conf = (os.getenv('NODETOOL') or 'nodetool').split()
         nodetool_cmd.cmd = shutil.which(nodetool_cmd.conf[0])
         if nodetool_cmd.cmd is None:
             nodetool_cmd.failed = True

--- a/test/cqlpy/test_compaction.py
+++ b/test/cqlpy/test_compaction.py
@@ -192,3 +192,21 @@ def test_compactionstats_after_major_compaction(scylla_only, cql, test_keyspace_
             nodetool.compact(cql, table)
             tasks, stats = get_compaction_stats(cql, table)
             assert tasks == 0, f"Found {tasks} pending compaction tasks unexpectedly: stats={stats}"
+
+# A simple test to exercise nodetool.compact() and nodetool.compact_keyspace()
+# for both Scylla and Cassandra. It is less of a test for Scylla, more of a
+# test for these utility functions which have different code paths for Scylla
+# and Cassandra. We just check the operation doesn't fail - not what it does.
+# Unlike Cassandra's nodetool, our nodetool.compact() utility function can
+# flush memtables before compacting (and does this by default), so we want
+# to check this option enabled and disabled.
+def test_nodetool_py_compact(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "p int PRIMARY KEY, v int") as table:
+        for i in range(2):
+            cql.execute(f"INSERT INTO {table} (p, v) VALUES ({i}, {i})")
+            nodetool.flush(cql, table)
+        cql.execute(f"INSERT INTO {table} (p, v) VALUES (3, 3)")
+        nodetool.compact(cql, table, flush_memtables=False)
+        nodetool.compact(cql, table, flush_memtables=True)
+        nodetool.compact_keyspace(cql, test_keyspace, flush_memtables=False)
+        nodetool.compact_keyspace(cql, test_keyspace, flush_memtables=True)


### PR DESCRIPTION
In test/cqlpy/nodetool.py we have utility functions that present the classic nodetool functions, like nodetool.flush() or nodetool.compact(), for tests that run on either Cassandra or Scylla:
 * When a test is running on Scylla, we use the REST API and the test doesn't need to run JMX (yikes!) or have access to Scylla's nodetool.
 * When a test is running on Cassandra, we use the "nodetool" command that comes with Cassandra.

So each of the functions in nodetool.py have two variants - for Scylla and for Cassandra.

This patch fixes the Cassandra version of nodetool.compact() and nodetool.compact_keyspace(), which got broken recently but nobody noticed because all the tests that needed it happened to be scylla_only. This makes this fix not critical, but it's still not a good idea to have incorrect utility functions in our test framework.

The broken code was introduced when we recently decided to add the option flush_memtables - defaulting to True - to these functions. This option never existed in Cassandra's nodetool, and the code to handle it in the Cassandra case was completely wrong - it had reversed logic, and also used a non-existent nodetool option.

The fix is very simple - if the flush_memtables option is true (as it is by default), nodetool.compact() calls two Cassandra nodetool commands: First "nodetool flush" (for all memtables) and then "nodetool compact" for the requested table or keyspace.

This patch also introduces a small sanity check for nodetool.compact() and nodetool.compact_keyspace(), each with flush_memtables set to false and to true. Note that this is not a real regression test for the issue fixed here - the test didn't fail when the flush_memtables logic was reverse or when an invalid option was passed to nodetool (nodetool just ignored it). But maybe the new test can cach other future cases of this function breaking.
