### PR TITLE
Enforce strict skip_bug signature with link/reason validation and CI checks

### DIFF
--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1279,7 +1279,10 @@ def test_wait_for_vector_index_active(vs, needs_vector_store):
 # and this test used to fail before this was fixed.
 # To save a bit of time, we don't test all combinations of hash and range
 # key types but test each type at least once as a hash key and a range key.
-@pytest.mark.skip_bug(reason="Bug in vector store for non-string keys, fails very slowly so let's skip")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/VECTOR-374",
+    reason="Bug in vector store for non-string keys, fails very slowly",
+)
 @pytest.mark.parametrize('hash_type,range_type', [
     ('N', None), ('B', None), ('S', 'N'),  ('S', 'B'),
 ], ids=[

--- a/test/cluster/dtest/bypass_cache_test.py
+++ b/test/cluster/dtest/bypass_cache_test.py
@@ -184,7 +184,10 @@ class TestBypassCache(Tester):
             session.execute(query.format(idx, varchar_c, varchar_v))
         return session
 
-    @pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/6045")
+    @pytest.mark.skip_bug(
+        link="https://github.com/scylladb/scylladb/issues/6045",
+        reason="metric 'select_partition_range_scan' misbehaves: instead of increase by 1 is increasing by 2",
+    )
     def test_range_scan_bypass_cache(self):
         session = self.insert_data_for_scan_range()
         node = self.cluster.nodelist()[0]

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -254,7 +254,10 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
 # `rf_rack_valid_keyspaces` is enabled. On the other hand, materialized views in tablet-based keyspaces
 # require the configuration option to be used.
 # Hence, we need to rewrite this test.
-@pytest.mark.skip_bug(reason="scylladb/scylladb#26540")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/26540",
+    reason="Test doesn't work with the configuration option rf_rack_valid_keyspaces",
+)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altered_dc: str):
     servers = []

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -333,7 +333,10 @@ async def test_create_keyspace_after_config_update(manager: ManagerClient, objec
     else:
         updated_ep['credentials_file'] = ''
         updated_expected_conf = f'{{ "type": "gs", "credentials_file": "{updated_ep["credentials_file"]}" }}'
-        skip_bug("https://scylladb.atlassian.net/browse/SCYLLADB-1559")
+        skip_bug(
+            link="https://scylladb.atlassian.net/browse/SCYLLADB-1559",
+            reason="Flaky test due to race condition closing the GCS object storage client while operations are in flight",
+        )
 
     await manager.server_update_config(server.server_id, 'object_storage_endpoints', updated_objconf)
     await wait_for_config(manager, server, 'object_storage_endpoints', {updated_ep['name']: updated_expected_conf})

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -22,8 +22,9 @@ logger = logging.getLogger(__name__)
     "use_tablets",
     [
         pytest.param(False, id="vnodes"),
-        pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(reason="issue #20282"), pytest.mark.nightly]),
-    ],
+        pytest.param(True, id="tablets", marks=[pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/20282", reason="Coredump and error of: failed to log message: fmt='Requested location for node {} not in topology",),pytest.mark.nightly])
+    ]
 )
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:
     CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled" if use_tablets else "disabled"}

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -177,7 +177,10 @@ async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) 
             expected_error=f"Feature '{TEST_FEATURE_NAME}' was previously enabled in the cluster")
 
 
-@pytest.mark.skip_bug(reason="issue #14194")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/14194",
+    reason="Nodes removed from the cluster may prevent features from being enabled for A_VERY_LONG_TIME (3 days) ",
+)
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
     """Upgrades all but one node in the cluster to enable the test feature.
        Then, the last one is shut down and removed via `nodetool removenode`.

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -429,12 +429,18 @@ async def do_test_tablet_incremental_repair_with_split_and_merge(manager, do_spl
 
     await verify_repaired_and_unrepaired_keys(manager, scylla_path, servers, ks, repaired_keys, unrepaired_keys)
 
-@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/24153",
+    reason="token_group_based_splitting_mutation_writer - Token group id cannot go backwards, current=0, previous=1",
+)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split_and_merge(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=True)
 
-@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/24153")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/24153",
+    reason="token_group_based_splitting_mutation_writer - Token group id cannot go backwards, current=0, previous=1 ",
+)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_incremental_repair_with_split(manager: ManagerClient):
     await do_test_tablet_incremental_repair_with_split_and_merge(manager, do_split=True, do_merge=False)

--- a/test/cluster/test_start_bootstrapped_with_invalid_seed.py
+++ b/test/cluster/test_start_bootstrapped_with_invalid_seed.py
@@ -15,7 +15,10 @@ logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.prepare_3_nodes_cluster
 
 
-@pytest.mark.skip_bug(reason="Test is disabled due to scylladb/scylladb#28153")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/28153",
+    reason="Test is disabled",
+)
 async def test_start_bootstrapped_with_invalid_seed(manager: ManagerClient):
     """
     Issue https://github.com/scylladb/scylladb/issues/14945.

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -1263,7 +1263,10 @@ async def test_abort_forwarded_write_upon_shutdown(manager: ManagerClient):
             await stop_fut
 
 
-@pytest.mark.skip_bug(reason="SCYLLADB-1056")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/SCYLLADB-1056",
+    reason="Speed up abortion of applier fiber in raft::server_impl::abort",
+)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerClient):
     """
@@ -1330,7 +1333,10 @@ async def test_abort_state_machine_apply_after_dropping_table(manager: ManagerCl
         await log.wait_for(rf"apply\(\): execution for tablet \S+, group_id={group_id} aborted", from_mark=mark)
 
 
-@pytest.mark.skip_bug(reason="SCYLLADB-1056")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/SCYLLADB-1056",
+    reason="Speed up abortion of applier fiber in raft::server_impl::abort",
+)
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_abort_state_machine_apply_during_shutdown(manager: ManagerClient):
     """

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -114,7 +114,10 @@ async def test_tablet_repair_progress(manager: ManagerClient):
 async def test_tablet_repair_progress_split(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_split=True)
 
-@pytest.mark.skip_bug(reason="https://github.com/scylladb/scylladb/issues/26844")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/26844",
+    reason="Tablet repair scheduler crashes",
+)
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_repair_progress_merge(manager: ManagerClient):
     await do_test_tablet_repair_progress_split_merge(manager, do_merge=True)

--- a/test/cluster/test_topology_remove_decom.py
+++ b/test/cluster/test_topology_remove_decom.py
@@ -68,7 +68,10 @@ async def test_decommission_node_add_column(manager: ManagerClient, random_table
     await random_tables.verify_schema()
 
 
-@pytest.mark.skip_bug(reason="Wait for @slow attribute, #11713")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/11713",
+    reason="Wait for @slow attribute",
+)
 async def test_remove_node_with_concurrent_ddl(manager: ManagerClient, random_tables: RandomTables):
     stopped = False
     ddl_failed = False

