### PR TITLE
vector_search: fix decimal/varint precision loss in filter

### DIFF
--- a/test/boost/big_decimal_test.cc
+++ b/test/boost/big_decimal_test.cc
@@ -10,6 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 #include "utils/big_decimal.hh"
+#include "types/types.hh"
 #include "marshal_exception.hh"
 
 namespace {
@@ -116,6 +117,133 @@ BOOST_AUTO_TEST_CASE(test_big_decimal_construct_from_string) {
     BOOST_REQUIRE_THROW(big_decimal("1E2147483649"), marshal_exception);
     // 1.2E-2147483647 : scale(2147483648) > int32::max()
     BOOST_REQUIRE_THROW(big_decimal("1.2E-2147483647"), marshal_exception);
+}
+
+// Test to_string_canonical() against the Java BigDecimal.toString() specification.
+// See: https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+// Plain form is used iff scale >= 0 AND adjusted_exp >= -6
+// (where adjusted_exp = num_digits - 1 - scale).
+// Negative scales always produce exponential form.
+BOOST_AUTO_TEST_CASE(test_big_decimal_to_string_canonical) {
+    // Zero with various scales
+    BOOST_REQUIRE_EQUAL(big_decimal("0").to_string_canonical(), "0");
+    BOOST_REQUIRE_EQUAL(big_decimal("0.0").to_string_canonical(), "0.0");
+    BOOST_REQUIRE_EQUAL(big_decimal("0.00").to_string_canonical(), "0.00");
+    BOOST_REQUIRE_EQUAL(big_decimal("0E-7").to_string_canonical(), "0E-7");
+    BOOST_REQUIRE_EQUAL(big_decimal("0E+7").to_string_canonical(), "0E+7");
+
+    // Plain form - integer (scale == 0)
+    BOOST_REQUIRE_EQUAL(big_decimal("123").to_string_canonical(), "123");
+    BOOST_REQUIRE_EQUAL(big_decimal("1").to_string_canonical(), "1");
+
+    // Plain form - fractional, dot inside digit string
+    BOOST_REQUIRE_EQUAL(big_decimal("1.23").to_string_canonical(), "1.23");   // scale=2, adj_exp=0
+    BOOST_REQUIRE_EQUAL(big_decimal("12.3").to_string_canonical(), "12.3");   // scale=1, adj_exp=1
+
+    // Plain form - fractional, leading zeros after "0."
+    // scale=6, num_digits=3, adj_exp = 2-6 = -4  (>= -6 -> plain)
+    BOOST_REQUIRE_EQUAL(big_decimal("0.000123").to_string_canonical(), "0.000123");
+    // scale=7, num_digits=3, adj_exp = 2-7 = -5  (>= -6 -> plain)
+    BOOST_REQUIRE_EQUAL(big_decimal("0.0000123").to_string_canonical(), "0.0000123");
+    // scale=8, num_digits=3, adj_exp = 2-8 = -6  (== -6 -> still plain)
+    BOOST_REQUIRE_EQUAL(big_decimal("0.00000123").to_string_canonical(), "0.00000123");
+
+    // Exponential form - scale > 0 but adjusted_exp < -6
+    // scale=9, num_digits=3, adj_exp = 2-9 = -7  (< -6 -> exp form)
+    BOOST_REQUIRE_EQUAL(big_decimal("1.23E-7").to_string_canonical(), "1.23E-7");
+
+    // Exponential form - negative scale (always exp form regardless of magnitude)
+    // big_decimal("1.23E+3") -> unscaled=123, scale=-1
+    BOOST_REQUIRE_EQUAL(big_decimal("1.23E+3").to_string_canonical(), "1.23E+3");
+    // big_decimal("1E+1") -> unscaled=1, scale=-1
+    BOOST_REQUIRE_EQUAL(big_decimal("1E+1").to_string_canonical(), "1E+1");
+
+    // Negative numbers
+    BOOST_REQUIRE_EQUAL(big_decimal("-45.6").to_string_canonical(), "-45.6");
+    BOOST_REQUIRE_EQUAL(big_decimal("-1.23E+3").to_string_canonical(), "-1.23E+3");
+    BOOST_REQUIRE_EQUAL(big_decimal("-1.23E-7").to_string_canonical(), "-1.23E-7");
+
+    // DoS / OOM guard: extreme scales must not allocate unbounded memory.
+    // to_string() would previously expand trailing zeros in a loop;
+    // to_string_canonical() uses exponential notation instead.
+    BOOST_REQUIRE_EQUAL(big_decimal("1E+1000000000").to_string_canonical(), "1E+1000000000"); // scale = -1e9
+    BOOST_REQUIRE_EQUAL(big_decimal("1E-999999999").to_string_canonical(), "1E-999999999");  // scale = +1e9 (close to int32 max)
+
+    // Round-trip: parse -> to_string_canonical -> re-parse -> value equality
+    auto check_roundtrip = [](const char* s) {
+        big_decimal orig(s);
+        auto str = orig.to_string_canonical();
+        big_decimal reparsed(str);
+        BOOST_REQUIRE((orig <=> reparsed) == std::strong_ordering::equal);
+    };
+    check_roundtrip("0");
+    check_roundtrip("0.0");
+    check_roundtrip("0.00");
+    check_roundtrip("0E-7");
+    check_roundtrip("0E+7");
+    check_roundtrip("1");
+    check_roundtrip("123");
+    check_roundtrip("1.23");
+    check_roundtrip("0.000123");
+    check_roundtrip("0.00000123");
+    check_roundtrip("1.23E-7");
+    check_roundtrip("1.23E+3");
+    check_roundtrip("-45.6");
+    check_roundtrip("1E+1000000000");
+}
+
+// Verify the hash/equality contract for decimal_type: numerically equal
+// big_decimal values with different (unscaled, scale) representations must
+// produce the same hash via decimal_type->hash(). This is required because
+// decimal_type comparison (used by clustering_key::equality) is value-based
+// - it deserializes and uses big_decimal::operator<=> - so hash() must
+// agree: equal values must hash equally.
+BOOST_AUTO_TEST_CASE(test_big_decimal_hash_contract) {
+    auto check = [](const char* desc, const big_decimal& a, const big_decimal& b) {
+        BOOST_TEST_CONTEXT(desc) {
+            // Precondition: a and b are numerically equal.
+            BOOST_REQUIRE((a <=> b) == std::strong_ordering::equal);
+            // Serialize both to bytes.
+            auto bytes_a = decimal_type->decompose(a);
+            auto bytes_b = decimal_type->decompose(b);
+            // The byte representations must differ (otherwise the test is trivial).
+            BOOST_REQUIRE_NE(bytes_a, bytes_b);
+            // Hash contract: equal values must produce equal hashes.
+            auto hash_a = decimal_type->hash(bytes_view(bytes_a));
+            auto hash_b = decimal_type->hash(bytes_view(bytes_b));
+            BOOST_REQUIRE_EQUAL(hash_a, hash_b);
+        }
+    };
+
+    // (1230, scale=0) vs (123, scale=-1): both equal 1230
+    check("1230 vs 1.23E+3",
+        big_decimal(0, 1230),
+        big_decimal(-1, 123));
+
+    // (70, scale=1) vs (7, scale=0): both equal 7
+    check("7.0 vs 7",
+        big_decimal(1, 70),
+        big_decimal(0, 7));
+
+    // (100, scale=2) vs (1, scale=0): both equal 1
+    check("1.00 vs 1",
+        big_decimal(2, 100),
+        big_decimal(0, 1));
+
+    // Negative values: (-500, scale=2) vs (-5, scale=0): both equal -5
+    check("-5.00 vs -5",
+        big_decimal(2, -500),
+        big_decimal(0, -5));
+
+    // Zero with different scales: (0, scale=5) vs (0, scale=0)
+    check("0E-5 vs 0",
+        big_decimal(5, 0),
+        big_decimal(0, 0));
+
+    // Negative scale: (-2, 12300) vs (0, 1230000): both equal 1230000
+    check("1.23E+6 vs 1230000",
+        big_decimal(-2, 12300),
+        big_decimal(0, 1230000));
 }
 
 BOOST_AUTO_TEST_CASE(test_big_decimal_div) {

--- a/test/cqlpy/cassandra_tests/validation/entities/json_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/json_test.py
@@ -772,7 +772,7 @@ def testToJsonFct(cql, test_keyspace):
             # Scylla may print floating-point numbers with different choice
             # of capitalization, exponent, etc, so we use EquivalentJson.
             # Note that some representations may be equivalent, but
-            # objectively bad - see issue #80002.
+            # objectively bad - see issue #8002.
             assert_rows(execute(cql, table, "SELECT k, toJson(decimalval) FROM %s WHERE k = ?", 0), [0, EquivalentJson("-1.23E-12")])
 
             # ================ double ================

--- a/test/cqlpy/test_type_decimal.py
+++ b/test/cqlpy/test_type_decimal.py
@@ -14,7 +14,9 @@ import pytest
 from cassandra.protocol import InvalidRequest
 
 from . import nodetool
-from .util import new_test_table, unique_key_int
+from .util import new_test_table, unique_key_int, new_materialized_view, new_secondary_index
+from .test_materialized_view import wait_for_view_built
+from .test_secondary_index import wait_for_index
 
 @pytest.fixture(scope="module")
 def table1(cql, test_keyspace):
@@ -128,3 +130,253 @@ def test_decimal_clustering_key_inline_overflow_exponent(cql, table1):
         # 1.1234e-2147483647 but what we read is 1.1234E+2147483649 - the
         # "scale" got wrapped around the 32 bit integer.
         assert list(cql.execute(f"SELECT c from {table1} where p = {p}")) == [(Decimal(n),)]
+
+# Verify that decimal partition keys and clustering keys have fundamentally
+# different identity semantics:
+#
+#   - Partition key: raw-bytes identity. Two different (scale, unscaled)
+#     representations of the same numeric value serialize to different bytes,
+#     produce different tokens, and live in different partitions.
+#
+#   - Clustering key: value-based comparison (DecimalType.compare() delegates
+#     to BigDecimal.compareTo()). Different representations of the same value
+#     are the same clustering key - a second INSERT overwrites the first.
+#     The stored clustering key bytes are NOT normalized; the last write's
+#     representation is preserved.
+#
+# This is consistent with Cassandra.
+#
+# NOTE: Python's Decimal normalizes some string forms - e.g. Decimal('123E+1')
+# and Decimal('1.23E+3') produce the same as_tuple() - so the CQL driver
+# would serialize them identically.  We use the Decimal tuple constructor
+# where needed to get genuinely distinct wire representations of the same
+# numeric value.
+def test_decimal_key_representation(cql, test_keyspace):
+    # Three representations of the numeric value 1230, each with a distinct
+    # (unscaled, scale) pair and therefore distinct wire bytes:
+    d1 = Decimal('1230')                   # as_tuple: (0, (1,2,3,0), 0)
+    d2 = Decimal('1.23E+3')               # as_tuple: (0, (1,2,3), 1)
+    d3 = Decimal((0, (1,2,3,0,0), -1))    # as_tuple: (0, (1,2,3,0,0), -1)
+    d_other = Decimal('456')
+    # Sanity: all three are numerically equal but have distinct as_tuple()
+    # (i.e., distinct (sign, digits, exponent) triples), meaning the CQL
+    # driver will serialize them to different wire bytes.
+    assert d1 == d2 == d3
+    assert len({d1.as_tuple(), d2.as_tuple(), d3.as_tuple()}) == 3
+
+    with new_test_table(cql, test_keyspace,
+            "p decimal, c decimal, v text, PRIMARY KEY (p, c)") as table:
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (p, c, v) VALUES (?, ?, ?)")
+
+        # Insert 1: (p=d1, c=d1, v='a') - new row in partition d1.
+        cql.execute(stmt, [d1, d1, 'a'])
+        # Insert 2: (p=d1, c=d2, v='b') - same PK bytes as insert 1, same CK
+        # *value* but different CK representation -> overwrites insert 1.
+        cql.execute(stmt, [d1, d2, 'b'])
+        # Insert 3: (p=d1, c=d_other, v='c') - same partition, different CK
+        # value -> new row alongside the overwritten one.
+        cql.execute(stmt, [d1, d_other, 'c'])
+        # Insert 4: (p=d2, c=d1, v='d') - different PK representation -> different
+        # partition entirely, despite the same numeric PK value.
+        cql.execute(stmt, [d2, d1, 'd'])
+
+        # --- Partition d1: should have exactly 2 rows ---
+        rows_d1 = list(cql.execute(
+            cql.prepare(f"SELECT c, v FROM {table} WHERE p = ?"),
+            [d1]))
+        assert len(rows_d1) == 2
+        # One row for CK~=1230 (overwritten to 'b') and one for CK=456 ('c').
+        by_v = {r.v: r for r in rows_d1}
+        assert set(by_v.keys()) == {'b', 'c'}
+        # The CK of the overwritten row carries the first writer's
+        # representation (d1), proving the CK bytes are not normalized.
+        assert by_v['b'].c.as_tuple() == d1.as_tuple()
+        # The other row's CK should be exactly as written.
+        assert by_v['c'].c.as_tuple() == d_other.as_tuple()
+
+        # --- Partition d2: should have exactly 1 row ---
+        rows_d2 = list(cql.execute(
+            cql.prepare(f"SELECT c, v FROM {table} WHERE p = ?"),
+            [d2]))
+        assert len(rows_d2) == 1
+        assert rows_d2[0].v == 'd'
+        # CK bytes are preserved as written (d1's representation).
+        assert rows_d2[0].c.as_tuple() == d1.as_tuple()
+
+        # --- Partition d3: should be empty ---
+        # d3 is yet another representation of 1230 that was never used as a PK
+        # in any insert.  Because PK identity is byte-based, this is a distinct
+        # (and empty) partition.
+        rows_d3 = list(cql.execute(
+            cql.prepare(f"SELECT c, v FROM {table} WHERE p = ?"),
+            [d3]))
+        assert len(rows_d3) == 0
+
+        # --- Cross-representation CK lookup ---
+        # Look up a row in partition d2 using d3 as the CK - a representation
+        # that was never used for writing.  Because CK comparison is value-based,
+        # this should find the row (v='d').
+        rows_cross = list(cql.execute(
+            cql.prepare(
+                f"SELECT v FROM {table} WHERE p = ? AND c = ?"),
+            [d2, d3]))
+        assert len(rows_cross) == 1
+        assert rows_cross[0].v == 'd'
+
+# Decimal values with different (unscaled, scale) representations that
+# are numerically equal have different serialized bytes. This test
+# documents how that byte-vs-value distinction manifests across
+# secondary indexes and materialized views:
+#
+# - ALLOW FILTERING: value-based comparison - finds all matching rows
+#   regardless of representation.
+# - Secondary index: the indexed column becomes a partition key in the
+#   SI backing table, so lookup is byte-based - only finds rows whose
+#   stored bytes match the query value exactly.
+# - MV with decimal as partition key: byte-based identity - different
+#   representations create different MV partitions.
+# - MV with decimal as clustering key: value-based comparison -
+#   different representations resolve to the same clustering position.
+#
+# All behaviors are Cassandra-compatible.
+def test_decimal_si_and_mv_representation(cql, test_keyspace):
+    d1 = Decimal((0, (1,2,3,0), 0))    # unscaled=1230, scale=0
+    d2 = Decimal((0, (1,2,3), 1))       # unscaled=123, scale=-1, value=1230
+    assert d1 == d2
+    assert d1.as_tuple() != d2.as_tuple()
+
+    with new_test_table(cql, test_keyspace,
+            "p int PRIMARY KEY, v decimal, data text") as table:
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (p, v, data) VALUES (?, ?, ?)")
+        cql.execute(stmt, [1, d1, 'a'])
+        cql.execute(stmt, [2, d2, 'b'])
+
+        # --- ALLOW FILTERING: value-based - finds both rows ---
+        rows = list(cql.execute(cql.prepare(
+            f"SELECT p FROM {table} WHERE v = ? ALLOW FILTERING"), [d1]))
+        assert sorted(r.p for r in rows) == [1, 2]
+        rows = list(cql.execute(cql.prepare(
+            f"SELECT p FROM {table} WHERE v = ? ALLOW FILTERING"), [d2]))
+        assert sorted(r.p for r in rows) == [1, 2]
+
+        # --- Secondary index: byte-based - each repr finds only its row ---
+        with new_secondary_index(cql, table, 'v') as idx:
+            ks, idx_name = idx.split('.')
+            wait_for_index(cql, ks, idx_name)
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT p FROM {table} WHERE v = ?"), [d1]))
+            assert [r.p for r in rows] == [1]
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT p FROM {table} WHERE v = ?"), [d2]))
+            assert [r.p for r in rows] == [2]
+
+        # --- MV with decimal as partition key: byte-based ---
+        with new_materialized_view(cql, table, '*', 'v, p',
+                'v is not null and p is not null') as mv:
+            wait_for_view_built(cql, mv)
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT p, data FROM {mv} WHERE v = ?"), [d1]))
+            assert len(rows) == 1 and rows[0].p == 1
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT p, data FROM {mv} WHERE v = ?"), [d2]))
+            assert len(rows) == 1 and rows[0].p == 2
+
+        # --- MV with decimal as clustering key: value-based ---
+        with new_materialized_view(cql, table, '*', 'p, v',
+                'v is not null and p is not null') as mv:
+            wait_for_view_built(cql, mv)
+            # Query p=1 using d2 (different repr) - finds it.
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT data FROM {mv} WHERE p = ? AND v = ?"),
+                [1, d2]))
+            assert len(rows) == 1 and rows[0].data == 'a'
+            # Query p=2 using d1 (different repr) - finds it.
+            rows = list(cql.execute(cql.prepare(
+                f"SELECT data FROM {mv} WHERE p = ? AND v = ?"),
+                [2, d1]))
+            assert len(rows) == 1 and rows[0].data == 'b'
+
+# Decimal operator+= OOM on extreme scale difference.
+# Adding two decimals with very different scales in operator+= rescales
+# both operands to the larger scale via pow(10, scale_diff). CQL's
+# decimal type allows arbitrary scales (int32 range), so a table with
+# values like 1e1000000000 and 1 forces pow(10, 1000000000) when
+# computing SUM() or AVG(), allocating a number with ~1 billion digits.
+# This is the same class of DoS as issue #8002 (to_string OOM)
+# but in arithmetic.
+# This test is skipped because it would hang or crash the tests.
+# Reproduces SCYLLADB-1576
+@pytest.mark.skip_bug(reason="SCYLLADB-1576")
+def test_decimal_sum_extreme_scale_oom(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int, c decimal, PRIMARY KEY (p)") as table:
+        stmt = cql.prepare(f"INSERT INTO {table} (p, c) VALUES (?, ?)")
+        cql.execute(stmt, [1, Decimal('1e1000000000')])
+        cql.execute(stmt, [2, Decimal('1')])
+        result = list(cql.execute(f"SELECT sum(c) FROM {table}"))
+        assert len(result) == 1
+
+# Verify that toJson() on decimal values produces output consistent with
+# Java's BigDecimal.toString() specification.
+# See: https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+#
+# The toJson() function in CQL calls the type's toJSONString(), which
+# for DecimalType delegates to BigDecimal.toString(). This test can be
+# run on Cassandra to validate the expected output strings.
+#
+# Scylla's to_string() currently diverges from Java in several cases:
+# - Zero with scale (e.g. 0.0, 0.00) loses the scale
+# - Negative scale values are expanded instead of using exponential form
+# Once to_string() is fixed (SCYLLADB-1574), this test should pass and
+# the xfail can be removed.
+@pytest.mark.xfail(reason="SCYLLADB-1574")
+def test_decimal_tojson_representation(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p int PRIMARY KEY, v decimal") as table:
+        stmt = cql.prepare(f"INSERT INTO {table} (p, v) VALUES (?, ?)")
+        cases = [
+            # (input, expected toJson output per Java BigDecimal.toString())
+
+            # Plain integers -- scale=0, no surprises
+            (Decimal('0'), '0'),
+            (Decimal('123'), '123'),
+            (Decimal('-45'), '-45'),
+
+            # Plain fractional -- scale>0, adjusted_exp >= -6
+            (Decimal('1.23'), '1.23'),
+            (Decimal('0.001'), '0.001'),
+            (Decimal('-1.23'), '-1.23'),
+
+            # Zero with scale -- Scylla's to_string() loses scale info
+            (Decimal('0.0'), '0.0'),
+            (Decimal('0.00'), '0.00'),
+
+            # adjusted_exp boundary: -6 is plain, -7 switches to exponential
+            # adj_exp = num_digits - 1 - scale
+            # 0.00000123: digits=123, adj_exp = 2 - 8 = -6 -> plain
+            (Decimal('0.00000123'), '0.00000123'),
+            # 0.000000123: digits=123, adj_exp = 2 - 9 = -7 -> exponential
+            (Decimal('0.000000123'), '1.23E-7'),
+
+            # Negative scale boundary: scale=0 is plain, scale<0 is exponential.
+            # Scylla's to_string() expands these to plain form instead.
+            # scale=0 -> plain
+            (Decimal('1230'), '1230'),
+            (Decimal('10'), '10'),
+            (Decimal('100'), '100'),
+            # scale=-1 -> exponential
+            (Decimal((0, (1, 2, 3), 1)), '1.23E+3'),
+            (Decimal((0, (1,), 1)), '1E+1'),
+            # scale=-2 -> exponential
+            (Decimal((0, (1,), 2)), '1E+2'),
+        ]
+        for i, (val, expected) in enumerate(cases):
+            cql.execute(stmt, [i, val])
+            rows = list(cql.execute(
+                f"SELECT toJson(v) FROM {table} WHERE p = {i}"))
+            assert len(rows) == 1
+            assert rows[0][0] == expected, \
+                f"For input {val} (as_tuple={val.as_tuple()}): " \
+                f"expected toJson={expected!r}, got {rows[0][0]!r}"

--- a/test/cqlpy/test_type_varint.py
+++ b/test/cqlpy/test_type_varint.py
@@ -1,0 +1,104 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+#############################################################################
+# Tests involving the "varint" column type, focusing on non-canonical
+# byte representations.
+#
+# The CQL varint type uses signed big-endian two's complement encoding.
+# The canonical form is minimal: no redundant leading 0x00 (for non-negative)
+# or 0xFF (for negative) bytes.  However, non-canonical representations with
+# extra leading sign-extension bytes (e.g., 0x00 0x01 instead of 0x01 for
+# the value 1) are accepted by both Scylla and Cassandra and can be produced
+# by drivers via prepared-statement bind variables.
+#
+# The key issue is the same as for decimal (see test_type_decimal.py):
+# partition keys are identified by raw byte representation (fed into the
+# partitioner hash), while clustering keys are compared by semantic value.
+# Two non-canonical representations of the same varint value will hash to
+# different partitions but compare as equal in clustering order.
+#############################################################################
+
+import cassandra.cqltypes
+import pytest
+
+from .util import new_test_table, unique_key_int
+
+
+class NonCanonicalVarint:
+    """Wrapper around an int that causes the patched driver serializer to
+    produce a non-canonical (padded) varint encoding.
+
+    For non-negative values, one extra leading 0x00 byte is prepended.
+    For negative values, one extra leading 0xFF byte is prepended.
+    """
+    def __init__(self, value):
+        self.value = value
+
+
+# Original serializer, saved once at import time.
+_orig_serialize = cassandra.cqltypes.IntegerType.serialize
+
+
+def _patched_serialize(val, protocol_version):
+    if isinstance(val, NonCanonicalVarint):
+        canonical = _orig_serialize(val.value, protocol_version)
+        pad = b'\xff' if val.value < 0 else b'\x00'
+        return pad + canonical
+    return _orig_serialize(val, protocol_version)
+
+
+@pytest.fixture(autouse=True)
+def _patch_varint_serializer():
+    cassandra.cqltypes.IntegerType.serialize = staticmethod(_patched_serialize)
+    yield
+    cassandra.cqltypes.IntegerType.serialize = _orig_serialize
+
+
+# Verify that the same varint value with canonical vs non-canonical byte
+# encoding behaves differently as a partition key (byte-based identity)
+# but identically as a clustering key (value-based comparison).
+# This mirrors test_decimal_key_representation in test_type_decimal.py.
+# We test both positive (sign-extension 0x00) and negative (0xFF) values.
+def test_varint_key_representation(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace,
+            "p varint, c varint, v text, PRIMARY KEY (p, c)") as table:
+        stmt = cql.prepare(
+            f"INSERT INTO {table} (p, c, v) VALUES (?, ?, ?)")
+
+        for val, label in [(1, 'pos'), (-1, 'neg')]:
+            canonical = val
+            non_canonical = NonCanonicalVarint(val)
+
+            # Insert with canonical PK and CK.
+            cql.execute(stmt, [canonical, canonical, f'{label}_a'])
+            # Same canonical PK, non-canonical CK — same CK *value*, so
+            # this overwrites the previous row (CK comparison is value-based).
+            cql.execute(stmt, [canonical, non_canonical, f'{label}_b'])
+            # Non-canonical PK — different partition entirely, despite
+            # the same numeric PK value (PK identity is byte-based).
+            cql.execute(stmt, [non_canonical, canonical, f'{label}_c'])
+
+            # Canonical partition: 1 row (overwritten to _b).
+            rows = list(cql.execute(
+                cql.prepare(f"SELECT v FROM {table} WHERE p = ?"),
+                [canonical]))
+            assert len(rows) == 1
+            assert rows[0].v == f'{label}_b'
+
+            # Non-canonical partition: 1 row.
+            rows_nc = list(cql.execute(
+                cql.prepare(f"SELECT v FROM {table} WHERE p = ?"),
+                [non_canonical]))
+            assert len(rows_nc) == 1
+            assert rows_nc[0].v == f'{label}_c'
+
+            # Cross-representation CK lookup: non-canonical CK in
+            # canonical partition should find the row.
+            rows_cross = list(cql.execute(
+                cql.prepare(
+                    f"SELECT v FROM {table} WHERE p = ? AND c = ?"),
+                [canonical, non_canonical]))
+            assert len(rows_cross) == 1
+            assert rows_cross[0].v == f'{label}_b'

--- a/test/vector_search/filter_test.cc
+++ b/test/vector_search/filter_test.cc
@@ -13,6 +13,8 @@
 #include "cql3/util.hh"
 #include "test/lib/cql_assertions.hh"
 #include "test/lib/cql_test_env.hh"
+#include "types/types.hh"
+#include "utils/big_decimal.hh"
 #include "utils/rjson.hh"
 #include "vector_search/filter.hh"
 
@@ -443,6 +445,74 @@ SEASTAR_TEST_CASE(to_json_nonprimary_key_bind_marker) {
         auto json = rjson::print(filter.to_json(options));
 
         auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":1},{"type":"==","lhs":"r","rhs":99}],"allow_filtering":true})json";
+        BOOST_CHECK_EQUAL(json, expected);
+    });
+}
+
+// Decimal and varint filter values must be serialized as JSON strings, not
+// bare JSON numbers - to avoid precision loss.
+SEASTAR_TEST_CASE(to_json_decimal) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(pk decimal, ck int, v vector<float, 3>, primary key(pk, ck))");
+
+        // Basic literal value.
+        auto restr = make_restrictions("pk=1.23", e);
+        auto json = get_restrictions_json(*restr, false);
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"1.23"}],"allow_filtering":false})json";
+        BOOST_CHECK_EQUAL(json, expected);
+
+        // Value exceeding double precision (more than 15-16 significant digits).
+        restr = make_restrictions("pk=98765432109876543210.12345", e);
+        json = get_restrictions_json(*restr, false);
+        expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"98765432109876543210.12345"}],"allow_filtering":false})json";
+        BOOST_CHECK_EQUAL(json, expected);
+
+        // Same value via bind marker.
+        restr = make_restrictions("pk=?", e);
+        auto filter = vector_search::prepare_filter(*restr, false);
+        std::vector<raw_value> bind_values = {
+            raw_value::make_value(decimal_type->decompose(big_decimal("98765432109876543210.12345")))};
+        auto options = make_query_options(std::move(bind_values));
+        json = rjson::print(filter.to_json(options));
+        BOOST_CHECK_EQUAL(json, expected);
+
+        // Integer decimal exceeding uint64_max (18446744073709551615).
+        restr = make_restrictions("pk=98765432109876543210", e);
+        json = get_restrictions_json(*restr, false);
+        expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"98765432109876543210"}],"allow_filtering":false})json";
+        BOOST_CHECK_EQUAL(json, expected);
+
+        // Exact representation: "1.230" (scale=3, unscaled=1230) must stay
+        // "1.230", not be normalized to "1.23". These are different partition
+        // keys because the wire format differs.
+        restr = make_restrictions("pk=?", e);
+        auto filter2 = vector_search::prepare_filter(*restr, false);
+        std::vector<raw_value> bind_values2 = {
+            raw_value::make_value(decimal_type->decompose(big_decimal("1.230")))};
+        auto options2 = make_query_options(std::move(bind_values2));
+        json = rjson::print(filter2.to_json(options2));
+        expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"1.230"}],"allow_filtering":false})json";
+        BOOST_CHECK_EQUAL(json, expected);
+    });
+}
+
+SEASTAR_TEST_CASE(to_json_varint) {
+    return do_with_cql_env_thread([](cql_test_env& e) {
+        cquery_nofail(e, "create table ks.t(pk varint, ck int, v vector<float, 3>, primary key(pk, ck))");
+
+        // Value exceeding uint64_max (18446744073709551615).
+        auto restr = make_restrictions("pk=98765432109876543210", e);
+        auto json = get_restrictions_json(*restr, false);
+        auto expected = R"json({"restrictions":[{"type":"==","lhs":"pk","rhs":"98765432109876543210"}],"allow_filtering":false})json";
+        BOOST_CHECK_EQUAL(json, expected);
+
+        // Same value via bind marker.
+        restr = make_restrictions("pk=?", e);
+        auto filter = vector_search::prepare_filter(*restr, false);
+        std::vector<raw_value> bind_values = {
+            raw_value::make_value(varint_type->decompose(utils::multiprecision_int("98765432109876543210")))};
+        auto options = make_query_options(std::move(bind_values));
+        json = rjson::print(filter.to_json(options));
         BOOST_CHECK_EQUAL(json, expected);
     });
 }

