### PR TITLE
 Add a node_owner column (locator::host_id) to system.sstables and     make it part of the partition key

### DIFF
--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1144,7 +1144,7 @@ schema_ptr system_keyspace::sstables_registry() {
     static thread_local auto schema = [] {
         auto id = generate_legacy_id(NAME, SSTABLES_REGISTRY);
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
-            .with_column("owner", uuid_type, column_kind::partition_key)
+            .with_column("table_id", uuid_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
             .with_column("state", utf8_type)
@@ -3404,37 +3404,37 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
     co_return cdc::topology_description{std::move(entries)};
 }
 
-future<> system_keyspace::sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
-    static const auto req = format("INSERT INTO system.{} (owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
-    slogger.trace("Inserting {}.{} into {}", owner, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, owner.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+future<> system_keyspace::sstables_registry_create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
+    static const auto req = format("INSERT INTO system.{} (table_id, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    slogger.trace("Inserting {}.{} into {}", tid, desc.generation, SSTABLES_REGISTRY);
+    co_await execute_cql(req, tid.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status) {
-    static const auto req = format("UPDATE system.{} SET status = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Updating {}.{} -> status={} in {}", owner, gen, status, SSTABLES_REGISTRY);
-    co_await execute_cql(req, status, owner.id, gen).discard_result();
+future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, sstables::generation_type gen, sstring status) {
+    static const auto req = format("UPDATE system.{} SET status = ? WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Updating {}.{} -> status={} in {}", tid, gen, status, SSTABLES_REGISTRY);
+    co_await execute_cql(req, status, tid.id, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) {
-    static const auto req = format("UPDATE system.{} SET state = ? WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
+future<> system_keyspace::sstables_registry_update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) {
+    static const auto req = format("UPDATE system.{} SET state = ? WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
-    slogger.trace("Updating {}.{} -> state={} in {}", owner, gen, new_state, SSTABLES_REGISTRY);
-    co_await execute_cql(req, new_state, owner.id, gen).discard_result();
+    slogger.trace("Updating {}.{} -> state={} in {}", tid, gen, new_state, SSTABLES_REGISTRY);
+    co_await execute_cql(req, new_state, tid.id, gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_delete_entry(table_id owner, sstables::generation_type gen) {
-    static const auto req = format("DELETE FROM system.{} WHERE owner = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Removing {}.{} from {}", owner, gen, SSTABLES_REGISTRY);
-    co_await execute_cql(req, owner.id, gen).discard_result();
+future<> system_keyspace::sstables_registry_delete_entry(table_id tid, sstables::generation_type gen) {
+    static const auto req = format("DELETE FROM system.{} WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Removing {}.{} from {}", tid, gen, SSTABLES_REGISTRY);
+    co_await execute_cql(req, tid.id, gen).discard_result();
 
 }
 
-future<> system_keyspace::sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer) {
-    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE owner = ?", SSTABLES_REGISTRY);
-    slogger.trace("Listing {} entries from {}", owner, SSTABLES_REGISTRY);
+future<> system_keyspace::sstables_registry_list(table_id tid, sstable_registry_entry_consumer consumer) {
+    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE table_id = ?", SSTABLES_REGISTRY);
+    slogger.trace("Listing {} entries from {}", tid, SSTABLES_REGISTRY);
 
-    co_await _qp.query_internal(req, db::consistency_level::ONE, { owner.id }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
+    co_await _qp.query_internal(req, db::consistency_level::ONE, { tid.id }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));

--- a/db/system_keyspace.cc
+++ b/db/system_keyspace.cc
@@ -1145,6 +1145,7 @@ schema_ptr system_keyspace::sstables_registry() {
         auto id = generate_legacy_id(NAME, SSTABLES_REGISTRY);
         return schema_builder(NAME, SSTABLES_REGISTRY, id)
             .with_column("table_id", uuid_type, column_kind::partition_key)
+            .with_column("node_owner", uuid_type, column_kind::partition_key)
             .with_column("generation", timeuuid_type, column_kind::clustering_key)
             .with_column("status", utf8_type)
             .with_column("state", utf8_type)
@@ -3404,37 +3405,37 @@ system_keyspace::read_cdc_generation_opt(utils::UUID id) {
     co_return cdc::topology_description{std::move(entries)};
 }
 
-future<> system_keyspace::sstables_registry_create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
-    static const auto req = format("INSERT INTO system.{} (table_id, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
-    slogger.trace("Inserting {}.{} into {}", tid, desc.generation, SSTABLES_REGISTRY);
-    co_await execute_cql(req, tid.id, desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
+future<> system_keyspace::sstables_registry_create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) {
+    static const auto req = format("INSERT INTO system.{} (table_id, node_owner, generation, status, state, version, format) VALUES (?, ?, ?, ?, ?, ?, ?)", SSTABLES_REGISTRY);
+    slogger.trace("Inserting {}.{}.{} into {}", tid, node_owner, desc.generation, SSTABLES_REGISTRY);
+    co_await execute_cql(req, tid.id, node_owner.uuid(), desc.generation, status, sstables::state_to_dir(state), fmt::to_string(desc.version), fmt::to_string(desc.format)).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, sstables::generation_type gen, sstring status) {
-    static const auto req = format("UPDATE system.{} SET status = ? WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Updating {}.{} -> status={} in {}", tid, gen, status, SSTABLES_REGISTRY);
-    co_await execute_cql(req, status, tid.id, gen).discard_result();
+future<> system_keyspace::sstables_registry_update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) {
+    static const auto req = format("UPDATE system.{} SET status = ? WHERE table_id = ? AND node_owner = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Updating {}.{}.{} -> status={} in {}", tid, node_owner, gen, status, SSTABLES_REGISTRY);
+    co_await execute_cql(req, status, tid.id, node_owner.uuid(), gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) {
-    static const auto req = format("UPDATE system.{} SET state = ? WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
+future<> system_keyspace::sstables_registry_update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) {
+    static const auto req = format("UPDATE system.{} SET state = ? WHERE table_id = ? AND node_owner = ? AND generation = ?", SSTABLES_REGISTRY);
     auto new_state = sstables::state_to_dir(state);
-    slogger.trace("Updating {}.{} -> state={} in {}", tid, gen, new_state, SSTABLES_REGISTRY);
-    co_await execute_cql(req, new_state, tid.id, gen).discard_result();
+    slogger.trace("Updating {}.{}.{} -> state={} in {}", tid, node_owner, gen, new_state, SSTABLES_REGISTRY);
+    co_await execute_cql(req, new_state, tid.id, node_owner.uuid(), gen).discard_result();
 }
 
-future<> system_keyspace::sstables_registry_delete_entry(table_id tid, sstables::generation_type gen) {
-    static const auto req = format("DELETE FROM system.{} WHERE table_id = ? AND generation = ?", SSTABLES_REGISTRY);
-    slogger.trace("Removing {}.{} from {}", tid, gen, SSTABLES_REGISTRY);
-    co_await execute_cql(req, tid.id, gen).discard_result();
+future<> system_keyspace::sstables_registry_delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen) {
+    static const auto req = format("DELETE FROM system.{} WHERE table_id = ? AND node_owner = ? AND generation = ?", SSTABLES_REGISTRY);
+    slogger.trace("Removing {}.{}.{} from {}", tid, node_owner, gen, SSTABLES_REGISTRY);
+    co_await execute_cql(req, tid.id, node_owner.uuid(), gen).discard_result();
 
 }
 
-future<> system_keyspace::sstables_registry_list(table_id tid, sstable_registry_entry_consumer consumer) {
-    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE table_id = ?", SSTABLES_REGISTRY);
-    slogger.trace("Listing {} entries from {}", tid, SSTABLES_REGISTRY);
+future<> system_keyspace::sstables_registry_list(table_id tid, locator::host_id node_owner, sstable_registry_entry_consumer consumer) {
+    static const auto req = format("SELECT status, state, generation, version, format FROM system.{} WHERE table_id = ? AND node_owner = ?", SSTABLES_REGISTRY);
+    slogger.trace("Listing {}.{} entries from {}", tid, node_owner, SSTABLES_REGISTRY);
 
-    co_await _qp.query_internal(req, db::consistency_level::ONE, { tid.id }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
+    co_await _qp.query_internal(req, db::consistency_level::ONE, { tid.id, node_owner.uuid() }, 1000, [ consumer = std::move(consumer) ] (const cql3::untyped_result_set::row& row) -> future<stop_iteration> {
         auto status = row.get_as<sstring>("status");
         auto state = sstables::state_from_dir(row.get_as<sstring>("state"));
         auto gen = sstables::generation_type(row.get_as<utils::UUID>("generation"));

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -658,12 +658,12 @@ public:
     future<mutation> make_view_builder_version_mutation(api::timestamp_type ts, view_builder_version_t version);
     future<view_builder_version_t> get_view_builder_version();
 
-    future<> sstables_registry_create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
-    future<> sstables_registry_update_entry_status(table_id tid, sstables::generation_type gen, sstring status);
-    future<> sstables_registry_update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state);
-    future<> sstables_registry_delete_entry(table_id tid, sstables::generation_type gen);
+    future<> sstables_registry_create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
+    future<> sstables_registry_update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status);
+    future<> sstables_registry_update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state);
+    future<> sstables_registry_delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
-    future<> sstables_registry_list(table_id tid, sstable_registry_entry_consumer consumer);
+    future<> sstables_registry_list(table_id tid, locator::host_id node_owner, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);

--- a/db/system_keyspace.hh
+++ b/db/system_keyspace.hh
@@ -658,12 +658,12 @@ public:
     future<mutation> make_view_builder_version_mutation(api::timestamp_type ts, view_builder_version_t version);
     future<view_builder_version_t> get_view_builder_version();
 
-    future<> sstables_registry_create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
-    future<> sstables_registry_update_entry_status(table_id owner, sstables::generation_type gen, sstring status);
-    future<> sstables_registry_update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state);
-    future<> sstables_registry_delete_entry(table_id owner, sstables::generation_type gen);
+    future<> sstables_registry_create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc);
+    future<> sstables_registry_update_entry_status(table_id tid, sstables::generation_type gen, sstring status);
+    future<> sstables_registry_update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state);
+    future<> sstables_registry_delete_entry(table_id tid, sstables::generation_type gen);
     using sstable_registry_entry_consumer = sstables::sstables_registry::entry_consumer;
-    future<> sstables_registry_list(table_id owner, sstable_registry_entry_consumer consumer);
+    future<> sstables_registry_list(table_id tid, sstable_registry_entry_consumer consumer);
 
     future<std::optional<sstring>> load_group0_upgrade_state();
     future<> save_group0_upgrade_state(sstring);

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -15,24 +15,24 @@ class system_keyspace_sstables_registry : public sstables::sstables_registry {
 public:
     system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
 
-    virtual seastar::future<> create_entry(table_id owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
-        return _keyspace->sstables_registry_create_entry(owner, status, state, desc);
+    virtual seastar::future<> create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
+        return _keyspace->sstables_registry_create_entry(tid, status, state, desc);
     }
 
-    virtual seastar::future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
-        return _keyspace->sstables_registry_update_entry_status(owner, gen, status);
+    virtual seastar::future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) override {
+        return _keyspace->sstables_registry_update_entry_status(tid, gen, status);
     }
 
-    virtual seastar::future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
-        return _keyspace->sstables_registry_update_entry_state(owner, gen, state);
+    virtual seastar::future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) override {
+        return _keyspace->sstables_registry_update_entry_state(tid, gen, state);
     }
 
-    virtual seastar::future<> delete_entry(table_id owner, sstables::generation_type gen) override {
-        return _keyspace->sstables_registry_delete_entry(owner, gen);
+    virtual seastar::future<> delete_entry(table_id tid, sstables::generation_type gen) override {
+        return _keyspace->sstables_registry_delete_entry(tid, gen);
     }
 
-    virtual seastar::future<> sstables_registry_list(table_id owner, entry_consumer consumer) override {
-        return _keyspace->sstables_registry_list(owner, std::move(consumer));
+    virtual seastar::future<> sstables_registry_list(table_id tid, entry_consumer consumer) override {
+        return _keyspace->sstables_registry_list(tid, std::move(consumer));
     }
 };
 

--- a/db/system_keyspace_sstables_registry.hh
+++ b/db/system_keyspace_sstables_registry.hh
@@ -15,24 +15,24 @@ class system_keyspace_sstables_registry : public sstables::sstables_registry {
 public:
     system_keyspace_sstables_registry(system_keyspace& keyspace) : _keyspace(keyspace.shared_from_this()) {}
 
-    virtual seastar::future<> create_entry(table_id tid, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
-        return _keyspace->sstables_registry_create_entry(tid, status, state, desc);
+    virtual seastar::future<> create_entry(table_id tid, locator::host_id node_owner, sstring status, sstables::sstable_state state, sstables::entry_descriptor desc) override {
+        return _keyspace->sstables_registry_create_entry(tid, node_owner, status, state, desc);
     }
 
-    virtual seastar::future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) override {
-        return _keyspace->sstables_registry_update_entry_status(tid, gen, status);
+    virtual seastar::future<> update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) override {
+        return _keyspace->sstables_registry_update_entry_status(tid, node_owner, gen, status);
     }
 
-    virtual seastar::future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) override {
-        return _keyspace->sstables_registry_update_entry_state(tid, gen, state);
+    virtual seastar::future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) override {
+        return _keyspace->sstables_registry_update_entry_state(tid, node_owner, gen, state);
     }
 
-    virtual seastar::future<> delete_entry(table_id tid, sstables::generation_type gen) override {
-        return _keyspace->sstables_registry_delete_entry(tid, gen);
+    virtual seastar::future<> delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen) override {
+        return _keyspace->sstables_registry_delete_entry(tid, node_owner, gen);
     }
 
-    virtual seastar::future<> sstables_registry_list(table_id tid, entry_consumer consumer) override {
-        return _keyspace->sstables_registry_list(tid, std::move(consumer));
+    virtual seastar::future<> sstables_registry_list(table_id tid, locator::host_id node_owner, entry_consumer consumer) override {
+        return _keyspace->sstables_registry_list(tid, node_owner, std::move(consumer));
     }
 };
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -56,9 +56,10 @@ sstable_directory::filesystem_components_lister::filesystem_components_lister(st
 {
 }
 
-sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid)
+sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid, locator::host_id node_owner)
         : _sstables_registry(sstables_registry)
         , _table_id(std::move(tid))
+        , _node_owner(node_owner)
 {
 }
 
@@ -89,7 +90,7 @@ sstable_directory::make_components_lister() {
                     if (owner.id.is_null()) {
                         on_internal_error(sstlog, fmt::format("{} storage options is missing 'owner'", os.type));
                     }
-                    return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), owner);
+                    return std::make_unique<sstable_directory::sstables_registry_components_lister>(_manager.sstables_registry(), owner, _manager.get_local_host_id());
                 }
             }, os.location);
         }
@@ -426,8 +427,8 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 }
 
 future<> sstable_directory::sstables_registry_components_lister::process(sstable_directory& directory, process_flags flags) {
-    dirlog.debug("Start processing registry entry {} (state {})", _table_id, directory._state);
-    return _sstables_registry.sstables_registry_list(_table_id, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
+    dirlog.debug("Start processing registry entry {}.{} (state {})", _table_id, _node_owner, directory._state);
+    return _sstables_registry.sstables_registry_list(_table_id, _node_owner, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
         if (state != directory._state) {
             return make_ready_future<>();
         }
@@ -483,7 +484,7 @@ future<> sstable_directory::restore_components_lister::commit() {
 
 future<> sstable_directory::sstables_registry_components_lister::garbage_collect(storage& st) {
     std::set<generation_type> gens_to_remove;
-    co_await _sstables_registry.sstables_registry_list(_table_id, coroutine::lambda([&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
+    co_await _sstables_registry.sstables_registry_list(_table_id, _node_owner, coroutine::lambda([&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
         if (status == "sealed") {
             co_return;
         }
@@ -493,7 +494,7 @@ future<> sstable_directory::sstables_registry_components_lister::garbage_collect
         co_await st.remove_by_registry_entry(std::move(desc));
     }));
     co_await coroutine::parallel_for_each(gens_to_remove, [this] (auto gen) -> future<> {
-        co_await _sstables_registry.delete_entry(_table_id, gen);
+        co_await _sstables_registry.delete_entry(_table_id, _node_owner, gen);
     });
 }
 

--- a/sstables/sstable_directory.cc
+++ b/sstables/sstable_directory.cc
@@ -56,9 +56,9 @@ sstable_directory::filesystem_components_lister::filesystem_components_lister(st
 {
 }
 
-sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id owner)
+sstable_directory::sstables_registry_components_lister::sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid)
         : _sstables_registry(sstables_registry)
-        , _owner(std::move(owner))
+        , _table_id(std::move(tid))
 {
 }
 
@@ -426,20 +426,20 @@ future<> sstable_directory::filesystem_components_lister::process(sstable_direct
 }
 
 future<> sstable_directory::sstables_registry_components_lister::process(sstable_directory& directory, process_flags flags) {
-    dirlog.debug("Start processing registry entry {} (state {})", _owner, directory._state);
-    return _sstables_registry.sstables_registry_list(_owner, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
+    dirlog.debug("Start processing registry entry {} (state {})", _table_id, directory._state);
+    return _sstables_registry.sstables_registry_list(_table_id, [this, flags, &directory] (sstring status, sstable_state state, entry_descriptor desc) {
         if (state != directory._state) {
             return make_ready_future<>();
         }
         if (status != "sealed") {
-            dirlog.warn("Skip processing {} {} entry from {} (must have been picked up by garbage collector)", status, desc.generation, _owner);
+            dirlog.warn("Skip processing {} {} entry from {} (must have been picked up by garbage collector)", status, desc.generation, _table_id);
             return make_ready_future<>();
         }
         if (!sstable_generation_generator::maybe_owned_by_this_shard(desc.generation)) {
             return make_ready_future<>();
         }
 
-        dirlog.debug("Processing {} entry from {}", desc.generation, _owner);
+        dirlog.debug("Processing {} entry from {}", desc.generation, _table_id);
         return directory.process_descriptor(std::move(desc), flags,
                                             [&directory] { return *directory._storage_opts; });
     });
@@ -483,7 +483,7 @@ future<> sstable_directory::restore_components_lister::commit() {
 
 future<> sstable_directory::sstables_registry_components_lister::garbage_collect(storage& st) {
     std::set<generation_type> gens_to_remove;
-    co_await _sstables_registry.sstables_registry_list(_owner, coroutine::lambda([&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
+    co_await _sstables_registry.sstables_registry_list(_table_id, coroutine::lambda([&st, &gens_to_remove] (sstring status, sstable_state state, entry_descriptor desc) -> future<> {
         if (status == "sealed") {
             co_return;
         }
@@ -493,7 +493,7 @@ future<> sstable_directory::sstables_registry_components_lister::garbage_collect
         co_await st.remove_by_registry_entry(std::move(desc));
     }));
     co_await coroutine::parallel_for_each(gens_to_remove, [this] (auto gen) -> future<> {
-        co_await _sstables_registry.delete_entry(_owner, gen);
+        co_await _sstables_registry.delete_entry(_table_id, gen);
     });
 }
 

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -142,11 +142,12 @@ public:
     class sstables_registry_components_lister final : public components_lister {
         sstables_registry& _sstables_registry;
         table_id _table_id;
+        locator::host_id _node_owner;
 
         future<> garbage_collect(storage&);
 
     public:
-        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid);
+        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid, locator::host_id node_owner);
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;

--- a/sstables/sstable_directory.hh
+++ b/sstables/sstable_directory.hh
@@ -141,12 +141,12 @@ public:
 
     class sstables_registry_components_lister final : public components_lister {
         sstables_registry& _sstables_registry;
-        table_id _owner;
+        table_id _table_id;
 
         future<> garbage_collect(storage&);
 
     public:
-        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id owner);
+        sstables_registry_components_lister(sstables::sstables_registry& sstables_registry, table_id tid);
 
         virtual future<> process(sstable_directory& directory, process_flags flags) override;
         virtual future<> commit() override;

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -7,6 +7,7 @@
 
 #include <seastar/core/sstring.hh>
 #include <seastar/core/future.hh>
+#include "locator/host_id.hh"
 #include "schema/schema_fwd.hh"
 #include "seastarx.hh"
 
@@ -19,12 +20,12 @@ namespace sstables {
 class sstables_registry {
 public:
     virtual ~sstables_registry();
-    virtual future<> create_entry(table_id tid, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
-    virtual future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) = 0;
-    virtual future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) = 0;
-    virtual future<> delete_entry(table_id tid, sstables::generation_type gen) = 0;
+    virtual future<> create_entry(table_id tid, locator::host_id node_owner, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
+    virtual future<> update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) = 0;
+    virtual future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) = 0;
+    virtual future<> delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen) = 0;
     using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
-    virtual future<> sstables_registry_list(table_id tid, entry_consumer consumer) = 0;
+    virtual future<> sstables_registry_list(table_id tid, locator::host_id node_owner, entry_consumer consumer) = 0;
 };
 
 } // namespace sstables

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -19,12 +19,12 @@ namespace sstables {
 class sstables_registry {
 public:
     virtual ~sstables_registry();
-    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
-    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) = 0;
-    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) = 0;
-    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) = 0;
+    virtual future<> create_entry(table_id tid, sstring status, sstable_state state, sstables::entry_descriptor desc) = 0;
+    virtual future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) = 0;
+    virtual future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) = 0;
+    virtual future<> delete_entry(table_id tid, sstables::generation_type gen) = 0;
     using entry_consumer = noncopyable_function<future<>(sstring status, sstables::sstable_state state, sstables::entry_descriptor desc)>;
-    virtual future<> sstables_registry_list(table_id owner, entry_consumer consumer) = 0;
+    virtual future<> sstables_registry_list(table_id tid, entry_consumer consumer) = 0;
 };
 
 } // namespace sstables

--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -729,7 +729,7 @@ object_name object_storage_base::make_object_name(const sstable& sst, sstring co
 
 void object_storage_base::open(sstable& sst) {
     entry_descriptor desc(sst._generation, sst._version, sst._format, component_type::TOC);
-    sst.manager().sstables_registry().create_entry(owner(), status_creating, sst._state, std::move(desc)).get();
+    sst.manager().sstables_registry().create_entry(owner(), sst.manager().get_local_host_id(), status_creating, sst._state, std::move(desc)).get();
 
     memory_data_sink_buffers bufs;
     auto out = data_sink(std::make_unique<memory_data_sink>(bufs));
@@ -817,7 +817,7 @@ future<data_sink> object_storage_base::make_component_sink(sstable& sst, compone
 }
 
 future<> object_storage_base::seal(const sstable& sst) {
-    co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.generation(), status_sealed);
+    co_await sst.manager().sstables_registry().update_entry_status(owner(), sst.manager().get_local_host_id(), sst.generation(), status_sealed);
 }
 
 future<> object_storage_base::change_state(const sstable& sst, sstable_state state, generation_type generation, delayed_commit_changes* delay) {
@@ -827,19 +827,20 @@ future<> object_storage_base::change_state(const sstable& sst, sstable_state sta
         // is moved from upload directory and this is another issue for S3 (#13018)
         co_await coroutine::return_exception(std::runtime_error("Cannot change state and generation of an S3 object"));
     }
-    co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.generation(), state);
+    co_await sst.manager().sstables_registry().update_entry_state(owner(), sst.manager().get_local_host_id(), sst.generation(), state);
 }
 
 future<> object_storage_base::wipe(const sstable& sst, sync_dir) noexcept {
     auto& sstables_registry = sst.manager().sstables_registry();
+    auto node_owner = sst.manager().get_local_host_id();
 
-    co_await sstables_registry.update_entry_status(owner(), sst.generation(), status_removing);
+    co_await sstables_registry.update_entry_status(owner(), node_owner, sst.generation(), status_removing);
 
     co_await coroutine::parallel_for_each(sst._recognized_components, [this, &sst] (auto type) -> future<> {
         co_await delete_object(make_object_name(sst, type));
     });
 
-    co_await sstables_registry.delete_entry(owner(), sst.generation());
+    co_await sstables_registry.delete_entry(owner(), node_owner, sst.generation());
 }
 
 future<atomic_delete_context> object_storage_base::atomic_delete_prepare(const std::vector<shared_sstable>&) const {
@@ -892,7 +893,8 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
 
     // Register the cloned sstable as "creating" in the registry
     entry_descriptor desc(gen, sst.get_version(), sst.get_format(), component_type::TOC);
-    co_await sst.manager().sstables_registry().create_entry(owner(), status_creating, sst.state(), desc);
+    auto node_owner = sst.manager().get_local_host_id();
+    co_await sst.manager().sstables_registry().create_entry(owner(), node_owner, status_creating, sst.state(), desc);
 
     // Copy all component objects from the source to the destination generation.
     co_await coroutine::parallel_for_each(sst.all_components(), [this, &sst, &gen] (const std::pair<component_type, sstring>& p) -> future<> {
@@ -901,7 +903,7 @@ future<> object_storage_base::clone(const sstable& sst, generation_type gen, boo
 
     if (!leave_unsealed) {
         // Mark the cloned sstable as sealed in the registry
-        co_await sst.manager().sstables_registry().update_entry_status(owner(), gen, status_sealed);
+        co_await sst.manager().sstables_registry().update_entry_status(owner(), node_owner, gen, status_sealed);
     }
 
     sstlog.debug("clone sst: {} generation={}: done", sst.get_filename(), gen);

--- a/test/boost/sstable_compaction_test.cc
+++ b/test/boost/sstable_compaction_test.cc
@@ -7405,6 +7405,7 @@ void object_storage_sstable_clone_leaving_unsealed_dest_sstable(test_env& env) {
         env.manager()
             .sstables_registry()
             .sstables_registry_list(table.schema()->id(),
+                                    env.manager().get_local_host_id(),
                                     [&checked, sst_desc = sst2->get_descriptor(component_type::TOC)](
                                         sstring status, sstable_state state, entry_descriptor desc) {
                                         if (desc.generation == sst_desc.generation) {
@@ -7426,6 +7427,7 @@ void object_storage_sstable_clone_leaving_unsealed_dest_sstable(test_env& env) {
         env.manager()
             .sstables_registry()
             .sstables_registry_list(table.schema()->id(),
+                                    env.manager().get_local_host_id(),
                                     [&checked, sst_desc = sst3->get_descriptor(component_type::TOC)](
                                         sstring status, sstable_state, entry_descriptor desc) {
                                         if (desc.generation == sst_desc.generation) {

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -132,11 +132,11 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
         # Mark the sstables as "removing" to simulate the problem
         res = cql.execute("SELECT * FROM system.sstables;")
         for row in res:
-            sstable_entries.append((row.table_id, row.generation))
-        print(f'Found entries: {[ str(ent[1]) for ent in sstable_entries ]}')
-        for table_id, gen in sstable_entries:
+            sstable_entries.append((row.table_id, row.node_owner, row.generation))
+        print(f'Found entries: {[ str(ent[2]) for ent in sstable_entries ]}')
+        for table_id, node_owner, gen in sstable_entries:
             cql.execute("UPDATE system.sstables SET status = 'removing'"
-                         f" WHERE table_id = {table_id} AND generation = {gen};")
+                         f" WHERE table_id = {table_id} AND node_owner = {node_owner} AND generation = {gen};")
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
@@ -151,7 +151,7 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
         print(f'Found objects: {[ objects ]}')
         for o in objects:
             for ent in sstable_entries:
-                assert not o.key.startswith(str(ent[1])), f'Sstable object not cleaned, found {o.key}'
+                assert not o.key.startswith(str(ent[2])), f'Sstable object not cleaned, found {o.key}'
 
 
 @pytest.mark.asyncio
@@ -181,7 +181,7 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
         assert len(list(res)) > 0, 'No entries in registry'
         for row in res:
             cql.execute("UPDATE system.sstables SET state = 'quarantine'"
-                         f" WHERE table_id = {row.table_id} AND generation = {row.generation};")
+                         f" WHERE table_id = {row.table_id} AND node_owner = {row.node_owner} AND generation = {row.generation};")
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -75,8 +75,8 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
         tid = cql.execute(f"SELECT id FROM system_schema.tables WHERE keyspace_name = '{ks}' AND table_name = 'test'").one()
         res = cql.execute("SELECT * FROM system.sstables;")
         for row in res:
-            assert row.owner == tid.id, \
-                f'Unexpected entry owner in registry: {row.owner}'
+            assert row.table_id == tid.id, \
+                f'Unexpected entry table_id in registry: {row.table_id}'
             assert row.status == 'sealed', f'Unexpected entry status in registry: {row.status}'
 
         if replication_factor > 1:
@@ -105,7 +105,7 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
         cql.execute(f"DROP TABLE {ks}.test;")
         # Check that the ownership table is de-populated
         res = cql.execute("SELECT * FROM system.sstables;")
-        rows = "\n".join(f"{row.owner} {row.status}" for row in res)
+        rows = "\n".join(f"{row.table_id} {row.status}" for row in res)
         assert not rows, 'Unexpected entries in registry'
 
 @pytest.mark.asyncio
@@ -132,11 +132,11 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
         # Mark the sstables as "removing" to simulate the problem
         res = cql.execute("SELECT * FROM system.sstables;")
         for row in res:
-            sstable_entries.append((row.owner, row.generation))
+            sstable_entries.append((row.table_id, row.generation))
         print(f'Found entries: {[ str(ent[1]) for ent in sstable_entries ]}')
-        for owner, gen in sstable_entries:
+        for table_id, gen in sstable_entries:
             cql.execute("UPDATE system.sstables SET status = 'removing'"
-                         f" WHERE owner = {owner} AND generation = {gen};")
+                         f" WHERE table_id = {table_id} AND generation = {gen};")
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
@@ -181,7 +181,7 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
         assert len(list(res)) > 0, 'No entries in registry'
         for row in res:
             cql.execute("UPDATE system.sstables SET state = 'quarantine'"
-                         f" WHERE owner = {row.owner} AND generation = {row.generation};")
+                         f" WHERE table_id = {row.table_id} AND generation = {row.generation};")
 
         print('Restart scylla')
         await manager.server_restart(server.server_id)
@@ -249,7 +249,7 @@ async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_sto
 
         print(f'Check the sstables table')
         res = cql.execute("SELECT * FROM system.sstables;")
-        ssts = "\n".join(f"{row.owner} {row.generation} {row.status}" for row in res)
+        ssts = "\n".join(f"{row.table_id} {row.generation} {row.status}" for row in res)
         print(f'sstables:\n{ssts}')
 
         print('Restart scylla')

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -312,14 +312,15 @@ class mock_sstables_registry : public sstables::sstables_registry {
         sstables::sstable_state state;
         sstables::entry_descriptor desc;
     };
-    std::map<std::pair<table_id, generation_type>, entry> _entries;
+    using key_type = std::tuple<table_id, locator::host_id, generation_type>;
+    std::map<key_type, entry> _entries;
 public:
-    virtual future<> create_entry(table_id tid, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
-        _entries.emplace(std::make_pair(tid, desc.generation), entry { status, state, desc });
+    virtual future<> create_entry(table_id tid, locator::host_id node_owner, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
+        _entries.emplace(key_type{tid, node_owner, desc.generation}, entry { status, state, desc });
         co_return;
     };
-    virtual future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) override {
-        auto it = _entries.find(std::make_pair(tid, gen));
+    virtual future<> update_entry_status(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstring status) override {
+        auto it = _entries.find(key_type{tid, node_owner, gen});
         if (it != _entries.end()) {
             it->second.status = status;
         } else {
@@ -327,8 +328,8 @@ public:
         }
         co_return;
     }
-    virtual future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) override {
-        auto it = _entries.find(std::make_pair(tid, gen));
+    virtual future<> update_entry_state(table_id tid, locator::host_id node_owner, sstables::generation_type gen, sstables::sstable_state state) override {
+        auto it = _entries.find(key_type{tid, node_owner, gen});
         if (it != _entries.end()) {
             it->second.state = state;
         } else {
@@ -336,8 +337,8 @@ public:
         }
         co_return;
     }
-    virtual future<> delete_entry(table_id tid, sstables::generation_type gen) override {
-        auto it = _entries.find(std::make_pair(tid, gen));
+    virtual future<> delete_entry(table_id tid, locator::host_id node_owner, sstables::generation_type gen) override {
+        auto it = _entries.find(key_type{tid, node_owner, gen});
         if (it != _entries.end()) {
             _entries.erase(it);
         } else {
@@ -345,9 +346,9 @@ public:
         }
         co_return;
     }
-    virtual future<> sstables_registry_list(table_id tid, entry_consumer consumer) override {
-        for (auto& [loc_and_gen, e] : _entries) {
-            if (loc_and_gen.first == tid) {
+    virtual future<> sstables_registry_list(table_id tid, locator::host_id node_owner, entry_consumer consumer) override {
+        for (auto& [key, e] : _entries) {
+            if (std::get<0>(key) == tid && std::get<1>(key) == node_owner) {
                 co_await consumer(e.status, e.state, e.desc);
             }
         }

--- a/test/lib/test_services.cc
+++ b/test/lib/test_services.cc
@@ -314,12 +314,12 @@ class mock_sstables_registry : public sstables::sstables_registry {
     };
     std::map<std::pair<table_id, generation_type>, entry> _entries;
 public:
-    virtual future<> create_entry(table_id owner, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
-        _entries.emplace(std::make_pair(owner, desc.generation), entry { status, state, desc });
+    virtual future<> create_entry(table_id tid, sstring status, sstable_state state, sstables::entry_descriptor desc) override {
+        _entries.emplace(std::make_pair(tid, desc.generation), entry { status, state, desc });
         co_return;
     };
-    virtual future<> update_entry_status(table_id owner, sstables::generation_type gen, sstring status) override {
-        auto it = _entries.find(std::make_pair(owner, gen));
+    virtual future<> update_entry_status(table_id tid, sstables::generation_type gen, sstring status) override {
+        auto it = _entries.find(std::make_pair(tid, gen));
         if (it != _entries.end()) {
             it->second.status = status;
         } else {
@@ -327,8 +327,8 @@ public:
         }
         co_return;
     }
-    virtual future<> update_entry_state(table_id owner, sstables::generation_type gen, sstables::sstable_state state) override {
-        auto it = _entries.find(std::make_pair(owner, gen));
+    virtual future<> update_entry_state(table_id tid, sstables::generation_type gen, sstables::sstable_state state) override {
+        auto it = _entries.find(std::make_pair(tid, gen));
         if (it != _entries.end()) {
             it->second.state = state;
         } else {
@@ -336,8 +336,8 @@ public:
         }
         co_return;
     }
-    virtual future<> delete_entry(table_id owner, sstables::generation_type gen) override {
-        auto it = _entries.find(std::make_pair(owner, gen));
+    virtual future<> delete_entry(table_id tid, sstables::generation_type gen) override {
+        auto it = _entries.find(std::make_pair(tid, gen));
         if (it != _entries.end()) {
             _entries.erase(it);
         } else {
@@ -345,9 +345,9 @@ public:
         }
         co_return;
     }
-    virtual future<> sstables_registry_list(table_id owner, entry_consumer consumer) override {
+    virtual future<> sstables_registry_list(table_id tid, entry_consumer consumer) override {
         for (auto& [loc_and_gen, e] : _entries) {
-            if (loc_and_gen.first == owner) {
+            if (loc_and_gen.first == tid) {
                 co_await consumer(e.status, e.state, e.desc);
             }
         }


### PR DESCRIPTION
Add a node_owner column (locator::host_id) to system.sstables and make it part of the partition key, so the primary key becomesv PRIMARY KEY ((table_id, node_owner), generation).

This is the first step toward moving the sstables registry into system_distributed: once distributed, each node's startup scan  must read only the rows it owns, which requires the owning node to be part of the partition key. Partitioning by (table_id, node_owner) turns that scan into a single-partition read of exactly the local node's rows.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1562
No need to backport this, keyspace over object storage is experimental feature