--- a/test/cqlpy/cassandra_tests/validation/entities/type_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/type_test.py
@@ -20,7 +20,10 @@ def testNonExistingOnes(cql, test_keyspace):
     # reported instead of just doing nothing:
     execute(cql, test_keyspace, "DROP TYPE IF EXISTS keyspace_does_not_exist.type_does_not_exist")
 
-@pytest.mark.skip_bug(reason="Issue #9300")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/9300",
+    reason="testNowToUUIDCompatibility is flaky",
+)
 def testNowToUUIDCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b uuid, PRIMARY KEY (a, b))") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")
@@ -33,7 +36,10 @@ def testDateCompatibility(cql, test_keyspace):
         execute(cql, table, "INSERT INTO %s (a, b, c, d) VALUES (1, unixTimestampOf(now()), dateOf(now()), dateOf(now()))")
         assert len(list(execute(cql, table, "SELECT * FROM %s WHERE a=1 AND b <= toUnixTimestamp(now())"))) == 1
 
-@pytest.mark.skip_bug(reason="Issue #9300")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/9300",
+    reason="testNowToUUIDCompatibility is flaky",
+)
 def testReversedTypeCompatibility(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b timeuuid, PRIMARY KEY (a, b)) WITH CLUSTERING ORDER BY (b DESC)") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (0, now())")

--- a/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
+++ b/test/cqlpy/cassandra_tests/validation/entities/uf_types_test.py
@@ -35,7 +35,10 @@ def read_function_from_file(file_name, wasm_name=None, udf_name=None):
         print(f"Can't open {wat_path}.\nPlease build Wasm examples.")
         exit(1)
 
-@pytest.mark.skip_bug(reason="Issue #22799")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/22799",
+    reason="CI regression, no understanding why this started happening ",
+)
 def test_complex_null_values(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(txt text, i int)") as type:
         schema = f"(key int primary key, lst list<double>, st set<text>, mp map<int, boolean>, tup frozen<tuple<double, text, int, boolean>>, udt frozen<{type}>)"
@@ -163,7 +166,10 @@ def test_types_with_and_without_nulls(cql, test_keyspace):
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 1"), row("called"))
                     assertRows(execute(cql, table, f"SELECT {fun_name}({type_def.column_name}) FROM %s WHERE key = 2"), row(None))
 
-@pytest.mark.skip_bug(reason="Issue #13746")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/13746",
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands",
+)
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -200,7 +206,10 @@ def test_function_with_frozen_set_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<set<int>>)")
 
-@pytest.mark.skip_bug(reason="Issue #13746")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/13746",
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands",
+)
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -237,7 +246,10 @@ def test_function_with_frozen_list_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<list<int>>)")
 
-@pytest.mark.skip_bug(reason="Issue #13746")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/13746",
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands",
+)
 @pytest.mark.xfail(reason="Issue #13855")
 @pytest.mark.xfail(reason="Issue #13860")
 @pytest.mark.xfail(reason="Issue #13866")
@@ -274,7 +286,10 @@ def test_function_with_frozen_map_type(cql, test_keyspace):
 
             assertInvalidMessage(cql, "", "cannot be frozen", f"DROP FUNCTION {test_keyspace}.{ret_name}(frozen<map<int, int>>)")
 
-@pytest.mark.skip_bug(reason="Issue #13746")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/13746",
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands",
+)
 def test_function_with_frozen_tuple_type(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int PRIMARY KEY, b frozen<tuple<int, int>>)") as table:
         with new_secondary_index(cql, table, "b"):
@@ -311,7 +326,10 @@ def test_function_with_frozen_tuple_type(cql, test_keyspace):
             cql.execute(f"DROP FUNCTION {test_keyspace}.{fun_name} (frozen<tuple<int, int>>)")
             assertRowCount(cql.execute(f"SELECT * from system_schema.functions WHERE keyspace_name = '{test_keyspace}' AND function_name = '{fun_name}'"), 0)
 
-@pytest.mark.skip_bug(reason="Issue #13746")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/13746",
+    reason="UDF can only be used in SELECT, and abort when used in WHERE, or in INSERT/UPDATE/DELETE commands",
+)
 def test_function_with_frozen_udt_type(cql, test_keyspace):
     with create_type(cql, test_keyspace, "(f int)") as type:
         with create_table(cql, test_keyspace, f"(a int PRIMARY KEY, b frozen<{type}>)") as table:

--- a/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
+++ b/test/cqlpy/cassandra_tests/validation/operations/compact_storage_test.py
@@ -4265,7 +4265,10 @@ def testInsertWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip_bug(reason="issue #12815")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/12815",
+    reason="test currently crashes Scylla we have to skip it instead of xfail",
+)
 def testInsertWithCompactNonStaticFormat(cql, test_keyspace):
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testInsertWithCompactTable(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
@@ -4339,7 +4342,10 @@ def testSelectWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip_bug(reason="issue #12815")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/12815",
+    reason="currently crashes Scylla we have to skip it instead of xfail",
+)
 def testSelectWithCompactNonStaticFormat(cql, test_keyspace):
     with create_table(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a,b)) WITH COMPACT STORAGE") as table:
         execute(cql, table, "INSERT INTO %s (a, b) VALUES (1, 1)")
@@ -4403,7 +4409,10 @@ def testUpdateWithCompactStaticFormat(cql, test_keyspace):
 # Test for CASSANDRA-13917
 # Reproduces #12815.
 # Because it currently crashes Scylla we have to skip it instead of xfail...
-@pytest.mark.skip_bug(reason="issue #12815")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/12815",
+    reason="currently crashes Scylla we have to skip it instead of xfail",
+)
 def testUpdateWithCompactNonStaticFormat(cql, test_keyspace):
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")
     do_testUpdateWithCompactFormat(cql, test_keyspace, "(a int, b int, v int, PRIMARY KEY (a, b)) WITH COMPACT STORAGE")

--- a/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
+++ b/test/cqlpy/cassandra_tests/vector_invalid_query_test.py
@@ -233,8 +233,10 @@ def test_ann_ordering_not_allowed_without_index_where_indexed_column_exists_in_q
             "SELECT * FROM %s WHERE c >= 100 ORDER BY v ANN OF [1] LIMIT 4 ALLOW FILTERING"
         )
 
