### PR TITLE
alternator: implement ProjectionType=KEYS_ONLY for GSI and LSI

### DIFF
--- a/alternator/executor.cc
+++ b/alternator/executor.cc
@@ -554,10 +554,12 @@ future<rjson::value> executor::fill_table_description(schema_ptr schema, table_s
                 rjson::add(view_entry, "IndexArn", generate_arn_for_index(*schema, index_name));
                 // Add index's KeySchema and collect types for AttributeDefinitions:
                 describe_key_schema(view_entry, *vptr, &key_attribute_types, db::get_tags_of_table(vptr));
-                // Add projection type
+                // Add projection type: KEYS_ONLY if the view has no ":attrs" column,
+                // ALL otherwise.
                 rjson::value projection = rjson::empty_object();
-                rjson::add(projection, "ProjectionType", "ALL");
-                // FIXME: we have to get ProjectionType from the schema when it is added
+                const bool is_keys_only = projection_is_keys_only(*vptr);
+                rjson::add(projection, "ProjectionType",
+                    rjson::from_string(is_keys_only ? std::string_view("KEYS_ONLY") : std::string_view("ALL")));
                 rjson::add(view_entry, "Projection", std::move(projection));
                 // Local secondary indexes are marked by an extra '!' sign occurring before the ':' delimiter
                 bool is_lsi = (delim_it > 1 && cf_name[delim_it-1] == '!');
@@ -837,6 +839,40 @@ static std::pair<std::string, std::string> parse_key_schema(const rjson::value& 
         range_key = v->GetString();
     }
     return {hash_key, range_key};
+}
+
+// Parse the "Projection" parameter of a GSI or LSI definition.
+// Returns true if ProjectionType=KEYS_ONLY, false if ProjectionType=ALL
+// (the default when Projection is absent). Throws ValidationException for
+// unsupported projection types (currently INCLUDE).
+static bool parse_projection_type(const rjson::value& index_def, std::string_view context) {
+    const rjson::value* projection = rjson::find(index_def, "Projection");
+    if (!projection) {
+        return false; // default is ALL
+    }
+    if (!projection->IsObject()) {
+        throw api_error::validation(fmt::format("{} Projection must be an object", context));
+    }
+    const rjson::value* projection_type = rjson::find(*projection, "ProjectionType");
+    if (!projection_type || !projection_type->IsString()) {
+        throw api_error::validation(fmt::format("{} Projection must have a ProjectionType string", context));
+    }
+    std::string_view type = rjson::to_string_view(*projection_type);
+    if (type == "KEYS_ONLY") {
+        if (rjson::find(*projection, "NonKeyAttributes")) {
+            throw api_error::validation(fmt::format("{} NonKeyAttributes is not allowed when ProjectionType is not INCLUDE", context));
+        }
+        return true;
+    } else if (type == "ALL") {
+        if (rjson::find(*projection, "NonKeyAttributes")) {
+            throw api_error::validation(fmt::format("{} NonKeyAttributes is not allowed when ProjectionType is not INCLUDE", context));
+        }
+        return false;
+    } else if (type == "INCLUDE") {
+        throw api_error::validation(fmt::format("{} ProjectionType=INCLUDE is not yet supported", context));
+    } else {
+        throw api_error::validation(fmt::format("{} Unknown ProjectionType '{}'. Allowed: KEYS_ONLY, ALL, INCLUDE", context, type));
+    }
 }
 
 arn_parts parse_arn(std::string_view arn, std::string_view arn_field_name, std::string_view type_name, std::string_view expected_postfix) {
@@ -1490,8 +1526,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             if (range_key.empty()) {
                 co_return api_error::validation("LocalSecondaryIndex requires that the base table have a range key");
             }
-            // FIXME: read and handle "Projection" parameter. This will
-            // require the MV code to copy just parts of the attrs map.
+            bool keys_only = parse_projection_type(l, "LocalSecondaryIndexes");
             schema_builder view_builder(this_smp_shard_count(), keyspace_name, vname);
             auto [view_hash_key, view_range_key] = parse_key_schema(l, "Local Secondary Index");
             if (view_hash_key != hash_key) {
@@ -1513,10 +1548,16 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             if (!range_key.empty() && view_range_key != range_key) {
                 add_column(view_builder, range_key, *attribute_definitions, column_kind::clustering_key);
             }
-            view_builder.with_column(bytes(executor::ATTRS_COLUMN_NAME), attrs_type(), column_kind::regular_column);
-            // Note above we don't need to add virtual columns, as all
-            // base columns were copied to view. TODO: reconsider the need
-            // for virtual columns when we support Projection.
+            // NOTE: If keys_only, the ":attrs" column from the base is not
+            // copied into the view. In CQL, this would mean that we may need
+            // to add a "virtual column" in this case. But in Alternator, we
+            // don't - in Alternator every write writes a new CQL row marker,
+            // you can't delete an item by deleting its last attribute (see
+            // test_item.py::test_empty_update_delete), so virtual columns
+            // are not needed.
+            if (!keys_only) {
+                view_builder.with_column(bytes(executor::ATTRS_COLUMN_NAME), attrs_type(), column_kind::regular_column);
+            }
             // LSIs have no tags, but Scylla's "synchronous_updates" feature
             // (which an LSIs need), is actually implemented as a tag so we
             // need to add it here:
@@ -1543,8 +1584,7 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             }
             std::string vname(view_name(table_name, index_name));
             elogger.trace("Adding GSI {}", index_name);
-            // FIXME: read and handle "Projection" parameter. This will
-            // require the MV code to copy just parts of the attrs map.
+            bool keys_only = parse_projection_type(g, "GlobalSecondaryIndexes");
             schema_builder view_builder(this_smp_shard_count(), keyspace_name, vname);
             auto [view_hash_key, view_range_key] = parse_key_schema(g, "GlobalSecondaryIndexes");
 
@@ -1578,6 +1618,10 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
             if (!range_key.empty() && range_key != view_hash_key && range_key != view_range_key) {
                 add_column(view_builder, range_key, *attribute_definitions, column_kind::clustering_key);
                 spurious_base_key_added_as_range_key = true;
+            }
+            // Unless KEYS_ONLY, the view needs to have the ":attrs" column.
+            if (!keys_only) {
+                view_builder.with_column(bytes(executor::ATTRS_COLUMN_NAME), attrs_type(), column_kind::regular_column);
             }
             std::map<sstring, sstring> tags;
             if (view_range_key.empty() && spurious_base_key_added_as_range_key) {
@@ -1723,15 +1767,25 @@ future<executor::request_return_type> executor::create_table_on_shard0(service::
 
     schema_ptr schema = builder.build();
     for (auto& view_builder : view_builders) {
-        // Note below we don't need to add virtual columns, as all
-        // base columns were copied to view. TODO: reconsider the need
-        // for virtual columns when we support Projection.
-        for (const column_definition& regular_cdef : schema->regular_columns()) {
-            if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
-                view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+        const bool keys_only = !view_builder.has_column(
+                cql3::column_identifier(sstring(executor::ATTRS_COLUMN_NAME), true));
+        // NOTE: as we explained in an earlier comment, when the projection is
+        // KEYS_ONLY and we don't copy some columns to the view (notably ":attrs"),
+        // we still don't need to add virtual columns to the view.
+        if (!keys_only) {
+            // For ALL projection, copy all regular columns from the base table to the view.
+            for (const column_definition& regular_cdef : schema->regular_columns()) {
+                if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
+                    view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+                }
             }
         }
-        const bool include_all_columns = true;
+        // The "include_all_columns" flag has no practical effect in
+        // Alternator and we could have really set it to anything. But it
+        // affects CQL's DESCRIBE MATERIALIZED VIEW (true produces "SELECT *",
+        // false produces a SELECT listing the view's explicit columns),
+        // as well as ALTER TABLE ... ADD COLUMN.
+        const bool include_all_columns = !keys_only;
         view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
     }
 
@@ -2185,8 +2239,7 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         }
 
                         elogger.trace("Adding GSI {}", index_name);
-                        // FIXME: read and handle "Projection" parameter. This will
-                        // require the MV code to copy just parts of the attrs map.
+                        bool keys_only = parse_projection_type(it->value, "GlobalSecondaryIndexUpdates");
                         schema_builder view_builder(this_smp_shard_count(), keyspace_name, vname);
                         auto [view_hash_key, view_range_key] = parse_key_schema(it->value, "GlobalSecondaryIndexUpdates");
                         // If an attribute is already a real column in the base
@@ -2227,15 +2280,24 @@ future<executor::request_return_type> executor::update_table(client_state& clien
                         }
                         // GSIs have no tags:
                         view_builder.add_extension(db::tags_extension::NAME, ::make_shared<db::tags_extension>());
-                        // Note below we don't need to add virtual columns, as all
-                        // base columns were copied to view. TODO: reconsider the need
-                        // for virtual columns when we support Projection.
-                        for (const column_definition& regular_cdef : schema->regular_columns()) {
-                            if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
-                                view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+                        // NOTE: as we explained in an earlier comment, when
+                        // keys_only and we don't copy some columns to the
+                        // view (notably ":attrs"), we still don't need to add
+                        // virtual columns to the view.
+                        if (!keys_only) {
+                            for (const column_definition& regular_cdef : schema->regular_columns()) {
+                                if (!view_builder.has_column(*cql3::to_identifier(regular_cdef))) {
+                                    view_builder.with_column(regular_cdef.name(), regular_cdef.type, column_kind::regular_column);
+                                }
                             }
                         }
-                        const bool include_all_columns = true;
+                        // The "include_all_columns" flag has no practical
+                        // effect in Alternator and we could have really set
+                        // it to anything. But it affects CQL's DESCRIBE
+                        // MATERIALIZED VIEW (true produces "SELECT *", false
+                        // produces a SELECT listing the view's explicit
+                        // columns), as well as ALTER TABLE ... ADD COLUMN.
+                        const bool include_all_columns = !keys_only;
                         view_builder.with_view_info(schema, include_all_columns, ""/*where clause*/);
                         new_views.emplace_back(view_builder.build());
                     } else if (op == "Delete") {

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -40,6 +40,7 @@
 #include "utils/overloaded_functor.hh"
 #include "utils/error_injection.hh"
 #include "vector_search/vector_store_client.hh"
+#include "view_info.hh"
 #include <seastar/core/abort_on_expiry.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -284,6 +285,20 @@ static select_type parse_select(const rjson::value& request, table_or_view_type 
         select));
 }
 
+// For a GSI with KEYS_ONLY projection, when SPECIFIC_ATTRIBUTES is requested
+// (via AttributesToGet or ProjectionExpression), validate that all the
+// requested attributes are key columns (i.e., are projected into the GSI).
+static void validate_gsi_keys_only_attrs(const schema& s, const attrs_to_get& specific_attrs) {
+    for (const auto& [attr, _] : specific_attrs) {
+        const column_definition* cdef = s.get_column_definition(to_bytes(attr));
+        if (!cdef || (!cdef->is_partition_key() && !cdef->is_clustering_key())) {
+            throw api_error::validation(
+                format("Attribute '{}' is not projected into the index. "
+                       "Use Select=ALL_PROJECTED_ATTRIBUTES or restrict the query to projected attributes.", attr));
+        }
+    }
+}
+
 // "filter" represents a condition that can be applied to individual items
 // read by a Query or Scan operation, to decide whether to keep the item.
 // A filter is constructed from a Query or Scan request. This uses the
@@ -308,6 +323,7 @@ public:
     enum class request_type { SCAN, QUERY };
     // Note that a filter does not store pointers to the query used to
     // construct it.
+    filter() = default;  // constructs an empty (pass-all) filter
     filter(parsed::expression_cache& parsed_expression_cache, const rjson::value& request, request_type rt,
             std::unordered_set<std::string>& used_attribute_names,
             std::unordered_set<std::string>& used_attribute_values);
