### PR TITLE
mutation_reader: throw on incompatible schema downgrade instead of silently dropping cells

### DIFF
--- a/idl/replica_exception.idl.hh
+++ b/idl/replica_exception.idl.hh
@@ -27,13 +27,18 @@ class critical_disk_utilization_exception {
     sstring failed_action();
 };
 
+class incompatible_schema_downgrade_exception {
+    sstring message();
+};
+
 struct exception_variant {
     std::variant<replica::unknown_exception,
             replica::no_exception,
             replica::rate_limit_exception,
             replica::stale_topology_exception,
             replica::abort_requested_exception,
-            replica::critical_disk_utilization_exception
+            replica::critical_disk_utilization_exception,
+            replica::incompatible_schema_downgrade_exception
     > reason;
 };
 

--- a/mutation/converting_mutation_partition_applier.cc
+++ b/mutation/converting_mutation_partition_applier.cc
@@ -13,6 +13,7 @@
 #include "mutation/mutation_partition_view.hh"
 #include "mutation/mutation_partition.hh"
 #include "schema/schema.hh"
+#include "replica/exceptions.hh"
 
 bool
 converting_mutation_partition_applier::is_compatible(const column_definition& new_def, const abstract_type& old_type, column_kind kind) {
@@ -33,16 +34,31 @@ converting_mutation_partition_applier::upgrade_cell(const abstract_type& new_typ
 }
 
 void
-converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell) {
-    if (!is_compatible(new_def, old_type, kind) || cell.timestamp() <= new_def.dropped_at()) {
+converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type,
+                                                   atomic_cell_view cell, bool is_downgrade) {
+    if (!is_compatible(new_def, old_type, kind)) {
+        if (is_downgrade) {
+            throw replica::incompatible_schema_downgrade_exception(fmt::format(
+                "Incompatible schema downgrade: column '{}' type {} is not compatible with {}",
+                new_def.name_as_text(), new_def.type->name(), old_type.name()));
+        }
+        return;
+    }
+    if (cell.timestamp() <= new_def.dropped_at()) {
         return;
     }
     dst.apply(new_def, upgrade_cell(*new_def.type, old_type, cell));
 }
 
 void
-converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell) {
+converting_mutation_partition_applier::accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type,
+                                                   collection_mutation_view cell, bool is_downgrade) {
     if (!is_compatible(new_def, old_type, kind)) {
+        if (is_downgrade) {
+            throw replica::incompatible_schema_downgrade_exception(fmt::format(
+                "Incompatible schema downgrade: column '{}' type {} is not compatible with {}",
+                new_def.name_as_text(), new_def.type->name(), old_type.name()));
+        }
         return;
     }
 
@@ -167,10 +183,11 @@ converting_mutation_partition_applier::accept_row_cell(column_id id, collection_
 }
 
 void
-converting_mutation_partition_applier::append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell) {
+converting_mutation_partition_applier::append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def,
+                                                   const atomic_cell_or_collection& cell, bool is_downgrade) {
     if (new_def.is_atomic()) {
-        accept_cell(dst, kind, new_def, *old_def.type, cell.as_atomic_cell(old_def));
+        accept_cell(dst, kind, new_def, *old_def.type, cell.as_atomic_cell(old_def), is_downgrade);
     } else {
-        accept_cell(dst, kind, new_def, *old_def.type, cell.as_collection_mutation());
+        accept_cell(dst, kind, new_def, *old_def.type, cell.as_collection_mutation(), is_downgrade);
     }
 }

--- a/mutation/converting_mutation_partition_applier.hh
+++ b/mutation/converting_mutation_partition_applier.hh
@@ -34,8 +34,11 @@ private:
     static bool is_compatible(const column_definition& new_def, const abstract_type& old_type, column_kind kind);
     static atomic_cell upgrade_cell(const abstract_type& new_type, const abstract_type& old_type, atomic_cell_view cell,
                                     atomic_cell::collection_member cm = atomic_cell::collection_member::no);
