### PR TITLE
alternator: add optional CRC header in responses.

### DIFF
--- a/alternator/http_compression.cc
+++ b/alternator/http_compression.cc
@@ -221,11 +221,17 @@ future<std::unique_ptr<http::reply>> response_compressor::generate_reply(std::un
     response_compressor::compression_type ct = find_compression(accept_encoding, response_body.size());
     if (ct != response_compressor::compression_type::none) {
         rep->add_header("Content-Encoding", get_encoding_name(ct));
-        return compress(ct, cfg, std::move(response_body)).then([rep = std::move(rep), content_type] (chunked_content compressed) mutable {
+        return compress(ct, cfg, std::move(response_body)).then([this, rep = std::move(rep), content_type] (chunked_content compressed) mutable {
             rep->write_body(content_type, flatten(std::move(compressed)));
+            if (cfg.alternator_response_crc32_header()) {
+                rep->add_header("x-amz-crc32", compute_crc32(rep->_content));
+            }
             return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
         });
     } else {
+        if (cfg.alternator_response_crc32_header()) {
+            rep->add_header("x-amz-crc32", compute_crc32(response_body));
+        }
         // Note that despite the move, response_body (std::string) is copied
         // into an sstring when passed to write_body().
         rep->write_body(content_type, std::move(response_body));
@@ -262,6 +268,26 @@ private:
     }
 };
 
+// A data_sink_impl that collects written buffers into a chunked_content
+// without copying or flattening. Used to buffer a body_writer's output
+// while computing a CRC32 over it.
+class chunked_content_sink_impl : public data_sink_impl {
+    chunked_content& _cc;
+public:
+    explicit chunked_content_sink_impl(chunked_content& cc) : _cc(cc) {}
+    future<> put(std::span<temporary_buffer<char>> data) override {
+        for (auto& buf : data) {
+            if (!buf.empty()) {
+                _cc.push_back(std::move(buf));
+            }
+        }
+        return make_ready_future<>();
+    }
+    future<> close() override {
+        return make_ready_future<>();
+    }
+};
+
 body_writer compress(response_compressor::compression_type ct, const db::config& cfg, body_writer&& bw) {
     return [bw = std::move(bw), ct, level = cfg.alternator_response_gzip_compression_level()](output_stream<char>&& out) mutable -> future<> {
         output_stream_options opts;
@@ -287,13 +313,40 @@ body_writer compress(response_compressor::compression_type ct, const db::config&
 
 future<std::unique_ptr<http::reply>> response_compressor::generate_reply(std::unique_ptr<http::reply> rep, sstring accept_encoding, std::optional<std::string_view> content_type, body_writer&& body_writer) {
     response_compressor::compression_type ct = find_compression(accept_encoding, std::numeric_limits<size_t>::max());
+    auto bw = std::move(body_writer);
     if (ct != response_compressor::compression_type::none) {
         rep->add_header("Content-Encoding", get_encoding_name(ct));
-        rep->write_body(content_type, compress(ct, cfg, std::move(body_writer)));
-    } else {
-        rep->write_body(content_type, std::move(body_writer));
+        bw = compress(ct, cfg, std::move(bw));
     }
-    return make_ready_future<std::unique_ptr<http::reply>>(std::move(rep));
+    if (!cfg.alternator_response_crc32_header()) {
+        rep->write_body(content_type, std::move(bw));
+        co_return std::move(rep);
+    }
+    // If we're still here we were asked to compute the CRC and we need the
+    // entire buffer to compute it but only have a body_writer. Unfortunately,
+    // this means that we need to ask the body writer to produce its entire
+    // output and buffer it all in memory. But at least we'll save this body
+    // in non-contiguous chunks as we don't need a huge contiguous allocation.
+    chunked_content chunks;
+    {
+        output_stream_options opts;
+        opts.trim_to_size = true;
+        co_await bw(output_stream<char>(data_sink(std::make_unique<chunked_content_sink_impl>(chunks)), compressed_buffer_size, opts));
+    }
+    uLong crc = ::crc32(0L, Z_NULL, 0);
+    for (const auto& buf : chunks) {
+        crc = ::crc32(crc, reinterpret_cast<const Bytef*>(buf.get()), buf.size());
+        co_await coroutine::maybe_yield();
+    }
+    rep->add_header("x-amz-crc32", fmt::format("{}", static_cast<uint32_t>(crc)));
+    rep->write_body(content_type, [chunks = std::move(chunks)](output_stream<char>&& out_) mutable -> future<> {
+        auto out = std::move(out_);
+        for (auto& buf : chunks) {
+            co_await out.write(std::move(buf));
+        }
+        co_await out.close();
+    });
+    co_return std::move(rep);
 }
 
 } // namespace alternator

--- a/alternator/server.cc
+++ b/alternator/server.cc
@@ -165,7 +165,8 @@ public:
                 }
              }, std::move(res));
          });