@@ -414,6 +430,28 @@ void filter::for_filters_on(const noncopyable_function<void(std::string_view)>& 
             }
         }, *_imp);
     }
+}
+
+// For an index (GSI or LSI) with non-ALL projection, validate that all
+// attributes used by the filter are key columns projected into the index.
+// DynamoDB rejects filtering on non-projected attributes even for LSI
+// and Select=ALL_ATTRIBUTES, where filtering could have been allowed because
+// the entire items are read (from the base table) anyway.
+// FIXME: this implementation is for ProjectionType=KEYS_ONLY only; When we
+// implement ProjectionType=INCLUDE, we will need to implement a check for
+// it as well.
+static void validate_only_projected_attrs_in_filter(const schema& s, std::string_view index_name, const filter& f) {
+    if (!projection_is_keys_only(s)) {
+        return;
+    }
+    f.for_filters_on([&] (std::string_view attr) {
+        const column_definition* cdef = s.get_column_definition(to_bytes(attr));
+        if (!cdef || (!cdef->is_partition_key() && !cdef->is_clustering_key())) {
+            throw api_error::validation(
+                format("Secondary index {} does not project one or more filter attributes: {}",
+                       index_name, attr));
+        }
+    });
 }
 
 class describe_items_visitor {
@@ -609,6 +647,180 @@ static rjson::value encode_paging_state(const schema& schema, const service::pag
 // point for when to switch from a rapidjson array to a chunked_vector.
 static constexpr int max_items_for_rapidjson_array = 256;
 
+// do_query_lsi_with_base_fetch() handles the case of a Query on an LSI with
+// KEYS_ONLY projection when the user requested ALL_ATTRIBUTES or
+// SPECIFIC_ATTRIBUTES which includes non-projected attributes. Because the
+// LSI view does not contain the ":attrs" column, querying it directly would
+// only return key columns. The correct approach is:
+//   1. Query the LSI view to get results in LSI sort-key order.
+//   2. For each LSI result row, extract the base-table primary key (p, c).
+//   3. Do a point read on the base table to retrieve all attributes.
+// This preserves the LSI sort order while returning full item data.
+// FIXME: step 2 currently reads the base table one row at a time, which is
+// inefficient.
+static future<executor::request_return_type> do_query_lsi_with_base_fetch(
+        service::storage_proxy& proxy,
+        schema_ptr lsi_schema,
+        schema_ptr base_schema,
+        const rjson::value* exclusive_start_key,
+        dht::partition_range_vector partition_ranges,
+        std::vector<query::clustering_range> ck_bounds,
+        std::optional<attrs_to_get> attrs_to_get,
+        uint32_t limit,
+        db::consistency_level cl,
+        filter filter,
+        query::partition_slice::option_set custom_opts,
+        service::client_state& client_state,
+        alternator::stats& stats,
+        tracing::trace_state_ptr trace_state,
+        service_permit permit,
+        bool enforce_authorization,
+        bool warn_authorization) {
+    lw_shared_ptr<service::pager::paging_state> old_paging_state = nullptr;
+
+    auto query_schema = lsi_schema;
+    const bool reversed = custom_opts.contains<query::partition_slice::option::reversed>();
+    if (reversed) {
+        query_schema = lsi_schema->get_reversed();
+        std::reverse(ck_bounds.begin(), ck_bounds.end());
+        for (auto& bound : ck_bounds) {
+            bound = query::reverse(bound);
+        }
+    }
+
+    if (exclusive_start_key) {
+        partition_key pk = pk_from_json(*exclusive_start_key, lsi_schema);
+        auto pos = position_in_partition::for_partition_start();
+        if (lsi_schema->clustering_key_size() > 0) {
+            pos = pos_from_json(*exclusive_start_key, lsi_schema);
+        }
+        old_paging_state = make_lw_shared<service::pager::paging_state>(pk, pos, query::max_partitions, query_id::create_null_id(), service::pager::paging_state::replicas_per_token_range{}, std::nullopt, 0);
+    }
+
+    co_await verify_permission(enforce_authorization, warn_authorization, client_state, lsi_schema, auth::permission::SELECT, stats);
+    co_await verify_permission(enforce_authorization, warn_authorization, client_state, base_schema, auth::permission::SELECT, stats);
+
+    // Step 1: Query the LSI to get key-only rows in LSI sort order.
+    // The LSI is KEYS_ONLY so it has no ":attrs" column, but it does have
+    // all DynamoDB key columns: the base partition key (p), the LSI sort key (b),
+    // and the base clustering key (c). We need p and c to look up the base table.
+    auto lsi_regular_columns =
+            lsi_schema->regular_columns() | std::views::transform(&column_definition::id)
+            | std::ranges::to<query::column_id_vector>();
+    auto lsi_static_columns =
+            lsi_schema->static_columns() | std::views::transform(&column_definition::id)
+            | std::ranges::to<query::column_id_vector>();
+    auto lsi_selection = cql3::selection::selection::wildcard(lsi_schema);
+    query::partition_slice::option_set opts = lsi_selection->get_query_options();
+    opts.add(custom_opts);
+    auto lsi_partition_slice = query::partition_slice(ck_bounds, std::move(lsi_static_columns), std::move(lsi_regular_columns), opts);
+    auto lsi_command = ::make_lw_shared<query::read_command>(query_schema->id(), query_schema->version(), lsi_partition_slice, proxy.get_max_result_size(lsi_partition_slice),
+        query::tombstone_limit(proxy.get_tombstone_limit()));
+
+    auto query_state_ptr = std::make_unique<service::query_state>(client_state, trace_state, permit);
+    lsi_command->slice.options.set<query::partition_slice::option::allow_short_read>();
+    auto query_options = std::make_unique<cql3::query_options>(cl, std::vector<cql3::raw_value>{});
+    query_options = std::make_unique<cql3::query_options>(std::move(query_options), std::move(old_paging_state));
+    auto p = service::pager::query_pagers::pager(proxy, query_schema, lsi_selection, *query_state_ptr, *query_options, lsi_command, std::move(partition_ranges), nullptr);
+
+    // Fetch up to limit rows from the LSI (no filter applied at this stage).
+    std::unique_ptr<cql3::result_set> lsi_rs = co_await p->fetch_page(limit, gc_clock::now(), executor::default_timeout());
+    if (!p->is_exhausted()) {
+        lsi_rs->get_metadata().set_paging_state(p->state());
+    }
+    auto paging_state = lsi_rs->get_metadata().paging_state();
+
+    // Extract key-only items from LSI result set.
+    // We don't apply attrs_to_get here - we need all key columns
+    // (p, b, c) to reconstruct the base table primary key. We apply the
+    // filter here on the LSI items: DynamoDB forbids FilterExpression from
+    // referencing non-projected attributes, so all filter attributes are
+    // present in the KEYS_ONLY LSI item, and filtering here avoids
+    // unnecessary base table reads for non-matching items.
+    std::optional<alternator::attrs_to_get> no_attrs;
+    alternator::filter empty_filter;  // default-constructed, passes all items
+    describe_items_visitor lsi_visitor(lsi_selection->get_columns(), no_attrs, empty_filter);
+    co_await lsi_rs->visit_gently(lsi_visitor);
+    auto lsi_items = std::move(lsi_visitor).get_items();
+
+    // Step 2: For each LSI row, do a point read on the base table.
+    auto base_selection = cql3::selection::selection::wildcard(base_schema);
+    auto base_regular_columns = base_schema->regular_columns()
+            | std::views::transform(&column_definition::id)
+            | std::ranges::to<query::column_id_vector>();
+
+    auto timeout = executor::default_timeout();
+    auto shared_attrs_to_get = ::make_shared<const std::optional<alternator::attrs_to_get>>(std::move(attrs_to_get));
+
+    utils::chunked_vector<rjson::value> items;
+    int matched_count = 0;
+    int scanned_count = static_cast<int>(lsi_items.size());
+
+    for (auto& lsi_item : lsi_items) {
+        // Apply filter on the LSI item before reading from the base table.
+        // DynamoDB forbids FilterExpression from referencing non-projected
+        // attributes on a KEYS_ONLY LSI, so all filter attributes are
+        // guaranteed to be present in the LSI item. Filtering here avoids
+        // unnecessary base table reads for items that won't pass the filter.
+        // Filtering here is also necessary for correctness - it allows the
+        // filter to use columns that the user might have asked not to be
+        // included in the final output item (Select=SPECIFIC_ATTRIBUTES).
+        if (filter && !filter.check(lsi_item)) {
+            co_await coroutine::maybe_yield();
+            continue;
+        }
+        // Extract base table primary key from the LSI item JSON.
+        // The LSI item has columns p (base partition key), b (LSI sort key),
+        // and c (base clustering key). pk_from_json / ck_from_json use the
+        // base schema to extract only p and c.
+        partition_key base_pk = pk_from_json(lsi_item, base_schema);
+        clustering_key base_ck = ck_from_json(lsi_item, base_schema);
+        std::vector<query::clustering_range> base_ck_bounds_single{
+            query::clustering_range::make_singular(base_ck)
+        };
+        auto base_partition_slice = query::partition_slice(std::move(base_ck_bounds_single), {},
+                base_regular_columns, base_selection->get_query_options());
+        auto base_command = ::make_lw_shared<query::read_command>(
+                base_schema->id(), base_schema->version(), base_partition_slice,
+                proxy.get_max_result_size(base_partition_slice),
+                query::tombstone_limit(proxy.get_tombstone_limit()));
+        service::storage_proxy::coordinator_query_result qr =
+                co_await proxy.query(base_schema, base_command,
+                        {dht::partition_range(dht::decorate_key(*base_schema, base_pk))},
+                        cl,
+                        service::storage_proxy::coordinator_query_options(
+                                timeout, permit, client_state, trace_state));
+        ++stats.lsi_reads_from_base_table;
+        ++get_stats_from_schema(proxy, *base_schema)->lsi_reads_from_base_table;
+        auto opt_item = describe_single_item(base_schema, base_partition_slice,
+                *base_selection, *qr.query_result, *shared_attrs_to_get);
+        if (opt_item) {
+            ++matched_count;
+            items.push_back(std::move(*opt_item));
+        }
+        co_await coroutine::maybe_yield();
+    }
+
+    rjson::value response = rjson::empty_object();
+    rjson::add(response, "Count", rjson::value(matched_count));
+    rjson::add(response, "ScannedCount", rjson::value(scanned_count));
+    if (paging_state) {
+        rjson::add(response, "LastEvaluatedKey", encode_paging_state(*lsi_schema, *paging_state));
+    }
+    if (items.size() >= max_items_for_rapidjson_array) {
+        co_return make_streamed_with_extra_array(std::move(response), "Items", std::move(items));
+    }
+    rjson::value items_json = rjson::empty_array();
+    for (auto& item : items) {
+        rjson::push_back(items_json, std::move(item));
+    }
+    rjson::add(response, "Items", std::move(items_json));
+    if (is_big(response)) {
+        co_return make_streamed(std::move(response));
+    }
+    co_return rjson::print(std::move(response));
+}
+
 static future<executor::request_return_type> do_query(service::storage_proxy& proxy,
         schema_ptr table_schema,
         const rjson::value* exclusive_start_key,
@@ -780,10 +992,28 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
     }
 
     select_type select = parse_select(request, table_type);
+    // For GSI with KEYS_ONLY projection, Select=ALL_ATTRIBUTES is not allowed
+    // because a GSI will not do a base-table lookup. For LSI, ALL_ATTRIBUTES
+    // is allowed even with KEYS_ONLY - Scylla will retrieve the full item
+    // from the base table.
+    if (select == select_type::regular &&
+            !request.HasMember("AttributesToGet") &&
+            !request.HasMember("ProjectionExpression") &&
+            table_type == table_or_view_type::gsi &&
+            projection_is_keys_only(*schema)) {
+        return make_ready_future<request_return_type>(api_error::validation(
+            "Select=ALL_ATTRIBUTES is not supported for GSI with ProjectionType=KEYS_ONLY. Use Select=ALL_PROJECTED_ATTRIBUTES or Select=SPECIFIC_ATTRIBUTES."));
+    }
 
     std::unordered_set<std::string> used_attribute_names;
     std::unordered_set<std::string> used_attribute_values;
     auto attrs_to_get = calculate_attrs_to_get(request, *_parsed_expression_cache, used_attribute_names, select);
+
+    // For GSI with KEYS_ONLY, validate that specific requested attributes
+    // are key columns (projected into the index).
+    if (attrs_to_get && table_type == table_or_view_type::gsi && projection_is_keys_only(*schema)) {
+        validate_gsi_keys_only_attrs(*schema, *attrs_to_get);
+    }
 
     dht::partition_range_vector partition_ranges;
     if (segment) {
@@ -809,10 +1039,38 @@ future<executor::request_return_type> executor::scan(client_state& client_state,
     // optimized the filtering by modifying partition_ranges and/or
     // ck_bounds. We haven't done this optimization yet.
 
+    if (table_type == table_or_view_type::gsi || table_type == table_or_view_type::lsi) {
+        validate_only_projected_attrs_in_filter(*schema, rjson::to_string_view(*rjson::find(request, "IndexName")), filter);
+    }
+
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     const rjson::value* expression_attribute_values = rjson::find(request, "ExpressionAttributeValues");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "Scan");
     verify_all_are_used(expression_attribute_values, used_attribute_values, "ExpressionAttributeValues", "Scan");
+
+    // For an LSI with KEYS_ONLY projection, scanning the LSI view directly
+    // would only return key columns (no ":attrs"). When the user requests
+    // ALL_ATTRIBUTES or SPECIFIC_ATTRIBUTES for non-projected (non-key)
+    // attributes, we must do a per-item point read on the base table.
+    // However, if Select=SPECIFIC_ATTRIBUTES and all requested attributes are
+    // key columns already present in the LSI view, we can read the LSI
+    // directly without touching the base table (the efficient path).
+    if (table_type == table_or_view_type::lsi &&
+            select != select_type::projection &&
+            select != select_type::count &&
+            projection_is_keys_only(*schema)) {
+        bool all_attrs_in_lsi_view = select == select_type::regular && attrs_to_get &&
+                std::ranges::all_of(*attrs_to_get, [&schema](const auto& attr) {
+                    return schema->get_column_definition(to_bytes(attr.first)) != nullptr;
+                });
+        if (!all_attrs_in_lsi_view) {
+            schema_ptr base_schema = _proxy.data_dictionary().find_schema(schema->view_info()->base_id());
+            return do_query_lsi_with_base_fetch(_proxy, schema, base_schema, exclusive_start_key,
+                    std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
+                    std::move(filter), query::partition_slice::option_set(), client_state, _stats, trace_state, std::move(permit),
+                    _enforce_authorization, _warn_authorization);
+        }
+    }
 
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
             std::move(filter), query::partition_slice::option_set(), client_state, _stats, trace_state, std::move(permit), _enforce_authorization, _warn_authorization);
@@ -1726,13 +1984,62 @@ future<executor::request_return_type> executor::query(client_state& client_state
         break;
     }
 
+    if (table_type == table_or_view_type::gsi || table_type == table_or_view_type::lsi) {
+        validate_only_projected_attrs_in_filter(*schema, rjson::to_string_view(*rjson::find(request, "IndexName")), filter);
+    }
+
     select_type select = parse_select(request, table_type);
+    // For GSI with KEYS_ONLY projection, Select=ALL_ATTRIBUTES is not allowed
+    // because a GSI cannot do a base-table lookup. For LSI, Select=ALL_ATTRIBUTES
+    // is allowed even with KEYS_ONLY because an LSI shares the same partition
+    // as the base table, so Scylla can retrieve the full item.
+    if (select == select_type::regular &&
+            !request.HasMember("AttributesToGet") &&
+            !request.HasMember("ProjectionExpression") &&
+            table_type == table_or_view_type::gsi &&
+            projection_is_keys_only(*schema)) {
+        return make_ready_future<request_return_type>(api_error::validation(
+            "Select=ALL_ATTRIBUTES is not supported for GSI with ProjectionType=KEYS_ONLY. Use Select=ALL_PROJECTED_ATTRIBUTES or a ProjectionExpression instead."));
+    }
 
     auto attrs_to_get = calculate_attrs_to_get(request, *_parsed_expression_cache, used_attribute_names, select);
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "Query");
     verify_all_are_used(expression_attribute_values, used_attribute_values, "ExpressionAttributeValues", "Query");
+
+    // For GSI with KEYS_ONLY, validate that specific requested attributes
+    // are key columns (projected into the index).
+    if (attrs_to_get && table_type == table_or_view_type::gsi && projection_is_keys_only(*schema)) {
+        validate_gsi_keys_only_attrs(*schema, *attrs_to_get);
+    }
     query::partition_slice::option_set opts;
     opts.set_if<query::partition_slice::option::reversed>(!forward);
+
+    // For an LSI with KEYS_ONLY projection, querying the LSI view directly
+    // would only return key columns (no ":attrs"). When the user requests
+    // ALL_ATTRIBUTES or SPECIFIC_ATTRIBUTES for non-projected (non-key)
+    // attributes, we must do a per-item point read on the base table.
+    // However, if Select=SPECIFIC_ATTRIBUTES and all requested attributes are
+    // key columns already present in the LSI view, we can read the LSI
+    // directly without touching the base table (the efficient path).
+    if (table_type == table_or_view_type::lsi &&
+            select != select_type::projection &&
+            select != select_type::count &&
+            projection_is_keys_only(*schema)) {
+        // Check if all requested attributes are real columns in the LSI view
+        // (i.e., key columns). If so, we can skip the base-table fetch.
+        bool all_attrs_in_lsi_view = select == select_type::regular && attrs_to_get &&
+                std::ranges::all_of(*attrs_to_get, [&schema](const auto& attr) {
+                    return schema->get_column_definition(to_bytes(attr.first)) != nullptr;
+                });
+        if (!all_attrs_in_lsi_view) {
+            schema_ptr base_schema = _proxy.data_dictionary().find_schema(schema->view_info()->base_id());
+            return do_query_lsi_with_base_fetch(_proxy, schema, base_schema, exclusive_start_key,
+                    std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
+                    std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit),
+                    _enforce_authorization, _warn_authorization);
+        }
+    }
+
     return do_query(_proxy, schema, exclusive_start_key, std::move(partition_ranges), std::move(ck_bounds), std::move(attrs_to_get), limit, cl,
             std::move(filter), opts, client_state, _stats, std::move(trace_state), std::move(permit), _enforce_authorization, _warn_authorization);
 }

