### PR TITLE
test: fix disabled test handling and deduplicate CLI test arguments

### DIFF
--- a/test.py
+++ b/test.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import dataclasses
 import math
 import shlex
 import textwrap
+from bisect import insort
 from random import randint
 
 import pytest
@@ -241,6 +243,73 @@ def parse_cmd_line() -> argparse.Namespace:
     return args
 
 
+# TODO: Remove _CollectionArgument and _deduplicate_test_args once we update
+# to pytest 9.x, which fixes argument deduplication:
+# https://github.com/pytest-dev/pytest/issues/12083
+@dataclasses.dataclass(frozen=True, order=True)
+class _CollectionArgument:
+    """Resolved collection argument for deduplication.
+
+    A version-independent subset of pytest's CollectionArgument that
+    includes the fields needed for normalization (parametrization and
+    original_index were added in pytest 9.0).
+
+    ``a in b`` means ``b`` subsumes (contains) ``a``.  Adapted from
+    pytest 9.0.3 ``_pytest.main.is_collection_argument_subsumed_by``.
+    """
+    path: pathlib.Path
+    parts: tuple[str, ...]
+    parametrization: str
+    original_index: int
+
+    def __contains__(self, other: _CollectionArgument) -> bool:
+        if self.path != other.path:
+            return not self.parts and other.path.is_relative_to(self.path)
+        if len(self.parts) > len(other.parts) or other.parts[:len(self.parts)] != self.parts:
+            return False
+        return not self.parametrization or self.parametrization == other.parametrization
+
+
+def _deduplicate_test_args(args: list[str]) -> list[str]:
+    """Remove duplicate and subsumed test arguments.
+
+    Resolves and normalizes CLI test arguments, then applies the normalization
+    algorithm from pytest 9.0.3 to remove exact duplicates and arguments whose
+    paths are contained within another argument's path.
+    For example, ``["test/cql", "test/cql/lua_test.cql"]`` becomes ``["test/cql"]``.
+    """
+    if not args:
+        return args
+    invocation_path = pathlib.Path.cwd()
+    resolved_sorted: list[_CollectionArgument] = []
+    unresolved_indices: set[int] = set()
+    for i, arg in enumerate(args):
+        # Adapted from pytest 9.0.3 _pytest.main.resolve_collection_argument.
+        base, squacket, rest = arg.partition("[")
+        strpath, *parts = base.split("::")
+        fspath = pathlib.Path(os.path.abspath(invocation_path / strpath))
+        if not fspath.exists():
+            # Keep unresolved args — let pytest report the error.
+            unresolved_indices.add(i)
+            continue
+        insort(resolved_sorted, _CollectionArgument(
+            path=fspath,
+            parts=tuple(parts),
+            parametrization=squacket + rest,
+            original_index=i,
+        ))
+
+    # Normalize: remove duplicates and subsumed arguments using an O(n log n)
+    # sort-based algorithm adapted from pytest 9.0.3.
+    normalized = resolved_sorted[:1]
+    for ca in resolved_sorted[1:]:
+        if ca not in normalized[-1]:
+            normalized.append(ca)
+
+    kept_indices = {ca.original_index for ca in normalized} | unresolved_indices
+    return [arg for i, arg in enumerate(args) if i in kept_indices]
+
+
 def run_pytest(options: argparse.Namespace) -> int:
     # When tests are executed in parallel on different hosts, we need to distinguish results from them.
     # So HOST_ID needed to not overwrite results from different hosts during Jenkins will copy to one directory.
@@ -249,7 +318,7 @@ def run_pytest(options: argparse.Namespace) -> int:
 
     report_dir =  temp_dir / 'report'
     junit_output_file = report_dir / f'pytest_cpp_{HOST_ID}.xml'
