### PR TITLE
alternator: add more vector search features

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -608,6 +608,10 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
             rjson::value projection = rjson::empty_object();
             rjson::add(projection, "ProjectionType", "KEYS_ONLY");
             rjson::add(entry, "Projection", std::move(projection));
+            auto sf_it = opts.find("similarity_function");
+            if (sf_it != opts.end()) {
+                rjson::add(entry, "SimilarityFunction", rjson::from_string(sf_it->second));
+            }
             // Report IndexStatus and Backfilling based on the vector store's
             // reported state: SERVING -> ACTIVE, BOOTSTRAPPING -> CREATING+Backfilling,
             // anything else (INITIALIZING, unreachable, etc.) -> CREATING.
@@ -1389,6 +1393,20 @@ static future<> wait_for_schema_agreement_after_ddl(service::migration_manager& 
     }
 }
 
+// Parses an optional SimilarityFunction field from a VectorIndexes or
+// VectorIndexUpdates entry. Returns the value or the default "COSINE" if
+// the field is absent. The "source" parameter is used in error messages.
+static std::string get_similarity_function(const rjson::value& vector_index, std::string_view source) {
+    std::string sf = get_string_attribute(vector_index, "SimilarityFunction", "COSINE");
+    static constexpr std::array<std::string_view, 3> valid_sf = {"EUCLIDEAN", "COSINE", "DOT_PRODUCT"};
+    if (!std::ranges::contains(valid_sf, std::string_view(sf))) {
+        throw api_error::validation(fmt::format(
+            "{} SimilarityFunction '{}' is not valid. Valid values are: EUCLIDEAN, COSINE, DOT_PRODUCT.",
+            source, sf));
+    }
+    return sf;
+}
+
 future<executor::request_return_type> executor::create_table_on_shard0(service::client_state&& client_state, tracing::trace_state_ptr trace_state, rjson::value request, bool enforce_authorization, bool warn_authorization,
             const db::tablets_mode_t::mode tablets_mode, std::unique_ptr<audit::audit_info_alternator>& audit_info) {
     throwing_assert(this_shard_id() == 0);
@@ -1609,6 +1627,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
                 }
             }
             int dimensions = get_dimensions(*vector_attribute_v, "VectorIndexes");
+            std::string similarity_function = get_similarity_function(v, "VectorIndexes");
             // The optional Projection parameter is only supported with
             // ProjectionType=KEYS_ONLY. Other values are not yet supported.
             const rjson::value* projection_v = rjson::find(v, "Projection");
@@ -1627,6 +1646,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             index_options[db::index::secondary_index::custom_class_option_name] = "vector_index";
             index_options[cql3::statements::index_target::target_option_name] = sstring(attribute_name);
             index_options["dimensions"] = std::to_string(dimensions);
+            index_options["similarity_function"] = similarity_function;
             builder.with_index(index_metadata{sstring(index_name), index_options,
                     index_metadata_kind::custom, index_metadata::is_local_index(false)});
         }
@@ -2026,6 +2046,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                             "VectorIndexUpdates AttributeName '{}' is already the target of an existing vector index.", attribute_name));
                     }
                     int dimensions = get_dimensions(*vector_attribute_v, "VectorIndexUpdates");
+                    std::string similarity_function = get_similarity_function(it->value, "VectorIndexUpdates");
                     // The optional Projection parameter is only supported with
                     // ProjectionType=KEYS_ONLY. Other values are not yet supported.
                     const rjson::value* projection_v = rjson::find(it->value, "Projection");
@@ -2046,6 +2067,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                     index_options[db::index::secondary_index::custom_class_option_name] = "vector_index";
                     index_options[cql3::statements::index_target::target_option_name] = sstring(attribute_name);
                     index_options["dimensions"] = std::to_string(dimensions);