-    }) { }
+    }),
+            _cfg(config) { }
 
     api_handler(const api_handler&) = delete;
     future<std::unique_ptr<reply>> handle(const sstring& path,
@@ -199,8 +200,13 @@ protected:
         sstring content = rjson::print(std::move(results));
         slogger.trace("api_handler error case: {}", content);
         rep.set_status(err._http_code);
+        if (_cfg.alternator_response_crc32_header()) {
+            rep.add_header("x-amz-crc32", compute_crc32(content));
+        }
         rep.write_body(_content_type, std::move(content));
     }
+
+    const db::config& _cfg;
 };
 
 class gated_handler : public handler_base {
@@ -1133,6 +1139,14 @@ const char* api_error::what() const noexcept {
         _what_string = fmt::format("{} {}: {}", std::to_underlying(_http_code), _type, _msg);
     }
     return _what_string.c_str();
+}
+
+sstring compute_crc32(std::string_view data) {
+    // note that zlib's crc32() function only works on data.size() up to 4GB,
+    // it will be incorrect for larger responses, but this is fine because
+    // Alternator responses can't reach that size anyway.
+    uLong crc = ::crc32(0, reinterpret_cast<const Bytef*>(data.data()), data.size());
+    return fmt::format("{}", static_cast<uint32_t>(crc));
 }
 
 }

--- a/alternator/server.hh
+++ b/alternator/server.hh
@@ -123,5 +123,10 @@ private:
     future<executor::request_return_type> handle_api_request(std::unique_ptr<http::request> req);
 };
 
+/// Compute the CRC32 checksum (RFC 1952 / zlib polynomial) of the given data
+/// and return it as a decimal string. This is the value used in the
+/// x-amz-crc32 HTTP response header that DynamoDB adds to every response.
+sstring compute_crc32(std::string_view data);
+
 }
 

--- a/db/config.cc
+++ b/db/config.cc
@@ -1660,6 +1660,10 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "Disable the Date header in HTTP responses from Alternator.")
     , alternator_http_response_server_header(this, "alternator_http_response_server_header", liveness::LiveUpdate, value_status::Used, "",
         "Value for the Server header in HTTP responses from Alternator. An empty string (the default) omits the Server header entirely.")
