### PR TITLE
sstables/replica: Add diagnostics for unlinked SSTable being opened or re-added

### DIFF
--- a/replica/table.cc
+++ b/replica/table.cc
@@ -548,6 +548,10 @@ compaction_group::do_add_sstable(lw_shared_ptr<sstables::sstable_set> sstables, 
     if (belongs_to_other_shard(sstable->get_shards_for_this_sstable())) {
         on_internal_error(tlogger, format("Attempted to load the shared SSTable {} at table", sstable->get_filename()));
     }
+    if (sstable->unlinked_at()) {
+        on_internal_error(tlogger, fmt::format("Attempted to add already-unlinked SSTable {} (origin: \"{}\", unlinked_at: {}) to table",
+                sstable->get_filename(), sstable->get_origin(), *sstable->unlinked_at()));
+    }
     // allow in-progress reads to continue using old list
     auto new_sstables = make_lw_shared<sstables::sstable_set>(*sstables);
     new_sstables->insert(sstable);
@@ -2518,6 +2522,10 @@ compaction_group::update_sstable_sets_on_compaction_completion(compaction::compa
             // Segregate output sstables according to their owner compaction group.
             // If not in splitting mode, then all output sstables will belong to the same group.
             for (auto& sst : _desc.new_sstables) {
+                if (sst->unlinked_at()) {
+                    on_internal_error(tlogger, fmt::format("Compaction output SSTable {} (origin: \"{}\", unlinked_at: {}) was already unlinked before being added to table",
+                            sst->get_filename(), sst->get_origin(), *sst->unlinked_at()));
+                }
                 auto& cg = _t.compaction_group_for_sstable(sst);
                 _cg_desc[&cg].desc.new_sstables.push_back(sst);
             }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -234,8 +234,16 @@ future<file> sstable::new_sstable_component_file(const io_error_handler& error_h
         return make_checked_file(error_handler, std::move(f));
     });
 
-    return f.handle_exception([this, type, &error_handler] (auto ep) {
-        sstlog.error("Could not create SSTable component {}. Found exception: {}", filename(type), ep);
+    return f.handle_exception([this, type, flags, &error_handler] (auto ep) {
+        const bool is_create = (flags & open_flags::create) != open_flags{};
+        const auto unlinked_at_str = _unlinked_at
+                ? fmt::format("{}", *_unlinked_at) : std::string("never");
+        if (!is_create) {
+            sstlog.error("Could not open SSTable component {} (origin: \"{}\", unlinked_at: {}). Found exception: {}",
+                    filename(type), _origin, unlinked_at_str, ep);
+        } else {
+            sstlog.error("Could not create SSTable component {}. Found exception: {}", filename(type), ep);
+        }
         try {
             error_handler(ep);
         } catch (...) {
@@ -3207,7 +3215,7 @@ future<std::optional<uint32_t>> sstable::read_digest() {
     if (_components->digest) {
         co_return *_components->digest;
     }
-    if (!has_component(component_type::Digest) || _unlinked) {
+    if (!has_component(component_type::Digest) || _unlinked_at) {
         co_return std::nullopt;
     }
     uint32_t digest;
@@ -3285,7 +3293,7 @@ future<lw_shared_ptr<checksum>> sstable::read_checksum() {
     if (_components->checksum) {
         co_return _components->checksum->shared_from_this();
     }
-    if (!has_component(component_type::CRC) || _unlinked) {
+    if (!has_component(component_type::CRC) || _unlinked_at) {
         co_return nullptr;
     }
     lw_shared_ptr<checksum> checksum;
@@ -3499,7 +3507,7 @@ future<> sstable::close_files() {
     }
 
     auto unlinked = make_ready_future<>();
-    if (_marked_for_deletion != mark_for_deletion::none && !_unlinked) {
+    if (_marked_for_deletion != mark_for_deletion::none && !_unlinked_at) {
         // If a deletion fails for some reason we
         // log and ignore this failure, because on startup we'll again try to
         // clean up unused sstables, and because we'll never reuse the same
@@ -3770,11 +3778,11 @@ future<>
 sstable::unlink(storage::sync_dir sync) noexcept {
     // Serialize with other calls to unlink or potentially ongoing mutations.
     auto lock = co_await get_units(_mutate_sem, 1);
-    if (_unlinked) {
+    if (_unlinked_at) {
         co_return;
     }
 
-    _unlinked = true;
+    _unlinked_at = db_clock::now();
     _on_delete(*this);
 
     auto remove_fut = _storage->wipe(*this, sync);

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -641,7 +641,7 @@ private:
     mutable std::optional<size_t> _total_reclaimable_memory{0};
     // Total memory reclaimed so far from this sstable
     size_t _total_memory_reclaimed{0};
-    bool _unlinked{false};
+    std::optional<db_clock::time_point> _unlinked_at;
     const bool _ignore_component_digest_mismatch;
 
     // The mutate semaphore is used to serialize operations like rewrite_statistics
@@ -1108,6 +1108,10 @@ public:
 
     const sstring& get_origin() const noexcept {
         return _origin;
+    }
+
+    const std::optional<db_clock::time_point>& unlinked_at() const noexcept {
+        return _unlinked_at;
     }
 
     // sstable_id is null iff not present in scylla_metadata


### PR DESCRIPTION
We observed crashes with the following error:

  Could not create SSTable component .../me-...-big-Scylla.db.
  Found exception: std::filesystem::filesystem_error (error system:2,
  filesystem error: open failed: No such file or directory [...])

Two problems were identified:

1. The error message said "Could not create" even though the file was opened read-only (no O_CREAT).  The misleading wording made triage harder.

2. When the open fails with ENOENT we had no way to tell whether the SSTable was legitimately missing (e.g. a bug in a different layer) or whether it had already been unlinked but a stale reference kept it in the compaction group's SSTable set, causing a later attempt to re-open it to fail.

To address both problems and aid future investigations:

* Fix the error message: use "Could not open" when the file is not opened in create mode, and "Could not create" only when O_CREAT is present.

* Track deletion time: add `_deleted_at` (std::optional<db_clock::time_point>) to sstable, set in sstable::unlink() to db_clock::now().  A public accessor deleted_at() is provided; its engagedness is the canonical "this sstable has been unlinked" indicator.

* Enrich the ENOENT log: when opening a component fails with ENOENT, log the sstable origin and deleted_at so that we can immediately tell whether the SSTable was already unlinked (and when) at the time of the failed open.

* Enforce the invariant at insertion points: add on_internal_error() guards (which log a backtrace) in the two places where sstables are inserted into a compaction group's SSTable set:

  - compaction_group::do_add_sstable() — covers all normal add paths (flush, repair, streaming, distributed loader, etc.)

  - sstable_list_updater::prepare() inside compaction_group::update_sstable_sets_on_compaction_completion() — covers compaction output sstables.

  Both checks fire if deleted_at() is already engaged, which would
  mean an unlinked SSTable is being re-inserted, violating the
  invariant that once unlinked an SSTable must never be added back to
  a set.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1759.

This diagnostics can make it easier to investigate some ongoing issue, so backporting to 2025.4, 2026.1 and 2026.2