### PR TITLE
hints: discard hints for removenode/replace, drain for decommission

### DIFF
--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -640,7 +640,7 @@ bool manager::check_dc_for(endpoint_id ep) const noexcept {
     }
 }
 
-future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip) noexcept {
+future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip, std::optional<service::topology_request> reason) noexcept {
     if (!started() || stopping() || draining_all()) {
         co_return;
     }

--- a/db/hints/manager.cc
+++ b/db/hints/manager.cc
@@ -41,6 +41,7 @@
 #include "locator/host_id.hh"
 #include "locator/token_metadata.hh"
 #include "replica/database.hh"
+#include "db/system_keyspace.hh"
 #include "service/storage_proxy.hh"
 #include "utils/directories.hh"
 #include "utils/disk-error-handler.hh"
@@ -641,17 +642,18 @@ bool manager::check_dc_for(endpoint_id ep) const noexcept {
 }
 
 future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip, std::optional<service::topology_request> reason) noexcept {
+    bool discard = (reason == service::topology_request::remove || reason == service::topology_request::replace);
     if (!started() || stopping() || draining_all()) {
         co_return;
     }
 
-    if (!replay_allowed()) {
-        auto reason = seastar::format("Precondition violdated while trying to drain {} / {}: "
-                "hint replay is not allowed", host_id, ip);
-        on_internal_error(manager_logger, std::move(reason));
+    if (!discard && !replay_allowed()) {
+        // Hint replay is not yet allowed; drain_left_nodes() will handle this
+        // host once replay is enabled.
+        co_return;
     }
 
-    manager_logger.info("Draining starts for {}", host_id);
+    manager_logger.info("{} starts for {}", discard ? "Discarding" : "Draining", host_id);
 
     const auto holder = seastar::gate::holder{_draining_eps_gate};
     // As long as we hold on to this lock, no migration of hinted handoff to host IDs
@@ -683,15 +685,29 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip, std::opti
         });
     };
 
+    // After discarding, remove the directory and all its contents without replaying hints.
+    auto discard_ep_manager = [] (hint_endpoint_manager& ep_man) -> future<> {
+        co_await ep_man.stop(drain::no);
+        co_await ep_man.with_file_update_mutex([&ep_man] -> future<> {
+            return seastar::recursive_remove_directory(ep_man.hints_dir()).then([&ep_man] {
+                manager_logger.info("Discarded hint directory for {}", ep_man.end_point_key());
+            });
+        });
+    };
+
     std::exception_ptr eptr = nullptr;
