### PR TITLE
doc: update the node size limit

### DIFF
--- a/docs/reference/limits.rst
+++ b/docs/reference/limits.rst
@@ -16,7 +16,7 @@ Cluster and Node Limits
    * - Nodes per cluster
      - Low hundreds
    * - Node size
-     - 256 vcpu
+     - 4096 CPUs
   
 See :ref:`Hardware Requirements <system-requirements-hardware>` for storage
 and memory requirements and limits.


### PR DESCRIPTION
This PR increases the node size limit from 256 to 4096 CPUs based on https://github.com/scylladb/seastar/commit/be1f566488b26d0e392ef0816680b98ad8f45038

Fixes SCYLLADB-1676

Backport feedback needed:
@avikivity I'm adding the backport label based on https://scylladb.atlassian.net/browse/SCYLLADB-1676 but please confirm if this is the correct backport version.