-@pytest.mark.skip_bug(reason="We pass all restricted queries to vector store, once VECTOR-374 is done, this work as expected" \
-                             "However, the test won't work even then as pytest does not support vector store.")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/VECTOR-374",
+    reason="Restricted queries are passed to vector store and pytest does not support vector store",
+)
 def test_cannot_post_filter_on_non_indexed_column_with_ann_ordering(cql, test_keyspace):
     ANN_REQUIRES_INDEXED_FILTERING_MESSAGE = (
         SCYLLA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE if is_scylla(cql) else CASSANDRA_ANN_REQUIRES_INDEXED_FILTERING_MESSAGE

--- a/test/cqlpy/test_json.py
+++ b/test/cqlpy/test_json.py
@@ -493,7 +493,10 @@ def test_fromjson_timestamp_submilli(cql, table1, cassandra_bug):
 # We need to skip this test because in debug mode memory allocation is not
 # bounded, and this test can hang or crash instead of failing immediately.
 # We also have a smaller xfailing test below, test_tojson_decimal_high_mantissa2.
-@pytest.mark.skip_bug(reason="issue #8002")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/8002",
+    reason="this test can hang or crash instead of failing immediately",
+)
 def test_tojson_decimal_high_mantissa(cql, table1):
     p = unique_key_int()
     stmt = cql.prepare(f"INSERT INTO {table1} (p, dec) VALUES ({p}, ?)")

--- a/test/cqlpy/test_lwt.py
+++ b/test/cqlpy/test_lwt.py
@@ -449,7 +449,10 @@ def test_lwt_counter_syntax_float_on_integer(cql, table1, scylla_only):
 # CPU and memory usage. Reproduces SCYLLADB-1576.
 # This test needs to be skipped while SCYLLADB-1576 is not fixed, otherwise
 # it will cause the test suite to hang or crash.
-@pytest.mark.skip_bug(reason="SCYLLADB-1576: hangs or OOMs instead of rejecting")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/SCYLLADB-1576",
+    reason="Hangs or OOMs instead of rejecting",
+)
 def test_lwt_counter_syntax_decimal_magnitude_difference(cql, test_keyspace, scylla_only):
     # 1e100000000 is stored compactly as (unscaled=1, scale=-100000000), but
     # adding 1 to it forces alignment of decimal points, potentially allocating

--- a/test/cqlpy/test_materialized_view.py
+++ b/test/cqlpy/test_materialized_view.py
@@ -430,7 +430,10 @@ def test_oversized_base_regular_view_key(cql, test_keyspace, cassandra_bug):
 # This test currently breaks the build (it repeats a failing build step,
 # and never complete) and we cannot quickly recognize this failure, so
 # to avoid a very slow failure, we currently "skip" this test.
-@pytest.mark.skip_bug(reason="issue #8627, fails very slow")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/8627",
+    reason="Fails very slow",
+)
 def test_oversized_base_regular_view_key_build(cql, test_keyspace, cassandra_bug):
     with new_test_table(cql, test_keyspace, 'p int primary key, v text') as table:
         # No materialized view yet - a "big" value in v is perfectly fine:

--- a/test/cqlpy/test_native_functions.py
+++ b/test/cqlpy/test_native_functions.py
@@ -152,7 +152,10 @@ def test_totimestamp_date(cql, table1):
 # current Python driver because of bugs it has in converting extreme
 # timestamps - https://github.com/scylladb/python-driver/issues/255 -
 # so the test is skipped.
-@pytest.mark.skip_bug(reason="Python driver bug https://github.com/scylladb/python-driver/issues/255")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/python-driver/issues/255",
+    reason="Python driver bug",
+)
 def test_totimestamp_date_extreme(cql, table1):
     p = unique_key_int()
     # The day 2**31-2**29 is 2**29 days before the epoch - it's a useless date

--- a/test/cqlpy/test_secondary_index.py
+++ b/test/cqlpy/test_secondary_index.py
@@ -1441,7 +1441,10 @@ def test_static_column_index_build(cql, test_keyspace):
 # restrictions. Reproduces #12829.
 # NOTE: currently marked with skip instead of xfail because
 # on_internal_error() crashes Scylla.
-@pytest.mark.skip_bug(reason="issue #12829")
+@pytest.mark.skip_bug(
+    link="https://github.com/scylladb/scylladb/issues/12829",
+    reason="test marked with skip instead of xfail because on_internal_error() crashes Scylla",
+)
 def test_static_column_index_restrictions(cql, test_keyspace):
     schema = 'pk int, c int, s int STATIC, v int, PRIMARY KEY(pk, c)'
     with new_test_table(cql, test_keyspace, schema) as table:

--- a/test/cqlpy/test_type_decimal.py
+++ b/test/cqlpy/test_type_decimal.py
@@ -308,7 +308,10 @@ def test_decimal_si_and_mv_representation(cql, test_keyspace):
 # but in arithmetic.
 # This test is skipped because it would hang or crash the tests.
 # Reproduces SCYLLADB-1576
-@pytest.mark.skip_bug(reason="SCYLLADB-1576")
+@pytest.mark.skip_bug(
+    link="https://scylladb.atlassian.net/browse/SCYLLADB-1576",
+    reason="Decimal operator+= OOM on extreme scale difference",
+)
 def test_decimal_sum_extreme_scale_oom(cql, test_keyspace):
     with new_test_table(cql, test_keyspace,
             "p int, c decimal, PRIMARY KEY (p)") as table:

--- a/test/pylib/skip_reason_plugin.py
+++ b/test/pylib/skip_reason_plugin.py
@@ -11,7 +11,10 @@ project's ``conftest.py`` via :class:`SkipReasonPlugin`.
 
 Usage as decorator (after conftest.py registers the plugin)::
 
-    @pytest.mark.skip_bug(reason="scylladb/scylladb#12345")
+    @pytest.mark.skip_bug(
+        link="https://github.com/scylladb/scylladb/issues/12345",
+        reason="Known repair scheduler crash",
+    )
     @pytest.mark.skip_not_implemented(reason="no per tablet support yet")
 
 Usage at runtime (inside test body or fixture) — prefer the
