### PR TITLE
test: fix flaky test_tablets_split_merge_with_many_tables

### DIFF
--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -378,7 +378,7 @@ async def test_tablet_merge_cross_rack_migrations(manager: ManagerClient, racks)
 @pytest.mark.asyncio
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: ManagerClient, racks = 2):
-    cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200',]
+    cmdline = ['--smp', '4', '-m', '2G', '--target-tablet-size-in-bytes', '30000', '--max-task-backlog', '200', '--logger-log-level', 'load_balancer=debug']
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
 
     servers = []
@@ -390,7 +390,7 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Man
     cql = manager.get_cql()
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': 1}}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH compression = {{'sstable_compression': ''}};")
-    num_tables = 200 if build_mode != 'debug' else 20
+    num_tables = 200 if build_mode != 'debug' else 5
     await asyncio.gather(*[cql.run_async(f"CREATE TABLE {ks}.test{i} (pk int PRIMARY KEY, c blob);") for i in range(1, num_tables)])
 
     async def check_logs(when):


### PR DESCRIPTION
In debug mode, this test can timeout during tablets merge. While the test already decreases the number of tables in debug mode (20 tables, instead of 200 for dev mode), this is not enough, and the test can still timeout during merge. This change reduces the number of tables from 20 to 5 in debug mode.

It also drops the log level for lead_balancer to debug. This should make any potential future problems with this test easier to investigate.

Fixes: SCYLLADB-1717

This needs to be backported to versions 2026.1 and 2026.2 and 2025.4