### PR TITLE
alternator: Graduate Alternator Streams from experimental

### DIFF
--- a/alternator/streams.cc
+++ b/alternator/streams.cc
@@ -1508,10 +1508,6 @@ bool executor::add_stream_options(const rjson::value& stream_specification, sche
     }
 
     if (stream_enabled->GetBool()) {
-        if (!sp.features().alternator_streams) {
-            throw api_error::validation("StreamSpecification: alternator streams feature not enabled in cluster.");
-        }
-
         cdc::options opts;
         opts.enabled(true);
         opts.tablet_merge_blocked(true);

--- a/db/config.cc
+++ b/db/config.cc
@@ -1921,7 +1921,7 @@ std::map<sstring, db::experimental_features_t::feature> db::experimental_feature
         {"lwt", feature::UNUSED},
         {"udf", feature::UDF},
         {"cdc", feature::UNUSED},
-        {"alternator-streams", feature::ALTERNATOR_STREAMS},
+        {"alternator-streams", feature::UNUSED},
         {"alternator-ttl", feature::UNUSED },
         {"consistent-topology-changes", feature::UNUSED},
         {"broadcast-tables", feature::BROADCAST_TABLES},

--- a/db/config.hh
+++ b/db/config.hh
@@ -115,7 +115,6 @@ struct experimental_features_t {
     enum class feature {
         UNUSED,
         UDF,
-        ALTERNATOR_STREAMS,
         BROADCAST_TABLES,
         KEYSPACE_STORAGE_OPTIONS,
         STRONGLY_CONSISTENT_TABLES,

--- a/init.cc
+++ b/init.cc
@@ -87,9 +87,6 @@ std::set<sstring> get_disabled_features_from_db_config(const db::config& cfg, st
         }
     }
 
-    if (!cfg.check_experimental(db::experimental_features_t::feature::ALTERNATOR_STREAMS)) {
-        disabled.insert("ALTERNATOR_STREAMS"s);
-    }
     if (!cfg.check_experimental(db::experimental_features_t::feature::KEYSPACE_STORAGE_OPTIONS)) {
         disabled.insert("KEYSPACE_STORAGE_OPTIONS"s);
     }

--- a/test/alternator/run
+++ b/test/alternator/run
@@ -70,11 +70,6 @@ def run_alternator_cmd(pid, dir):
         # now that this parameter is used also by CQL's per-row TTL.
         #'--alternator-ttl-period-in-seconds', '0.5',
         '--alternator-allow-system-table-write=1',
-        # Allow testing experimental features. Following issue #9467, we need
-        # to add here specific experimental features as they are introduced.
-        # We only list here Alternator-specific experimental features - CQL
-        # ones are listed in test/cqlpy/run.py.
-        '--experimental-features=alternator-streams',
         # this is required by test_streams.py test_parent_filtering and test_get_records_with_alternating_tablets_count
         # setting the value using scylla_config_temporary won't work, because the value is read
         # at the start and then periodically with `tablet-load-stats-refresh-interval-in-seconds`

--- a/test/alternator/test_config.yaml
+++ b/test/alternator/test_config.yaml
@@ -15,7 +15,6 @@ extra_scylla_config_options:
   {
     experimental_features: [
                              udf,
-                             alternator-streams,
                              keyspace-storage-options
     ],
     alternator_port: 8000,

--- a/test/boost/config_test.cc
+++ b/test/boost/config_test.cc
@@ -876,7 +876,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_cdc) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -888,7 +887,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_unused) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -900,7 +898,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_udf) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UDF});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -909,10 +906,9 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_alternator_streams) {
     auto cfg_ptr = std::make_unique<config>();
     config& cfg = *cfg_ptr;
     cfg.read_from_yaml("experimental_features:\n    - alternator-streams\n", throw_on_error);
-    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::ALTERNATOR_STREAMS});
-    BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
+    BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::UNUSED});
+    BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -924,7 +920,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_broadcast_tables) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::BROADCAST_TABLES});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(cfg.check_experimental(ef::BROADCAST_TABLES));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
@@ -937,7 +932,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_keyspace_storage_options) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), features{ef::KEYSPACE_STORAGE_OPTIONS});
     BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -949,7 +943,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_multiple) {
     BOOST_CHECK_EQUAL(cfg.experimental_features(), (features{ef::UNUSED, ef::UNUSED, ef::UNUSED}));
     BOOST_CHECK(cfg.check_experimental(ef::UNUSED));
     BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-    BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
     BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
     return make_ready_future();
 }
@@ -964,7 +957,6 @@ SEASTAR_TEST_CASE(test_parse_experimental_features_invalid) {
                            BOOST_REQUIRE_NE(msg.find("line 2, column 7"), msg.npos);
                            BOOST_CHECK(!cfg.check_experimental(ef::UNUSED));
                            BOOST_CHECK(!cfg.check_experimental(ef::UDF));
-                           BOOST_CHECK(!cfg.check_experimental(ef::ALTERNATOR_STREAMS));
                            BOOST_CHECK(!cfg.check_experimental(ef::KEYSPACE_STORAGE_OPTIONS));
                        });
     return make_ready_future();

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -108,7 +108,6 @@ def make_scylla_conf(mode: str, workdir: pathlib.Path, host_addr: str, seed_addr
         # to add here specific experimental features as they are introduced.
         'enable_user_defined_functions': True,
         'experimental_features': ['udf',
-                                  'alternator-streams',
                                   'broadcast-tables',
                                   'keyspace-storage-options',
                                   'views-with-tablets'],


### PR DESCRIPTION
As a final step for https://scylladb.atlassian.net/browse/SCYLLADB-461 we need to graduate Alternator Streams from experimental.
So let's remove `--experimental-features=alternator-streams` and map the obsolete config string to `UNUSED` for backward compatibility. Also, remove the related gating of the feature.
Finally, stop providing the config flag in test configs.

Fixes SCYLLADB-1680
Fixes #16367

To documentation tracked by https://scylladb.atlassian.net/browse/SCYLLADB-462 still remains.

This PR needs to hit 2026.2, so (only) if it branches before the PR is merged to `master`, we'd need to backport.