### PR TITLE
transport/cql: cache SUPPORTED response body and skip compressing small responses

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1643,6 +1643,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Name the bind variable of an IN restriction \"IN(column)\" (if false, the operator is spelled in lowercase, \"in(column)\").")
     , max_relations_in_where_clause(this, "max_relations_in_where_clause", liveness::LiveUpdate, value_status::Used, 100,
             "Maximum number of relations allowed in a WHERE clause. Queries with too many relations can cause quadratic complexity.")
+    , cql_response_compression_threshold_in_bytes(this, "cql_response_compression_threshold_in_bytes", liveness::LiveUpdate, value_status::Used, 1024,
+            "CQL responses with a body smaller than this are sent uncompressed, even on connections that negotiated compression; compressing small bodies costs CPU and saves few or no bytes. 0 compresses all responses.")
     , select_internal_page_size(this, "select_internal_page_size", liveness::LiveUpdate, value_status::Used, 10000,
             "SELECT statements with aggregation or GROUP BYs or a secondary index may use this page size for their internal reading data, not the page size specified in the query options.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1611,6 +1611,8 @@ db::config::config(std::shared_ptr<db::extensions> exts)
             "Name the bind variable of an IN restriction \"IN(column)\" (if false, the operator is spelled in lowercase, \"in(column)\").")
     , max_relations_in_where_clause(this, "max_relations_in_where_clause", liveness::LiveUpdate, value_status::Used, 100,
             "Maximum number of relations allowed in a WHERE clause. Queries with too many relations can cause quadratic complexity.")
