### PR TITLE
strong_consistency: forward reads to the raft leader

### DIFF
--- a/cql3/statements/strong_consistency/select_statement.cc
+++ b/cql3/statements/strong_consistency/select_statement.cc
@@ -18,9 +18,15 @@ namespace cql3::statements::strong_consistency {
 
 using result_message = cql_transport::messages::result_message;
 
-static void validate_consistency_level(const db::consistency_level& cl) {
-    if (cl != db::consistency_level::QUORUM && cl != db::consistency_level::LOCAL_QUORUM &&
-        cl != db::consistency_level::ONE && cl != db::consistency_level::LOCAL_ONE) {
+static service::strong_consistency::read_type parse_consistency_level(const db::consistency_level& cl) {
+    switch (cl) {
+    case db::consistency_level::QUORUM:
+    case db::consistency_level::LOCAL_QUORUM:
+        return service::strong_consistency::read_type::linearizable;
+    case db::consistency_level::ONE:
+    case db::consistency_level::LOCAL_ONE:
+        return service::strong_consistency::read_type::non_linearizable;
+    default:
         throw exceptions::invalid_request_exception("Strongly consistent reads must use QUORUM/LOCAL_QUORUM or ONE/LOCAL_ONE consistency level");
     }
 }
@@ -29,7 +35,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
         service::query_state& state, 
         const query_options& options) const
 {
-    validate_consistency_level(options.get_consistency());
+    auto read_type = parse_consistency_level(options.get_consistency());
 
     const auto key_ranges = _restrictions->get_partition_key_ranges(options);
     if (key_ranges.size() != 1 || !query::is_single_partition(key_ranges[0])) {
@@ -52,7 +58,7 @@ future<::shared_ptr<result_message>> select_statement::do_execute(query_processo
     const auto timeout = db::timeout_clock::now() + get_timeout(state.get_client_state(), options);
     auto [coordinator, holder] = qp.acquire_strongly_consistent_coordinator();
     auto query_result = co_await coordinator.get().query(_query_schema, *read_command,
-        key_ranges, state.get_trace_state(), timeout, state.get_client_state().get_abort_source());
+        key_ranges, read_type, state.get_trace_state(), timeout, state.get_client_state().get_abort_source());
 
     using namespace service::strong_consistency;
     if (auto* redirect = get_if<need_redirect>(&query_result)) {

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -404,11 +404,34 @@ auto coordinator::query(schema_ptr schema,
     auto mark_read_latency = defer([this, &lc] { _stats.read.mark(lc.stop().latency()); });
 
     try {
-        auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source(), false);
+        auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source(), rtype == read_type::linearizable);
         if (auto* redirect = get_if<need_redirect>(&op_result)) {
             co_return std::move(*redirect);
         }
         auto& op = get<operation_ctx>(op_result);
+
+        if (rtype == read_type::linearizable) {
+            // For linearizable reads we may need to forward to the raft leader.
+            while (true) {
+                auto disposition = op.raft_server.begin_read(aoe.abort_source());
+                if (const auto* not_a_leader = get_if<raft::not_a_leader>(&disposition)) {
+                    const auto leader_host_id = locator::host_id{not_a_leader->leader.uuid()};
+                    const auto* target = find_replica(op.tablet_info, leader_host_id);
+                    if (!target) {
+                        on_internal_error(logger,
+                            ::format("query(): table {}.{}, tablet {}, current leader {} is not a replica, replicas {}",
+                                schema->ks_name(), schema->cf_name(), op.tablet_id, leader_host_id, op.tablet_info.replicas));
+                    }
+                    co_return need_redirect{*target};
+                }
+                if (auto* wait_for_leader = get_if<raft_server::need_wait_for_leader>(&disposition)) {
+                    co_await std::move(wait_for_leader->future);
+                    continue;
+                }
+                break;
+            }
+        }
+        // We're either a raft leader or it's a non-linearizable read. In both cases we can directly execute the read on this replica.
 
         co_await utils::get_local_injector().inject("sc_coordinator_wait_before_query_read_barrier",
             utils::wait_for_message(5min));
@@ -428,16 +451,17 @@ auto coordinator::query(schema_ptr schema,
         //     method was triggered.
         // * seastar::abort_requested_exception: Can be thrown by create_operation_ctx.
         // * timed_out_error: Can be thrown by the abort_on_expiry.
+        // * seastar::condition_variable_timed_out: Can be thrown by begin_read's wait_for_leader.
         //
         // We handle them collectively here.
         if (try_catch<raft::request_aborted>(ex) || try_catch<seastar::abort_requested_exception>(ex)
-                || try_catch<timed_out_error>(ex)) {
+                || try_catch<timed_out_error>(ex) || try_catch<seastar::condition_variable_timed_out>(ex)) {
             logger.trace("query(): request timed out with error {}, table {}.{}, read cmd {}",
                 ex, schema->ks_name(), schema->cf_name(), cmd);
             ++_stats.read_errors_timeout;
             co_return coroutine::return_exception(read_timeout(schema->ks_name(), schema->cf_name()));
         } else {
-            logger.trace("mutate(): unknown exception {}, table {}.{}, read cmd {}",
+            logger.trace("query(): unknown exception {}, table {}.{}, read cmd {}",
                 ex, schema->ks_name(), schema->cf_name(), cmd);
             ++_stats.read_errors_other;
             // We know nothing about other errors. Let the CQL server convert them to SERVER_ERROR.

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -447,10 +447,12 @@ auto coordinator::query(schema_ptr schema,
         }
         // We're either a raft leader or it's a non-linearizable read. In both cases we can directly execute the read on this replica.
 
-        co_await utils::get_local_injector().inject("sc_coordinator_wait_before_query_read_barrier",
-            utils::wait_for_message(5min));
+        if (rtype == read_type::linearizable) {
+            co_await utils::get_local_injector().inject("sc_coordinator_wait_before_query_read_barrier",
+                utils::wait_for_message(5min));
 
-        co_await op.raft_server.server().read_barrier(&aoe.abort_source());
+            co_await op.raft_server.server().read_barrier(&aoe.abort_source());
+        }
 
         auto [result, cache_temp] = co_await _db.query(schema, cmd,
             query::result_options::only_result(), ranges, trace_state, timeout);

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -390,6 +390,7 @@ future<value_or_redirect<>> coordinator::mutate(schema_ptr schema,
 auto coordinator::query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
+        read_type rtype,
         tracing::trace_state_ptr trace_state,
         timeout_clock::time_point timeout,
         abort_source& as

--- a/service/strong_consistency/coordinator.cc
+++ b/service/strong_consistency/coordinator.cc
@@ -52,6 +52,7 @@ struct read_timeout : public exceptions::read_timeout_exception {
 void stats::register_stats() {
     namespace sm = seastar::metrics;
     sm::label reason_label("reason");
+    sm::label read_type_label("read_type");
 
     _metrics.add_group("strong_consistency_coordinator", {
         sm::make_summary("write_latency_summary", sm::description("Strong consistency write latency summary"),
@@ -85,11 +86,22 @@ void stats::register_stats() {
             .set_skip_when_empty(),
 
         sm::make_summary("read_latency_summary", sm::description("Strong consistency read latency summary"),
-            [this] { return to_metrics_summary(read.summary()); }).set_skip_when_empty(),
+            [this] { return to_metrics_summary(linearizable_read.summary()); })(read_type_label("linearizable"))
+            .set_skip_when_empty(),
 
         sm::make_histogram("read_latency", sm::description("Strong consistency read latency histogram"),
-            {}, [this] { return to_metrics_histogram(read.histogram()); })
-            .aggregate({seastar::metrics::shard_label}).set_skip_when_empty(),
+            {}, [this] { return to_metrics_histogram(linearizable_read.histogram()); })
+            .aggregate({seastar::metrics::shard_label})(read_type_label("linearizable"))
+            .set_skip_when_empty(),
+
+        sm::make_summary("read_latency_summary", sm::description("Strong consistency read latency summary"),
+            [this] { return to_metrics_summary(non_linearizable_read.summary()); })(read_type_label("non_linearizable"))
+            .set_skip_when_empty(),
+
+        sm::make_histogram("read_latency", sm::description("Strong consistency read latency histogram"),
+            {}, [this] { return to_metrics_histogram(non_linearizable_read.histogram()); })
+            .aggregate({seastar::metrics::shard_label})(read_type_label("non_linearizable"))
+            .set_skip_when_empty(),
 
         sm::make_counter("read_errors", read_errors_timeout,
             sm::description("number of strong consistency read requests that failed"),
@@ -401,7 +413,9 @@ auto coordinator::query(schema_ptr schema,
 
     utils::latency_counter lc;
     lc.start();
-    auto mark_read_latency = defer([this, &lc] { _stats.read.mark(lc.stop().latency()); });
+    auto& read_stats = (rtype == read_type::linearizable)
+        ? _stats.linearizable_read : _stats.non_linearizable_read;
+    auto mark_read_latency = defer([&read_stats, &lc] () mutable { read_stats.mark(lc.stop().latency()); });
 
     try {
         auto op_result = co_await create_operation_ctx(*schema, ranges[0].start()->value().token(), aoe.abort_source(), rtype == read_type::linearizable);

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -53,7 +53,8 @@ struct stats {
     uint64_t write_node_bounces = 0;
     uint64_t write_shard_bounces = 0;
 
-    utils::timed_rate_moving_average_summary_and_histogram read;
+    utils::timed_rate_moving_average_summary_and_histogram linearizable_read;
+    utils::timed_rate_moving_average_summary_and_histogram non_linearizable_read;
     uint64_t read_errors_timeout = 0;
     uint64_t read_errors_other = 0;
     uint64_t read_node_bounces = 0;

--- a/service/strong_consistency/coordinator.hh
+++ b/service/strong_consistency/coordinator.hh
@@ -24,6 +24,20 @@ namespace service::strong_consistency {
 
 class groups_manager;
 
+// Classifies a strongly consistent read based on the CQL consistency level.
+//
+// linearizable: the read is forwarded to the raft leader, where read_barrier()
+//   is performed locally. This we we read the most up-to-date aplied data.
+//   Currently mapped from CL=QUORUM (the default).
+//
+// non_linearizable: the read is performed on the local replica without
+//   a read_barrier. Because of this, the read may return slightly stale data,
+//   so reads from different nodes may not be linearizable. Currently mapped from CL=ONE.
+enum class read_type {
+    linearizable,
+    non_linearizable,
+};
+
 struct need_redirect {
     locator::tablet_replica target;
     noncopyable_function<void(locator::host_id)> on_node_resolved;
@@ -81,6 +95,7 @@ public:
     future<query_result_type> query(schema_ptr schema,
         const query::read_command& cmd,
         const dht::partition_range_vector& ranges,
+        read_type rtype,
         tracing::trace_state_ptr trace_state,
         timeout_clock::time_point timeout,
         abort_source& as);

--- a/service/strong_consistency/groups_manager.cc
+++ b/service/strong_consistency/groups_manager.cc
@@ -89,6 +89,17 @@ auto raft_server::begin_mutate(abort_source& as) -> begin_mutate_result {
     return timestamp_with_term{new_ts, term};
 }
 
+auto raft_server::begin_read(abort_source& as) -> begin_read_result {
+    const auto leader = _state.server->current_leader();
+    if (!leader) {
+        return need_wait_for_leader{_state.server->wait_for_leader(&as)};
+    }
+    if (leader != _state.server->id()) {
+        return raft::not_a_leader{leader};
+    }
+    return ok{};
+}
+
 groups_manager::groups_manager(netw::messaging_service& ms, 
         raft_group_registry& raft_gr, cql3::query_processor& qp,
         replica::database& db, service::migration_manager& mm, db::system_keyspace& sys_ks, gms::feature_service& features,

--- a/service/strong_consistency/groups_manager.hh
+++ b/service/strong_consistency/groups_manager.hh
@@ -222,6 +222,14 @@ public:
     };
     using begin_mutate_result = std::variant<timestamp_with_term, raft::not_a_leader, need_wait_for_leader>;
     begin_mutate_result begin_mutate(abort_source&);
+
+    // Possible results:
+    //   ok - this node is the leader, proceed with read_barrier() locally
+    //   raft::not_a_leader - this node is not a leader, redirect to the leader
+    //   need_wait_for_leader - the leader is unknown, the caller needs to wait and retry
+    struct ok {};
+    using begin_read_result = std::variant<ok, raft::not_a_leader, need_wait_for_leader>;
+    begin_read_result begin_read(abort_source&);
 };
 
 }

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -16,6 +16,7 @@ from cassandra.policies import FallthroughRetryPolicy
 from cassandra.protocol import InvalidRequest
 from cassandra.query import SimpleStatement, BoundStatement
 from test.pylib.tablets import get_all_tablet_replicas, get_tablet_replicas
+from test.pylib.rest_client import read_barrier
 
 import asyncio
 import pytest
@@ -1466,3 +1467,100 @@ async def test_leader_cache_eliminates_redirect(manager: ManagerClient):
             rows = await cql.run_async(f"SELECT * FROM {table} WHERE pk = 25", host=non_replica_host)
             assert len(rows) == 1
             assert rows[0].value == 25
+
+@pytest.mark.asyncio
+async def test_read_forwarding(manager: ManagerClient):
+    """
+    Verify read forwarding behavior for strongly consistent tables:
+    - CL=QUORUM reads (linearizable) are forwarded to the raft leader
+    - CL=ONE reads (non-linearizable) work on any replica without forwarding
+    - Linearizability: a CL=QUORUM read after a write always sees the write
+    Use a 4-node cluster with RF=3 to have:
+    - a leader replica
+    - 2 follower replicas, one of which is not required for quorum
+    - a non-replica node
+    """
+
+    logger.info("Bootstrapping cluster")
+    servers = await manager.servers_add(4, config=DEFAULT_CONFIG, cmdline=DEFAULT_CMDLINE, auto_rack_dc='my_dc')
+    (cql, hosts) = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    def host_by_host_id(host_id):
+        for hid, host in zip(host_ids, hosts):
+            if hid == host_id:
+                return host
+        raise RuntimeError(f"Can't find host for host_id {host_id}")
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        async with new_test_table(manager, ks, "pk int PRIMARY KEY, c int") as table:
+            table_name = table.split('.')[-1]
+            group_id = await get_table_raft_group_id(manager, ks, table_name)
+
+            for server in servers:
+                try:
+                    leader_host_id = await wait_for_leader(manager, server, group_id)
+                    break
+                except:
+                    continue
+
+            leader_host = host_by_host_id(leader_host_id)
+
+            tablet_replicas = await get_tablet_replicas(manager, servers[0], ks, table_name, 0)
+            replica_host_ids = [replica[0] for replica in tablet_replicas]
+            non_leader_replica_host_id = [hid for hid in replica_host_ids if str(hid) != str(leader_host_id)][0]
+            non_leader_replica_host = host_by_host_id(non_leader_replica_host_id)
+            non_replica_host_id = [hid for hid in host_ids if str(hid) not in [str(r) for r in replica_host_ids]][0]
+            non_replica_host = host_by_host_id(non_replica_host_id)
+
+            async def get_metric(host, name, labels={}):
+                metrics = await manager.metrics.query(host.address)
+                return metrics.get(name, labels) or 0
+
+            async def check_read(cl, send_to, expect_fwd, read_type=None, sc_metric_host=None):
+                """Execute a read and verify forwarding behavior and coordinator metrics."""
+                label = f"CL={ConsistencyLevel.value_to_name[cl]} on {send_to.address}"
+                logger.info(f"Testing read: {label}")
+
+                stmt = SimpleStatement(f"SELECT * FROM {table} WHERE pk = 1", consistency_level=cl)
+
+                fwd_before = await get_metric(send_to, 'scylla_transport_requests_forwarded_successfully')
+                sc_before = await get_metric(sc_metric_host, f'scylla_strong_consistency_coordinator_read_latency_count', {'read_type': read_type}) if read_type else None
+
+                rows = await cql.run_async(stmt, host=send_to)
+                assert len(rows) == 1
+                assert rows[0].c == 100
+
+                fwd_after = await get_metric(send_to, 'scylla_transport_requests_forwarded_successfully')
+                if expect_fwd:
+                    assert fwd_after > fwd_before, f"{label}: expected forwarding"
+                else:
+                    assert fwd_after == fwd_before, f"{label}: unexpected forwarding"
+
+                if read_type:
+                    sc_after = await get_metric(sc_metric_host, f'scylla_strong_consistency_coordinator_read_latency_count', {'read_type': read_type})
+                    assert sc_after > sc_before, f"{label}: expected {read_type} scylla_strong_consistency_coordinator_read_latency_count to increment on {sc_metric_host.address}"
+
+            await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES (1, 100)", host=leader_host)
+
+            # CL=QUORUM: linearizable, forwarded to leader
+            await check_read(ConsistencyLevel.QUORUM, leader_host, expect_fwd=False,
+                             read_type='linearizable', sc_metric_host=leader_host)
+            await check_read(ConsistencyLevel.QUORUM, non_leader_replica_host, expect_fwd=True,
+                             read_type='linearizable', sc_metric_host=leader_host)
+            await check_read(ConsistencyLevel.QUORUM, non_replica_host, expect_fwd=True,
+                             read_type='linearizable', sc_metric_host=leader_host)
+
+            # CL=ONE: no forwarding, executed on the local replica
+            await read_barrier(manager.api, non_leader_replica_host.address, group_id=group_id, timeout=30)
+            await check_read(ConsistencyLevel.ONE, non_leader_replica_host, expect_fwd=False,
+                             read_type='non_linearizable', sc_metric_host=non_leader_replica_host)
+
+            # --- Linearizability: write then CL=QUORUM read from follower ---
+            logger.info("Testing linearizability: write + CL=QUORUM read from follower (10 iterations)")
+            for i in range(10):
+                await cql.run_async(f"INSERT INTO {table} (pk, c) VALUES ({100 + i}, {i * 10})")
+                read_stmt = SimpleStatement(f"SELECT * FROM {table} WHERE pk = {100 + i}", consistency_level=ConsistencyLevel.QUORUM)
+                rows = await cql.run_async(read_stmt, host=non_leader_replica_host)
+                assert len(rows) == 1, f"Expected 1 row for pk={100 + i}, got {len(rows)}"
+                assert rows[0].c == i * 10, f"Linearizability violation: pk={100 + i}, expected c={i * 10}, got c={rows[0].c}"

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -162,12 +162,12 @@ async def test_basic_write_read(manager: ManagerClient):
             leader_metrics_query = await manager.metrics.query(leader_host.address)
             leader_metrics = {
                 'scylla_strong_consistency_coordinator_write_latency_count': leader_metrics_query.get('scylla_strong_consistency_coordinator_write_latency_count') or 0,
-                'scylla_strong_consistency_coordinator_read_latency_count':  leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count') or 0,
+                'scylla_strong_consistency_coordinator_read_latency_count':  leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count', {'read_type': 'linearizable'}) or 0,
             }
             non_leader_metrics_query = await manager.metrics.query(non_leader_replica_host.address)
             non_leader_metrics = {
                 'scylla_strong_consistency_coordinator_write_node_bounces': non_leader_metrics_query.get('scylla_strong_consistency_coordinator_write_node_bounces') or 0,
-                'scylla_strong_consistency_coordinator_read_latency_count': non_leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count') or 0,
+                'scylla_strong_consistency_coordinator_read_latency_count': non_leader_metrics_query.get('scylla_strong_consistency_coordinator_read_latency_count', {'read_type': 'linearizable'}) or 0,
             }
             non_replica_metrics_query = await manager.metrics.query(non_replica_host.address)
             non_replica_metrics = {
@@ -216,7 +216,7 @@ async def test_basic_write_read(manager: ManagerClient):
         insert_stmt = cql.prepare(f"INSERT INTO {ks}.test (pk, c) VALUES (?, ?)")
         bound_insert_stmt = BoundStatement(insert_stmt)
         select_stmt = cql.prepare(f"SELECT * FROM {ks}.test WHERE pk = ?")
-        bound_select_stmt = BoundStatement(select_stmt, consistency_level=ConsistencyLevel.ONE)
+        bound_select_stmt = BoundStatement(select_stmt, consistency_level=ConsistencyLevel.QUORUM)
         bound_select_stmt.bind([10])
 
         logger.info(f"Run prepared INSERT statement on leader {leader_host}")


### PR DESCRIPTION
Strongly consistent reads currently call read_barrier() on whichever
replica happens to process the request. When a follower runs
read_barrier(), it sends an RPC to the leader to get the current read
index, then waits for its local apply index to catch up. If the follower
is behind, this wait can be significant.

By forwarding linearizable reads to the leader, we don't need an RPC from replica to leader to get the index to wait for apply -- it's available locally.

Note that read_barrier() is still required on the leader to confirm it
is still the leader and guarantee linearizability. A future optimization
would be to implement leases in the raft library, which could eliminate
read_barrier() on the leader entirely.

The CL-to-behavior mapping is isolated in a single parse_consistency_level()
function:
- CL=(LOCAL_)QUORUM -> linearizable: forwarded to the raft leader
- CL=(LOCAL_)ONE -> non-linearizable: existing behavior (no read_barrier()/forwarding, may return stale results)
- All other CLs -> invalid request

Read forwarding reuses the same CQL-layer bounce_to_node() mechanism
that write forwarding already uses. The transport layer's existing
requests_forwarded_* metrics automatically count forwarded reads.
Coordinator-level metrics (linearizable_reads, non_linearizable_reads,
writes) are added for visibility into the strong consistency workload.

Fixes: SCYLLADB-1157