### PR TITLE
test: per-bucket isolation for S3/GCS object storage tests

### DIFF
--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -8,6 +8,7 @@
 
 
 #include <unordered_set>
+#include <regex>
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
@@ -71,6 +72,65 @@ static shared_ptr<s3::client> make_minio_client(semaphore& mem) {
     return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem);
 }
 
+using client_maker_function = std::function<shared_ptr<s3::client>(semaphore&)>;
+
+// Per-test S3 fixture: creates an S3 client and a unique bucket on
+// construction, closes the client and deletes the bucket (with all
+// objects) on destruction.
+// Must be used inside a seastar::thread context.
+//
+// Bucket name is derived from the Boost test name + pid,
+// making it unique across concurrent test processes and multiple
+// fixtures within a single test.
+class s3_test_fixture {
+    shared_ptr<s3::client> _client;
+    sstring _bucket;
+
+    // S3 bucket names must be 3-63 chars, alphanumeric and hyphens only, no consecutive hyphens, no leading/trailing hyphen.
+    static sstring get_sanitized_bucket_name() {
+        static constexpr std::string_view prefix = "s3-"sv;
+        static constexpr size_t prefix_len = prefix.length();
+        const std::string suffix = format("-{}", ::getpid());
+        static const std::regex re("[^A-Za-z0-9]+");
+
+        const std::string normalized_test_name =
+            std::regex_replace(boost::unit_test::framework::current_test_unit().p_name.get(), re, "-").substr(0, 63 - prefix_len - suffix.length());
+        // e.g. "s3-test-chunked-download-data-source-with-delays-proxy-335888"
+        return format("{}{}{}", prefix, normalized_test_name, suffix);
+    }
+
+public:
+    s3_test_fixture(const client_maker_function& maker, semaphore& mem)
+        : _client(maker(mem))
+        , _bucket(get_sanitized_bucket_name())
+    {
+        testlog.info("Creating test bucket {}", _bucket);
+        _client->create_bucket(_bucket).get();
+    }
+
+    ~s3_test_fixture() {
+        try {
+            testlog.info("Cleaning up test bucket {}", _bucket);
+            _client->delete_bucket_with_objects(_bucket).get();
+            testlog.info("Deleted test bucket {}", _bucket);
+            _client->close().get();
+        } catch (...) {
+            testlog.error("Failed to clean up fixture for bucket {}: {}", _bucket, std::current_exception());
+        }
+    }
+
+    s3_test_fixture(const s3_test_fixture&) = delete;
+    s3_test_fixture& operator=(const s3_test_fixture&) = delete;
+
+    const sstring& bucket() const { return _bucket; }
+    shared_ptr<s3::client> client() const { return _client; }
+
+    // Format an object path: /<bucket>/<object_name>
+    sstring object_path(std::string_view object_name) const {
+        return fmt::format("/{}/{}", _bucket, object_name);
+    }
+};
+
 static future<uint32_t> create_file(const std::string& path, size_t file_size) {
     uint32_t ret_val = crc32_utils::init_checksum();
     file f = co_await open_file_dma(path, open_flags::truncate | open_flags::create | open_flags::wo);
@@ -87,21 +147,16 @@ static future<uint32_t> create_file(const std::string& path, size_t file_size) {
     co_return ret_val;
 }
 
-using client_maker_function = std::function<shared_ptr<s3::client>(semaphore&)>;
-
 /*
  * Tests below expect minio server to be running on localhost
- * with the bucket named env['S3_BUCKET_FOR_TEST'] created with
- * unrestricted anonymous read-write access
+ * with s3_test_fixture creating per-test buckets for isolation
  */
 
 void client_put_get_object(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client\n");
     semaphore mem(16 << 20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testobject");
 
     testlog.info("Put object {}\n", name);
     temporary_buffer<char> data = sstring("1234567890").release();
@@ -142,20 +197,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_put_get_object_proxy) {
     client_put_get_object(make_proxy_client);
 }
 
-static auto deferred_delete_object(shared_ptr<s3::client> client, sstring name) {
-    return seastar::defer([client, name] {
-        testlog.info("Delete object: {}\n", name);
-        client->delete_object(name).get();
-    });
-}
-
 void do_test_client_multipart_upload(const client_maker_function& client_maker, bool with_copy_upload) {
-    const sstring name(fmt::format("/{}/test{}object-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), with_copy_upload ? "jumbo" : "large", ::getpid()));
-
-    testlog.info("Make client\n");
     semaphore mem(16<<20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path(fmt::format("test{}object", with_copy_upload ? "jumbo" : "large"));
 
     testlog.info("Upload object (with copy = {})\n", with_copy_upload);
     auto out = output_stream<char>(
@@ -175,7 +221,6 @@ void do_test_client_multipart_upload(const client_maker_function& client_maker, 
 
     testlog.info("Flush multipart upload\n");
     out.flush().get();
-    auto delete_object = deferred_delete_object(cln, name);
 
     testlog.info("Closing\n");
     close.close_now();
@@ -218,13 +263,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_copy_upload_proxy) {
 }
 
 void client_multipart_upload_fallback(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testfbobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client");
     semaphore mem(0);
     mem.broken(); // so that any attempt to use it throws
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testfbobject");
 
     testlog.info("Upload object");
     auto out = output_stream<char>(cln->make_upload_sink(name));
@@ -235,7 +278,6 @@ void client_multipart_upload_fallback(const client_maker_function& client_maker)
 
     testlog.info("Flush upload");
     out.flush().get(); // if it tries to do regular flush, memory claim would throw
-    auto delete_object = deferred_delete_object(cln, name);
 
     testlog.info("Closing");
     close.close_now();
@@ -255,20 +297,19 @@ SEASTAR_THREAD_TEST_CASE(test_client_multipart_upload_fallback_proxy) {
 
 using with_remainder_t = bool_class<class with_remainder_tag>;
 
-future<> test_client_upload_file(const client_maker_function& client_maker, std::string_view test_name, size_t total_size, size_t memory_size) {
+void test_client_upload_file(const client_maker_function& client_maker, size_t total_size, size_t memory_size) {
     tmpdir tmp;
     const auto file_path = tmp.path() / "test";
 
-    auto expected_checksum = co_await create_file(file_path, total_size);
-    const auto object_name = fmt::format("/{}/{}-{}",
-                                         tests::getenv_safe("S3_BUCKET_FOR_TEST"),
-                                         test_name,
-                                         ::getpid());
+    auto expected_checksum = create_file(file_path, total_size).get();
+
+    semaphore guard_mem(memory_size);
+    s3_test_fixture guard(client_maker, guard_mem);
+    auto client = guard.client();
+    const auto object_name = guard.object_path("upload-test");
 
     // 2. upload the file to s3
-    semaphore mem{memory_size};
-    auto client = client_maker(mem);
-    co_await client->upload_file(file_path, object_name);
+    client->upload_file(file_path, object_name).get();
     // 3. retrieve the object from s3 and retrieve the object from S3 and
     //    compare it with the pattern
     uint32_t actual_checksum = crc32_utils::init_checksum();
@@ -276,7 +317,7 @@ future<> test_client_upload_file(const client_maker_function& client_maker, std:
     auto input = make_file_input_stream(readable_file);
     size_t actual_size = 0;
     for (;;) {
-        auto buf = co_await input.read();
+        auto buf = input.read().get();
         if (buf.empty()) {
             // empty() signifies the end of stream
             break;
@@ -291,72 +332,67 @@ future<> test_client_upload_file(const client_maker_function& client_maker, std:
     BOOST_CHECK_EQUAL(total_size, actual_size);
     BOOST_CHECK_EQUAL(expected_checksum, actual_checksum);
 
-    co_await readable_file.close();
-    co_await input.close();
-    co_await client->delete_object(object_name);
-    co_await client->close();
+    readable_file.close().get();
+    input.close().get();
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_multi_part_without_remainder_minio) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_without_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size, memory_size);
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_multi_part_without_remainder_proxy) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_without_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = 4 * part_size;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size, memory_size);
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_multi_part_with_remainder_minio) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_with_remainder_minio) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size, memory_size);
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_multi_part_with_remainder_proxy) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_multi_part_with_remainder_proxy) {
     const size_t part_size = 5_MiB;
     const size_t remainder_size = part_size / 2;
     const size_t total_size = 4 * part_size + remainder_size;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size, memory_size);
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_single_part_minio) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_single_part_minio) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_minio_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_minio_client, total_size, memory_size);
 }
 
-SEASTAR_TEST_CASE(test_client_upload_file_single_part_proxy) {
+SEASTAR_THREAD_TEST_CASE(test_client_upload_file_single_part_proxy) {
     const size_t part_size = 5_MiB;
     const size_t total_size = part_size / 2;
     const size_t memory_size = part_size;
-    co_await test_client_upload_file(make_proxy_client, seastar_test::get_name(), total_size, memory_size);
+    test_client_upload_file(make_proxy_client, total_size, memory_size);
 }
 
 
 SEASTAR_THREAD_TEST_CASE(test_client_abort_stuck_semaphore) {
-    const sstring base_name(fmt::format("test_object-{}", ::getpid()));
     constexpr size_t object_size = 128_KiB;
 
     tmpdir tmp;
-    const auto file_path = tmp.path() / base_name;
+    const auto file_path = tmp.path() / "test_object";
 
     create_file(file_path, object_size).get();
 
-    testlog.info("Make client\n");
     semaphore mem(32_KiB);
-    auto cln = make_minio_client(mem);
-    auto close_client = deferred_close(*cln);
-    const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
-    auto delete_object = deferred_delete_object(cln, object_name);
+    s3_test_fixture guard(make_minio_client, mem);
+    auto cln = guard.client();
+    const auto object_name = guard.object_path("test_object");
     abort_source as;
     auto upload = cln->upload_file(file_path, object_name, {}, {}, &as);
     auto ex = std::make_exception_ptr(std::runtime_error("Cancelling!"));
@@ -369,17 +405,14 @@ SEASTAR_THREAD_TEST_CASE(test_client_abort_stuck_semaphore) {
 }
 
 void client_readable_file(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testroobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client\n");
     semaphore mem(16<<20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testroobject");
 
     testlog.info("Put object {}\n", name);
     temporary_buffer<char> data = sstring("1234567890ABCDEF").release();
     cln->put_object(name, std::move(data)).get();
-    auto delete_object = deferred_delete_object(cln, name);
 
     auto f = cln->make_readable_file(name);
     auto close_readable_file = deferred_close(f);
@@ -419,18 +452,15 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file_proxy) {
 }
 
 void client_readable_file_stream(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/teststreamobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client\n");
     semaphore mem(16<<20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("teststreamobject");
 
     testlog.info("Put object {}\n", name);
     sstring sample("1F2E3D4C5B6A70899807A6B5C4D3E2F1");
     temporary_buffer<char> data(sample.c_str(), sample.size());
     cln->put_object(name, std::move(data)).get();
-    auto delete_object = deferred_delete_object(cln, name);
 
     auto f = cln->make_readable_file(name);
     auto close_readable_file = deferred_close(f);
@@ -451,15 +481,13 @@ SEASTAR_THREAD_TEST_CASE(test_client_readable_file_stream_proxy) {
 }
 
 void client_put_get_tagging(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testobject-{}",
-                                   tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     semaphore mem(16<<20);
-    auto client = client_maker(mem);
+    s3_test_fixture guard(client_maker, mem);
+    auto client = guard.client();
+    const auto name = guard.object_path("testobject");
 
-    auto close_client = deferred_close(*client);
     auto data = sstring("1234567890ABCDEF").release();
     client->put_object(name, std::move(data)).get();
-    auto delete_object = deferred_delete_object(client, name);
 
     {
         auto tagset = client->get_object_tagging(name).get();
@@ -502,11 +530,11 @@ static std::unordered_set<sstring> populate_bucket(shared_ptr<s3::client> client
 }
 
 void client_list_objects(const client_maker_function& client_maker) {
-    const sstring bucket = tests::getenv_safe("S3_BUCKET_FOR_TEST");
-    const sstring prefix(fmt::format("testprefix-{}/", ::getpid()));
     semaphore mem(16<<20);
-    auto client = client_maker(mem);
-    auto close_client = deferred_close(*client);
+    s3_test_fixture guard(client_maker, mem);
+    auto client = guard.client();
+    const sstring& bucket = guard.bucket();
+    const sstring prefix("testprefix/");
 
     // Put extra object to check list-by-prefix filters it out
     temporary_buffer<char> data = sstring("1234567890").release();
@@ -534,11 +562,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_proxy) {
 }
 
 void client_list_objects_incomplete(const client_maker_function& client_maker) {
-    const sstring bucket = tests::getenv_safe("S3_BUCKET_FOR_TEST");
-    const sstring prefix(fmt::format("testprefix-{}/", ::getpid()));
     semaphore mem(16<<20);
-    auto client = client_maker(mem);
-    auto close_client = deferred_close(*client);
+    s3_test_fixture guard(client_maker, mem);
+    auto client = guard.client();
+    const sstring& bucket = guard.bucket();
+    const sstring prefix("testprefix/");
 
     populate_bucket(client, bucket, prefix, 8);
 
@@ -558,8 +586,10 @@ SEASTAR_THREAD_TEST_CASE(test_client_list_objects_incomplete_proxy) {
     client_list_objects_incomplete(make_proxy_client);
 }
 
+// Not using s3_test_fixture here — the test intentionally targets a
+// non-existent bucket, so there is no bucket to create or clean up.
 void client_broken_bucket(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testobject-{}", "NO_BUCKET", ::getpid()));
+    const sstring name("/NO_BUCKET/testobject");
     semaphore mem(16 << 20);
     auto client = client_maker(mem);
 
@@ -575,11 +605,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_broken_bucket_minio) {
 }
 
 void client_missing_prefix(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    s3_test_fixture guard(client_maker, mem);
+    auto client = guard.client();
+    const auto name = guard.object_path("testobject");
 
-    auto close_client = deferred_close(*client);
     BOOST_REQUIRE_EXCEPTION(client->get_object_size(name).get(), storage_io_error, [](const storage_io_error& e) {
         return e.code().value() == ENOENT && e.what() == "S3 request failed. Code: 117. Reason:  HTTP code: 404 Not Found"sv;
     });
@@ -590,11 +620,11 @@ SEASTAR_THREAD_TEST_CASE(test_client_missing_prefix_minio) {
 }
 
 void client_access_missing_object(const client_maker_function& client_maker) {
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
     semaphore mem(16 << 20);
-    auto client = client_maker(mem);
+    s3_test_fixture guard(client_maker, mem);
+    auto client = guard.client();
+    const auto name = guard.object_path("testobject");
 
-    auto close_client = deferred_close(*client);
     BOOST_REQUIRE_EXCEPTION(client->get_object_tagging(name).get(), storage_io_error, [](const storage_io_error& e) {
         return e.code().value() == ENOENT && e.what() == "S3 request failed. Code: 133. Reason: The specified key does not exist."sv;
     });
@@ -606,12 +636,10 @@ SEASTAR_THREAD_TEST_CASE(test_client_access_missing_object_minio) {
 
 SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
     // Pay attention, we are reuploading the same file during the test
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
     semaphore mem(16 << 20);
-    auto cln = make_minio_client(mem);
-    auto close_client = deferred_close(*cln);
-    auto delete_object = deferred_delete_object(cln, name);
+    s3_test_fixture guard(make_minio_client, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testobject");
     constexpr std::string_view content{"1234567890"};
     for (auto i : {1, 2}) {
         testlog.info("Put object {}, iteration {}", name, i);
@@ -655,13 +683,10 @@ SEASTAR_THREAD_TEST_CASE(test_object_reupload) {
 }
 
 void test_download_data_source(const client_maker_function& client_maker, bool is_chunked, unsigned chunks) {
-    const sstring name(fmt::format("/{}/testdatasourceobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
-    testlog.info("Make client\n");
     semaphore mem(16<<20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
-    auto delete_object = deferred_delete_object(cln, name);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testdatasourceobject");
 
     static constexpr unsigned chunk_size = 1000;
     testlog.info("Preparation: Upload object");
@@ -702,19 +727,14 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_proxy) {
 }
 
 void test_chunked_download_data_source(const client_maker_function& client_maker, size_t object_size) {
-    const sstring base_name(fmt::format("test_object-{}", ::getpid()));
-
     tmpdir tmp;
-    const auto file_path = tmp.path() / base_name;
-
+    const auto file_path = tmp.path() / "test_object";
     create_file(file_path, object_size).get();
 
-    testlog.info("Make client\n");
     semaphore mem(16 << 20);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
-    const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
-    auto delete_object = deferred_delete_object(cln, object_name);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto object_name = guard.object_path("test_object");
     cln->upload_file(file_path, object_name).get();
 
     testlog.info("Download object");
@@ -765,8 +785,6 @@ void test_chunked_download_data_source(const client_maker_function& client_maker
 #else
     testlog.info("Skipping error injection test, as it requires SCYLLA_ENABLE_ERROR_INJECTION to be enabled");
 #endif
-
-    cln->delete_object(object_name).get();
 }
 
 SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_minio) {
@@ -778,19 +796,14 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_with_delays_proxy) {
 }
 
 void do_test_chunked_download_data_source_memory(const client_maker_function& client_maker, size_t object_size) {
-    const sstring base_name(fmt::format("test_object-{}", ::getpid()));
-
     tmpdir tmp;
-    const auto file_path = tmp.path() / base_name;
-
+    const auto file_path = tmp.path() / "test_object";
     create_file(file_path, object_size).get();
 
-    testlog.info("Make client\n");
-    semaphore mem(1_MiB);
-    auto cln = client_maker(mem);
-    auto close_client = deferred_close(*cln);
-    const auto object_name = fmt::format("/{}/{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), base_name);
-    auto delete_object = deferred_delete_object(cln, object_name);
+    semaphore guard_mem(1_MiB);
+    s3_test_fixture guard(client_maker, guard_mem);
+    auto cln = guard.client();
+    const auto object_name = guard.object_path("test_object");
     cln->upload_file(file_path, object_name).get();
 
     testlog.info("Test client memory exhaust");
@@ -830,14 +843,11 @@ SEASTAR_THREAD_TEST_CASE(test_chunked_download_data_source_memory) {
 }
 
 void test_object_copy(const client_maker_function& client_maker, size_t chunk_size, size_t chunks) {
-    const sstring name(fmt::format("/{}/testobject-{}", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-    const sstring name_copy(fmt::format("/{}/testobject-{}-copy", tests::getenv_safe("S3_BUCKET_FOR_TEST"), ::getpid()));
-
     semaphore mem(16 << 20);
-    auto cln = client_maker(mem);;
-    auto close_client = deferred_close(*cln);
-    auto delete_object = deferred_delete_object(cln, name);
-    auto delete_copy_object = deferred_delete_object(cln, name_copy);
+    s3_test_fixture guard(client_maker, mem);
+    auto cln = guard.client();
+    const auto name = guard.object_path("testobject");
+    const auto name_copy = guard.object_path("testobject-copy");
 
     auto out = output_stream<char>(cln->make_upload_sink(name));
     auto rnd = tests::random::get_bytes(chunk_size);

--- a/test/boost/s3_test.cc
+++ b/test/boost/s3_test.cc
@@ -42,6 +42,34 @@
 using namespace std::string_view_literals;
 using namespace std::chrono_literals;
 
+// Retry strategy for tests: same retryability logic as the default AWS
+// strategy but with a fixed 1ms delay between retries instead of
+// exponential backoff, to keep tests fast.
+class test_retry_strategy : public seastar::http::experimental::retry_strategy {
+    unsigned _max_retries;
+
+public:
+    test_retry_strategy(unsigned max_retries = 10) : _max_retries(max_retries) {}
+
+    future<bool> should_retry(std::exception_ptr error, unsigned attempted_retries) const override {
+        if (attempted_retries >= _max_retries) {
+            co_return false;
+        }
+        auto err = aws::aws_error::from_exception_ptr(error);
+        if (err.is_retryable() != utils::http::retryable::yes) {
+            co_return false;
+        }
+        if (attempted_retries > 0) {
+            co_await seastar::sleep(1ms);
+        }
+        co_return true;
+    }
+};
+
+static std::unique_ptr<seastar::http::experimental::retry_strategy> make_test_retry_strategy() {
+    return std::make_unique<test_retry_strategy>();
+}
+
 // The test can be run on real AWS-S3 bucket. For that, create a bucket with
 // permissive enough policy and then run the test with env set respectively
 // E.g. like this
@@ -60,7 +88,7 @@ static shared_ptr<s3::client> make_proxy_client(semaphore& mem) {
         .use_https = false,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem);
+    return s3::client::make(tests::getenv_safe("PROXY_S3_SERVER_HOST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem, make_test_retry_strategy());
 }
 
 static shared_ptr<s3::client> make_minio_client(semaphore& mem) {
@@ -69,7 +97,7 @@ static shared_ptr<s3::client> make_minio_client(semaphore& mem) {
         .use_https = ::getenv("AWS_DEFAULT_REGION") != nullptr,
         .region = ::getenv("AWS_DEFAULT_REGION") ? : "local",
     };
-    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem);
+    return s3::client::make(tests::getenv_safe("S3_SERVER_ADDRESS_FOR_TEST"), make_lw_shared<s3::endpoint_config>(std::move(cfg)), mem, make_test_retry_strategy());
 }
 
 using client_maker_function = std::function<shared_ptr<s3::client>(semaphore&)>;

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -6,6 +6,8 @@
 
 import os
 import logging
+import re
+import uuid
 
 # use minio_server
 from test.pylib.minio_server import MinioServer
@@ -33,6 +35,22 @@ def format_tuples(tuples=None, **kwargs):
 def keyspace_options(object_storage, rf=1):
     storage_opts = format_tuples(type=f'{object_storage.type}', endpoint=object_storage.address, bucket=object_storage.bucket_name)
     return f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND STORAGE = {storage_opts}"
+
+
+def _make_bucket_name(test_name: str) -> str:
+    """Generate a valid S3 bucket name from a pytest test name.
+
+    S3 bucket naming rules: lowercase, digits, hyphens only; 3-63 chars;
+    must start/end with a letter or digit.
+    """
+    # Lowercase, replace non-alphanumeric runs with a single hyphen, strip leading/trailing hyphens
+    name = re.sub(r'[^a-z0-9]+', '-', test_name.lower()).strip('-')
+    # Add a short unique suffix to avoid collisions (e.g. parametrized tests with same prefix)
+    suffix = uuid.uuid4().hex[:8]
+    # Truncate so total length (name + '-' + suffix) <= 63
+    max_prefix = 63 - len(suffix) - 1
+    name = name[:max_prefix].rstrip('-')
+    return f"{name}-{suffix}"
 
 
 class S3_Server:
@@ -66,6 +84,22 @@ class S3_Server:
             config=boto3.session.Config(signature_version='s3v4'),
             verify=False
         )
+
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using boto3."""
+        self.bucket_name = _make_bucket_name(test_name)
+        resource = self.get_resource()
+        resource.Bucket(self.bucket_name).create()
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using boto3."""
+        try:
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            bucket.delete()
+        except Exception:
+            pass
 
     async def start(self):
         pass
@@ -134,12 +168,14 @@ def create_s3_server(pytestconfig, tmpdir):
     return server
 
 @pytest.fixture(scope="function")
-async def s3_server(pytestconfig, tmpdir):
+async def s3_server(request, pytestconfig, tmpdir):
     server = create_s3_server(pytestconfig, tmpdir)
     await server.start()
+    server.create_test_bucket(request.node.name)
     try:
         yield server
     finally:
+        server.destroy_test_bucket()
         await server.stop()
 
 class GSFront:
@@ -170,6 +206,22 @@ class GSFront:
             config=boto3.session.Config(signature_version='s3v4'),
             verify=False
         )
+
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using boto3."""
+        self.bucket_name = _make_bucket_name(test_name)
+        resource = self.get_resource()
+        resource.Bucket(self.bucket_name).create()
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using boto3."""
+        try:
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            bucket.delete()
+        except Exception:
+            pass
 
     async def start(self):
         pass
@@ -236,6 +288,32 @@ class GSServer(GSFront):
         if response.status_code not in [200, 201]:
             raise Exception(f'Could not create test bucket: {response}')
 
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using GCS HTTP API (fake server doesn't support S3 XML for this)."""
+        self.bucket_name = _make_bucket_name(test_name)
+        response = requests.post(f'{self.endpoint}/storage/v1/b?project=testproject', json={
+            'name': self.bucket_name, 'location': 'US', 'storageClass': 'STANDARD',
+            'iamConfiguration': {
+                'uniformBucketLevelAccess': {
+                    'enabled': True,
+                }
+            }
+        }, timeout=10)
+        if response.status_code not in [200, 201]:
+            raise Exception(f'Could not create test bucket: {response}')
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using GCS HTTP API."""
+        try:
+            # List and delete all objects first using boto3 (listing works on fake GCS)
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            # Delete the bucket via GCS HTTP API
+            requests.delete(f'{self.endpoint}/storage/v1/b/{self.bucket_name}', timeout=10)
+        except Exception:
+            pass
+
     async def stop(self):
         if self.server:
             await self.server.stop()
@@ -257,18 +335,27 @@ async def object_storage(request, pytestconfig, tmpdir):
     else:
         server = create_s3_server(pytestconfig, tmpdir)
 
+    bucket_created = False
     try:
         await server.start()
+        server.create_test_bucket(request.node.name)
+        bucket_created = True
         yield server
     finally:
+        if bucket_created:
+            server.destroy_test_bucket()
         await server.stop()
 
 @pytest.fixture(scope="function")
-async def s3_storage(pytestconfig, tmpdir):
+async def s3_storage(request, pytestconfig, tmpdir):
     server = create_s3_server(pytestconfig, tmpdir)
-
+    bucket_created = False
     try:
         await server.start()
+        server.create_test_bucket(request.node.name)
+        bucket_created = True
         yield server
     finally:
+        if bucket_created:
+            server.destroy_test_bucket()
         await server.stop()

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -4,334 +4,32 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 
-import os
-import logging
-import re
-import uuid
-
-# use minio_server
-from test.pylib.minio_server import MinioServer
-from test.pylib.suite.python import add_s3_options
-from test.pylib.dockerized_service import DockerizedServer
-from operator import attrgetter
 
 import pytest
-import boto3
-import requests
+
+from test.pylib.suite.python import add_s3_options
+from test.pylib.object_storage import (
+    format_tuples,
+    keyspace_options,
+    create_s3_server,
+    create_gs_server,
+    GSFront,
+    GSServer,
+    S3Server,
+    S3_Server,
+    MinioWrapper,
+    s3_server,
+)
+
 
 def pytest_addoption(parser):
     add_s3_options(parser)
 
 
-def format_tuples(tuples=None, **kwargs):
-    '''format a dict to structured values (tuples) in CQL'''
-    if tuples is None:
-        tuples = {}
-    tuples.update(kwargs)
-    body = ', '.join(f"'{key}': '{value}'" for key, value in tuples.items())
-    return f'{{ {body} }}'
-
-
-def keyspace_options(object_storage, rf=1):
-    storage_opts = format_tuples(type=f'{object_storage.type}', endpoint=object_storage.address, bucket=object_storage.bucket_name)
-    return f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND STORAGE = {storage_opts}"
-
-
-def _make_bucket_name(test_name: str) -> str:
-    """Generate a valid S3 bucket name from a pytest test name.
-
-    S3 bucket naming rules: lowercase, digits, hyphens only; 3-63 chars;
-    must start/end with a letter or digit.
-    """
-    # Lowercase, replace non-alphanumeric runs with a single hyphen, strip leading/trailing hyphens
-    name = re.sub(r'[^a-z0-9]+', '-', test_name.lower()).strip('-')
-    # Add a short unique suffix to avoid collisions (e.g. parametrized tests with same prefix)
-    suffix = uuid.uuid4().hex[:8]
-    # Truncate so total length (name + '-' + suffix) <= 63
-    max_prefix = 63 - len(suffix) - 1
-    name = name[:max_prefix].rstrip('-')
-    return f"{name}-{suffix}"
-
-
-class S3_Server:
-    def __init__(self, tempdir: str, address: str, port: int, acc_key: str, secret_key: str, region: str, bucket_name):
-        self.tempdir = tempdir
-        self.ip = address
-        self.port = port
-        self.address = f'http://{self.ip}:{self.port}'
-        self.acc_key = acc_key
-        self.secret_key = secret_key
-        self.region = region
-        self.bucket_name = bucket_name
-
-    def __repr__(self):
-        return f"[unknown] {self.address}/{self.bucket_name}"
-
-    @property
-    def type(self):
-        return 'S3'
-
-    def create_endpoint_conf(self):
-        return MinioServer.create_conf(self.address, self.region)
-
-    def get_resource(self):
-        """Creates boto3.resource object that can be used to communicate to the given server"""
-        return boto3.resource('s3',
-            endpoint_url=self.address,
-            aws_access_key_id=self.acc_key,
-            aws_secret_access_key=self.secret_key,
-            aws_session_token=None,
-            config=boto3.session.Config(signature_version='s3v4'),
-            verify=False
-        )
-
-    def create_test_bucket(self, test_name: str):
-        """Create a unique per-test bucket using boto3."""
-        self.bucket_name = _make_bucket_name(test_name)
-        resource = self.get_resource()
-        resource.Bucket(self.bucket_name).create()
-
-    def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using boto3."""
-        try:
-            resource = self.get_resource()
-            bucket = resource.Bucket(self.bucket_name)
-            bucket.objects.all().delete()
-            bucket.delete()
-        except Exception:
-            pass
-
-    async def start(self):
-        pass
-
-    async def stop(self):
-        pass
-
-class MinioWrapper(S3_Server):
-    def __init__(self, tempdir):
-        self.server = MinioServer(tempdir,
-                                  '127.0.0.1',
-                                  logging.getLogger('minio'))
-        super().__init__(
-                tempdir,
-                self.server.address,
-                self.server.port,
-                self.server.access_key,
-                self.server.secret_key,
-                MinioServer.DEFAULT_REGION,
-                self.server.bucket_name)
-
-    def create_endpoint_conf(self):
-        return MinioServer.create_conf(self.address, self.region)
-
-    async def start(self):
-        return self.server.start()
-
-    async def stop(self):
-        return self.server.stop()
-
-def create_s3_server(pytestconfig, tmpdir):
-    server = None
-    s3_server_address = pytestconfig.getoption('--s3-server-address')
-    s3_server_port = pytestconfig.getoption('--s3-server-port')
-    aws_acc_key = pytestconfig.getoption('--aws-access-key')
-    aws_secret_key = pytestconfig.getoption('--aws-secret-key')
-    aws_region = pytestconfig.getoption('--aws-region')
-    s3_server_bucket = pytestconfig.getoption('--s3-server-bucket')
-
-    default_address = os.environ.get(MinioServer.ENV_ADDRESS)
-    default_port = os.environ.get(MinioServer.ENV_PORT)
-    default_acc_key = os.environ.get(MinioServer.ENV_ACCESS_KEY)
-    default_secret_key = os.environ.get(MinioServer.ENV_SECRET_KEY)
-    default_region = MinioServer.DEFAULT_REGION
-    default_bucket = os.environ.get(MinioServer.ENV_BUCKET)
-
-    tempdir = tmpdir.strpath
-    if s3_server_address:
-        server = S3_Server(tempdir,
-                           s3_server_address,
-                           s3_server_port,
-                           aws_acc_key,
-                           aws_secret_key,
-                           aws_region,
-                           s3_server_bucket)
-    elif default_address:
-        server = S3_Server(tempdir,
-                           default_address,
-                           int(default_port),
-                           default_acc_key,
-                           default_secret_key,
-                           default_region,
-                           default_bucket)
-    else:
-        server = MinioWrapper(tempdir)
-    return server
-
-@pytest.fixture(scope="function")
-async def s3_server(request, pytestconfig, tmpdir):
-    server = create_s3_server(pytestconfig, tmpdir)
-    await server.start()
-    server.create_test_bucket(request.node.name)
-    try:
-        yield server
-    finally:
-        server.destroy_test_bucket()
-        await server.stop()
-
-class GSFront:
-    def __init__(self, endpoint, bucket_name, credentials_file):
-        self.endpoint = endpoint
-        self.bucket_name = bucket_name
-        self.credentials_file = credentials_file
-
-    @property
-    def address(self):
-        return self.endpoint
-
-    @property
-    def type(self):
-        return 'GS'
-
-    def create_endpoint_conf(self):
-        endpoint = {'name': self.endpoint, 
-                    'type': 'gs',
-                    'credentials_file': self.credentials_file if self.credentials_file else 'none'
-                    }
-        return [endpoint]
-
-    def get_resource(self):
-        """Creates boto3.resource object that can be used to communicate to the given server"""
-        return boto3.resource('s3',
-            endpoint_url=self.endpoint,
-            config=boto3.session.Config(signature_version='s3v4'),
-            verify=False
-        )
-
-    def create_test_bucket(self, test_name: str):
-        """Create a unique per-test bucket using boto3."""
-        self.bucket_name = _make_bucket_name(test_name)
-        resource = self.get_resource()
-        resource.Bucket(self.bucket_name).create()
-
-    def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using boto3."""
-        try:
-            resource = self.get_resource()
-            bucket = resource.Bucket(self.bucket_name)
-            bucket.objects.all().delete()
-            bucket.delete()
-        except Exception:
-            pass
-
-    async def start(self):
-        pass
-    async def stop(self):
-        pass
-
-class GSServer(GSFront):
-    def __init__(self, tmpdir):
-        super(GSServer, self).__init__(None, 'testbucket', None)
-        self.server = None
-        self.host = None
-        self.port = None
-        self.oldvars = {}
-        self.vars = { 'GS_SERVER_ADDRESS_FOR_TEST': attrgetter('endpoint'),
-                      'GS_BUCKET_FOR_TEST': attrgetter('bucket_name'), 
-                      'GS_CREDENTIALS_FILE': attrgetter('credentials_file'), 
-                      }
-        self.tmpdir = tmpdir
-
-    def publish(self):
-        self.endpoint = f'http://{self.host}:{self.port}'
-        self.oldvars = { k : os.environ.get(k) for k in self.vars }
-        for k, v in self.vars.items():
-            val = v(self)
-            if val:
-                os.environ[k] = val
-
-    def unpublish(self):
-        for k in self.vars:
-            v = self.oldvars.get(k)
-            if v:
-                os.environ[k] = v
-            elif os.environ.get(k):
-                del os.environ[k]
-
-    def _image_args(self, host, port):
-        # pylint: disable=unused-argument
-        # note: need to set 'public-host' to the IP we connect to, to make XML (s3) API work for listing
-        return ["-scheme", "http", "-log-level", "debug", "--port", f'{port}', '-public-host', '127.0.0.1']
-
-    async def start(self):
-        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.52.3", self.tmpdir, 
-                                       logfilenamebase="fake-gcs-server",
-                                       image_args=self._image_args,
-                                       success_string="server started at",
-                                       failure_string="address already in use",
-                                       port=4443
-                                       )
-        await self.server.start()
-        self.port = self.server.port
-        self.host = self.server.host
-        self.publish()
-
-        # create bucket. can't use boto, because fake server does not support xml syntax 
-        # for anything beyong listing
-        response = requests.post(f'{self.endpoint}/storage/v1/b?project=testproject', json = {
-            'name': self.bucket_name, 'location' : 'US', 'storageClass' : 'STANDARD',
-            'iamConfiguration': {
-                'uniformBucketLevelAccess' : {
-                    'enabled': True,
-                }
-            }
-        }, timeout = 10)
-        if response.status_code not in [200, 201]:
-            raise Exception(f'Could not create test bucket: {response}')
-
-    def create_test_bucket(self, test_name: str):
-        """Create a unique per-test bucket using GCS HTTP API (fake server doesn't support S3 XML for this)."""
-        self.bucket_name = _make_bucket_name(test_name)
-        response = requests.post(f'{self.endpoint}/storage/v1/b?project=testproject', json={
-            'name': self.bucket_name, 'location': 'US', 'storageClass': 'STANDARD',
-            'iamConfiguration': {
-                'uniformBucketLevelAccess': {
-                    'enabled': True,
-                }
-            }
-        }, timeout=10)
-        if response.status_code not in [200, 201]:
-            raise Exception(f'Could not create test bucket: {response}')
-
-    def destroy_test_bucket(self):
-        """Empty and delete the per-test bucket using GCS HTTP API."""
-        try:
-            # List and delete all objects first using boto3 (listing works on fake GCS)
-            resource = self.get_resource()
-            bucket = resource.Bucket(self.bucket_name)
-            bucket.objects.all().delete()
-            # Delete the bucket via GCS HTTP API
-            requests.delete(f'{self.endpoint}/storage/v1/b/{self.bucket_name}', timeout=10)
-        except Exception:
-            pass
-
-    async def stop(self):
-        if self.server:
-            await self.server.stop()
-        self.unpublish()
-
-@pytest.fixture(scope="function", params=['s3','gs'])
+@pytest.fixture(scope="function", params=['s3', 'gs'])
 async def object_storage(request, pytestconfig, tmpdir):
-    server = None
-
     if request.param == 'gs':
-        endpoint = os.environ.get('GS_SERVER_ADDRESS_FOR_TEST')
-        bucket = os.environ.get('GS_BUCKET_FOR_TEST')
-        credentials_file = os.environ.get('GS_CREDENTIALS_FILE')
-
-        if endpoint is not None and bucket is not None:
-            server = GSFront(endpoint, bucket, credentials_file)
-        else:
-            server = GSServer(tmpdir)
+        server = create_gs_server(tmpdir)
     else:
         server = create_s3_server(pytestconfig, tmpdir)
 
@@ -345,6 +43,7 @@ async def object_storage(request, pytestconfig, tmpdir):
         if bucket_created:
             server.destroy_test_bucket()
         await server.stop()
+
 
 @pytest.fixture(scope="function")
 async def s3_storage(request, pytestconfig, tmpdir):

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -12,7 +12,7 @@ from cassandra.protocol import ConfigurationException
 from cassandra.query import SimpleStatement, ConsistencyLevel
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import reconnect_driver
-from test.cluster.object_store.conftest import format_tuples, keyspace_options
+from test.pylib.object_storage import format_tuples, keyspace_options
 from test.cqlpy.rest_api import scylla_inject_error
 from test.cluster.test_config import wait_for_config
 from test.cluster.util import new_test_keyspace

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -19,7 +19,7 @@ from collections import defaultdict
 from cassandra.cluster import ConsistencyLevel
 from test.pylib.minio_server import MinioServer
 from test.pylib.manager_client import ManagerClient
-from test.cluster.object_store.conftest import format_tuples
+from test.pylib.object_storage import format_tuples
 from test.cluster.object_store.test_backup import topo, take_snapshot, do_test_streaming_scopes
 from test.cluster.util import new_test_keyspace
 from test.pylib.rest_client import read_barrier

--- a/test/cqlpy/test_tools.py
+++ b/test/cqlpy/test_tools.py
@@ -31,7 +31,7 @@ from typing import Iterable, Type, Union
 from cassandra.util import Duration
 import yaml
 
-from test.cluster.object_store.conftest import s3_server
+from test.pylib.object_storage import s3_server
 
 
 def simple_no_clustering_table(cql, keyspace):

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -118,6 +118,11 @@ class MinioServer:
             "s3:ListBucketMultipartUploads",
             "s3:GetBucketLocation",
         ]
+        global_actions = [
+            "s3:CreateBucket",
+            "s3:DeleteBucket",
+            "s3:ListAllMyBuckets",
+        ]
         object_actions = [
             "s3:AbortMultipartUpload",
             "s3:DeleteObject",
@@ -133,13 +138,19 @@ class MinioServer:
                 'Action': bucket_actions,
                 'Effect': 'Allow',
                 'Principal': {'AWS': ['*']},
-                'Resource': [ f'arn:aws:s3:::{self.bucket_name}' ]
+                'Resource': [ 'arn:aws:s3:::*' ]
+            },
+            {
+                'Action': global_actions,
+                'Effect': 'Allow',
+                'Principal': {'AWS': ['*']},
+                'Resource': [ 'arn:aws:s3:::*' ]
             },
             {
                 'Action': object_actions,
                 'Effect': 'Allow',
                 'Principal': {'AWS': ['*']},
-                'Resource': [ f'arn:aws:s3:::{self.bucket_name}/*' ]
+                'Resource': [ 'arn:aws:s3:::*/*' ]
             }
         ]
         return {'Statement': statement,

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -1,0 +1,340 @@
+#
+# Copyright (C) 2023-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Reusable object-storage helpers for S3 and GCS test fixtures.
+
+Classes, factory functions, and shared pytest fixtures used by
+test/cluster/object_store/ and test/cqlpy/ tests.
+"""
+
+import os
+import logging
+import re
+import uuid
+
+from test.pylib.minio_server import MinioServer
+from test.pylib.dockerized_service import DockerizedServer
+from operator import attrgetter
+
+import pytest
+import boto3
+import requests
+
+
+def format_tuples(tuples=None, **kwargs):
+    '''format a dict to structured values (tuples) in CQL'''
+    if tuples is None:
+        tuples = {}
+    tuples.update(kwargs)
+    body = ', '.join(f"'{key}': '{value}'" for key, value in tuples.items())
+    return f'{{ {body} }}'
+
+
+def keyspace_options(object_storage, rf=1):
+    storage_opts = format_tuples(type=f'{object_storage.type}', endpoint=object_storage.address, bucket=object_storage.bucket_name)
+    return f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND STORAGE = {storage_opts}"
+
+
+def _make_bucket_name(test_name: str) -> str:
+    """Generate a valid S3 bucket name from a pytest test name.
+
+    S3 bucket naming rules: lowercase, digits, hyphens only; 3-63 chars;
+    must start/end with a letter or digit.
+    """
+    # Lowercase, replace non-alphanumeric runs with a single hyphen, strip leading/trailing hyphens
+    name = re.sub(r'[^a-z0-9]+', '-', test_name.lower()).strip('-')
+    # Add a short unique suffix to avoid collisions (e.g. parametrized tests with same prefix)
+    suffix = uuid.uuid4().hex[:8]
+    # Truncate so total length (name + '-' + suffix) <= 63
+    max_prefix = 63 - len(suffix) - 1
+    name = name[:max_prefix].rstrip('-')
+    return f"{name}-{suffix}"
+
+
+class S3Server:
+    def __init__(self, tempdir: str, address: str, port: int, acc_key: str, secret_key: str, region: str, bucket_name):
+        self.tempdir = tempdir
+        self.ip = address
+        self.port = port
+        self.address = f'http://{self.ip}:{self.port}'
+        self.acc_key = acc_key
+        self.secret_key = secret_key
+        self.region = region
+        self.bucket_name = bucket_name
+
+    def __repr__(self):
+        return f"[unknown] {self.address}/{self.bucket_name}"
+
+    @property
+    def type(self):
+        return 'S3'
+
+    def create_endpoint_conf(self):
+        return MinioServer.create_conf(self.address, self.region)
+
+    def get_resource(self):
+        """Creates boto3.resource object that can be used to communicate to the given server"""
+        return boto3.resource('s3',
+            endpoint_url=self.address,
+            aws_access_key_id=self.acc_key,
+            aws_secret_access_key=self.secret_key,
+            aws_session_token=None,
+            config=boto3.session.Config(signature_version='s3v4'),
+            verify=False
+        )
+
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using boto3."""
+        self.bucket_name = _make_bucket_name(test_name)
+        resource = self.get_resource()
+        resource.Bucket(self.bucket_name).create()
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using boto3."""
+        try:
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            bucket.delete()
+        except Exception as e:
+            logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+
+# Keep the old name as an alias for backward compatibility
+S3_Server = S3Server
+
+
+class MinioWrapper(S3Server):
+    def __init__(self, tempdir):
+        self.server = MinioServer(tempdir,
+                                  '127.0.0.1',
+                                  logging.getLogger('minio'))
+        super().__init__(
+                tempdir,
+                self.server.address,
+                self.server.port,
+                self.server.access_key,
+                self.server.secret_key,
+                MinioServer.DEFAULT_REGION,
+                self.server.bucket_name)
+
+    def create_endpoint_conf(self):
+        return MinioServer.create_conf(self.address, self.region)
+
+    async def start(self):
+        return self.server.start()
+
+    async def stop(self):
+        return self.server.stop()
+
+
+class GSFront:
+    def __init__(self, endpoint, bucket_name, credentials_file):
+        self.endpoint = endpoint
+        self.bucket_name = bucket_name
+        self.credentials_file = credentials_file
+
+    @property
+    def address(self):
+        return self.endpoint
+
+    @property
+    def type(self):
+        return 'GS'
+
+    def create_endpoint_conf(self):
+        endpoint = {'name': self.endpoint,
+                    'type': 'gs',
+                    'credentials_file': self.credentials_file if self.credentials_file else 'none'
+                    }
+        return [endpoint]
+
+    def get_resource(self):
+        """Creates boto3.resource object that can be used to communicate to the given server"""
+        return boto3.resource('s3',
+            endpoint_url=self.endpoint,
+            config=boto3.session.Config(signature_version='s3v4'),
+            verify=False
+        )
+
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using boto3."""
+        self.bucket_name = _make_bucket_name(test_name)
+        resource = self.get_resource()
+        resource.Bucket(self.bucket_name).create()
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using boto3."""
+        try:
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            bucket.delete()
+        except Exception as e:
+            logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+
+    async def start(self):
+        pass
+
+    async def stop(self):
+        pass
+
+
+class GSServerImpl(GSFront):
+    def __init__(self, tmpdir):
+        super(GSServerImpl, self).__init__(None, 'testbucket', None)
+        self.server = None
+        self.host = None
+        self.port = None
+        self.oldvars = {}
+        self.vars = { 'GS_SERVER_ADDRESS_FOR_TEST': attrgetter('endpoint'),
+                      'GS_BUCKET_FOR_TEST': attrgetter('bucket_name'),
+                      'GS_CREDENTIALS_FILE': attrgetter('credentials_file'),
+                      }
+        self.tmpdir = tmpdir
+
+    def publish(self):
+        self.endpoint = f'http://{self.host}:{self.port}'
+        self.oldvars = { k : os.environ.get(k) for k in self.vars }
+        for k, v in self.vars.items():
+            val = v(self)
+            if val:
+                os.environ[k] = val
+
+    def unpublish(self):
+        for k in self.vars:
+            v = self.oldvars.get(k)
+            if v:
+                os.environ[k] = v
+            elif os.environ.get(k):
+                del os.environ[k]
+
+    def _image_args(self, host, port):
+        # pylint: disable=unused-argument
+        # note: need to set 'public-host' to the IP we connect to, to make XML (s3) API work for listing
+        return ["-scheme", "http", "-log-level", "debug", "--port", f'{port}', '-public-host', '127.0.0.1']
+
+    async def start(self):
+        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.52.3", self.tmpdir,
+                                       logfilenamebase="fake-gcs-server",
+                                       image_args=self._image_args,
+                                       success_string="server started at",
+                                       failure_string="address already in use",
+                                       port=4443
+                                       )
+        await self.server.start()
+        self.port = self.server.port
+        self.host = self.server.host
+        self.publish()
+
+
+    def create_test_bucket(self, test_name: str):
+        """Create a unique per-test bucket using GCS HTTP API (fake server doesn't support S3 XML for this)."""
+        self.bucket_name = _make_bucket_name(test_name)
+        response = requests.post(f'{self.endpoint}/storage/v1/b?project=testproject', json={
+            'name': self.bucket_name, 'location': 'US', 'storageClass': 'STANDARD',
+            'iamConfiguration': {
+                'uniformBucketLevelAccess': {
+                    'enabled': True,
+                }
+            }
+        }, timeout=10)
+        if response.status_code not in [200, 201]:
+            raise Exception(f'Could not create test bucket: {response}')
+
+    def destroy_test_bucket(self):
+        """Empty and delete the per-test bucket using GCS HTTP API."""
+        try:
+            # List and delete all objects first using boto3 (listing works on fake GCS)
+            resource = self.get_resource()
+            bucket = resource.Bucket(self.bucket_name)
+            bucket.objects.all().delete()
+            # Delete the bucket via GCS HTTP API
+            requests.delete(f'{self.endpoint}/storage/v1/b/{self.bucket_name}', timeout=10)
+        except Exception as e:
+            logging.warning("Failed to destroy test bucket %s: %s", self.bucket_name, e)
+
+    async def stop(self):
+        if self.server:
+            await self.server.stop()
+        self.unpublish()
+
+
+# Keep the old name as an alias for backward compatibility (conftest.py imports it)
+GSServer = GSServerImpl
+
+
+def create_s3_server(pytestconfig, tmpdir):
+    server = None
+    s3_server_address = pytestconfig.getoption('--s3-server-address')
+    s3_server_port = pytestconfig.getoption('--s3-server-port')
+    aws_acc_key = pytestconfig.getoption('--aws-access-key')
+    aws_secret_key = pytestconfig.getoption('--aws-secret-key')
+    aws_region = pytestconfig.getoption('--aws-region')
+    s3_server_bucket = pytestconfig.getoption('--s3-server-bucket')
+
+    default_address = os.environ.get(MinioServer.ENV_ADDRESS)
+    default_port = os.environ.get(MinioServer.ENV_PORT)
+    default_acc_key = os.environ.get(MinioServer.ENV_ACCESS_KEY)
+    default_secret_key = os.environ.get(MinioServer.ENV_SECRET_KEY)
+    default_region = MinioServer.DEFAULT_REGION
+    default_bucket = os.environ.get(MinioServer.ENV_BUCKET)
+
+    # Note: bucket_name passed here is overwritten by create_test_bucket() when
+    # using the s3_server fixture. The --s3-server-bucket option currently only
+    # affects code paths that use server.bucket_name directly without the fixture.
+    tempdir = tmpdir.strpath
+    if s3_server_address:
+        server = S3Server(tempdir,
+                          s3_server_address,
+                          s3_server_port,
+                          aws_acc_key,
+                          aws_secret_key,
+                          aws_region,
+                          s3_server_bucket)
+    elif default_address:
+        server = S3Server(tempdir,
+                          default_address,
+                          int(default_port),
+                          default_acc_key,
+                          default_secret_key,
+                          default_region,
+                          default_bucket)
+    else:
+        server = MinioWrapper(tempdir)
+    return server
+
+
+def create_gs_server(tmpdir):
+    endpoint = os.environ.get('GS_SERVER_ADDRESS_FOR_TEST')
+    bucket = os.environ.get('GS_BUCKET_FOR_TEST')
+    credentials_file = os.environ.get('GS_CREDENTIALS_FILE')
+
+    if endpoint is not None and bucket is not None:
+        return GSFront(endpoint, bucket, credentials_file)
+    return GSServerImpl(tmpdir)
+
+
+@pytest.fixture(scope="function")
+async def s3_server(request, pytestconfig, tmpdir):
+    server = create_s3_server(pytestconfig, tmpdir)
+    await server.start()
+    bucket_created = False
+    try:
+        server.create_test_bucket(request.node.name)
+        bucket_created = True
+        yield server
+    finally:
+        if bucket_created:
+            server.destroy_test_bucket()
+        await server.stop()
+

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -665,6 +665,61 @@ future<> client::delete_object(sstring object_name, seastar::abort_source* as) {
     co_await make_request(std::move(req), ignore_reply, http::reply::status_type::no_content, as);
 }
 
+future<> client::create_bucket(sstring bucket_name, seastar::abort_source* as) {
+    s3l.trace("PUT bucket /{}", bucket_name);
+    auto req = http::request::make("PUT", _host, format("/{}", bucket_name));
+    co_await make_request(std::move(req), ignore_reply, *_retry_strategy,
+        [&bucket_name](std::exception_ptr ex) {
+            try {
+                std::rethrow_exception(ex);
+            } catch (const aws::aws_exception& e) {
+                if (e.error().get_error_type() == aws::aws_error_type::BUCKET_ALREADY_OWNED_BY_YOU) {
+                    s3l.debug("create_bucket /{}: bucket already owned by us, treating as success", bucket_name);
+                    return;
+                }
+            }
+            map_s3_client_exception(std::move(ex));
+        }, http::reply::status_type::ok, as);
+}
+
+future<> client::delete_bucket(sstring bucket_name, seastar::abort_source* as) {
+    s3l.trace("DELETE bucket /{}", bucket_name);
+    auto req = http::request::make("DELETE", _host, format("/{}", bucket_name));
+    co_await make_request(std::move(req), ignore_reply, http::reply::status_type::no_content, as);
+}
+
+future<> client::delete_bucket_with_objects(sstring bucket_name, seastar::abort_source* as) {
+    s3l.trace("DELETE bucket with objects /{}", bucket_name);
+    bucket_lister lister(shared_from_this(), bucket_name, "", 100);
+    constexpr size_t default_concurrency = 16;
+    std::vector<directory_entry> entries;
+    entries.reserve(default_concurrency);
+    bool stop = false;
+    while (true) {
+        std::optional<directory_entry> entry;
+        while (entries.size() < default_concurrency) {
+            entry = co_await lister.get();
+            if (entry) {
+                entries.push_back(std::move(*entry));
+            } else {
+                stop = true;
+                break;
+            }
+        }
+        if (!entries.empty()) {
+            co_await max_concurrent_for_each(entries, default_concurrency, [this, as, bucket_name](const auto& entry) {
+                return delete_object(format("/{}/{}", bucket_name, entry.name), as);
+            });
+            entries.clear();
+        }
+        if (stop) {
+            break;
+        }
+    }
+    co_await lister.close();
+    co_await delete_bucket(bucket_name, as);
+}
+
 sstring parse_multipart_copy_upload_etag(sstring& body) {
     auto doc = std::make_unique<rapidxml::xml_document<>>();
     try {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -153,6 +153,10 @@ shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, s
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }
 
+shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, std::unique_ptr<http::experimental::retry_strategy> rs, global_factory gf) {
+    return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{}, std::move(rs));
+}
+
 shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf) {
     auto url = utils::http::parse_simple_url(ep);
     endpoint_config cfg = {

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -187,6 +187,7 @@ public:
 
     client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::experimental::retry_strategy> rs = nullptr);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
+    static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, std::unique_ptr<seastar::http::experimental::retry_strategy> rs, global_factory gf = {});
     static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {});
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -200,6 +200,9 @@ public:
     future<> put_object(sstring object_name, ::memory_data_sink_buffers bufs, seastar::abort_source* = nullptr);
     future<> copy_object(sstring source_object, sstring target_object, std::optional<size_t> part_size = {}, std::optional<tag> tag = {}, seastar::abort_source* = nullptr);
     future<> delete_object(sstring object_name, seastar::abort_source* = nullptr);
+    future<> create_bucket(sstring bucket_name, seastar::abort_source* = nullptr);
+    future<> delete_bucket(sstring bucket_name, seastar::abort_source* = nullptr);
+    future<> delete_bucket_with_objects(sstring bucket_name, seastar::abort_source* = nullptr);
 
     file make_readable_file(sstring object_name, seastar::abort_source* = nullptr);
     data_sink make_upload_sink(sstring object_name, seastar::abort_source* = nullptr);


### PR DESCRIPTION
This series adds per-test bucket isolation to all S3 and GCS object storage tests. Previously, every test shared a single pre-created bucket, which meant tests could interfere with each other through leftover objects and could not run concurrently across multiple `test.py` processes without risking collisions.

### Changes

New `create_bucket`, `delete_bucket`, and `delete_bucket_with_objects` methods on `s3::client`, following the existing `make_request` pattern. `create_bucket` handles the `BUCKET_ALREADY_OWNED_BY_YOU` error gracefully.

A new `s3_test_fixture` RAII class for C++ Boost tests that creates a uniquely-named bucket on construction (derived from the Boost test name and pid) and tears down everything — objects, bucket, client — on destruction. All S3 tests in `s3_test.cc` are migrated to use it, removing manual `deferred_delete_object` and `deferred_close` boilerplate. The minio server policy is broadened to allow dynamic bucket creation/deletion.

A `client::make` overload that accepts a custom `retry_strategy`, used in tests with a fast 1ms retry delay instead of exponential backoff, significantly reducing test runtime for transient errors during bucket lifecycle operations.

Python-side (`test/cluster/object_store`): each pytest fixture (`object_storage`, `s3_storage`, `s3_server`) now creates a unique bucket per test function via `create_test_bucket()` and destroys it on teardown. Bucket names are sanitized from the pytest node name with a short UUID suffix for uniqueness.

Object storage helpers (`S3Server`, `MinioWrapper`, `GSFront`, `GSServerImpl`, factory functions, CQL helpers, `s3_server` fixture) are extracted from `test/cluster/object_store/conftest.py` into a shared `test/pylib/object_storage.py` module, eliminating duplication across test suites. The conftest becomes a thin re-export wrapper. Old class names are preserved as aliases for backward compatibility.

## Test execution improvement with new test specific retry_strategy implementation
| Test Name                                                    | new test specific retry strategy execution time (ms) | original execution time (ms) |   Δ (ms) | Speedup |
|--------------------------------------------------------------|----------------:|-------------:|---------:|--------:|
| test_client_upload_file_multi_part_with_remainder_proxy      |          19,261 |       61,395 | −42,134  | **3.2×** |
| test_client_upload_file_multi_part_without_remainder_proxy   |          16,901 |       53,688 | −36,787  | **3.2×** |
| test_client_upload_file_single_part_proxy                    |           3,478 |        6,789 |  −3,311  | **2.0×** |
| test_client_multipart_copy_upload_proxy                      |           1,303 |        1,619 |    −316  | 1.2×    |
| test_client_put_get_object_proxy                             |             150 |          365 |    −215  | **2.4×** |
| test_client_readable_file_stream_proxy                       |             125 |          327 |    −202  | **2.6×** |
| test_small_object_copy_proxy                                 |             205 |          389 |    −184  | 1.9×    |
| test_client_put_get_tagging_proxy                            |             181 |          350 |    −169  | 1.9×    |
| test_client_multipart_upload_proxy                           |           1,252 |        1,416 |    −164  | 1.1×    |
| test_client_list_objects_proxy                               |             729 |          881 |    −152  | 1.2×    |
| test_chunked_download_data_source_with_delays_proxy          |             830 |          960 |    −130  | 1.2×    |
| test_client_readable_file_proxy                              |             148 |          279 |    −131  | 1.9×    |
| test_client_upload_file_multi_part_with_remainder_minio      |           3,358 |        3,170 |    +188  | 0.9×    |
| test_client_upload_file_multi_part_without_remainder_minio   |           3,131 |        2,929 |    +202  | 0.9×    |
| test_client_upload_file_single_part_minio                    |             519 |          421 |     +98  | 0.8×    |
| test_download_data_source_proxy                              |             180 |          237 |     −57  | 1.3×    |
| test_client_list_objects_incomplete_proxy                     |             590 |          641 |     −51  | 1.1×    |
| test_large_object_copy_proxy                                 |             952 |          991 |     −39  | 1.0×    |
| test_client_multipart_upload_fallback_proxy                  |             148 |          185 |     −37  | 1.3×    |
| test_client_multipart_copy_upload_minio                      |             641 |          674 |     −33  | 1.1×    |

No backport needed — this is a test infrastructure improvement with no production code impact beyond the new `s3::client` methods.