+    , cql_response_compression_threshold_in_bytes(this, "cql_response_compression_threshold_in_bytes", liveness::LiveUpdate, value_status::Used, 1024,
+            "CQL responses with a body smaller than this are sent uncompressed, even on connections that negotiated compression; compressing small bodies costs CPU and saves few or no bytes. 0 compresses all responses.")
     , select_internal_page_size(this, "select_internal_page_size", liveness::LiveUpdate, value_status::Used, 10000,
             "SELECT statements with aggregation or GROUP BYs or a secondary index may use this page size for their internal reading data, not the page size specified in the query options.")
     , alternator_port(this, "alternator_port", value_status::Used, 0, "Alternator API port.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -511,6 +511,7 @@ public:
     named_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     named_value<bool> cql_in_bind_variable_name_uses_uppercase_operator;
     named_value<uint32_t> max_relations_in_where_clause;
+    named_value<uint32_t> cql_response_compression_threshold_in_bytes;
     named_value<uint32_t> select_internal_page_size;
 
     named_value<uint16_t> alternator_port;

--- a/db/config.hh
+++ b/db/config.hh
@@ -513,6 +513,7 @@ public:
     named_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     named_value<bool> cql_in_bind_variable_name_uses_uppercase_operator;
     named_value<uint32_t> max_relations_in_where_clause;
+    named_value<uint32_t> cql_response_compression_threshold_in_bytes;
     named_value<uint32_t> select_internal_page_size;
 
     named_value<uint16_t> alternator_port;

--- a/test/boost/transport_test.cc
+++ b/test/boost/transport_test.cc
@@ -34,6 +34,13 @@ bool operator==(const cql3::raw_value_view& a, const cql3::raw_value_view& b) {
 
 } // namespace cql3
 
+static memory_data_sink_buffers write_message_to_buffers(cql_transport::response& res, uint8_t version, cql_transport::cql_compression compression, size_t compression_threshold) {
+    memory_data_sink_buffers buffers;
+    output_stream<char> out(data_sink(std::make_unique<memory_data_sink>(buffers)));
+    res.write_message(out, version, compression, compression_threshold, deleter()).get();
+    return buffers;
+}
+
 SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     auto stream_id = tests::random::get_int<int16_t>();
     auto opcode = tests::random::get_int<uint8_t>(uint8_t(cql_transport::cql_binary_opcode::AUTH_SUCCESS));
@@ -93,11 +100,7 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     res.serialize({sc::change_type::CREATED, sc::target_type::FUNCTION, "foo", "bar", "zed"}, version);
     res.serialize({sc::change_type::CREATED, sc::target_type::AGGREGATE, "foo", "bar", "zed"}, version);
 
-    memory_data_sink_buffers buffers;
-    {
-        output_stream<char> out(data_sink(std::make_unique<memory_data_sink>(buffers)));
-        res.write_message(out, version, cql_transport::cql_compression::none, deleter()).get();
-    }
+    auto buffers = write_message_to_buffers(res, version, cql_transport::cql_compression::none, 0);
     auto total_length = buffers.size();
     auto fbufs = fragmented_temporary_buffer(buffers.buffers() | std::views::as_rvalue | std::ranges::to<std::vector>(), total_length);
 
@@ -166,6 +169,52 @@ SEASTAR_THREAD_TEST_CASE(test_response_request_reader) {
     BOOST_CHECK_EQUAL(req.read_string().value(), "zed");
 }
 
+// Reflects the response as written to the wire: (frame flags, frame body).
+static std::pair<uint8_t, bytes> write_response_frame(cql_transport::response& res, cql_transport::cql_compression compression, size_t compression_threshold) {
+    auto buffers = write_message_to_buffers(res, 4, compression, compression_threshold);
+    bytes frame(bytes::initialized_later(), buffers.size());
+    size_t off = 0;
+    for (auto& buf : buffers.buffers()) {
+        std::copy_n(buf.get(), buf.size(), reinterpret_cast<char*>(frame.data()) + off);
+        off += buf.size();
+    }
+    BOOST_REQUIRE_GE(frame.size(), 9);
+    return {uint8_t(frame[1]), frame.substr(9)};
+}
+
+static cql_transport::response make_response_with_body(size_t size) {
+    auto res = cql_transport::response(0, cql_transport::cql_binary_opcode::RESULT, tracing::trace_state_ptr());
+    for (size_t i = 0; i < size / 8; ++i) {
+        res.write_long(0x0101010101010101);
+    }
+    return res;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_response_compression_threshold) {
+    constexpr size_t threshold = 1024;
+    constexpr uint8_t compression_flag = 0x01;
+
+    // Body below the threshold: sent uncompressed, no compression flag.
+    auto small = make_response_with_body(512);
+    auto [flags, body] = write_response_frame(small, cql_transport::cql_compression::lz4, threshold);
+    BOOST_CHECK(!(flags & compression_flag));
+    BOOST_CHECK_EQUAL(body.size(), 512);
+
+    // Body at/above the threshold: compressed, flag set, 4-byte length prefix.
+    auto large = make_response_with_body(2048);
+    std::tie(flags, body) = write_response_frame(large, cql_transport::cql_compression::lz4, threshold);
+    BOOST_CHECK(flags & compression_flag);
+    BOOST_REQUIRE_GE(body.size(), 4);
+    uint32_t uncompressed_len = (uint8_t(body[0]) << 24) | (uint8_t(body[1]) << 16) | (uint8_t(body[2]) << 8) | uint8_t(body[3]);
+    BOOST_CHECK_EQUAL(uncompressed_len, 2048);
+    BOOST_CHECK_LT(body.size(), 2048); // repetitive content must shrink
+
+    // Threshold 0 compresses everything.
+    auto small2 = make_response_with_body(512);
+    std::tie(flags, body) = write_response_frame(small2, cql_transport::cql_compression::lz4, 0);
+    BOOST_CHECK(flags & compression_flag);
+}
+
 SEASTAR_THREAD_TEST_CASE(test_response_metadata_changed_for_empty_request_metadata_id) {
     auto col = make_lw_shared<cql3::column_specification>(
             "ks", "cf", ::make_shared<cql3::column_identifier>("v", true), utf8_type);
@@ -181,11 +230,7 @@ SEASTAR_THREAD_TEST_CASE(test_response_metadata_changed_for_empty_request_metada
             cql3::cql_metadata_id_type(bytes_view(dummy_request_bytes)),
             cql3::cql_metadata_id_type(bytes_view(expected_metadata_id))), true);
 
-    memory_data_sink_buffers buffers;
-    {
-        output_stream<char> out(data_sink(std::make_unique<memory_data_sink>(buffers)));
-        res.write_message(out, 4, cql_transport::cql_compression::none, deleter()).get();
-    }
+    auto buffers = write_message_to_buffers(res, 4, cql_transport::cql_compression::none, 0);
     auto total_length = buffers.size();
     auto fbufs = fragmented_temporary_buffer(buffers.buffers() | std::views::as_rvalue | std::ranges::to<std::vector>(), total_length);
 

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -267,6 +267,7 @@ future<> controller::do_start_server() {
               .max_concurrent_requests = cfg.max_concurrent_requests_per_shard,
               .cql_duplicate_bind_variable_names_refer_to_same_variable = cfg.cql_duplicate_bind_variable_names_refer_to_same_variable,
               .max_relations_in_where_clause = cfg.max_relations_in_where_clause,
+              .response_compression_threshold = cfg.cql_response_compression_threshold_in_bytes,
               .cql_in_bind_variable_name_uses_uppercase_operator = cfg.cql_in_bind_variable_name_uses_uppercase_operator,
               .uninitialized_connections_semaphore_cpu_concurrency = cfg.uninitialized_connections_semaphore_cpu_concurrency,
               .request_timeout_on_shutdown_in_seconds = cfg.request_timeout_on_shutdown_in_seconds

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -82,6 +82,7 @@ public:
     void write_consistency(db::consistency_level c);
     void write_string_map(std::map<sstring, sstring> string_map);
     void write_string_multimap(std::multimap<sstring, sstring> string_map);
+    void append_body(const bytes_ostream& body);
     void write_string_bytes_map(const std::unordered_map<sstring, bytes>& map);
     void write_value(bytes_opt value);
     void write_value(std::optional<managed_bytes_view> value);

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -89,7 +89,7 @@ public:
     void write(const cql3::metadata& m, const cql_metadata_id_wrapper& request_metadata_id, bool no_metadata = false);
     void write(const cql3::prepared_metadata& m, uint8_t version);
 
-    future<> write_message(output_stream<char>& out, uint8_t version, cql_compression compression, seastar::deleter);
+    future<> write_message(output_stream<char>& out, uint8_t version, cql_compression compression, size_t compression_threshold, seastar::deleter);
 
     cql_binary_opcode opcode() const {
         return _opcode;

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2327,12 +2327,13 @@ void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_serv
     _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response)] () mutable {
         cql_server::response& r = *response;
         auto del = make_deleter([response = std::move(response)] {});
-        return r.write_message(_write_buf, _version, compression, std::move(del));
+        return r.write_message(_write_buf, _version, compression, _server._config.response_compression_threshold(), std::move(del));
     });
 }
 