--- a/utils/big_decimal.cc
+++ b/utils/big_decimal.cc
@@ -140,6 +140,60 @@ sstring big_decimal::to_string() const
     return str;
 }
 
+// Java BigDecimal.toString() spec (JDK 8+):
+// See: https://docs.oracle.com/javase/8/docs/api/java/math/BigDecimal.html#toString--
+//   adjusted_exp = -scale + (precision - 1)
+//   if scale >= 0 AND adjusted_exp >= -6: plain decimal (no exponent)
+//   otherwise: exponential notation with 'E' suffix
+//
+// This guarantees a bijective mapping from (unscaled, scale) to string.
+// Using int64_t for adjusted_exp to avoid overflow when scale is extreme.
+//
+// This could replace to_string(), but doing so has wider consequences
+// (e.g. hash/equality contract for decimal_type) described in SCYLLADB-1574.
+sstring big_decimal::to_string_canonical() const
+{
+    boost::multiprecision::cpp_int num = boost::multiprecision::abs(_unscaled_value);
+    auto digits = !_unscaled_value ? std::string("0") : num.str(); // decimal digits, no sign
+    int64_t precision = static_cast<int64_t>(digits.size());
+    int64_t adjusted_exp = -static_cast<int64_t>(_scale) + (precision - 1);
+
+    std::string result;
+    if (_unscaled_value < 0) {
+        result += '-';
+    }
+
+    if (_scale >= 0 && adjusted_exp >= -6) {
+        // Plain decimal form (no exponent).
+        int64_t int_digits = precision - static_cast<int64_t>(_scale);
+        if (int_digits > 0) {
+            result.append(digits.data(), int_digits);
+            if (_scale > 0) {
+                result += '.';
+                result.append(digits.data() + int_digits, _scale);
+            }
+        } else {
+            result += "0.";
+            result.append(-int_digits, '0');
+            result.append(digits);
+        }
+    } else {
+        // Exponential notation.
+        result += digits[0];
+        if (precision > 1) {
+            result += '.';
+            result.append(digits.data() + 1, precision - 1);
+        }
+        result += 'E';
+        if (adjusted_exp >= 0) {
+            result += '+';
+        }
+        result += std::to_string(adjusted_exp);
+    }
+
+    return sstring(result);
+}
+
 std::strong_ordering big_decimal::tri_cmp_slow(const big_decimal& other) const
 {
     auto max_scale = std::max(_scale, other._scale);

--- a/utils/big_decimal.hh
+++ b/utils/big_decimal.hh
@@ -43,6 +43,14 @@ public:
 
     sstring to_string() const;
 
+    // Exact string representation following the Java BigDecimal.toString() spec
+    // (JDK 8+). Unlike to_string(), this is bijective: each (unscaled, scale)
+    // pair maps to a unique string. Uses exponential notation when the exponent
+    // is large or the scale is negative. This could replace to_string(), but
+    // doing so has wider consequences (e.g. hash/equality contract for
+    // decimal_type) described in SCYLLADB-1574.
+    sstring to_string_canonical() const;
+
     std::strong_ordering operator<=>(const big_decimal& other) const;
 
     big_decimal& operator+=(const big_decimal& other);

--- a/vector_search/filter.cc
+++ b/vector_search/filter.cc
@@ -12,6 +12,7 @@
 #include "cql3/expr/expr-utils.hh"
 #include "cql3/expr/evaluate.hh"
 #include "types/json_utils.hh"
+#include "utils/big_decimal.hh"
 
 namespace vector_search {
 
@@ -59,7 +60,22 @@ rjson::value value_to_json(const data_type& type, const cql3::raw_value& val) {
     if (val.is_null()) {
         return rjson::null_value();
     }
-    auto json_str = to_json_string(*type, to_bytes(val.view()));
+    auto base_type = type->is_reversed() ? type->underlying_type() : type;
+    // For decimal and varint types, rjson::parse() on the JSON string would
+    // parse through a double, losing precision for large values. Instead,
+    // produce the numeric string directly and wrap it with rjson::from_string()
+    // which preserves the exact digits.
+    // TODO: once to_json_string() uses a lossless representation for these
+    // types (SCYLLADB-1574), revert its common use.
+    if (base_type == decimal_type) {
+        auto bd = value_cast<big_decimal>(base_type->deserialize(to_bytes(val.view())));
+        return rjson::from_string(bd.to_string_canonical());
+    }
+    if (base_type == varint_type) {
+        auto json_str = to_json_string(*base_type, to_bytes(val.view()));
+        return rjson::from_string(json_str);
+    }
+    auto json_str = to_json_string(*base_type, to_bytes(val.view()));
     return rjson::parse(json_str);
 }
 


### PR DESCRIPTION
value_to_json() converts CQL values to JSON for vector search filters. For decimal and varint types, it used rjson::parse() on the JSON string, which parses through a double and silently loses precision for values exceeding ~15 significant digits — producing wrong filter results.

Additionally, for decimal type we need an exact string representation that preserves the original (unscaled, scale) pair, because partition keys use byte-level identity: different serialized representations of the same numeric value are distinct rows, so the filter must reproduce the exact representation stored in the key.

Add big_decimal::to_string_canonical() which follows the Java BigDecimal toString() spec (JDK 8+), producing a bijective string representation that uses exponential notation for extreme scales instead of expanding trailing zeros (which could cause OOM). This could replace to_string(), but doing so has wider consequences (e.g. hash/equality contract for decimal_type) described in SCYLLADB-1574. Use it in value_to_json() for decimal_type, and use rjson::from_string() for varint_type, both bypassing the lossy double parse path.

Tests cover the new to_string_canonical() and the filter fix, as well as existing decimal type behavior (key representation, clustering order, toJson) that we rely on and must not break. The CQL decimal type tests (test_type_decimal.py) also pass against Cassandra.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1583
Refs: https://scylladb.atlassian.net/browse/SCYLLADB-1574

Filtering was added in 2026.1 and this fix should be backported to enable full support of Decimal and Varint keys types.