@@ -21,7 +24,6 @@ convenience wrappers from :mod:`test.pylib.skip_types`::
     skip_env("need --runveryslow option")
 """
 
-from __future__ import annotations
 
 from collections.abc import Callable
 from enum import StrEnum
@@ -61,7 +63,7 @@ class SkipReasonPlugin:
 
     Args:
         skip_types: A :class:`~enum.StrEnum` whose members define the
-            typed skip markers.  Each member's ``marker_name`` property
+            typed skip markers. Each member's ``marker_name`` property
             becomes the pytest marker name, and its value becomes the
             tag written to reports.
         report_callback: Optional callback invoked with
@@ -78,10 +80,24 @@ class SkipReasonPlugin:
         self._skip_types = skip_types
         self._report_callback = report_callback
 
-    @staticmethod
-    def _get_reason(mark: pytest.Mark) -> str:
-        """Extract reason from a marker (keyword or positional)."""
-        return mark.kwargs.get("reason") or (mark.args[0] if mark.args else "")
+    def _get_reason(
+        self,
+        mark: pytest.Mark,
+        *,
+        marker_name: str,
+        nodeid: str,
+    ) -> str:
+        """Extract normalized skip reason from a marker.
+        Delegates marker-specific validation to the skip type definition.
+        """
+        context = f"Marker @pytest.mark.{marker_name} on {nodeid}"
+        skip_types = self._skip_types
+        handler = getattr(skip_types, f"get_reason_{marker_name}", None)
+        if handler is None:
+            handler = getattr(skip_types, "get_reason_default", None)
+        if handler is None:
+            return mark.kwargs.get("reason") or (mark.args[0] if mark.args else "")
+        return handler(mark, context)
 
     @staticmethod
     def _parse_skip_type(longrepr) -> tuple[str, str] | None:
@@ -103,7 +119,7 @@ class SkipReasonPlugin:
             # Convert typed skip markers to real pytest.mark.skip.
             for st in self._skip_types:
                 for mark in item.iter_markers(st.marker_name):
-                    reason = self._get_reason(mark)
+                    reason = self._get_reason(mark, marker_name=st.marker_name, nodeid=item.nodeid)
                     if not reason:
                         raise pytest.UsageError(
                             f"Marker @pytest.mark.{st.marker_name} on {item.nodeid} "
@@ -116,7 +132,7 @@ class SkipReasonPlugin:
             # Reject bare pytest.mark.skip not added by typed markers.
             # skip_mode sets SKIP_TYPE_KEY before this hook runs (trylast).
             if SKIP_TYPE_KEY not in item.stash:
-                bare = [self._get_reason(m) for m in item.iter_markers("skip")]
+                bare = [self._get_reason(m, marker_name="skip", nodeid=item.nodeid) for m in item.iter_markers("skip")]
                 if bare:
                     alternatives = ", ".join(
                         f"@pytest.mark.{st.marker_name}" for st in self._skip_types)

--- a/test/pylib/skip_reason_plugin.py
+++ b/test/pylib/skip_reason_plugin.py
@@ -33,6 +33,7 @@ import pytest
 # StashKeys to carry skip metadata from collection to reporting.
 SKIP_TYPE_KEY = pytest.StashKey[str]()
 SKIP_REASON_KEY = pytest.StashKey[str]()
+SKIP_MARKER_ERROR_KEY = pytest.StashKey[str]()
 
 
 def skip(reason: str, skip_type: StrEnum):
@@ -112,6 +113,23 @@ class SkipReasonPlugin:
             return tag, reason.lstrip()
         return None
 
+    @staticmethod
+    def _is_xdist_worker(config: pytest.Config) -> bool:
+        """Return True when running inside an xdist worker process."""
+        return hasattr(config, "workerinput")
+
+    def _handle_collection_error(self, item: pytest.Item, error: pytest.UsageError) -> None:
+        """Raise collection errors normally, but downgrade on xdist workers.
+
+        Worker-side UsageError/collection exceptions can crash xdist workers and
+        surface as INTERNALERROR in the controller. Under xdist workers, stash
+        the validation message and fail the test in setup instead.
+        """
+        message = str(error)
+        if not self._is_xdist_worker(item.config):
+            raise error
+        item.stash[SKIP_MARKER_ERROR_KEY] = message
+
     @pytest.hookimpl(trylast=True)
     def pytest_collection_modifyitems(self, items: list[pytest.Item]) -> None:
         """Apply typed markers and warn on bare skips."""
@@ -119,12 +137,17 @@ class SkipReasonPlugin:
             # Convert typed skip markers to real pytest.mark.skip.
             for st in self._skip_types:
                 for mark in item.iter_markers(st.marker_name):
-                    reason = self._get_reason(mark, marker_name=st.marker_name, nodeid=item.nodeid)
+                    try:
+                        reason = self._get_reason(mark, marker_name=st.marker_name, nodeid=item.nodeid)
+                    except pytest.UsageError as exc:
+                        self._handle_collection_error(item, exc)
+                        continue
                     if not reason:
-                        raise pytest.UsageError(
+                        self._handle_collection_error(item, pytest.UsageError(
                             f"Marker @pytest.mark.{st.marker_name} on {item.nodeid} "
                             f"requires a 'reason' argument."
-                        )
+                        ))
+                        continue
                     item.add_marker(pytest.mark.skip(reason=f"[{st}] {reason}"))
                     item.stash[SKIP_TYPE_KEY] = str(st)
                     item.stash[SKIP_REASON_KEY] = reason
@@ -136,10 +159,16 @@ class SkipReasonPlugin:
                 if bare:
                     alternatives = ", ".join(
                         f"@pytest.mark.{st.marker_name}" for st in self._skip_types)
-                    raise pytest.UsageError(
+                    self._handle_collection_error(item, pytest.UsageError(
                         f"Untyped skip on {item.nodeid}: {'; '.join(bare)}. "
                         f"Use {alternatives} instead.",
-                    )
+                    ))
+
+    def pytest_runtest_setup(self, item: pytest.Item) -> None:
+        """Fail invalid marker definitions as regular test failures on xdist workers."""
+        marker_error = item.stash.get(SKIP_MARKER_ERROR_KEY, None)
+        if marker_error:
+            pytest.fail(marker_error, pytrace=False)
 
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_makereport(self, item: pytest.Item):

--- a/test/pylib/skip_types.py
+++ b/test/pylib/skip_types.py
@@ -25,16 +25,25 @@ Usage::
 from enum import StrEnum
 
 import re
+
 import pytest
+
 from test.pylib.skip_reason_plugin import skip
 
+
+_GITHUB_ISSUE_LINK_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+/issues/\d+/?$")
+_JIRA_LINK_RE = re.compile(r"^https://scylladb\.atlassian\.net/browse/[A-Z][A-Z0-9]+-\d+$")
+
+
+def _is_valid_skip_bug_link(link: str) -> bool:
+    """Return True if *link* is a supported skip_bug issue URL."""
+    return bool(_GITHUB_ISSUE_LINK_RE.fullmatch(link) or _JIRA_LINK_RE.fullmatch(link))
 
 
 # ScyllaDB-specific skip categories.
 # Each member name (lowercased) is the pytest marker, e.g.
 # ``SKIP_BUG`` → ``@pytest.mark.skip_bug``, tag ``"bug"``.
 class SkipType(StrEnum):
-
     SKIP_BUG = "bug"
     SKIP_NOT_IMPLEMENTED = "not_implemented"
     SKIP_SLOW = "slow"
@@ -45,11 +54,9 @@ class SkipType(StrEnum):
         """Validate and format skip_bug arguments."""
         link = link.strip()
         reason = reason.strip()
-        _GITHUB_ISSUE_LINK_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+/issues/\d+/?$")
-        _JIRA_LINK_RE = re.compile(r"^https://scylladb\.atlassian\.net/browse/[A-Z][A-Z0-9]+-\d+$")
         if not link:
             raise pytest.UsageError(f"{context}: 'link' is required.")
-        if not (_GITHUB_ISSUE_LINK_RE.fullmatch(link) or _JIRA_LINK_RE.fullmatch(link)):
+        if not _is_valid_skip_bug_link(link):
             raise pytest.UsageError(
                 f"{context}: invalid 'link' value {link!r}. "
                 "Expected a GitHub issue URL or a ScyllaDB Jira URL.",

--- a/test/pylib/skip_types.py
+++ b/test/pylib/skip_types.py
@@ -22,24 +22,55 @@ Usage::
     skip_env("HTTPS-specific tests need the '--https' option")
 """
 
