### PR TITLE
docs: expand OCI Object Storage configuration section

### DIFF
--- a/docs/operating-scylla/admin.rst
+++ b/docs/operating-scylla/admin.rst
@@ -152,12 +152,39 @@ Using Oracle OCI Object Storage
 =================================
 
 Oracle Cloud Infrastructure (OCI) Object Storage is compatible with the Amazon
-S3 API, so it works with ScyllaDB without additional configuration.
+S3 API, so ScyllaDB can use it without any special configuration beyond
+specifying the OCI S3-compatible endpoint.
 
-To use OCI Object Storage, follow the same configuration as for AWS S3, and
-specify your OCI S3-compatible endpoint.
+**Endpoint URL format**
 
-Example:
+OCI S3-compatible endpoint URLs follow this pattern:
+
+.. code-block:: none
+
+   https://<namespace>.compat.objectstorage.<region>.oci.customer-oci.com:443
+
+Where:
+
+* ``<namespace>`` is your OCI Object Storage namespace.
+* ``<region>`` is the OCI region identifier, e.g. ``us-ashburn-1``.
+
+**Credentials**
+
+OCI does not expose an instance metadata endpoint compatible with AWS STS/EC2,
+so credentials **must** be supplied explicitly via environment variables. You
+need to create a Customer Secret Key in the OCI Console and set:
+
+.. code-block:: bash
+
+   export AWS_ACCESS_KEY_ID=<customer_secret_key_access_key>
+   export AWS_SECRET_ACCESS_KEY=<customer_secret_key_secret>
+
+.. note::
+
+   The ``iam_role_arn`` field is specific to AWS IAM and should be omitted
+   when configuring an OCI endpoint.
+
+**Configuration example**
 
 .. code:: yaml
 


### PR DESCRIPTION
The existing OCI section in admin.rst was a minimal stub that only showed a config snippet without explaining how to actually set up connectivity.

Add documentation for:
- The OCI S3-compatible endpoint URL format (namespace + region)
- How to find the OCI namespace via the Console or CLI
- That credentials must be set explicitly via AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY using OCI Customer Secret Keys (unlike AWS, OCI has no instance metadata fallback compatible with STS/EC2)
- A note that iam_role_arn is AWS-specific and should be omitted for OCI

Fixes: SCYLLADB-501

Backport: should be backported to 2026.2, which is the one where we debuted OCI support (at least documented it).