### PR TITLE
storage_proxy: Move maintenance_mode onto storage_proxy::config

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -1358,6 +1358,7 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             };
             spcfg.hinted_handoff_enabled = hinted_handoff_enabled;
             spcfg.available_memory = memory::stats().total_memory();
+            spcfg.maintenance_mode = maintenance_mode_enabled{cfg->maintenance_mode()};
             smp_service_group_config storage_proxy_smp_service_group_config;
             // Assuming less than 1kB per queued request, this limits storage_proxy submit_to() queues to 5MB or less
             storage_proxy_smp_service_group_config.max_nonlocal_requests = 5000;

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3337,6 +3337,7 @@ storage_proxy::storage_proxy(sharded<replica::database>& db, storage_proxy::conf
     , _hints_for_views_manager(*this, _db.local().get_config().view_hints_directory(), {}, _db.local().get_config().max_hint_window_in_ms(), _hints_resource_manager, _db, cfg.hints_sched_group)
     , _stats_key(stats_key)
     , _features(feat)
+    , _maintenance_mode(cfg.maintenance_mode)
     , _background_write_throttle_threahsold(cfg.available_memory / 10)
     , _mutate_stage{"storage_proxy_mutate", &storage_proxy::do_mutate}
     , _max_view_update_backlog(max_view_update_backlog)
@@ -7103,7 +7104,7 @@ host_id_vector_replica_set storage_proxy::get_endpoints_for_reading(const schema
     auto endpoints = erm.get_replicas_for_reading(token);
     // Skip for non-debug builds and maintenance mode.
     if constexpr (tools::build_info::is_debug_build()) {
-        if (!_db.local().get_config().maintenance_mode()) {
+        if (!_maintenance_mode) {
             validate_read_replicas(erm, endpoints);
         }
     }

--- a/service/storage_proxy.hh
+++ b/service/storage_proxy.hh
@@ -40,6 +40,7 @@
 #include "dht/token_range_endpoints.hh"
 #include "service/storage_service.hh"
 #include "service/cas_shard.hh"
+#include "service/maintenance_mode.hh"
 #include "service/storage_proxy_fwd.hh"
 
 class reconcilable_result;
@@ -197,6 +198,7 @@ public:
         // with writes.
         smp_service_group write_ack_smp_service_group = default_smp_service_group();
         scheduling_group hints_sched_group;
+        maintenance_mode_enabled maintenance_mode = maintenance_mode_enabled::no;
     };
 private:
 
@@ -294,6 +296,7 @@ private:
     scheduling_group_key _stats_key;
     storage_proxy_stats::global_stats _global_stats;
     gms::feature_service& _features;
+    maintenance_mode_enabled _maintenance_mode;
 
     class remote;
     std::unique_ptr<remote> _remote;


### PR DESCRIPTION
Stop reading maintenance_mode through replica::database's db::config. Add a properly typed maintenance_mode_enabled field to storage_proxy::config, populate it in main.cc from cfg->maintenance_mode() (same as messaging_service::config), and use a cached member in storage_proxy instead of db.local().get_config().maintenance_mode().

Global config usage cleanup, not backporting