### PR TITLE
test/nodetool: fix mock server port race by using a fixed port on a unique IP

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -6,7 +6,6 @@
 
 import os
 import random
-import socket
 import subprocess
 import sys
 import time
@@ -43,6 +42,10 @@ class ServerAddress(NamedTuple):
 
 @pytest.fixture(scope="module")
 async def server_address(request, testpy_test: None|Test):
+    # Each test module gets a unique IP, so a fixed port suffices and
+    # avoids any port-collision or TOCTOU concerns. This mirrors the
+    # approach used in test/cqlpy/run.py.
+    port = 12345
     # unshare(1) -rn drops us in a new network namespace in which the "lo" is
     # not up yet, so let's set it up first.
     if request.config.getoption('--run-within-unshare', default=False):
@@ -52,22 +55,13 @@ async def server_address(request, testpy_test: None|Test):
         except FileNotFoundError:
             args = "/sbin/ifconfig lo up".split()
             subprocess.run(args, check=True)
-        # we use a fixed ip and port, because the network namespace is not shared
+        # the network namespace isn't shared, so any IP works
         ip = '127.0.0.1'
-        port = 12345
     else:
         if testpy_test is not None:
             ip = await testpy_test.suite.hosts.lease_host()
         else:
             ip = f"127.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}"
-        # Ask the OS to pick a free port by binding to port 0. This avoids
-        # collisions with ports still in TIME_WAIT from a previous test module
-        # that used the same IP. SO_REUSEADDR is set on the probe socket so it
-        # can reclaim a TIME_WAIT port itself
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            s.bind((ip, 0))
-            port = s.getsockname()[1]
     yield ServerAddress(ip, port)
     if testpy_test is not None:
         await testpy_test.suite.hosts.release_host(ip)

--- a/test/nodetool/rest_api_mock.py
+++ b/test/nodetool/rest_api_mock.py
@@ -257,7 +257,10 @@ async def run_server(ip, port):
 
     runner = aiohttp.web.AppRunner(app)
     await runner.setup()
-    site = aiohttp.web.TCPSite(runner, ip, port, reuse_address=True, reuse_port=True)
+    # reuse_address lets the server bind even if a previous mock server
+    # left the (ip, port) pair in TIME_WAIT. This can happen when the host
+    # registry recycles an IP across modules.
+    site = aiohttp.web.TCPSite(runner, ip, port, reuse_address=True)
     await site.start()
 
     try:


### PR DESCRIPTION
Symptom: the rest_api_mock subprocess exits with status 1 during fixture
setup, e.g.:

    subprocess.CalledProcessError: Command '[..., 'rest_api_mock.py',
        '127.29.88.1', '34093']' returned non-zero exit status 1

Root cause: aiohttp's TCPSite.start() raises OSError(EADDRINUSE) and the
process exits 1. The bind fails because of how the (ip, port) pair is
chosen across modules within one test.py process:

  * Each test module leases a 127.x.y.z IP from the host registry. The
    registry recycles released IPs, so the same IP is shared across
    modules sequentially.
  * The original code picked the port via random.randint(10000, 65535).
    A previous module on the same IP could have left that port in
    TIME_WAIT (or worse, still actively in use) when a later module
    happened to pick the same port.

[SCYLLADB-1275](https://scylladb.atlassian.net/browse/SCYLLADB-1275) (PR 29314) tried to fix this by binding a probe socket to
(ip, 0) to obtain an OS-assigned free port, closing the probe, then
launching the mock server which would bind to that port. Two issues
remained:

  1. TOCTOU: between probe close and mock-server bind, any other process
     on the host could grab the just-freed port.
  2. TIME_WAIT could still bite if the host registry recycled an IP and
     the OS reused the same port number for the probe.

Fix: drop port discovery entirely. Use a fixed port (12345, matching the
unshare-namespace path already in this fixture) on the unique IP from
the host registry. Because IPs are unique per test module within one
test.py process, the (ip, 12345) pair is unique to each module, so no
port-collision dance is needed.

reuse_address=True on TCPSite handles the residual TIME_WAIT case when
the host registry recycles an IP within the same test.py process and
the previous mock server's socket has not finished TIME_WAIT yet.
reuse_port=True is dropped, as it was only useful while attempting to
have multiple processes share a single port.

This mirrors the design used in test/cqlpy/run.py: pick a unique IP,
keep the port fixed.

Fixes: SCYLLADB-1718

No need to backport, only seen on master.

[SCYLLADB-1275]: https://scylladb.atlassian.net/browse/SCYLLADB-1275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