-    files_to_run = options.name or [str(TOP_SRC_DIR / 'test/')]
+    files_to_run = _deduplicate_test_args(options.name) or [str(TOP_SRC_DIR / 'test/')]
     args = [
         '--color=yes',
         f'--repeat={options.repeat}',

--- a/test.py
+++ b/test.py
@@ -185,6 +185,8 @@ def parse_cmd_line() -> argparse.Namespace:
                         help="Specific byte limit for failure injection (random by default)")
     parser.add_argument('--skip-internet-dependent-tests', action="store_true",
                         help="Skip tests which depend on artifacts from the internet.")
+    parser.add_argument('--keep-duplicates', action='store_true', default=False,
+                        help="Do not deduplicate test arguments.")
     parser.add_argument("--pytest-arg", action='store', type=str,
                         default=None, dest="pytest_arg",
                         help="Additional command line arguments to pass to pytest, for example ./test.py --pytest-arg=\"-v -x\"")
@@ -318,7 +320,8 @@ def run_pytest(options: argparse.Namespace) -> int:
 
     report_dir =  temp_dir / 'report'
     junit_output_file = report_dir / f'pytest_cpp_{HOST_ID}.xml'
-    files_to_run = _deduplicate_test_args(options.name) or [str(TOP_SRC_DIR / 'test/')]
+    files_to_run = options.name if options.keep_duplicates else _deduplicate_test_args(options.name)
+    files_to_run = files_to_run or [str(TOP_SRC_DIR / 'test/')]
     args = [
         '--color=yes',
         f'--repeat={options.repeat}',
@@ -338,6 +341,8 @@ def run_pytest(options: argparse.Namespace) -> int:
         ])
     if options.verbose:
         args.append('-v')
+    if options.keep_duplicates:
+        args.append('--keep-duplicates')
     if options.quiet:
         args.append('--quiet')
         args.extend(['-p','no:sugar'])

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -72,15 +72,11 @@ class CppFile(pytest.File, ABC):
         self.test_name = self.path.stem
 
     # Implement following properties as cached_property because they are read-only, and based on stash items which
-    # will be assigned in test/pylib/runner.py::pytest_collect_file() hook after a CppFile instance was created.
+    # will be assigned in test/pylib/runner.py::pytest_collect_file() and modify_pytest_item() after instance creation.
 
     @cached_property
     def build_mode(self) -> str:
         return self.stash[BUILD_MODE]
-
-    @cached_property
-    def run_id(self) -> int:
-        return self.stash[RUN_ID]
 
     @cached_property
     def suite_config(self) -> dict[str, Any]:
@@ -166,9 +162,13 @@ class CppTestCase(pytest.Item):
         self.own_markers = [getattr(pytest.mark, mark_name) for mark_name in own_markers]
         self.add_marker(pytest.mark.cpp)
 
+    @cached_property
+    def run_id(self) -> int:
+        return self.stash[RUN_ID]
+
     def get_artifact_path(self, extra: str = "", suffix: str = "") -> pathlib.Path:
         return self.parent.log_dir / ".".join(
-            (self.path.relative_to(TEST_DIR).with_suffix("") / f"{self.name}{extra}.{self.parent.run_id}{suffix}").parts
+            (self.path.relative_to(TEST_DIR).with_suffix("") / f"{self.name}{extra}.{self.run_id}{suffix}").parts
         )
 
     def make_testpy_test_object_mock(self) -> SimpleNamespace:
