### PR TITLE
load_balancer: fix tablet allocator dropped table

### DIFF
--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1698,10 +1698,14 @@ public:
         co_return std::move(plan);
     }
 
+    // Returns the schema and tablet-aware replication strategy for a given table.
+    // Returns {nullptr, nullptr} if the table has been dropped concurrently (race between
+    // the token metadata snapshot and the live schema).
     std::tuple<schema_ptr, const tablet_aware_replication_strategy*> get_schema_and_rs(table_id table) {
         auto t = _db.get_tables_metadata().get_table_if_exists(table);
         if (!t) {
-            on_internal_error(lblogger, format("Table {} does not exist", table));
+            lblogger.debug("Table {} no longer exists, skipping", table);
+            return {nullptr, nullptr};
         }
 
         auto s = t->schema();
@@ -1716,6 +1720,8 @@ public:
         return {s, rs};
     }
 
+    // Returns the tablet-aware replication strategy for a given table, or nullptr
+    // if the table has been dropped concurrently.
     const tablet_aware_replication_strategy* get_rs(table_id id) {
         auto [s, rs] = get_schema_and_rs(id);
         return rs;
@@ -1739,6 +1745,7 @@ public:
         sstring target_tablet_count_reason; // Winning rule for target_tablet_count value.
         std::optional<uint64_t> avg_tablet_size; // nullopt when stats not yet available.
         bool pow2_count; // Whether tablet count for the table should be a power of two.
+        bool tablet_merges_allowed; // Whether merges are allowed for the table.
 
         // Final tablet count.
         // It's target_tablet_count aligned to power of 2 if pow2_count == true.
@@ -1893,6 +1900,17 @@ public:
             table_plan.current_tablet_count = tablet_count;
             table_plan.pow2_count = tablet_options.pow2_count.value_or(
                     _db.features().arbitrary_tablet_boundaries ? db::tablet_options::default_pow2_count : true);
+            table_plan.tablet_merges_allowed = !s->tablet_merges_forbidden();
+            if (!table_plan.tablet_merges_allowed) {
+                // Block merge decisions for Alternator tablet tables whose
+                // stream configuration forbids merges. Tablet merges produce
+                // 2 parents per child which is incompatible with the DynamoDB
+                // Streams API. If a merge is already in progress on the tmap,
+                // suppressing new_resize_decision here causes the existing
+                // revocation logic in tables_being_resized to cancel the merge.
+                lblogger.debug("Table {} ({}.{}): suppressing new merge decision because tablet merges are forbidden",
+                            table, s->ks_name(), s->cf_name());
+            }
 
             rs_by_table[table] = rs;
 
@@ -2000,6 +2018,9 @@ public:
             }
             const auto& tmap = _tm->tablets().get_tablet_map(table);
             auto [s, rs] = get_schema_and_rs(table);