+    , alternator_response_crc32_header(this, "alternator_response_crc32_header", liveness::LiveUpdate, value_status::Used, false,
+            "When true, Alternator adds an 'x-amz-crc32' header to each "
+            "response containing the CRC32 checksum of the response body. "
+            "Disabled by default because it adds CPU overhead.")
     , abort_on_ebadf(this, "abort_on_ebadf", value_status::Used, true, "Abort the server on incorrect file descriptor access. Throws exception when disabled.")
     , sanitizer_report_backtrace(this, "sanitizer_report_backtrace", value_status::Used, false,
             "In debug mode, report log-structured allocator sanitizer violations with a backtrace. Slow.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -535,6 +535,7 @@ public:
     named_value<bool> alternator_http_response_disable_content_type_header;
     named_value<bool> alternator_http_response_disable_date_header;
     named_value<sstring> alternator_http_response_server_header;
+    named_value<bool> alternator_response_crc32_header;
 
     named_value<bool> abort_on_ebadf;
 

--- a/docs/alternator/alternator.md
+++ b/docs/alternator/alternator.md
@@ -62,13 +62,6 @@ the correct client address. The reverse proxy must be configured to use
 [Proxy Protocol v2](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt)
 (the binary header format).
 
-By default, ScyllaDB saves a snapshot of deleted tables. But Alternator does
-not offer an API to restore these snapshots, so these snapshots are not useful
-and waste disk space - deleting a table does not recover any disk space.
-It is therefore recommended to disable this automatic-snapshotting feature
-by configuring the **auto_snapshot** option to `false`.
-See also <https://github.com/scylladb/scylladb/issues/5283>.
-
 DynamoDB applications specify a single "endpoint" address, e.g.,
 `dynamodb.us-east-1.amazonaws.com`. Behind the scenes, a DNS server and/or
 load balancers distribute the connections to many different backend nodes.
@@ -76,6 +69,37 @@ Alternator does not provide such a load-balancing setup, so you should
 either set one up, or set up the client library to do the load balancing
 itself. Instructions, code and examples for doing this can be found in the
 [Alternator Load Balancing project](https://github.com/scylladb/alternator-load-balancing/).
+
+### Additional configuration options
+
+#### Disabling automatic snapshots for deleted tables
+By default, ScyllaDB saves a snapshot of deleted tables. But Alternator does
+not currently offer an API to restore these snapshots. With these snapshots
+enabled, deleting a table does not recover any disk space.
+It is therefore recommended to disable this automatic-snapshotting feature
+by configuring the **auto_snapshot** option to `false`.
+See also <https://github.com/scylladb/scylladb/issues/5283>.
+
+#### Configuring compression for large responses
+If clients send an `Accept-Encoding: gzip` header indicating they support
+gzip compression, ScyllaDB can compress responses that exceed a configurable
+size threshold. The **alternator_response_compression_threshold_in_bytes**
+option sets this threshold (in bytes). Responses smaller than the threshold
+are sent uncompressed even if the client supports compression. This option
+defaults to `4096`, matching DynamoDB's behavior of compressing responses
+larger than 4096 bytes when the client supports it. Setting this option to
+`0` disables compression entirely.
+
+#### Enabling CRC32 response headers for client compatibility
+DynamoDB includes a `x-amz-crc32` header in every response, containing a
+CRC32 checksum of the response body. Most DynamoDB SDKs do not check this
+header, so by default Alternator does not calculate and return it to avoid
+the performance overhead. If you need this header for compatibility with
+a client that checks it, set the **alternator_response_crc32_header** option
+to `true`. Be aware that because HTTP response headers must be sent before
+the body, enabling this option requires buffering the entire response body
+in memory before sending anything, adding both memory overhead and CPU
+overhead for the checksum calculation.
 
 ## Alternator design and implementation
 

--- a/test/alternator/test_crc.py
+++ b/test/alternator/test_crc.py
@@ -1,0 +1,153 @@
+# Copyright 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+# Tests for CRC response header (x-amz-crc32) support.
+# DynamoDB always returns this header, but most SDKs do not check it, so by
+# default Alternator doesn't bother to calculate and return it - as it's a
+# waste of performance. However, if a customer for some reason requires this
+# CRC for compatibility, this option can be enabled, and the goal of this test
+# file is to check that it is correctly calculated, just like in DynamoDB.
+
+import pytest
+import binascii
+import json
+import requests
+from contextlib import contextmanager
+from .util import get_signed_request, is_aws, scylla_config_temporary, random_string
+
+# Make a manual request, similar to manual_request() from util.py but without
+# parsing the response at all. Returns the unparsed response object, from which
+# you can read response.headers, response.content and response.status_code.
+# This function asks the server to NOT compress responses, by sending
+# "Accept-Encoding: identity" in the request.
+def unparsed_manual_request_uncompressed(dynamodb, op, payload):
+    req = get_signed_request(dynamodb, op, payload,
+                             extra_headers={'Accept-Encoding': 'identity'})
+    res = requests.post(req.url, headers=req.headers, data=req.body, verify=False)
+    return res
+
+# Make a manual request, similar to unparsed_manual_request_uncompressed() but
+# asks the server to compress the response (using Accept-Encoding: gzip) and
+# returns both the response object and the raw compressed body bytes as a tuple
+# (response, body), without decompressing the body.
+# Note that this function does not force the server to compress the response -
+# it may still decide to not compress it, e.g., based on the response length.
+def unparsed_manual_request_compressed(dynamodb, op, payload):
+    req = get_signed_request(dynamodb, op, payload,
+                             extra_headers={'Accept-Encoding': 'gzip'})
+    response = requests.post(req.url, headers=req.headers, data=req.body,
+                             verify=False, stream=True)
+    response.raw.decode_content = False
+    try:
+        body = response.raw.read()
+    finally:
+        response.close()
+    return response, body
+
+# Context manager to temporarily enable the x-amz-crc32 header in responses
+# in Alternator (since it's off by default). For DynamoDB, this is a no-op
+# because DynamoDB always sends this header.
+@contextmanager
+def crc32_header_enabled(dynamodb):
+    with scylla_config_temporary(dynamodb, 'alternator_response_crc32_header', 'true', nop=is_aws(dynamodb)):
+        yield
+
+# Check that the x-amz-crc32 header value matches the CRC32 of the response
+# body.
+def check_crc32(headers, body):
+    assert 'x-amz-crc32' in headers
+    header_crc = int(headers['x-amz-crc32'])
+    response_crc = binascii.crc32(body)
+    assert response_crc == header_crc
+
+# A simple test that the x-amz-crc32 header is present in a response of a
+# simple request and has the correct value
+def test_crc32_header(dynamodb, test_table_s):
+    p = random_string()
+    test_table_s.put_item(Item={'p': p, 'x': 'hello'})
+    with crc32_header_enabled(dynamodb):
+        response = unparsed_manual_request_uncompressed(dynamodb, 'GetItem',
+            json.dumps({'TableName': test_table_s.name,
+                        'Key': {'p': {'S': p}},
+                        'ConsistentRead': True}))
+    assert response.status_code == 200
+    check_crc32(response.headers, response.content)
+
+# On Alternator, by default the x-amz-crc32 header should not be returned,
+# because alternator_response_crc32_header is disabled by default.
+# This test is scylla_only (skipped on DynamoDB), because in DynamoDB there
+# is no way to disable the header.
+def test_crc32_header_disabled_by_default(dynamodb, test_table_s, scylla_only):
+    p = random_string()
+    test_table_s.put_item(Item={'p': p})
+    response = unparsed_manual_request_uncompressed(dynamodb, 'GetItem',
+        json.dumps({'TableName': test_table_s.name, 'Key': {'p': {'S': p}}}))
+    assert response.status_code == 200
+    assert 'x-amz-crc32' not in response.headers
+
+# Test that the CRC is also correct on error responses.
+def test_crc32_header_on_error(dynamodb):
+    with crc32_header_enabled(dynamodb):
+        # Request a non-existent table to trigger a ResourceNotFoundException
+        response = unparsed_manual_request_uncompressed(dynamodb, 'GetItem',
+            json.dumps({'TableName': 'nonexistent_table_xyz',
+                        'Key': {'p': {'S': 'x'}}}))
+    assert response.status_code != 200
+    check_crc32(response.headers, response.content)
+
+# Test that when the response is compressed, the CRC header is calculated over
+# the *compressed* data - not for the uncompressed response body.
+def test_crc32_header_with_compression(dynamodb, test_table_s):
+    p = random_string()
+    # Large enough to exceed DynamoDB/Alternator's compression threshold (~4 KB)
+    large_value = 'x' * 5000
+    test_table_s.put_item(Item={'p': p, 'data': large_value})
+    with crc32_header_enabled(dynamodb):
+        # On Alternator, we can set the response compression threshold to also
+        # be 4KB, which is already the default on DynamoDB.
+        with scylla_config_temporary(dynamodb, f'alternator_response_compression_threshold_in_bytes', '4096', nop=is_aws(dynamodb)):
+            response, body = unparsed_manual_request_compressed(dynamodb, 'GetItem',
+                json.dumps({'TableName': test_table_s.name,
+                            'Key': {'p': {'S': p}},
+                            'ConsistentRead': True}))
+    # Verify the response body was actually compressed, otherwise this test
+    # doesn't exercise the compression code path.
+    assert response.headers.get('Content-Encoding', '').lower() == 'gzip'
+    assert body[:2] == b'\x1f\x8b'  # gzip magic bytes
+    # Finally verify the CRC header is correct for the compressed body
+    check_crc32(response.headers, body)
+
+# For large BatchGetItem responses (among other things), Alternator uses a
+# different code path that streams the response, and will need to collect it
+# all (and compress it all, if compression is active) to calculate the CRC
+# before sending the first byte of the response. So this test exercises this
+# case.
+def test_crc32_header_with_streaming(dynamodb, test_table_s):
+    p = random_string()
+    large_value = 'x' * 100001
+    test_table_s.put_item(Item={'p': p, 'data': large_value})
+    with crc32_header_enabled(dynamodb):
+        response = unparsed_manual_request_uncompressed(dynamodb, 'BatchGetItem',
+            json.dumps({'RequestItems': {test_table_s.name: {
+                'Keys': [{'p': {'S': p}}],
+                'ConsistentRead': True}}}))
+    assert response.status_code == 200
+    check_crc32(response.headers, response.content)
+
+def test_crc32_header_with_streaming_and_compression(dynamodb, test_table_s):
+    p = random_string()
+    large_value = 'x' * 100001
+    test_table_s.put_item(Item={'p': p, 'data': large_value})
+    with crc32_header_enabled(dynamodb):
+        with scylla_config_temporary(dynamodb, 'alternator_response_compression_threshold_in_bytes', '4096', nop=is_aws(dynamodb)):
+            response, body = unparsed_manual_request_compressed(dynamodb, 'BatchGetItem',
+                json.dumps({'RequestItems': {test_table_s.name: {
+                    'Keys': [{'p': {'S': p}}],
+                    'ConsistentRead': True}}}))
+    # Verify the response body was actually compressed, otherwise this test
+    # doesn't exercise the compression code path.
+    assert response.headers.get('Content-Encoding', '').lower() == 'gzip'
+    assert body[:2] == b'\x1f\x8b'  # gzip magic bytes
+    # Finally verify the CRC header is correct for the compressed body
+    check_crc32(response.headers, body)


### PR DESCRIPTION
DynamoDB responses have a "“x-amz-crc32” header with a 32-bit CRC checksum of the response. Most SDKs just ignore these checksums so until today Alternator never wrote them an nobody complained (almost... some users complained that they are seeing ugly log messages about the missing CRC values).

In this series, we add the x-amz-crc32 response header feature, but only enable it *optionally*, and keep it disabled by default. The new feature has a performance cost: Not only does it need to do the extra CRC calculations, also to be able to  write the CRC header _before_ the body, it can't write large response bodies incrementally and needs to buffer them in memory - increasing the memory usage of Alternator. Note that even in this worst case, this buffering doesn't require contiguous memory.

Fixes #5039