+                    index_options["similarity_function"] = similarity_function;
                     builder.with_index(index_metadata{index_name, index_options,
                             index_metadata_kind::custom, index_metadata::is_local_index(false)});
                 } else if (op == "Delete") {

--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -2341,6 +2341,23 @@ void validate_value(const rjson::value& v, const char* caller) {
             // DynamoDB uses a SerializationException in this case, not ValidationException.
             throw api_error::serialization(format("{}: number value must be encoded as string '{}'", caller, v));
         }
+    } else if (type == float32vector_type_name) {
+        // Alternator-only optimized vector type (more optimized than a list-
+        // of-number). The value must be an array of numbers (floating-point
+        // JSON numbers, not strings as in the "N" type). Each element must
+        // fit in a 32-bit float.
+        if (!it->value.IsArray()) {
+            throw api_error::validation(format("{}: improperly formatted vector '{}'", caller, v));
+        }
+        for (const rjson::value& element : it->value.GetArray()) {
+            if (!element.IsNumber()) {
+                throw api_error::validation(format("{}: vector elements must be numbers, got '{}'", caller, element));
+            }
+            if (!std::isfinite(static_cast<float>(element.GetDouble()))) {
+                throw api_error::validation(format("{}: vector element '{}' cannot be represented as a 32-bit float",
+                    caller, element.GetDouble()));
+            }
+        }
     } else if (type != "L" && type != "M" && type != "BOOL" && type != "NULL") {
         // TODO: can do more sanity checks on the content of the above types.
         throw api_error::validation(fmt::format("{}: unknown type {} for value {}", caller, type, v));
@@ -2523,16 +2540,26 @@ static void validate_value_if_vector_index_attribute(
     // value is a DynamoDB typed value: an object with one member whose key
     // is the type tag. validate_value() already checked the overall shape.
     std::string_view value_type = rjson::to_string_view(value.MemberBegin()->name);
-    if (value_type != "L") {
+    if (value_type != "L" && value_type != float32vector_type_name) {
         throw api_error::validation(fmt::format(
-            "Vector index attribute '{}' must be a list of {} numbers, got type {}",
+            "Vector index attribute '{}' must be a list or vector of {} numbers, got type {}",
             attr_name, dimensions, value_type));
     }
     const rjson::value& list = value.MemberBegin()->value;
     if (!list.IsArray() || (int)list.Size() != dimensions) {
         throw api_error::validation(fmt::format(
-            "Vector index attribute '{}' must be a list of exactly {} numbers, got {} elements",
+            "Vector index attribute '{}' must be a list or vector of exactly {} numbers, got {} elements",
             attr_name, dimensions, list.IsArray() ? (int)list.Size() : -1));
+    }
+    // In the "L" case the components of the vector can be any legal "N"-type
+    // numbers (DynamoDB decimals) - so if this vector value is to be indexed
+    // we need to verify that these numbers fit in 32-bit float.
+    // In the "FLOAT32VECTOR" case we don't need to do this check here:
+    // "FLOAT32VECTOR" components are always (regardless of indexing) required
+    // to fit in 32-bit floats, so validate_value() already verified that they
+    // do.
+    if (value_type == float32vector_type_name) {
+        return;
     }
     for (const rjson::value& elem : list.GetArray()) {
         if (!elem.IsObject() || elem.MemberCount() != 1 ||

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1234,6 +1234,7 @@ static future<executor::request_return_type> query_vector(
         parsed::expression_cache& parsed_expr_cache) {
     schema_ptr base_schema = get_table(proxy, request);
     get_stats_from_schema(proxy, *base_schema)->api_operations.query++;
+    stats.vector_search.query++;
     tracing::add_alternator_table_name(trace_state, base_schema->cf_name());
 
     // If vector search is requested, IndexName must be given and must
@@ -1406,6 +1407,7 @@ static future<executor::request_return_type> query_vector(
         co_return api_error::validation(error_msg);
     }
     const std::vector<vector_search::primary_key>& pkeys = pkeys_result.value();
+    stats.vector_search.query_items_from_vs += pkeys.size();
 
     // For SELECT=COUNT with no filter: skip fetching from the base table and
     // just return the count of candidates returned by the vector store.
@@ -1446,7 +1448,9 @@ static future<executor::request_return_type> query_vector(
             rjson::push_back(items_json, std::move(item));
         }
         rjson::value response = rjson::empty_object();
-        rjson::add(response, "Count", rjson::value(static_cast<int>(items_json.Size())));
+        auto count = static_cast<int>(items_json.Size());
+        rjson::add(response, "Count", rjson::value(count));
+        stats.vector_search.query_returned_items += count;
         rjson::add(response, "ScannedCount", rjson::value(static_cast<int>(pkeys.size())));
         rjson::add(response, "Items", std::move(items_json));
         co_return rjson::print(std::move(response));
@@ -1474,6 +1478,7 @@ static future<executor::request_return_type> query_vector(
     // Query each primary key individually, in the order returned by the
     // vector store, to preserve vector-distance ordering in the response.
     // FIXME: do this more efficiently with a batched read that preserves ordering.
+    stats.vector_search.query_items_from_base_table += pkeys.size();
     for (const auto& pkey : pkeys) {
         std::vector<query::clustering_range> bounds{
                 base_schema->clustering_key_size() > 0
@@ -1548,7 +1553,9 @@ static future<executor::request_return_type> query_vector(
     if (select == select_type::count) {
         rjson::add(response, "Count", rjson::value(matched_count));
     } else {
-        rjson::add(response, "Count", rjson::value(static_cast<int>(items_json.Size())));
+        auto count = static_cast<int>(items_json.Size());
+        rjson::add(response, "Count", rjson::value(count));
+        stats.vector_search.query_returned_items += count;
         rjson::add(response, "Items", std::move(items_json));
     }
     rjson::add(response, "ScannedCount", rjson::value(static_cast<int>(pkeys.size())));

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1221,6 +1221,78 @@ calculate_bounds_condition_expression(schema_ptr schema,
     return {std::move(partition_ranges), std::move(ck_bounds)};
 }
 
+// Parses a vector value (of type "FLOAT32VECTOR" or "L"-of-"N") into an
+// std::vector<float>. Throws api_error::validation if the value is invalid
+// or the vector's length doesn't match the required dimensions.
+static std::vector<float> parse_vector(const rjson::value& value, int dimensions, std::string_view source) {
+    std::vector<float> out;
+    if (!value.IsObject() || value.MemberCount() != 1) {
+        throw api_error::validation(format("{} must be a value with type 'FLOAT32VECTOR' or 'L'", source));
+    }
+    const rjson::value* v = rjson::find(value, float32vector_type_name);
+    if (v) {
+        // "FLOAT32VECTOR" type: array of JSON floating-point numbers.
+        if (!v->IsArray()) {
+            throw api_error::validation(
+                format("{} FLOAT32VECTOR must be a list of numbers", source));
+        }
+        const auto& arr = v->GetArray();
+        if ((int)arr.Size() != dimensions) {
+            throw api_error::validation(
+                format("{} length {} does not match index Dimensions {}",
+                    source, arr.Size(), dimensions));
+        }
+        out.reserve(arr.Size());
+        for (const rjson::value& elem : arr) {
+            if (!elem.IsNumber()) {
+                throw api_error::validation(
+                    format("{} must contain only numbers", source));
+            }
+            float f = static_cast<float>(elem.GetDouble());
+            if (!std::isfinite(f)) {
+                throw api_error::validation(
+                    format("{} element '{}' cannot be represented as a 32-bit float",
+                        source, elem.GetDouble()));
+            }
+            out.push_back(f);
+        }
+    } else {
+        // "L" type: list of "N" numbers.
+        const rjson::value* qv_list = rjson::find(value, "L");
+        if (!qv_list || !qv_list->IsArray()) {
+            throw api_error::validation(
+                format("{} must be a list of numbers", source));
+        }
+        const auto& arr = qv_list->GetArray();
+        if ((int)arr.Size() != dimensions) {
+            throw api_error::validation(
+                format("{} length {} does not match index Dimensions {}",
+                    source, arr.Size(), dimensions));
+        }
+        out.reserve(arr.Size());
+        for (const rjson::value& elem : arr) {
+            if (!elem.IsObject()) {
+                throw api_error::validation(
+                    format("{} must contain only numbers", source));
+            }
+            const rjson::value* n_val = rjson::find(elem, "N");
+            if (!n_val || !n_val->IsString()) {
+                throw api_error::validation(
+                    format("{} must contain only numbers", source));
+            }
+            std::string_view num_str = rjson::to_string_view(*n_val);
+            float f;
+            auto [ptr, ec] = std::from_chars(num_str.data(), num_str.data() + num_str.size(), f);
+            if (ec != std::errc{} || ptr != num_str.data() + num_str.size() || !std::isfinite(f)) {
+                throw api_error::validation(
+                    format("{} element '{}' is not a valid number", source, num_str));
+            }
+            out.push_back(f);
+        }
+    }
+    return out;
+}
+
 static future<executor::request_return_type> query_vector(
         service::storage_proxy& proxy,
         vector_search::vector_store_client& vsc,
@@ -1277,49 +1349,18 @@ static future<executor::request_return_type> query_vector(
         co_return api_error::validation(
             "VectorSearch requires a VectorSearch parameter");
     }
+    // QueryVector should be a DynamoDB value of type "L" (a list of "N"
+    // numbers) or the Alternator-specific "FLOAT32VECTOR" type (an array of
+    // JSON floats). The number of elements must be exactly the "dimensions"
+    // defined for this vector index. We'll now validate all these assumptions
+    // and parse all the numbers in the vector into an std::vector<float>
+    // query_vec - the type that ann() wants.
     const rjson::value* query_vector = rjson::find(*vector_search, "QueryVector");
-    if (!query_vector || !query_vector->IsObject()) {
+    if (!query_vector) {
         co_return api_error::validation(
             "VectorSearch requires a QueryVector parameter");
     }
-    // QueryVector should be is a DynamoDB value, which must be of type "L"
-    // (a list), containing only elements of type "N" (numbers). The number
-    // of these elements must be exactly the "dimensions" defined for this
-    // vector index. We'll now validate all these assumptions and parse
-    // all the numbers in the vector into an std::vector<float> query_vec -
-    // the type that ann() wants.
-    const rjson::value* qv_list = rjson::find(*query_vector, "L");
-    if (!qv_list || !qv_list->IsArray()) {
-        co_return api_error::validation(
-            "VectorSearch QueryVector must be a list of numbers");
-    }
-    const auto& arr = qv_list->GetArray();
-    if ((int)arr.Size() != dimensions) {
-        co_return api_error::validation(
-            format("VectorSearch QueryVector length {} does not match index Dimensions {}",
-                arr.Size(), dimensions));
-    }
-    std::vector<float> query_vec;
-    query_vec.reserve(arr.Size());
-    for (const rjson::value& elem : arr) {
-        if (!elem.IsObject()) {
-            co_return api_error::validation(
-                "VectorSearch QueryVector must contain only numbers");
-        }
-        const rjson::value* n_val = rjson::find(elem, "N");
-        if (!n_val || !n_val->IsString()) {
-            co_return api_error::validation(
-                "VectorSearch QueryVector must contain only numbers");
-        }
-        std::string_view num_str = rjson::to_string_view(*n_val);
-        float f;
-        auto [ptr, ec] = std::from_chars(num_str.data(), num_str.data() + num_str.size(), f);
-        if (ec != std::errc{} || ptr != num_str.data() + num_str.size() || !std::isfinite(f)) {
-            co_return api_error::validation(
-                format("VectorSearch QueryVector element '{}' is not a valid number", num_str));
-        }
-        query_vec.push_back(f);
-    }
+    std::vector<float> query_vec = parse_vector(*query_vector, dimensions, "VectorSearch QueryVector");
 
     // Limit is mandatory for vector search: it defines k, the number of
     // nearest neighbors to return.

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1293,6 +1293,17 @@ static std::vector<float> parse_vector(const rjson::value& value, int dimensions
     return out;
 }
 
+// Converts a similarity score (float) to a JSON value. JSON does not support
+// infinite or NaN values, so if the score is infinite (which can happen with
+// the DOT_PRODUCT similarity function on non-normalized vectors) we clamp to
+// the nearest representable finite float.
+static rjson::value similarity_to_json(float s) {
+    if (!std::isfinite(s)) {
+        s = s > 0 ? std::numeric_limits<float>::max() : std::numeric_limits<float>::lowest();
+    }
+    return rjson::value(s);
+}
+
 static future<executor::request_return_type> query_vector(
         service::storage_proxy& proxy,
         vector_search::vector_store_client& vsc,
@@ -1392,6 +1403,23 @@ static future<executor::request_return_type> query_vector(
             "VectorSearch does not support ScanIndexForward");
     }
 
+    // VectorSearch.ReturnScores: if set to SIMILARITY, the response will
+    // include a Scores[] array parallel to Items[], containing the
+    // similarity score for each returned item. Defaults to NONE.
+    bool return_scores = false;
+    if (const rjson::value* rsv = rjson::find(*vector_search, "ReturnScores")) {
+        if (!rsv->IsString()) {
+            co_return api_error::validation("VectorSearch ReturnScores must be a string");
+        }
+        std::string_view rsv_str = rjson::to_string_view(*rsv);
+        if (rsv_str == "SIMILARITY") {
+            return_scores = true;
+        } else if (rsv_str != "NONE") {
+            co_return api_error::validation(
+                "VectorSearch ReturnScores must be NONE or SIMILARITY");
+        }
+    }
+
     std::unordered_set<std::string> used_attribute_names;
     std::unordered_set<std::string> used_attribute_values;
     // Parse the Select parameter and determine which attributes to return.
@@ -1403,6 +1431,10 @@ static future<executor::request_return_type> query_vector(
     // the vector index - these additional attributes will also be usable for
     // filtering). COUNT returns only the count without items.
     select_type select = parse_select(request, table_or_view_type::vector_index);
+    if (return_scores && select == select_type::count) {
+        co_return api_error::validation(
+            "VectorSearch ReturnScores=SIMILARITY is not supported with Select=COUNT");
+    }
     std::optional<alternator::attrs_to_get> attrs_to_get_opt;
     if (select == select_type::projection) {
         // ALL_PROJECTED_ATTRIBUTES for a vector index: return only key attributes.
@@ -1466,6 +1498,7 @@ static future<executor::request_return_type> query_vector(
     // fetch to apply it.
     if (select == select_type::projection && !flt) {
         rjson::value items_json = rjson::empty_array();
+        rjson::value scores_json = rjson::empty_array();
         for (const auto& pkey : pkeys) {
             rjson::value item = rjson::empty_object();
             std::vector<bytes> exploded_pk = pkey.partition.key().explode();
@@ -1487,6 +1520,9 @@ static future<executor::request_return_type> query_vector(
                 }
             }
             rjson::push_back(items_json, std::move(item));
+            if (return_scores) {
+                rjson::push_back(scores_json, similarity_to_json(pkey.similarity));
+            }
         }
         rjson::value response = rjson::empty_object();
         auto count = static_cast<int>(items_json.Size());
@@ -1494,6 +1530,9 @@ static future<executor::request_return_type> query_vector(
         stats.vector_search.query_returned_items += count;
         rjson::add(response, "ScannedCount", rjson::value(static_cast<int>(pkeys.size())));
         rjson::add(response, "Items", std::move(items_json));
+        if (return_scores) {
+            rjson::add(response, "Scores", std::move(scores_json));
+        }
         co_return rjson::print(std::move(response));
     }
 
@@ -1514,6 +1553,7 @@ static future<executor::request_return_type> query_vector(
         flt ? std::nullopt : std::move(attrs_to_get_opt));
 
     rjson::value items_json = rjson::empty_array();
+    rjson::value scores_json = rjson::empty_array();
     int matched_count = 0;
 
     // Query each primary key individually, in the order returned by the
@@ -1541,6 +1581,9 @@ static future<executor::request_return_type> query_vector(
                 *selection, *qr.query_result, *attrs_to_get);
         if (opt_item && (!flt || flt.check(*opt_item))) {
             ++matched_count;
+            if (return_scores) {
+                rjson::push_back(scores_json, similarity_to_json(pkey.similarity));
+            }
             if (select != select_type::count) {
                 if (select == select_type::projection) {
                     // A filter caused us to fall through here instead of
@@ -1598,6 +1641,9 @@ static future<executor::request_return_type> query_vector(
         rjson::add(response, "Count", rjson::value(count));
         stats.vector_search.query_returned_items += count;
         rjson::add(response, "Items", std::move(items_json));
+        if (return_scores) {
+            rjson::add(response, "Scores", std::move(scores_json));
+        }
     }
     rjson::add(response, "ScannedCount", rjson::value(static_cast<int>(pkeys.size())));
     co_return rjson::print(std::move(response));

--- a/alternator/serialization.cc
+++ b/alternator/serialization.cc
@@ -15,6 +15,9 @@
 #include "types/json_utils.hh"
 #include "mutation/position_in_partition.hh"
 #include "alternator/executor_util.hh"
+#include "utils/bit_cast.hh"
+#include <seastar/net/byteorder.hh>
+#include <bit>
 
 static logging::logger slogger("alternator-serialization");
 
@@ -27,6 +30,7 @@ type_info type_info_from_string(std::string_view type) {
         {"B", {alternator_type::B, bytes_type}},
         {"BOOL", {alternator_type::BOOL, boolean_type}},
         {"N", {alternator_type::N, decimal_type}}, //FIXME: Replace with custom Alternator type when implemented
+        {float32vector_type_name, {alternator_type::FLOAT32VECTOR, nullptr}},
     };
     auto it = type_infos.find(type);
     if (it == type_infos.end()) {
@@ -41,6 +45,7 @@ type_representation represent_type(alternator_type atype) {
         {alternator_type::B, {"B", bytes_type}},
         {alternator_type::BOOL, {"BOOL", boolean_type}},
         {alternator_type::N, {"N", decimal_type}}, //FIXME: Replace with custom Alternator type when implemented
+        {alternator_type::FLOAT32VECTOR, {std::string(float32vector_type_name), nullptr}},
     };
     auto it = type_representations.find(atype);
     if (it == type_representations.end()) {
@@ -195,6 +200,27 @@ bytes serialize_item(const rjson::value& item) {
         return bytes{int8_t(type_info.atype)} + to_bytes(rjson::print(item));
     }
 
+    // FLOAT32VECTOR is serialized as a 1-byte type tag followed by the
+    // big-endian IEEE 754 float32 values. No explicit element count is stored:
+    // the count is implicitly len(remaining_bytes) / 4.
+    if (type_info.atype == alternator_type::FLOAT32VECTOR) {
+        const rjson::value& arr = it->value;
+        if (!arr.IsArray()) {
+            throw api_error::validation(format("FLOAT32VECTOR value must be an array: {}", item));
+        }
+        const auto& elements = arr.GetArray();
+        bytes out(bytes::initialized_later(), 1 + elements.Size() * sizeof(uint32_t));
+        out[0] = int8_t(alternator_type::FLOAT32VECTOR);
+        auto* p = out.data() + 1;
+        for (const rjson::value& element : elements) {
+            float f = element.GetFloat();
+            uint32_t bits = net::hton(std::bit_cast<uint32_t>(f));
+            write_unaligned<uint32_t>(p, bits);
+            p += sizeof(uint32_t);
+        }
+        return out;
+    }
+
     bytes_ostream bo;
     bo.write(bytes{int8_t(type_info.atype)});
     visit(*type_info.dtype, from_json_visitor{it->value, bo});
@@ -239,6 +265,21 @@ rjson::value deserialize_item(bytes_view bv) {
         slogger.trace("Non-optimal deserialization of alternator type {}", int8_t(atype));
         return rjson::parse(std::string_view(reinterpret_cast<const char *>(bv.data()), bv.size()));
     }
+
+    if (atype == alternator_type::FLOAT32VECTOR) {
+        if (bv.size() % sizeof(uint32_t) != 0) {
+            throw api_error::validation("FLOAT32VECTOR: byte length not a multiple of 4");
+        }
+        rjson::value arr(rapidjson::kArrayType);
+        while (!bv.empty()) {
+            uint32_t bits_be = read_unaligned<uint32_t>(bv.data());
+            bv.remove_prefix(sizeof(uint32_t));
+            rjson::push_back(arr, rjson::value(std::bit_cast<float>(net::ntoh(bits_be))));
+        }
+        rjson::add_with_string_name(deserialized, float32vector_type_name, std::move(arr));
+        return deserialized;
+    }
+
     type_representation type_representation = represent_type(atype);
     visit(*type_representation.dtype, to_json_visitor{deserialized, type_representation.ident, bv});
 

--- a/alternator/serialization.hh
+++ b/alternator/serialization.hh
@@ -22,8 +22,18 @@ class position_in_partition;
 namespace alternator {
 
 enum class alternator_type : int8_t {
-    S, B, BOOL, N, NOT_SUPPORTED_YET
+    // Do not reorder or delete entries in this enum, because these values are
+    // written to disk as part of the item encoding.
+    S, B, BOOL, N, NOT_SUPPORTED_YET, FLOAT32VECTOR
 };
+
+// FLOAT32VECTOR is an Alternator-only extension to DynamoDB's JSON type
+// system. It takes a JSON array of numbers (not quoted strings as the N type
+// does) and states that for these numbers, only the precision and range of
+// 32-bit floats is guaranteed. This allows Alternator to store these vectors
+// much more efficiently than if they were a JSON array of N's - we store
+// them as big-endian 32-bit IEEE 754 floats, exactly 4 bytes each.
+inline constexpr std::string_view float32vector_type_name = "FLOAT32VECTOR";
 
 struct type_info {
     alternator_type atype;

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -175,6 +175,18 @@ static void register_metrics_with_optional_table(seastar::metrics::metric_groups
                     seastar::metrics::description("Counts number of misses of cached expressions"), labels)(expression_label("ProjectionExpression")).aggregate(aggregate_labels).set_skip_when_empty()
     });
 
+    // Vector search metrics
+    metrics.add_group(group_name, {
+            seastar::metrics::make_total_operations("vector_search_query", stats.vector_search.query,
+                    seastar::metrics::description("number of Query operations with VectorSearch"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("vector_search_query_returned_items", stats.vector_search.query_returned_items,
+                    seastar::metrics::description("total number of items returned by Query operations with VectorSearch"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("vector_search_query_items_from_vs", stats.vector_search.query_items_from_vs,
+                    seastar::metrics::description("total number of nearest neighbors found by the vector store (some may be post-filtered and not returned)"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("vector_search_query_items_from_base_table", stats.vector_search.query_items_from_base_table,
+                    seastar::metrics::description("total number of items read from the base table by vector search queries"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+    });
+
     // Only register the following metrics for the global metrics, not per-table
     if (!has_table) {
         metrics.add_group("alternator", {

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -81,6 +81,27 @@ public:
         batch_histogram batch_get_item_histogram;
         batch_histogram batch_write_item_histogram;
     } api_operations;
+    // Metrics for vector search operations
+    struct {
+        // Number of Query requests with VectorSearch. Note that these
+        // requests are also counted in api_operations.query.
+        uint64_t query = 0;
+        // Total number of items actually returned by vector search queries.
+        // Similar to "Count" in the results, except that when SELECT="COUNT"
+        // no items are really returned, so this metric isn't incremented.
+        uint64_t query_returned_items = 0;
+        // Total number of nearest neighbors found by the vector store
+        // (some of them may be post-filtered or re-scored and not returned).
+        uint64_t query_items_from_vs = 0;
+        // Total number of items read from the base table by vector search
+        // queries. Some vector search queries (e.g., those with
+        // SELECT="COUNT" or SELECT="ALL_PROJECTED_ATTRIBUTES") may not
+        // need to read items from the base table (what they get from the
+        // vector store is enough), so this metric isn't incremented.
+        uint64_t query_items_from_base_table = 0;
+    } vector_search;
+
+
     // Operation size metrics
     struct {
         // Item size statistics collected per table and aggregated per node.

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -378,20 +378,20 @@ The response always includes two count fields:
 > supported for vector search queries and will be rejected with a
 > `ValidationException`. Use `FilterExpression` instead.
 
-**ReturnSimilarity field:**
+**ReturnScores field:**
 
 By default, a vector search `Query` response contains only the matched items
 (or a count) — it does not include how similar each result is to the query
 vector. To also receive similarity scores, set the optional
-`ReturnSimilarity` field inside the `VectorSearch` parameter:
+`ReturnScores` field inside the `VectorSearch` parameter:
 
 | Value | Behavior |
-|-------|---------|
+|-------|----------|
 | `NONE` | Default. No similarity scores are returned. |
-| `SIMILARITY` | Each response includes a `Similarities` array parallel to `Items`, with one floating-point score per item. |
+| `SIMILARITY` | Each response includes a `Scores` array parallel to `Items`, with one floating-point score per item. |
 
-The `Similarities` array is always the same length as `Items` and in the same
-order: `Similarities[i]` is the similarity score for `Items[i]`.
+The `Scores` array is always the same length as `Items` and in the same
+order: `Scores[i]` is the similarity score for `Items[i]`.
 
 **What the similarity score means:**
 
@@ -407,7 +407,7 @@ depends on the similarity function:
 | `EUCLIDEAN` | 0.0 to 1.0 | Euclidean distance _d_ in `[0, inf)` is mapped to `1 / (1 + d)`. similarity 1.0 means identical vectors, 0.0 means infinitely far apart. |
 | `DOT_PRODUCT` | Unbounded | Uses the same distance definition and mapping as `COSINE`. For L2-normalized vectors the result is identical to `COSINE` and stays in [0, 1]. For unnormalized vectors the value may exceed 1 or be negative. |
 
-`ReturnSimilarity=SIMILARITY` is not allowed with `Select=COUNT`,
+`ReturnScores=SIMILARITY` is not allowed with `Select=COUNT`,
 since `COUNT` returns no `Items` array.
 
 Example:
@@ -415,9 +415,9 @@ Example:
 response = table.query(
     IndexName='embedding-index',
     Limit=5,
-    VectorSearch={'QueryVector': {'FLOAT32VECTOR': [0.1, -0.3, 0.7, ...]}, 'ReturnSimilarity': 'SIMILARITY'},
+    VectorSearch={'QueryVector': {'FLOAT32VECTOR': [0.1, -0.3, 0.7, ...]}, 'ReturnScores': 'SIMILARITY'},
 )
-for item, score in zip(response['Items'], response['Similarities']):
+for item, score in zip(response['Items'], response['Scores']):
     print(f"  {item['id']}  similarity={score:.4f}")
 ```
 

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -51,6 +51,7 @@ It is a list of vector index definitions, each specifying:
 | `IndexName` | String | Unique name for this vector index. Follows the same naming rules as table names: 3–192 characters, matching the regex `[a-zA-Z0-9._-]+`. |
 | `VectorAttribute` | Structure | Describes the attribute to index (see below). |
 | `Projection` | Structure | Optional. Specifies which attributes are projected into the vector index (see below). |
+| `SimilarityFunction` | String | Optional. The distance metric used for nearest-neighbor search. See below. |
 
 **VectorAttribute fields:**
 
@@ -58,6 +59,14 @@ It is a list of vector index definitions, each specifying:
 |-------|------|-------------|
 | `AttributeName` | String | The item attribute that holds the vector. It must not be a key column. |
 | `Dimensions` | Integer | The fixed size of the vector (number of elements). |
+
+**SimilarityFunction values:**
+
+| Value | Description |
+|-------|-------------|
+| `COSINE` | Cosine similarity (angular distance). **Default when `SimilarityFunction` is omitted.** |
+| `EUCLIDEAN` | Euclidean (L2) distance. |
+| `DOT_PRODUCT` | Inner product (dot product). Useful when vectors are normalized. |
 
 **Projection fields:**
 
@@ -115,7 +124,8 @@ Each element of the list is an object with exactly one of the following keys:
   "Create": {
     "IndexName": "my-vector-index",
     "VectorAttribute": {"AttributeName": "embedding", "Dimensions": 1536},
-    "Projection": {"ProjectionType": "KEYS_ONLY"}
+    "Projection": {"ProjectionType": "KEYS_ONLY"},
+    "SimilarityFunction": "COSINE"
   }
 }
 ```
@@ -124,6 +134,9 @@ The `Projection` field in the `Create` action is optional and accepts the same
 values as the `Projection` field in `CreateTable`'s `VectorIndexes` (see above).
 Currently only `ProjectionType=KEYS_ONLY` is supported; it is also the default
 when `Projection` is omitted.
+
+The `SimilarityFunction` field is also optional and accepts the same values as
+in `CreateTable`'s `VectorIndexes` (see above). Defaults to `COSINE` when omitted.
 
 **Delete:**
 ```json
@@ -147,6 +160,9 @@ objects each containing `IndexName`, `VectorAttribute`
 (`AttributeName` + `Dimensions`), and `Projection` (`ProjectionType`).
 Currently `Projection` always contains `{"ProjectionType": "KEYS_ONLY"}`
 because that is the only supported projection type.
+If a `SimilarityFunction` was specified at index creation, it is returned
+at the index level (alongside `IndexName`, `VectorAttribute`, and `Projection`).
+When `SimilarityFunction` was not specified, `COSINE` is returned as the default.
 
 Each vector index entry also includes status fields that mirror the standard
 behavior of `GlobalSecondaryIndexes` in DynamoDB:

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -326,3 +326,15 @@ The response always includes two count fields:
 > **Note:** `QueryFilter` (the legacy non-expression filter API) is **not**
 > supported for vector search queries and will be rejected with a
 > `ValidationException`. Use `FilterExpression` instead.
+
+## Metrics
+
+ScyllaDB exposes the following metrics (under the `alternator` group) for
+monitoring vector search activity:
+
+| Metric | Description |
+|--------|-------------|
+| `vector_search_query` | Number of `Query` operations that included a `VectorSearch` parameter. These are also counted in the general `operation{op="Query"}` metric. |
+| `vector_search_query_returned_items` | Total number of items returned across all vector search queries. Not incremented for `Select=COUNT` queries, since no items are actually returned in that case. |
+| `vector_search_query_items_from_vs` | Total number of nearest-neighbor candidates returned by the vector store. Some candidates may be filtered out by a `FilterExpression` and not appear in the final response. |
+| `vector_search_query_items_from_base_table` | Total number of items read from the base table by vector search queries. Queries using `Select=ALL_PROJECTED_ATTRIBUTES` without a filter, or `Select=COUNT` without a filter, bypass the base-table read entirely and do not increment this counter. |

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -34,8 +34,11 @@ The workflow has three steps:
 
 1. **Create** a table (or update an existing one) with one or more
    _vector indexes_.
-2. **Write** items that include the indexed vector attribute, just like any
-   other list attribute.
+2. **Write** items that include the indexed vector attribute. The attribute
+   can be stored as a standard DynamoDB list (`L`) of number (`N`) elements,
+   or as a ScyllaDB-specific optimized vector type (`FLOAT32VECTOR`) — a list of
+   JSON floating-point numbers that is stored internally as compact 4-byte
+   floats rather than JSON-encoded strings, saving space and parse overhead.
 3. **Query** using the `VectorSearch` parameter to retrieve the _k_ nearest
    neighbors.
 
@@ -194,6 +197,28 @@ transitions to monitoring CDC for ongoing changes, and `IndexStatus` becomes
   `BatchWriteItem`. A missing value for the indexed attribute is always
   allowed; such items simply are not indexed.
 
+**Optimized vector storage format (`FLOAT32VECTOR` type):**
+
+As a ScyllaDB extension, the indexed vector attribute may be written using
+the `FLOAT32VECTOR` type instead of the standard `L` type. With the `FLOAT32VECTOR` type the value
+is a JSON array of plain floating-point numbers (not strings):
+
+```json
+// Standard DynamoDB list-of-numbers format:
+{"embedding": {"L": [{"N": "0.1"}, {"N": "-0.3"}, {"N": "0.7"}]}}
+
+// Optimized FLOAT32VECTOR format (ScyllaDB extension):
+{"embedding": {"FLOAT32VECTOR": [0.1, -0.3, 0.7]}}
+```
+
+Both representations are accepted for writes and queries. The `FLOAT32VECTOR`
+format is stored internally as packed 4-byte IEEE 754 floats (big-endian),
+rather than as JSON with string-encoded numbers. This reduces storage space
+and avoids JSON parsing overhead when the vector is read back. For large,
+high-dimensional vectors the space saving is significant: a 1536-dimension
+vector takes 6145 bytes with `FLOAT32VECTOR` versus roughly 25 KB with `L`/`N`
+strings.
+
 > **Important:** Applications must wait until `IndexStatus` is `"ACTIVE"` before
 > issuing `Query` requests against a vector index. Queries on a vector index
 > whose `IndexStatus` is still `"CREATING"` may fail. This applies both when
@@ -214,15 +239,25 @@ vector search rather than a standard key-condition query.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `QueryVector` | AttributeValue (list `L`) | The query vector as a DynamoDB `AttributeValue` of type `L`. Every element must be of type `N` (number). |
+| `QueryVector` | AttributeValue (list `L` or vector `FLOAT32VECTOR`) | The query vector as a DynamoDB `AttributeValue`. Use type `L` with `N` elements (standard DynamoDB) or the optimized ScyllaDB `FLOAT32VECTOR` type with plain floating-point elements. |
 
 Example:
 ```python
+# Standard DynamoDB format:
 response = table.query(
     IndexName='embedding-index',
     Limit=10,
     VectorSearch={
         'QueryVector': {'L': [{'N': '0.1'}, {'N': '-0.3'}, {'N': '0.7'}, ...]},
+    },
+)
+
+# Optimized ScyllaDB FLOAT32VECTOR format:
+response = table.query(
+    IndexName='embedding-index',
+    Limit=10,
+    VectorSearch={
+        'QueryVector': {'FLOAT32VECTOR': [0.1, -0.3, 0.7, ...]},
     },
 )
 ```
@@ -232,7 +267,7 @@ response = table.query(
 | Parameter | Details |
 |-----------|---------|
 | `IndexName` | Required. Must name a vector index on this table (not a GSI or LSI). |
-| `VectorSearch.QueryVector` | Required. A DynamoDB `AttributeValue` of type `L`; all elements must be of type `N` (number). |
+| `VectorSearch.QueryVector` | Required. A DynamoDB `AttributeValue` of type `L` (all elements of type `N`) or the ScyllaDB-specific type `FLOAT32VECTOR` (plain floating-point JSON numbers). |
 | QueryVector length | Must match the `Dimensions` configured for the named vector index. |
 | `Limit` | Required. Defines _k_ — how many nearest neighbors to return. Must be a positive integer. |
 
@@ -342,6 +377,49 @@ The response always includes two count fields:
 > **Note:** `QueryFilter` (the legacy non-expression filter API) is **not**
 > supported for vector search queries and will be rejected with a
 > `ValidationException`. Use `FilterExpression` instead.
+
+**ReturnSimilarity field:**
+
+By default, a vector search `Query` response contains only the matched items
+(or a count) — it does not include how similar each result is to the query
+vector. To also receive similarity scores, set the optional
+`ReturnSimilarity` field inside the `VectorSearch` parameter:
+
+| Value | Behavior |
+|-------|---------|
+| `NONE` | Default. No similarity scores are returned. |
+| `SIMILARITY` | Each response includes a `Similarities` array parallel to `Items`, with one floating-point score per item. |
+
+The `Similarities` array is always the same length as `Items` and in the same
+order: `Similarities[i]` is the similarity score for `Items[i]`.
+
+**What the similarity score means:**
+
+The similarity score is a floating-point number computed from the distance
+between the query vector and each result's stored vector, using the index's
+`SimilarityFunction`. A **higher** score means a **closer** (more similar)
+match, so results appear in descending similarity order.  The score range
+depends on the similarity function:
+
+| `SimilarityFunction` | Range | Mapping |
+|----------------------|-------|---------|
+| `COSINE` (default) | 0.0 to 1.0 | The cosine of the angle between the two vectors is in `[-1, 1]`. So taking `(1 + cos)/2` gives us a similarity value in `[0, 1]`: 1.0 means identical direction, 0.5 means orthogonal vectors, 0.0 means opposite direction. |
+| `EUCLIDEAN` | 0.0 to 1.0 | Euclidean distance _d_ in `[0, inf)` is mapped to `1 / (1 + d)`. similarity 1.0 means identical vectors, 0.0 means infinitely far apart. |
+| `DOT_PRODUCT` | Unbounded | Uses the same distance definition and mapping as `COSINE`. For L2-normalized vectors the result is identical to `COSINE` and stays in [0, 1]. For unnormalized vectors the value may exceed 1 or be negative. |
+
+`ReturnSimilarity=SIMILARITY` is not allowed with `Select=COUNT`,
+since `COUNT` returns no `Items` array.
+
+Example:
+```python
+response = table.query(
+    IndexName='embedding-index',
+    Limit=5,
+    VectorSearch={'QueryVector': {'FLOAT32VECTOR': [0.1, -0.3, 0.7, ...]}, 'ReturnSimilarity': 'SIMILARITY'},
+)
+for item, score in zip(response['Items'], response['Similarities']):
+    print(f"  {item['id']}  similarity={score:.4f}")
+```
 
 ## Metrics
 

--- a/test/alternator/test_encoding.py
+++ b/test/alternator/test_encoding.py
@@ -29,6 +29,8 @@
 # - All other DynamoDB types (NULL, L, M, SS, NS, BS) are stored as type byte
 #   4 (NOT_SUPPORTED_YET) followed by the JSON encoding of the full typed
 #   DynamoDB value (e.g., {"NULL":true} or {"L":[...]}).
+# - There is also the byte 5 (FLOAT32VECTOR). This encoding is not checked
+#   in this file, it is checked in test_vector.py::test_vector_encoding.
 #
 # The order of entries in the alternator_type enum is critical: the numeric
 # value of each type is written to disk, so it must not change.

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -35,8 +35,8 @@ from botocore.exceptions import ClientError
 
 from test.alternator.test_cql_rbac import new_dynamodb, new_role
 from test.alternator.util import random_string, new_test_table, is_aws, scylla_config_read, scylla_config_temporary, get_signed_request
-from test.alternator.test_vector import vs
 from test.pylib.skip_types import skip_env
+from test.alternator.test_vector import vs, needs_vector_store, wait_for_vector_index_active, table_vs
 
 # Fixture for checking if we are able to test Scylla metrics. Scylla metrics
 # are not available on AWS (of course), but may also not be available for
@@ -420,6 +420,65 @@ def test_query_vector_operations(vs, metrics):
                         VectorSearch={'QueryVector': [1, 2, 3]}, Limit=1)
                 except ClientError:
                     pass
+
+# Test that the three vector search item-count metrics -
+#  * scylla_alternator_vector_search_query_returned_items,
+#  * scylla_alternator_vector_search_query_items_from_vs,
+#  * scylla_alternator_vector_search_query_items_from_base_table
+# are incremented as needed for a vector search query.
+# This test requires a configured vector store and will be skipped otherwise.
+def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        # Insert items before enabling the vector index, so the prefill scan
+        # will index them and if we wait for the index to become ACTIVE
+        # we can be sure these items are indexed.
+        for i in range(3):
+            table.put_item(Item={'p': random_string(), 'v': [i, 0, 0]})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+
+        # A SELECT=ALL_ATTRIBUTES query fetches 2 items from the base table,
+        # so all three metrics must increase by exactly 2.
+        vs_metric = 'scylla_alternator_vector_search_query_items_from_vs'
+        returned_metric = 'scylla_alternator_vector_search_query_returned_items'
+        base_metric = 'scylla_alternator_vector_search_query_items_from_base_table'
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='ALL_ATTRIBUTES')
+        assert result['Count'] == 2
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 2
+        assert after[base_metric] - before[base_metric] == 2
+
+        # A SELECT=COUNT query doesn't return any items, so increments only
+        # items_from_vs, not the other two:
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='COUNT')
+        assert result['Count'] == 2
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 0
+        assert after[base_metric] - before[base_metric] == 0
+
+        # A SELECT=ALL_PROJECTED_ATTRIBUTES query increments items_from_vs
+        # and returned_items, but not items_from_base_table.
+        the_metrics = get_metrics(metrics)
+        before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='ALL_PROJECTED_ATTRIBUTES')
+        assert result['Count'] == 2
+        the_metrics = get_metrics(metrics)
+        after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        assert after[vs_metric] - before[vs_metric] == 2
+        assert after[returned_metric] - before[returned_metric] == 2
+        assert after[base_metric] - before[base_metric] == 0
 
 # Test counters for DescribeEndpoints:
 def test_describe_endpoints_operations(dynamodb, metrics):

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -9,6 +9,8 @@
 
 import pytest
 import time
+import json
+import struct
 import decimal
 from decimal import Decimal
 from contextlib import contextmanager
@@ -17,8 +19,8 @@ from functools import cache
 from botocore.exceptions import ClientError
 import boto3.dynamodb.types
 
-from .util import random_string, new_test_table, unique_table_name, scylla_config_read, scylla_config_write, client_no_transform, is_aws
 from test.pylib.skip_types import skip_env
+from .util import random_string, new_test_table, unique_table_name, scylla_config_read, scylla_config_write, client_no_transform, is_aws, manual_request
 
 # Monkey-patch the boto3 library to stop doing its own error-checking on
 # numbers. This works around a bug https://github.com/boto/boto3/issues/2500
@@ -113,6 +115,19 @@ def vs(new_dynamodb_session, dynamodb):
             },
             'required': ['QueryVector'],
         },
+        # For VectorSearch.ReturnSimilarity response:
+        'SimilarityScore': {'type': 'double'},
+        'SimilaritiesList': {
+            'type': 'list',
+            'member': {'shape': 'SimilarityScore'},
+        },
+        # For the 'FLOAT32VECTOR' (optimized vector) type: a list of raw JSON
+        # numbers.
+        'Float32VectorElement': {'type': 'double'},
+        'Float32VectorAttributeValue': {
+            'type': 'list',
+            'member': {'shape': 'Float32VectorElement'},
+        },
     }
     # Register the new shapes:
     service_model = client.meta.service_model
@@ -155,7 +170,44 @@ def vs(new_dynamodb_session, dynamodb):
     output_shape._cache.pop('members', None)
     shape_resolver._shape_cache.pop('TableDescription', None)
 
+    # Add FLOAT32VECTOR (the new optimized vector type) to the AttributeValue
+    # shape, so that boto3 will accept and pass through the FLOAT32VECTOR type
+    # in requests and responses. FLOAT32VECTOR holds a list of floating-point
+    # numbers.
+    attribute_value_shape = shape_resolver.get_shape_by_name('AttributeValue')
+    attribute_value_shape._shape_model['members']['FLOAT32VECTOR'] = {'shape': 'Float32VectorAttributeValue'}
+    attribute_value_shape._cache.pop('members', None)
+    shape_resolver._shape_cache.pop('AttributeValue', None)
+
+    # Monkey-patch boto3 resource's TypeSerializer so that values of type
+    # "Vector" (a class defined below) are serialized into the JSON request as
+    # {"FLOAT32VECTOR": [1.0, ...]} (JSON numbers) instead of the standard
+    # list encoding {"L": [{"N": "1.0"}, ...]}. This allows the high-level
+    # resource interface (table.put_item etc.) to send Vector attributes
+    # without needing client_no_transform.
+    _orig_serialize = boto3.dynamodb.types.TypeSerializer.serialize
+    def _serialize_with_vector(self, value):
+        if isinstance(value, Vector):
+            return {'FLOAT32VECTOR': list(value)}
+        return _orig_serialize(self, value)
+    boto3.dynamodb.types.TypeSerializer.serialize = _serialize_with_vector
+    boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector = lambda self, value: Vector(value)
+
     yield resource
+
+    # Restore the original serialize method and remove the deserializer patch.
+    boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
+    del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
+
+# Use the Vector(list) type for test values that are meant to be stored as
+# optimized vectors (array of floats instead of JSON list of numbers).
+# The serialization monkey-patching in the vs fixture will cause this list
+# to be serialized and sent to Alternator as
+# {'FLOAT32VECTOR': [1.0, 2.0, ...]}} instead of the standard list-of-numbers
+# {'L': [{'N': '1.0'}, ...]}.
+class Vector(list):
+    pass
+
 
 # A simple test for the vector type. In vector search, a vector is simply
 # an array of known size that contains only numbers. In the DynamoDB API,
@@ -2276,6 +2328,282 @@ def test_createtable_query_similarity_function(vs, needs_vector_store):
             assert result['Items'][0]['p'] == expected_p, \
                 f'For SimilarityFunction={sf}, expected nearest item {expected_p}, ' \
                 f'got {result["Items"][0]["p"]}'
+
+# Tests for the optimized vector type, "FLOAT32VECTOR". This is a new type not
+# supported by DynamoDB. It knows all elements are numbers and only guarantees
+# 32-bit floating point precision, so allows Scylla to store the vector much
+# more efficiently, using 32-bit floats instead of textual JSON representation.
+
+# Check that we can write and then read back a "FLOAT32VECTOR" top-level
+# attribute. We use manual_request() to bypass boto3's serializer entirely,
+# because boto3 does not know the "FLOAT32VECTOR" type and would reject it
+# before sending. Scylla shouldn't reject this value - in the worst case it
+# could store the attribute as a JSON string
+# {"FLOAT32VECTOR": [1.0, 2.0, 3.0]} - but ideally it should understand the
+# "FLOAT32VECTOR" type and store it as a native array of floats.
+#
+# Writing tests with "manual_request" is ugly. So in the next tests we will
+# check the same thing with progressively more convenient ways to write the
+# test.
+def test_put_and_get_toplevel_v_manual_request(test_table_s):
+    p = random_string()
+    v = [1.0, 2.0, 3.0]
+    manual_request(test_table_s, 'PutItem', json.dumps({
+        'TableName': test_table_s.name,
+        'Item': {'p': {'S': p}, 'v': {'FLOAT32VECTOR': v}},
+    }))
+    result = manual_request(test_table_s, 'GetItem', json.dumps({
+        'TableName': test_table_s.name,
+        'Key': {'p': {'S': p}},
+        'ConsistentRead': True,
+    }))
+    assert 'Item' in result
+    assert result['Item']['p'] == {'S': p}
+    assert result['Item']['v'] == {'FLOAT32VECTOR': v}
+
+# Same as test_put_and_get_toplevel_v_manual_request, but using the vs
+# fixture (which patches the 'FLOAT32VECTOR' shape into boto3's
+# AttributeValue) and client_no_transform, so boto3 can serialize and
+# deserialize the 'FLOAT32VECTOR' type.
+#
+# Writing tests with "client_no_transform" is still a bit ugly, so the
+# next test will do the same thing again even more conveniently.
+def test_put_and_get_toplevel_v_client_no_transform(test_table_s, vs):
+    p = random_string()
+    v = [1.0, 2.0, 3.0]
+    with client_no_transform(vs.meta.client) as client:
+        client.put_item(
+            TableName=test_table_s.name,
+            Item={'p': {'S': p}, 'v': {'FLOAT32VECTOR': v}},
+        )
+        result = client.get_item(
+            TableName=test_table_s.name,
+            Key={'p': {'S': p}},
+            ConsistentRead=True,
+        )
+    assert 'Item' in result
+    assert result['Item']['p'] == {'S': p}
+    assert result['Item']['v'] == {'FLOAT32VECTOR': v}
+
+# Finally is the same test again, using the new Vector(...) instead of
+# ugly hacks like manual_request and client_no_transform. This finally
+# looks like a good enough API to give to users, and is the approach
+# we'll use below for the rest of the tests for the optimized vector type.
+# Note: we must use a table from the vs fixture (here table_vs) and not an
+# ordinary table (like test_table_s), because the FLOAT32VECTOR type is only
+# patched into the AttributeValue shape of the vs client. An ordinary table's
+# client would fail when botocore encounters the unknown FLOAT32VECTOR member.
+def test_put_and_get_toplevel_v(table_vs):
+    p = random_string()
+    v = Vector([1.0, 2.0, 3.0])
+    table_vs.put_item(Item={'p': p, 'v': v})
+    result = table_vs.get_item(Key={'p': p}, ConsistentRead=True)
+    assert 'Item' in result
+    assert result['Item']['p'] == p
+    assert result['Item']['v'] == v
+
+# Test that on a table with vector index enabled, we can't insert a vector
+# with a floating-point value that doesn't fit in 32 bits.
+def test_vector_float32_range(table_vs):
+    p = random_string()
+    # 1e100 and -1e100 are finite doubles but become infinite as 32-bit float
+    with pytest.raises(ClientError, match='ValidationException.*32-bit'):
+        table_vs.put_item(Item={'p': p, 'v': Vector([1.0, 1e100, 3.0])})
+    with pytest.raises(ClientError, match='ValidationException.*32-bit'):
+        table_vs.put_item(Item={'p': p, 'v': Vector([1.0, -1e100, 3.0])})
+
+# Actually, the limitation that vector components must be finite (like all
+# numbers in JSON) when saved as 32-bit floats doesn't require a vector
+# index to be enabled. It should be enforced for any FLOAT32VECTOR attribute,
+# even if it's not indexed.
+def test_vector_float32_range_no_index(test_table_s, vs):
+    p = random_string()
+    # test_table_s has no vector index on it - but we should still reject
+    # a "FLOAT32VECTOR" attribute value whose elements overflow 32-bit float.
+    with pytest.raises(ClientError, match='ValidationException.*32-bit'):
+        vs.meta.client.put_item(TableName=test_table_s.name,
+            Item={'p': p, 'v': Vector([1.0, 1e100, 3.0])})
+    with pytest.raises(ClientError, match='ValidationException.*32-bit'):
+        vs.meta.client.put_item(TableName=test_table_s.name,
+            Item={'p': p, 'v': Vector([1.0, -1e100, 3.0])})
+
+# A floating-point numbers with more significant digits than a 32-bit float
+# allows is allowed, but silently truncated to 32-bit precision. It is *not*
+# rejected. Check that we can read it back with some loss of precision,
+# below the 32-bit float epsilon.
+def test_vector_float32_precision(table_vs):
+    p = random_string()
+    # FLT_EPSILON is the difference between 1.0 and the next representable
+    # 32-bit float greater than 1.0. Any value between 1 and 1+FLT_EPSILON
+    # will be indistinguishable from 1.0 when truncated to 32-bit float
+    # precision.
+    FLT_EPSILON = 1.1920928955078125e-7
+    # x = 1.0 + FLT_EPSILON/2 is distinguishable from 1.0 in Python's
+    # double-precision (64-bit) floating-point, but indistinguishable from
+    # 1.0 when Alternator will save it as 32-bit and read it back.
+    x = 1.0 + FLT_EPSILON / 2
+    table_vs.put_item(Item={'p': p, 'v': Vector([1.0, x, 3.0])})
+    result = table_vs.get_item(Key={'p': p}, ConsistentRead=True)
+    v = result['Item']['v']
+    assert isinstance(v, Vector)
+    # The middle value should be truncated to 32-bit float precision, so it
+    # should be equal to 1.0 within the 32-bit float epsilon (but not equal
+    # to the original value which had more precision).
+    assert abs(v[1] - 1.0) < FLT_EPSILON
+
+# Continue the test above (test_vector_float32_precision) to confirm that
+# the vector components are really truncated to 32-bit precision and not
+# wastefully stored with higher precision.
+# Importantly, this test proves that the vector value is stored in an
+# *optimized* way, and validates its main benefit over the unoptimized
+# list-of-numbers approach.
+def test_vector_float32_optimized(table_vs):
+    p = random_string()
+    FLT_EPSILON = 1.1920928955078125e-7
+    x = 1.0 + FLT_EPSILON / 2
+    table_vs.put_item(Item={'p': p, 'v': Vector([1.0, x, 3.0])})
+    result = table_vs.get_item(Key={'p': p}, ConsistentRead=True)
+    v = result['Item']['v']
+    # The middle value should be truncated to exactly 1.0.
+    assert v[1] == 1.0
+
+# Test more directly (using CQL) that the vector is stored in the underlying
+# table in an optimized way - and also exactly how it is encoded. It's
+# important that we don't unintentionally change this encoding, because the
+# vector store needs to know how to read it.
+# This test is similar to the tests in test_encoding.py.
+def test_vector_encoding(table_vs, cql):
+    p = random_string()
+    # We pick example values that have an accurate representation in
+    # 32-bit float, so we know exactly what we expect to be stored.
+    table_vs.put_item(Item={'p': p, 'v': Vector([1.0, 2.5, -3.25])})
+    ks = 'alternator_' + table_vs.name
+    cf = table_vs.name
+    rows = list(cql.execute(
+        f'SELECT ":attrs" FROM "{ks}"."{cf}" WHERE p = \'{p}\''))
+    assert len(rows) == 1
+    attrs = rows[0][0]
+    assert 'v' in attrs
+    # The 'v' attribute should be encoded by a single byte 5
+    # (alternator_type::FLOAT32VECTOR) followed directly by the 3 float32
+    # values 1.0, 2.5, -3.25 in big-endian binary. No explicit length field.
+    ALTERNATOR_TYPE_FLOAT32VECTOR = 5
+    v = attrs['v']
+    assert isinstance(v, bytes)
+    assert v[0] == ALTERNATOR_TYPE_FLOAT32VECTOR
+    N = 3
+    assert len(v) == 1 + N * 4
+    # We can check that the values are correct by unpacking them as big-endian
+    # float32 values.
+    values = struct.unpack('>' + 'f' * N, v[1:])
+    assert values == (1.0, 2.5, -3.25)
+
+# Test that we can use a "vector" attribute as a non top-level attribute.
+# It might be stored unoptimized as a JSON value ({"FLOAT32VECTOR": [...]}) but it
+# should still work and be retrievable and searchable.
+def test_put_and_get_nested_vector_value(table_vs):
+    p = random_string()
+    # Store a Vector nested inside a map attribute, not as a top-level attribute.
+    item = {'p': p, 'nested': {'v': Vector([1.0, 2.0, 3.0])}}
+    table_vs.put_item(Item=item)
+    result = table_vs.get_item(Key={'p': p}, ConsistentRead=True)
+    assert 'Item' in result
+    # Because the vector elements are whole numbers, we expect them to be
+    # returned without loss of precision, whether or not they were stored
+    # in an optimized way or not (which we don't want to assert in this
+    # test). So we can check that the returned item is exactly equal to the
+    # original item we put, including the nested Vector.
+    assert result['Item'] == item
+
+# When an attribute does not yet have a vector index on it, it is possible
+# to write to it vectors of any length (even the zero length). But when
+# the attribute does have an vector index, writes with the wrong length are
+# rejected.
+def test_vector_float32vector_any_length_without_index(test_table_s, vs):
+    p = random_string()
+    for length in [0, 1, 3, 42]:
+        # Without a vector index, FLOAT32VECTOR vectors of any length
+        # (including empty) are allowed:
+        vs.meta.client.put_item(TableName=test_table_s.name,
+            Item={'p': p, 'v': Vector([1.0 for i in range(length)])})
+
+def test_vector_float32vector_wrong_length_with_index(table_vs):
+    p = random_string()
+    # table_vs has a vector index on 'v' with Dimensions=3, so only length-3
+    # FLOAT32VECTOR vectors are accepted. Other lengths should be rejected.
+    for bad_length in [0, 1, 2, 4, 42]:
+        with pytest.raises(ClientError, match='ValidationException.*exactly 3'):
+            table_vs.put_item(Item={'p': p, 'v': Vector([1.0 for i in range(bad_length)])})
+
+# Test a vector-search Query when some of the vector attributes are written
+# using the optimized "FLOAT32VECTOR" type. The optimized vector type is
+# recommended, but not mandatory - users can also use a list of numbers
+# ("L" of "N"), so to confirm this, this test writes one vector with an
+# optimized type and one with an unoptimized type, and checks that both are
+# visible in the vector search results.
+def test_query_vector_float32vector_and_lon(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_v = random_string()  # written with the optimized FLOAT32VECTOR type
+        p_l = random_string()  # written with the standard L-of-N type
+        table.put_item(Item={'p': p_v, 'v': Vector([1.0, 0.0, 0.0])})
+        table.put_item(Item={'p': p_l, 'v': [Decimal("1"), Decimal("0"), Decimal("0")]})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        # wait_for_vector_index_active() ensures the prefill scan is complete,
+        # so both items are guaranteed to be indexed.
+        wait_for_vector_index_active(table, 'vind')
+
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [Decimal("1"), Decimal("0"), Decimal("0")]},
+            Limit=2,
+        )
+        assert {item['p'] for item in result.get('Items', [])} == {p_v, p_l}
+
+        # QueryVector can also be given as a "FLOAT32VECTOR" type if we want,
+        # instead of a list of numbers. Verify that this really works:
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1, 0, 0])},
+            Limit=2,
+        )
+        assert {item['p'] for item in result.get('Items', [])} == {p_v, p_l}
+
+# In test_query_vector_float32vector_and_lon we verified that "FLOAT32VECTOR"
+# and "L"-of-"N" vectors are both indexed for the prefill case (the items were
+# written before the index was created). For completeness, we should also
+# check that they are also read correctly when written after the index is
+# created - i.e. when noticed with CDC.
+def test_query_vector_float32vector_and_lon_cdc(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[{'IndexName': 'vind',
+                            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}]) as table:
+        # Wait until the vector store is ready (prefill of the empty table
+        # has completed), to ensure our writes are picked up via CDC, not
+        # prefill.
+        wait_for_vector_index_active(table, 'vind')
+        p_v = random_string()  # written with the optimized FLOAT32VECTOR type
+        p_l = random_string()  # written with the standard L-of-N type
+        table.put_item(Item={'p': p_v, 'v': Vector([1.0, 0.0, 0.0])})
+        table.put_item(Item={'p': p_l, 'v': [Decimal("1"), Decimal("0"), Decimal("0")]})
+        # Retry the query until both items appear in the vector search results.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [Decimal("1"), Decimal("0"), Decimal("0")]},
+                Limit=2,
+            )
+            if {item['p'] for item in result.get('Items', [])} == {p_v, p_l}:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for V-type and L-type items to appear via CDC')
+            time.sleep(0.1)
 
 ##############################################################################
 # CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -112,14 +112,15 @@ def vs(new_dynamodb_session, dynamodb):
             'type': 'structure',
             'members': {
                 'QueryVector': {'shape': 'AttributeValue'},
+                'ReturnScores': {'shape': 'String'},
             },
             'required': ['QueryVector'],
         },
-        # For VectorSearch.ReturnSimilarity response:
-        'SimilarityScore': {'type': 'double'},
-        'SimilaritiesList': {
+        # For VectorSearch.ReturnScores response:
+        'Score': {'type': 'double'},
+        'ScoresList': {
             'type': 'list',
-            'member': {'shape': 'SimilarityScore'},
+            'member': {'shape': 'Score'},
         },
         # For the 'FLOAT32VECTOR' (optimized vector) type: a list of raw JSON
         # numbers.
@@ -160,6 +161,11 @@ def vs(new_dynamodb_session, dynamodb):
         'shape': 'VectorSearch'
     }
     input_shape._cache.pop('members', None)
+
+    # Add Scores list to Query output
+    query_output_shape = query_op.output_shape
+    query_output_shape._shape_model['members']['Scores'] = {'shape': 'ScoresList'}
+    query_output_shape._cache.pop('members', None)
 
     # Add a VectorIndexes field to "TableDescription", the shape returned
     # by DescribeTable and also CreateTable
@@ -2604,6 +2610,204 @@ def test_query_vector_float32vector_and_lon_cdc(vs, needs_vector_store):
             if time.monotonic() > deadline:
                 pytest.fail('Timed out waiting for V-type and L-type items to appear via CDC')
             time.sleep(0.1)
+
+# Test that VectorSearch.ReturnScores rejects unknown values and the
+# SIMILARITY+COUNT combination. No vector store needed.
+def test_query_vectorsearch_return_similarity_bad(table_vs):
+    # Unknown value is rejected:
+    with pytest.raises(ClientError, match='ValidationException.*ReturnScores'):
+        table_vs.query(IndexName='vind',
+            VectorSearch={'QueryVector': [1, 2, 3], 'ReturnScores': 'GARBAGE'}, Limit=1)
+    # SIMILARITY with Select=COUNT is rejected:
+    with pytest.raises(ClientError, match='ValidationException.*COUNT'):
+        table_vs.query(IndexName='vind',
+            VectorSearch={'QueryVector': [1, 2, 3], 'ReturnScores': 'SIMILARITY'}, Limit=1,
+            Select='COUNT')
+
+# Test for VectorSearch.ReturnScores - if set to NONE (the default),
+# a "Scores" field is missing in the response, but with SIMILARITY,
+# a "Scores" field is present and contains the similarity values for
+# each returned item. We verify the length matches Items, the scores are in
+# descending order, and exact scores match expected COSINE similarity values
+# for known vectors.
+def test_query_vectorsearch_return_similarity(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        # Insert 4 items at known COSINE similarity to query vector [1, 0, 0]:
+        #   p1 at [1, 0, 0]   cos=1.0    -> similarity 1.0 (identical)
+        #   p2 at [1, 0.1, 0] cos~=0.995 -> similarity ~ 0.9975
+        #   p3 at [0, 1, 0]   cos=0.0    -> similarity 0.5 (orthogonal)
+        #   p4 at [-1, 0, 0]  cos=-1.0   -> similarity 0.0 (opposite)
+        p1, p2, p3, p4 = random_string(), random_string(), random_string(), random_string()
+        table.put_item(Item={'p': p1, 'v': Vector([1.0,  0.0,  0.0])})
+        table.put_item(Item={'p': p2, 'v': Vector([1.0,  0.1,  0.0])})
+        table.put_item(Item={'p': p3, 'v': Vector([0.0,  1.0,  0.0])})
+        table.put_item(Item={'p': p4, 'v': Vector([-1.0, 0.0,  0.0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'SimilarityFunction': 'COSINE'}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Without ReturnScores (or with NONE), no Scores in response.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1.0, 0.0, 0.0])},
+            Limit=4)
+        assert 'Scores' not in result
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1.0, 0.0, 0.0]), 'ReturnScores': 'NONE'},
+            Limit=4)
+        assert 'Scores' not in result
+        # With SIMILARITY, Scores is present, same length as Items, and
+        # in descending order (nearest neighbor has the highest score).
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1.0, 0.0, 0.0]), 'ReturnScores': 'SIMILARITY'},
+            Limit=4)
+        assert [item['p'] for item in result['Items']] == [p1, p2, p3, p4]
+        assert 'Scores' in result
+        sims = result['Scores']
+        assert len(sims) == 4
+        # Scores must be in descending order.
+        assert sims == sorted(sims, reverse=True)
+        # Map item key to its position in the result list.
+        pos = {item['p']: i for i, item in enumerate(result['Items'])}
+        # Known similarity values for three easy cases:
+        assert sims[pos[p1]] == pytest.approx(1.0, abs=1e-5)
+        assert sims[pos[p3]] == pytest.approx(0.5, abs=1e-5)
+        assert sims[pos[p4]] == pytest.approx(0.0, abs=1e-5)
+        # Use FilterExpression to only leave p1 and p3 in the results, and
+        # verify their similarity values are still correct and in the right
+        # order.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1.0, 0.0, 0.0]), 'ReturnScores': 'SIMILARITY'},
+            Limit=4,
+            FilterExpression='p = :p1 OR p = :p3',
+            ExpressionAttributeValues={':p1': p1, ':p3': p3},
+        )
+        assert [item['p'] for item in result['Items']] == [p1, p3]
+        assert result['ScannedCount'] == 4
+        assert result['Count'] == 2
+        sims = result['Scores']
+        assert len(sims) == 2
+        assert sims[0] == pytest.approx(1.0, abs=1e-5)
+        assert sims[1] == pytest.approx(0.5, abs=1e-5)
+
+# Another ReturnScores=SIMILARITY test, for a different similarity
+# function (EUCLIDEAN).
+def test_query_vectorsearch_return_similarity2(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': Vector([2.0, 0.0, 0.0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'SimilarityFunction': 'EUCLIDEAN'}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([1.0, 0.0, 0.0]), 'ReturnScores': 'SIMILARITY'},
+            Limit=1)
+        assert len(result['Items']) == 1 and result['Items'][0]['p'] == p
+        # The EUCLIDEAN similarity is defined as 1/(1+d) where d is the L2
+        # distance. The L2 distance between our query vector and single item
+        # is 1.0, so similarity is 1/(1+1) = 0.5.
+        assert result['Scores'] == [pytest.approx(0.5, abs=1e-5)]
+
+# The DOT_PRODUCT similarity function is not bounded if vectors are not
+# normalized (have an arbitrary magnitude, not 1.0). It is possible that the
+# similarity value returned with ReturnScores=SIMILARITY could be beyond
+# the range of 32-bit float even for valid float32 vectors. In this case, the
+# implementation should not cause an error or drop this item - it should
+# return the item correctly with a very high (even if not mathematically
+# accurate) similarity score.
+def test_query_vectorsearch_return_similarity_dot_product_overflow(vs, needs_vector_store):
+    # Two float32 vectors with very large - but valid - magnitude BIG,
+    # have a dot product of BIG^2, which overflows float32 to +infinity.
+    BIG = 1e38 # Valid 32-bit number, but close to the maximum
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': Vector([BIG, 0.0, 0.0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'SimilarityFunction': 'DOT_PRODUCT'}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([BIG, 0.0, 0.0]),
+                          'ReturnScores': 'SIMILARITY'},
+            Limit=1,
+            Select='ALL_ATTRIBUTES')
+        assert len(result['Items']) == 1 and result['Items'][0]['p'] == p
+        assert 'Scores' in result
+        # The dot product BIG * BIG overflows float32 to infinity.
+        # Since JSON can't represent infinity and must return some number,
+        # we don't really care what it returns, as long as it's very large.
+        # Let's just verify it's larger than BIG itself.
+        assert result['Scores'][0] >= BIG
+
+# Test that DOT_PRODUCT similarity correctly orders three items:
+# one very highly similar (large positive dot product overflowing 32 bits),
+# one mildly similar (small positive), and one very highly dissimilar
+# (large negative overflowing 32 bits).
+# The vector store should return them in descending score order.
+# We also check the Scores themselves: the highly similar item should have
+# a score much larger than 1, the mildly similar item around 1, and the
+# highly dissimilar item should have a large negative score.
+#
+# This test reproduces a bug in the vector store: When the similarity score
+# overflows the 32-bit calculation, it returns the same value "null" for both
+# +infinity and -infinity. Alternator currently assumes it's +infinity
+# (because only the results with the *highest* scores are returned from the
+# query), but in test like this one when we inspect all the items and their
+# scores, we can catch this discrepancy - the -inf result also gets
+# incorrectly returned as +inf. This test is marked xfail until the bug is
+# fixed.
+@pytest.mark.xfail(reason='vector store returns same "null" similarity for both +inf and -inf')
+def test_query_vectorsearch_return_similarity_dot_product_overflow2(vs, needs_vector_store):
+    BIG = 1e38  # Near FLT_MAX; dot product BIG * BIG overflows float32
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_high = random_string()
+        p_mid  = random_string()
+        p_low  = random_string()
+        table.put_item(Item={'p': p_high, 'v': Vector([BIG,  0.0, 0.0])})
+        table.put_item(Item={'p': p_mid,  'v': Vector([0.0,  0.0, 0.0])})
+        table.put_item(Item={'p': p_low,  'v': Vector([-BIG, 0.0, 0.0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+             'SimilarityFunction': 'DOT_PRODUCT'}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([BIG, 0.0, 0.0]),
+                          'ReturnScores': 'SIMILARITY'},
+            Limit=3,
+            Select='ALL_ATTRIBUTES')
+        items = result['Items']
+        scores = result['Scores']
+        assert len(items) == 3
+        assert len(scores) == 3
+        # Results must be in descending score order (highest dot product first).
+        assert [item['p'] for item in items] == [p_high, p_mid, p_low]
+        # The highly similar item's score should be large and positive
+        assert scores[0] > BIG
+        # The mildly similar item's dot product is 0, the "similarity"
+        # converts it to 0.5 (since similarity is defined as (dot+1)/2
+        # to map from [-1,1] to [0,1] if vectors are normalized).
+        assert scores[1] == pytest.approx(0.5, abs=1e-5)
+        # The highly dissimilar item's score should be large and negative.
+        assert scores[2] < -BIG
 
 ##############################################################################
 # CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -60,6 +60,7 @@ def vs(new_dynamodb_session, dynamodb):
                 'IndexName': {'shape': 'String'},
                 'VectorAttribute': {'shape': 'VectorAttribute'},
                 'Projection': {'shape': 'Projection'},
+                'SimilarityFunction': {'shape': 'String'},
                 # The following two fields are only returned in DescribeTable's
                 # output, not accepted in CreateTable's input.
                 'IndexStatus': {'shape': 'String'},
@@ -93,6 +94,7 @@ def vs(new_dynamodb_session, dynamodb):
                 'IndexName': {'shape': 'String'},
                 'VectorAttribute': {'shape': 'VectorAttribute'},
                 'Projection': {'shape': 'Projection'},
+                'SimilarityFunction': {'shape': 'String'},
             },
             'required': ['IndexName', 'VectorAttribute'],
         },
@@ -2158,6 +2160,122 @@ def test_query_vectorsearch_queryvector_bad_number_string(table_vs, needs_vector
                     VectorSearch={'QueryVector': {'L': [{'N': '1'}, {'N': bad_num}, {'N': '0'}]}},
                     Limit=1,
                 )
+
+# Test that when creating a vector index via UpdateTable, an optional
+# SimilarityFunction can be specified. The valid values are EUCLIDEAN,
+# COSINE, DOT_PRODUCT, and an invalid value should be rejected.
+# DescribeTable should return the SimilarityFunction that was set.
+def test_updatetable_vectorindex_similarity_function(vs):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        # A bad SimilarityFunction should be rejected:
+        with pytest.raises(ClientError, match='ValidationException.*SimilarityFunction'):
+            table.update(VectorIndexUpdates=[{'Create':
+                {'IndexName': 'ind',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                 'SimilarityFunction': 'BAD_FUNCTION'}}])
+        # Each of the valid SimilarityFunction values should be accepted and
+        # returned by DescribeTable. We use a different attribute name for
+        # each to avoid conflicts.
+        for sf in ['EUCLIDEAN', 'COSINE', 'DOT_PRODUCT']:
+            table.update(VectorIndexUpdates=[{'Create':
+                {'IndexName': f'ind_{sf}',
+                 'VectorAttribute': {'AttributeName': f'v_{sf}', 'Dimensions': 3},
+                 'SimilarityFunction': sf}}])
+            desc = table.meta.client.describe_table(TableName=table.name)
+            indexes = {vi['IndexName']: vi for vi in desc['Table']['VectorIndexes']}
+            assert f'ind_{sf}' in indexes
+            assert indexes[f'ind_{sf}']['SimilarityFunction'] == sf
+        # Without an explicit SimilarityFunction, a default ("COSINE") is
+        # used and DescribeTable should return it:
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'ind_default',
+             'VectorAttribute': {'AttributeName': 'v_default', 'Dimensions': 3}}}])
+        desc = table.meta.client.describe_table(TableName=table.name)
+        indexes = {vi['IndexName']: vi for vi in desc['Table']['VectorIndexes']}
+        assert 'ind_default' in indexes
+        assert indexes['ind_default']['SimilarityFunction'] == 'COSINE'
+
+# Same as test_updatetable_vectorindex_similarity_function() above, but
+# for CreateTable instead of UpdateTable.
+def test_createtable_vectorindex_similarity_function(vs):
+    # A bad SimilarityFunction should be rejected:
+    with pytest.raises(ClientError, match='ValidationException.*SimilarityFunction'):
+        with new_test_table(vs,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+                VectorIndexes=[{'IndexName': 'ind',
+                                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                                'SimilarityFunction': 'BAD_FUNCTION'}]) as table:
+            pass
+    # Each of the valid SimilarityFunction values should be accepted and
+    # returned by DescribeTable.
+    for sf in ['EUCLIDEAN', 'COSINE', 'DOT_PRODUCT']:
+        with new_test_table(vs,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+                VectorIndexes=[{'IndexName': 'ind',
+                                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                                'SimilarityFunction': sf}]) as table:
+            desc = table.meta.client.describe_table(TableName=table.name)
+            indexes = {vi['IndexName']: vi for vi in desc['Table']['VectorIndexes']}
+            assert indexes['ind']['SimilarityFunction'] == sf
+    # Without an explicit SimilarityFunction, COSINE is the default and
+    # DescribeTable should return it:
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            VectorIndexes=[{'IndexName': 'ind',
+                            'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}]) as table:
+        desc = table.meta.client.describe_table(TableName=table.name)
+        indexes = {vi['IndexName']: vi for vi in desc['Table']['VectorIndexes']}
+        assert indexes['ind']['SimilarityFunction'] == 'COSINE'
+
+# Test that the different SimilarityFunction values (EUCLIDEAN, COSINE,
+# DOT_PRODUCT) chosen during CreateTable actually work as expected in
+# subsequent vector-search queries, returning different result orders for
+# the same query vector.
+def test_createtable_query_similarity_function(vs, needs_vector_store):
+    # Choose 3 items whose nearest-neighbor under query [1, 0, 0] differs
+    # depending on the similarity function:
+    #
+    #   p_small = [0.5, 0, 0]   - perfect direction, small magnitude
+    #   p_big   = [2, 0.01, 0]  - large magnitude, nearly perfect direction
+    #   p_close = [1, 0.3, 0]   - moderate magnitude, clearly off direction
+    #
+    # Under COSINE  (angle only, higher=closer):  p_small is nearest (cosine=1.0)
+    # Under DOT_PRODUCT (inner product, higher=closer): p_big is nearest (dot=2)
+    # Under EUCLIDEAN (L2 distance, lower=closer): p_close is nearest (dist=0.3)
+    p_small = random_string()
+    p_big   = random_string()
+    p_close = random_string()
+    for sf, expected_p in [('COSINE', p_small),
+                            ('DOT_PRODUCT', p_big),
+                            ('EUCLIDEAN', p_close)]:
+        with new_test_table(vs,
+                KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+                AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+            table.put_item(Item={'p': p_small, 'v': [Decimal("0.5"), Decimal("0"),    Decimal("0")]})
+            table.put_item(Item={'p': p_big,   'v': [Decimal("2"),   Decimal("0.01"), Decimal("0")]})
+            table.put_item(Item={'p': p_close, 'v': [Decimal("1"),   Decimal("0.3"),  Decimal("0")]})
+            table.update(VectorIndexUpdates=[{'Create': {
+                'IndexName': 'vind',
+                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                'SimilarityFunction': sf,
+            }}])
+            wait_for_vector_index_active(table, 'vind')
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [Decimal("1"), Decimal("0"), Decimal("0")]},
+                Limit=1,
+                Select='ALL_PROJECTED_ATTRIBUTES',
+            )
+            assert len(result['Items']) == 1, \
+                f'Expected 1 result for SimilarityFunction={sf}'
+            assert result['Items'][0]['p'] == expected_p, \
+                f'For SimilarityFunction={sf}, expected nearest item {expected_p}, ' \
+                f'got {result["Items"][0]["p"]}'
 
 ##############################################################################
 # CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:

--- a/test/cqlpy/test_vector_search_with_vector_store_mock.py
+++ b/test/cqlpy/test_vector_search_with_vector_store_mock.py
@@ -34,7 +34,7 @@ class Request:
 @dataclass
 class Response:
     status: int = 200
-    body: str = '{"primary_keys":{"pk1":[],"pk2":[],"ck1":[],"ck2":[]},"distances":[]}'
+    body: str = '{"primary_keys":{"pk1":[],"pk2":[],"ck1":[],"ck2":[]},"similarity_scores":[]}'
 
 
 class VectorStoreMock:
@@ -131,7 +131,7 @@ def test_vector_search_ann_with_partition_key_in_restriction(cql, test_keyspace,
         cql.execute(
             f"INSERT INTO {table} (pk1, pk2, ck1, ck2, embedding) VALUES (5, 7, 9, 2, [0.1, 0.2, 0.3])")
         vector_store_mock.set_next_ann_response(200, json.dumps({"primary_keys": {
-                                                "pk1": [5], "pk2": [7], "ck1": [9], "ck2": [2]}, "distances": [0.1]}))
+                                                "pk1": [5], "pk2": [7], "ck1": [9], "ck2": [2]}, "similarity_scores": [0.1]}))
 
         result = cql.execute(
             f"SELECT pk1, pk2, ck1, ck2 FROM {table} WHERE pk1 IN (5, 6) ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2")

--- a/test/vector_search/rescoring_test.cc
+++ b/test/vector_search/rescoring_test.cc
@@ -229,7 +229,7 @@ SEASTAR_TEST_CASE(oversampled_vector_store_results_are_limited_to_cql_limit) {
                     "primary_keys": {
                         "id": [1, 2]
                     },
-                    "distances": [0, 0]
+                    "similarity_scores": [0, 0]
                 })"});
                 auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0, 0, 0] LIMIT 1;");
 
@@ -257,7 +257,7 @@ SEASTAR_TEST_CASE(result_returned_by_vector_store_is_rescored) {
                     // Mock Response: Return all keys but in REVERSE similarity order.
                     server->next_ann_response({http::reply::status_type::ok, R"({
                         "primary_keys": { "id": [4, 3, 2, 1] },
-                        "distances": [0, 0, 0, 0]
+                        "similarity_scores": [0, 0, 0, 0]
                     })"});
                     auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0.1, 0.1] LIMIT 2;");
 
@@ -289,7 +289,7 @@ SEASTAR_TEST_CASE(f32_quantization_disables_rescoring) {
                 // Mock Response: Return all keys but in REVERSE similarity order.
                 server->next_ann_response({http::reply::status_type::ok, R"({
                     "primary_keys": { "id": [4, 3, 2, 1] },
-                    "distances": [0, 0, 0, 0]
+                    "similarity_scores": [0, 0, 0, 0]
                 })"});
                 auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0.1, 0.1] LIMIT 2;");
 
@@ -325,7 +325,7 @@ SEASTAR_TEST_CASE(similarity_function_returns_correctly_rescored_results) {
                         // Mock Response: Return all keys but in REVERSE similarity order.
                         server->next_ann_response({http::reply::status_type::ok, R"({
                             "primary_keys": { "id": [4, 3, 2, 1] },
-                            "distances": [0, 0, 0, 0]
+                            "similarity_scores": [0, 0, 0, 0]
                         })"});
                         auto msg = co_await env.execute_cql(fmt::format(
                                 "SELECT id, similarity_{}({}) FROM ks.cf ORDER BY embedding ANN OF [0.1, 0.1] LIMIT 2;", params.function_name, func_args));
@@ -363,7 +363,7 @@ SEASTAR_TEST_CASE(wildcard_select_is_correctly_rescored) {
                     // Mock Response: Return all keys but in REVERSE similarity order.
                     server->next_ann_response({http::reply::status_type::ok, R"({
                         "primary_keys": { "id": [4, 3, 2, 1] },
-                        "distances": [0, 0, 0, 0]
+                        "similarity_scores": [0, 0, 0, 0]
                     })"});
                     auto msg = co_await env.execute_cql("SELECT * FROM ks.cf ORDER BY embedding ANN OF [0.1, 0.1] LIMIT 2;");
 
@@ -399,7 +399,7 @@ SEASTAR_TEST_CASE(select_similarity_function_other_than_ann_ordering) {
                 // Mock Response: Return all keys but in REVERSE similarity order.
                 server->next_ann_response({http::reply::status_type::ok, R"({
                     "primary_keys": { "id": [4, 3, 2, 1] },
-                    "distances": [0, 0, 0, 0]
+                    "similarity_scores": [0, 0, 0, 0]
                 })"});
                 auto prep = co_await env.prepare(fmt::format(
                         "SELECT id, similarity_{}(embedding, ?) FROM ks.cf ORDER BY embedding ANN OF ? LIMIT 2;", params.function_name));
@@ -442,7 +442,7 @@ SEASTAR_TEST_CASE(no_nulls_in_rescored_results, *boost::unit_test::expected_fail
                     // Mock Response: Return all keys but in REVERSE similarity order.
                     server->next_ann_response({http::reply::status_type::ok, R"({
                         "primary_keys": { "id": [55, 17, 16, 15, 2] },
-                        "distances": [0, 0, 0, 0, 0]
+                        "similarity_scores": [0, 0, 0, 0, 0]
                     })"});
                     auto msg = co_await env.execute_cql("SELECT id FROM ks.cf ORDER BY embedding ANN OF [0.1, 0.1] LIMIT 3;");
 
@@ -474,7 +474,7 @@ SEASTAR_TEST_CASE(rescoring_with_zerovector_query) {
 
                     server->next_ann_response({http::reply::status_type::ok, R"({
                         "primary_keys": { "id": [4, 3, 2, 1] },
-                        "distances": [0, 0, 0, 0]
+                        "similarity_scores": [0, 0, 0, 0]
                     })"});
 
                     // For cosine similarity the ANN vector query would fail as `similarity_cosine` function did not support zero vectors.

--- a/test/vector_search/utils.hh
+++ b/test/vector_search/utils.hh
@@ -121,7 +121,7 @@ constexpr auto CORRECT_RESPONSE_FOR_TEST_TABLE = R"({
         "ck1": [9, 1],
         "ck2": [2, 3]
     },
-    "distances": [0.1, 0.2]
+    "similarity_scores": [0.1, 0.2]
 })";
 
 inline auto create_test_table(cql_test_env& env, const seastar::sstring& ks, const seastar::sstring& cf) -> future<schema_ptr> {

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -373,7 +373,7 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
                 BOOST_CHECK_EQUAL(err->message, "idx2 not found");
 
                 // missing primary_keys in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys1":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"similarity_scores":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!server->ann_requests().empty());
                 BOOST_REQUIRE_EQUAL(server->ann_requests().back().body, R"({"vector":[0.1,0.2,0.3],"limit":2})");
@@ -381,32 +381,32 @@ SEASTAR_TEST_CASE(vector_store_client_test_ann_request) {
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
-                // missing distances in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances1":[0.1,0.2]})"});
+                // missing similarity_scores in the reply - service should return format error
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"similarity_scores1":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // missing pk1 key in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk11":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk11":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2,3]},"similarity_scores":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // missing ck1 key in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck11":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck11":[9,1],"ck2":[2,3]},"similarity_scores":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of pk2 key in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7],"ck1":[9,1],"ck2":[2,3]},"distances":[0.1,0.2]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7],"ck1":[9,1],"ck2":[2,3]},"similarity_scores":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
 
                 // wrong size of ck2 key in the reply - service should return format error
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2]},"distances":[0.1,0.2]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5,6],"pk2":[7,8],"ck1":[9,1],"ck2":[2]},"similarity_scores":[0.1,0.2]})"});
                 keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 BOOST_REQUIRE(!keys);
                 BOOST_CHECK(std::holds_alternative<vector_store_client::service_reply_format_error>(keys.error()));
@@ -441,13 +441,51 @@ SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_request) {
                 vs.start_background_tasks();
 
                 // correct reply - service should return keys
-                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5],"pk2":[7],"ck1":[9],"ck2":[2]},"distances":[0.1]})"});
+                server->next_ann_response({status_type::ok, R"({"primary_keys":{"pk1":[5],"pk2":[7],"ck1":[9],"ck2":[2]},"similarity_scores":[0.1]})"});
                 auto filter = rjson::parse(R"({"restrictions":[{"type":"==","lhs":"pk1","rhs":5}],"allow_filtering":false})");
                 auto keys = co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, filter, as.reset());
                 BOOST_REQUIRE(keys);
                 BOOST_REQUIRE_EQUAL(keys->size(), 1);
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).partition.key().explode()), "[05, 07]");
                 BOOST_CHECK_EQUAL(seastar::format("{}", keys->at(0).clustering.explode()), "[09, 02]");
+            },
+            cfg)
+            .finally([&server] {
+                return server->stop();
+            });
+}
+
+SEASTAR_TEST_CASE(vector_store_client_test_filtering_ann_cql) {
+    // Similar to `vector_store_client_test_filtering_ann_request`,
+    // but uses CQL query to verify that the WHERE clause expression (this time with IN operator) is handled correctly.
+    using namespace test::vector_search;
+    auto server = co_await make_vs_mock_server();
+    auto cfg = make_config();
+    cfg.db_config->vector_store_primary_uri.set(format("http://good.authority.here:{}", server->port()));
+    co_await do_with_cql_env(
+            [&server](cql_test_env& env) -> future<> {
+                auto schema = co_await create_test_table(env, "ks", "idx");
+                // Create the vector index and insert test data
+                co_await env.execute_cql("CREATE CUSTOM INDEX embedding_idx ON ks.idx (embedding) USING 'vector_index'");
+                co_await env.execute_cql("INSERT INTO ks.idx (pk1, pk2, ck1, ck2, embedding) VALUES (5, 7, 9, 2, [0.1, 0.2, 0.3])");
+
+                auto& vs = env.local_qp().vector_store_client();
+                configure(vs).with_dns({{"good.authority.here", "127.0.0.1"}});
+                vs.start_background_tasks();
+
+                // Mock response - service should return keys matching the WHERE filter
+                server->next_ann_response({http::reply::status_type::ok, R"({"primary_keys":{"pk1":[5],"pk2":[7],"ck1":[9],"ck2":[2]},"similarity_scores":[0.1]})"});
+
+                // Execute CQL query with WHERE clause filter
+                auto msg = co_await env.execute_cql("SELECT pk1, pk2, ck1, ck2 FROM ks.idx WHERE pk1 IN (5, 6) ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 2");
+
+                // Process results - expect 1 row with values [5, 7, 9, 2]
+                assert_that(msg).is_rows().with_rows({{
+                    {byte_type->decompose(int8_t(5))},
+                    {byte_type->decompose(int8_t(7))},
+                    {byte_type->decompose(int8_t(9))},
+                    {byte_type->decompose(int8_t(2))},
+                }});
             },
             cfg)
             .finally([&server] {

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -152,18 +152,22 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
         return std::unexpected{service_reply_format_error{}};
     }
 
-    if (!json.HasMember("distances")) {
-        vslogger.error("Vector Store returned invalid JSON: missing 'distances'");
+    if (!json.HasMember("similarity_scores")) {
+        vslogger.error("Vector Store returned invalid JSON: missing 'similarity_scores'");
         return std::unexpected{service_reply_format_error{}};
     }
-    auto const& distances_json = json["distances"];
-    if (!distances_json.IsArray()) {
-        vslogger.error("Vector Store returned invalid JSON: 'distances' is not an array");
+    auto const& similarity_json = json["similarity_scores"];
+    if (!similarity_json.IsArray()) {
+        vslogger.error("Vector Store returned invalid JSON: 'similarity_scores' is not an array");
         return std::unexpected{service_reply_format_error{}};
     }
-    auto const& distances_arr = json["distances"].GetArray();
+    auto const& similarity_arr = json["similarity_scores"].GetArray();
 
-    auto size = distances_arr.Size();
+    // We assume that the similarity_arr, and all the key arrays in keys_json
+    // have the same length, which is the number of nearest neighbors returned
+    // by the vector store.
+    auto size = similarity_arr.Size();
+
     auto keys = primary_keys{};
     for (auto idx = 0U; idx < size; ++idx) {
         auto pk = pk_from_json(keys_json, idx, schema);
@@ -174,7 +178,23 @@ auto read_ann_json(rjson::value const& json, schema_ptr const& schema) -> std::e
         if (!ck) {
             return std::unexpected{ck.error()};
         }
-        keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck});
+        auto const& sim_val = similarity_arr[idx];
+        if (sim_val.IsNumber()) {
+            keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, sim_val.GetFloat()});
+        } else if (sim_val.IsNull()) {
+            // JSON does not support infinite values, and serde_json serializes
+            // both +inf and -inf as null. This can only happen with the
+            // DOT_PRODUCT similarity function when the dot product overflows
+            // float32 (very high magnitude vectors). Since we can't distinguish
+            // +inf from -inf here, we use +inf as a conservative approximation
+            // (the item will be ranked highly, which is appropriate for a very
+            // large positive dot product; the -inf case is very unlikely in
+            // practice).
+            keys.push_back(primary_key{dht::decorate_key(*schema, *pk), *ck, std::numeric_limits<float>::infinity()});
+        } else {
+            vslogger.error("Vector Store returned invalid JSON: 'similarity_scores[{}]'={} is not a number", idx, rjson::print(sim_val));
+            return std::unexpected{service_reply_format_error{}};
+        }
     }
     return std::move(keys);
 }

--- a/vector_search/vector_store_client.hh
+++ b/vector_search/vector_store_client.hh
@@ -33,6 +33,11 @@ namespace vector_search {
 struct primary_key {
     dht::decorated_key partition;
     clustering_key_prefix clustering;
+    /// The similarity score returned by the vector store (higher = more
+    /// similar, and earlier in the result set). Similarity is in the range
+    /// [0.0, 1.0] for cosine and euclidean; unbounded for dot product on
+    /// non-normalized vectors.
+    float similarity = 0.0f;
 };
 
 /// A client with the vector-store service.
@@ -89,7 +94,11 @@ public:
     /// Query the vector store for the current status of a specific vector index.
     auto get_index_status(keyspace_name keyspace, index_name name, abort_source& as) -> future<index_status>;
 
-    /// Request the vector store service for the primary keys of the nearest neighbors
+    /// Request the vector store service for the primary keys of the nearest
+    /// neighbors. Each returned primary_key has its similarity field set to
+    /// the similarity score returned by the vector store, which sorts the
+    /// results in decreasing similarity order (higher similarity score = more
+    /// similar).
     auto ann(keyspace_name keyspace, index_name name, schema_ptr schema, vs_vector vs_vector, limit limit, const rjson::value& filter, abort_source& as)
             -> future<std::expected<primary_keys, ann_error>>;
 


### PR DESCRIPTION
Recently (in commit 37fc1507f0798a3eae14c6a17aa7370f9155c92c) we added vector search support for Alternator.
That implementation was functional, but did not yet support all the features that we had envisioned.

This patch series adds some of the missing features to Alternator's vector search. Each feature is described in more detail in its own patch.

* Metrics related to vector search usage in Alternator.
* `SimilarityFunction` option when creating a vector index to choose the similarity function. Defaults to `COSINE` (the existing default). Other options are `DOT_PRODUCT` and `EUCLIDEAN`.
* An optimized vector type, `{"FLOAT32VECTOR": [1.0, 2.0, ..]}`, which is stored on disk efficiently as 32-bit floats, **not** a JSON.
* A Query VectorSearch option `ReturnScores` asking to return the similarity score calculated for each returned result (the results are sorted in decreasing similarity score - the highest similarity is the best and returned first).