+            if (s == nullptr || rs == nullptr) {
+                continue;
+            }
             auto tablet_options = combine_tablet_options(
                     tables | std::views::transform([&] (table_id table) { return _db.get_tables_metadata().get_table_if_exists(table); })
                            | std::views::filter([] (auto t) { return t != nullptr; })
@@ -2132,7 +2153,7 @@ public:
             } else if (table_plan.target_tablet_count_aligned < table_plan.current_tablet_count) {
                 // Needed to avoid oscillations, because we reduce the count by a factor of 2.
                 // FIXME: Once we have a way to split individual tablets, we can achieve exactly the desired tablet count.
-                if (div_ceil(table_plan.current_tablet_count, 2) >= table_plan.target_tablet_count_aligned) {
+                if (table_plan.tablet_merges_allowed && div_ceil(table_plan.current_tablet_count, 2) >= table_plan.target_tablet_count_aligned) {
                     auto& tmap = _tm->tablets().get_tablet_map(table);
                     auto cur_decision = tmap.resize_decision();
                     if (cur_decision.is_merge()) {
@@ -2181,21 +2202,6 @@ public:
 
             resize_decision new_resize_decision;
             new_resize_decision.way = table_plan.resize_decision;
-
-            // Block merge decisions for Alternator tablet tables whose
-            // stream configuration forbids merges. Tablet merges produce
-            // 2 parents per child which is incompatible with the DynamoDB
-            // Streams API. If a merge is already in progress on the tmap,
-            // suppressing new_resize_decision here causes the existing
-            // revocation logic in tables_being_resized to cancel the merge.
-            if (new_resize_decision.is_merge()) {
-                auto [s, rs] = get_schema_and_rs(table);
-                if (s->tablet_merges_forbidden()) {
-                    lblogger.debug("Table {} ({}.{}): suppressing new merge decision because tablet merges are forbidden",
-                                   table, s->ks_name(), s->cf_name());
-                    new_resize_decision = {};
-                }
-            }
 
             table_size_desc size_desc {
                 .avg_tablet_size = *table_plan.avg_tablet_size,
@@ -2857,6 +2863,10 @@ public:
         std::unordered_map<sstring, int> rack_load;
 
         auto rs = get_rs(tablet.table);
+        if (rs == nullptr) {
+            // Table was dropped concurrently. Skip this tablet.
+            return skip_info{};
+        }
 
         auto get_viable_targets = [&] () {
             std::unordered_set<host_id> viable_targets;

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -6876,4 +6876,61 @@ SEASTAR_THREAD_TEST_CASE(test_tablet_options_min_and_max_tablet_count) {
     }, cfg).get();
 }
 
+SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_dropped_table) {
+    // Verifies that balance_tablets() gracefully handles a table that exists
+    // in the token metadata snapshot but has been dropped from the live schema.
+    // This simulates the race where a DROP TABLE is applied between yield
+    // points during load balancer planning.
+    do_with_cql_env_thread([] (auto& e) {
+        topology_builder topo(e);
+
+        unsigned shard_count = 2;
+        auto host1 = topo.add_node(node_state::normal, shard_count);
+        auto host2 = topo.add_node(node_state::normal, shard_count);
+        auto host3 = topo.add_node(node_state::normal, shard_count);
+
+        auto ks_name = add_keyspace(e, {{topo.dc(), 1}}, 4);
+        auto table1 = add_table(e, ks_name).get();
+
+        mutate_tablets(e, [&] (tablet_metadata& tmeta) -> future<> {
+            tablet_map tmap(4);
+            auto tid = tmap.first_tablet();
+            tmap.set_tablet(tid, tablet_info{tablet_replica_set{tablet_replica{host1, 0}}});
+            tid = *tmap.next_tablet(tid);
+            tmap.set_tablet(tid, tablet_info{tablet_replica_set{tablet_replica{host1, 1}}});
+            tid = *tmap.next_tablet(tid);
+            tmap.set_tablet(tid, tablet_info{tablet_replica_set{tablet_replica{host2, 0}}});
+            tid = *tmap.next_tablet(tid);
+            tmap.set_tablet(tid, tablet_info{tablet_replica_set{tablet_replica{host2, 1}}});
+            tmeta.set_tablet_map(table1, std::move(tmap));
+            co_return;
+        });
+
+        auto& stm = e.shared_token_metadata().local();
+
+        shared_load_stats& load_stats = topo.get_shared_load_stats();
+        load_stats.set_default_tablet_sizes(stm.get());
+
+        // Capture the token metadata snapshot while the table still exists.
+        auto stale_tm = stm.get();
+
+        // Drop the table from the live schema. The stale snapshot still has
+        // the table's tablet map, simulating the race condition.
+        e.execute_cql(fmt::format("DROP TABLE \"{}\".\"{}\"", ks_name, table1.to_sstring())).get();
+
+        // balance_tablets should handle the stale table gracefully without
+        // throwing or aborting.
+        auto& talloc = e.get_tablet_allocator().local();
+        auto& topology = e.get_topology_state_machine().local()._topology;
+        auto& sys_ks = e.get_system_keyspace().local();
+        auto plan = talloc.balance_tablets(stale_tm, &topology, &sys_ks,
+                                           load_stats.get(), {}).get();
+
+        // No migrations should reference the dropped table.
+        for (auto& mig : plan.migrations()) {
+            BOOST_REQUIRE_NE(mig.tablet.table, table1);
+        }
+    }).get();
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

- Handle dropped tables gracefully in the tablet load balancer's `get_schema_and_rs()` instead of aborting with `on_internal_error`
- The load balancer operates on a token metadata snapshot but accesses the live schema for table lookups. A DROP TABLE applied by another fiber between coroutine yield points can remove a table from the live schema while it still exists in the snapshot, causing an abort.

## Changes

`get_schema_and_rs()` now returns `std::optional` and logs a warning in debug log level instead of aborting when a table is missing. All callers skip dropped tables:
- `make_sizing_plan`: skips to next table
- `make_resize_plan`: skips to next table (merge suppression is moot)
- `check_constraints`: returns `skip_info{}` with empty viable targets
- `get_rs`: returns `nullptr`, checked by `check_constraints`

## Race Condition

The call chain is: `make_plan` → `make_internode_plan` → `check_constraints` → `get_rs` → `get_schema_and_rs`. The `make_internode_plan` coroutine has multiple `co_await` yield points (`maybe_yield`, `pick_candidate`) between building the candidate tablet list and checking replication constraints. A DROP TABLE schema mutation applied during any of these yields removes the table from `_db.get_tables_metadata()` while the candidate list still references it.

## Testing

Added `test_load_balancing_with_dropped_table` which simulates the race by capturing a token metadata snapshot, dropping the table, then calling `balance_tablets` with the stale snapshot.

Fixes: SCYLLADB-1664

This fix needs to be backported to versions: 2025.4, 2026.1