### PR TITLE
audit: fix maintenance socket startup/shutdown ordering

### DIFF
--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -194,14 +194,27 @@ future<> audit::start_audit(const db::config& cfg, sharded<locator::shared_token
                                   std::move(audited_keyspaces),
                                   std::move(audited_tables),
                                   std::move(audited_categories),
-                                  std::cref(cfg))
-    .then([&cfg] {
-        if (!audit_instance().local_is_initialized()) {
-            return make_ready_future<>();
-        }
-        return audit_instance().invoke_on_all([&cfg] (audit& local_audit) {
-            return local_audit.start(cfg);
+                                  std::cref(cfg));
+}
+
+future<> audit::start_storage(const db::config& cfg) {
+    if (!audit_instance().local_is_initialized()) {
+        return make_ready_future<>();
+    }
+    return audit_instance().invoke_on_all([&cfg] (audit& local_audit) {
+        return local_audit._storage_helper_ptr->start(cfg).then([&local_audit] {
+            local_audit._storage_running = true;
         });
+    });
+}
+
+future<> audit::stop_storage() {
+    if (!audit_instance().local_is_initialized()) {
+        return make_ready_future<>();
+    }
+    return audit_instance().invoke_on_all([] (audit& local_audit) {
+        local_audit._storage_running = false;
+        return local_audit._storage_helper_ptr->stop();
     });
 }
 
@@ -223,14 +236,6 @@ audit_info_ptr audit::create_audit_info(statement_category cat, const sstring& k
     return std::make_unique<audit_info>(cat, keyspace, table, batch);
 }
 
-future<> audit::start(const db::config& cfg) {
-    return _storage_helper_ptr->start(cfg);
-}
-
-future<> audit::stop() {
-    return _storage_helper_ptr->stop();
-}
-
 future<> audit::shutdown() {
     return make_ready_future<>();
 }
@@ -241,6 +246,12 @@ future<> audit::log(const audit_info& audit_info, const service::client_state& c
     const sstring& username = client_state.user() ? client_state.user()->name.value_or(anonymous_username) : no_username;
     socket_address client_ip = client_state.get_client_address().addr();
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
+    if (!_storage_running) {
+        on_internal_error_noexcept(logger, fmt::format("Audit log dropped (storage not ready): node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
+            node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
+            audit_info.query(), client_ip, audit_info.table(), username));
+        return make_ready_future<>();
+    }
     if (logger.is_enabled(logging::log_level::debug)) {
         logger.debug("Log written: node_ip {} category {} cl {} error {} keyspace {} query '{}' client_ip {} table {} username {}",
             node_ip, audit_info.category_string(), cl, error, audit_info.keyspace(),
@@ -286,6 +297,11 @@ future<> inspect(const audit_info_alternator& ai, const service::client_state& c
 
 future<> audit::log_login(const sstring& username, socket_address client_ip, bool error) noexcept {
     socket_address node_ip = _token_metadata.get()->get_topology().my_address().addr();
+    if (!_storage_running) {
+        on_internal_error_noexcept(logger, fmt::format("Audit login log dropped (storage not ready): node_ip {} client_ip {} username {} error {}",
+            node_ip, client_ip, username, error ? "true" : "false"));
+        return make_ready_future<>();
+    }
     if (logger.is_enabled(logging::log_level::debug)) {
         logger.debug("Login log written: node_ip {}, client_ip {}, username {}, error {}",
             node_ip, client_ip, username, error ? "true" : "false");

--- a/audit/audit.cc
+++ b/audit/audit.cc
@@ -223,6 +223,7 @@ future<> audit::stop_audit() {
         return make_ready_future<>();
     }
     return audit::audit::audit_instance().invoke_on_all([] (auto& local_audit) {
+        SCYLLA_ASSERT(!local_audit._storage_running);
         return local_audit.shutdown();
     }).then([] {
         return audit::audit::audit_instance().stop();

--- a/audit/audit.hh
+++ b/audit/audit.hh
@@ -141,6 +141,7 @@ private:
     category_set _audited_categories;
 
     std::unique_ptr<storage_helper> _storage_helper_ptr;
+    bool _storage_running = false;
 
     const db::config& _cfg;
     utils::observer<sstring> _cfg_keyspaces_observer;
@@ -163,6 +164,8 @@ public:
         return audit_instance().local();
     }
     static future<> start_audit(const db::config& cfg, sharded<locator::shared_token_metadata>& stm, sharded<cql3::query_processor>& qp, sharded<service::migration_manager>& mm);
+    static future<> start_storage(const db::config& cfg);
+    static future<> stop_storage();
     static future<> stop_audit();
     static audit_info_ptr create_audit_info(statement_category cat, const sstring& keyspace, const sstring& table, bool batch = false);
     audit(locator::shared_token_metadata& stm,
@@ -174,8 +177,6 @@ public:
           category_set&& audited_categories,
           const db::config& cfg);
     ~audit();
-    future<> start(const db::config& cfg);
-    future<> stop();
     future<> shutdown();
     bool should_log(const audit_info& audit_info) const;
     bool will_log(statement_category cat, std::string_view keyspace = {}, std::string_view table = {}) const;

--- a/main.cc
+++ b/main.cc
@@ -2352,15 +2352,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             }).get();
             stop_signal.ready(false);
 
-            if (cfg->maintenance_socket() != "ignore") {
-                // Enable role operations now that node joined the cluster
-                maintenance_auth_service.invoke_on_all([](auth::service& svc) {
-                    return auth::ensure_role_operations_are_enabled(svc);
-                }).get();
-
-                start_cql(*cql_maintenance_server_ctl, stop_maintenance_cql, "maintenance native server");
-            }
-
             // At this point, `locator::topology` should be stable, i.e. we should have complete information
             // about the layout of the cluster (= list of nodes along with the racks/DCs).
             startlog.info("Verifying that all of the keyspaces are RF-rack-valid");
@@ -2378,6 +2369,15 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             auto audit_storage_stop = defer([] {
                 audit::audit::stop_storage().get();
             });
+
+            if (cfg->maintenance_socket() != "ignore") {
+                // Enable role operations now that node joined the cluster
+                maintenance_auth_service.invoke_on_all([](auth::service& svc) {
+                    return auth::ensure_role_operations_are_enabled(svc);
+                }).get();
+
+                start_cql(*cql_maintenance_server_ctl, stop_maintenance_cql, "maintenance native server");
+            }
 
             // Semantic validation of sstable compression parameters from config.
             // Adding here (i.e., after `join_cluster`) to ensure that the

--- a/main.cc
+++ b/main.cc
@@ -1810,6 +1810,18 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             utils::get_local_injector().inject("stop_after_starting_migration_manager",
                 [] { std::raise(SIGSTOP); });
 
+            // Audit must be constructed before the maintenance socket so
+            // that on shutdown (reverse destruction order) the audit service
+            // outlives the maintenance socket and in-flight queries can
+            // still reach audit::inspect() safely.
+            checkpoint(stop_signal, "starting audit service");
+            audit::audit::start_audit(*cfg, token_metadata, qp, mm).handle_exception([&] (auto&& e) {
+                startlog.error("audit start failed: {}", e);
+            }).get();
+            auto audit_stop = defer([] {
+                audit::audit::stop_audit().get();
+            });
+
             // XXX: stop_raft has to happen before query_processor and migration_manager
             // is stopped, since some groups keep using the query
             // processor until are stopped inside stop_raft.
@@ -2356,14 +2368,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
 
             startlog.info("Verifying that all of the tablet keyspaces use rack list replication factors");
             db.local().check_rack_list_everywhere(cfg->enforce_rack_list());
-
-            checkpoint(stop_signal, "starting audit service");
-            audit::audit::start_audit(*cfg, token_metadata, qp, mm).handle_exception([&] (auto&& e) {
-                startlog.error("audit start failed: {}", e);
-            }).get();
-            auto audit_stop = defer([] {
-                audit::audit::stop_audit().get();
-            });
 
             // The table-based audit backend needs Raft (via join_cluster)
             // to create its keyspace and table.

--- a/main.cc
+++ b/main.cc
@@ -2357,14 +2357,22 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             startlog.info("Verifying that all of the tablet keyspaces use rack list replication factors");
             db.local().check_rack_list_everywhere(cfg->enforce_rack_list());
 
-            // Start audit service after join_cluster so that the table-based audit backend
-            // can properly create its keyspace and table.
             checkpoint(stop_signal, "starting audit service");
             audit::audit::start_audit(*cfg, token_metadata, qp, mm).handle_exception([&] (auto&& e) {
                 startlog.error("audit start failed: {}", e);
             }).get();
             auto audit_stop = defer([] {
                 audit::audit::stop_audit().get();
+            });
+
+            // The table-based audit backend needs Raft (via join_cluster)
+            // to create its keyspace and table.
+            checkpoint(stop_signal, "starting audit storage");
+            audit::audit::start_storage(*cfg).handle_exception([&] (auto&& e) {
+                startlog.error("audit storage start failed: {}", e);
+            }).get();
+            auto audit_storage_stop = defer([] {
+                audit::audit::stop_storage().get();
             });
 
             // Semantic validation of sstable compression parameters from config.

--- a/main.cc
+++ b/main.cc
@@ -2363,9 +2363,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             // The table-based audit backend needs Raft (via join_cluster)
             // to create its keyspace and table.
             checkpoint(stop_signal, "starting audit storage");
-            audit::audit::start_storage(*cfg).handle_exception([&] (auto&& e) {
-                startlog.error("audit storage start failed: {}", e);
-            }).get();
+            audit::audit::start_storage(*cfg).get();
             auto audit_storage_stop = defer([] {
                 audit::audit::stop_storage().get();
             });

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -29,12 +29,16 @@ import pytest
 from cassandra import AlreadyExists, AuthenticationFailed, ConsistencyLevel, InvalidRequest, Unauthorized, Unavailable, WriteFailure
 from cassandra.auth import PlainTextAuthProvider
 from cassandra.cluster import NoHostAvailable, Session, EXEC_PROFILE_DEFAULT
+from cassandra.connection import UnixSocketEndPoint
+from cassandra.policies import WhiteListRoundRobinPolicy
 from cassandra.query import BatchStatement, BatchType, SimpleStatement, named_tuple_factory
 
+from test.cluster.conftest import cluster_con
 from test.cluster.dtest.dtest_class import create_ks, wait_for
 from test.cluster.dtest.tools.assertions import assert_invalid
 from test.cluster.dtest.tools.data import rows_to_list, run_in_parallel
 
+from test.pylib.driver_utils import safe_driver_shutdown
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
 from test.pylib.skip_types import skip_env
@@ -1863,6 +1867,44 @@ class CQLAuditTester(AuditTester):
             finally:
                 session.execute("DROP KEYSPACE IF EXISTS kss")
 
+    # Unix domain sockets have no IP peer address.  Seastar's
+    # socket_address::addr() falls through to the default case for
+    # AF_UNIX and returns a zero-initialised in6_addr, i.e. "::".
+    MAINTENANCE_SOCKET_SOURCE = "::"
+
+    async def _test_audit_maintenance_socket_user_creation(self, manager, helper_class):
+        with helper_class() as helper:
+            session = await self.prepare(
+                user="cassandra", password="cassandra",
+                helper=helper,
+                audit_settings={**helper.audit_default_settings, "audit_categories": "DCL", "audit_keyspaces": ""},
+                create_keyspace=False,
+            )
+
+            servers = await manager.running_servers()
+            server = servers[0]
+            socket_path = await manager.server_get_maintenance_socket_path(server.server_id)
+
+            logger.info("Connecting to maintenance socket")
+            endpoint = UnixSocketEndPoint(socket_path)
+            maint_cluster = cluster_con([endpoint],
+                                        load_balancing_policy=WhiteListRoundRobinPolicy([endpoint]))
+            maint_session = maint_cluster.connect()
+
+            role_name = "audit_test_admin"
+            create_stmt = f"CREATE ROLE {role_name} WITH PASSWORD = 'secret' AND SUPERUSER = true AND LOGIN = true"
+            expected_operation = f"CREATE ROLE {role_name} WITH PASSWORD = '***' AND SUPERUSER = true AND LOGIN = true"
+
+            logger.info("Creating superuser via maintenance socket and verifying audit entry")
+            expected_entries = [AuditEntry(category="DCL", statement=expected_operation,
+                                          user="anonymous", table="", ks="", cl="LOCAL_QUORUM", error=False,
+                                          source=self.MAINTENANCE_SOCKET_SOURCE)]
+            with self.assert_entries_were_added(session, expected_entries):
+                maint_session.execute(create_stmt)
+
+            logger.info("Cleaning up created role")
+            maint_session.execute(f"DROP ROLE IF EXISTS {role_name}")
+            safe_driver_shutdown(maint_cluster)
 
 # AuditBackendTable, no auth, rf=1
 
@@ -1953,6 +1995,14 @@ async def test_insert_failure_standalone(manager: ManagerClient):
 async def test_service_level_statements_standalone(manager: ManagerClient):
     """audit=table, auth, cmdline=--smp 1 — standalone due to special cmdline."""
     await CQLAuditTester(manager)._test_service_level_statements()
+
+
+async def test_audit_maintenance_socket_user_creation(manager: ManagerClient):
+    """Verify that creating a superuser via the maintenance socket is audited."""
+    t = CQLAuditTester(manager)
+    await t._test_audit_maintenance_socket_user_creation(manager, AuditBackendTable)
+    Syslog = functools.partial(AuditBackendSyslog, socket_path=syslog_socket_path)
+    await t._test_audit_maintenance_socket_user_creation(manager, Syslog)
 
 
 # AuditBackendSyslog, no auth, rf=1

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -273,6 +273,7 @@ class AuditEntry:
     statement: str
     table: str
     user: str
+    source: str = "127.0.0.1"
 
 
 class AuditBackend:
@@ -449,6 +450,13 @@ class AuditBackendSyslog(AuditBackend):
             entries.append(self.line_to_row(line, idx))
         return { self.audit_mode(): entries }
 
+    @staticmethod
+    def _parse_address(addr_port):
+        """Extract IP from 'ip:port' (IPv4) or '[ip]:port' (IPv6)."""
+        if addr_port.startswith("["):
+            return addr_port[1:addr_port.index("]")]
+        return addr_port.split(":")[0]
+
     def line_to_row(self, line, idx):
         metadata, data = line.split(": ", 1)
         data = "".join(data.splitlines()) # Remove newlines
@@ -460,9 +468,9 @@ class AuditBackendSyslog(AuditBackend):
         # and make sure it doesn't change during the test (e.g. when the test is running at 23:59:59)
         date = datetime.datetime(2000, 1, 1, 0, 0)
 
-        node = match.group("node").split(":")[0]
+        node = self._parse_address(match.group("node"))
         statement = match.group("query").replace("\\", "")
-        source = match.group("client_ip").split(":")[0]
+        source = self._parse_address(match.group("client_ip"))
         event_time = uuid.UUID(int=idx)
         t = self.named_tuple_factory(date, node, event_time, match.group("category"), match.group("cl"), match.group("error") == "true", match.group("keyspace"), statement, source, match.group("table"), match.group("username"))
         return t
@@ -582,6 +590,7 @@ class CQLAuditTester(AuditTester):
         user="anonymous",
         cl="ONE",
         error=False,
+        source="127.0.0.1",
     ):
         self.assert_audit_row_fields(row)
         assert row.node in self.server_addresses
@@ -590,7 +599,7 @@ class CQLAuditTester(AuditTester):
         assert row.error == error
         assert row.keyspace_name == ks
         assert row.operation == statement
-        assert row.source == "127.0.0.1"
+        assert row.source == source
         assert row.table_name == table
         assert row.username == user
 
@@ -814,7 +823,7 @@ class CQLAuditTester(AuditTester):
             sorted_new_rows = sorted(new_rows, key=lambda row: (row.node, row.category, row.consistency, row.error, row.keyspace_name, row.operation, row.source, row.table_name, row.username))
             assert len(sorted_new_rows) == len(expected_entries)
             for row, entry in zip(sorted_new_rows, sorted(expected_entries)):
-                self.assert_audit_row_eq(row, entry.category, entry.statement, entry.table, entry.ks, entry.user, entry.cl, entry.error)
+                self.assert_audit_row_eq(row, entry.category, entry.statement, entry.table, entry.ks, entry.user, entry.cl, entry.error, entry.source)
 
     async def verify_keyspace(self, audit_settings=None, helper=None):
         """

--- a/test/perf/perf_simple_query.cc
+++ b/test/perf/perf_simple_query.cc
@@ -371,8 +371,12 @@ int scylla_simple_query_main(int argc, char** argv) {
             audit::audit::start_audit(env.local_db().get_config(), env.get_shared_token_metadata(), env.qp(), env.migration_manager()).handle_exception([&] (auto&& e) {
                 fmt::print("audit start failed: {}", e);
             }).get();
+            audit::audit::start_storage(env.local_db().get_config()).get();
             auto audit_stop = defer([] {
                 audit::audit::stop_audit().get();
+            });
+            auto audit_storage_stop = defer([] {
+                audit::audit::stop_storage().get();
             });
             auto results = do_cql_test(env, cfg);
             aggregated_perf_results agg(results);


### PR DESCRIPTION
This series addresses three problems in the audit startup/shutdown
sequence:
1. [BUG] Shutdown SIGABRT. During graceful shutdown, deferred stops run in reverse order of construction. With the audit service constructed after the maintenance socket, audit was destroyed first, and in-flight queries on the maintenance socket could hit the destroyed audit service (assertion failure in sharded::local()).
2. [BUG] Startup audit bypass. The maintenance socket opened before audit storage was initialized, allowing queries (e.g. creating a superuser) to bypass auditing in that window.
3. [PROBLEM] Blocks SCYLLADB-1430. The existing order prevents audit configuration from being driven by group0 state, because audit started before group0.

The series is organized as: a test-helper refactor, a test for the audited maintenance-socket flow, a startup-phase split, the construction-order fix and its shutdown-race test, and finally the storage-before-socket fix and its startup-window test.

Fixes SCYLLADB-1615

No backport, bugs don't seem severe enough to justify backporting.