### PR TITLE
cql3: functions: avoid duplicate candidates when keyspace is "system"

### DIFF
--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -469,8 +469,16 @@ functions::get(data_dictionary::database db,
     };
     if (!name.has_keyspace()) {
         // add 'SYSTEM' (native) candidates
-        add_declared(name.as_native_function());
-        add_declared(function_name(keyspace, name.name));
+        auto native = name.as_native_function();
+        add_declared(native);
+        // Avoid adding the same candidates twice when the current keyspace is
+        // the system keyspace: in that case `function_name(keyspace, name.name)`
+        // is equal to `name.as_native_function()` and would resolve to the same
+        // entries in `_declared`, leading to a spurious "Ambiguous call" error.
+        auto user_name = function_name(keyspace, name.name);
+        if (user_name != native) {
+            add_declared(user_name);
+        }
     } else {
         // function name is fully qualified (keyspace + name)
         add_declared(name);

--- a/cql3/functions/functions.cc
+++ b/cql3/functions/functions.cc
@@ -473,7 +473,13 @@ functions::get(data_dictionary::database db,
     if (!name.has_keyspace()) {
         // add 'SYSTEM' (native) candidates
         add_declared(name.as_native_function());
-        add_declared(function_name(keyspace, name.name));
+        // Skip the duplicate when the current keyspace is already the system
+        // keyspace: there `function_name(keyspace, name.name)` equals the native
+        // name and would add the same `_declared` entries again, causing a
+        // spurious "Ambiguous call" error.
+        if (keyspace != db::system_keyspace_name()) {
+            add_declared(function_name(keyspace, name.name));
+        }
     } else {
         // function name is fully qualified (keyspace + name)
         add_declared(name);

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -191,3 +191,24 @@ def test_set_intersection_fn(cql, tbl_set, scylla_only):
         cql.execute(f"SELECT set_intersection(s1, p) FROM {tbl_set} WHERE p={p1}")
     with pytest.raises(InvalidRequest, match='both arguments are of the same set type'):
         cql.execute(f"SELECT set_intersection(s1, s3) FROM {tbl_set} WHERE p={p1}")
+
+# When an unqualified native function (e.g. intAsBlob) is called from a query
+# whose target table is in the `system` keyspace, overload resolution must not
+# add the same candidate twice, once via the native ("system") name and once
+# via the current keyspace name, which is also "system". Duplicate candidates
+# trigger a spurious "Ambiguous call to function" error, especially with bind
+# markers, where overload resolution cannot short-circuit on EXACT_MATCH.
+def test_native_function_in_system_keyspace_query(cql):
+    # Literal argument: EXACT_MATCH fast path.
+    assert [(b'\x00\x00\x00\x04',)] == list(
+        cql.execute("SELECT intAsBlob(4) FROM system.local"))
+    # Bind marker: WEAKLY_ASSIGNABLE path, where the duplicate-candidate bug bites.
+    stmt = cql.prepare("SELECT intAsBlob(?) FROM system.local")
+    assert [(b'\x00\x00\x00\x04',)] == list(cql.execute(stmt, [4]))
+    # Nested unqualified calls.
+    stmt = cql.prepare("SELECT blobAsInt(intAsBlob(?)) FROM system.local")
+    assert [(4,)] == list(cql.execute(stmt, [4]))
+    # Fully-qualified form: regression guard for the `else` branch of the
+    # overload-resolution lookup.
+    assert [(b'\x00\x00\x00\x04',)] == list(
+        cql.execute("SELECT system.intAsBlob(4) FROM system.local"))

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -194,3 +194,25 @@ def test_set_intersection_fn(cql, tbl_set, scylla_only):
         cql.execute(f"SELECT set_intersection(s1, p) FROM {tbl_set} WHERE p={p1}")
     with pytest.raises(InvalidRequest, match='both arguments are of the same set type'):
         cql.execute(f"SELECT set_intersection(s1, s3) FROM {tbl_set} WHERE p={p1}")
+
+# An unqualified native function (e.g. intAsBlob) called against a `system`
+# keyspace table used to be added as a candidate twice. It was registered once
+# under the native "system" name, and once under the current keyspace, which is
+# also "system". A weakly-assignable argument then matched both copies and
+# raised a spurious "Ambiguous call to function" InvalidRequest error.
+# Reproduces SCYLLADB-1682.
+#
+# "Ambiguous call to function" is a hard error, so the regression check is
+# simply that these queries execute without raising: if the duplicate candidate
+# came back, the call would throw InvalidRequest and fail the test.
+def test_native_function_in_system_keyspace_query(cql):
+    # Literal: weakly assignable to int under the current type inference.
+    list(cql.execute("SELECT intAsBlob(4) FROM system.local"))
+    # Bind marker: untyped by construction, so the canonical reproducer.
+    stmt = cql.prepare("SELECT intAsBlob(?) FROM system.local")
+    list(cql.execute(stmt, [4]))
+    # Nested unqualified calls.
+    stmt = cql.prepare("SELECT blobAsInt(intAsBlob(?)) FROM system.local")
+    list(cql.execute(stmt, [4]))
+    # Fully-qualified call takes the single-candidate path; regression guard.
+    list(cql.execute("SELECT system.intAsBlob(4) FROM system.local"))


### PR DESCRIPTION
Calling an unqualified native function (for example, `intAsBlob`) in a query against a system keyspace table can fail with an
"Ambiguous call to function" error:
```
    SELECT intAsBlob(?) FROM system.local;
```

In `functions::get_function` the resolver looks up unqualified candidates twice: once via the system keyspace and once via the query's current keyspace. When the query targets a system table both lookups produce the same key, so the same _declared entries are added twice. A weakly assignable argument, like a bind marker or an untyped literal like `intAsBlob(4)`, matches both copies and trips the ambiguity check. An `EXACT_MATCH` would hide it.

Fix: skip the second add_declared call when the user-qualified name equals the native one. Pre-existing behavior - the relevant code has been in `functions.cc` since 2015.

Tests: cqlpy/test_native_functions.py covers literal, bind marker, nested, and fully-qualified forms.

Fixes SCYLLADB-1682

An improvement addressing an old issue. This is neither a bug fix nor a CI stability issue. No backport needed.