### PR TITLE
alternator/ttl: demote 'sleeping until next period' log to debug

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -889,7 +889,7 @@ future<> expiration_service::run() {
         std::chrono::milliseconds period(long(_db.get_config().alternator_ttl_period_in_seconds() * 1000));
         if (scan_duration < period) {
             try {
-                tlogger.info("sleeping {} seconds until next period", (period - scan_duration).count()/1000.0);
+                tlogger.debug("sleeping {} seconds until next period", (period - scan_duration).count()/1000.0);
                 co_await seastar::sleep_abortable(period - scan_duration, _abort_source);
             } catch(seastar::sleep_aborted&) {}
         } else {


### PR DESCRIPTION
I've seen tests where over 80% of the log content was this log spamming every 0.5 seconds. Demote it to debug to reduce the noise.

Backport: small improvement, no backup.