### PR TITLE
doc: mark Vector Search in Alternator as Cloud-only

### DIFF
--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -1,5 +1,11 @@
 # Alternator Vector Search
 
+```{admonition} Availability
+:class: important
+
+The Vector Search feature is only available in [ScyllaDB Cloud](https://cloud.docs.scylladb.com/) - a fully managed DBaaS running ScyllaDB.
+```
+
 ## Introduction
 
 Alternator vector search is a ScyllaDB extension to the DynamoDB-compatible


### PR DESCRIPTION
This PR adds the information missing from the Alternator docs that Vector Search is only available in ScyllaDB Cloud.

Fixes https://github.com/scylladb/scylladb/issues/29661

The Vector Search page was added in version 2026.2, so this PR must be backported to branch-2026.2 to avoid confusing customers.