-future<> cql_server::response::write_message(output_stream<char>& out, uint8_t version, cql_compression compression, seastar::deleter del) {
-    if (compression != cql_compression::none) {
+future<> cql_server::response::write_message(output_stream<char>& out, uint8_t version, cql_compression compression, size_t compression_threshold, seastar::deleter del) {
+    // Bodies below the threshold are too small to benefit from compression.
+    if (compression != cql_compression::none && _body.size() >= compression_threshold) {
         compress(compression);
     }
     utils::result_with_exception_ptr<temporary_buffer<char>> frame = make_frame(version, _body.size());

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -340,6 +340,8 @@ cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_s
     , _stats_key(stats_key)
     , _used_by_maintenance_socket(used_by_maintenance_socket)
 {
+    build_supported_body();
+
     namespace sm = seastar::metrics;
 
     if (used_by_maintenance_socket) {
@@ -971,9 +973,9 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
     }
 }
 
-cql_protocol_extension_enum_set cql_server::connection::supported_cql_protocol_extensions() const {
+cql_protocol_extension_enum_set cql_server::supported_cql_protocol_extensions() const {
     auto exts = cql_protocol_extension_enum_set::full();
-    const bool strongly_consistent_tables = _server._query_processor.local().db().get_config().check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES);
+    const bool strongly_consistent_tables = _query_processor.local().db().get_config().check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES);
     if (!strongly_consistent_tables) {
         exts.remove(cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
     }
@@ -1472,7 +1474,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
     co_await _client_state.set_client_options(_server._connection_options_keys_and_values, options);
 
     cql_protocol_extension_enum_set cql_proto_exts;
-    for (cql_protocol_extension ext : supported_cql_protocol_extensions()) {
+    for (cql_protocol_extension ext : _server._supported_protocol_extensions) {
         if (options.contains(protocol_extension_name(ext))) {
             cql_proto_exts.set(ext);
         }
@@ -2263,8 +2265,10 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_auth_challeng
     return response;
 }
 
-std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int16_t stream, const tracing::trace_state_ptr& tr_state) const
+// Cache the serialized SUPPORTED body; all values are constant per-shard.
+void cql_server::build_supported_body()
 {
+    _supported_protocol_extensions = supported_cql_protocol_extensions();
     std::multimap<sstring, sstring> opts;
     opts.insert({"CQL_VERSION", cql3::query_processor::CQL_VERSION});
     opts.insert({"COMPRESSION", "lz4"});
@@ -2273,21 +2277,25 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
     // e.g. CQL driver configuration.
     opts.insert({"CLIENT_OPTIONS", ""});
     // Let drivers identify the connected node without an extra system.local query.
-    opts.insert({"SCYLLA_HOST_ID", _server._gossiper.my_host_id().to_sstring()});
-    if (_server._config.allow_shard_aware_drivers) {
+    const auto host_id = _gossiper.my_host_id();
+    if (!host_id) {
+        on_internal_error(clogger, "building SUPPORTED body before the host id is set");
+    }
+    opts.insert({"SCYLLA_HOST_ID", host_id.to_sstring()});
+    if (_config.allow_shard_aware_drivers) {
         opts.insert({"SCYLLA_SHARD", format("{:d}", this_shard_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", this_smp_shard_count())});
         opts.insert({"SCYLLA_SHARDING_ALGORITHM", dht::cpu_sharding_algorithm_name()});
-        if (_server._config.shard_aware_transport_port) {
-            opts.insert({"SCYLLA_SHARD_AWARE_PORT", format("{:d}", *_server._config.shard_aware_transport_port)});
+        if (_config.shard_aware_transport_port) {
+            opts.insert({"SCYLLA_SHARD_AWARE_PORT", format("{:d}", *_config.shard_aware_transport_port)});
         }
-        if (_server._config.shard_aware_transport_port_ssl) {
-            opts.insert({"SCYLLA_SHARD_AWARE_PORT_SSL", format("{:d}", *_server._config.shard_aware_transport_port_ssl)});
+        if (_config.shard_aware_transport_port_ssl) {
+            opts.insert({"SCYLLA_SHARD_AWARE_PORT_SSL", format("{:d}", *_config.shard_aware_transport_port_ssl)});
         }
-        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _server._config.sharding_ignore_msb)});
-        opts.insert({"SCYLLA_PARTITIONER", _server._config.partitioner_name});
+        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _config.sharding_ignore_msb)});
+        opts.insert({"SCYLLA_PARTITIONER", _config.partitioner_name});
     }
-    for (cql_protocol_extension ext : supported_cql_protocol_extensions()) {
+    for (cql_protocol_extension ext : _supported_protocol_extensions) {
         const sstring ext_key_name = protocol_extension_name(ext);
         std::vector<sstring> params = additional_options_for_proto_ext(ext);
         if (params.empty()) {
@@ -2298,8 +2306,17 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
             }
         }
     }
+    // Serialize into a temporary response and keep the body as bytes_ostream
+    cql_server::response tmp(0, cql_binary_opcode::SUPPORTED, tracing::trace_state_ptr());
+    tmp.write_string_multimap(std::move(opts));
+    _supported_body = std::move(tmp).extract_body();
+    _supported_body.linearize(); // single fragment: per-request copies allocate once
+}
+
+std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int16_t stream, const tracing::trace_state_ptr& tr_state) const
+{
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::SUPPORTED, tr_state);
-    response->write_string_multimap(std::move(opts));
+    response->append_body(_server._supported_body);
     return response;
 }
 
@@ -2667,6 +2684,11 @@ void cql_server::response::write_string_multimap(std::multimap<sstring, sstring>
         write_string(key);
         write_string_list(values);
     }
+}
+
+void cql_server::response::append_body(const bytes_ostream& body)
+{
+    _body.append(body);
 }
 
 void cql_server::response::write_string_bytes_map(const std::unordered_map<sstring, bytes>& map)

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -2456,12 +2456,13 @@ void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_serv
     _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response)] () mutable {
         cql_server::response& r = *response;
         auto del = make_deleter([response = std::move(response)] {});
-        return r.write_message(_write_buf, _version, compression, std::move(del));
+        return r.write_message(_write_buf, _version, compression, _server._config.response_compression_threshold(), std::move(del));
     });
 }
 
