### PR TITLE
test: rename tmpdir/tempdir_base/tempdir to workdir/volatile_dir

### DIFF
--- a/test.py
+++ b/test.py
@@ -108,8 +108,10 @@ def parse_cmd_line() -> argparse.Namespace:
         action="store",
         help=name_help,
     )
-    parser.add_argument("--tmpdir", action="store", default=str(TOP_SRC_DIR / "testlog"),
-                        help="Path to temporary test data and log files.  The data is further segregated per build mode.")
+    parser.add_argument("--test-artifact-dir", "--tmpdir", action="store", default=str(TOP_SRC_DIR / "testlog"),
+                        dest="test_artifact_dir",
+                        help="Path to the top-level test work and log directory.  The data is further segregated per build mode. "
+                             "--tmpdir is deprecated; use --test-artifact-dir.")
     parser.add_argument("--gather-metrics", action=argparse.BooleanOptionalAction, default=True)
     parser.add_argument("--max-failures", type=int, default=0,
                         help="Maximum number of failures to tolerate before cancelling rest of tests.")
@@ -142,7 +144,7 @@ def parse_cmd_line() -> argparse.Namespace:
                         " acceptable format). Consider using --jobs too")
     parser.add_argument('--log-level', action="store",
                         help="Log level for Python logging module. The log "
-                        "is in {tmpdir}/test.py.log. Default: INFO",
+                        "is in {test_artifact_dir}/test.py.log. Default: INFO",
                         default="INFO",
                         choices=["CRITICAL", "ERROR", "WARNING", "INFO",
                                  "DEBUG"],
@@ -162,7 +164,7 @@ def parse_cmd_line() -> argparse.Namespace:
                              "To exclude e.g. slow tests you can write --markers 'not slow'.")
     parser.add_argument('--coverage', action = 'store_true', default = False,
                         help="When running code instrumented with coverage support"
-                             "Will route the profiles to `tmpdir`/mode/coverage/`suite` and post process them in order to generate "
+                             "Will route the profiles to `test_artifact_dir`/mode/coverage/`suite` and post process them in order to generate "
                              "lcov file per suite, lcov file per mode, and an lcov file for the entire run, "
                              "The lcov files can eventually be used for generating coverage reports")
     parser.add_argument("--coverage-mode",action = 'append', type = str, dest = "coverage_modes",
@@ -240,7 +242,7 @@ def parse_cmd_line() -> argparse.Namespace:
             raise RuntimeError(f"The following modes weren't built or ran (using the '--mode' option): {missing_coverage_modes}")
         args.coverage = True
 
-    args.tmpdir = os.path.abspath(args.tmpdir)
+    args.test_artifact_dir = os.path.abspath(args.test_artifact_dir)
 
     return args
 
@@ -316,9 +318,9 @@ def run_pytest(options: argparse.Namespace) -> int:
     # When tests are executed in parallel on different hosts, we need to distinguish results from them.
     # So HOST_ID needed to not overwrite results from different hosts during Jenkins will copy to one directory.
 
-    temp_dir = pathlib.Path(options.tmpdir).absolute()
+    artifact_dir = pathlib.Path(options.test_artifact_dir).absolute()
 
-    report_dir =  temp_dir / 'report'
+    report_dir =  artifact_dir / 'report'
     junit_output_file = report_dir / f'pytest_cpp_{HOST_ID}.xml'
     files_to_run = options.name if options.keep_duplicates else _deduplicate_test_args(options.name)
     files_to_run = files_to_run or [str(TOP_SRC_DIR / 'test/')]
@@ -334,7 +336,7 @@ def run_pytest(options: argparse.Namespace) -> int:
             f'--junit-xml={junit_output_file}',
             "-rf",
             f'-n{options.jobs}',
-            f'--tmpdir={temp_dir}',
+            f'--test-artifact-dir={artifact_dir}',
             f'--maxfail={options.max_failures}',
             f'--alluredir={report_dir / f"allure_{HOST_ID}"}',
             f'--dist=worksteal',
@@ -438,7 +440,7 @@ async def process_coverage(options):
     ran_suites = list({test.suite for test in TestSuite.all_tests() if test.suite.need_coverage()})
 
     def suite_coverage_path(suite) -> pathlib.Path:
-        return pathlib.Path(suite.options.tmpdir) / suite.mode / 'coverage' / suite.name
+        return pathlib.Path(suite.options.test_artifact_dir) / suite.mode / 'coverage' / suite.name
 
     def pathsize(path : pathlib.Path):
         if path.is_file():
@@ -613,7 +615,7 @@ async def process_coverage(options):
     modes_trace_files  = {}
     for mode, suite_traces in suits_trace_files.items():
 
-        target_trace_file = pathlib.Path(options.tmpdir) / mode / "coverage" / f"{mode}_coverage.info"
+        target_trace_file = pathlib.Path(options.test_artifact_dir) / mode / "coverage" / f"{mode}_coverage.info"
         start_time = time.time()
         logger.info(f"Consolidating trace files for mode {mode}.")
         await coverage_utils.lcov_combine_traces(lcovs = suite_traces.values(),
@@ -634,7 +636,7 @@ async def process_coverage(options):
     #5. create one consolidated file with all trace information
     logger.info(f"Consolidating all trace files for this run.")
     start_time = time.time()
-    target_trace_file = pathlib.Path(options.tmpdir) / "test_coverage.info"
+    target_trace_file = pathlib.Path(options.test_artifact_dir) / "test_coverage.info"
     await coverage_utils.lcov_combine_traces(lcovs = modes_trace_files.values(),
                                              output_lcov = target_trace_file,
                                              clear_on_success = False,
@@ -648,13 +650,13 @@ async def process_coverage(options):
     logger.info(f"Done consolidating all trace files for this run - time: {humanfriendly.format_timespan(time.time() - start_time)}.")
 
     logger.info(f"Creating textual report.")
-    proc = await asyncio.create_subprocess_shell(f"lcov --summary --rc lcov_branch_coverage=1 {options.tmpdir}/test_coverage.info 2>/dev/null > {options.tmpdir}/test_coverage_report.txt")
+    proc = await asyncio.create_subprocess_shell(f"lcov --summary --rc lcov_branch_coverage=1 {options.test_artifact_dir}/test_coverage.info 2>/dev/null > {options.test_artifact_dir}/test_coverage_report.txt")
     await proc.wait()
-    with open(pathlib.Path(options.tmpdir) /"test_coverage_report.txt") as f:
+    with open(pathlib.Path(options.test_artifact_dir) /"test_coverage_report.txt") as f:
         summary = f.readlines()
-    proc = await asyncio.create_subprocess_shell(f"lcov --list --rc lcov_branch_coverage=1 {options.tmpdir}/test_coverage.info  2>/dev/null >> {options.tmpdir}/test_coverage_report.txt")
+    proc = await asyncio.create_subprocess_shell(f"lcov --list --rc lcov_branch_coverage=1 {options.test_artifact_dir}/test_coverage.info  2>/dev/null >> {options.test_artifact_dir}/test_coverage_report.txt")
     await proc.wait()
-    logger.info(f"Done creating textual report. ({options.tmpdir}/test_coverage_report.txt)")
+    logger.info(f"Done creating textual report. ({options.test_artifact_dir}/test_coverage_report.txt)")
     total_processing_time = time.time() - total_processing_time
     ROOT_NODE.data.time = total_processing_time
 

--- a/test/cluster/object_store/conftest.py
+++ b/test/cluster/object_store/conftest.py
@@ -36,8 +36,8 @@ def keyspace_options(object_storage, rf=1):
 
 
 class S3_Server:
-    def __init__(self, tempdir: str, address: str, port: int, acc_key: str, secret_key: str, region: str, bucket_name):
-        self.tempdir = tempdir
+    def __init__(self, workdir: str, address: str, port: int, acc_key: str, secret_key: str, region: str, bucket_name):
+        self.workdir = workdir
         self.ip = address
         self.port = port
         self.address = f'http://{self.ip}:{self.port}'
@@ -74,12 +74,12 @@ class S3_Server:
         pass
 
 class MinioWrapper(S3_Server):
-    def __init__(self, tempdir):
-        self.server = MinioServer(tempdir,
+    def __init__(self, workdir):
+        self.server = MinioServer(workdir,
                                   '127.0.0.1',
                                   logging.getLogger('minio'))
         super().__init__(
-                tempdir,
+                workdir,
                 self.server.address,
                 self.server.port,
                 self.server.access_key,
@@ -112,9 +112,9 @@ def create_s3_server(pytestconfig, tmpdir):
     default_region = MinioServer.DEFAULT_REGION
     default_bucket = os.environ.get(MinioServer.ENV_BUCKET)
 
-    tempdir = tmpdir.strpath
+    workdir = tmpdir.strpath
     if s3_server_address:
-        server = S3_Server(tempdir,
+        server = S3_Server(workdir,
                            s3_server_address,
                            s3_server_port,
                            aws_acc_key,
@@ -122,7 +122,7 @@ def create_s3_server(pytestconfig, tmpdir):
                            aws_region,
                            s3_server_bucket)
     elif default_address:
-        server = S3_Server(tempdir,
+        server = S3_Server(workdir,
                            default_address,
                            int(default_port),
                            default_acc_key,
@@ -130,7 +130,7 @@ def create_s3_server(pytestconfig, tmpdir):
                            default_region,
                            default_bucket)
     else:
-        server = MinioWrapper(tempdir)
+        server = MinioWrapper(workdir)
     return server
 
 @pytest.fixture(scope="function")
@@ -177,7 +177,7 @@ class GSFront:
         pass
 
 class GSServer(GSFront):
-    def __init__(self, tmpdir):
+    def __init__(self, workdir):
         super(GSServer, self).__init__(None, 'testbucket', None)
         self.server = None
         self.host = None
@@ -187,7 +187,7 @@ class GSServer(GSFront):
                       'GS_BUCKET_FOR_TEST': attrgetter('bucket_name'), 
                       'GS_CREDENTIALS_FILE': attrgetter('credentials_file'), 
                       }
-        self.tmpdir = tmpdir
+        self.workdir = workdir
 
     def publish(self):
         self.endpoint = f'http://{self.host}:{self.port}'
@@ -211,7 +211,7 @@ class GSServer(GSFront):
         return ["-scheme", "http", "-log-level", "debug", "--port", f'{port}', '-public-host', '127.0.0.1']
 
     async def start(self):
-        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.52.3", self.tmpdir, 
+        self.server = DockerizedServer("docker.io/fsouza/fake-gcs-server:1.52.3", self.workdir, 
                                        logfilenamebase="fake-gcs-server",
                                        image_args=self._image_args,
                                        success_string="server started at",

--- a/test/cluster/storage/conftest.py
+++ b/test/cluster/storage/conftest.py
@@ -23,7 +23,7 @@ from test.pylib.util import gather_safely
 @pytest.fixture(scope="function")
 def volumes_factory(pytestconfig, build_mode, request):
     hash = str(uuid.uuid4())
-    base = pathlib.Path(f"{pytestconfig.getoption("tmpdir")}/{build_mode}/volumes/{hash}")
+    base = pathlib.Path(pytestconfig.getoption('test_artifact_dir')) / build_mode / "volumes" / hash
     volumes = []
 
     @dataclass

--- a/test/manual/bti_cassandra_compatibility_test.py
+++ b/test/manual/bti_cassandra_compatibility_test.py
@@ -622,7 +622,7 @@ if __name__ == "__main__":
     parser.add_argument("--partition-count", type=int, help="Max number of partitions")
     parser.add_argument("--row-count", type=int, help="Max number of rows per partition")
     parser.add_argument("--build-mode", type=str, default="release", help="Scylla build mode")
-    parser.add_argument("--tmpdir", type=str, help="Temporary directory")
+    parser.add_argument("--test-artifact-dir", "--tmpdir", type=str, dest="test_artifact_dir", help="Test artifact directory")
     args = parser.parse_args()
 
     # logging.getLogger().setLevel(logging.NOTSET)
@@ -635,7 +635,7 @@ if __name__ == "__main__":
     module_logger.info(f"Arguments: {args}")
 
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
-    with tempfile.TemporaryDirectory(delete=False, dir=args.tmpdir) as workdir:
+    with tempfile.TemporaryDirectory(delete=False, dir=args.test_artifact_dir) as workdir:
         LOGDIR.set(f"{workdir}/logs")
         os.makedirs(LOGDIR.get(), exist_ok=True)
         GLOBAL_LOGFILE.set(f"{workdir}/global.log")

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -88,7 +88,7 @@ class CppFile(pytest.File, ABC):
 
     @cached_property
     def log_dir(self) -> pathlib.Path:
-        return pathlib.Path(self.config.getoption("--tmpdir")).joinpath(self.build_mode).absolute()
+        return pathlib.Path(self.config.getoption("--test-artifact-dir")).joinpath(self.build_mode).absolute()
 
     @cached_property
     def exe_path(self) -> pathlib.Path:

--- a/test/pylib/dockerized_service.py
+++ b/test/pylib/dockerized_service.py
@@ -19,7 +19,7 @@ class DockerizedServer:
     """class for running an external dockerized service image, typically mock server"""
     # pylint: disable=too-many-instance-attributes
 
-    def __init__(self, image, tmpdir, logfilenamebase, 
+    def __init__(self, image, workdir, logfilenamebase, 
                  success_string : Callable[[str, int], bool] | str,
                  failure_string : Callable[[str, int], bool] | str,
                  docker_args : Callable[[str, int], list[str]] | list[str] = [],
@@ -28,7 +28,7 @@ class DockerizedServer:
                  port = None):
         self.image = image
         self.host = host
-        self.tmpdir = tmpdir
+        self.workdir = workdir
         self.logfilenamebase = logfilenamebase
         self.docker_args: Callable[[str, int], list[str]] = (lambda host,port : docker_args) if isinstance(docker_args, list) else docker_args
         self.image_args: Callable[[str, int], list[str]] = (lambda host,port : image_args) if isinstance(image_args, list) else image_args
@@ -47,7 +47,7 @@ class DockerizedServer:
                                                 if exe is not None)).resolve()
         sid = str(uuid.uuid4())
         name = f'{self.logfilenamebase}-{sid}'
-        logfilename = (pathlib.Path(self.tmpdir) / name).with_suffix(".log")
+        logfilename = (pathlib.Path(self.workdir) / name).with_suffix(".log")
         self.logfile = logfilename.open("wb")
 
         docker_args = self.docker_args(self.host, self.service_port)

--- a/test/pylib/encryption_provider.py
+++ b/test/pylib/encryption_provider.py
@@ -29,9 +29,9 @@ class KeyProvider(Enum):
 
 class KeyProviderFactory:
     """Base class for provider factories"""
-    def __init__(self, key_provider : KeyProvider, tmpdir):
+    def __init__(self, key_provider : KeyProvider, workdir):
         self.key_provider = key_provider
-        self.system_key_location = os.path.join(tmpdir, "resources/system_keys")
+        self.system_key_location = os.path.join(workdir, "resources/system_keys")
 
     async def __aenter__(self):
         return self
@@ -61,9 +61,9 @@ class KeyProviderFactory:
 
 class LocalFileSystemKeyProviderFactory(KeyProviderFactory):
     """LocalFileSystemKeyProviderFactory proxy"""
-    def __init__(self, tmpdir):
-        super(LocalFileSystemKeyProviderFactory, self).__init__(KeyProvider.local, tmpdir)
-        self.secret_file = os.path.join(tmpdir, "test/node1/conf/data_encryption_keys")
+    def __init__(self, workdir):
+        super(LocalFileSystemKeyProviderFactory, self).__init__(KeyProvider.local, workdir)
+        self.secret_file = os.path.join(workdir, "test/node1/conf/data_encryption_keys")
 
     def additional_cf_options(self) -> dict[str, str]:
         """scylla.conf entries for provider"""
@@ -71,8 +71,8 @@ class LocalFileSystemKeyProviderFactory(KeyProviderFactory):
 
 class ReplicatedKeyProviderFactory(KeyProviderFactory):
     """ReplicatedKeyProviderFactory proxy"""
-    def __init__(self, tmpdir, scylla_exe):
-        super(ReplicatedKeyProviderFactory, self).__init__(KeyProvider.replicated, tmpdir)
+    def __init__(self, workdir, scylla_exe):
+        super(ReplicatedKeyProviderFactory, self).__init__(KeyProvider.replicated, workdir)
         self.system_key_file_name = "system_key"
         self.scylla_exe = scylla_exe
 
@@ -90,9 +90,9 @@ class ReplicatedKeyProviderFactory(KeyProviderFactory):
 
 class KmipKeyProviderFactory(KeyProviderFactory):
     """KmipKeyProviderFactory proxy"""
-    def __init__(self, tmpdir):
-        super(KmipKeyProviderFactory, self).__init__(KeyProvider.kmip, tmpdir)
-        self.tmpdir = tmpdir
+    def __init__(self, workdir):
+        super(KmipKeyProviderFactory, self).__init__(KeyProvider.kmip, workdir)
+        self.workdir = workdir
         self.kmip_server_wrapper = None
         self.kmip_host = "kmip_test"
         self.kmip_port = 0
@@ -131,13 +131,13 @@ class KmipKeyProviderFactory(KeyProviderFactory):
             hostname="127.0.0.1",
             config_path=None,
             certificate_path=self.certs["certfile"],
-            policy_path=self.tmpdir.strpath,
+            policy_path=self.workdir.strpath,
             key_path=self.certs["keyfile"],
             ca_path=self.certs["truststore"],
             auth_suite="TLS1.2",
             database_path=':memory:',
             logging_level='DEBUG',
-            log_path=os.path.join(self.tmpdir, "pykmip.log"),
+            log_path=os.path.join(self.workdir, "pykmip.log"),
             enable_tls_client_auth=False,
         )
         self.kmip_server_wrapper.start()
@@ -170,9 +170,9 @@ class KmipKeyProviderFactory(KeyProviderFactory):
 
 class KMSKeyProviderFactory(KeyProviderFactory):
     """KMSKeyProviderFactory proxy"""
-    def __init__(self, tmpdir):
-        super(KMSKeyProviderFactory, self).__init__(KeyProvider.kms, tmpdir)
-        self.tmpdir = tmpdir
+    def __init__(self, workdir):
+        super(KMSKeyProviderFactory, self).__init__(KeyProvider.kms, workdir)
+        self.workdir = workdir
         self.master_key = "alias/Scylla-test"
         self.kms_host = "kms_test"
         self.endpoint_url = None
@@ -184,7 +184,7 @@ class KMSKeyProviderFactory(KeyProviderFactory):
         aws_region = os.getenv('KMS_AWS_REGION')
  
         if master_key is None:
-            self.server = DockerizedServer("docker.io/nsmithuk/local-kms:3", self.tmpdir,
+            self.server = DockerizedServer("docker.io/nsmithuk/local-kms:3", self.workdir,
                                            logfilenamebase="local-kms",
                                            success_string="Local KMS started on",
                                            failure_string="address already in use",
@@ -248,9 +248,9 @@ class KMSKeyProviderFactory(KeyProviderFactory):
 
 class AzureKeyProviderFactory(KeyProviderFactory):
     """AzureKeyProviderFactory proxy"""
-    def __init__(self, tmpdir):
-        super(AzureKeyProviderFactory, self).__init__(KeyProvider.azure, tmpdir)
-        self.tmpdir = tmpdir
+    def __init__(self, workdir):
+        super(AzureKeyProviderFactory, self).__init__(KeyProvider.azure, workdir)
+        self.workdir = workdir
         self.azure_host = "azure_test"
         self.azure_server = None
         self.host = None;
@@ -286,19 +286,19 @@ class AzureKeyProviderFactory(KeyProviderFactory):
     def require_restart(self):
         return True
 
-def make_key_provider_factory(provider: KeyProvider, tmpdir, scylla_exe):
+def make_key_provider_factory(provider: KeyProvider, workdir, scylla_exe):
     """Create key provider factory for enum"""
     res = None
     if provider == KeyProvider.local:
-        res = LocalFileSystemKeyProviderFactory(tmpdir)
+        res = LocalFileSystemKeyProviderFactory(workdir)
     elif provider == KeyProvider.replicated:
-        res = ReplicatedKeyProviderFactory(tmpdir, scylla_exe)
+        res = ReplicatedKeyProviderFactory(workdir, scylla_exe)
     elif provider == KeyProvider.kmip:
-        res = KmipKeyProviderFactory(tmpdir)
+        res = KmipKeyProviderFactory(workdir)
     elif provider == KeyProvider.kms:
-        res = KMSKeyProviderFactory(tmpdir)
+        res = KMSKeyProviderFactory(workdir)
     elif provider == KeyProvider.azure:
-        res = AzureKeyProviderFactory(tmpdir)
+        res = AzureKeyProviderFactory(workdir)
     else:
         raise RuntimeError(f'Unknown key_provider: {provider}')
 

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -35,15 +35,15 @@ class MinioServer:
 
     log_file: BufferedWriter
 
-    def __init__(self, tempdir_base, address, logger):
+    def __init__(self, workdir, address, logger):
         self.srv_exe = shutil.which('minio')
         self.address = address
         self.port = None
-        self.tempdir_base = pathlib.Path(tempdir_base)
-        tempdir = tempfile.mkdtemp(dir=tempdir_base, prefix="minio-")
-        self.tempdir = pathlib.Path(tempdir)
-        self.rootdir = self.tempdir / 'minio_root'
-        self.mcdir = self.tempdir / 'mc'
+        self.workdir = pathlib.Path(workdir)
+        volatile_dir = tempfile.mkdtemp(dir=workdir, prefix="minio-")
+        self.volatile_dir = pathlib.Path(volatile_dir)
+        self.rootdir = self.volatile_dir / 'minio_root'
+        self.mcdir = self.volatile_dir / 'mc'
         self.logger = logger
         self.cmd: Optional[Process] = None
         self.default_user = 'minioadmin'
@@ -51,7 +51,7 @@ class MinioServer:
         self.bucket_name = 'testbucket'
         self.access_key = os.environ.get(self.ENV_ACCESS_KEY, ''.join(random.choice(string.hexdigits) for i in range(16)))
         self.secret_key = os.environ.get(self.ENV_SECRET_KEY, ''.join(random.choice(string.hexdigits) for i in range(32)))
-        self.log_filename = (self.tempdir_base / 'minio').with_suffix(".log")
+        self.log_filename = (self.workdir / 'minio').with_suffix(".log")
         self.old_env = dict()
         self.default_config = None
 
@@ -286,18 +286,18 @@ class MinioServer:
         finally:
             self.logger.info('Killed minio server')
             self.cmd = None
-            shutil.rmtree(self.tempdir)
+            shutil.rmtree(self.volatile_dir)
 
 
 async def main():
     parser = argparse.ArgumentParser(description="Start a MinIO server")
-    parser.add_argument('--tempdir')
+    parser.add_argument('--test-artifact-dir', '--tempdir', dest='test_artifact_dir')
     parser.add_argument('--host', default='127.0.0.1')
     args = parser.parse_args()
-    with tempfile.TemporaryDirectory(suffix='-minio', dir=args.tempdir) as tempdir:
-        if args.tempdir is None:
-            print(f'{tempdir=}')
-        server = MinioServer(tempdir, args.host, logging.getLogger('minio'))
+    with tempfile.TemporaryDirectory(suffix='-minio', dir=args.test_artifact_dir) as workdir:
+        if args.test_artifact_dir is None:
+            print(f'{workdir=}')
+        server = MinioServer(workdir, args.host, logging.getLogger('minio'))
         await server.start()
         server.print_environ()
         try:

--- a/test/pylib/resource_gather.py
+++ b/test/pylib/resource_gather.py
@@ -310,9 +310,9 @@ def setup_cgroup(is_required: bool) -> None:
                 f.write(controllers)
 
 
-async def monitor_resources(cancel_event: Event, stop_event: Event, tmpdir: Path) -> None:
+async def monitor_resources(cancel_event: Event, stop_event: Event, workdir: Path) -> None:
     """Continuously monitors CPU and memory utilization."""
-    sqlite_writer = SQLiteWriter(tmpdir / DEFAULT_DB_NAME)
+    sqlite_writer = SQLiteWriter(workdir / DEFAULT_DB_NAME)
     while not cancel_event.is_set() and not stop_event.is_set():
         timeline_record = SystemResourceMetric(
             host_id=HOST_ID,
@@ -331,7 +331,7 @@ async def no_monitor() -> None:
     pass
 
 
-def run_resource_watcher(is_required: bool, cancel_event: Event, stop_event:Event, tmpdir: str) -> Task:
+def run_resource_watcher(is_required: bool, cancel_event: Event, stop_event:Event, workdir: str) -> Task:
     if is_required:
-        return asyncio.create_task(monitor_resources(cancel_event, stop_event, Path(tmpdir)))
+        return asyncio.create_task(monitor_resources(cancel_event, stop_event, Path(workdir)))
     return asyncio.create_task(no_monitor())

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -68,8 +68,10 @@ _pytest_config: pytest.Config | None = None
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption('--mode', choices=ALL_MODES, action="append", dest="modes",
                      help="Run only tests for given build mode(s)")
-    parser.addoption('--tmpdir', action='store', default=str(TOP_SRC_DIR / 'testlog'),
-                     help='Path to temporary test data and log files.  The data is further segregated per build mode.')
+    parser.addoption('--test-artifact-dir', '--tmpdir', action='store', default=str(TOP_SRC_DIR / 'testlog'),
+                     dest='test_artifact_dir',
+                     help='Path to the top-level test work and log directory.  The data is further segregated per build mode.  '
+                          '--tmpdir is a deprecated alias for --test-artifact-dir.')
     parser.addoption('--run_id', action='store', default=None, help='Run id for the test run')
     parser.addoption('--byte-limit', action="store", default=randint(0, 2000), type=int,
                      help="Specific byte limit for failure injection (random by default)")
@@ -93,7 +95,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                      help="Save test log output on success and skip cleanup before the run.")
     parser.addoption('--coverage', action='store_true', default=False,
                      help="When running code instrumented with coverage support"
-                          "Will route the profiles to `tmpdir`/mode/coverage/`suite` and post process them in order to generate "
+                          "Will route the profiles to `test_artifact_dir`/mode/coverage/`suite` and post process them in order to generate "
                           "lcov file per suite, lcov file per mode, and an lcov file for the entire run, "
                           "The lcov files can eventually be used for generating coverage reports")
     parser.addoption("--coverage-mode", action='append', type=str, dest="coverage_modes",
@@ -190,10 +192,10 @@ def pytest_sessionstart(session: pytest.Session) -> None:
 
     # Run stuff just once for the main pytest process (not in xdist workers).
     if not is_xdist_worker:
-        temp_dir = pathlib.Path(session.config.getoption("--tmpdir")).absolute()
+        artifact_dir = pathlib.Path(session.config.getoption("--test-artifact-dir")).absolute()
 
         prepare_environment(
-            tempdir_base=temp_dir,
+            test_artifact_dir=artifact_dir,
             modes=get_modes_to_run(session.config),
             gather_metrics=session.config.getoption("--gather-metrics"),
             save_log_on_success=session.config.getoption("--save-log-on-success"),
@@ -276,7 +278,7 @@ def pytest_configure(config: pytest.Config) -> None:
     global _pytest_config
     _pytest_config = config
 
-    pytest_log_dir = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_LOG_FOLDER
+    pytest_log_dir = pathlib.Path(_pytest_config.getoption("--test-artifact-dir")).absolute() / PYTEST_LOG_FOLDER
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     # If this is an xdist worker, set up logging to a separate file for this worker. Otherwise, set up logging for the main process.
     if worker_id is not None:
@@ -366,7 +368,7 @@ def pytest_runtest_makereport(item, call):
 
     rep = outcome.get_result()
     # we only look at actual failing test calls, not setup/teardown
-    pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--tmpdir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
+    pytest_tests_logs = pathlib.Path(_pytest_config.getoption("--test-artifact-dir")).absolute() / PYTEST_TESTS_LOGS_FOLDER
     if rep.failed or (_pytest_config.getoption("--save-log-on-success") and rep.when == "teardown"):
         mode = "a" if os.path.exists(pytest_tests_logs) else "w"
         with open(pytest_tests_logs/ f"{item._nodeid.replace("::", "-").replace("/", "-")}-{rep.when}-{HOST_ID}.log",mode) as f:

--- a/test/pylib/suite/base.py
+++ b/test/pylib/suite/base.py
@@ -93,7 +93,7 @@ class TestSuite(ABC):
 
     def __init__(self, path: str, cfg: dict, options: argparse.Namespace, mode: str) -> None:
         self.suite_path = pathlib.Path(path)
-        self.log_dir = pathlib.Path(options.tmpdir) / mode
+        self.log_dir = pathlib.Path(options.test_artifact_dir) / mode
         self.name = str(self.suite_path.name)
         self.cfg = cfg
         self.options = options
@@ -521,26 +521,26 @@ def prepare_dir(dirname: pathlib.Path, pattern: str, save_log_on_success: bool) 
                 p.unlink()
 
 @universalasync.async_to_sync_wraps
-async def prepare_environment(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool, save_log_on_success: bool,
+async def prepare_environment(test_artifact_dir: pathlib.Path, modes: list[str], gather_metrics: bool, save_log_on_success: bool,
                         toxiproxy_byte_limit: int) -> None:
-    prepare_dirs(tempdir_base, modes, gather_metrics, save_log_on_success=save_log_on_success)
-    await start_3rd_party_services(tempdir_base=tempdir_base, toxiproxy_byte_limit=toxiproxy_byte_limit)
+    prepare_dirs(test_artifact_dir, modes, gather_metrics, save_log_on_success=save_log_on_success)
+    await start_3rd_party_services(test_artifact_dir=test_artifact_dir, toxiproxy_byte_limit=toxiproxy_byte_limit)
 
-def prepare_dirs(tempdir_base: pathlib.Path, modes: list[str], gather_metrics: bool, save_log_on_success: bool = False) -> None:
+def prepare_dirs(test_artifact_dir: pathlib.Path, modes: list[str], gather_metrics: bool, save_log_on_success: bool = False) -> None:
     setup_cgroup(gather_metrics)
-    prepare_dir(tempdir_base, "*.log", save_log_on_success)
-    prepare_dir(tempdir_base/ PYTEST_TESTS_LOGS_FOLDER, "*.log", save_log_on_success)
+    prepare_dir(test_artifact_dir, "*.log", save_log_on_success)
+    prepare_dir(test_artifact_dir/ PYTEST_TESTS_LOGS_FOLDER, "*.log", save_log_on_success)
     for directory in ['report', 'ldap_instances']:
-        full_path_directory = tempdir_base / directory
+        full_path_directory = test_artifact_dir / directory
         prepare_dir(full_path_directory, '*', save_log_on_success)
     for mode in modes:
-        prepare_dir(tempdir_base / mode, "*.log", save_log_on_success)
-        prepare_dir(tempdir_base / mode, "*.reject", save_log_on_success)
-        prepare_dir(tempdir_base / mode / "xml", "*.xml", save_log_on_success)
-        prepare_dir(tempdir_base / mode / "failed_test", "*", save_log_on_success)
-        prepare_dir(tempdir_base / mode / "allure", "*.xml", save_log_on_success)
+        prepare_dir(test_artifact_dir / mode, "*.log", save_log_on_success)
+        prepare_dir(test_artifact_dir / mode, "*.reject", save_log_on_success)
+        prepare_dir(test_artifact_dir / mode / "xml", "*.xml", save_log_on_success)
+        prepare_dir(test_artifact_dir / mode / "failed_test", "*", save_log_on_success)
+        prepare_dir(test_artifact_dir / mode / "allure", "*.xml", save_log_on_success)
         if TEST_RUNNER != "pytest":
-            prepare_dir(tempdir_base / mode / "pytest", "*", save_log_on_success)
+            prepare_dir(test_artifact_dir / mode / "pytest", "*", save_log_on_success)
 
 
 def _make_service_logger(logger_name: str, log_file: pathlib.Path) -> logging.Logger:
@@ -560,23 +560,23 @@ def _make_service_logger(logger_name: str, log_file: pathlib.Path) -> logging.Lo
 
 
 @universalasync.async_to_sync_wraps
-async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_limit: int):
+async def start_3rd_party_services(test_artifact_dir: pathlib.Path, toxiproxy_byte_limit: int):
     hosts = HostRegistry()
 
     finalize = start_ldap(
         host=await hosts.lease_host(),
         port=5000,
-        instance_root=tempdir_base / 'ldap_instances',
+        instance_root=test_artifact_dir / 'ldap_instances',
         toxiproxy_byte_limit=toxiproxy_byte_limit)
     async def make_async_finalize():
         finalize()
 
     TestSuite.artifacts.add_exit_artifact(None, make_async_finalize)
     ms = MinioServer(
-        tempdir_base=str(tempdir_base),
+        workdir=str(test_artifact_dir),
         address=await hosts.lease_host(),
         logger=LogPrefixAdapter(
-            logger=_make_service_logger("minio", tempdir_base / "minio.log"),
+            logger=_make_service_logger("minio", test_artifact_dir / "minio.log"),
             extra={"prefix": "minio"},
         ),
     )
@@ -589,7 +589,7 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
         host=await hosts.lease_host(),
         port=2012,
         logger=LogPrefixAdapter(
-            logger=_make_service_logger("s3_mock", tempdir_base / "s3_mock.log"),
+            logger=_make_service_logger("s3_mock", test_artifact_dir / "s3_mock.log"),
             extra={"prefix": "s3_mock"},
         ),
     )
@@ -604,7 +604,7 @@ async def start_3rd_party_services(tempdir_base: pathlib.Path, toxiproxy_byte_li
         max_retries=3,
         seed=int(time.time()),
         logger=LogPrefixAdapter(
-            logger=_make_service_logger("s3_proxy", tempdir_base / "s3_proxy.log"),
+            logger=_make_service_logger("s3_proxy", test_artifact_dir / "s3_proxy.log"),
             extra={"prefix": "s3_proxy"},
         ),
     )

--- a/test/pylib/suite/python.py
+++ b/test/pylib/suite/python.py
@@ -189,7 +189,7 @@ class PythonTest(Test):
             "-rs",
             "--run_id={}".format(self.id),
             "--mode={}".format(self.mode),
-            "--tmpdir={}".format(options.tmpdir),
+            "--test-artifact-dir={}".format(options.test_artifact_dir),
         ]
         if options.gather_metrics:
             self.args.append("--gather-metrics")

--- a/test/scylla_gdb/test_schema_commands.py
+++ b/test/scylla_gdb/test_schema_commands.py
@@ -38,9 +38,9 @@ def test_schema(gdb_cmd, command):
 
 
 def test_generate_object_graph(gdb_cmd, request):
-    tmpdir = request.config.getoption("--tmpdir")
+    workdir = request.config.getoption("--test-artifact-dir")
     result = execute_gdb_command(
-        gdb_cmd, f"generate-object-graph -o {tmpdir}/og.dot -d 2 -t 10 $get_schema()"
+        gdb_cmd, f"generate-object-graph -o {workdir}/og.dot -d 2 -t 10 $get_schema()"
     )
     assert result.returncode == 0, (
         f"GDB command `generate-object-graph` failed. stdout: {result.stdout} stderr: {result.stderr}"


### PR DESCRIPTION
Rationalize confusing variable names across the test infrastructure:

- workdir: the persistent top-level test log directory (was tmpdir, tempdir_base, options.tmpdir)
- volatile_dir: MinIO's temp subdirectory destroyed on stop (was self.tempdir in MinioServer)

The --tmpdir CLI flag is kept as a deprecated backward-compatible alias for the new --workdir flag.

Skipped: test/cqlpy/run.py (different concept, per-process temp dirs).

test framework improvement, so no backport