### PR TITLE
commitlog: fix abort and silent corruption in oversized_allocation

### DIFF
--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1807,6 +1807,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                 auto max_write = data_size - off;
                 auto to_write = std::min(avail, max_write);
                 auto rem = max_write - to_write;
+                auto saved_strm = strm;
                 partial_writer pw(writer, i, to_write, strm.read_view(to_write).value(), rem, off, id);
 
                 switch (s->allocate(pw, fake_permit, timeout)) {
@@ -1816,6 +1817,7 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                     case write_result::ok:
                         break;
                     case write_result::must_sync:
+                        strm = saved_strm;
                         s = co_await with_timeout(timeout, s->sync());
                         continue;
                     case write_result::no_space:

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1821,8 +1821,17 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                         s = co_await with_timeout(timeout, s->sync());
                         continue;
                     case write_result::no_space:
-                        [[fallthrough]];
+                        clogger.debug("oversized fragment {} for id={} off={}/{} rejected with no_space "
+                                            "(seg_pos={}, to_write={}, avail={}, max_size={}); retrying on a new segment",
+                                            i, id, off, data_size, s->position(), to_write, avail, max_size);
+                        strm = saved_strm;
+                        co_await s->close();
+                        s = co_await get_segment();
+                        continue;
                     case write_result::too_large:
+                        clogger.error("oversized fragment {} for id={} off={}/{} rejected with too_large "
+                                            "(seg_pos={}, to_write={}, avail={}, max_size={}, max_mutation_size={})",
+                                            i, id, off, data_size, s->position(), to_write, avail, max_size, max_mutation_size);
                         assert(0); // should not reach
                         failed = true;
                         break;

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -1427,6 +1427,17 @@ public:
 
     position_type next_position(size_t size) const {
         auto used = _buffer_ostream_size - _buffer_ostream.size();
+        // #SCYLLADB-1757 - if the buffer is empty, a subsequent allocation
+        // will call new_buffer(), which prepends segment_overhead_size (and
+        // descriptor_header_size for the very first buffer of the segment).
+        // Mirror that here so callers asking "would size+overheads fit?" get
+        // a faithful answer instead of an optimistic underestimate.
+        if (_buffer.empty()) {
+            used += segment_overhead_size;
+            if (_file_pos == 0) {
+                used += descriptor_header_size;
+            }
+        }
         used += size;
         return _file_pos + used + sector_overhead(used);
     }

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -53,6 +53,7 @@
 #include "utils/log.hh"
 #include "commitlog_entry.hh"
 #include "commitlog_extensions.hh"
+#include "oversized_alloc_helpers.hh"
 
 #include "utils/checked-file-impl.hh"
 #include "utils/disk-error-handler.hh"
@@ -1763,12 +1764,11 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                 continue;
             }
 
-            auto align = s->_alignment; 
-            auto sector_size = align - detail::sector_overhead_size;
-          
-            auto buffer = acquire_buffer(data_size, align);
+            auto initial_align = s->_alignment;
+
+            auto buffer = acquire_buffer(data_size, initial_align);
             {
-                base_ostream_type buffer_ostream = frag_ostream_type(detail::sector_split_iterator(buffer.begin(), buffer.end(), align, 0), buffer.size_bytes());
+                base_ostream_type buffer_ostream = frag_ostream_type(detail::sector_split_iterator(buffer.begin(), buffer.end(), initial_align, 0), buffer.size_bytes());
                 writer.write(*s, buffer_ostream, i);
             }
             auto strm = buffer.get_istream();
@@ -1781,35 +1781,31 @@ future<> db::commitlog::segment_manager::oversized_allocation(entry_writer& writ
                     co_await s->close();
                     s = co_await get_segment();
                 }
-                // bytes not counting overhead                
-                auto buf_rem = std::min(max_size - s->position(), s->_buffer_ostream.size());
+                // SCYLLADB-1757: re-read alignment from the *current* segment
+                // every iteration. Recycled segments use disk_write_dma_alignment
+                // (e.g. 4096), freshly preallocated segments use
+                // disk_overwrite_dma_alignment (e.g. 512). Capturing this once
+                // before the loop made the avail math diverge from the actual
+                // segment after a get_segment() reacquire.
+                const auto align = s->_alignment;
 