-future<> cql_server::response::write_message(output_stream<char>& out, uint8_t version, cql_compression compression, seastar::deleter del) {
-    if (compression != cql_compression::none) {
+future<> cql_server::response::write_message(output_stream<char>& out, uint8_t version, cql_compression compression, size_t compression_threshold, seastar::deleter del) {
+    // Bodies below the threshold are too small to benefit from compression.
+    if (compression != cql_compression::none && _body.size() >= compression_threshold) {
         compress(compression);
     }
     utils::result_with_exception_ptr<temporary_buffer<char>> frame = make_frame(version, _body.size());

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -339,6 +339,8 @@ cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_s
     , _stats_key(stats_key)
     , _used_by_maintenance_socket(used_by_maintenance_socket)
 {
+    build_supported_body();
+
     namespace sm = seastar::metrics;
 
     if (used_by_maintenance_socket) {
@@ -970,9 +972,9 @@ std::unique_ptr<cql_server::response> cql_server::handle_exception(int16_t strea
     }
 }
 
-cql_protocol_extension_enum_set cql_server::connection::supported_cql_protocol_extensions() const {
+cql_protocol_extension_enum_set cql_server::supported_cql_protocol_extensions() const {
     auto exts = cql_protocol_extension_enum_set::full();
-    const bool strongly_consistent_tables = _server._query_processor.local().db().get_config().check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES);
+    const bool strongly_consistent_tables = _query_processor.local().db().get_config().check_experimental(db::experimental_features_t::feature::STRONGLY_CONSISTENT_TABLES);
     if (!strongly_consistent_tables) {
         exts.remove(cql_protocol_extension::TABLETS_ROUTING_V2_EXPERIMENTAL);
     }
@@ -1471,7 +1473,7 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_st
     co_await _client_state.set_client_options(_server._connection_options_keys_and_values, options);
 
     cql_protocol_extension_enum_set cql_proto_exts;
-    for (cql_protocol_extension ext : supported_cql_protocol_extensions()) {
+    for (cql_protocol_extension ext : _server._supported_protocol_extensions) {
         if (options.contains(protocol_extension_name(ext))) {
             cql_proto_exts.set(ext);
         }
@@ -2134,8 +2136,10 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_auth_challeng
     return response;
 }
 
-std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int16_t stream, const tracing::trace_state_ptr& tr_state) const
+// Cache the serialized SUPPORTED body; all values are constant per-shard.
+void cql_server::build_supported_body()
 {
+    _supported_protocol_extensions = supported_cql_protocol_extensions();
     std::multimap<sstring, sstring> opts;
     opts.insert({"CQL_VERSION", cql3::query_processor::CQL_VERSION});
     opts.insert({"COMPRESSION", "lz4"});
@@ -2144,21 +2148,25 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
     // e.g. CQL driver configuration.
     opts.insert({"CLIENT_OPTIONS", ""});
     // Let drivers identify the connected node without an extra system.local query.
-    opts.insert({"SCYLLA_HOST_ID", _server._gossiper.my_host_id().to_sstring()});
-    if (_server._config.allow_shard_aware_drivers) {
+    const auto host_id = _gossiper.my_host_id();
+    if (!host_id) {
+        on_internal_error(clogger, "building SUPPORTED body before the host id is set");
+    }
+    opts.insert({"SCYLLA_HOST_ID", host_id.to_sstring()});
+    if (_config.allow_shard_aware_drivers) {
         opts.insert({"SCYLLA_SHARD", format("{:d}", this_shard_id())});
         opts.insert({"SCYLLA_NR_SHARDS", format("{:d}", this_smp_shard_count())});
         opts.insert({"SCYLLA_SHARDING_ALGORITHM", dht::cpu_sharding_algorithm_name()});
-        if (_server._config.shard_aware_transport_port) {
-            opts.insert({"SCYLLA_SHARD_AWARE_PORT", format("{:d}", *_server._config.shard_aware_transport_port)});
+        if (_config.shard_aware_transport_port) {
+            opts.insert({"SCYLLA_SHARD_AWARE_PORT", format("{:d}", *_config.shard_aware_transport_port)});
         }
-        if (_server._config.shard_aware_transport_port_ssl) {
-            opts.insert({"SCYLLA_SHARD_AWARE_PORT_SSL", format("{:d}", *_server._config.shard_aware_transport_port_ssl)});
+        if (_config.shard_aware_transport_port_ssl) {
+            opts.insert({"SCYLLA_SHARD_AWARE_PORT_SSL", format("{:d}", *_config.shard_aware_transport_port_ssl)});
         }
-        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _server._config.sharding_ignore_msb)});
-        opts.insert({"SCYLLA_PARTITIONER", _server._config.partitioner_name});
+        opts.insert({"SCYLLA_SHARDING_IGNORE_MSB", format("{:d}", _config.sharding_ignore_msb)});
+        opts.insert({"SCYLLA_PARTITIONER", _config.partitioner_name});
     }
-    for (cql_protocol_extension ext : supported_cql_protocol_extensions()) {
+    for (cql_protocol_extension ext : _supported_protocol_extensions) {
         const sstring ext_key_name = protocol_extension_name(ext);
         std::vector<sstring> params = additional_options_for_proto_ext(ext);
         if (params.empty()) {
@@ -2169,8 +2177,17 @@ std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int
             }
         }
     }
+    // Serialize into a temporary response and keep the body as bytes_ostream
+    cql_server::response tmp(0, cql_binary_opcode::SUPPORTED, tracing::trace_state_ptr());
+    tmp.write_string_multimap(std::move(opts));
+    _supported_body = std::move(tmp).extract_body();
+    _supported_body.linearize(); // single fragment: per-request copies allocate once
+}
+
+std::unique_ptr<cql_server::response> cql_server::connection::make_supported(int16_t stream, const tracing::trace_state_ptr& tr_state) const
+{
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::SUPPORTED, tr_state);
-    response->write_string_multimap(std::move(opts));
+    response->append_body(_server._supported_body);
     return response;
 }
 
@@ -2538,6 +2555,11 @@ void cql_server::response::write_string_multimap(std::multimap<sstring, sstring>
         write_string(key);
         write_string_list(values);
     }
+}
+
+void cql_server::response::append_body(const bytes_ostream& body)
+{
+    _body.append(body);
 }
 
 void cql_server::response::write_string_bytes_map(const std::unordered_map<sstring, bytes>& map)

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -130,6 +130,7 @@ struct cql_server_config {
     utils::updateable_value<uint32_t> max_concurrent_requests;
     utils::updateable_value<bool> cql_duplicate_bind_variable_names_refer_to_same_variable;
     utils::updateable_value<uint32_t> max_relations_in_where_clause;
+    utils::updateable_value<uint32_t> response_compression_threshold;
     utils::updateable_value<bool> cql_in_bind_variable_name_uses_uppercase_operator;
     utils::updateable_value<uint32_t> uninitialized_connections_semaphore_cpu_concurrency;
     utils::updateable_value<uint32_t> request_timeout_on_shutdown_in_seconds;

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -24,6 +24,7 @@
 #include <boost/intrusive/list.hpp>
 #include <seastar/net/tls.hh>
 #include <seastar/core/metrics_registration.hh>
+#include "bytes_ostream.hh"
 #include "utils/fragmented_temporary_buffer.hh"
 #include "utils/result.hh"
 #include "service_permit.hh"
@@ -243,6 +244,8 @@ private:
     std::unique_ptr<event_notifier> _notifier;
 private:
     client_options_cache_type _connection_options_keys_and_values;
+    bytes_ostream _supported_body; // cached serialized body for SUPPORTED responses
+    cql_protocol_extension_enum_set _supported_protocol_extensions;
     transport_stats _stats;
     auth::service& _auth_service;
     qos::service_level_controller& _sl_controller;
@@ -283,6 +286,8 @@ public:
     future<std::vector<connection_service_level_params>> get_connections_service_level_params();
 private:
     class fmt_visitor;
+    void build_supported_body();
+    cql_protocol_extension_enum_set supported_cql_protocol_extensions() const;
     friend class connection;
     friend std::unique_ptr<cql_server::response> make_result(int16_t stream, messages::result_message& msg,
             const tracing::trace_state_ptr& tr_state, cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata);
@@ -346,7 +351,6 @@ private:
         service::client_state& get_client_state() { return _client_state; }
         scheduling_group get_scheduling_group() const { return _current_scheduling_group; }
     private:
-        cql_protocol_extension_enum_set supported_cql_protocol_extensions() const;
         friend class process_request_executor;
 
         future<foreign_ptr<std::unique_ptr<cql_server::response>>> process_request_one(fragmented_temporary_buffer::istream buf, uint8_t op, uint16_t stream, uint8_t flags, service::client_state& client_state, tracing_request_type tracing_request, service_permit permit, api::timestamp_type request_start_timestamp);


### PR DESCRIPTION
## Motivation

Reduce the needless overhead of repeatedly constructing the same SUPPORTED message on every OPTIONS request. The OPTIONS→SUPPORTED pair is used by drivers not only during connection establishment but also as a CQL-protocol-level keepalive: some clients (Python) send it on idle connections, GoCQL sends it every 30 seconds on every connection.

## Summary

### Commit 1: Cache SUPPORTED response body
- Serialize the SUPPORTED body once at `cql_server` construction (per shard) and reuse it on every OPTIONS request — all values are constant for the server's lifetime
- Eliminates per-request: ~15 multimap node allocations + sstring copies, 4-6 `format()` calls, and full `write_string_multimap` serialization; the per-request cost becomes 1 `make_unique<response>` + 1 copy of the ~530-byte cached body (linearized, so the copy allocates once)
- The supported protocol-extension set is likewise computed once, and `process_startup()` uses the same cached set the SUPPORTED body was built from, so the two can never diverge
- The host id is guarded with `on_internal_error` at cache-build time: it is set once before any `cql_server` is constructed and can never change, but the cache would silently serve a zero UUID forever if startup order ever changed
- With 10K shard-aware clients (33 connections each, 30s heartbeat), this eliminates ~275K-330K heap allocations/sec per node (~93% reduction) on a 32-shard node

### Commit 2: Don't compress responses smaller than a threshold
- Compressing small bodies saves neither packets nor meaningful bytes: the ~530-byte SUPPORTED body measures 532 → 473 (~11%) with lz4 — still a single TCP segment — and a small QUERY RESULT actually **grows** (47 → 49 bytes). It does cost a `compress()` call and its buffer allocations on every response
- The threshold is a live-updatable config option, `cql_response_compression_threshold_in_bytes` (default 1024, mirroring `alternator_response_compression_threshold_in_bytes`); `0` restores unconditional compression
- Sending an uncompressed frame on a compression-negotiated connection is legal: the protocol's compression flag is **per-frame**. Verified that all maintained drivers check the flag before decompressing: gocql, python, rust, java 3.x, java 4.x (which itself never compresses its own OPTIONS/STARTUP requests), C#, and the go native-protocol library used by cql-proxy and zdm-proxy; cpp-driver (and thus PHP) and Node.js do not implement CQL compression at all

Earlier revisions of this PR pre-compressed the cached body with lz4 instead; measurement showed lz4 achieves only ~11% on this body (mostly-unique short strings — UUID, partitioner name, option keys — where lz4 can only match repeated key prefixes), both sizes fit one TCP segment, and the always-uncompressed approach is simpler and extends the fast path to all connection types.

**Note for release notes:** this changes default wire behavior — after upgrade, responses with a body smaller than 1 KiB are sent uncompressed (with the per-frame compression flag clear) even on compression-negotiated connections. Set `cql_response_compression_threshold_in_bytes: 0` to restore unconditional compression.

## Testing
- New unit test (`test_response_compression_threshold`) covers both sides of the threshold and the `0` = always-compress contract
- `boost/transport_test`, `boost/generic_server_test`, `boost/cql_query_test`, `cqlpy/test_native_transport`: 154/154 pass
- Raw-protocol validation: heartbeat SUPPORTED on an lz4 connection arrives uncompressed and byte-identical to the pre-STARTUP one; a 64KB RESULT on the same connection still compresses (to ~15KB)
- Each commit builds standalone (bisect-safe)

No need to backport, benign improvement.

Fixes: https://github.com/scylladb/scylladb/issues/14386
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-Assisted: Yes, OpenCode/Opus 4.6 + Claude Code/Fable 5