--- a/alternator/executor_util.cc
+++ b/alternator/executor_util.cc
@@ -571,4 +571,8 @@ void filter_batch_request_items_by_tbl_name(rjson::value& request, const audit::
     }
 }
 
+bool projection_is_keys_only(const schema& s) {
+    return s.get_column_definition(bytes(executor::ATTRS_COLUMN_NAME)) == nullptr;
+}
+
 } // namespace alternator

--- a/alternator/executor_util.hh
+++ b/alternator/executor_util.hh
@@ -250,4 +250,8 @@ std::optional<rjson::value> describe_single_item(schema_ptr,
 /// help avoid large allocations/many re-allocs.
 body_writer make_streamed(rjson::value&&);
 
+/// Returns true if the given GSI or LSI view schema has KEYS_ONLY projection.
+/// Such views do not contain the executor::ATTRS_COLUMN_NAME column.
+bool projection_is_keys_only(const schema& s);
+
 } // namespace alternator

--- a/alternator/stats.cc
+++ b/alternator/stats.cc
@@ -108,6 +108,8 @@ static void register_metrics_with_optional_table(seastar::metrics::metric_groups
                     seastar::metrics::description("number of total operations via Alternator API"), labels)(basic_level).aggregate(aggregate_labels).set_skip_when_empty(),
             seastar::metrics::make_total_operations("reads_before_write", stats.reads_before_write,
                     seastar::metrics::description("number of performed read-before-write operations"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
+            seastar::metrics::make_total_operations("lsi_reads_from_base_table", stats.lsi_reads_from_base_table,
+                    seastar::metrics::description("number of base-table row reads triggered by LSI queries needing non-projected attributes"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
             seastar::metrics::make_total_operations("write_using_lwt", stats.write_using_lwt,
                     seastar::metrics::description("number of writes that used LWT"), labels).aggregate(aggregate_labels).set_skip_when_empty(),
             seastar::metrics::make_total_operations("shard_bounce_for_lwt", stats.shard_bounce_for_lwt,

--- a/alternator/stats.hh
+++ b/alternator/stats.hh
@@ -143,6 +143,7 @@ public:
     uint64_t total_operations = 0;
     uint64_t unsupported_operations = 0;
     uint64_t reads_before_write = 0;
+    uint64_t lsi_reads_from_base_table = 0;
     uint64_t write_using_lwt = 0;
     uint64_t shard_bounce_for_lwt = 0;
     uint64_t requests_blocked_memory = 0;

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -328,10 +328,12 @@ behave the same in Alternator. However, there are a few features which we have
 not implemented yet. Unimplemented features return an error when used, so
 they should be easy to detect. Here is a list of these unimplemented features:
 
-* GSI (Global Secondary Index) and LSI (Local Secondary Index) may be
-  configured to project only a subset of the base-table attributes to the
-  index. This option is not yet respected by Alternator - all attributes
-  are projected. This wastes some disk space when it is not needed.
+* GSI (Global Secondary Index) and LSI (Local Secondary Index) have a
+  ProjectionType option to include only a subset of the base-table attributes
+  in the index. The settings ProjectionType=ALL and ProjectionType=KEYS_ONLY
+  are supported, but ProjectionType=INCLUDE is not. If you do need to use
+  INCLUDE, use ALL instead - it will waste some space but give you access to
+  all the attributes, including those you need.
   <https://github.com/scylladb/scylla/issues/5036>
 
 * DynamoDB's multi-item transaction feature (TransactWriteItems,

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -202,6 +202,9 @@ def cql_table_name(tab):
 def cql_gsi_name(tab, gsi):
     return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name + ":" + gsi)
 
+def cql_lsi_name(tab, lsi):
+    return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name + "!:" + lsi)
+
 def cql_cdclog_name(tab):
     return maybe_quote('alternator_' + tab.name) + '.' + maybe_quote(tab.name + "_scylla_cdc_log")
 
@@ -405,43 +408,125 @@ def test_rbac_query(dynamodb, cql, test_table):
 # from a view (GSI or LSI) instead of from the base table. We decided that
 # the base table and each individual view can have *separate* permissions,
 # so granting SELECT permission on the base table does not allow reading
-# a view, and vice versa. This test verifies this.
+# a view, and vice versa. This test verifies this for both GSI and LSI.
 # Note that if a table is created *by* a role, the auto-grant feature
 # (tested below) ensures that this role can read the base and all views.
 # So here the table is not created by the role - but rather by the superuser,
 # and the permissions are granted explicitly to the role on a specific table.
-def test_rbac_query_separate_index_permissions(dynamodb, cql):
-    schema = {
-        'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-        'AttributeDefinitions': [
-                    { 'AttributeName': 'p', 'AttributeType': 'S' },
-                    { 'AttributeName': 'x', 'AttributeType': 'S' } ],
-        'GlobalSecondaryIndexes': [
-            {   'IndexName': 'hello',
-                'KeySchema': [
-                    { 'AttributeName': 'x', 'KeyType': 'HASH' },
-                ],
-                'Projection': { 'ProjectionType': 'ALL' }
-            } ]
-    }
+@pytest.mark.parametrize('index_type', ['gsi', 'lsi'])
+def test_rbac_query_separate_index_permissions(dynamodb, cql, index_type):
+    if index_type == 'gsi':
+        schema = {
+            'KeySchema': [ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
+            'AttributeDefinitions': [
+                { 'AttributeName': 'p', 'AttributeType': 'S' },
+                { 'AttributeName': 'x', 'AttributeType': 'S' } ],
+            'GlobalSecondaryIndexes': [
+                {   'IndexName': 'hello',
+                    'KeySchema': [ { 'AttributeName': 'x', 'KeyType': 'HASH' } ],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                } ]
+        }
+        index_name_fn = cql_gsi_name
+        index_key_conditions = {'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}
+    else:  # lsi
+        schema = {
+            'KeySchema': [
+                { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+            ],
+            'AttributeDefinitions': [
+                { 'AttributeName': 'p', 'AttributeType': 'S' },
+                { 'AttributeName': 'c', 'AttributeType': 'S' },
+                { 'AttributeName': 'x', 'AttributeType': 'S' } ],
+            'LocalSecondaryIndexes': [
+                {   'IndexName': 'hello',
+                    'KeySchema': [
+                        { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                        { 'AttributeName': 'x', 'KeyType': 'RANGE' }
+                    ],
+                    'Projection': { 'ProjectionType': 'ALL' }
+                } ]
+        }
+        index_name_fn = cql_lsi_name
+        # LSI shares the base table's partition key, so query by 'p'
+        index_key_conditions = {'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}
     with new_test_table(dynamodb, **schema) as table:
         with new_role(cql) as (role, key):
             with new_dynamodb(dynamodb, role, key) as d:
                 tab = d.Table(table.name)
                 # Without extra permissions, the new role can read neither
-                # the base table nore the view:
+                # the base table nor the view:
                 unauthorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                unauthorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                unauthorized(lambda: tab.query(IndexName='hello', KeyConditions=index_key_conditions))
                 # Granting permissions on the base table we can read the
                 # base table but NOT the view:
                 with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
                     authorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                    unauthorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                # Granting permissions on the GSI we can read the GSI but not
+                    unauthorized(lambda: tab.query(IndexName='hello', KeyConditions=index_key_conditions))
+                # Granting permissions on the index we can read the index but not
                 # the base table:
-                with temporary_grant(cql, 'SELECT', cql_gsi_name(tab, 'hello'), role):
+                with temporary_grant(cql, 'SELECT', index_name_fn(tab, 'hello'), role):
                     unauthorized(lambda: tab.query(KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
-                    authorized(lambda: tab.query(IndexName='hello', KeyConditions={'x': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}}))
+                    authorized(lambda: tab.query(IndexName='hello', KeyConditions=index_key_conditions))
+
+# When querying an LSI that has only projects some of the attributes (e.g.,
+# ProjectionType=KEYS_ONLY) with Select=ALL_ATTRIBUTES or SPECIFIC_ATTRIBUTES
+# (allowed only for LSI), Alternator needs to read non-projected attributes
+# from the base table in addition to scanning the LSI. This test verifies that
+# SELECT permissions on *both* the LSI and the base table are required for
+# such a query to succeed - neither the LSI permission nor the base-table
+# permission is enough alone.
+def test_rbac_lsi_query_all_attributes_permissions(dynamodb, cql):
+    schema = {
+        'KeySchema': [
+            { 'AttributeName': 'p', 'KeyType': 'HASH' },
+            { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+        ],
+        'AttributeDefinitions': [
+            { 'AttributeName': 'p', 'AttributeType': 'S' },
+            { 'AttributeName': 'c', 'AttributeType': 'S' },
+            { 'AttributeName': 'x', 'AttributeType': 'S' }
+        ],
+        'LocalSecondaryIndexes': [
+            {   'IndexName': 'lsi',
+                'KeySchema': [
+                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'x', 'KeyType': 'RANGE' }
+                ],
+                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+            }
+        ]
+    }
+    with new_test_table(dynamodb, **schema) as table:
+        with new_role(cql) as (role, key):
+            with new_dynamodb(dynamodb, role, key) as d:
+                tab = d.Table(table.name)
+                # Run the same permission test for two types of Select that
+                # both require a base-table fetch: ALL_ATTRIBUTES and
+                # SPECIFIC_ATTRIBUTES with a non-key attribute.
+                for (select, extra_kwargs) in [
+                        ('ALL_ATTRIBUTES', {}),
+                        ('SPECIFIC_ATTRIBUTES', {'ProjectionExpression': 'v'})]:
+                    query_lsi = lambda: tab.query(IndexName='lsi', Select=select,
+                        KeyConditions={'p': {'AttributeValueList': ['hi'], 'ComparisonOperator': 'EQ'}},
+                        **extra_kwargs)
+                    # Without any permissions, the LSI query fails:
+                    unauthorized(query_lsi)
+                    # With only base table SELECT, the query still fails because
+                    # the LSI permission is missing:
+                    with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
+                        unauthorized(query_lsi)
+                    # With only LSI SELECT, the query still fails because
+                    # requesting non-projected attributes triggers a base table
+                    # fetch and the base table permission is missing:
+                    with temporary_grant(cql, 'SELECT', cql_lsi_name(tab, 'lsi'), role):
+                        unauthorized(query_lsi)
+                    # With SELECT on both the LSI and the base table, the query
+                    # succeeds:
+                    with temporary_grant(cql, 'SELECT', cql_lsi_name(tab, 'lsi'), role):
+                        with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
+                            authorized(query_lsi)
 
 # Test Scan's support of permissions - the "SELECT" permission is needed.
 def test_rbac_scan(dynamodb, cql, test_table):

--- a/test/alternator/test_cql_schema.py
+++ b/test/alternator/test_cql_schema.py
@@ -161,3 +161,78 @@ def test_alternator_aux_tables(dynamodb, table1, option):
     # Check Streams log table:
     alternator_cdc_schema = scylla_get_schema(dynamodb, cql_table_for_cdclog(table1))
     assert alternator_base_schema[option] == alternator_cdc_schema[option]
+
+# Test that on a GSI and LSI with ProjectionType=ALL, the view has in its
+# schema include_all_columns=True - but for ProjectionType=KEYS_ONLY it is
+# false. This schema flag doesn't actually have any real effect on Alternator
+# or its use of materialized views (which only cares about which columns
+# exist in the view table). Rather, this flag is mainly used by CQL's
+# DESCRIBE MATERIALIZED VIEW and ALTER TABLE ... ADD COLUMN. But let's check
+# it is correct just in case somebody tries to use CQL's "DESCRIBE
+# MATERIALIZED VIEW" or "ALTER TABLE ... ADD COLUMN" on an Alternator table.
+def test_include_all_columns(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[
+            { 'AttributeName': 'p', 'KeyType': 'HASH' },
+            { 'AttributeName': 'c', 'KeyType': 'RANGE' },
+        ],
+        AttributeDefinitions=[
+            { 'AttributeName': 'p', 'AttributeType': 'S' },
+            { 'AttributeName': 'c', 'AttributeType': 'S' },
+            { 'AttributeName': 'x', 'AttributeType': 'S' },
+        ],
+        GlobalSecondaryIndexes=[
+            {   'IndexName': 'gsi_all',
+                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                'Projection': { 'ProjectionType': 'ALL' }
+            },
+            {   'IndexName': 'gsi_keys_only',
+                'KeySchema': [{ 'AttributeName': 'x', 'KeyType': 'HASH' }],
+                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+            },
+        ],
+        LocalSecondaryIndexes=[
+            {   'IndexName': 'lsi_all',
+                'KeySchema': [
+                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+                ],
+                'Projection': { 'ProjectionType': 'ALL' }
+            },
+            {   'IndexName': 'lsi_keys_only',
+                'KeySchema': [
+                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'x', 'KeyType': 'RANGE' },
+                ],
+                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+            },
+        ],
+    ) as table:
+        gsi_all_schema = scylla_get_schema(dynamodb, cql_table_for_gsi(table, 'gsi_all'))
+        assert gsi_all_schema['include_all_columns'] == 'true'
+        gsi_keys_only_schema = scylla_get_schema(dynamodb, cql_table_for_gsi(table, 'gsi_keys_only'))
+        assert gsi_keys_only_schema['include_all_columns'] == 'false'
+        lsi_all_schema = scylla_get_schema(dynamodb, cql_table_for_lsi(table, 'lsi_all'))
+        assert lsi_all_schema['include_all_columns'] == 'true'
+        lsi_keys_only_schema = scylla_get_schema(dynamodb, cql_table_for_lsi(table, 'lsi_keys_only'))
+        assert lsi_keys_only_schema['include_all_columns'] == 'false'
+        # Now add more GSIs via UpdateTable and check that these new GSIs also
+        # have the correct "include_all_columns" flag:
+        table.meta.client.update_table(TableName=table.name,
+            AttributeDefinitions=[{'AttributeName': 'y', 'AttributeType': 'S'}],
+            GlobalSecondaryIndexUpdates=[{'Create': {
+                'IndexName': 'gsi_all_2',
+                'KeySchema': [{'AttributeName': 'y', 'KeyType': 'HASH'}],
+                'Projection': {'ProjectionType': 'ALL'},
+            }}])
+        gsi_all_2_schema = scylla_get_schema(dynamodb, cql_table_for_gsi(table, 'gsi_all_2'))
+        assert gsi_all_2_schema['include_all_columns'] == 'true'
+        table.meta.client.update_table(TableName=table.name,
+            AttributeDefinitions=[{'AttributeName': 'y', 'AttributeType': 'S'}],
+            GlobalSecondaryIndexUpdates=[{'Create': {
+                'IndexName': 'gsi_keys_only_2',
+                'KeySchema': [{'AttributeName': 'y', 'KeyType': 'HASH'}],
+                'Projection': {'ProjectionType': 'KEYS_ONLY'},
+            }}])
+        gsi_keys_only_2_schema = scylla_get_schema(dynamodb, cql_table_for_gsi(table, 'gsi_keys_only_2'))
+        assert gsi_keys_only_2_schema['include_all_columns'] == 'false'

--- a/test/alternator/test_gsi.py
+++ b/test/alternator/test_gsi.py
@@ -1255,7 +1255,6 @@ def test_gsi_describe_table_schema_all(dynamodb):
 # "ProjectionType:: KEYS_ONLY" works. We note that it projects both
 # the index's key, *and* the base table's key. So items which had different
 # base-table keys cannot suddenly become the same item in the index.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_keys_only(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -1282,7 +1281,7 @@ def test_gsi_projection_keys_only(dynamodb):
 # Test for "ProjectionType: INCLUDE". The secondary table includes the
 # its own and the base's keys (as in KEYS_ONLY) plus the extra keys given
 # in NonKeyAttributes.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_include(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -1312,7 +1311,6 @@ def test_gsi_projection_include(dynamodb):
 
 # Test that when "ProjectionType" is set to anything but "INCLUDE" (i.e.,
 # "ALL" or "KEYS_ONLY"), "NonKeyAttributes" must not be specified.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_projection_nonkeyattributess_forbidden(dynamodb):
     for projection_type in ['ALL', 'KEYS_ONLY']:
         with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
@@ -1336,7 +1334,7 @@ def test_gsi_projection_nonkeyattributess_forbidden(dynamodb):
 # Despite the name "NonKeyAttributes", key attributes *may* be listed.
 # But they have no effect - because key attributes are always projected
 # anyway.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_include_keyattributes(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -1370,7 +1368,7 @@ def test_gsi_projection_include_keyattributes(dynamodb):
 # GSI keys currently become actual Scylla columns - while regular attributes
 # do not (they are elements of a single map column), so we need to remember
 # to project both real columns and map elements into the view.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_include_otherkey(dynamodb):
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
@@ -1418,7 +1416,7 @@ def test_gsi_projection_include_otherkey(dynamodb):
         assert_index_scan(table, 'indexx', expected_items)
 
 # With ProjectionType=INCLUDE, NonKeyAttributes must not be missing:
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_error_missing_nonkeyattributes(dynamodb):
     with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
         with new_test_table(dynamodb,
@@ -1437,29 +1435,8 @@ def test_gsi_projection_error_missing_nonkeyattributes(dynamodb):
             ]) as table:
             pass
 
-# With ProjectionType!=INCLUDE, NonKeyAttributes must not be present:
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
-def test_gsi_projection_error_superflous_nonkeyattributes(dynamodb):
-    with pytest.raises(ClientError, match='ValidationException.*NonKeyAttributes'):
-        with new_test_table(dynamodb,
-            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
-            AttributeDefinitions=[
-                { 'AttributeName': 'p', 'AttributeType': 'S' },
-                { 'AttributeName': 'x', 'AttributeType': 'S' },
-            ],
-            GlobalSecondaryIndexes=[
-                {   'IndexName': 'hello',
-                    'KeySchema': [
-                        { 'AttributeName': 'x', 'KeyType': 'HASH' },
-                    ],
-                    'Projection': { 'ProjectionType': 'ALL',
-                                    'NonKeyAttributes': ['a'] }
-                }
-            ]) as table:
-            pass
-
 # Duplicate attribute names in NonKeyAttributes of INCLUDE are not allowed:
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_error_duplicate(dynamodb):
     with pytest.raises(ClientError, match='ValidationException.*Duplicate'):
         with new_test_table(dynamodb,
@@ -1482,7 +1459,7 @@ def test_gsi_projection_error_duplicate(dynamodb):
 # NonKeyAttributes must be a list of strings. Non-strings in this list
 # result, for some reason, in SerializationException instead of the more
 # usual ValidationException.
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
 def test_gsi_projection_error_nonstring_nonkeyattributes(dynamodb):
     with pytest.raises(ClientError, match='SerializationException'):
         with new_test_table(dynamodb,
@@ -1503,7 +1480,6 @@ def test_gsi_projection_error_nonstring_nonkeyattributes(dynamodb):
             pass
 
 # An unsupported ProjectionType value should result in an error:
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_bad_projection_type(dynamodb):
     with pytest.raises(ClientError, match='ValidationException.*nonsense'):
         with new_test_table(dynamodb,
@@ -1523,7 +1499,6 @@ def test_gsi_bad_projection_type(dynamodb):
 # "Projection" is optional - and Boto3 allows it to be missing. But in
 # fact, it is not allowed to be missing: DynamoDB complains: "Unknown
 # ProjectionType: null".
-@pytest.mark.xfail(reason="GSI projection not supported - issue #5036")
 def test_gsi_missing_projection_type(dynamodb):
     with pytest.raises(ClientError, match='ValidationException.*ProjectionType'):
         with new_test_table(dynamodb,
@@ -1693,8 +1668,14 @@ def test_gsi_query_select_1(test_table_gsi_1):
         Select='COUNT',
         KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
 
-@pytest.mark.xfail(reason="Projection not supported yet. Issue #5036")
-def test_gsi_query_select_2(dynamodb):
+@pytest.mark.parametrize('projection_type', [
+    'KEYS_ONLY',
+    pytest.param('INCLUDE', marks=pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")),
+])
+def test_gsi_query_select_2(dynamodb, projection_type):
+    projection = {'ProjectionType': projection_type}
+    if projection_type == 'INCLUDE':
+        projection['NonKeyAttributes'] = ['a']
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' } ],
         AttributeDefinitions=[
@@ -1704,8 +1685,7 @@ def test_gsi_query_select_2(dynamodb):
         GlobalSecondaryIndexes=[
             {   'IndexName': 'hello',
                 'KeySchema': [ { 'AttributeName': 'x', 'KeyType': 'HASH' } ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a'] }
+                'Projection': projection,
             }
         ]) as table:
         items = [{'p': random_string(), 'x': random_string(), 'a': random_string(), 'b': random_string()} for i in range(10)]
@@ -1714,10 +1694,14 @@ def test_gsi_query_select_2(dynamodb):
                 batch.put_item(item)
         x = items[0]['x']
         # Unlike in base tables, here Select=ALL_PROJECTED_ATTRIBUTES is
-        # allowed, and only the projected attributes are returned (in this
-        # case the key of both base and GSI ('p' and 'x') and 'a' - but not
-        # 'b'. Moreover, it is the default if Select isn't specified at all.
-        expected_items = [{'p': z['p'], 'x': z['x'], 'a': z['a']} for z in items if z['x'] == x]
+        # allowed, and only the projected attributes are returned.
+        # For INCLUDE: the key of both base and GSI ('p' and 'x') and 'a' - but not 'b'.
+        # For KEYS_ONLY: only the key attributes ('p' and 'x') - no 'a' or 'b'.
+        if projection_type == 'INCLUDE':
+            expected_items = [{'p': z['p'], 'x': z['x'], 'a': z['a']} for z in items if z['x'] == x]
+        else:
+            expected_items = [{'p': z['p'], 'x': z['x']} for z in items if z['x'] == x]
+        # ALL_PROJECTED_ATTRIBUTES is the default if Select isn't specified at all.
         assert_index_query(table, 'hello', expected_items,
             KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
         assert_index_query(table, 'hello', expected_items,
@@ -1729,14 +1713,19 @@ def test_gsi_query_select_2(dynamodb):
             assert_index_query(table, 'hello', expected_items,
                 Select='ALL_ATTRIBUTES',
                 KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
-        # SPECIFIC_ATTRIBUTES (with AttributesToGet / ProjectionExpression)
-        # is allowed for the projected attributes, but not allowed for
-        # unprojected attributes:
-        expected_items = [{'a': z['a']} for z in items if z['x'] == x]
-        assert_index_query(table, 'hello', expected_items,
+        # SPECIFIC_ATTRIBUTES for a projected key attribute ('x') is allowed:
+        expected_keys = [{'x': z['x']} for z in items if z['x'] == x]
+        assert_index_query(table, 'hello', expected_keys,
             Select='SPECIFIC_ATTRIBUTES',
-            AttributesToGet=['a'],
+            AttributesToGet=['x'],
             KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        if projection_type == 'INCLUDE':
+            # For INCLUDE, 'a' is projected so SPECIFIC_ATTRIBUTES for 'a' is allowed:
+            expected_items = [{'a': z['a']} for z in items if z['x'] == x]
+            assert_index_query(table, 'hello', expected_items,
+                Select='SPECIFIC_ATTRIBUTES',
+                AttributesToGet=['a'],
+                KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
         # Requesting an unprojected attribute 'b' via AttributesToGet or
         # ProjectionExpression returns an explicit error, not silent nothing.
         with pytest.raises(ClientError, match='ValidationException.*project'):
@@ -1747,7 +1736,7 @@ def test_gsi_query_select_2(dynamodb):
         with pytest.raises(ClientError, match='ValidationException.*project'):
             table.query(IndexName='hello',
                 ProjectionExpression='b',
-            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+                KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
         # Select=COUNT is also allowed, and doesn't return item content
         assert not 'Items' in table.query(ConsistentRead=False,
             IndexName='hello',
@@ -2413,3 +2402,255 @@ def test_gsi_query_exclusivestartkey_spurious_column(test_table_gsi_5):
     exclusive_start_key['y'] = 'meerkat'
     with pytest.raises(ClientError, match='ValidationException.*starting key'):
         test_table_gsi_5.query(ExclusiveStartKey=exclusive_start_key, **query_args)
+
+# Test that after creating a GSI with different ProjectionType options
+# (ALL, KEYS_ONLY, INCLUDE), DescribeTable is able to show the correct
+# ProjectionType and the GSI. For ProjectionType=INCLUDE, it should also show
+# the correct NonKeyAttributes created with the GSI.
+# Also check that if the Projection option is missing, the default is ALL
+# and should be reported as such by DescribeTable.
+# We test creating the GSI to be described in two ways - via CreateTable
+# (creating a base table and a GSI together) and via UpdateTable (adding a
+# new GSI to an existing table).
+@pytest.mark.parametrize('projection_type', [
+    None,
+    'ALL',
+    'KEYS_ONLY',
+    pytest.param('INCLUDE', marks=pytest.mark.xfail(reason='Issue #5036 - ProjectionType=INCLUDE not yet supported')),
+])
+def test_gsi_projection_type_describe(dynamodb, projection_type):
+    non_key_attrs = ['extra', 'hello']
+    gsi_spec = {
+        'IndexName': 'gsi',
+        'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+    }
+    if projection_type is not None:
+        projection = {'ProjectionType': projection_type}
+        if projection_type == 'INCLUDE':
+            projection['NonKeyAttributes'] = non_key_attrs
+        gsi_spec['Projection'] = projection
+        expected_projection_type = projection_type
+    else:
+        # None means no Projection option specified at all; DynamoDB defaults to ALL.
+        expected_projection_type = 'ALL'
+    with new_test_table(dynamodb,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'S'},
+                {'AttributeName': 'x', 'AttributeType': 'S'},
+            ],
+            GlobalSecondaryIndexes=[gsi_spec]) as table:
+        desc = table.meta.client.describe_table(TableName=table.name)
+        gsi_list = desc['Table']['GlobalSecondaryIndexes']
+        assert len(gsi_list) == 1
+        assert gsi_list[0]['Projection']['ProjectionType'] == expected_projection_type
+        if projection_type == 'INCLUDE':
+            assert sorted(gsi_list[0]['Projection']['NonKeyAttributes']) == sorted(non_key_attrs)
+        # Above we created the GSI with CreateTable and showed DescribeTable
+        # describes its Projection correctly. Now we also want to show that if
+        # we add a GSI with UpdateTable, DescribeTable also describes its
+        # Projection correctly.
+        gsi2_spec = {
+            'IndexName': 'gsi2',
+            'KeySchema': [{'AttributeName': 'y', 'KeyType': 'HASH'}],
+        }
+        if projection_type is not None:
+            gsi2_spec['Projection'] = projection
+        dynamodb.meta.client.update_table(TableName=table.name,
+            AttributeDefinitions=[{'AttributeName': 'y', 'AttributeType': 'S'}],
+            GlobalSecondaryIndexUpdates=[{'Create': gsi2_spec}])
+        wait_for_gsi(table, 'gsi2')
+        desc2 = table.meta.client.describe_table(TableName=table.name)
+        gsi2_list = [g for g in desc2['Table']['GlobalSecondaryIndexes'] if g['IndexName'] == 'gsi2']
+        assert len(gsi2_list) == 1
+        assert gsi2_list[0]['Projection']['ProjectionType'] == expected_projection_type
+        if projection_type == 'INCLUDE':
+            assert sorted(gsi2_list[0]['Projection']['NonKeyAttributes']) == sorted(non_key_attrs)
+
+# When we have ProjectionType=KEYS_ONLY and the GSI has a new key column that
+# was not a key column in the base table, all the other non-key base table
+# attributes should not be projected to the GSI, but the new key column should
+# be projected to the GSI, and should be readable from the GSI.
+def test_gsi_keys_only_new_key_readable(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'x', 'AttributeType': 'S'},
+        ],
+        GlobalSecondaryIndexes=[{
+            'IndexName': 'gsi',
+            'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+            'Projection': {'ProjectionType': 'KEYS_ONLY'},
+        }]) as table:
+        items = [{'p': random_string(), 'x': random_string(), 'a': random_string()} for _ in range(5)]
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(item)
+        x = items[0]['x']
+        # Default query uses SELECT=ALL_PROJECTED_ATTRIBUTES, so should
+        # return both key columns: base key 'p' and the newGSI key 'x'
+        # (which was a non-key attribute in the base table).
+        # Non-key attribute 'a' is not projected and should not appear.
+        expected_items = [{'p': z['p'], 'x': z['x']} for z in items if z['x'] == x]
+        assert_index_query(table, 'gsi', expected_items,
+            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        # Requesting 'x' (the new GSI key) via SPECIFIC_ATTRIBUTES also works:
+        expected_keys = [{'x': z['x']} for z in items if z['x'] == x]
+        assert_index_query(table, 'gsi', expected_keys,
+            Select='SPECIFIC_ATTRIBUTES',
+            AttributesToGet=['x'],
+            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        # Requesting 'p' (the base table key, also projected) also works:
+        expected_keys = [{'p': z['p']} for z in items if z['x'] == x]
+        assert_index_query(table, 'gsi', expected_keys,
+            Select='SPECIFIC_ATTRIBUTES',
+            AttributesToGet=['p'],
+            KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+        # Requesting the non-projected attribute 'a' should fail with a
+        # ValidationException.
+        with pytest.raises(ClientError, match='ValidationException.*project'):
+            table.query(ConsistentRead=False, IndexName='gsi',
+                Select='SPECIFIC_ATTRIBUTES',
+                AttributesToGet=['a'],
+                KeyConditions={'x': {'AttributeValueList': [x], 'ComparisonOperator': 'EQ'}})
+
+# Check that filtering (FilterExpression) on non-projected attributes is not
+# allowed on a KEYS_ONLY GSI. DynamoDB rejects this with a ValidationException
+# saying the index does not project the filter attribute.
+def test_gsi_keys_only_filter_on_non_projected_attribute(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                   {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'c', 'AttributeType': 'S'},
+            {'AttributeName': 'x', 'AttributeType': 'S'},
+        ],
+        GlobalSecondaryIndexes=[{
+            'IndexName': 'hello',
+            'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+            'Projection': {'ProjectionType': 'KEYS_ONLY'},
+        }]) as table:
+        p = random_string()
+        items = [{'p': p, 'c': str(i), 'x': str(i), 'd': str(i)} for i in range(5)]
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(item)
+        # Filtering on 'd' (a non-projected attribute) is not allowed.
+        with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+            full_query(table, ConsistentRead=False, IndexName='hello',
+                KeyConditions={'x': {'AttributeValueList': ['2'], 'ComparisonOperator': 'EQ'}},
+                FilterExpression='d = :d',
+                ExpressionAttributeValues={':d': '2'})
+        # Filtering on 'x' (the GSI's key column) is also not allowed, but for
+        # a different reason not related to projection: key attributes must be
+        # used in KeyConditions/KeyConditionExpression, not FilterExpression.
+        # The error message is different.
+        with pytest.raises(ClientError, match='ValidationException.*primary key'):
+            full_query(table, ConsistentRead=False, IndexName='hello',
+                KeyConditions={'x': {'AttributeValueList': ['2'], 'ComparisonOperator': 'EQ'}},
+                FilterExpression='x = :val',
+                ExpressionAttributeValues={':val': '2'})
+        # Curiously, there remains one single attribute we may filter on - c.
+        # This is because c is not officially part of the GSI key schema, but
+        # is still projected because it is one of the base table's key
+        # attributes so DynamoDB does allow filtering on it.
+        results = full_query(table, ConsistentRead=False, IndexName='hello',
+            KeyConditions={'x': {'AttributeValueList': ['2'], 'ComparisonOperator': 'EQ'}},
+            FilterExpression='c = :val',
+            ExpressionAttributeValues={':val': '2'})
+        assert len(results) == 1 and results[0]['c'] == '2'
+
+# Same as test_gsi_keys_only_filter_on_non_projected_attribute but for
+# ProjectionType=INCLUDE. The INCLUDE list contains 'e' but not 'd', so
+# filtering on 'd' should be rejected, while filtering on 'e' (or key
+# attributes) should work.
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
+def test_gsi_include_filter_on_non_projected_attribute(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                   {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'c', 'AttributeType': 'S'},
+            {'AttributeName': 'x', 'AttributeType': 'S'},
+        ],
+        GlobalSecondaryIndexes=[{
+            'IndexName': 'hello',
+            'KeySchema': [{'AttributeName': 'x', 'KeyType': 'HASH'}],
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['e']},
+        }]) as table:
+        p = random_string()
+        items = [{'p': p, 'c': str(i), 'x': str(i), 'd': str(i), 'e': str(i)} for i in range(5)]
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(item)
+        # Filtering on 'd' (not in the INCLUDE list) is not allowed.
+        with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+            full_query(table, ConsistentRead=False, IndexName='hello',
+                KeyConditions={'x': {'AttributeValueList': ['2'], 'ComparisonOperator': 'EQ'}},
+                FilterExpression='d = :d',
+                ExpressionAttributeValues={':d': '2'})
+        # Filtering on 'e' (included in the projection) must be allowed.
+        results = full_query(table, ConsistentRead=False, IndexName='hello',
+            KeyConditions={'x': {'AttributeValueList': ['2'], 'ComparisonOperator': 'EQ'}},
+            FilterExpression='e = :e',
+            ExpressionAttributeValues={':e': '2'})
+        assert len(results) == 1 and results[0]['e'] == '2'
+
+# In test_item.py we have several tests for "empty items" - these are
+# items that have only key attributes, but they still exist. In particular,
+# creating an item with some non-key attributes and then deleting these
+# attributes with UpdateItem leaves an empty item behind - it does not
+# delete the whole item. We want to verify that such empty items are still
+# visible in a GSI, including in a GSI that projects only keys.
+#
+# This test helps explain why unlike in CQL, in Alternator we don't need to
+# add virtual columns for unprojected base colmns, even when the view key have
+# the same columns as the base key (as is the case in this test). Unlike CQL
+# where modifying unprojected base columns can cause the view item to change
+# its liveness (appear and disappear), this is not the case in Alternator -
+# even if you add and remove attributes to the base-table item, the GSI item
+# will always be there - possibly empty but does not disappear or reappear.
+@pytest.mark.parametrize('projection_type', ['ALL', 'KEYS_ONLY'])
+def test_gsi_empty_item_visible(dynamodb, projection_type):
+    # The base table has hash key 'p' and sort key 'c'. The GSI uses the
+    # inverted key schema (c HASH, p RANGE), so all base key columns appear
+    # in the GSI key. This is the interesting case for KEYS_ONLY: `:attrs`
+    # is absent from the view, but because c and p are base primary key
+    # columns the view condition is always satisfied.
+    with new_test_table(dynamodb,
+        KeySchema=[
+            {'AttributeName': 'p', 'KeyType': 'HASH'},
+            {'AttributeName': 'c', 'KeyType': 'RANGE'},
+        ],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'c', 'AttributeType': 'S'},
+        ],
+        GlobalSecondaryIndexes=[{
+            'IndexName': 'gsi',
+            'KeySchema': [
+                {'AttributeName': 'c', 'KeyType': 'HASH'},
+                {'AttributeName': 'p', 'KeyType': 'RANGE'},
+            ],
+            'Projection': {'ProjectionType': projection_type},
+        }]) as table:
+        p = random_string()
+        c = random_string()
+        # Case 1: PutItem with only the key attributes (no other attributes).
+        # The item is "empty" in the sense of having no non-key attributes,
+        # and should still be visible in the GSI.
+        table.put_item(Item={'p': p, 'c': c})
+        assert_index_query(table, 'gsi', [{'p': p, 'c': c}],
+            KeyConditions={'c': {'AttributeValueList': [c], 'ComparisonOperator': 'EQ'}})
+        # Case 2: Create an item with a non-key attribute 'a', then delete 'a'
+        # via UpdateItem. The resulting item has only key attributes but should
+        # still be visible in the GSI.
+        p2 = random_string()
+        c2 = random_string()
+        table.put_item(Item={'p': p2, 'c': c2, 'a': random_string()})
+        table.update_item(Key={'p': p2, 'c': c2}, AttributeUpdates={'a': {'Action': 'DELETE'}})
+        assert_index_query(table, 'gsi', [{'p': p2, 'c': c2}],
+            KeyConditions={'c': {'AttributeValueList': [c2], 'ComparisonOperator': 'EQ'}})

--- a/test/alternator/test_limits.py
+++ b/test/alternator/test_limits.py
@@ -356,8 +356,8 @@ def test_limit_attribute_length_gsi_lsi_bad_incoherent_names(dynamodb):
 # This limitation is only true to attributes *explicitly* projected by name -
 # attributes projected as part as ALL can be bigger (up to the usual 64KB
 # limit).
-# Reproduces issue #9169.
-@pytest.mark.xfail(reason="issue #5036: projection in GSI and LSI not supported")
+# Reproduces issues #9169, #5036.
+@pytest.mark.xfail(reason="issue #5036: ProjectionType=INCLUDE not yet supported")
 def test_limit_attribute_length_gsi_lsi_projection_bad(dynamodb):
     too_long_name = random_string(256)
     with pytest.raises(ClientError, match='ValidationException.*25[56]'):

--- a/test/alternator/test_lsi.py
+++ b/test/alternator/test_lsi.py
@@ -15,6 +15,7 @@ import requests
 from botocore.exceptions import ClientError
 
 from test.alternator.util import create_test_table, new_test_table, random_string, full_scan, full_query, multiset, unique_table_name
+from test.alternator.test_metrics import metrics, get_metric
 
 
 # LSIs support strongly-consistent reads, so the following functions do not
@@ -386,9 +387,286 @@ def test_lsi_get_not_projected_attribute(test_table_lsi_keys_only):
                        'b': {'AttributeValueList': [b2], 'ComparisonOperator': 'EQ'}},
         Select='SPECIFIC_ATTRIBUTES', AttributesToGet=['d'])
 
+# Check that querying an entire LSI partition (all items with the same hash
+# key) works correctly: ALL_PROJECTED_ATTRIBUTES returns only the projected
+# attributes (in this case, key columns p, c, b), while ALL_ATTRIBUTES returns
+# the full items (including the non-projected attribute d). The items are
+# returned sorted by the LSI sort key 'b', which is a different order than the
+# base table sort key 'c'.
+def test_lsi_get_whole_partition(test_table_lsi_keys_only):
+    p = random_string()
+    # Write several items into the same partition 'p', with distinct 'b' and
+    # 'c' values so the LSI order (by b) differs from the base order (by c).
+    items = [{'p': p, 'c': str(i), 'b': str(9 - i), 'd': random_string()} for i in range(5)]
+    with test_table_lsi_keys_only.batch_writer() as batch:
+        for item in items:
+            batch.put_item(item)
+    # Query the whole partition via the LSI.
+    # ALL_PROJECTED_ATTRIBUTES: expect only projected columns p, c, b - no d,
+    # returned in LSI sort order (by 'b').
+    expected_projected_ordered = sorted(
+        [{'p': i['p'], 'c': i['c'], 'b': i['b']} for i in items],
+        key=lambda x: x['b'])
+    result = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='ALL_PROJECTED_ATTRIBUTES')
+    assert result == expected_projected_ordered
+    # ALL_ATTRIBUTES: expect full items including non-projected attribute d,
+    # also in LSI sort order (by 'b').
+    expected_ordered = sorted(items, key=lambda x: x['b'])
+    result = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='ALL_ATTRIBUTES')
+    assert result == expected_ordered
+
+# Check that Scan on a KEYS_ONLY LSI with Select=ALL_ATTRIBUTES or
+# Select=SPECIFIC_ATTRIBUTES (for a non-projected attribute) correctly
+# fetches full items from the base table rather than returning only
+# the projected key columns. This is the Scan version of the other tests
+# we have for Query.
+def test_lsi_keys_only_scan_all_attributes(dynamodb):
+    # Scan does not support restricting to a specific partition so
+    # unfortunately we can't re-use a shared table.
+    with new_test_table(dynamodb,
+        KeySchema=[
+            { 'AttributeName': 'p', 'KeyType': 'HASH' },
+            { 'AttributeName': 'c', 'KeyType': 'RANGE' }
+        ],
+        AttributeDefinitions=[
+            { 'AttributeName': 'p', 'AttributeType': 'S' },
+            { 'AttributeName': 'c', 'AttributeType': 'S' },
+            { 'AttributeName': 'b', 'AttributeType': 'S' }
+        ],
+        LocalSecondaryIndexes=[
+            {   'IndexName': 'hello',
+                'KeySchema': [
+                    { 'AttributeName': 'p', 'KeyType': 'HASH' },
+                    { 'AttributeName': 'b', 'KeyType': 'RANGE' }
+                ],
+                'Projection': { 'ProjectionType': 'KEYS_ONLY' }
+            }
+        ]) as table:
+        items = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'd': random_string()} for i in range(5)]
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(item)
+        # Scan with Select=ALL_PROJECTED_ATTRIBUTES: only projected key columns
+        # p, c, b are returned (not the non-projected attribute d).
+        results = full_scan(table, IndexName='hello', Select='ALL_PROJECTED_ATTRIBUTES')
+        expected_projected = [{'p': i['p'], 'c': i['c'], 'b': i['b']} for i in items]
+        assert multiset(results) == multiset(expected_projected)
+        # Scan with Select=ALL_ATTRIBUTES: full items including the non-
+        # projected attribute d must be fetched from the base table.
+        results = full_scan(table, IndexName='hello', Select='ALL_ATTRIBUTES')
+        assert multiset(results) == multiset(items)
+        # Scan with Select=SPECIFIC_ATTRIBUTES requesting only the non-
+        # projected attribute d: also requires a base-table fetch per item.
+        results = full_scan(table, IndexName='hello', Select='SPECIFIC_ATTRIBUTES', AttributesToGet=['d'])
+        assert multiset(results) == multiset([{'d': i['d']} for i in items])
+
+# Check that filtering (FilterExpression) on non-projected attributes is not
+# allowed on a KEYS_ONLY LSI. DynamoDB rejects this with a ValidationException
+# saying the index does not project the filter attribute. DynamoDB forbids
+# filtering on non-projected attributes even when the read is with
+# Select=ALL_ATTRIBUTES (which LSI supports). Filtering on non-projected
+# attributes could have been allowed in this case - because the full items
+# are read from the base table so filtering could access them. But since
+# DynamoDB forbids it, Alternator will forbid it too.
+# Forbidding filtering on non-projected attributes has a performance advantage
+# because it allows DynamoDB to apply the filter before fetching unneeded
+# rows from the base table.
+def test_lsi_keys_only_filter_on_non_projected_attribute(test_table_lsi_keys_only):
+    p = random_string()
+    items = [{'p': p, 'c': str(i), 'b': str(i), 'd': str(i)} for i in range(5)]
+    with test_table_lsi_keys_only.batch_writer() as batch:
+        for item in items:
+            batch.put_item(item)
+    # Filtering on 'd' (a non-projected attribute) is not allowed.
+    with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+        full_query(test_table_lsi_keys_only, IndexName='hello',
+            KeyConditionExpression='p = :p',
+            FilterExpression='d = :d',
+            ExpressionAttributeValues={':p': p, ':d': '2'})
+    # With Select=ALL_ATTRIBUTES, DynamoDB reads the entire items and
+    # could in theory filter on 'd', but still forbids it.
+    with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+        full_query(test_table_lsi_keys_only, IndexName='hello',
+            KeyConditionExpression='p = :p',
+            FilterExpression='d = :d',
+            ExpressionAttributeValues={':p': p, ':d': '2'},
+            Select='ALL_ATTRIBUTES')
+    # Similarly, Select=SPECIFIC_ATTRIBUTES (and ProjectionExpression)
+    # requesting 'd' also makes 'd' available and could in theory filter on
+    # 'd', but is still forbidden.
+    with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+        full_query(test_table_lsi_keys_only, IndexName='hello',
+            KeyConditionExpression='p = :p',
+            FilterExpression='d = :d',
+            ExpressionAttributeValues={':p': p, ':d': '2'},
+            Select='SPECIFIC_ATTRIBUTES',
+            ProjectionExpression='d')
+    # Filtering on the LSI's key columns (p, b) is also not allowed, but for a
+    # different reason not related to projection: Key attributes must be used
+    # in KeyConditions/KeyConditionExpression, not in FilterExpression.
+    # The error message is different.
+    for key_attr in ['p', 'b']:
+        with pytest.raises(ClientError, match='ValidationException.*primary key'):
+            full_query(test_table_lsi_keys_only, IndexName='hello',
+                KeyConditionExpression='p = :p',
+                FilterExpression=f'{key_attr} = :val',
+                ExpressionAttributeValues={':p': p, ':val': '2'})
+    # Curiously, there remains one single attribute we may filter on - c.
+    # This is because c is not officially part of the LSI key schema, but
+    # is still projected because it is one of the base table's key attributes
+    # so DynamoDB does allow filtering on it.
+    results = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditionExpression='p = :p',
+        FilterExpression='c = :val',
+        ExpressionAttributeValues={':p': p, ':val': '2'})
+    assert len(results) == 1 and results[0]['c'] == '2'
+    # Make sure filtering on 'c' still works even if explicitly asks for
+    # with SPECIFIC_ATTRIBUTES just for 'd'.
+    results = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditionExpression='p = :p',
+        FilterExpression='c = :val',
+        ExpressionAttributeValues={':p': p, ':val': '2'},
+        Select='SPECIFIC_ATTRIBUTES', ProjectionExpression='d')
+    assert len(results) == 1 and results[0]['d'] == '2'
+
+# In test_filter_expression.py::test_filter_expression_and_projection_expression
+# we check that when selecting specific attributes with ProjectionExpression,
+# we can still filter on unselected attributes. Let's check this also in the
+# separate code path of an LSI with ProjectionType=KEYS_ONLY which selects
+# a non-projected (non-key) attribute. In such a case we should be able to
+# filter on a key attribute, but return only another, non-key, attribute.
+def test_lsi_keys_only_filter_expression_and_projection_expression(test_table_lsi_keys_only):
+    p = random_string()
+    items = [{'p': p, 'c': str(i), 'b': str(i), 'd': str(i)} for i in range(5)]
+    with test_table_lsi_keys_only.batch_writer() as batch:
+        for item in items:
+            batch.put_item(item)
+    # Filter on 'c' (a key attribute, projected into KEYS_ONLY LSI) but
+    # project only 'd' (a non-projected, non-key attribute requiring a
+    # base-table fetch). The result should contain only the 'd' attribute
+    # of the item whose 'c' matches the filter.
+    results = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditionExpression='p = :p',
+        FilterExpression='c = :c',
+        ProjectionExpression='d',
+        ExpressionAttributeValues={':p': p, ':c': '2'})
+    assert len(results) == 1 and results[0] == {'d': '2'}
+
+# Same as test_lsi_filter_on_non_projected_attribute but for
+# ProjectionType=INCLUDE. The INCLUDE list contains 'e' but not 'd', so
+# filtering on 'd' should be rejected, while filtering on 'e' (or key
+# attributes) should work.
+@pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")
+def test_lsi_include_filter_on_non_projected_attribute(dynamodb):
+    with new_test_table(dynamodb,
+        KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}, {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+        AttributeDefinitions=[
+            {'AttributeName': 'p', 'AttributeType': 'S'},
+            {'AttributeName': 'c', 'AttributeType': 'S'},
+            {'AttributeName': 'b', 'AttributeType': 'S'},
+        ],
+        LocalSecondaryIndexes=[{
+            'IndexName': 'hello',
+            'KeySchema': [
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+                {'AttributeName': 'b', 'KeyType': 'RANGE'},
+            ],
+            'Projection': {'ProjectionType': 'INCLUDE', 'NonKeyAttributes': ['e']},
+        }]) as table:
+        p = random_string()
+        items = [{'p': p, 'c': str(i), 'b': str(i), 'd': str(i), 'e': str(i)} for i in range(5)]
+        with table.batch_writer() as batch:
+            for item in items:
+                batch.put_item(item)
+        # Filtering on 'd' (not in the INCLUDE list) is not allowed.
+        with pytest.raises(ClientError, match='ValidationException.*hello.*does not project.*filter.*d'):
+            full_query(table, IndexName='hello',
+                KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+                FilterExpression='d = :d',
+                ExpressionAttributeValues={':d': '2'})
+        # Filtering on 'e' (included in the projection) must be allowed.
+        results = full_query(table, IndexName='hello',
+            KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+            FilterExpression='e = :e',
+            ExpressionAttributeValues={':e': '2'})
+        assert len(results) == 1 and results[0]['e'] == '2'
+
+# Check that querying a KEYS_ONLY LSI uses base-table reads only when needed:
+#  - Selecting projected (key) columns directly reads from the LSI view without
+#    touching the base table (efficient path).
+#  - Selecting a non-projected column (Select=SPECIFIC_ATTRIBUTES with 'd')
+#    must fall back to a base-table point read per item (inefficient path).
+#  - Select=ALL_ATTRIBUTES also triggers per-item base-table reads.
+# To check whether base-table reads happened, the test uses the metric
+# scylla_alternator_table_lsi_reads_from_base_table (using the per-table
+# metric makes this test safe even if there is concurrent activity on the
+# same Scylla instance).
+# This test is Scylla-specific, so it is skipped on AWS.
+def test_lsi_query_select_efficiency(test_table_lsi_keys_only, metrics):
+    p = random_string()
+    items = [{'p': p, 'c': str(i), 'b': str(i), 'd': str(i)} for i in range(5)]
+    with test_table_lsi_keys_only.batch_writer() as batch:
+        for item in items:
+            batch.put_item(item)
+    per_table_metric = 'scylla_alternator_table_lsi_reads_from_base_table'
+    table_labels = {'cf': test_table_lsi_keys_only.name}
+    # Query with default Select (ALL_PROJECTED_ATTRIBUTES): reads only from
+    # the LSI view - no base-table reads should happen.
+    before = get_metric(metrics, per_table_metric, table_labels)
+    full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}})
+    after = get_metric(metrics, per_table_metric, table_labels)
+    assert after == before
+    # Same with explicit Select=ALL_PROJECTED_ATTRIBUTES.
+    before = after
+    full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='ALL_PROJECTED_ATTRIBUTES')
+    after = get_metric(metrics, per_table_metric, table_labels)
+    assert after == before
+    # Query with Select=SPECIFIC_ATTRIBUTES for key columns (p, c and b) only.
+    # Also no base-table reads needed since key columns are projected.
+    before = get_metric(metrics, per_table_metric, table_labels)
+    full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='SPECIFIC_ATTRIBUTES', AttributesToGet=['p', 'c', 'b'])
+    after = get_metric(metrics, per_table_metric, table_labels)
+    assert after == before
+    # Query with Select=SPECIFIC_ATTRIBUTES for a non-projected column 'd':
+    # must do one base-table read per item.
+    before = get_metric(metrics, per_table_metric, table_labels)
+    results = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='SPECIFIC_ATTRIBUTES', AttributesToGet=['d'])
+    after = get_metric(metrics, per_table_metric, table_labels)
+    assert len(results) == len(items)
+    assert after - before == len(items)
+    # Sanity check: confirm that only the requested attribute 'd' is returned
+    # (not even the key columns are returned).
+    assert all(set(r.keys()) == {'d'} for r in results)
+    # Query with Select=ALL_ATTRIBUTES: also does one base-table read per item.
+    # Also use this opportunity to check that global (not per-table) metric
+    # scylla_alternator_lsi_reads_from_base_table is updated as well.
+    before = get_metric(metrics, per_table_metric, table_labels)
+    global_metric = 'scylla_alternator_lsi_reads_from_base_table'
+    before_global = get_metric(metrics, global_metric)
+    results = full_query(test_table_lsi_keys_only, IndexName='hello',
+        KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'}},
+        Select='ALL_ATTRIBUTES')
+    after = get_metric(metrics, per_table_metric, table_labels)
+    after_global = get_metric(metrics, global_metric)
+    assert len(results) == len(items)
+    assert after - before == len(items)
+    # The global metric may have increased by more than len(items) due to
+    # concurrent activity, but must have increased by at least len(items).
+    assert after_global - before_global >= len(items)
+
 # Check that by default (Select=ALL_PROJECTED_ATTRIBUTES), only projected
 # attributes are extracted