-    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell);
-    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell);public:
+    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, atomic_cell_view cell,
+                            bool is_downgrade = false);
+    static void accept_cell(row& dst, column_kind kind, const column_definition& new_def, const abstract_type& old_type, collection_mutation_view cell,
+                            bool is_downgrade = false);
+public:
     converting_mutation_partition_applier(
             const column_mapping& visited_column_mapping,
             const schema& target_schema,
@@ -52,5 +55,9 @@ private:
 
     // Appends the cell to dst upgrading it to the new schema.
     // Cells must have monotonic names.
-    static void append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def, const atomic_cell_or_collection& cell);
+    // When is_downgrade is true and a cell type is incompatible, throws
+    // replica::incompatible_schema_downgrade_exception instead of silently
+    // dropping the cell.
+    static void append_cell(row& dst, column_kind kind, const column_definition& new_def, const column_definition& old_def,
+                            const atomic_cell_or_collection& cell, bool is_downgrade = false);
 };

--- a/readers/mutation_reader.cc
+++ b/readers/mutation_reader.cc
@@ -10,6 +10,7 @@
 
 #include "readers/mutation_reader.hh"
 #include "mutation/mutation_rebuilder.hh"
+#include "schema/schema.hh"
 #include "schema_upgrader.hh"
 
 logging::logger mrlog("mutation_reader");
@@ -77,7 +78,22 @@ future<bool> mutation_reader::impl::fill_buffer_from(Source& source) {
 template future<bool> mutation_reader::impl::fill_buffer_from<mutation_reader>(mutation_reader&);
 
 void mutation_reader::do_upgrade_schema(const schema_ptr& s) {
-    *this = transform(std::move(*this), schema_upgrader_v2(s));
+    // With raft-based schema management, schema versions are timeuuid (v1) with
+    // monotonically increasing timestamps. This allows us to detect if we're
+    // asked to "downgrade" data from a newer schema to an older one. A downgrade
+    // can cause silent data loss in converting_mutation_partition_applier when
+    // column types are not value-compatible in the downgrade direction
+    // (e.g. varint->int).
+    //
+    // This can happen when a read is in flight with an old schema (from a stale
+    // prepared statement) while an ALTER TABLE has already committed a new schema
+    // to the memtable. We pass the is_downgrade flag to the upgrader so that
+    // accept_cell can throw instead of silently dropping incompatible cells.
+    const auto target_ver = s->version().uuid();
+    const auto current_ver = schema()->version().uuid();
+    const bool is_downgrade = target_ver.is_timestamp() && current_ver.is_timestamp()
+            && target_ver.timestamp() < current_ver.timestamp();
+    *this = transform(std::move(*this), schema_upgrader_v2(s, is_downgrade));
 }
 
 void mutation_reader::on_close_error(std::unique_ptr<impl> i, std::exception_ptr ep) noexcept {

--- a/replica/exceptions.cc
+++ b/replica/exceptions.cc
@@ -25,6 +25,8 @@ exception_variant try_encode_replica_exception(std::exception_ptr eptr) {
         return abort_requested_exception();
     } catch (const critical_disk_utilization_exception& e) {
         return e;
+    } catch (const incompatible_schema_downgrade_exception& e) {
+        return e;
     } catch (...) {
         return no_exception{};
     }

--- a/replica/exceptions.hh
+++ b/replica/exceptions.hh
@@ -82,13 +82,29 @@ public:
 
 using abort_requested_exception = seastar::abort_requested_exception;
 
+/// Thrown when a schema downgrade (converting data from a newer schema to an
+/// older one) encounters an incompatible column type. This means a cell would
+/// be silently dropped, causing data loss. With raft-based schema versions
+/// (timeuuid/v1), we can detect downgrades and throw instead of losing data.
+class incompatible_schema_downgrade_exception final : public replica_exception {
+    seastar::sstring _message;
+public:
+    incompatible_schema_downgrade_exception(seastar::sstring message)
+        : _message(std::move(message))
+    { }
+
+    const seastar::sstring& message() const { return _message; }
+    virtual const char* what() const noexcept override { return _message.c_str(); }
+};
+
 struct exception_variant {
     std::variant<unknown_exception,
             no_exception,
             rate_limit_exception,
             stale_topology_exception,
             abort_requested_exception,
-            critical_disk_utilization_exception
+            critical_disk_utilization_exception,
+            incompatible_schema_downgrade_exception
     > reason;
 
     exception_variant()

--- a/schema_upgrader.hh
+++ b/schema_upgrader.hh
@@ -63,6 +63,7 @@ public:
 class schema_upgrader_v2 {
     schema_ptr _prev;
     schema_ptr _new;
+    bool _is_downgrade;
     std::optional<reader_permit> _permit;
 private:
     row transform(row&& r, column_kind kind) {
@@ -71,14 +72,16 @@ private:
             const column_definition& col = _prev->column_at(kind, id);
             const column_definition* new_col = _new->get_column_definition(col.name());
             if (new_col) {
-                converting_mutation_partition_applier::append_cell(new_row, kind, *new_col, col, std::move(cell));
+                converting_mutation_partition_applier::append_cell(new_row, kind, *new_col, col, std::move(cell),
+                    _is_downgrade);
             }
         });
         return new_row;
     }
 public:
-    schema_upgrader_v2(schema_ptr s)
+    schema_upgrader_v2(schema_ptr s, bool is_downgrade = false)
         : _new(std::move(s))
+        , _is_downgrade(is_downgrade)
     { }
     schema_ptr operator()(schema_ptr old) {
         _prev = std::move(old);

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -793,6 +793,9 @@ private:
                     } else if constexpr (std::is_same_v<Ex, replica::critical_disk_utilization_exception>) {
                         msg = e.what();
                         return error::FAILURE;
+                    } else if constexpr (std::is_same_v<Ex, replica::incompatible_schema_downgrade_exception>) {
+                        msg = e.what();
+                        return error::FAILURE;
                     }
                 }, exception->reason);
             }
