### PR TITLE
test: fix memtable_snapshot_source to not yield inside scoped_critical_alloc_section

### DIFF
--- a/test/lib/memtable_snapshot_source.hh
+++ b/test/lib/memtable_snapshot_source.hh
@@ -91,7 +91,11 @@ public:
                 // Waiting on the future should not be covered by critical section.
                 f->get();
 
-                memory::scoped_critical_alloc_section dfg;
+                // compact() creates a reader_concurrency_semaphore_wrapper whose destructor
+                // calls stop().get(), which may yield. Holding scoped_critical_alloc_section
+                // across a yield point leaks the critical section counter to other fibers
+                // scheduled by the reactor, which corrupts with_allocation_failures() counting
+                // in test fibers. See: https://scylladb.atlassian.net/browse/SCYLLADB-1441
                 while (should_compact()) {
                     compact();
                 }


### PR DESCRIPTION
compact() creates a reader_concurrency_semaphore_wrapper whose destructor calls stop().get(), which can yield the fiber. The compactor loop was wrapping compact() in a scoped_critical_alloc_section, but since the critical section counter is reactor-local (not per-fiber), yielding inside it leaks the counter to other fibers scheduled while the compactor is suspended.

This corrupts with_allocation_failures() counting in test fibers: when is_critical_alloc_section() returns true, on_alloc_point() skips incrementing _alloc_count, causing bad_alloc to be thrown at an unexpected point — potentially in a noexcept context, leading to std::terminate.

Fix by removing the scoped_critical_alloc_section from the compact() loop. The guard was overly broad and weakened allocation failure testing by masking allocations inside compact() itself.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1441

Backport: test cleanup, no backport