-@pytest.mark.xfail(reason="LSI in alternator currently only implement full projections")
 def test_lsi_get_all_projected_attributes(test_table_lsi_keys_only):
     items1 = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'd': random_string()} for i in range(10)]
     p1, b1, d1 = items1[0]['p'], items1[0]['b'], items1[0]['d']
@@ -398,6 +676,9 @@ def test_lsi_get_all_projected_attributes(test_table_lsi_keys_only):
     with test_table_lsi_keys_only.batch_writer() as batch:
         for item in items:
             batch.put_item(item)
+    # The default Select is ALL_PROJECTED_ATTRIBUTES, which returns only the
+    # projected attributes, which are the key attributes - p, c and b. The
+    # attribute d is not projected and should not appear.
     expected_items = [{'p': i['p'], 'c': i['c'],'b': i['b']} for i in items if i['p'] == p1 and i['b'] == b1]
     assert_index_query(test_table_lsi_keys_only, 'hello', expected_items,
         KeyConditions={'p': {'AttributeValueList': [p1], 'ComparisonOperator': 'EQ'},
@@ -407,8 +688,14 @@ def test_lsi_get_all_projected_attributes(test_table_lsi_keys_only):
 # a test 'test_query_select' for this parameter on a query of a normal (base)
 # table, but for GSI and LSI the ALL_PROJECTED_ATTRIBUTES is additionally
 # allowed (and in fact is the default), and we want to test it.
-@pytest.mark.xfail(reason="Projection and Select not supported yet. Issue #5036, #5058")
-def test_lsi_query_select(dynamodb):
+@pytest.mark.parametrize('projection_type', [
+    'KEYS_ONLY',
+    pytest.param('INCLUDE', marks=pytest.mark.xfail(reason="Issue #5036 - ProjectionType=INCLUDE not yet supported")),
+])
+def test_lsi_query_select(dynamodb, projection_type):
+    projection = {'ProjectionType': projection_type}
+    if projection_type == 'INCLUDE':
+        projection['NonKeyAttributes'] = ['a']
     with new_test_table(dynamodb,
         KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
         AttributeDefinitions=[
@@ -422,8 +709,7 @@ def test_lsi_query_select(dynamodb):
                     { 'AttributeName': 'p', 'KeyType': 'HASH' },
                     { 'AttributeName': 'b', 'KeyType': 'RANGE' }
                 ],
-                'Projection': { 'ProjectionType': 'INCLUDE',
-                                'NonKeyAttributes': ['a'] }
+                'Projection': projection,
             }
         ]) as table:
         items = [{'p': random_string(), 'c': random_string(), 'b': random_string(), 'a': random_string(), 'x': random_string()} for i in range(10)]