-                size_t avail;
-                if (buf_rem > align) {
-                    auto rem2 = buf_rem - (1 + buf_rem/sector_size) * detail::sector_overhead_size;
-                    avail = std::min(rem2, max_mutation_size)
-                        - segment::entry_overhead_size
-                        - segment::fragmented_entry_overhead_size
-                        ;
-                    assert(avail < buf_rem);
-                } else {
+                size_t avail = commitlog_oversized_alloc::in_buffer_fragment_payload(
+                        align, s->_buffer_ostream.size(), s->position(),
+                        max_size, max_mutation_size);
+
+                if (avail == 0) {
+                    // In-buffer math has nothing to give: cycle and try the
+                    // freshly-emptied buffer / next segment's file tail.
                     co_await s->cycle();
                     auto pos = s->position();
-                    auto max = std::max<size_t>(pos, max_file_size);
-                    auto file_rem = max - pos;
 
-                    if (file_rem < align) {
+                    avail = commitlog_oversized_alloc::post_cycle_fragment_payload(
+                            align, pos, max_file_size, max_mutation_size);
+
+                    if (avail == 0) {
                         co_await s->close();
                         continue;
                     }
-
-                    auto rem2 = file_rem - (1 + file_rem/sector_size) * detail::sector_overhead_size;
-                    avail = std::min(rem2, max_mutation_size) 
-                        - segment::entry_overhead_size
-                        - segment::fragmented_entry_overhead_size
-                        - (pos == 0 ? segment::descriptor_header_size : 0)
-                        - segment::segment_overhead_size
-                        ;
                 }
                 if (!seg_ptr) {
                     seg_ptr = s;

--- a/db/commitlog/commitlog.cc
+++ b/db/commitlog/commitlog.cc
@@ -817,11 +817,11 @@ public:
     friend struct fmt::formatter<cf_mark>;
 
     // The commit log entry overhead in bytes (int: length + int: head checksum)
-    static constexpr size_t entry_overhead_size = 2 * sizeof(uint32_t);
+    static constexpr size_t entry_overhead_size = detail::entry_overhead_size;
     static constexpr size_t multi_entry_overhead_size = entry_overhead_size + sizeof(uint32_t);
-    static constexpr size_t fragmented_entry_overhead_size = 4 * sizeof(uint32_t);
-    static constexpr size_t segment_overhead_size = 2 * sizeof(uint32_t);
-    static constexpr size_t descriptor_header_size = 6 * sizeof(uint32_t);
+    static constexpr size_t fragmented_entry_overhead_size = detail::fragmented_entry_overhead_size;
+    static constexpr size_t segment_overhead_size = detail::segment_overhead_size;
+    static constexpr size_t descriptor_header_size = detail::descriptor_header_size;
     static constexpr uint32_t segment_magic = ('S'<<24) |('C'<< 16) | ('L' << 8) | 'C';
     static constexpr uint32_t multi_entry_size_magic = 0xffffffff;
     static constexpr uint32_t fragmented_entry_size_magic = 0xfffffffe;

--- a/db/commitlog/commitlog_entry.hh
+++ b/db/commitlog/commitlog_entry.hh
@@ -22,6 +22,10 @@ namespace detail {
     using base_iterator = typename std::vector<temporary_buffer<char>>::const_iterator;
 
     static constexpr auto sector_overhead_size = sizeof(uint32_t) + sizeof(db::segment_id_type);
+    inline constexpr size_t entry_overhead_size            = 2 * sizeof(uint32_t);
+    inline constexpr size_t fragmented_entry_overhead_size = 4 * sizeof(uint32_t);
+    inline constexpr size_t segment_overhead_size          = 2 * sizeof(uint32_t);
+    inline constexpr size_t descriptor_header_size         = 6 * sizeof(uint32_t);
 
     // iterator adaptor to enable splitting normal
     // frag-buffer temporary buffer objects into 

--- a/db/commitlog/oversized_alloc_helpers.hh
+++ b/db/commitlog/oversized_alloc_helpers.hh
@@ -22,6 +22,12 @@
 
 namespace db::commitlog_oversized_alloc {
 
+// Per-fragment entry framing both helpers must subtract from the raw
+// available bytes: the fixed-size entry header plus the marker that
+// flags the entry as a fragmented one.
+inline constexpr size_t total_entry_overhead =
+        detail::entry_overhead_size + detail::fragmented_entry_overhead_size;
+
 /**
  * Maximum number of payload bytes (user mutation bytes, excluding any
  * CRC, sector, entry, segment or descriptor framing) of an oversized
@@ -55,9 +61,10 @@ inline size_t in_buffer_fragment_payload(
         return 0;
     }
     const size_t rem2 = buf_rem - (1 + buf_rem / sector_size) * detail::sector_overhead_size;
-    const size_t entry_ovh = detail::entry_overhead_size + detail::fragmented_entry_overhead_size;
-    const size_t cap = std::min(rem2, max_mutation_size);
-    const size_t result = cap > entry_ovh ? cap - entry_ovh : 0;
+    const size_t avail_pre_overhead = std::min(rem2, max_mutation_size);
+    const size_t result = avail_pre_overhead > total_entry_overhead
+            ? avail_pre_overhead - total_entry_overhead
+            : 0;
     assert(result < buf_rem);
     return result;
 }
@@ -91,10 +98,11 @@ inline size_t post_cycle_fragment_payload(
     }
     const size_t rem2 = file_rem - (1 + file_rem / sector_size) * detail::sector_overhead_size;
     const size_t first_buffer_ovh = (file_pos == 0 ? detail::descriptor_header_size : 0) + detail::segment_overhead_size;
-    const size_t entry_ovh = detail::entry_overhead_size + detail::fragmented_entry_overhead_size;
-    const size_t fixed_ovh = first_buffer_ovh + entry_ovh;
-    const size_t cap = std::min(rem2, max_mutation_size);
-    const size_t result = cap > fixed_ovh ? cap - fixed_ovh : 0;
+    const size_t fixed_ovh = first_buffer_ovh + total_entry_overhead;
+    const size_t avail_pre_overhead = std::min(rem2, max_mutation_size);
+    const size_t result = avail_pre_overhead > fixed_ovh
+            ? avail_pre_overhead - fixed_ovh
+            : 0;
     assert(result < file_rem);
     return result;
 }
@@ -115,8 +123,7 @@ inline size_t projected_post_cycle_position(
     const size_t fixed_ovh =
         (file_pos == 0 ? detail::descriptor_header_size : 0)
         + detail::segment_overhead_size
-        + detail::entry_overhead_size
-        + detail::fragmented_entry_overhead_size;
+        + total_entry_overhead;
     const size_t used = payload_bytes + fixed_ovh;
     const size_t sector_size = alignment - detail::sector_overhead_size;
     const size_t sector_ovh = (used / sector_size) * detail::sector_overhead_size;

--- a/db/commitlog/oversized_alloc_helpers.hh
+++ b/db/commitlog/oversized_alloc_helpers.hh
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+
+#include "commitlog_entry.hh"
+
+// Pure helpers for the per-fragment payload math used by
+// segment_manager::oversized_allocation. Extracted as free functions with
+// no I/O or segment_manager dependencies. The arithmetic is then unit-
+// testable in isolation, and the production loop calls a single helper per
+// branch instead of inlining the formula.
+
+namespace db::commitlog_oversized_alloc {
+
+/**
+ * Maximum number of payload bytes (user mutation bytes, excluding any
+ * CRC, sector, entry, segment or descriptor framing) of an oversized
+ * fragment that can be appended to the *already-allocated* buffer of a
+ * segment.
+ *
+ * @param alignment              the segment's on-disk alignment in bytes.
+ * @param buffer_data_remaining  bytes free in the current buffer's data
+ *                               ostream (excludes the per-buffer header).
+ * @param segment_position       the segment's current logical write
+ *                               position (file_pos + buffer position).
+ * @param max_segment_size       upper bound on segment_position the
+ *                               segment is allowed to reach.
+ * @param max_mutation_size      upper bound on a single fragment's payload.
+ * @return  the recommended payload size in bytes, or 0 when the buffer
+ *          cannot host another fragment.
+ */
+inline size_t in_buffer_fragment_payload(
+        size_t alignment,
+        size_t buffer_data_remaining,
+        size_t segment_position,
+        size_t max_segment_size,
+        size_t max_mutation_size) {
+    if (segment_position >= max_segment_size) {
+        return 0;
+    }
+    const size_t sector_size = alignment - detail::sector_overhead_size;
+    const size_t buf_rem = std::min(max_segment_size - segment_position, buffer_data_remaining);
+    if (buf_rem <= alignment) {
+        // caller falls through to post_cycle_fragment_payload().
+        return 0;
+    }
+    const size_t rem2 = buf_rem - (1 + buf_rem / sector_size) * detail::sector_overhead_size;
+    const size_t entry_ovh = detail::entry_overhead_size + detail::fragmented_entry_overhead_size;
+    const size_t cap = std::min(rem2, max_mutation_size);
+    const size_t result = cap > entry_ovh ? cap - entry_ovh : 0;
+    assert(result < buf_rem);
+    return result;
+}
+
+/**
+ * Maximum payload bytes for a fragment that will land in the *next*
+ * buffer of a segment (after a cycle, or in a freshly-opened segment).
+ * Accounts for the per-buffer chunk header and, when file_pos is zero,
+ * the per-file descriptor header.
+ *
+ * @param alignment          the segment's on-disk alignment in bytes.
+ * @param file_pos           the segment's current on-disk file position.
+ * @param max_segment_size   upper bound on file_pos the segment is
+ *                           allowed to reach.
+ * @param max_mutation_size  upper bound on a single fragment's payload.
+ * @return  the recommended payload size in bytes, or 0 when the segment
+ *          cannot host another fragment header.
+ */
+inline size_t post_cycle_fragment_payload(
+        size_t alignment,
+        size_t file_pos,
+        size_t max_segment_size,
+        size_t max_mutation_size) {
+    if (file_pos >= max_segment_size) {
+        return 0;
+    }
+    const size_t sector_size = alignment - detail::sector_overhead_size;
+    const size_t file_rem = max_segment_size - file_pos;
+    if (file_rem < alignment) {
+        return 0;
+    }
+    const size_t rem2 = file_rem - (1 + file_rem / sector_size) * detail::sector_overhead_size;
+    const size_t first_buffer_ovh = (file_pos == 0 ? detail::descriptor_header_size : 0) + detail::segment_overhead_size;
+    const size_t entry_ovh = detail::entry_overhead_size + detail::fragmented_entry_overhead_size;
+    const size_t fixed_ovh = first_buffer_ovh + entry_ovh;
+    const size_t cap = std::min(rem2, max_mutation_size);
+    const size_t result = cap > fixed_ovh ? cap - fixed_ovh : 0;
+    assert(result < file_rem);
+    return result;
+}
+
+/**
+ * Inverse of post_cycle_fragment_payload: given a recommended payload,
+ * returns the on-disk position the segment would advance to after the
+ * write. Mirrors segment::next_position semantics for the case where
+ * the buffer is empty / about to be cycled.
+ *
+ * Used by tests to assert that a recommended payload, padded with all
+ * overheads, never crosses max_segment_size.
+ */
+inline size_t projected_post_cycle_position(
+        size_t alignment,
+        size_t file_pos,
+        size_t payload_bytes) {
+    const size_t fixed_ovh =
+        (file_pos == 0 ? detail::descriptor_header_size : 0)
+        + detail::segment_overhead_size
+        + detail::entry_overhead_size
+        + detail::fragmented_entry_overhead_size;
+    const size_t used = payload_bytes + fixed_ovh;
+    const size_t sector_size = alignment - detail::sector_overhead_size;
+    const size_t sector_ovh = (used / sector_size) * detail::sector_overhead_size;
+    return file_pos + used + sector_ovh;
+}
+
+} // namespace db::commitlog_oversized_alloc

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -37,6 +37,7 @@
 #include "db/commitlog/commitlog.hh"
 #include "db/commitlog/commitlog_replayer.hh"
 #include "db/commitlog/commitlog_extensions.hh"
+#include "db/commitlog/oversized_alloc_helpers.hh"
 #include "db/commitlog/rp_set.hh"
 #include "db/extensions.hh"
 #include "readers/combined.hh"
@@ -2409,6 +2410,140 @@ SEASTAR_TEST_CASE(test_commitlog_replay_segment_order) {
             BOOST_CHECK_GT(replayed_ids[i], replayed_ids[i - 1]);
         }
     });
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+
+// Pure-function tests for db::commitlog_oversized_alloc helpers. The
+// scenario constants below reproduce the SCYLLADB-1757 trial-diag-2.log
+// capture (8 MiB segment cap, 512/4096-byte alignments observed on XFS).
+
+namespace {
+
+constexpr size_t kMiB       = 1024 * 1024;
+constexpr size_t kAlign512  = 512;   // disk_overwrite_dma_alignment on XFS
+constexpr size_t kAlign4096 = 4096;  // disk_write_dma_alignment on XFS
+
+} // namespace
+
+BOOST_AUTO_TEST_SUITE(commitlog_oversized_alloc_helpers_test)
+
+using namespace db::commitlog_oversized_alloc;
+
+// Sanity: empty segment, post-cycle (i.e. brand new buffer) payload is well
+// under max_segment_size and the projected on-disk position respects the cap.
+BOOST_AUTO_TEST_CASE(post_cycle_payload_fits_in_segment) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+
+    for (size_t alignment : { kAlign512, kAlign4096 }) {
+        for (size_t file_pos : { size_t{0}, size_t{4 * kMiB}, max_seg - 16 * 1024 }) {
+            const size_t payload = post_cycle_fragment_payload(alignment, file_pos, max_seg, max_mut);
+            BOOST_TEST_CONTEXT("alignment=" << alignment << " file_pos=" << file_pos) {
+                BOOST_REQUIRE_GT(payload, 0u);
+                const size_t projected = projected_post_cycle_position(alignment, file_pos, payload);
+                BOOST_REQUIRE_LE(projected, max_seg);
+                // Adding one more byte must not also fit (helper is tight).
+                const size_t projected_plus_one = projected_post_cycle_position(alignment, file_pos, payload + 1);
+                BOOST_REQUIRE_GT(projected_plus_one, projected);
+            }
+        }
+    }
+}
+
+// Boundary: file_pos == max_segment_size (or beyond) leaves no room.
+BOOST_AUTO_TEST_CASE(post_cycle_at_or_past_max_returns_zero) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+
+    BOOST_CHECK_EQUAL(post_cycle_fragment_payload(kAlign512, max_seg, max_seg, max_mut), 0u);
+    BOOST_CHECK_EQUAL(post_cycle_fragment_payload(kAlign512, max_seg + 1, max_seg, max_mut), 0u);
+    // Less than one alignment of room.
+    BOOST_CHECK_EQUAL(post_cycle_fragment_payload(kAlign4096, max_seg - 100, max_seg, max_mut), 0u);
+}
+
+// Boundary: in-buffer helper returns 0 (caller falls through to post_cycle)
+// when the buffer cannot host an alignment-sized chunk.
+BOOST_AUTO_TEST_CASE(in_buffer_too_small_returns_zero) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+
+    BOOST_CHECK_EQUAL(in_buffer_fragment_payload(kAlign4096, /*buf_data_remaining=*/4096, /*pos=*/0, max_seg, max_mut), 0u);
+    BOOST_CHECK_EQUAL(in_buffer_fragment_payload(kAlign512, /*buf_data_remaining=*/512, /*pos=*/0, max_seg, max_mut), 0u);
+    // Way past max_segment_size.
+    BOOST_CHECK_EQUAL(in_buffer_fragment_payload(kAlign512, /*buf_data_remaining=*/1 << 20, /*pos=*/max_seg, max_seg, max_mut), 0u);
+}
+
+// In-buffer payload is always strictly less than buffer_data_remaining (after
+// subtracting per-sector and per-entry overhead).
+BOOST_AUTO_TEST_CASE(in_buffer_payload_is_bounded_by_buffer) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+
+    for (size_t alignment : { kAlign512, kAlign4096 }) {
+        for (size_t buf_rem : { size_t{16 * 1024}, size_t{1 * kMiB}, size_t{6 * kMiB} }) {
+            const size_t payload = in_buffer_fragment_payload(alignment, buf_rem, /*pos=*/0, max_seg, max_mut);
+            BOOST_TEST_CONTEXT("alignment=" << alignment << " buf_rem=" << buf_rem) {
+                if (payload > 0) {
+                    BOOST_CHECK_LT(payload, buf_rem);
+                }
+            }
+        }
+    }
+}
+
+// Regression test for #SCYLLADB-1757: with the production trial-diag-2.log
+// numbers (alignment=512, max_seg=8MiB, file_pos=4295168, fresh buffer), the
+// helper computed against the *correct* alignment returns a payload that fits.
+// Computing against the stale 4096 alignment returns a strictly larger payload
+// that, when written into the 512-aligned segment, would push next_position
+// past max_seg. This is precisely the assert(0) trip path.
+BOOST_AUTO_TEST_CASE(scylladb_1757_stale_alignment_overshoots) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+    constexpr size_t file_pos = 4295168; // observed in trial-diag-2.log
+
+    const size_t correct_payload = post_cycle_fragment_payload(kAlign512, file_pos, max_seg, max_mut);
+    const size_t stale_payload   = post_cycle_fragment_payload(kAlign4096, file_pos, max_seg, max_mut);
+
+    BOOST_REQUIRE_GT(correct_payload, 0u);
+    // The 4096-alignment math has less per-sector overhead and so admits MORE
+    // payload than the actual 512-alignment segment can host. This monotone
+    // gap is the crux of the bug.
+    BOOST_REQUIRE_GT(stale_payload, correct_payload);
+
+    // The correct payload fits.
+    BOOST_CHECK_LE(projected_post_cycle_position(kAlign512, file_pos, correct_payload), max_seg);
+    // The stale payload, when written into the 512-aligned segment, overshoots.
+    BOOST_CHECK_GT(projected_post_cycle_position(kAlign512, file_pos, stale_payload), max_seg);
+}
+
+// Generalise the previous test: across a grid of file positions, the
+// helper using each alignment must always produce a payload that fits when
+// fed back into the *same* alignment's projection. Stale-alignment use
+// (cross-alignment projection) is allowed to exceed; correct use must not.
+BOOST_AUTO_TEST_CASE(post_cycle_payload_fits_under_matching_alignment) {
+    constexpr size_t max_seg = 8 * kMiB;
+    constexpr size_t max_mut = max_seg / 2;
+
+    for (size_t alignment : { kAlign512, kAlign4096 }) {
+        // Sweep through file positions in alignment-sized steps; cover both
+        // the very start (descriptor header path) and positions deep into
+        // the segment.
+        for (size_t step = 0; step < 32; ++step) {
+            const size_t file_pos = step * alignment * 7919; // sparse stride
+            if (file_pos >= max_seg) {
+                continue;
+            }
+            const size_t payload = post_cycle_fragment_payload(alignment, file_pos, max_seg, max_mut);
+            if (payload == 0) {
+                continue;
+            }
+            BOOST_TEST_CONTEXT("alignment=" << alignment << " file_pos=" << file_pos) {
+                BOOST_REQUIRE_LE(projected_post_cycle_position(alignment, file_pos, payload), max_seg);
+            }
+        }
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes issues in `db::commitlog::segment_manager::oversized_allocation`'s per-fragment inner loop, which handles mutations larger than a single commitlog segment. The symptom is an `assert(0)` abort at `commitlog.cc:1824` on the `no_space` arm of the inner switch, caused by the outer loop's `avail` calculation and `segment::allocate`'s internal size check using slightly different sector-overhead accounting and disagreeing at non-aligned positions on a partially-filled segment.

While restructuring that arm, the same loop's `must_sync` arm was found to leak the `istream` cursor. `read_view(n)` advances the cursor unconditionally. A `must_sync` retry skips past the bytes that should have been written, silently corrupting the on-disk fragment layout without any error at write time. Both arms now snapshot the `istream` before constructing the `partial_writer` and restore it on retry. The `too_large` arm keeps its assert but logs diagnostic state before aborting.

The files needed to reproduce the issue are attached as `repro.tar.gz` in https://scylladb.atlassian.net/browse/SCYLLADB-1757.

Fixes SCYLLADB-1757

The issue fixed by this PR is present on older branches and should be backported.