+
+    std::function<future<>(hint_endpoint_manager&)> process_ep_manager =
+        discard ? std::function<future<>(hint_endpoint_manager&)>(discard_ep_manager)
+                : std::function<future<>(hint_endpoint_manager&)>(drain_ep_manager);
 
     if (_proxy.local_db().get_token_metadata().get_topology().is_me(host_id)) {
         set_draining_all();
 
         try {
             co_await coroutine::parallel_for_each(_ep_managers | std::views::values,
-                    [&drain_ep_manager] (hint_endpoint_manager& ep_man) {
-                return drain_ep_manager(ep_man);
+                    [&process_ep_manager] (hint_endpoint_manager& ep_man) {
+                return process_ep_manager(ep_man);
             });
         } catch (...) {
             eptr = std::current_exception();
@@ -720,7 +736,7 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip, std::opti
 
             if (it != _ep_managers.end()) {
                 try {
-                    co_await drain_ep_manager(it->second);
+                    co_await process_ep_manager(it->second);
                 } catch (...) {
                     eptr = std::current_exception();
                 }
@@ -735,10 +751,10 @@ future<> manager::drain_for(endpoint_id host_id, gms::inet_address ip, std::opti
     }
 
     if (eptr) {
-        manager_logger.error("Exception when draining {}: {}", host_id, eptr);
+        manager_logger.error("Exception when {} hints for {}: {}", discard ? "discarding" : "draining", host_id, eptr);
     }
 
-    manager_logger.info("drain_for: finished draining {}", host_id);
+    manager_logger.info("drain_for: finished {} hints for {}", discard ? "discarding" : "draining", host_id);
 }
 
 void manager::update_backlog(size_t backlog, size_t max_backlog) {
@@ -989,11 +1005,25 @@ future<> manager::perform_migration() {
 //                 this constraint early on with possible future refactors in mind. It should be easier
 //                 to modify the function this way.
 future<> manager::drain_left_nodes() {
+    // Build the set of hosts that have endpoint managers but are no longer normal token owners.
+    std::unordered_set<locator::host_id> left_hosts;
     for (const auto& [host_id, ep_man] : _ep_managers) {
         if (!_proxy.get_token_metadata_ptr()->is_normal_token_owner(host_id)) {
-            // It's safe to discard this future. It's awaited in `manager::stop()`.
-            (void) drain_for(host_id, {});
+            left_hosts.insert(host_id);
         }
+    }
+
+    // Query the topology_requests table to determine the reason each host left the cluster.
+    auto host_requests = co_await _proxy.system_keyspace().get_topology_request_for_hosts(left_hosts);
+
+    for (const auto& host_id : left_hosts) {
+        auto it = host_requests.find(host_id);
+        std::optional<service::topology_request> reason;
+        if (it != host_requests.end()) {
+            reason = it->second;
+        }
+        // It's safe to discard this future. It's awaited in `manager::stop()`.
+        (void) drain_for(host_id, {}, reason);
     }
 
     co_return;

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -27,9 +27,11 @@
 #include "db/hints/sync_point.hh"
 #include "gms/inet_address.hh"
 #include "locator/abstract_replication_strategy.hh"
+#include "service/topology_state_machine.hh"
 
 // STD.
 #include <chrono>
+#include <optional>
 #include <span>
 #include <unordered_map>
 
@@ -325,7 +327,8 @@ public:
     ///
     /// \param host_id host ID of the node that left the cluster
     /// \param ip the IP of the node that left the cluster
-    future<> drain_for(endpoint_id host_id, gms::inet_address ip) noexcept;
+    /// \param reason the topology request that caused the node to leave (nullopt if unknown)
+    future<> drain_for(endpoint_id host_id, gms::inet_address ip, std::optional<service::topology_request> reason = std::nullopt) noexcept;
 
     void update_backlog(size_t backlog, size_t max_backlog);
 

--- a/db/hints/manager.hh
+++ b/db/hints/manager.hh
@@ -313,17 +313,26 @@ public:
     bool have_ep_manager(const std::variant<locator::host_id, gms::inet_address>& ep) const noexcept;
 
 public:
-    /// \brief Initiate the draining when we detect that the node has left the cluster.
+    /// \brief Initiate the draining or discarding when we detect that the node has left the cluster.
     ///
     /// If the node that has left is the current node - drains all pending hints to all nodes.
-    /// Otherwise drains hints to the node that has left.
+    /// Otherwise drains or discards hints to the node that has left, depending on the `reason` parameter:
+    /// * If reason is unegaged or reason is topology_requests::decommission: hints will be drained.
+    /// * If reason is either topology_requests::remove or topology_requests::replace: hints will be discarded.
     ///
-    /// In both cases - removes the corresponding hints' directories after all hints have been drained and erases the
+    /// Decomission redistributes data on the leaving replica among the other replicas.
+    /// So any pending hints to this replica has to be broadcasted to all replicas.
+    /// Removenode redistributes the former data of the leaving replica among other replicas,
+    /// while replace rebuilds the joining replica from the other replicas.
+    /// In both cases the leaving node's data is lost and for quorum continuity it is strongly recommended that
+    /// these node ops use RBNO, or repair right after the node op. So hints are redundant in either case.
+    ///
+    /// In both cases - removes the corresponding hints' directories and erases the
     /// corresponding hint_endpoint_manager objects.
     ///
-    /// Preconditions:
-    /// * Hint replay must be allowed (i.e. `replay_allowed()` must be true) throughout
-    ///   the execution of this function.
+    /// If hint replay is not yet allowed and a drain (not discard) is requested,
+    /// this function returns immediately without error; the drain will be performed
+    /// later by drain_left_nodes() once hint replay is enabled.
     ///
     /// \param host_id host ID of the node that left the cluster
     /// \param ip the IP of the node that left the cluster

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -314,6 +314,7 @@ schema_ptr system_keyspace::topology_requests() {
         return schema_builder(NAME, TOPOLOGY_REQUESTS, std::optional(id))
             .with_column("id", timeuuid_type, column_kind::partition_key)
             .with_column("initiating_host", uuid_type)
+            .with_column("target_host", uuid_type)
             .with_column("request_type", utf8_type)
             .with_column("start_time", timestamp_type)
             .with_column("done", boolean_type)
@@ -3541,6 +3542,9 @@ system_keyspace::topology_requests_entry system_keyspace::topology_request_row_t
     entry.id = id;
     if (row.has("initiating_host")) {
         entry.initiating_host = row.get_as<utils::UUID>("initiating_host");
+    }
+    if (row.has("target_host")) {
+        entry.target_host = row.get_as<utils::UUID>("target_host");
     }
     if (row.has("request_type")) {
         auto rts = row.get_as<sstring>("request_type");

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -3657,6 +3657,29 @@ future<system_keyspace::topology_requests_entries> system_keyspace::get_node_ops
     }, end_time_limit);
 }
 
+future<std::unordered_map<locator::host_id, service::topology_request>> system_keyspace::get_topology_request_for_hosts(std::unordered_set<locator::host_id> hosts) {
+    std::unordered_map<locator::host_id, service::topology_request> result;
+    co_await _qp.query_internal(
+        format("SELECT target_host, request_type FROM system.{}", TOPOLOGY_REQUESTS),
+        [&result, &hosts] (const cql3::untyped_result_set_row& row) -> future<stop_iteration> {
+            if (!row.has("target_host") || !row.has("request_type")) {
+                co_return stop_iteration::no;
+            }
+            auto target_host = locator::host_id(row.get_as<utils::UUID>("target_host"));
+            if (!hosts.contains(target_host)) {
+                co_return stop_iteration::no;
+            }
+            auto req_type_str = row.get_as<sstring>("request_type");
+            auto req_type = service::try_topology_request_from_string(req_type_str);
+            if (!req_type) {
+                co_return stop_iteration::no;
+            }
+            result.emplace(target_host, *req_type);
+            co_return stop_iteration::no;
+        });
+    co_return result;
+}
+
 future<mutation> system_keyspace::get_insert_dict_mutation(
     std::string_view name,
     bytes data,

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -412,6 +412,7 @@ public:
     struct topology_requests_entry {
         utils::UUID id;
         utils::UUID initiating_host;
+        std::optional<utils::UUID> target_host;
         std::variant<std::monostate, service::topology_request, service::global_topology_request> request_type;
         db_clock::time_point start_time;
         bool done;

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -691,6 +691,11 @@ public:
     future<std::optional<topology_requests_entry>> get_topology_request_entry_opt(utils::UUID id);
     future<system_keyspace::topology_requests_entries> get_topology_request_entries(std::vector<std::variant<service::topology_request, service::global_topology_request>> request_types, db_clock::time_point end_time_limit);
     future<topology_requests_entries> get_node_ops_request_entries(db_clock::time_point end_time_limit);
+    // For each host in `hosts` that has a matching target_host in the topology_requests table,
+    // returns the corresponding topology_request for that host.
+    // Hosts not present in the table (e.g. because the feature flag was not yet active when they
+    // left) are omitted from the result; callers should treat them as unknown / default to draining.
+    future<std::unordered_map<locator::host_id, service::topology_request>> get_topology_request_for_hosts(std::unordered_set<locator::host_id> hosts);
 
 public:
     future<std::optional<bool>> get_service_level_driver_created();

--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -119,6 +119,7 @@ public:
     gms::feature supports_consistent_topology_changes { *this, "SUPPORTS_CONSISTENT_TOPOLOGY_CHANGES"sv };
     gms::feature host_id_based_hinted_handoff { *this, "HOST_ID_BASED_HINTED_HANDOFF"sv };
     gms::feature topology_requests_type_column { *this, "TOPOLOGY_REQUESTS_TYPE_COLUMN"sv };
+    gms::feature topology_requests_target_host_column { *this, "TOPOLOGY_REQUESTS_TARGET_HOST_COLUMN"sv };
     gms::feature native_reverse_queries { *this, "NATIVE_REVERSE_QUERIES"sv };
     gms::feature zero_token_nodes { *this, "ZERO_TOKEN_NODES"sv };
     gms::feature views_with_tablets { *this, "VIEWS_WITH_TABLETS"sv };

--- a/node_ops/task_manager_module.cc
+++ b/node_ops/task_manager_module.cc
@@ -111,36 +111,21 @@ tasks::task_manager::task_group node_ops_virtual_task::get_group() const noexcep
     return tasks::task_manager::task_group::topology_change_group;
 }
 
-static std::map<tasks::task_id, locator::host_id> get_requests(const service::topology& topology) {
-    std::map<tasks::task_id, locator::host_id> result;
-    for (auto& request : topology.requests) {
-        auto* rs = topology.find(request.first);
-        if (rs) {
-            result.emplace(tasks::task_id(rs->second.request_id), locator::host_id(request.first.uuid()));
-        }
-    }
-    for (auto& [node, rs] : topology.transition_nodes) {
-        result.emplace(tasks::task_id(rs.request_id), locator::host_id(node.uuid()));
-    }
-    return result;
-}
-
 future<std::optional<tasks::virtual_task_hint>> node_ops_virtual_task::contains(tasks::task_id task_id) const {
     if (!task_id.uuid().is_timestamp()) {
         // Task id of node ops operation is always a timestamp.
         co_return std::nullopt;
     }
 
-    auto hint = std::make_optional<tasks::virtual_task_hint>({});
-    service::topology& topology = _ss._topology_state_machine._topology;
-    auto reqs = get_requests(topology);
-    if (reqs.contains(task_id)) {
-        hint->node_id = reqs.at(task_id);
-        co_return hint;
-    }
-
     auto entry = co_await _ss._sys_ks.local().get_topology_request_entry_opt(task_id.uuid());
-    co_return entry && std::holds_alternative<service::topology_request>(entry->request_type) ? hint : std::nullopt;
+    if (!entry || !std::holds_alternative<service::topology_request>(entry->request_type)) {
+        co_return std::nullopt;
+    }
+    auto hint = std::make_optional<tasks::virtual_task_hint>({});
+    if (entry->target_host) {
+        hint->node_id = locator::host_id(*entry->target_host);
+    }
+    co_return hint;
 }
 
 future<tasks::is_abortable> node_ops_virtual_task::is_abortable(tasks::virtual_task_hint hint) const {
@@ -165,12 +150,11 @@ future<> node_ops_virtual_task::abort(tasks::task_id id, tasks::virtual_task_hin
 future<std::vector<tasks::task_stats>> node_ops_virtual_task::get_stats() {
     db::system_keyspace& sys_ks = _ss._sys_ks.local();
     co_return std::ranges::to<std::vector<tasks::task_stats>>(co_await get_entries(sys_ks, get_task_manager().get_user_task_ttl())
-            | std::views::transform([reqs = get_requests(_ss._topology_state_machine._topology)] (const auto& e) {
-        auto id = tasks::task_id{e.first};
+            | std::views::transform([] (const auto& e) {
         auto& entry = e.second;
         tasks::virtual_task_hint hint;
-        if (reqs.contains(id)) {
-            hint.node_id = reqs.at(id);
+        if (entry.target_host) {
+            hint.node_id = locator::host_id(*entry.target_host);
         }
         return get_task_stats(entry, hint);
     }));

--- a/service/endpoint_lifecycle_subscriber.hh
+++ b/service/endpoint_lifecycle_subscriber.hh
@@ -10,8 +10,10 @@
 
 #pragma once
 
+#include <optional>
 #include "gms/inet_address.hh"
 #include "locator/host_id.hh"
+#include "service/topology_state_machine.hh"
 #include "utils/atomic_vector.hh"
 #include "service/client_routes.hh"
 
@@ -51,7 +53,7 @@ public:
      *
      * @param host_id the host ID of the endpoint that was released.
      */
-    virtual void on_released(const locator::host_id& host_id) {}
+    virtual void on_released(const locator::host_id& host_id, std::optional<service::topology_request> reason) {}
 
     /**
      * Called when a node is marked UP.
@@ -78,7 +80,7 @@ public:
 
     future<> notify_down(gms::inet_address endpoint, locator::host_id host_id);
     future<> notify_left(gms::inet_address endpoint, locator::host_id host_id);
-    future<> notify_released(locator::host_id host_id);
+    future<> notify_released(locator::host_id host_id, std::optional<service::topology_request> reason);
     future<> notify_up(gms::inet_address endpoint, locator::host_id host_id);
     future<> notify_joined(gms::inet_address endpoint, locator::host_id host_id);
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7416,7 +7416,7 @@ void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint, const lo
     }
 }
 
-void storage_proxy::on_released(const locator::host_id& hid) {
+void storage_proxy::on_released(const locator::host_id& hid, std::optional<service::topology_request> reason) {
     // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
     //
     // Hint replay must be allowed throughout the execution of `drain_for`
@@ -7426,11 +7426,12 @@ void storage_proxy::on_released(const locator::host_id& hid) {
     // Note that if we don't perform draining here because hint replay is not
     // allowed yet, it'll be conducted by a call to `db::hints::manager::drain_left_nodes()`,
     // which is called by `main.cc` after hint replay is turned on.
-    if (_hints_manager.replay_allowed() && _hints_manager.uses_host_id()) {
-        (void) _hints_manager.drain_for(hid, {});
+    bool discard = (reason == service::topology_request::remove);
+    if ((_hints_manager.replay_allowed() || discard) && _hints_manager.uses_host_id()) {
+        (void) _hints_manager.drain_for(hid, {}, reason);
     }
-    if (_hints_for_views_manager.replay_allowed() && _hints_for_views_manager.uses_host_id()) {
-        (void) _hints_for_views_manager.drain_for(hid, {});
+    if ((_hints_for_views_manager.replay_allowed() || discard) && _hints_for_views_manager.uses_host_id()) {
+        (void) _hints_for_views_manager.drain_for(hid, {}, reason);
     }
 }
 

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -7418,19 +7418,11 @@ void storage_proxy::on_leave_cluster(const gms::inet_address& endpoint, const lo
 
 void storage_proxy::on_released(const locator::host_id& hid, std::optional<service::topology_request> reason) {
     // Discarding these futures is safe. They're awaited by db::hints::manager::stop().
-    //
-    // Hint replay must be allowed throughout the execution of `drain_for`
-    // (it's a precondition of it). Once enabled in `main.cc`, it stays true
-    // throughout the life of the node.
-    //
-    // Note that if we don't perform draining here because hint replay is not
-    // allowed yet, it'll be conducted by a call to `db::hints::manager::drain_left_nodes()`,
-    // which is called by `main.cc` after hint replay is turned on.
-    bool discard = (reason == service::topology_request::remove);
-    if ((_hints_manager.replay_allowed() || discard) && _hints_manager.uses_host_id()) {
+    // drain_for() handles the replay_allowed() precondition check internally.
+    if (_hints_manager.uses_host_id()) {
         (void) _hints_manager.drain_for(hid, {}, reason);
     }
-    if ((_hints_for_views_manager.replay_allowed() || discard) && _hints_for_views_manager.uses_host_id()) {
+    if (_hints_for_views_manager.uses_host_id()) {
         (void) _hints_for_views_manager.drain_for(hid, {}, reason);
     }
 }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -880,7 +880,7 @@ public:
     }
 
     virtual void on_leave_cluster(const gms::inet_address& endpoint, const locator::host_id& hid) override;
-    virtual void on_released(const locator::host_id& hid) override;
+    virtual void on_released(const locator::host_id& hid, std::optional<service::topology_request> reason) override;
     virtual void on_down(const gms::inet_address& endpoint, locator::host_id hid) override;
 
     friend class abstract_read_executor;

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -1246,6 +1246,10 @@ utils::chunked_vector<canonical_mutation> storage_service::build_mutation_from_j
     rtbuilder.set("initiating_host", params.host_id.uuid())
              .set("done", false);
     rtbuilder.set("request_type", params.replaced_id ? topology_request::replace : topology_request::join);
+    if (_feature_service.topology_requests_target_host_column) {
+        auto target = params.replaced_id ? params.replaced_id->uuid() : params.host_id.uuid();
+        rtbuilder.set("target_host", target);
+    }
 
     utils::chunked_vector<canonical_mutation> muts = {builder.build(), rtbuilder.build()};
 
@@ -2702,6 +2706,9 @@ future<> storage_service::raft_decommission() {
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::leave);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", raft_server.id().uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("decommission: request decommission for {}", raft_server.id()));
 
@@ -2814,6 +2821,9 @@ future<> storage_service::raft_removenode(locator::host_id host_id, locator::hos
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::remove);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", id.uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("removenode: request remove for {}", id));
 
@@ -3399,6 +3409,9 @@ future<> storage_service::raft_rebuild(utils::optional_param sdc_param) {
         rtbuilder.set("initiating_host",_group0->group0_server().id().uuid())
                  .set("done", false);
         rtbuilder.set("request_type", topology_request::rebuild);
+        if (_feature_service.topology_requests_target_host_column) {
+            rtbuilder.set("target_host", raft_server.id().uuid());
+        }
         topology_change change{{builder.build(), rtbuilder.build()}};
         group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard, ::format("rebuild: request rebuild for {} ({})", raft_server.id(), source_dc));
 

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -621,7 +621,17 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
     if (prev_released) {
         auto nodes_to_release = get_released_nodes(t, *tmptr);
         std::erase_if(nodes_to_release, [&] (const auto& host_id) { return prev_released->contains(host_id); });
-        std::copy(nodes_to_release.begin(), nodes_to_release.end(), std::back_inserter(nodes_to_notify.released));
+        if (!nodes_to_release.empty()) {
+            auto host_requests = co_await _sys_ks.local().get_topology_request_for_hosts(nodes_to_release);
+            for (const auto& host_id : nodes_to_release) {
+                auto it = host_requests.find(host_id);
+                std::optional<service::topology_request> reason;
+                if (it != host_requests.end()) {
+                    reason = it->second;
+                }
+                nodes_to_notify.released.emplace_back(host_id, reason);
+            }
+        }
     }
 
     co_await when_all_succeed(sys_ks_futures.begin(), sys_ks_futures.end()).discard_result();
@@ -632,8 +642,8 @@ future<storage_service::nodes_to_notify_after_sync> storage_service::sync_raft_t
 }
 
 future<> storage_service::notify_nodes_after_sync(nodes_to_notify_after_sync&& nodes_to_notify) {
-    for (auto host_id : nodes_to_notify.released) {
-        co_await notify_released(host_id);
+    for (auto [host_id, reason] : nodes_to_notify.released) {
+        co_await notify_released(host_id, reason);
     }
     for (auto [ip, host_id] : nodes_to_notify.left) {
         co_await notify_left(ip, host_id);
@@ -6515,11 +6525,11 @@ future<> endpoint_lifecycle_notifier::notify_left(gms::inet_address endpoint, lo
     });
 }
 
-future<> endpoint_lifecycle_notifier::notify_released(locator::host_id hid) {
-    return seastar::async([this, hid] {
-        _subscribers.thread_for_each([hid] (endpoint_lifecycle_subscriber* subscriber) {
+future<> endpoint_lifecycle_notifier::notify_released(locator::host_id hid, std::optional<service::topology_request> reason) {
+    return seastar::async([this, hid, reason] {
+        _subscribers.thread_for_each([hid, reason] (endpoint_lifecycle_subscriber* subscriber) {
             try {
-                subscriber->on_released(hid);
+                subscriber->on_released(hid, reason);
             } catch (...) {
                 slogger.warn("Node released notification failed {}: {}", hid, std::current_exception());
             }
@@ -6534,9 +6544,9 @@ future<> storage_service::notify_left(inet_address endpoint, locator::host_id hi
     slogger.debug("Notify node {} has left the cluster", endpoint);
 }
 
-future<> storage_service::notify_released(locator::host_id hid) {
-    co_await container().invoke_on_all([hid] (auto&& ss) {
-        return ss._lifecycle_notifier.notify_released(hid);
+future<> storage_service::notify_released(locator::host_id hid, std::optional<service::topology_request> reason) {
+    co_await container().invoke_on_all([hid, reason] (auto&& ss) {
+        return ss._lifecycle_notifier.notify_released(hid, reason);
     });
     slogger.debug("Notify node {} been released from the cluster and no longer owns any tokens", hid);
 }

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -815,7 +815,7 @@ private:
 
     future<> notify_down(inet_address endpoint, locator::host_id hid);
     future<> notify_left(inet_address endpoint, locator::host_id hid);
-    future<> notify_released(locator::host_id hid);
+    future<> notify_released(locator::host_id hid, std::optional<service::topology_request> reason);
     future<> notify_up(inet_address endpoint, locator::host_id hid);
     future<> notify_joined(inet_address endpoint, locator::host_id hid);
     future<> notify_cql_change(inet_address endpoint, locator::host_id hid,bool ready);
@@ -997,7 +997,7 @@ private:
     struct nodes_to_notify_after_sync {
         std::vector<std::pair<gms::inet_address, locator::host_id>> left;
         std::vector<std::pair<gms::inet_address, locator::host_id>> joined;
-        std::vector<locator::host_id> released;
+        std::vector<std::pair<locator::host_id, std::optional<service::topology_request>>> released;
     };
 
     using host_id_to_ip_map_t = db::system_keyspace::host_id_to_ip_map_t;

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -325,8 +325,10 @@ async def test_draining_hints(manager: ManagerClient):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_canceling_hint_draining(manager: ManagerClient):
     """
-    This test verifies that draining hints is canceled as soon as we issue a shutdown,
-    but it's resumed after starting the node again.
+    Verifies that after a removenode, pending hints are discarded (not drained) even when
+    hint replay is paused via injection. Unlike draining, discarding does not replay hints
+    and therefore is not affected by the replay pause injection.
+    After the node is restarted, there should be no hint directory left for the removed node.
     """
     s1, s2, s3 = await manager.servers_add(3, auto_rack_dc="dc")
 
@@ -344,29 +346,56 @@ async def test_canceling_hint_draining(manager: ManagerClient):
     for i in range(1000):
         await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i + 1})", consistency_level=ConsistencyLevel.ANY))
 
-    sync_point = await create_sync_point(manager.api.client, s1.ip_addr)
+    s1_log = await manager.server_open_log(s1.server_id)
+    s1_mark = await s1_log.mark()
 
+    # Pause hint replay; discarding (used for removenode) is not affected by this injection.
     await manager.api.enable_injection(s1.ip_addr, "hinted_handoff_pause_hint_replay", False, {})
     nodetool.excludenode(cql, host_id2)
     await cql.run_async(f"ALTER KEYSPACE ks WITH REPLICATION = {{'class': 'NetworkTopologyStrategy', 'dc': {[s1.rack, s3.rack]}}}")
 
     await manager.remove_node(s1.server_id, s2.server_id)
-    await manager.server_stop_gracefully(s1.server_id)
+
+    # Discarding should proceed despite the replay pause.
+    await s1_log.wait_for(f"Discarding starts for {host_id2}", from_mark=s1_mark)
+    await s1_log.wait_for(f"Discarded hint directory for {host_id2}", from_mark=s1_mark)
+
+@pytest.mark.asyncio
+async def test_discarding_hints_on_removenode(manager: ManagerClient):
+    """
+    Verifies that hints are discarded (not drained) when a node is removed via removenode.
+    After removenode, the removed node's data is rebuilt via repair from other replicas,
+    so replaying hints to the current ring owners would be redundant.
+    This is a regression test for the fix to https://github.com/scylladb/scylladb/issues/XXXX.
+    """
+    s1, s2, _ = await manager.servers_add(3, config={
+        "error_injections_at_startup": ["decrease_hints_flush_period"]
+    })
+    cql = manager.get_cql()
+
+    host_id2 = await manager.get_host_id(s2.server_id)
+
+    await manager.api.set_logger_level(s1.ip_addr, "hints_manager", "trace")
+
+    await cql.run_async("CREATE KEYSPACE ks WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'enabled': false}")
+    await cql.run_async("CREATE TABLE ks.t (pk int PRIMARY KEY, v int)")
+
+    await manager.server_stop_gracefully(s2.server_id)
+
+    # Generate hints towards s2 on s1.
+    for i in range(100):
+        await cql.run_async(SimpleStatement(f"INSERT INTO ks.t (pk, v) VALUES ({i}, {i + 1})", consistency_level=ConsistencyLevel.ANY))
 
     s1_log = await manager.server_open_log(s1.server_id)
     s1_mark = await s1_log.mark()
 
-    await manager.server_update_cmdline(s1.server_id, ["--logger-log-level", "hints_manager=trace"])
-    await manager.server_start(s1.server_id)
+    # removenode: hints for the removed node should be discarded, not drained.
+    await manager.remove_node(s1.server_id, s2.server_id)
 
-    s1_log = await manager.server_open_log(s1.server_id)
-
-    # Make sure the node still knows about the decommissioned node and does start draining for it.
-    await s1_log.wait_for(f"Draining starts for {host_id2}", from_mark=s1_mark)
-
-    # Make sure draining finishes successfully.
-    assert await await_sync_point(manager.api.client, s1.ip_addr, sync_point, 60)
-    await s1_log.wait_for(f"Removed hint directory for {host_id2}")
+    # Verify that hints are discarded (not drained) - the log should say "Discarding starts for"
+    # not "Draining starts for".
+    await s1_log.wait_for(f"Discarding starts for {host_id2}", from_mark=s1_mark)
+    await s1_log.wait_for(f"Discarded hint directory for {host_id2}", from_mark=s1_mark)
 
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')


### PR DESCRIPTION
We recently observed hint flushing (replay) done as part of repair to time out, when there is a removed node. When a node leaves the cluster, hints for it are drained -- since the original target of the hints is not available anymore, the hints are broadcasted to all replicas, which is significantly more expensive than sending it to a single node. This handling is correct for node which was decommissioned: the data of this node was redistributed among other replicas, so hints for this node must be broadcasted. For removenode and replace this is redundant: in either case, the data of the leaving node is lost and the new replicas are rebuilt from scratch . It is also strongly recommended to use RBNO for these so hints are redundant.

This PR addresses this: `db::hints::manager::drain_for()`  receives a `topology_request` parameter and based on this it decides whether to drain (previous behaviour) or discard hints.

Fixes: SCYLLADB-1678
Fixes: SCYLLADB-639

Backport: fixes a tombstone-gc repair problem, needs backport to 2026.1 (where tombstone-gc repair is the default for all tables)