-from __future__ import annotations
-
 from enum import StrEnum
 
+import re
+import pytest
 from test.pylib.skip_reason_plugin import skip
 
 
-class SkipType(StrEnum):
-    """ScyllaDB-specific skip categories.
 
-    Each member name (lowercased) is the pytest marker, e.g.
-    ``SKIP_BUG`` → ``@pytest.mark.skip_bug``, tag ``"bug"``.
-    """
+# ScyllaDB-specific skip categories.
+# Each member name (lowercased) is the pytest marker, e.g.
+# ``SKIP_BUG`` → ``@pytest.mark.skip_bug``, tag ``"bug"``.
+class SkipType(StrEnum):
 
     SKIP_BUG = "bug"
     SKIP_NOT_IMPLEMENTED = "not_implemented"
     SKIP_SLOW = "slow"
     SKIP_ENV = "env"
+
+    @staticmethod
+    def _validate_skip_bug_args(link: str, reason: str, context: str) -> str:
+        """Validate and format skip_bug arguments."""
+        link = link.strip()
+        reason = reason.strip()
+        _GITHUB_ISSUE_LINK_RE = re.compile(r"^https://github\.com/[^/\s]+/[^/\s]+/issues/\d+/?$")
+        _JIRA_LINK_RE = re.compile(r"^https://scylladb\.atlassian\.net/browse/[A-Z][A-Z0-9]+-\d+$")
+        if not link:
+            raise pytest.UsageError(f"{context}: 'link' is required.")
+        if not (_GITHUB_ISSUE_LINK_RE.fullmatch(link) or _JIRA_LINK_RE.fullmatch(link)):
+            raise pytest.UsageError(
+                f"{context}: invalid 'link' value {link!r}. "
+                "Expected a GitHub issue URL or a ScyllaDB Jira URL.",
+            )
+        if not reason:
+            raise pytest.UsageError(f"{context}: 'reason' is required.")
+        return f"{reason} ({link})"
+
+    @staticmethod
+    def get_reason_default(mark, context):
+        """Default: just extract 'reason' or first arg."""
+        return mark.kwargs.get("reason") or (mark.args[0] if mark.args else "")
+
+    @staticmethod
+    def get_reason_skip_bug(mark, context):
+        """Strict skip_bug: require link and reason, validate link format."""
+        if mark.args:
+            raise pytest.UsageError(f"{context}: no longer accepts positional arguments; use link=... and reason=...")
+        if set(mark.kwargs) != {"link", "reason"}:
+            raise pytest.UsageError(f"{context}: requires both 'link' and 'reason' keyword arguments (got {sorted(mark.kwargs)}).")
+        return SkipType._validate_skip_bug_args(mark.kwargs["link"], mark.kwargs["reason"], context)
 
     @property
     def marker_name(self) -> str:
@@ -51,9 +82,11 @@ class SkipType(StrEnum):
 # so callers never need to import ``SkipType`` separately.
 
 
-def skip_bug(reason: str) -> None:
-    """Runtime skip for a known bug.  *reason* should be an issue reference."""
-    skip(reason, skip_type=SkipType.SKIP_BUG)
+def skip_bug(*, link: str, reason: str) -> None:
+    """Runtime skip for a known bug with strict ``link`` and ``reason`` fields."""
+    context = "skip_bug()"
+    msg = SkipType._validate_skip_bug_args(link, reason, context)
+    skip(msg, skip_type=SkipType.SKIP_BUG)
 
 
 def skip_not_implemented(reason: str) -> None:

