### PR TITLE
test: add Go to the toolchain required for Porcupine Scylla tests

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -72,6 +72,7 @@ debian_base_packages=(
 )
 
 fedora_packages=(
+    go
     clang
     clang-tools-extra
     compiler-rt


### PR DESCRIPTION
Add Go to the toolchain to enable Porcupine-based Scylla testing.

## Why

Porcupine requires Go and is used for linearizability checking in Scylla tests.

Compared to Knossos (used in Jepsen), Porcupine is much faster, which makes it a better fit for automated and repeated validation in our test environment.

It has also already found a bug (during https://github.com/scylladb/scylladb/pull/29085 implementation), so adding Go support provides immediate value.
https://scylladb.atlassian.net/browse/SCYLLADB-1563

## Impact
This change affects the test environment only and does not modify runtime behavior.