### PR TITLE
ci: split license header check to support fork PR comments

### DIFF
--- a/.github/workflows/check-license-header-comment.yaml
+++ b/.github/workflows/check-license-header-comment.yaml
@@ -1,0 +1,39 @@
+name: License Header Check - Comment
+
+on:
+  workflow_run:
+    workflows: ["License Header Check"]
+    types: [completed]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  comment-on-failure:
+    name: Comment on License Failure
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure'
+    permissions:
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download failure marker
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: license-check-failed
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr_number.txt', 'utf8').trim());
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `❌ License header check failed. Please ensure all new files include the SPDX header within the first 10 lines:\n\`\`\`\nLicenseRef-ScyllaDB-Source-Available-1.1\n\`\`\`\nSee action logs for details.`
+            });

--- a/.github/workflows/check-license-header.yaml
+++ b/.github/workflows/check-license-header.yaml
@@ -15,8 +15,8 @@ jobs:
   check-license-headers:
     name: Check License Headers
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
+    # check + artifact upload only; no token permissions needed
+    permissions: {}
 
     steps:
       - name: Checkout code
@@ -39,15 +39,13 @@ jobs:
             --check-lines "${{ env.HEADER_CHECK_LINES }}" \
             --extensions ${{ env.CHECKED_EXTENSIONS }}
 
-      - name: Comment on PR if check fails
+      - name: Save PR number
         if: failure()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: Upload failure marker
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          script: |
-            const license = '${{ env.LICENSE }}';
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `❌ License header check failed. Please ensure all new files include the header within the first ${{ env.HEADER_CHECK_LINES }} lines:\n\`\`\`\n${license}\n\`\`\`\nSee action logs for details.`
-            });
+          name: license-check-failed
+          path: pr_number.txt


### PR DESCRIPTION
## Summary
- The comment step in the license header check workflow fails with 403 on fork PRs because GitHub downgrades `GITHUB_TOKEN` to read-only
- Split into two workflows: `pull_request` for the check + artifact upload, `workflow_run` for posting the comment with write permissions
- No functional change to the license check itself

Need to backport to active branches - BUT - I don't know if they use license 1.1 or 1.0! @avikivity ?

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-2517
