### PR TITLE
configure.py: update compile_commands.json if stale

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -285,8 +285,12 @@ def generate_compdb(compdb, ninja, buildfile, modes):
                 os.symlink(compdb_target, compdb)
             except FileExistsError:
                 # if there is already a valid compile_commands.json link in the
-                # source root, we are done.
-                pass
+                # source root, we are done. if it's a stale link, update it.
+                if os.path.islink(compdb):
+                    current_target = os.readlink(compdb)
+                    if not os.path.exists(current_target):
+                        os.unlink(compdb)
+                        os.symlink(compdb_target, compdb)
             return
 
 


### PR DESCRIPTION
configure.py creates compile_commands.json in the root directory as a symbolic link to the file in one of the build directories. If the file already exists it does nothing.

However it may happen that the file exists but the target file does not exist. For example, if the build directory is removed and then building with a different mode. Then the file will remain as a stale symbolic link.

To address this, when the file exists check also if it's a valid symbolic link. If not, then recreate it with a valid target.

backport not needed - small improvement for development