@@ -432,11 +718,13 @@ def test_lsi_query_select(dynamodb):
                 batch.put_item(item)
         p = items[0]['p']
         b = items[0]['b']
-        # Although in LSI all attributes are available (as we'll check
-        # below) the default Select is ALL_PROJECTED_ATTRIBUTES, and
-        # returns just the projected attributes (in this case all key
-        # attributes in either base or LSI, and 'a' - but not 'x'):
-        expected_items = [{'p': z['p'], 'c': z['c'], 'b': z['b'], 'a': z['a']} for z in items if z['b'] == b]
+        # The default Select is ALL_PROJECTED_ATTRIBUTES, which returns only
+        # the projected attributes. For INCLUDE: p, c, b, a (but not x).
+        # For KEYS_ONLY: only the key attributes p, c, b.
+        if projection_type == 'INCLUDE':
+            expected_items = [{'p': z['p'], 'c': z['c'], 'b': z['b'], 'a': z['a']} for z in items if z['b'] == b]
+        else:
+            expected_items = [{'p': z['p'], 'c': z['c'], 'b': z['b']} for z in items if z['b'] == b]
         assert_index_query(table, 'hello', expected_items,
             KeyConditions={'p': {'AttributeValueList': [p], 'ComparisonOperator': 'EQ'},
                            'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
@@ -453,7 +741,8 @@ def test_lsi_query_select(dynamodb):
                            'b': {'AttributeValueList': [b], 'ComparisonOperator': 'EQ'}})
         # Also in LSI, SPECIFIC_ATTRIBUTES (with AttributesToGet /
         # ProjectionExpression) is allowed for any attribute, projected