@@ -179,7 +179,7 @@ class CppTestCase(pytest.Item):
         return SimpleNamespace(
             time_end=0,
             time_start=0,
-            id=self.parent.run_id,
+            id=self.run_id,
             mode=self.parent.build_mode,
             success=False,
             shortname=self.name,

--- a/test/pylib/cpp/base.py
+++ b/test/pylib/cpp/base.py
@@ -126,9 +126,6 @@ class CppFile(pytest.File, ABC):
         return args
 
     def collect(self) -> Iterator[CppTestCase]:
-        if BUILD_MODE not in self.stash:
-            return
-
         custom_args = self.suite_config.get("custom_args", {}).get(self.test_name, DEFAULT_CUSTOM_ARGS)
 
         for test_case in self.list_test_cases():

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -163,11 +163,6 @@ def scylla_binary(testpy_test) -> Path:
 
 
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    items[:] = [
-        item for item in items
-        if (parent_file := item.getparent(cls=pytest.File)) is not None
-           and BUILD_MODE in parent_file.stash
-    ]
     for item in items:
         modify_pytest_item(item=item)
 
@@ -348,8 +343,7 @@ def pytest_collect_file(file_path: pathlib.Path,
         repeats = list(product(build_modes, parent.config.run_ids))
 
         if not repeats:
-            parent.stash[REPEATING_FILES].remove(file_path)
-            return collectors
+            return []
 
         ihook = parent.ihook
         collectors = list(chain(collectors, chain.from_iterable(

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -326,6 +326,11 @@ def pytest_configure(config: pytest.Config) -> None:
         config.run_ids = tuple(range(1, repeat + 1))
 
 
+class DisabledFile(pytest.File):
+    def collect(self) -> list[pytest.Item]:
+        pytest.skip("All tests in this file are disabled in requested modes according to the suite config.")
+
+
 @pytest.hookimpl(wrapper=True)
 def pytest_collect_file(file_path: pathlib.Path,
                         parent: pytest.Collector) -> Generator[None, list[pytest.Collector], list[pytest.Collector]]:
@@ -340,19 +345,17 @@ def pytest_collect_file(file_path: pathlib.Path,
                 mode for mode in build_modes
                 if not suite_config.is_test_disabled(build_mode=mode, path=file_path)
             )
-        repeats = list(product(build_modes, parent.config.run_ids))
-
-        if not repeats:
-            return []
-
-        ihook = parent.ihook
-        collectors = list(chain(collectors, chain.from_iterable(
-            ihook.pytest_collect_file(file_path=file_path, parent=parent) for _ in range(1, len(repeats))
-        )))
-        for (build_mode, run_id), collector in zip(repeats, collectors, strict=True):
-            collector.stash[BUILD_MODE] = build_mode
-            collector.stash[RUN_ID] = run_id
-            collector.stash[TEST_SUITE] = suite_config
+        if repeats := list(product(build_modes, parent.config.run_ids)):
+            ihook = parent.ihook
+            collectors = list(chain(collectors, chain.from_iterable(
+                ihook.pytest_collect_file(file_path=file_path, parent=parent) for _ in range(1, len(repeats))
+            )))
+            for (build_mode, run_id), collector in zip(repeats, collectors, strict=True):
+                collector.stash[BUILD_MODE] = build_mode
+                collector.stash[RUN_ID] = run_id
+                collector.stash[TEST_SUITE] = suite_config
+        else:
+            collectors = [DisabledFile.from_parent(parent=parent, path=file_path)]
 
         parent.stash[REPEATING_FILES].remove(file_path)
 

--- a/test/pylib/runner.py
+++ b/test/pylib/runner.py
@@ -15,7 +15,7 @@ import random
 import sys
 from argparse import BooleanOptionalAction
 from collections import defaultdict
-from itertools import chain, count, product
+from itertools import chain, count
 from functools import cache, cached_property
 from pathlib import Path
 from random import randint
@@ -106,7 +106,7 @@ def pytest_addoption(parser: pytest.Parser) -> None:
                           " '--logger-log-level raft=trace --default-log-level error'")
     parser.addoption('--x-log2-compaction-groups', action="store", default="0", type=int,
                      help="Controls number of compaction groups to be used by Scylla tests. Value of 3 implies 8 groups.")
-    parser.addoption('--repeat', action="store", default="1", type=int,
+    parser.addoption('--repeat', action="store", default=1, type=int,
                      help="number of times to repeat test execution")
 
     # Pass information about Scylla node from test.py to pytest.
@@ -162,9 +162,10 @@ def scylla_binary(testpy_test) -> Path:
     return testpy_test.suite.scylla_exe
 
 
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
+    run_ids = defaultdict(lambda: count(start=int(config.getoption("--run_id") or 1)))
     for item in items:
-        modify_pytest_item(item=item)
+        modify_pytest_item(item=item, run_ids=run_ids)
 
     suites_order = defaultdict(count().__next__)  # number suites in order of appearance
 
@@ -316,14 +317,10 @@ def pytest_configure(config: pytest.Config) -> None:
 
     os.environ["TOPOLOGY_RANDOM_FAILURES_TEST_SHUFFLE_SEED"] = os.environ.get("TOPOLOGY_RANDOM_FAILURES_TEST_SHUFFLE_SEED", str(random.randint(0, sys.maxsize)))
     config.build_modes = get_modes_to_run(config)
-    repeat = int(config.getoption("--repeat"))
 
     if testpy_run_id := config.getoption("--run_id"):
-        if repeat != 1:
+        if config.getoption("--repeat") != 1:
             raise RuntimeError("Can't use --run_id and --repeat simultaneously.")
-        config.run_ids = (testpy_run_id,)
-    else:
-        config.run_ids = tuple(range(1, repeat + 1))
 
 
 class DisabledFile(pytest.File):
@@ -345,14 +342,13 @@ def pytest_collect_file(file_path: pathlib.Path,
                 mode for mode in build_modes
                 if not suite_config.is_test_disabled(build_mode=mode, path=file_path)
             )
-        if repeats := list(product(build_modes, parent.config.run_ids)):
+        if repeats := [mode for mode in build_modes for _ in range(parent.config.getoption("--repeat"))]:
             ihook = parent.ihook
             collectors = list(chain(collectors, chain.from_iterable(
                 ihook.pytest_collect_file(file_path=file_path, parent=parent) for _ in range(1, len(repeats))
             )))
-            for (build_mode, run_id), collector in zip(repeats, collectors, strict=True):
+            for build_mode, collector in zip(repeats, collectors, strict=True):
                 collector.stash[BUILD_MODE] = build_mode
-                collector.stash[RUN_ID] = run_id
                 collector.stash[TEST_SUITE] = suite_config
         else:
             collectors = [DisabledFile.from_parent(parent=parent, path=file_path)]
@@ -429,7 +425,7 @@ class TestSuiteConfig:
 
 TEST_SUITE = pytest.StashKey[TestSuiteConfig | None]()
 
-_STASH_KEYS_TO_COPY = BUILD_MODE, RUN_ID, TEST_SUITE
+_STASH_KEYS_TO_COPY = BUILD_MODE, TEST_SUITE
 
 
 def get_params_stash(node: _pytest.nodes.Node) -> pytest.Stash | None:
@@ -439,11 +435,12 @@ def get_params_stash(node: _pytest.nodes.Node) -> pytest.Stash | None:
     return parent.stash
 
 
-def modify_pytest_item(item: pytest.Item) -> None:
+def modify_pytest_item(item: pytest.Item, run_ids: defaultdict[tuple[str, str], count]) -> None:
     params_stash = get_params_stash(node=item)
 
     for key in _STASH_KEYS_TO_COPY:
         item.stash[key] = params_stash[key]
+    item.stash[RUN_ID] = next(run_ids[(item.stash[BUILD_MODE], item._nodeid)])
 
     suffix = f".{item.stash[BUILD_MODE]}.{item.stash[RUN_ID]}"
 


### PR DESCRIPTION
## Summary

- Revert the previous "test.py: fix test collection bug" commit (92c09d10) which worked around broken deduplication by filtering items without `BUILD_MODE` in `pytest_collection_modifyitems`. This approach masked the root cause and is superseded by the proper fixes below.
- Backport pytest 9.0.3's argument normalization algorithm into `test.py` to work around broken deduplication in pytest 8.3.5 ([pytest-dev/pytest#12083](https://github.com/pytest-dev/pytest/issues/12083)). Duplicate or subsumed test paths (e.g. `test/cql` and `test/cql/lua_test.cql`) are collapsed before invoking pytest. Revert when upgrading to pytest 9.x.
- Return a `DisabledFile` collector instead of an empty list in `pytest_collect_file` when all modes are disabled for a file, fixing a bug where subsequent files would not get their stash items set (`REPEATING_FILES`). Restructure `pytest_collect_file` to use a walrus operator (`if repeats := ...`) with a single `remove(file_path)` and `return collectors` at the end, eliminating the early return.
- Add `--keep-duplicates` CLI argument to bypass deduplication and forward to pytest.
- Move `RUN_ID` assignment from `pytest_collect_file` to `modify_pytest_item`. A shared `run_ids` cache (`defaultdict[tuple[str, str], count]`) is created in `pytest_collection_modifyitems` and passed to `modify_pytest_item`, keyed by `(build_mode, nodeid)` so each mode gets independent counters. This ensures unique run IDs even when `--keep-duplicates` causes the same file to be collected multiple times.
- Fix `--repeat` option default from string `"1"` to int `1` — argparse only applies `type=` to CLI-parsed values, not defaults.

## What is `--keep-duplicates`?

pytest normally deduplicates overlapping test arguments — e.g. `test/cql test/cql/lua_test.cql` collects `lua_test.cql` only once. The original `test.py` never performed this deduplication, and the pytest version in the toolchain image (8.3.5) has a bug that breaks it ([pytest-dev/pytest#12083](https://github.com/pytest-dev/pytest/issues/12083).)

Since we are moving to bare pytest, `test.py` should match pytest's default behavior: deduplicate. Because we cannot easily upgrade pytest, commit 2 backports the deduplication logic from pytest 9.0.3.

To match pytest's interface, `--keep-duplicates` is added as an opt-out. This lets a user intentionally run overlapping paths — e.g. `./test.py test/blah test/blah/test_foo.py --keep-duplicates` runs `test_foo.py` twice. The flag is forwarded to pytest and also skips the backported deduplication in `test.py`.

## Changes

### Commit 1: Revert "test.py: fix test collection bug"
- Revert 92c09d10 which filtered items without `BUILD_MODE` in `pytest_collection_modifyitems` and added an early return in `CppFile.collect()`. This workaround is superseded by the proper deduplication and `DisabledFile` fixes.

### Commit 2: `test.py` — deduplicate CLI test arguments
- Add `_CollectionArgument` dataclass (`order=True`, `__contains__` for subsumption) and `_deduplicate_test_args()` function, adapted from pytest 9.0.3. Marked with a TODO to remove once we update to pytest 9.x.
- Call `_deduplicate_test_args()` on `options.name` before passing to pytest.

### Commit 3: `test/pylib/runner.py` — fix disabled file collection
- Add `DisabledFile(pytest.File)` that skips collection with an informative message instead of returning an empty list.
- Restructure `pytest_collect_file` to use walrus operator: `if repeats := ...:` / `else:` — single `remove(file_path)` at end, no early return.

### Commit 4: `test.py`, `test/pylib/runner.py`, `test/pylib/cpp/base.py` — add --keep-duplicates and RUN_ID shared cache
- Add `--keep-duplicates` argument that skips deduplication and is forwarded to pytest.
- Create a shared `run_ids` cache in `pytest_collection_modifyitems` and pass it to `modify_pytest_item`, which assigns unique sequential RUN_IDs via `itertools.count`. The cache is keyed by `(build_mode, nodeid)` so each mode gets independent counters.
- Remove `RUN_ID` from `_STASH_KEYS_TO_COPY` — it is no longer set on collectors.
- Remove `CppFile.run_id` cached_property. `CppTestCase` now reads `RUN_ID` from its own item stash.
- Fix `--repeat` option default from `"1"` to `1` and drop redundant `int()` cast.

Closes SCYLLADB-1730