--- a/test/pylib_test/_scan_py_files.py
+++ b/test/pylib_test/_scan_py_files.py
@@ -1,0 +1,48 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Shared helpers for AST-based guard tests in ``pylib_test``.
+
+Centralizes the boilerplate (test-file enumeration + safe AST parsing)
+shared by ``test_no_bare_skips``, ``test_skip_bug_links`` and
+``test_pr_message_bug_references``.
+"""
+
+import ast
+import pathlib
+from collections.abc import Iterator
+
+from test import TEST_DIR
+
+# Directories under test/ that AST guard tests should not scan:
+# - 'pylib_test' contains the guards themselves and their fixtures
+#   (which intentionally embed example skip patterns).
+# - 'pylib' is shared framework code, not test code.
+FRAMEWORK_DIRS = frozenset({"pylib", "pylib_test"})
+
+
+def iter_test_py_files(*, exclude: frozenset[str] = FRAMEWORK_DIRS) -> Iterator[pathlib.Path]:
+    """Yield Python files under ``test/``, skipping ``__pycache__`` and *exclude* dirs."""
+    for path in sorted(TEST_DIR.rglob("*.py")):
+        rel = path.relative_to(TEST_DIR)
+        parts = rel.parts
+        if "__pycache__" in parts:
+            continue
+        if exclude and parts[0] in exclude:
+            continue
+        yield path
+
+
+def parse_python_file(path: pathlib.Path) -> ast.AST | None:
+    """Return the parsed AST of *path* or ``None`` on read/syntax errors."""
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return None
+    try:
+        return ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return None

--- a/test/pylib_test/test_no_bare_skips.py
+++ b/test/pylib_test/test_no_bare_skips.py
@@ -13,32 +13,19 @@ Any new skip must use the typed markers or the typed skip() helper.
 
 import ast
 import os
-import pathlib
 import subprocess
 import sys
 
-_TEST_ROOT = pathlib.Path(__file__).resolve().parent.parent
-
-def _iter_test_py_files():
-    """Yield all .py files under test/ excluding pylib_test/, pylib/ and __pycache__."""
-    for p in sorted(_TEST_ROOT.rglob("*.py")):
-        rel = p.relative_to(_TEST_ROOT)
-        parts = rel.parts
-        if "__pycache__" in parts:
-            continue
-        if parts[0] in ("pylib_test", "pylib"):
-            continue
-        yield p
+from test import TEST_DIR
+from test.pylib_test._scan_py_files import iter_test_py_files, parse_python_file
 
 
 def test_no_bare_pytest_skip_calls_in_codebase():
     """Verify no test files use bare pytest.skip() (must use typed skip() helper)."""
     violations = []
-    for path in _iter_test_py_files():
-        source = path.read_text()
-        try:
-            tree = ast.parse(source, filename=str(path))
-        except SyntaxError:
+    for path in iter_test_py_files():
+        tree = parse_python_file(path)
+        if tree is None:
             continue
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
@@ -78,7 +65,7 @@ def test_no_bare_skip_markers_in_collection():
          "--ignore=unit",
          "-p", "no:sugar"],
         capture_output=True, text=True,
-        cwd=str(_TEST_ROOT),
+        cwd=str(TEST_DIR),
         env=env,
     )
     # If a bare skip exists, plugin raises UsageError → non-zero exit.

--- a/test/pylib_test/test_pr_message_bug_references.py
+++ b/test/pylib_test/test_pr_message_bug_references.py
@@ -1,0 +1,187 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Guard fixed issues from staying in skip_bug references.
+
+CI provides PR_MESSAGE, which may contain lines like::
+
+    Fixes: SCYLLADB-123                                    # JIRA key
+    Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-123
+    Fixes: 9999                                            # GitHub issue in scylladb/scylladb
+    Fixes: #9999                                           # same, with leading '#'
+    Fixes: scylladb/scylla-enterprise#9999                 # cross-repo GitHub issue
+    Fixes: https://github.com/scylladb/scylla-enterprise/issues/9999
+
+For each fixed issue listed in PR_MESSAGE, this test verifies no Python
+test still references it via ``skip_bug()`` / ``@pytest.mark.skip_bug(...)``.
+
+CI runs this with::
+
+    ./tools/toolchain/dbuild -e PR_MESSAGE='<commit message>' -- \\
+        pytest test/pylib_test --junit-xml=testlog/framework_tests/framework_test.xml
+"""
+
+import ast
+import os
+import pathlib
+import re
+from collections.abc import Iterator
+
+import pytest
+
+from test.pylib_test._scan_py_files import iter_test_py_files, parse_python_file
+
+_FIXES_PREFIX = "fixes:"
+# Bare 'Fixes: 9999' / 'Fixes: #9999' refer to the main scylladb/scylladb repo.
+_DEFAULT_GH_REPO = "scylladb/scylladb"
+
+# Recognized GitHub issue URL forms in PR_MESSAGE 'Fixes:' tokens,
+# including an optional trailing slash.
+_GH_URL_RE = re.compile(
+    r"^https?://github\.com/(?P<owner>[^/\s]+)/(?P<repo>[^/\s]+)/issues/(?P<num>\d+)/?$",
+)
+# owner/repo#123 cross-repo shorthand.
+_GH_SHORTHAND_RE = re.compile(
+    r"^(?P<owner>[^/\s#]+)/(?P<repo>[^/\s#]+)#(?P<num>\d+)$",
+    re.IGNORECASE,
+)
+# Full JIRA browse URL.
+_JIRA_URL_RE = re.compile(
+    r"^https?://scylladb\.atlassian\.net/browse/(?P<key>[A-Z][A-Z0-9]+-\d+)$",
+    re.IGNORECASE,
+)
+# Bare JIRA key like SCYLLADB-123.
+_JIRA_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]+-\d+$")
+
+
+def _parse_fixes_token(token: str) -> tuple | None:
+    """Classify a ``Fixes:`` token.
+
+    Returns one of:
+      * ``('jira', KEY)``                — JIRA key (matched as substring).
+      * ``('gh', 'owner/repo', NUM)``    — GitHub issue. Bare numbers default
+                                            to the main scylladb/scylladb repo.
+      * ``None``                         — unrecognized token.
+    """
+    token = token.strip()
+    if not token:
+        return None
+
+    if (m := _JIRA_URL_RE.match(token)):
+        return ("jira", m.group("key").upper())
+
+    if (m := _GH_URL_RE.match(token)):
+        return ("gh", f"{m.group('owner')}/{m.group('repo')}".lower(), m.group("num"))
+
+    if (m := _GH_SHORTHAND_RE.match(token)):
+        return ("gh", f"{m.group('owner')}/{m.group('repo')}".lower(), m.group("num"))
+
+    bare = token.lstrip("#").upper()
+    if _JIRA_KEY_RE.match(bare):
+        return ("jira", bare)
+    if bare.isdigit():
+        return ("gh", _DEFAULT_GH_REPO, bare)
+
+    return None
+
+
+def _extract_fixed_issues(pr_message: str) -> list[tuple]:
+    """Extract issue references from ``Fixes:`` lines in PR_MESSAGE."""
+    issues: list[tuple] = []
+    for line in pr_message.splitlines():
+        stripped = line.strip()
+        if not stripped.lower().startswith(_FIXES_PREFIX):
+            continue
+        value = stripped[len(_FIXES_PREFIX):].strip()
+        if not value:
+            continue
+        parsed = _parse_fixes_token(value.split()[0])
+        if parsed is not None and parsed not in issues:
+            issues.append(parsed)
+    return issues
+
+
+def _is_skip_bug_call(node: ast.Call) -> bool:
+    """Match ``skip_bug(...)`` and ``<anything>.skip_bug(...)`` calls."""
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "skip_bug":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "skip_bug":
+        return True
+    return False
+
+
+def _iter_string_literals(node: ast.AST) -> Iterator[str]:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str):
+            yield child.value
+
+
+def _text_references_issue(text: str, issue: tuple) -> bool:
+    """Return True if ``text`` references the given issue.
+
+    * JIRA: case-insensitive substring of the key.
+    * GitHub: substring of '/owner/repo/issues/NUM' (case-insensitive).
+    """
+    kind = issue[0]
+    if kind == "jira":
+        return issue[1] in text.upper()
+    repo, num = issue[1], issue[2]
+    return f"/{repo}/issues/{num}" in text.lower()
+
+
+def _format_issue(issue: tuple) -> str:
+    if issue[0] == "jira":
+        return issue[1]
+    repo, num = issue[1], issue[2]
+    return f"{repo}#{num}"
+
+
+def _collect_violations(path: pathlib.Path, fixed_issues: list[tuple]) -> list[str]:
+    """Collect violations only from skip_bug(...) call sites."""
+    tree = parse_python_file(path)
+    if tree is None:
+        return []
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_skip_bug_call(node):
+            continue
+        for text in _iter_string_literals(node):
+            for issue in fixed_issues:
+                if _text_references_issue(text, issue):
+                    violations.append(
+                        f"  {path}:{node.lineno} references fixed issue "
+                        f"{_format_issue(issue)}: {text.strip()}"
+                    )
+    return violations
+
+
+def test_fixed_issues_not_referenced_by_skip_bug():
+    """Verify fixed issues from PR_MESSAGE are not referenced in skip_bug usage."""
+    pr_message = os.environ.get("PR_MESSAGE")
+    if not pr_message:
+        pytest.skip(
+            "PR_MESSAGE environment variable is not set. "
+            "This test is intended to run in CI with PR_MESSAGE provided."
+        )
+
+    fixed_issues = _extract_fixed_issues(pr_message)
+    if not fixed_issues:
+        pytest.skip(
+            "PR_MESSAGE has no recognized 'Fixes:' entry "
+            "(SCYLLADB-NNN, NNN, #NNN, owner/repo#NNN, or full GitHub/JIRA URL)"
+        )
+
+    violations: list[str] = []
+    for path in iter_test_py_files():
+        violations.extend(_collect_violations(path, fixed_issues))
+
+    assert not violations, (
+        "Found references to issue(s) marked as fixed in PR_MESSAGE. "
+        "Remove/adjust those references before merging:\n"
+        + "\n".join(violations)
+    )