-        # or not projected. Let's try 'a' (projected) and 'x' (not projected):
+        # or not projected. Let's try 'a' (projected in INCLUDE, not in
+        # KEYS_ONLY) and 'x' (not projected in either case):
         expected_items = [{'a': z['a'], 'x': z['x']} for z in items if z['b'] == b]
         assert_index_query(table, 'hello', expected_items,
             Select='SPECIFIC_ATTRIBUTES',
@@ -916,3 +1205,42 @@ def test_lsi_describe_table_schema_all(dynamodb):
         got_lsis = [ {k: v for k, v in got_lsi.items() if k in lsis[0]} for got_lsi in got_lsis ]
         # Use multiset to compare ignoring order
         assert multiset(got_lsis) == multiset(lsis)
+
+# Test that after creating an LSI with different ProjectionType options
+# (ALL, KEYS_ONLY, INCLUDE), DescribeTable is able to show the correct
+# ProjectionType and the LSI. For ProjectionType=INCLUDE, it should also show
+# the correct NonKeyAttributes created with the LSI.
+@pytest.mark.parametrize('projection_type', [
+    'ALL',
+    'KEYS_ONLY',
+    pytest.param('INCLUDE', marks=pytest.mark.xfail(reason='Issue #5036 - ProjectionType=INCLUDE not yet supported')),
+])
+def test_lsi_projection_type_describe(dynamodb, projection_type):
+    projection = {'ProjectionType': projection_type}
+    non_key_attrs = ['extra', 'hello']
+    if projection_type == 'INCLUDE':
+        projection['NonKeyAttributes'] = non_key_attrs
+    with new_test_table(dynamodb,
+            KeySchema=[
+                {'AttributeName': 'p', 'KeyType': 'HASH'},
+                {'AttributeName': 'c', 'KeyType': 'RANGE'},
+            ],
+            AttributeDefinitions=[
+                {'AttributeName': 'p', 'AttributeType': 'S'},
+                {'AttributeName': 'c', 'AttributeType': 'S'},
+                {'AttributeName': 'x', 'AttributeType': 'S'},
+            ],
+            LocalSecondaryIndexes=[{
+                'IndexName': 'lsi',
+                'KeySchema': [
+                    {'AttributeName': 'p', 'KeyType': 'HASH'},
+                    {'AttributeName': 'x', 'KeyType': 'RANGE'},
+                ],
+                'Projection': projection,
+            }]) as table:
+        desc = table.meta.client.describe_table(TableName=table.name)
+        lsi_list = desc['Table']['LocalSecondaryIndexes']
+        assert len(lsi_list) == 1
+        assert lsi_list[0]['Projection']['ProjectionType'] == projection_type
+        if projection_type == 'INCLUDE':
+            assert sorted(lsi_list[0]['Projection']['NonKeyAttributes']) == sorted(non_key_attrs)


### PR DESCRIPTION
In this patch we add support in Alternator's GSI and LSI for the ProjectionType=KEYS_ONLY option, which allows the index to not copy all not _all_ the attributes from the base table to the materialized view - as ProjectionType=ALL does and was the only option supported today. Before this patch, if ProjectionType=KEYS_ONLY was used, it was silently ignored and wasted space - the GSI/LSI was much bigger than it was supposed to be.

Note that the last remaining ProjectionType option, "INCLUDE", is still *not* supported in this patch, which is why this patch Refs #5036 but doesn't yet "Fixes" it. To implement KEYS_ONLY, as we do in this patch, we need to fully drop the ":attrs" map (the map holding all the non- key attributes) from the materialized view. Implementing INCLUDE will require more elaborate code which modifies a map - keeping only specific elements - while copying it from the base-table to view, a feature that we don't yet support in Scylla's materialized view implementation.

    Note that Alternator's behavior regarding ProjectionType=INCLUDE changes
    after this patch: Before this patch it was silently (and incorrectly)
    ignored - the new GSI/LSI contained all attributes instead of just a
    select few. So the application could read the attributes it cared
    about - but also other attributes. After this patch, INCLUDE is just
    rejected as an error. If a user wants to fallback to using ALL, they
    will need to change their application to use ALL.

Changes:

* CreateTable / UpdateTable: parse the Projection parameter for LSI and GSI definitions. For ProjectionType=KEYS_ONLY, omit the ":attrs" column from the materialized view schema. For ALL (the default), the view includes ":attrs" as before. ProjectionType=INCLUDE is rejected as not yet supported. NonKeyAttributes is rejected when ProjectionType is not INCLUDE.

* DescribeTable: report the correct ProjectionType (KEYS_ONLY or ALL) for each LSI/GSI by inspecting whether the view schema contains the ":attrs" column (via the new projection_is_keys_only() helper).

* Query on GSI with KEYS_ONLY: reject Select=ALL_ATTRIBUTES with a clear error, matching DynamoDB behavior (a GSI with KEYS_ONLY cannot do base-table lookups).

* Query on LSI with KEYS_ONLY: unlike GSI, DynamoDB allows Select=ALL_ATTRIBUTES on a KEYS_ONLY LSI. as the existing test test_lsi.py::test_lsi_get_not_projected_attribute shows, after reading the key columns from the LSI, we need do read the unprojected columns from the base table - this is similar to CQL's secondary index where a query begins by finding only the list of keys in the view but then needs to go to the base table to read each of these matching rows individually. Note that the second step is fairly *inefficient*: Despite the fact that in an LSI the base-table partition is on the same replica as the LSI's partition, they are not ordered the same so the second step is an inefficient loop of many random-access single-row reads - not a scan. We implement this part in a new do_query_lsi_with_base_fetch() function that:
    1. Queries the LSI view to get results in LSI sort-key order.
    2. For each row, extracts the base-table primary key from the LSI result (the LSI view schema always includes both the LSI sort key and the base clustering key).
    3. Does a point read on the base table to retrieve the full item. This preserves LSI sort order while returning complete item data.

* Added a metric scylla_alternator_lsi_reads_from_base_table which counts the number of inefficient base-table reads (count of rows) needed for LSI reads that ask to read non-projected attributes. This metric can be useful for users (who will want to avoid these inefficient reads as much as possible), but also important for our test that verifies that these inefficient base-table reads do not happen when not necessary.

* Tests: Remove now-passing xfail markers from test_gsi.py and test_lsi.py, and also add new tests for additional corner cases discovered during this development. As usual, all tests pass also on DynamoDB.