@@ -4828,15 +4831,23 @@ protected:
     size_t _failed = 0;
 
     virtual void on_failure(exceptions::coordinator_exception_container&& ex) = 0;
+    virtual void on_failure(std::exception_ptr&& ex) = 0;
     virtual void on_timeout() = 0;
     virtual size_t response_count() const = 0;
-    void fail_request(exceptions::coordinator_exception_container&& ex) {
+    template <typename TException>
+    void fail_request(TException&& ex) {
         _request_failed = true;
+        _timeout.cancel();
         // The exception container was created on the same shard,
         // so it should be cheap to clone and not throw
-        _done_promise.set_value(ex.clone());
-        _timeout.cancel();
-        on_failure(std::move(ex));
+        if constexpr (std::is_constructible_v<exceptions::coordinator_exception_container, TException>) {
+            auto container = exceptions::coordinator_exception_container(std::forward<TException>(ex));
+            _done_promise.set_value(container.clone());
+            on_failure(std::move(container));
+        } else {
+            _done_promise.set_exception(ex);
+            on_failure(std::move(ex));
+        }
     }
 public:
     abstract_read_resolver(schema_ptr schema, db::consistency_level cl, size_t target_count, storage_proxy::clock_type::time_point timeout)
@@ -4876,6 +4887,17 @@ public:
             // do not report aborts, they are triggered by shutdown or timeouts
         } else if (try_catch<gate_closed_exception>(eptr)) {
             // do not report gate_closed errors, they are triggered by shutdown (See #8995)
+        } else if (try_catch<replica::incompatible_schema_downgrade_exception>(eptr)) {
+            // A schema downgrade means this replica has data in a newer schema
+            // than the coordinator's query schema. Silently dropping incompatible
+            // cells would cause data loss. Propagate the exception directly so
+            // the CQL layer can trigger prepared statement re-preparation.
+            slogger.warn("Incompatible schema downgrade when reading from {}.{} via {}: {}",
+                         _schema->ks_name(), _schema->cf_name(), ep, eptr);
+            if (!_request_failed) {
+                fail_request(std::move(eptr));
+            }
+            return;
         } else if (auto ex = try_catch<rpc::remote_verb_error>(eptr)) {
             // Log remote read error with lower severity.
             // If it is really severe it we be handled on the host that sent
@@ -4921,14 +4943,25 @@ private:
     void on_timeout() override {
         fail_request(read_timeout_exception(_schema->ks_name(), _schema->cf_name(), _cl, _cl_responses, _block_for, _data_result));
     }
-    void on_failure(exceptions::coordinator_exception_container&& ex) override {
+    template <typename TException>
+    void do_on_failure(TException&& ex) {
         if (!_cl_reported) {
-            _cl_promise.set_value(std::move(ex));
+            if constexpr (utils::ExceptionContainer<TException>) {
+                _cl_promise.set_value(std::move(ex));
+            } else {
+                _cl_promise.set_exception(std::move(ex));
+            }
         }
         // we will not need them any more
         _data_result = foreign_ptr<lw_shared_ptr<query::result>>();
         _digest_results.clear();
         _on_disconnect = {};
+    }
+    void on_failure(exceptions::coordinator_exception_container&& ex) override {
+        do_on_failure(std::move(ex));
+    }
+    void on_failure(std::exception_ptr&& ex) override {
+        do_on_failure(std::move(ex));
     }
 public:
     digest_read_resolver(shared_ptr<storage_proxy> proxy,
@@ -5131,9 +5164,15 @@ private:
     void on_timeout() override {
         fail_request(read_timeout_exception(_schema->ks_name(), _schema->cf_name(), _cl, response_count(), _targets_count, response_count() != 0));
     }
-    void on_failure(exceptions::coordinator_exception_container&& ex) override {
+    void do_on_failure() {
         // we will not need them any more
         _data_results.clear();
+    }
+    void on_failure(exceptions::coordinator_exception_container&& ex) override {
+        do_on_failure();
+    }
+    void on_failure(std::exception_ptr&& ex) override {
+        do_on_failure();
     }
 
     virtual size_t response_count() const override {

--- a/test/cluster/test_alter_type_race.py
+++ b/test/cluster/test_alter_type_race.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="fix not yet applied")
 @pytest.mark.skip_mode(
     mode="release", reason="error injections are not supported in release mode"
 )

--- a/test/cluster/test_alter_type_race.py
+++ b/test/cluster/test_alter_type_race.py
@@ -1,0 +1,168 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+import asyncio
+import logging
+import pytest
+import time
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for_cql_and_get_hosts
+from test.pylib.tablets import get_tablet_replica
+from test.cluster.util import new_test_keyspace
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="fix not yet applied")
+@pytest.mark.skip_mode(
+    mode="release", reason="error injections are not supported in release mode"
+)
+async def test_alter_column_type_does_not_lose_data(manager: ManagerClient) -> None:
+    """
+    Reproduces a race condition where ALTER TABLE ... ALTER c TYPE varint
+    causes a transient data visibility loss.
+
+    The scenario: a read is in flight with an old schema (int) while ALTER TABLE
+    commits a new schema (varint) to the memtable. When the read resumes, the
+    replica tries to convert varint data back to int via schema_upgrader_v2's
+    converting_mutation_partition_applier::accept_cell. Since
+    int->is_value_compatible_with(varint) returns false, without the fix the
+    cell is silently dropped, making the query return NULL instead of the actual
+    value.
+
+    The fix: mutation_reader::do_upgrade_schema detects the schema version
+    downgrade (target schema is older than stream schema, both are raft-based
+    timeuuid) and throws incompatible_schema_downgrade_exception. The CQL
+    transport layer catches this and returns UNPREPARED to the driver, which
+    re-prepares with the latest schema and retries the query successfully.
+
+    The test exercises both read paths:
+    - Local: coordinator IS the replica (exception propagates in-process)
+    - Remote: coordinator is NOT the replica (exception propagates via RPC
+      using replica::exception_variant)
+    """
+    cmdline = [
+        "--logger-log-level",
+        "debug_error_injection=debug",
+    ]
+
+    servers = await manager.servers_add(2, cmdline=cmdline)
+    cql = manager.get_cql()
+    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(
+        manager,
+        "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+        " AND tablets = {'initial': 1}",
+    ) as ks:
+
+        async def find_replica_idx(table_name):
+            """Return the index into servers/hosts of the node holding the tablet replica."""
+            replica_host_id, _ = await get_tablet_replica(manager, servers[0], ks, table_name, 0)
+            for i, s in enumerate(servers):
+                host_id = await manager.get_host_id(s.server_id)
+                if host_id == replica_host_id:
+                    return i
+            raise RuntimeError(f"Could not find replica server for {table_name}")
+
+        async def run_race_scenario(table_name, local_coordinator, label):
+            """
+            Run the ALTER TYPE race scenario for a single table.
+
+            :param table_name: table to test (must already be created with int column)
+            :param local_coordinator: if True, coordinator = replica (local path);
+                                      if False, coordinator != replica (remote/RPC path)
+            :param label: label for log messages
+            """
+            replica_idx = await find_replica_idx(table_name)
+            coordinator_idx = replica_idx if local_coordinator else 1 - replica_idx
+            replica_server = servers[replica_idx]
+            coordinator_host = hosts[coordinator_idx]
+            replica_log = await manager.server_open_log(replica_server.server_id)
+
+            logger.info(f"[{label}] Table {table_name}: replica on server {replica_idx},"
+                        f" coordinator on server {coordinator_idx}")
+
+            await cql.run_async(f"INSERT INTO {ks}.{table_name} (pk, v) VALUES (1, 10)")
+
+            # Prepare SELECT with the original int schema
+            select_stmt = cql.prepare(f"SELECT v FROM {ks}.{table_name} WHERE pk = ?")
+
+            # Verify data is readable before ALTER
+            rows = await cql.run_async(select_stmt, [1], host=coordinator_host)
+            assert len(rows) == 1 and rows[0].v == 10, (
+                f"[{label}] Pre-ALTER check failed: {rows}"
+            )
+
+            # Pause reads on the replica inside table::query()
+            await manager.api.enable_injection(
+                replica_server.ip_addr,
+                "replica_query_wait",
+                one_shot=False,
+                parameters={"table": table_name},
+            )
+
+            log_mark = await replica_log.mark()
+
+            # Start the prepared SELECT — it will pause at the injection
+            logger.info(f"[{label}] Starting prepared SELECT (will pause at replica_query_wait)")
+            select_task = asyncio.ensure_future(
+                cql.run_async(select_stmt, [1], host=coordinator_host)
+            )
+
+            # Wait for the read to hit the injection point on the replica
+            await replica_log.wait_for(
+                "replica_query_wait: waiting",
+                from_mark=log_mark,
+                timeout=60,
+            )
+
+            # ALTER TABLE while the read is paused. This completes fully
+            # (commit + post_commit), so the memtable schema becomes varint
+            # and prepared statement caches are invalidated.
+            logger.info(f"[{label}] Running ALTER TABLE while read is paused")
+            await cql.run_async(f"ALTER TABLE {ks}.{table_name} ALTER v TYPE varint")
+            logger.info(f"[{label}] ALTER TABLE completed")
+
+            # Release the read. do_upgrade_schema detects the schema downgrade
+            # and accept_cell throws incompatible_schema_downgrade_exception.
+            # The exception propagates to the CQL layer as UNPREPARED; the
+            # driver re-prepares and retries.
+            logger.info(f"[{label}] Releasing replica_query_wait")
+            await manager.api.message_injection(
+                replica_server.ip_addr, "replica_query_wait"
+            )
+            await manager.api.disable_injection(
+                replica_server.ip_addr, "replica_query_wait"
+            )
+
+            logger.info(f"[{label}] Waiting for SELECT to complete (may re-prepare and retry)")
+            rows = await select_task
+            assert len(rows) == 1, f"[{label}] Expected 1 row, got {len(rows)}"
+            assert rows[0].v == 10, (
+                f"[{label}] Data loss detected during ALTER TYPE race:"
+                f" expected v=10, got v={rows[0].v}"
+            )
+
+            # Final verification with a fresh query
+            rows = await cql.run_async(f"SELECT v FROM {ks}.{table_name} WHERE pk = 1")
+            assert len(rows) == 1 and rows[0].v == 10, (
+                f"[{label}] Post-test verification failed: {rows}"
+            )
+            logger.info(f"[{label}] PASSED")
+
+        # Two tables because ALTER int->varint is one-way
+        await cql.run_async(f"CREATE TABLE {ks}.t_local (pk int PRIMARY KEY, v int)")
+        await cql.run_async(f"CREATE TABLE {ks}.t_remote (pk int PRIMARY KEY, v int)")
+
+        # Sub-test 1: coordinator IS the replica (local read path)
+        await run_race_scenario("t_local", local_coordinator=True, label="local")
+
+        # Sub-test 2: coordinator is NOT the replica (remote read path via RPC)
+        await run_race_scenario("t_remote", local_coordinator=False, label="remote")

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -73,6 +73,8 @@
 #include "utils/result.hh"
 #include "utils/reusable_buffer.hh"
 #include "utils/histogram_metrics_helper.hh"
+#include "replica/exceptions.hh"
+#include "utils/exceptions.hh"
 #include "utils/error_injection.hh"
 
 template<typename T = void>
@@ -1668,6 +1670,10 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
     }
 
     tracing::trace(trace_state, "Processing a statement");
+    // Save a copy of the prepared statement ID before cache_key is moved.
+    // Needed to construct prepared_query_not_found_exception if a schema
+    // version downgrade is detected during the read.
+    auto saved_id = bytes(id);
     return qp.local().execute_prepared_without_checking_exception_message(query_state, std::move(stmt), options, std::move(prepared), std::move(cache_key), needs_authorization)
             .then([trace_state = query_state.get_trace_state(), skip_metadata, q_state = std::move(q_state), stream, version, metadata_id = std::move(metadata_id)] (auto msg) mutable {
         if (msg->as_bounce()) {
@@ -1678,6 +1684,16 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
             tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
             return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, std::move(metadata_id), skip_metadata)));
         }
+    }).handle_exception([saved_id = std::move(saved_id)] (std::exception_ptr eptr) {
+        if (try_catch<replica::incompatible_schema_downgrade_exception>(eptr)) {
+            // A read detected that the memtable schema is newer than the schema
+            // used by the prepared statement. Return UNPREPARED to the client so
+            // the driver re-prepares with the latest schema and retries.
+            clogger.debug("Incompatible schema downgrade detected during read, triggering re-prepare: {}", eptr);
+            return make_exception_future<cql_server::process_fn_return_type>(
+                exceptions::prepared_query_not_found_exception(saved_id));
+        }
+        return make_exception_future<cql_server::process_fn_return_type>(std::move(eptr));
     });
 }
 

