### PR TITLE
rest: fix deprecated request::content access in formatters

### DIFF
--- a/ent/encryption/azure_host.cc
+++ b/ent/encryption/azure_host.cc
@@ -397,7 +397,7 @@ future<rjson::value> azure_host::impl::send_request(const sstring& host, unsigne
     client.add_header("Authorization", fmt::format("Bearer {}", token.token));
     client.content("application/json", std::move(rjson::print(body)));
 
-    azlog.trace("Sending request: {}", rest::redacted_request_type{ client.request(), filter });
+    azlog.trace("Sending request: {}", rest::redacted_request_type{ client, filter });
 
     auto res = co_await client.send();
     if (res.result() == http::reply::status_type::ok) {

--- a/ent/encryption/kms_host.cc
+++ b/ent/encryption/kms_host.cc
@@ -406,7 +406,7 @@ future<rjson::value> encryption::kms_host::impl::do_post(std::string_view target
         static constexpr const char* HOST_HEADER = "host";
 
         static auto logged_send = [](httpclient& client) -> future<result_type> {
-            kms_log.trace("Request: {}", client.request());
+            kms_log.trace("Request: {}", client);
             result_type res;
             try {
                 res = co_await client.send();
@@ -843,7 +843,7 @@ future<encryption::kms_host::impl::result_type> encryption::kms_host::impl::post
     client.content(query.content_type, query.content);
     client.method(httpclient::method_type::POST);
 
-    kms_log.trace("Request: {}", client.request());
+    kms_log.trace("Request: {}", client);
 
     auto res = co_await client.send();
 

--- a/utils/azure/identity/managed_identity_credentials.cc
+++ b/utils/azure/identity/managed_identity_credentials.cc
@@ -175,7 +175,7 @@ future<> managed_identity_credentials::refresh(const resource_type& resource_uri
         client.add_header("Metadata", "true");
 
         if (az_creds_logger.is_enabled(log_level::trace)) {
-            az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client.request(), filter });
+            az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client, filter });
         }
 
         auto res = co_await client.send();

--- a/utils/azure/identity/service_principal_credentials.cc
+++ b/utils/azure/identity/service_principal_credentials.cc
@@ -173,7 +173,7 @@ future<sstring> service_principal_credentials::post(const sstring& body) {
     client.content(mime_type, std::move(body));
 
     if (az_creds_logger.is_enabled(log_level::trace)) {
-        az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client.request(), filter });
+        az_creds_logger.trace("[{}] Sending request: {}", *this, rest::redacted_request_type{ client, filter });
     }
 
     auto res = co_await client.send();

--- a/utils/gcp/object_storage.cc
+++ b/utils/gcp/object_storage.cc
@@ -325,7 +325,7 @@ utils::gcp::storage::client::impl::send_with_retry(const std::string& path, cons
     req.add_header("Content-Length", std::to_string(req.request().content_length));
 
     gcp_storage.trace("Sending: {}", redacted_request_type {
-        req.request(),
+        req,
         bearer_filter()
     });
 

--- a/utils/rest/client.cc
+++ b/utils/rest/client.cc
@@ -40,6 +40,7 @@ void rest::request_wrapper::method(method_type type) {
 }
 
 void rest::request_wrapper::content(std::string_view content_type, std::string_view content) {
+    _body = content;
     _req.write_body(sstring(content_type), sstring(content));
 }
 
@@ -249,12 +250,13 @@ future<> rest::send_request(std::string_view uri
 constexpr auto linesep = '\n';
 
 auto 
-fmt::formatter<rest::httpclient::request_type>::format(const rest::httpclient::request_type& r, fmt::format_context& ctx) const -> decltype(ctx.out()) {
-    auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", r._method, r._url, r._version, linesep);
-    for (auto& [k, v] : r._headers) {
+fmt::formatter<rest::request_wrapper>::format(const rest::request_wrapper& r, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+    const auto& req = r.request();
+    auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", req._method, req._url, req._version, linesep);
+    for (auto& [k, v] : req._headers) {
         os = fmt::format_to(os, "{}: {}{}", k, v, linesep);
     }
-    os = fmt::format_to(os, "{}{}", linesep, r.content);
+    os = fmt::format_to(os, "{}{}", linesep, r.body());
     return os;
 }
 
@@ -278,11 +280,13 @@ fmt::formatter<seastar::http::reply>::format(const seastar::http::reply& r, fmt:
 auto
 fmt::formatter<rest::redacted_request_type>::format(const rest::redacted_request_type& rr, fmt::format_context& ctx) const -> decltype(ctx.out()) {
     const auto& r = rr.original;
-    auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", r._method, r._url, r._version, linesep);
-    for (auto& [k, v] : r._headers) {
+    const auto& req = r.request();
+    auto os = fmt::format_to(ctx.out(), "{} {} HTTP/{}{}", req._method, req._url, req._version, linesep);
+    for (auto& [k, v] : req._headers) {
         os = fmt::format_to(os, "{}: {}{}", k, rr.filter_header(k, v).value_or(v), linesep);
     }
-    os = fmt::format_to(os, "{}{}", linesep, rr.filter_body(r.content).value_or(r.content));
+    auto body = r.body();
+    os = fmt::format_to(os, "{}{}", linesep, rr.filter_body(body).value_or(std::string(body)));
     return os;
 }
 

--- a/utils/rest/client.hh
+++ b/utils/rest/client.hh
@@ -62,8 +62,12 @@ public:
     operator const request_type&() const {
         return request();
     }
+    std::string_view body() const {
+        return _body;
+    }
 protected:
     request_type _req;
+    std::string _body;
 };
 
 /**
@@ -152,7 +156,7 @@ struct redacted {
     }
 };
 
-using redacted_request_type = redacted<httpclient::request_type, http_log_filter::body_type::request>;
+using redacted_request_type = redacted<request_wrapper, http_log_filter::body_type::request>;
 using redacted_result_type  = redacted<httpclient::result_type, http_log_filter::body_type::response>;
 
 using key_value = std::pair<std::string_view, std::string_view>;
@@ -198,8 +202,15 @@ future<> send_request(std::string_view uri
 }
 
 template <>
-struct fmt::formatter<rest::httpclient::request_type> : fmt::formatter<std::string_view> {
-    auto format(const rest::httpclient::request_type&, fmt::format_context& ctx) const -> decltype(ctx.out());
+struct fmt::formatter<rest::request_wrapper> : fmt::formatter<std::string_view> {
+    auto format(const rest::request_wrapper&, fmt::format_context& ctx) const -> decltype(ctx.out());
+};
+
+template <>
+struct fmt::formatter<rest::httpclient> : fmt::formatter<rest::request_wrapper> {
+    auto format(const rest::httpclient& c, fmt::format_context& ctx) const -> decltype(ctx.out()) {
+        return fmt::formatter<rest::request_wrapper>::format(c, ctx);
+    }
 };
 
 template <>


### PR DESCRIPTION
seastar::http::request::content is deprecated on the client side; the intended API is write_body() to set the body, with no public accessor for reading it back.

The formatters for request_wrapper and redacted_request_type need to log the request body. Rather than calling the deprecated accessor, add a std::string _body member to request_wrapper that is set alongside the write_body() call in content(). The formatter then reads _body directly.

The extra copy doesn't matter: the bodies sent here are small JSON payloads (auth tokens, KMS requests), and request_wrapper is a short-lived per-request object.

Also rename fmt::formatter<httpclient::request_type> to fmt::formatter<request_wrapper>, since the formatter operates on the wrapper level, and add fmt::formatter<httpclient> delegating to it so that httpclient objects can be formatted directly. Update all callers that previously formatted client.request() to format the wrapper instead.

Minor code cleanup; not backporting.