--- a/test/pylib_test/test_skip_bug_links.py
+++ b/test/pylib_test/test_skip_bug_links.py
@@ -1,0 +1,59 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""Codebase guard test: validate links used by @pytest.mark.skip_bug.
+
+The link validator is intentionally imported from
+``test.pylib.skip_types`` so this CI guard and marker validation logic
+cannot drift apart.
+"""
+
+
+import ast
+
+from test.pylib.skip_types import _is_valid_skip_bug_link
+from test.pylib_test._scan_py_files import iter_test_py_files, parse_python_file
+
+
+def _is_skip_bug_marker(node: ast.Call) -> bool:
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr != "skip_bug":
+        return False
+    mark_attr = func.value
+    if not isinstance(mark_attr, ast.Attribute) or mark_attr.attr != "mark":
+        return False
+    base = mark_attr.value
+    return isinstance(base, ast.Name) and base.id == "pytest"
+
+
+def test_skip_bug_markers_use_valid_links():
+    violations: list[str] = []
+
+    for path in iter_test_py_files():
+        tree = parse_python_file(path)
+        if tree is None:
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not _is_skip_bug_marker(node):
+                continue
+
+            link_kw = next((kw for kw in node.keywords if kw.arg == "link"), None)
+            if link_kw is None:
+                violations.append(f"  {path}:{node.lineno} missing link=...")
+                continue
+
+            if not isinstance(link_kw.value, ast.Constant) or not isinstance(link_kw.value.value, str):
+                violations.append(f"  {path}:{node.lineno} link must be a string literal")
+                continue
+
+            link = link_kw.value.value
+            if not _is_valid_skip_bug_link(link):
+                violations.append(
+                    f"  {path}:{node.lineno} invalid link {link!r} (expected GitHub issue URL or ScyllaDB Jira URL)"
+                )
+
+    assert not violations, "Invalid @pytest.mark.skip_bug link(s) found:\n" + "\n".join(violations)

--- a/test/pylib_test/test_skip_reason_plugin.py
+++ b/test/pylib_test/test_skip_reason_plugin.py
@@ -23,12 +23,17 @@ _BASE_CONFTEST = textwrap.dedent("""\
     import enum
     import pytest
     from test.pylib.skip_reason_plugin import SkipReasonPlugin
+    from test.pylib.skip_types import SkipType as ProjectSkipType
 
     class SkipType(enum.StrEnum):
         SKIP_BUG = "bug"
         SKIP_NOT_IMPLEMENTED = "not_implemented"
         SKIP_SLOW = "slow"
         SKIP_ENV = "env"
+
+        get_reason_default = staticmethod(ProjectSkipType.get_reason_default)
+        get_reason_skip_bug = staticmethod(ProjectSkipType.get_reason_skip_bug)
+
         @property
         def marker_name(self):
             return self.name.lower()
@@ -52,16 +57,33 @@ def skippytest(pytester: pytest.Pytester) -> pytest.Pytester:
 
 # -- Typed markers ----------------------------------------------------------
 
-@pytest.mark.parametrize("marker, skip_type, reason", [
-    ("skip_bug",             "bug",            "scylladb/scylladb#99999"),
-    ("skip_not_implemented", "not_implemented", "feature X not built yet"),
-    ("skip_slow",            "slow",            "takes 10 minutes"),
-    ("skip_env",             "env",             "need --special-flag"),
-], ids=["bug", "not_implemented", "slow", "env"])
-def test_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
+def test_skip_bug_marker_skips_with_prefix(skippytest):
     skippytest.makepyfile(f"""
         import pytest
-        @pytest.mark.{marker}(reason="{reason}")
+        @pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/99999",
+            reason="Known tablet scheduler crash",
+        )
+        def test_target():
+            assert False
+    """)
+    result = skippytest.runpytest("-rs")
+    result.assert_outcomes(skipped=1)
+    out = result.stdout.str()
+    assert "[bug]" in out
+    assert "Known tablet scheduler crash" in out
+    assert "https://github.com/scylladb/scylladb/issues/99999" in out
+
+
+@pytest.mark.parametrize("marker, skip_type, reason", [
+    ("skip_not_implemented", "not_implemented", "feature X not built yet"),
+    ("skip_slow", "slow", "takes 10 minutes"),
+    ("skip_env", "env", "need --special-flag"),
+])
+def test_non_bug_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
+    skippytest.makepyfile(f"""
+        import pytest
+        @pytest.mark.{marker}(reason=\"{reason}\")
         def test_target():
             assert False
     """)
@@ -72,24 +94,42 @@ def test_typed_marker_skips_with_prefix(skippytest, marker, skip_type, reason):
     assert reason in out
 
 
-def test_typed_marker_positional_reason(skippytest):
-    """Reason passed as a positional arg (not keyword) must also work."""
+def test_skip_bug_positional_reason_rejected(skippytest):
+    """Old positional form for skip_bug must be rejected."""
     skippytest.makepyfile("""
         import pytest
         @pytest.mark.skip_bug("scylladb/scylladb#55555")
         def test_positional():
             assert False
     """)
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*no longer accepts positional arguments*"])
+    assert result.ret != 0
+
+
+@pytest.mark.parametrize("marker, skip_type", [
+    ("skip_not_implemented", "not_implemented"),
+    ("skip_slow", "slow"),
+    ("skip_env", "env"),
+])
+def test_typed_marker_positional_reason_accepted(skippytest, marker, skip_type):
+    """Non-bug typed markers still accept a positional reason for backwards compatibility."""
+    skippytest.makepyfile(f"""
+        import pytest
+        @pytest.mark.{marker}("positional reason")
+        def test_positional():
+            pass
+    """)
     result = skippytest.runpytest("-rs")
     result.assert_outcomes(skipped=1)
     out = result.stdout.str()
-    assert "[bug]" in out
-    assert "scylladb/scylladb#55555" in out
+    assert f"[{skip_type}]" in out
+    assert "positional reason" in out
 
 
 # -- Missing reason ---------------------------------------------------------
 
