### PR TITLE
transport: cql: Use round-robin policy for 9042 connections

### DIFF
--- a/test/cluster/test_shard_aware_connection_loop.py
+++ b/test/cluster/test_shard_aware_connection_loop.py
@@ -1,0 +1,190 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Reproducer for SCYLLADB-1618: Shard-aware drivers connecting to :9042
+can enter an infinite retry loop when there's a conntrack load imbalance.
+
+The shard-aware connection algorithm over port 9042 works as follows:
+1. Driver connects to :9042
+2. Server assigns the connection to the least-loaded shard (conntrack load balancer)
+3. Driver reads SCYLLA_SHARD from the SUPPORTED response
+4. If it's the target shard, done. Otherwise, cache as spare (at most 1 per shard,
+   closing the old spare if one exists).
+5. Retry from step 1.
+
+When there's a permanent imbalance in conntrack load >= 2 between shards,
+the driver wanting the most-loaded shard will never reach it. Each retry
+always gets the least-loaded shard, and closing old spares is a no-op
+for load balance.
+"""
+
+import asyncio
+import logging
+import struct
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+CQL_PORT = 9042
+
+
+def build_options_frame(stream: int = 0) -> bytes:
+    """Build a CQL protocol v4 OPTIONS frame."""
+    frame = bytearray()
+    frame.append(0x04)       # version 4
+    frame.append(0x00)       # flags
+    frame.extend(struct.pack('!H', stream))  # stream
+    frame.append(0x05)       # opcode: OPTIONS
+    frame.extend(struct.pack('!I', 0))       # body length: 0
+    return bytes(frame)
+
+
+def parse_string_multimap(data: bytes, offset: int) -> dict:
+    """Parse a CQL string multimap from bytes at the given offset.
+    Returns dict of key -> list of values.
+    """
+    result = {}
+    num_keys = struct.unpack_from('!H', data, offset)[0]
+    offset += 2
+
+    for _ in range(num_keys):
+        key_len = struct.unpack_from('!H', data, offset)[0]
+        offset += 2
+        key = data[offset:offset + key_len].decode('utf-8')
+        offset += key_len
+
+        num_values = struct.unpack_from('!H', data, offset)[0]
+        offset += 2
+        values = []
+        for _ in range(num_values):
+            val_len = struct.unpack_from('!H', data, offset)[0]
+            offset += 2
+            val = data[offset:offset + val_len].decode('utf-8')
+            offset += val_len
+            values.append(val)
+        result[key] = values
+
+    return result
+
+
+async def connect_and_get_shard(host: str, port: int):
+    """Open a TCP connection and send CQL OPTIONS to determine the assigned shard.
+    Returns (reader, writer, shard_id).
+    """
+    reader, writer = await asyncio.open_connection(host, port)
+
+    writer.write(build_options_frame(stream=0))
+    await writer.drain()
+
+    response = await asyncio.wait_for(reader.read(4096), timeout=10.0)
+    assert len(response) >= 9, f"Short response: {len(response)} bytes"
+    assert response[4] == 0x06, f"Expected SUPPORTED (0x06), got {hex(response[4])}"
+
+    # Body starts at offset 9 (after 9-byte frame header)
+    supported = parse_string_multimap(response, 9)
+    shard_id = int(supported['SCYLLA_SHARD'][0])
+
+    return reader, writer, shard_id
+
+
+async def close_conn(writer):
+    writer.close()
+    await writer.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_shard_aware_connection_loop(manager: ManagerClient):
+    """Reproducer for SCYLLADB-1618.
+
+    Creates a conntrack load imbalance on port 9042 and then simulates
+    the driver's shard-aware connection algorithm, showing that it cannot
+    reach the overloaded shard within a reasonable number of attempts.
+    """
+    num_shards = 2
+    server = await manager.server_add(cmdline=['--smp', str(num_shards)])
+    host = server.ip_addr
+
+    #
+    # Step 1: Create conntrack load imbalance on port 9042.
+    #
+    # Open several connections and categorize by shard, then close
+    # all connections on one shard so the other shard is "overloaded".
+    #
+    setup_conns = []
+    shard_conns = {s: [] for s in range(num_shards)}
+
+    for _ in range(6):
+        r, w, shard = await connect_and_get_shard(host, CQL_PORT)
+        setup_conns.append((r, w, shard))
+        shard_conns[shard].append(w)
+
+    # Pick the shard with fewer connections as the "light" shard.
+    # Close all its connections so the other shard becomes overloaded.
+    light_shard = min(shard_conns, key=lambda s: len(shard_conns[s]))
+    overloaded_shard = 1 - light_shard
+
+    logger.info("Shard connection counts before imbalance: %s",
+                {s: len(shard_conns[s]) for s in range(num_shards)})
+    logger.info("Closing all connections on shard %d to create imbalance", light_shard)
+
+    for w in shard_conns[light_shard]:
+        await close_conn(w)
+    shard_conns[light_shard].clear()
+
+    # Give conntrack time to process the closes (handle destructors
+    # send cross-shard messages).
+    await asyncio.sleep(0.5)
+
+    remaining = len(shard_conns[overloaded_shard])
+    logger.info("Conntrack imbalance: shard %d has %d connections, shard %d has 0",
+                overloaded_shard, remaining, light_shard)
+    assert remaining >= 2, \
+        f"Need imbalance >= 2, but overloaded shard only has {remaining} connections"
+
+    #
+    # Step 2: Simulate the driver's shard-aware algorithm trying to
+    # reach the overloaded shard.
+    #
+    # The driver keeps at most 1 spare connection per shard. When it
+    # gets a connection to a shard it already has a spare for, it
+    # closes the old spare (decrementing conntrack load) and stores
+    # the new one (already counted at accept time). Net effect on
+    # conntrack load: zero. So the imbalance persists and the driver
+    # is stuck in a loop.
+    #
+    spares = {}   # shard_id -> writer
+    max_attempts = 30
+    success = False
+
+    for attempt in range(1, max_attempts + 1):
+        r, w, shard = await connect_and_get_shard(host, CQL_PORT)
+
+        if shard == overloaded_shard:
+            logger.info("Reached overloaded shard %d on attempt %d", shard, attempt)
+            await close_conn(w)
+            success = True
+            break
+
+        logger.info("Attempt %d: wanted shard %d, got shard %d",
+                     attempt, overloaded_shard, shard)
+
+        # Driver behavior: keep at most 1 spare per shard.
+        if shard in spares:
+            await close_conn(spares[shard])
+        spares[shard] = w
+
+    for w in spares.values():
+        await close_conn(w)
+    for w in shard_conns[overloaded_shard]:
+        await close_conn(w)
+
+    assert success, (
+        f"Could not connect to shard {overloaded_shard} after {max_attempts} "
+        f"attempts — shard-aware retry loop is stuck (SCYLLADB-1618)"
+    )

--- a/test/perf/perf_generic_server.cc
+++ b/test/perf/perf_generic_server.cc
@@ -89,7 +89,7 @@ struct tester {
     }
 
     future<> start() {
-        return server.listen(addr(), nullptr, false, false, {});
+        return server.listen(addr(), nullptr, false, {});
     }
 
     future<> run() {

--- a/transport/controller.cc
+++ b/transport/controller.cc
@@ -76,8 +76,15 @@ future<> controller::start_server() {
 }
 
 static future<> listen_on_all_shards(sharded<cql_server>& cserver, socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> creds, bool is_shard_aware, bool keepalive, std::optional<file_permissions> unix_domain_socket_permissions, bool proxy_protocol = false) {
-    co_await cserver.invoke_on_all([addr, creds, is_shard_aware, keepalive, unix_domain_socket_permissions, proxy_protocol] (cql_server& server) {
-        return server.listen(addr, creds, is_shard_aware, keepalive, unix_domain_socket_permissions, proxy_protocol, [&c = server.container()]() -> auto& { return c.local(); });
+    // Non-shard-aware ports use round-robin to avoid the feedback loop
+    // between the conntrack load balancer and shard-aware driver retry
+    // logic (SCYLLADB-1618). Shard-aware ports use source-port-based
+    // routing.
+    auto lba = is_shard_aware
+        ? std::optional{server_socket::load_balancing_algorithm::port}
+        : std::optional{server_socket::load_balancing_algorithm::round_robin};
+    co_await cserver.invoke_on_all([addr, creds, keepalive, unix_domain_socket_permissions, proxy_protocol, lba] (cql_server& server) {
+        return server.listen(addr, creds, keepalive, unix_domain_socket_permissions, proxy_protocol, [&c = server.container()]() -> auto& { return c.local(); }, lba);
     });
 }
 

--- a/transport/generic_server.cc
+++ b/transport/generic_server.cc
@@ -313,7 +313,7 @@ future<> server::shutdown() {
 }
 
 future<>
-server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> builder, bool is_shard_aware, bool keepalive, std::optional<file_permissions> unix_domain_socket_permissions, bool proxy_protocol, std::function<server&()> get_shard_instance) {
+server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_builder> builder, bool keepalive, std::optional<file_permissions> unix_domain_socket_permissions, bool proxy_protocol, std::function<server&()> get_shard_instance, std::optional<server_socket::load_balancing_algorithm> lba) {
     // Note: We are making the assumption that if builder is provided it will be the same for each
     // invocation, regardless of address etc. In general, only CQL server will call this multiple times,
     // and if TLS, it will use the same cert set.
@@ -346,8 +346,8 @@ server::listen(socket_address addr, std::shared_ptr<seastar::tls::credentials_bu
     lo.reuse_address = true;
     lo.unix_domain_socket_permissions = unix_domain_socket_permissions;
     lo.proxy_protocol = proxy_protocol;
-    if (is_shard_aware) {
-        lo.lba = server_socket::load_balancing_algorithm::port;
+    if (lba) {
+        lo.lba = *lba;
     }
     server_socket ss;
     bool is_tls = false;

--- a/transport/generic_server.hh
+++ b/transport/generic_server.hh
@@ -144,10 +144,11 @@ public:
 
     future<> listen(socket_address addr,
         std::shared_ptr<seastar::tls::credentials_builder> creds,
-        bool is_shard_aware, bool keepalive,
+        bool keepalive,
         std::optional<file_permissions> unix_domain_socket_permissions,
         bool proxy_protocol = false,
-        std::function<server&()> get_shard_instance = {}
+        std::function<server&()> get_shard_instance = {},
+        std::optional<seastar::server_socket::load_balancing_algorithm> lba = {}
         );
 
     future<> do_accepts(int which, bool keepalive, socket_address server_addr, bool is_tls);


### PR DESCRIPTION
The algorithm for shard-aware connections over :9042 works like this:

 1. driver checks if there is spare connection for the shard it can steal (see step4)
 2. If not, driver makes a connection to :9042
 3. server on scylla side (shard 0) picks the shard according to load balancing policy (seastar::net::conntrack::load_balancer), which picks the shard which has the least amount of active connections created for that socket.
 4. driver checks which shard the connection landed on. If it’s the intended shard, the algorithm is done. If not, it is added to a cache of spare connections for the actual shard. If there is already a spare connection for the actual shard, the old one is closed. So the driver keeps at most 1 spare connection for shard.

This interacts badly with the load balancer, and can cause infinite retry loops where drivers are not able to connect to the shard they want.

Consider this simple example. If the initial conditions are such that there is permanent imbalance in active connections between shards, and the difference in load is larger than 1. A single driver which wants to establish connections to all shards will not be able to do that. Suppose it wants to connect to the shard which is most-loaded. It will first cycle over the less loaded shards, adding them as spares, which brings the load floor higher. But since the difference in load was more than 1, eventually it will hit one of the shards it already created a spare for. At which point it will close the connection of the old spare, reducing the load for that shard. So load stops changing, and the driver keeps getting that particular shard in a loop.

This problem shows up as constant CQL connection churn. It doesn’t stop the shard-aware request traffic, because the driver will pick another connection if there is no direct shard connection yet. It may make the driver use fewer connections, so can reduce effective concurrency for the client.

Connection churn has secondary effects too:
It was also observed to cause a higher load on the network-handling CPUs. It causes constant writes to audit tables because those connections go via authentication cycle.

This problem doesn't apply to connections to the 19042 port (advanced shard-awareness), where the shard is picked based on source port, and reflects the driver's intended shard. The driver will however fall back to 9042 if 19042 doesn't connect to the right shard, which is the case for setups where clients are behind NAT. We saw that in this case, the ratio of connections to 19042 vs 9042 is about 50/50.

Fixes: SCYLLADB-1618

Backport: no, because it's not a recent regression.

Depends on seastar PR: https://github.com/scylladb/seastar/pull/3371