### PR TITLE
vector_search: fix missing timeout on status check

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1320,7 +1320,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , vector_store_secondary_uri(this, "vector_store_secondary_uri", liveness::LiveUpdate, value_status::Used, "",
         "A comma-separated list of secondary vector store node URIs. These nodes are used as a fallback when all primary nodes are unavailable, and are typically located in a different availability zone for high availability.")
     , vector_store_unreachable_node_detection_time_in_ms(this, "vector_store_unreachable_node_detection_time_in_ms", liveness::LiveUpdate, value_status::Used, 3000,
-        "Time in milliseconds for detecting an unreachable vector store node. This value is applied to the TCP connect timeout, keepalive parameters, and TCP_USER_TIMEOUT. "
+        "Time in milliseconds for detecting an unreachable vector store node. This value is applied to the TCP connect timeout, keepalive parameters, TCP_USER_TIMEOUT, "
+        "and the deadline of the health-check request used to detect that an unreachable node became available again. "
         "When any of these mechanisms detects that a node is unreachable within this window, the client fails over to the next available vector store node.")
     , vector_store_encryption_options(this, "vector_store_encryption_options", value_status::Used, {},
         "Options for encrypted connections to the vector store. These options are used for HTTPS URIs in `vector_store_primary_uri` and `vector_store_secondary_uri`. The available options are:\n"

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -254,3 +254,29 @@ BOOST_AUTO_TEST_CASE(test_get_keepalive_parameters) {
     BOOST_CHECK_GE(params_0ms.interval.count(), 1);
     BOOST_CHECK_GE(static_cast<int>(params_0ms.count), 1);
 }
+
+SEASTAR_TEST_CASE(status_check_does_not_hang_when_server_accepts_tcp_but_does_not_respond_at_http) {
+    abort_source_timeout as;
+    auto server = co_await make_unavailable_server();
+
+    auto unreachable_node_detection_time = utils::updateable_value<uint32_t>{200};
+    client client{client_test_logger, make_endpoint(server), unreachable_node_detection_time, shared_ptr<seastar::tls::certificate_credentials>{}};
+
+    // The initial request should fail and trigger the status check loop.
+    auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
+    BOOST_CHECK(!res);
+    BOOST_CHECK(!client.is_up());
+
+    // Configure server to accept TCP connections but not respond to HTTP requests.
+    server->auto_shutdown_off();
+    auto initial_connections = server->connections().size();
+
+    // Wait for at least 2 retries to be attempted. Meaning that the client did not hang after the first attempt.
+    auto got_retries = co_await repeat_until([&server, initial_connections]() -> future<bool> {
+        co_return server->connections().size() - initial_connections >= 2;
+    });
+    BOOST_CHECK(got_retries);
+
+    co_await server->stop();
+    co_await client.close();
+}

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -291,3 +291,35 @@ BOOST_AUTO_TEST_CASE(test_get_keepalive_parameters) {
     BOOST_CHECK_GE(params_0ms.interval.count(), 1);
     BOOST_CHECK_GE(static_cast<int>(params_0ms.count), 1);
 }
+
+// Regression test for SCYLLADB-1561: check_status() hung indefinitely when the vector store
+// accepted a TCP connection but never responded at the HTTP layer.
+SEASTAR_TEST_CASE(status_check_does_not_hang_when_server_accepts_tcp_but_does_not_respond_at_http) {
+    abort_source_timeout as;
+    auto server = co_await make_unavailable_server();
+
+    auto unreachable_node_detection_time = utils::updateable_value<uint32_t>{2000};
+    client client{client_test_logger, make_endpoint(server), unreachable_node_detection_time, shared_ptr<seastar::tls::certificate_credentials>{}};
+
+    // The initial request should fail and trigger the status check loop.
+    auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
+    BOOST_CHECK(!res);
+    BOOST_CHECK(!client.is_up());
+
+    // Configure server to accept TCP connections but not respond to HTTP requests.
+    server->auto_shutdown_off();
+    auto initial_connections = server->connections().size();
+
+    // The status check opens a connection, never gets a reply, and is aborted after unreachable_node_detection_time (2s).
+    // Then does the loop open a second connection, so waiting for that second connection is what proves the first
+    // status check timed out instead of hanging forever.
+    auto got_retries = co_await repeat_until([&server, initial_connections]() -> future<bool> {
+        co_return server->connections().size() - initial_connections >= 2;
+    });
+    BOOST_CHECK(got_retries);
+
+    // Stop the server before closing the client so that the hanging connection is closed immediately.
+    co_await server->stop();
+    co_await server->shutdown_all_and_clear();
+    co_await client.close();
+}

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -181,7 +181,14 @@ seastar::future<client::response> client::request_impl(seastar::httpd::operation
 }
 
 seastar::future<bool> client::check_status() {
-    auto f = co_await coroutine::as_future(request_impl(httpd::operation_type::GET, "/api/v1/status", std::nullopt, http::reply::status_type::ok, _as));
+    auto timeout = std::chrono::milliseconds(_unreachable_node_detection_time_in_ms.get());
+    abort_on_expiry timeout_as(seastar::lowres_clock::now() + timeout);
+    utils::composite_abort_source composite_as;
+    composite_as.add(timeout_as.abort_source());
+    composite_as.add(_as);
+
+    auto f = co_await coroutine::as_future(
+            request_impl(httpd::operation_type::GET, "/api/v1/status", std::nullopt, http::reply::status_type::ok, composite_as.abort_source()));
     if (f.failed()) {
         f.ignore_ready_future();
         co_return false;

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -93,8 +93,8 @@ private:
         abort_source operation_as;
 
         abort_on_expiry timeout_as(seastar::lowres_clock::now() + timeout);
-        [[maybe_unused]] const auto timeout_sub = utils::chain_abort_source(operation_as, timeout_as.abort_source());
-        [[maybe_unused]] const auto as_sub = utils::chain_abort_source(operation_as, as);
+        const auto timeout_sub = utils::chain_abort_source(operation_as, timeout_as.abort_source());
+        const auto as_sub = utils::chain_abort_source(operation_as, as);
 
         auto f = co_await coroutine::as_future(
                 connect_with_as(socket_address(_endpoint.ip, _endpoint.port), _creds, _endpoint.host, operation_as));
@@ -213,7 +213,14 @@ seastar::future<client::response> client::request_impl(seastar::httpd::operation
 }
 
 seastar::future<bool> client::check_status() {
-    auto f = co_await coroutine::as_future(request_impl(httpd::operation_type::GET, "/api/v1/status", std::nullopt, http::reply::status_type::ok, _as));
+    auto timeout = std::chrono::milliseconds(_unreachable_node_detection_time_in_ms.get());
+    abort_source operation_as;
+    abort_on_expiry timeout_as(seastar::lowres_clock::now() + timeout);
+    const auto timeout_sub = utils::chain_abort_source(operation_as, timeout_as.abort_source());
+    const auto as_sub = utils::chain_abort_source(operation_as, _as);
+
+    auto f =
+            co_await coroutine::as_future(request_impl(httpd::operation_type::GET, "/api/v1/status", std::nullopt, http::reply::status_type::ok, operation_as));
     if (f.failed()) {
         f.ignore_ready_future();
         co_return false;


### PR DESCRIPTION
vector_search: fix missing timeout on status check

check_status() could hang indefinitely when the vector store accepted
a TCP connection but never responded at the HTTP layer.

Bound the health-check request with a dedicated abort_source that
combines an abort_on_expiry timer (derived from
unreachable_node_detection_time_in_ms) with the client's existing
abort source, using utils::chain_abort_source.

Fixes: SCYLLADB-1561

No backport needed, as this issue has never been observed in production. Hence it is not essential fix that needs to be backported.