-@pytest.mark.parametrize("marker", ["skip_bug", "skip_not_implemented"])
+@pytest.mark.parametrize("marker", ["skip_not_implemented", "skip_slow", "skip_env"])
 def test_missing_reason_is_rejected(skippytest, marker):
     skippytest.makepyfile(f"""
         import pytest
@@ -99,6 +139,30 @@ def test_missing_reason_is_rejected(skippytest, marker):
     """)
     result = skippytest.runpytest()
     result.stderr.fnmatch_lines(["*requires a 'reason' argument*"])
+    assert result.ret != 0
+
+
+def test_skip_bug_requires_link_and_reason(skippytest):
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(reason="Some explanation")
+        def test_missing_link():
+            pass
+    """)
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*requires both 'link' and 'reason'*"])
+    assert result.ret != 0
+
+
+def test_skip_bug_invalid_link_rejected(skippytest):
+    skippytest.makepyfile("""
+        import pytest
+        @pytest.mark.skip_bug(link="https://example.com/123", reason="Broken behavior")
+        def test_invalid_link():
+            pass
+    """)
+    result = skippytest.runpytest()
+    result.stderr.fnmatch_lines(["*invalid 'link' value*"])
     assert result.ret != 0
 
 
@@ -140,7 +204,10 @@ def test_bare_skip_in_pytest_param_rejected(skippytest):
 def test_typed_skip_does_not_reject(skippytest):
     skippytest.makepyfile("""
         import pytest
-        @pytest.mark.skip_bug(reason="scylladb/scylladb#11111")
+        @pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/11111",
+            reason="Known issue in validation pipeline",
+        )
         def test_typed():
             pass
     """)
@@ -188,7 +255,10 @@ def test_runtime_skip_populates_junit(skippytest, tmp_path):
 def test_junit_xml_contains_skip_type(skippytest, tmp_path):
     skippytest.makepyfile("""
         import pytest
-        @pytest.mark.skip_bug(reason="scylladb/scylladb#77777")
+        @pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/77777",
+            reason="Known issue in compaction path",
+        )
         def test_bug():
             pass
     """)
@@ -200,7 +270,8 @@ def test_junit_xml_contains_skip_type(skippytest, tmp_path):
     assert 'name="skip_type"' in xml
     assert 'value="bug"' in xml
     assert 'name="skip_reason"' in xml
-    assert "scylladb/scylladb#77777" in xml
+    assert "Known issue in compaction path" in xml
+    assert "https://github.com/scylladb/scylladb/issues/77777" in xml
 
 
 def test_report_callback_is_invoked(pytester: pytest.Pytester, tmp_path):
@@ -211,9 +282,14 @@ def test_report_callback_is_invoked(pytester: pytest.Pytester, tmp_path):
         import pytest
         from pathlib import Path
         from test.pylib.skip_reason_plugin import SkipReasonPlugin
+        from test.pylib.skip_types import SkipType as ProjectSkipType
 
         class SkipType(enum.StrEnum):
             SKIP_BUG = "bug"
+
+            get_reason_default = staticmethod(ProjectSkipType.get_reason_default)
+            get_reason_skip_bug = staticmethod(ProjectSkipType.get_reason_skip_bug)
+
             @property
             def marker_name(self):
                 return self.name.lower()
@@ -231,13 +307,16 @@ def test_report_callback_is_invoked(pytester: pytest.Pytester, tmp_path):
     )
     pytester.makepyfile("""
         import pytest
-        @pytest.mark.skip_bug(reason="scylladb/scylladb#44444")
+        @pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/44444",
+            reason="Known issue in callback flow",
+        )
         def test_cb():
             pass
     """)
     result = pytester.runpytest()
     result.assert_outcomes(skipped=1)
-    assert cb_path.read_text() == "bug:scylladb/scylladb#44444"
+    assert cb_path.read_text() == "bug:Known issue in callback flow (https://github.com/scylladb/scylladb/issues/44444)"
 
 
 # -- Typed marker + skip_mode interaction -----------------------------------
@@ -261,7 +340,10 @@ def test_typed_marker_with_skip_mode_populates_junit(skippytest, tmp_path):
     skippytest.makeconftest(_SKIP_MODE_CONFTEST)
     skippytest.makepyfile("""
         import pytest
-        @pytest.mark.skip_bug(reason="scylladb/scylladb#26844")
+        @pytest.mark.skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/26844",
+            reason="Tablet repair scheduler crashes",
+        )
         @pytest.mark.skip_mode(mode="release", reason="no error injections")
         def test_both():
             assert False
@@ -273,7 +355,8 @@ def test_typed_marker_with_skip_mode_populates_junit(skippytest, tmp_path):
     # JUnit XML must have the typed skip metadata.
     xml = xml_path.read_text()
     assert 'value="bug"' in xml
-    assert "scylladb/scylladb#26844" in xml
+    assert "Tablet repair scheduler crashes" in xml
+    assert "https://github.com/scylladb/scylladb/issues/26844" in xml
 
 
 def test_skip_mode_prefix_populates_junit(skippytest, tmp_path):

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -37,7 +37,7 @@ markers =
     non_gating: tests that are not run in CI/Next/Nightly verification, but can be run manually or on special job when needed
     nightly: for tests that are quite old, stable, and test functionality that rather not be changed or affected by other features, are partially covered in other tests, verify non-critical functionality, have not found any issues or regressions, too long to run on every PR,  and can be popped out from the CI run, but will continue run in Next/Nightly verification
     skip_mode(mode, reason, platform_key=None): Skip test in a specific build mode (e.g. dev, debug, release).
-    skip_bug(reason): Skip due to a known bug (reason = issue reference).
+    skip_bug(link=..., reason=...): Skip due to a known bug (link = issue URL, reason = human-readable explanation).
     skip_not_implemented(reason): Skip because the feature is not yet implemented.
     skip_slow(reason): Skip because the test is too slow for regular CI.
     skip_env(reason): Skip due to a missing environment requirement.

--- a/test/scylla_gdb/test_task_commands.py
+++ b/test/scylla_gdb/test_task_commands.py
@@ -35,7 +35,10 @@ def test_coroutine_frame(gdb_cmd):
     )
     if "COROUTINE_NOT_FOUND" in result.stdout:
         # See https://github.com/scylladb/scylladb/issues/22501
-        skip_bug("Failed to find coroutine task. Skipping test. https://github.com/scylladb/scylladb/issues/22501")
+        skip_bug(
+            link="https://github.com/scylladb/scylladb/issues/22501",
+            reason="Coroutine task cannot be found in this GDB scenario",
+        )
     assert result.returncode == 0, (
         f"GDB command `coro_frame` failed. stdout: {result.stdout} stderr: {result.stderr}"
     )


### PR DESCRIPTION
The number of tests that pass CI but later fail due to untracked "bug fix" removals is very high. This PR enforces a strict skip_bug signature and adds CI validation to catch stale markers proactively.

Fixes: SCYLLADB-1741

related PR in PKG - https://github.com/scylladb/scylla-pkg/pull/6129
