### PR TITLE
raft: do not throw commit_status_unknown from add_entry when possible

### DIFF
--- a/raft/server.cc
+++ b/raft/server.cc
@@ -239,7 +239,7 @@ private:
 
     // Drop waiter that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
-    void drop_waiters(std::optional<index_t> idx = {});
+    void drop_waiters(const snapshot_descriptor* snp = nullptr);
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
     // to be applied.
@@ -995,11 +995,11 @@ void server_impl::notify_waiters(std::map<index_t, op_status>& waiters,
     }
 }
 
-void server_impl::drop_waiters(std::optional<index_t> idx) {
+void server_impl::drop_waiters(const snapshot_descriptor* snp) {
     auto drop = [&] (std::map<index_t, op_status>& waiters) {
         while (waiters.size() != 0) {
             auto it = waiters.begin();
-            if (idx && it->first > *idx) {
+            if (snp && it->first > snp->idx) {
                 break;
             }
             auto [entry_idx, status] = std::move(*it);
@@ -1431,7 +1431,7 @@ future<> server_impl::applier_fiber() {
                 // Apply snapshot it to the state machine
                 logger.trace("[{}] apply_fiber applying snapshot {}", _id, snp.id);
                 co_await _state_machine->load_snapshot(snp.id);
-                drop_waiters(snp.idx);
+                drop_waiters(&snp);
                 _applied_idx = snp.idx;
                 _applied_index_changed.broadcast();
                 _stats.sm_load_snapshot++;

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -747,6 +747,8 @@ future<> server_impl::add_entry(command command, wait_type type, seastar::abort_
             throw not_a_leader{leader};
         }
         auto eid = co_await add_entry_on_leader(std::move(command), as);
+        co_await utils::get_local_injector().inject("block_raft_add_entry_before_wait_for_entry",
+                utils::wait_for_message(std::chrono::minutes(5)));
         co_return co_await wait_for_entry(eid, type, as);
     }
 

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -239,6 +239,9 @@ private:
 
     // Drop waiter that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
+    // When `snp` is provided (snapshot transfer case), waiters whose term matches
+    // the snapshot term are resolved successfully, since the snapshot-term match proves
+    // they were committed and included in the snapshot (by the Log Matching Property).
     void drop_waiters(const snapshot_descriptor* snp = nullptr);
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
@@ -556,12 +559,10 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
                 auto snap_term = _fsm->log_term_for(snap_idx);
                 SCYLLA_ASSERT(snap_term);
                 SCYLLA_ASSERT(snap_idx >= eid.idx);
-                if (type == wait_type::committed && snap_term == eid.term) {
+                if (snap_term == eid.term) {
                     logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away, but has the snapshot's term"
                                  " (snapshot index: {})", id(), eid.term, eid.idx, snap_idx);
                     co_return;
-
-                    // We don't do this for `wait_type::applied` - see below why.
                 }
 
                 logger.trace("[{}] wait_for_entry {}.{}: entry got truncated away", id(), eid.term, eid.idx);
@@ -570,20 +571,6 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
 
             if (*term != eid.term) {
                 throw dropped_entry();
-            }
-
-            if (type == wait_type::applied && _fsm->log_last_snapshot_idx() >= eid.idx) {
-                // We know the entry was committed but the wait type is `applied`
-                // and we don't know if the entry was applied with `state_machine::apply`
-                // (we may've loaded a snapshot before we managed to apply the entry).
-                // As specified by `add_entry`, throw `commit_status_unknown` in this case.
-                //
-                // FIXME: replace this with a different exception type - `commit_status_unknown`
-                // gives too much uncertainty while we know that the entry was committed
-                // and had to be applied on at least one server. Some callers of `add_entry`
-                // need to know only that the current state includes that entry, whether it was done
-                // through `apply` on this server or through receiving a snapshot.
-                throw commit_status_unknown();
             }
 
             co_return;
@@ -1004,8 +991,15 @@ void server_impl::drop_waiters(const snapshot_descriptor* snp) {
             }
             auto [entry_idx, status] = std::move(*it);
             waiters.erase(it);
-            status.done.set_exception(commit_status_unknown());
-            _stats.waiters_dropped++;
+            if (snp && status.term == snp->term) {
+                // entry_idx <= snapshot index and the entry's term matches the snapshot term.
+                // By the Log Matching Property the entry was committed and included in the snapshot.
+                status.done.set_value();
+                _stats.waiters_awoken++;
+            } else {
+                status.done.set_exception(commit_status_unknown());
+                _stats.waiters_dropped++;
+            }
         }
     };
     drop(_awaited_commits);

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -79,12 +79,12 @@ public:
     // The caller may pass a pointer to an abort_source to make the operation abortable.
     // If it passes nullptr, the operation is unabortable.
     //
-    // Successful `add_entry` with `wait_type::committed` does not guarantee that `state_machine::apply` will be called
-    // locally for this entry. Between the commit and the application we may receive a snapshot containing this entry,
-    // so the state machine's state 'jumps' forward in time, skipping the entry application.
-    // However, for `wait_type::applied`, we guarantee that the entry will be applied locally with `state_machine::apply`.
-    // If a snapshot causes the state machine to jump over the entry, `add_entry` will return `commit_status_unknown`
-    // (even if the snapshot included that entry).
+    // Successful `add_entry` does not guarantee that `state_machine::apply` will be called
+    // locally for this entry. Between the commit and the application we may load a snapshot
+    // containing this entry, so the state machine's state 'jumps' forward in time, skipping
+    // the local entry application. For `wait_type::applied` this should be fine, because
+    // state machine implementations shouldn't care whether an entry was applied via
+    // `state_machine::apply` or via a snapshot load.
     //
     // Exceptions:
     // raft::commit_status_unknown

--- a/raft/server.hh
+++ b/raft/server.hh
@@ -90,7 +90,7 @@ public:
     // raft::commit_status_unknown
     //     Thrown if the leader has changed and the log entry has either
     //     been replaced by the new leader or the server has lost track of it.
-    //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.L
+    //     It may also be thrown in case of a transport error while forwarding add_entry to the leader.
     // raft::dropped_entry
     //     Thrown if the entry was replaced because of a leader change.
     // raft::request_aborted

--- a/test/raft/raft_server_test.cc
+++ b/test/raft/raft_server_test.cc
@@ -203,3 +203,183 @@ SEASTAR_THREAD_TEST_CASE(test_wait_for_leader_on_aborted_server) {
 SEASTAR_THREAD_TEST_CASE(test_wait_for_state_change_on_aborted_server) {
     test_func_on_aborted_server_aux(&raft::server::wait_for_state_change);
 }
+
+// Auxiliary function for testing add_entry behavior when a snapshot that
+// includes the entry being added is taken before wait_for_entry runs.
+//
+// Uses a 1-node cluster with aggressive snapshotting and an error injection
+// point that pauses add_entry after the entry is added to the log but before
+// wait_for_entry checks its status. During the pause, the entry is committed,
+// applied, and a snapshot is taken.
+//
+// If `advance_snapshot_past_entry` is true, a second entry is added so the
+// snapshot moves past the first entry's index, fully truncating it from the
+// log (term_for returns nullopt). Otherwise the snapshot is taken at the
+// entry's index (term_for returns the snapshot's term).
+//
+// In both cases, wait_for_entry should succeed for both wait types, since
+// the snapshot's term matching the entry's term proves the entry was committed
+// and included in the snapshot.
+static void test_add_entry_load_snapshot_before_wait_aux(raft::wait_type type, bool advance_snapshot_past_entry) {
+#ifndef SCYLLA_ENABLE_ERROR_INJECTION
+    std::cerr << "Skipping test as it depends on error injection. Please run in mode where it's enabled (debug,dev).\n";
+    return;
+#endif
+    const size_t command_size = sizeof(size_t);
+    test_case test_config {
+        .nodes = 1,
+        .config = std::vector<raft::server::configuration>({
+            raft::server::configuration {
+                // Snapshot after every entry; truncate aggressively.
+                .snapshot_threshold = 1,
+                .snapshot_threshold_log_size = 1,
+                .snapshot_trailing = 0,
+                .snapshot_trailing_size = 0,
+                .max_log_size = 10 * (command_size + sizeof(raft::log_entry)),
+                .enable_forwarding = false,
+                .max_command_size = command_size
+            }
+         })
+    };
+    // apply_entries must be greater than the number of entries added
+    // during the test, otherwise the state machine's done promise fires
+    // prematurely.
+    auto cluster = raft_cluster<std::chrono::steady_clock>{
+        std::move(test_config),
+        ::apply_changes,
+        100,  // apply_entries
+        0,
+        0, false, tick_delay, rpc_config{}
+    };
+    cluster.start_all().get();
+    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+
+    cluster.add_entries(5, 0).get();
+
+    // one_shot: only the first add_entry is paused; the second one
+    // (if used) bypasses the injection.
+    utils::get_local_injector().enable("block_raft_add_entry_before_wait_for_entry", true);
+
+    auto& server = cluster.get_server(0);
+    auto fut = server.add_entry(create_command(42), type, nullptr);
+
+    // Wait for add_entry(42) to reach the injection point.
+    while (utils::get_local_injector().is_enabled("block_raft_add_entry_before_wait_for_entry")) {
+        seastar::thread::yield();
+    }
+
+    // Wait for the entry to be applied.
+    server.read_barrier(nullptr).get();
+
+    if (advance_snapshot_past_entry) {
+        // Add another entry so the snapshot moves past the first entry,
+        // fully truncating it from the log (term_for returns nullopt).
+        // The injection is one-shot and already consumed, so this goes through.
+        server.add_entry(create_command(43), raft::wait_type::applied, nullptr).get();
+    }
+
+    // Take a snapshot, truncating the entry from the log.
+    server.trigger_snapshot(nullptr).get();
+
+    // Unblock wait_for_entry.
+    utils::get_local_injector().receive_message("block_raft_add_entry_before_wait_for_entry");
+
+    // Both wait types should succeed: the snapshot's term matches the entry's
+    // term, proving the entry was committed and included in the snapshot.
+    BOOST_CHECK_NO_THROW(fut.get());
+}
+
+// Snapshot at the entry's index: term_for(eid.idx) returns the snapshot's term.
+// Tests wait_for_entry site where the removed `applied` check used to throw
+// commit_status_unknown.
+SEASTAR_THREAD_TEST_CASE(test_add_entry_applied_load_snapshot_at_entry) {
+    test_add_entry_load_snapshot_before_wait_aux(raft::wait_type::applied, false);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_add_entry_committed_load_snapshot_at_entry) {
+    test_add_entry_load_snapshot_before_wait_aux(raft::wait_type::committed, false);
+}
+
+// Snapshot past the entry's index: term_for(eid.idx) returns nullopt.
+// Tests the `!term` branch in wait_for_entry where `snap_term == eid.term`
+// now succeeds for both wait types.
+SEASTAR_THREAD_TEST_CASE(test_add_entry_applied_load_snapshot_past_entry) {
+    test_add_entry_load_snapshot_before_wait_aux(raft::wait_type::applied, true);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_add_entry_committed_load_snapshot_past_entry) {
+    test_add_entry_load_snapshot_before_wait_aux(raft::wait_type::committed, true);
+}
+
+// Auxiliary function for testing add_entry behavior when a follower receives
+// the entry via a snapshot (load_snapshot) instead of applying it locally.
+//
+// Setup: 3-node cluster. Node 1 (follower) is blocked from receiving
+// messages from the leader (node 0), but can still send to it. Node 1
+// forwards add_entry to the leader, which commits the entry (with node 2),
+// applies it, and takes a snapshot. When node 1 is reconnected, the leader
+// sends a snapshot (since the log entries are truncated). Node 1 loads the
+// snapshot via load_snapshot(), which calls drop_waiters(). The pending
+// waiter for the forwarded entry is resolved successfully because the
+// snapshot's term matches the entry's term.
+static void test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type type) {
+    const size_t command_size = sizeof(size_t);
+    raft::server::configuration srv_config {
+        .snapshot_threshold = 1,
+        .snapshot_threshold_log_size = 1,
+        .snapshot_trailing = 0,
+        .snapshot_trailing_size = 0,
+        .max_log_size = 10 * (command_size + sizeof(raft::log_entry)),
+        .max_command_size = command_size
+    };
+    test_case test_config {
+        .nodes = 3,
+        .config = std::vector<raft::server::configuration>({srv_config, srv_config, srv_config})
+    };
+    // apply_entries must be greater than the number of entries added
+    // during the test, otherwise the state machine's done promise fires
+    // prematurely.
+    auto cluster = raft_cluster<std::chrono::steady_clock>{
+        std::move(test_config),
+        ::apply_changes,
+        100,  // apply_entries
+        0,
+        0, false, tick_delay, rpc_config{}
+    };
+    cluster.start_all().get();
+    auto stop = defer([&cluster] { cluster.stop_all().get(); });
+
+    // Add a few entries so all nodes are caught up.
+    cluster.add_entries(5, 0).get();
+
+    // Block node 1 from receiving messages from node 0 (leader).
+    // Node 1 can still send to node 0 (forwarding works).
+    cluster.block_receive(1, 0);
+
+    // Node 1 forwards add_entry to node 0. Node 0 commits (with node 2),
+    // applies, and takes a snapshot. Node 1 registers a waiter but never
+    // receives the entry via append entries.
+    auto& follower = cluster.get_server(1);
+    auto fut = follower.add_entry(create_command(42), type, nullptr);
+
+    // Wait for the leader to commit, apply, and snapshot the entry.
+    auto& leader = cluster.get_server(0);
+    leader.read_barrier(nullptr).get();
+    leader.trigger_snapshot(nullptr).get();
+
+    // Reconnect node 1. The leader will send a snapshot since the log
+    // entries are truncated (snapshot_trailing = 0).
+    cluster.connect_all();
+
+    // drop_waiters resolves the waiter successfully since the snapshot's
+    // term matches the entry's term, proving it was committed.
+    BOOST_CHECK_NO_THROW(fut.get());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_add_entry_applied_wait_resolved_via_drop_waiters) {
+    test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type::applied);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_add_entry_committed_wait_resolved_via_drop_waiters) {
+    test_add_entry_wait_resolved_via_drop_waiters_aux(raft::wait_type::committed);
+}

--- a/test/raft/randomized_nemesis_test.cc
+++ b/test/raft/randomized_nemesis_test.cc
@@ -221,9 +221,25 @@ raft::command make_command(const cmd_id_t& cmd_id, const Input& input) {
     return cmd;
 }
 
+// Indicates that add_entry succeeded but apply() was not called locally
+// for this entry — a snapshot load subsumed it. The entry's effects
+// are included in the state machine's state (via the snapshot).
+struct apply_skipped {};
+
+std::ostream& operator<<(std::ostream& os, const apply_skipped&) {
+    return os << "apply_skipped";
+}
+
+template <>
+struct fmt::formatter<apply_skipped> : fmt::formatter<string_view> {
+    auto format(const apply_skipped&, fmt::format_context& ctx) const {
+        return fmt::format_to(ctx.out(), "apply_skipped");
+    }
+};
+
 // TODO: handle other errors?
 template <PureStateMachine M>
-using call_result_t = std::variant<typename M::output_t, timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::stopped_error, raft::not_a_member>;
+using call_result_t = std::variant<typename M::output_t, timed_out_error, raft::not_a_leader, raft::dropped_entry, raft::commit_status_unknown, raft::stopped_error, raft::not_a_member, apply_skipped>;
 
 // Wait for a future `f` to finish, but keep the result inside a `future`.
 // Works for `future<void>` as well as for `future<T>`.
@@ -319,7 +335,15 @@ future<call_result_t<M>> call(
                     std::rethrow_exception(add_entry_f.get_exception());
                 }
 
-                return std::move(output_f);
+                if (output_f.available()) {
+                    return std::move(output_f);
+                }
+
+                // add_entry succeeded but apply() hasn't been called locally — a snapshot load subsumed this entry.
+                // The output channel will never be written to. Discard it and signal via output_channel_dropped, which
+                // is converted to apply_skipped in the outer exception handler.
+                (void)output_f.discard_result().handle_exception_type([] (const output_channel_dropped&) {});
+                throw output_channel_dropped{};
             });
         }, std::move(input), std::move(f)));
     }).then([] (output_t output) {
@@ -327,6 +351,8 @@ future<call_result_t<M>> call(
     }).handle_exception([] (std::exception_ptr eptr) {
         try {
             std::rethrow_exception(eptr);
+        } catch (const output_channel_dropped&) {
+            return make_ready_future<call_result_t<M>>(apply_skipped{});
         } catch (raft::not_a_leader& e) {
             return make_ready_future<call_result_t<M>>(e);
         } catch (raft::not_a_member& e) {
@@ -3472,6 +3498,7 @@ SEASTAR_TEST_CASE(basic_generator_test) {
             size_t invocations{0};
             size_t successes{0};
             size_t failures{0};
+            size_t skipped_applies{0};
         };
 
         class consistency_checker {
@@ -3514,6 +3541,9 @@ SEASTAR_TEST_CASE(basic_generator_test) {
                         // TODO SCYLLA_ASSERT: only allowed if reconfigurations happen?
                         // SCYLLA_ASSERT(false); TODO debug this
                         ++_stats.failures;
+                    },
+                    [this] (apply_skipped&) {
+                        ++_stats.skipped_applies;
                     },
                     [this] (auto&) {
                         ++_stats.failures;
@@ -3561,8 +3591,8 @@ SEASTAR_TEST_CASE(basic_generator_test) {
             SCYLLA_ASSERT(false);
         }
 
-        tlogger.info("Finished generator run, time: {}, invocations: {}, successes: {}, failures: {}, total: {}",
-                timer.now(), stats.invocations, stats.successes, stats.failures, stats.successes + stats.failures);
+        tlogger.info("Finished generator run, time: {}, invocations: {}, successes: {}, failures: {}, skipped applies: {}, total: {}",
+                timer.now(), stats.invocations, stats.successes, stats.failures, stats.skipped_applies, stats.successes + stats.failures + stats.skipped_applies);
 
         // Liveness check: we must be able to obtain a final response after all the nemeses have stopped.
         // Due to possible multiple leaders at this point and the cluster stabilizing (for example there

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -359,6 +359,9 @@ public:
     future<> stop_all();
     future<> wait_all();
     void disconnect(size_t id, std::optional<raft::server_id> except = std::nullopt);
+    // Block node `to` from receiving messages from node `from`.
+    // Messages in the reverse direction (from `to` to `from`) are unaffected.
+    void block_receive(size_t to, size_t from);
     void connect_all();
     void elapse_elections();
     future<> elect_new_leader(size_t new_leader);
@@ -519,6 +522,10 @@ struct raft_cluster<Clock>::connected {
     void cut(raft::server_id id1, raft::server_id id2) {
         disconnected.insert({id1, id2});
         disconnected.insert({id2, id1});
+    }
+    // Block `to` from receiving messages from `from` (one-way).
+    void block_receive(raft::server_id to, raft::server_id from) {
+        disconnected.insert({to, from});
     }
     // Isolate a server
     void disconnect(raft::server_id id, std::optional<raft::server_id> except = std::nullopt) {
@@ -925,6 +932,11 @@ future<> raft_cluster<Clock>::wait_all() {
 template <typename Clock>
 void raft_cluster<Clock>::disconnect(size_t id, std::optional<raft::server_id> except) {
     _connected->disconnect(to_raft_id(id), except);
+}
+
+template <typename Clock>
+void raft_cluster<Clock>::block_receive(size_t to, size_t from) {
+    _connected->block_receive(to_raft_id(to), to_raft_id(from));
 }
 
 template <typename Clock>

--- a/test/raft/replication.hh
+++ b/test/raft/replication.hh
@@ -552,8 +552,8 @@ struct raft_cluster<Clock>::connected {
         disconnected.clear();
     }
     bool operator()(raft::server_id id1, raft::server_id id2) {
-        // It's connected if both ways are not disconnected
-        return !disconnected.contains({id1, id2}) && !disconnected.contains({id1, id2});
+        // Can id2 send to id1? (i.e. is the id2->id1 connection not blocked?)
+        return !disconnected.contains({id1, id2});
     }
 };
 


### PR DESCRIPTION
Previously, when a snapshot load subsumed a committed entry before apply()
was called locally, add_entry would throw commit_status_unknown -- even
though the entry was known to be committed and included in the snapshot.
This was overly pessimistic. Normal state machine implementations
shouldn't care whether an entry was applied via apply() or via a snapshot load.
Unnecessary commit_status_unknown caused flakiness of
test_frequent_snapshotting and unnecessary retries in group0. Raft groups
from strongly consistent tables couldn't hit unnecessary
commit_status_unknown's because they use wait_type::committed and
`enable_forwarding == false`.

Three sites are changed:

1. wait_for_entry (truncation case): the snapshot-term match optimization
   that proved the entry was committed now applies to both wait_type::committed
   and wait_type::applied, not just committed.

2. wait_for_entry (snapshot covers entry): instead of throwing
   commit_status_unknown when the snapshot index >= entry index, return
   successfully. The entry's effects are included in the state machine's
   state via the snapshot.

3. drop_waiters: when called from load_snapshot, pass the snapshot term.
   Waiters whose term matches the snapshot term are resolved successfully
   (set_value) instead of failing with commit_status_unknown, since the
   Log Matching Property guarantees they were committed and included.

This deflakes test_frequent_snapshotting: the test uses aggressive
snapshot settings (snapshot_threshold=1) causing wait_for_entry to
occasionally find the snapshot covering its entry. Previously this
threw commit_status_unknown, failing the test. With this fix,
wait_for_entry returns success. Note that apply() is never actually
skipped in this test -- the leader always applies entries locally
before taking a snapshot.

The nemesis test is updated to handle the new behavior:
call() detects when add_entry succeeded but the output channel was
not written (apply() skipped locally) and returns apply_skipped instead
of hanging. The linearizability checker in basic_generator_test counts
skipped applies separately from failures. basic_generator_test
exercises this path: skipped_applies > 0 occurs in some runs.

Fixes: SCYLLADB-1264

No backport: the changes are quite risky and the test being fixed
fails very rarely.