--- a/utils/exceptions.cc
+++ b/utils/exceptions.cc
@@ -92,4 +92,16 @@ void* utils::internal::try_catch_dynamic(std::exception_ptr& eptr, const std::ty
     return nullptr;
 }
 
+void* utils::internal::try_catch_exact(std::exception_ptr& eptr, const std::type_info* catch_type) noexcept {
+    void* raw_ptr = reinterpret_cast<void*&>(eptr);
+    const std::type_info* ex_type = utils::abi::get_cxa_exception(raw_ptr)->exceptionType;
+    // For final types no derived class exists, so a catch(T&) can only match
+    // the exact type. Skip the __do_catch inheritance hierarchy walk and just
+    // compare type_info directly.
+    if (*ex_type == *catch_type) {
+        return raw_ptr;
+    }
+    return nullptr;
+}
+
 #endif // __GLIBCXX__

--- a/utils/exceptions.hh
+++ b/utils/exceptions.hh
@@ -89,6 +89,7 @@ namespace utils::internal {
 
 #if defined(OPTIMIZED_EXCEPTION_HANDLING_AVAILABLE)
 void* try_catch_dynamic(std::exception_ptr& eptr, const std::type_info* catch_type) noexcept;
+void* try_catch_exact(std::exception_ptr& eptr, const std::type_info* catch_type) noexcept;
 
 using default_nested_exception_type = std::runtime_error;
 
@@ -139,7 +140,16 @@ inline T* try_catch(std::exception_ptr& eptr) noexcept {
             "T must not be a reference");
 
 #if defined(USE_OPTIMIZED_EXCEPTION_HANDLING)
-    void* opt_ptr = utils::internal::try_catch_dynamic(eptr, &typeid(std::remove_const_t<T>));
+    using raw_t = std::remove_const_t<T>;
+    void* opt_ptr;
+    // For final types no derived class can exist, so catch(T&) can only
+    // match the exact type. Use a direct typeid comparison and skip the
+    // __do_catch inheritance hierarchy walk.
+    if constexpr (std::is_final_v<raw_t>) {
+        opt_ptr = utils::internal::try_catch_exact(eptr, &typeid(raw_t));
+    } else {
+        opt_ptr = utils::internal::try_catch_dynamic(eptr, &typeid(raw_t));
+    }
     return reinterpret_cast<T*>(opt_ptr);
 #else
     try {


### PR DESCRIPTION
Type compatibility between CQL types is asymmetric. For example,
int -> varint is value-compatible (every int is a valid varint), but
varint -> int is not (a varint may not fit in an int). ALTER TABLE ...
ALTER c TYPE varint is allowed precisely because int -> varint is safe.

The mutation upgrade path (schema_upgrader_v2, used during reads to convert
data to the query's schema) assumes it is always upgrading: old data to a
newer schema. When types are incompatible in that direction, the cell is
silently dropped — which is correct for upgrades (the column was dropped
and re-added with an incompatible type, so old data is irrelevant).

However, a read that started before an ALTER TABLE may still hold a
reference to the pre-ALTER schema. When that read resumes, it encounters
data already written in the new schema (varint) but tries to convert it
back to the old schema (int). This is a downgrade, and the silent cell
drop causes data loss: the query returns NULL instead of the actual value.

The fix detects schema version downgrades by comparing raft-based timeuuid
schema versions in do_upgrade_schema (target timestamp < current timestamp
means the query schema is older than the data schema). When accept_cell
encounters an incompatible type during a downgrade, it throws
replica::incompatible_schema_downgrade_exception instead of silently
dropping the cell.

The exception propagates through the storage proxy read resolver to the CQL
transport layer, which converts it to UNPREPARED. The driver then
re-prepares with the latest schema and retries successfully.

For remote replicas, the exception is propagated via replica::exception_variant
(IDL-serialized RPC mechanism), ensuring correct behavior when the coordinator
and replica are on different nodes.

Fixes: https://github.com/scylladb/scylladb/issues/14401
Fixes: [SCYLLADB-1563](https://scylladb.atlassian.net/browse/SCYLLADB-1563)

[SCYLLADB-1563]: https://scylladb.atlassian.net/browse/SCYLLADB-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