### PR TITLE
Update seastar submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ else()
     set(Seastar_IO_URING ON CACHE BOOL "" FORCE)
     set(Seastar_SCHEDULING_GROUPS_COUNT 24 CACHE STRING "" FORCE)
     set(Seastar_UNUSED_RESULT_ERROR ON CACHE BOOL "" FORCE)
+    set(Seastar_OPENSSL OFF CACHE BOOL "" FORCE)
     # Match configure.py's build_seastar_shared_libs: Debug and Dev
     # build Seastar as a shared library, others build it static.
     if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Dev")

--- a/configure.py
+++ b/configure.py
@@ -2155,6 +2155,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=24',
         '-DSeastar_IO_URING=ON',
+        '-DSeastar_OPENSSL=OFF',
     ]
 
     if compiler_cache:

--- a/configure.py
+++ b/configure.py
@@ -2170,6 +2170,7 @@ def configure_seastar(build_dir, mode, mode_config, compiler_cache=None):
         '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
         '-DSeastar_SCHEDULING_GROUPS_COUNT=24',
         '-DSeastar_IO_URING=ON',
+        '-DSeastar_OPENSSL=OFF',
     ]
 
     if compiler_cache:

--- a/test/boost/encrypted_file_test.cc
+++ b/test/boost/encrypted_file_test.cc
@@ -578,9 +578,10 @@ static future<> test_random_data_source(std::vector<size_t> sizes) {
             auto v1 = std::string_view(read_buff.get(), size_to_compare);
             auto v2 = std::string_view(unified_buff.get() + pos, size_to_compare);
             BOOST_REQUIRE_EQUAL(v1, v2);
+            pos += size_to_compare;
             auto skip = unified_buff.size() - pos > 4113 ? 4097 : (unified_buff.size() - pos)/2;
             co_await encrypted_source.skip(skip);
-            pos += size_to_compare + skip;
+            pos += skip;
         }
         co_await encrypted_source.close();
     } catch (...) {

--- a/test/boost/gcp_object_storage_test.cc
+++ b/test/boost/gcp_object_storage_test.cc
@@ -232,8 +232,26 @@ SEASTAR_FIXTURE_TEST_CASE(test_gcp_storage_skip_read, local_gcs_wrapper, *check_
                 auto rem = file_size - pos;
                 auto skip = tests::random::get_int(std::min(rem, size_t(100)), rem);
                 auto read = std::min(rem - skip, size_t(tests::random::get_int(31, 2048)));
-                co_await is1.skip(skip);
-                co_await is2.skip(skip);
+
+                // Both streams may throw "premature end of stream" when
+                // skipping past EOF. Verify they agree and exit the loop.
+                auto is_premature_eof = [] (seastar::future<>&& f) {
+                    try {
+                        f.get();
+                        return false;
+                    } catch (const std::runtime_error& e) {
+                        if (std::string_view(e.what()).find("premature end of stream") != std::string_view::npos) {
+                            return true;
+                        }
+                        throw;
+                    }
+                };
+                bool is1_eof = co_await is1.skip(skip).then_wrapped(is_premature_eof);
+                bool is2_eof = co_await is2.skip(skip).then_wrapped(is_premature_eof);
+                BOOST_REQUIRE_EQUAL(is1_eof, is2_eof);
+                if (is1_eof) {
+                    break;
+                }
 
                 auto b1 = co_await is1.read_exactly(read);
                 auto b2 = co_await is2.read_exactly(read);

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -794,7 +794,13 @@ future<temporary_buffer<char>> utils::gcp::storage::client::object_data_source::
     auto buf_size = buffer_size();
     assert(buf_size <= _position);
     auto read_pos = _position - buf_size;
-    co_await seek(read_pos + n);
+    auto new_pos = read_pos + n;
+    co_await seek(new_pos);
+    // seek() clamps position to _size, so if the requested
+    // position exceeds _size we are skipping past EOF.
+    if (new_pos > _size) {
+        throw std::runtime_error("premature end of stream");
+    }
     // And get the next buffer
     co_return co_await get();
 }

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -249,30 +249,8 @@ future<> rest::send_request(std::string_view uri
 constexpr auto linesep = '\n';
 
 auto 
-fmt::formatter<rest::httpclient::request_type>::format(const rest::httpclient::request_type& r, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", r._method, r._url, r._version, linesep);
-    for (auto& [k, v] : r._headers) {
-        os = fmt::format_to(os, "{}: {}{}", k, v, linesep);
-    }
-    os = fmt::format_to(os, "{}{}", linesep, r.content);
-    return os;
-}
-
-auto 
 fmt::formatter<rest::httpclient::result_type>::format(const rest::httpclient::result_type& r, fmt::format_context& ctx) const -> decltype(ctx.out()) {
     return fmt::format_to(ctx.out(), "{}", r.reply);
-}
-
-auto 
-fmt::formatter<seastar::http::reply>::format(const seastar::http::reply& r, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    auto s = r.response_line();
-    // remove the trailing \r\n from response_line string. we want our own linebreak, hence substr.
-    auto os = fmt::format_to(ctx.out(), "{}{}", std::string_view(s).substr(0, s.size()-2), linesep);
-    for (auto& [k, v] : r._headers) {
-        os = fmt::format_to(os, "{}: {}{}", k, v, linesep);
-    }
-    os = fmt::format_to(os, "{}{}", linesep, r._content);
-    return os;
 }
 
 auto

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -198,11 +198,6 @@ future<> send_request(std::string_view uri
 }
 
 template <>
-struct fmt::formatter<rest::httpclient::request_type> : fmt::formatter<std::string_view> {
-    auto format(const rest::httpclient::request_type&, fmt::format_context& ctx) const -> decltype(ctx.out());
-};
-
-template <>
 struct fmt::formatter<rest::httpclient::result_type> : fmt::formatter<std::string_view> {
     auto format(const rest::httpclient::result_type&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };
@@ -215,9 +210,4 @@ struct fmt::formatter<rest::redacted_request_type> : fmt::formatter<std::string_
 template <>
 struct fmt::formatter<rest::redacted_result_type> : fmt::formatter<std::string_view> {
     auto format(const rest::redacted_result_type&, fmt::format_context& ctx) const -> decltype(ctx.out());
-};
-
-template <>
-struct fmt::formatter<seastar::http::reply> : fmt::formatter<std::string_view> {
-    auto format(const seastar::http::reply&, fmt::format_context& ctx) const -> decltype(ctx.out());
 };


### PR DESCRIPTION
Drop local formatter for seastar::http::reply, which should have
been added to Seastar in the first place, and now conflicts. Also
drop local formatters for types that are aliases for Seastar types
which have gained formatters.

Disable recently-gained TLS use of OpenSSL instead of gnutls. We
don't need it, and it causes link errors with LTO.

Fix incorrect skipping in encrypted_file_test, which computed
the remaining stream length but did not account for already
consumed size_to_compare.

Change utils::gcp::storage::client::object_data_source::skip()
to match new Seastar behavior (rejecting skip-past-eof with an
exception). This is needed since https://github.com/scylladb/scylladb/commit/30f1075544272a79c05bf29234a2a838e8e946f3 switched the test's
data source to a Seastar implementation. It is also more correct -
if we're asked to skip n bytes but the stream doesn't have n bytes,
this is a protocol violation.

Contains test fix from Pavel, exposed by [1]:

test: Handle premature EOF in test_gcp_storage_skip_read

The test intentionally uses file_size larger than the actual object to
exercise EOF behavior. When input_stream::skip() is called after EOF,
it throws std::runtime_error("premature end of stream"). Catch this
specific exception from both streams, verify they agree, and exit the
loop gracefully.

Signed-off-by: Pavel Emelyanov <xemul@scylladb.com>

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

[1] https://github.com/scylladb/seastar/commit/cbd1e17d2f16151ca304db533a2a65c39a7f4631, included in this Seastar submodule update

* seastar 4d268e0e...485a62b2 (50):
  > reactor: open_directory(): honor bypass_fsync
  > http: Add formatters for http::request and http::reply
  > Merge 'Assorted set of io-tester cleanups' from Pavel Emelyanov
    io_tester: Remove unused and internal-only accessor
    io_tester: Move think-time machinery into thinker_state
    io_tester: Move _file to io_class_data
    io_tester: Replace class_data::_start member with a local variable
    io_tester: Move _alignment from class_data to io_class_data
    io_tester: Remove buffer allocation from top-level request issuing
    io_tester: Cleanup context::stop() invocation
    io_tester: Allocate write buffer once to fill a file
    io_tester: Declare quantiles arrays as static constexpr
    io_tester: Drop class_data::type_str()
    io_tester: Replace != "" comparisons with .empty()
    io_tester: Replace gen_class_data() if/else chain with a switch
    io_tester: Deduplicate vectorized I/O classes
  > io_tester: fix crash from missing metric during startup
  > net: tls: adjust openssl integration to new module support
  > http/client: Count and export integrated queue length
  > Merge 'Introduce pipe_data_source_impl and pipe_data_sink_impl' from Pavel Emelyanov
    fstream: add pipe_data_source_impl and pipe_data_sink_impl
    pollable_fd: add write_some/write_all backed by writev
    pollable_fd: rename write_some/write_all(iovec) to send_some/send_all
  > reactor: Make pollable_fd_state helper methods private
  > module: extend seastar.cppm with comprehensive public API exports
  > Merge 'Add exhaustive input_stream invariant test + fixes' from Pavel Emelyanov
    tests: add exhaustive input_stream read/skip invariant test
    iostream: make skip() reject premature end of stream with exception
  > Merge 'Allow runtime selectability of GnuTLS or OpenSSL' from Noah Watkins
    net/tls: avoid potential read-past-buffer
    net/tls: move credential methods to generic tls layer
    net/tls: rename credentials_impl::dh_params to set_dh_params
    test/tls: enable openssl tls unit test
     test/tls: fix CA cert generation to use v3_ca extensions
    github: disable parallel test execution in alpine workflow
    crypto: support compiling seastar without gnutls
    net/tcp: use crypto provider for md5 calculation
    tls: fix test_peer_certificate_chain_handling for OpenSSL
    net/tls: fix test for self-signed server cert opoenssl compat
    net/tls: disable priority strings test for openssl provider
    core/crypto: expose crypto backend name for introspection
    test/tls: remove gnutls version guard
    net/tls: add openssl tls backend
    http: use backend agnostic tls error code
    net/tls: make error codes configurable by each tls backend
    net/tls: move reloadable_credentials to generic tls layer
    net/tls: move build_certificate to generic tls layer
    net/tls: move apply_to() to generic tls layer
    net/tls: move credential methods to generic tls layer
    net/tls: add OpenSSL-specific methods to public API with no-op defaults
    net/tls: introduce dh_params and credentials abstraction layer
    net/tls: add credentials_impl abstract base class
    net/tls: dispatch tls::error_category() through crypto_provider
    net/tls: dispatch wrap_client/wrap_server through crypto_provider
    net/tls: add tls_backend interface to crypto_provider
    net/tls: move public tls API methods to generic tls layer
    net/tls: move formatting utilities to generic tls layer
    net/tls: move credentials_builder blob methods to generic tls layer
    net/tls: move dh_params::from_file to generic tls layer
    net/tls: move abstract_credentials file methods to generic tls layer
    net/tls: move tls_socket_impl to generic tls layer
    net/tls: move server_session to general tls layer
    net/tls: move tls_connected_socket_impl to generic tls layer
    net/tls: move net::get_impl to generic tls layer
    net/tls: move session_ref to generic tls layer
    net/tls: add session_impl abstract interface for tls pluggability
    net/tls: rename tls.cc to be gnutls specific
    crypto: introduce crypto provider abstraction
    http: remove unused include
  > tls: test_send_two_large
  > rpc: include exception type for remote errors
  > GHA: increase timeout to 60 minutes
  > apps/httpd: replace deprecated reply::done() with write_body()
  > missing header(s)
  > net: Fix missing throw for runtime_error in create_native_net_device
  > tests/io_queue: account for token bucket refill granularity in bandwidth checks
  > Merge 'iovec: fix iovec_trim_front infinite loop on zero-length iovecs' from Travis Downs
    tests: add regression tests for zero-length iovec handling
    iovec: fix iovec_trim_front infinite loop on zero-length iovecs
  > util/process: graduate process management API from experimental
  > cooking: don't register ready.txt as a build output
  > sstring: make make_sstring not static
  > Add SparkyLinux to debian list in install-dependencies.sh
  > http: allow control over default response headers
  > Merge 'chunked_fifo: make cached chunk retention configurable' from Brandon Allard
    tests/perf: add chunked_fifo microbenchmarks
    chunked_fifo: set the default free chunk retention to 0
    chunked_fifo: make free chunk retention configurable
  > Merge 'reactor_backend: fix pollable_fd_state_completion reuse in io_uring' from Kefu Chai
    tests: add regression test for pollable_fd_state_completion reuse
    reactor_backend: use reset() in AIO and epoll poll paths
    reactor_backend: fix pollable_fd_state_completion reuse after co_await in io_uring
  > Merge 'coroutine: Generator cleanups' from Kefu Chai
    coroutine/generator: extract schedule_or_resume helper
    coroutine/generator: remove unused next_awaiter classes
    coroutine/generator: remove write-only _started field
    coroutine/generator: assert on unreachable path in buffered await_resume
    coroutine/generator: add elements_of tag and #include <ranges>
    coroutine/generator: add empty() to bounded_container concept
  > cmake: bump minimum Boost version to 1.79.0
  > seastar_test: remove unnecessary headers
  > cmake: bump minimum GnuTLS version to 3.7.4
  > Merge 'reactor: add get_all_io_queues() method' from Travis Downs
    tests: add unit test for reactor::get_all_io_queues()
    reactor: add get_all_io_queues() method
    reactor: move get_io_queue and try_get_io_queue to .cc file
  > http: deprecate reply::done(), remove _response_line dead field
  > core: Deprecate scattered_message
  > ci: add workflow dispatch to tests workflow
  > perf_tests: exit non-zero when -t pattern matches no tests
  > Replace duplicate SEGV_MAPERR check in sigsegv_action() with SEGV_ACCERR.
  > perf_tests: add total runtime to json output
  > Merge 'Relax large allocation error originating from json_list_template' from Robert Bindar
    implement move assignment operator for json_list_template
    json_list_template copy assignment operator reserves capacity upfront
  > perf_tests: add --no-perf-counters option
  > Merge 'Fix to_human_readable_value() ability to work with large values' from Pavel Emelyanov
    memory: Add compile-time test for value-to-human-readable conversion
    memory: Extend list of suffixes to have peta-s
    memory: Fix off-by-one in suffix calculation
    memory: Mark to_human_readable_value() and others constexpr
  > http: Improve writing of response_line() into the output
  > Merge 'websocket: add template parameter for text/binary frame mode and implement client-side WebSocket' from wangyuwei
    websocket: add template parameter for text/binary frame mode
    websocket: impl client side websocket function
  > file: Fix checks for file being read-only
  > reactor: Make do_dump_task_queue a task_queue method
  > Merge 'Implement fully mixed mode for output_stream-s' from Pavel Emelyanov
    tests/output_stream: sample type patterns in sanitizer builds
    tests/output_stream: extend invariant test to cover mixed write modes
    iostream: allow unrestricted mixing of buffered and zero-copy writes
    tests/output_stream: remove obsolete ad-hoc splitting tests
    tests/output_stream: add invariant-based splitting tests
    iostream: rename output_stream::_size to ::_buffer_size
  > reactor_backend: replace virtual bool methods with const bool_class members
  > resource: Avoid copying CPU vector to break it into groups
  > perf_tests: increase overhead column precision to 3 decimal places
  > Merge 'Move reactor::fdatasync() into posix_file_impl' from Pavel Emelyanov
    reactor: Deprecate fdatasync() method
    file: Do fdatasync() right in the posix_file_impl::flush()
    file: Propagate aio_fdatasync to posix_file_impl
    reactor: Move reactor::fdatasync() code to file.cc
    reactor,file: Make full use of file_open_options::durable bit
    file: Add file_open_options::durable boolean
    file: Account io_stats::fsyncs in posix_file_impl::flush()
    reactor: Move _fsyncs counter onto io_stats
  > http: Remove connection::write_body()