### PR TITLE
scylla-gdb: fix compaction-tasks command for intrusive list

### DIFF
--- a/scylla-gdb.py
+++ b/scylla-gdb.py
@@ -5466,10 +5466,9 @@ class scylla_compaction_tasks(gdb.Command):
         try:
             task_list = list(intrusive_list(cm['_tasks']))
         except gdb.error: # 6.2 compatibility
-            task_list = list(std_list(cm['_tasks']))
+            task_list = [seastar_shared_ptr(t).get().dereference() for t in std_list(cm['_tasks'])]
 
         for task in task_list:
-            task = seastar_shared_ptr(task).get().dereference()
             schema = schema_ptr(task['_compacting_table'].dereference()['_schema'])
             key = 'type={}, state={:5}, {}'.format(task['_type'], str(task['_state']), schema.table_name())
             task_hist.add(key)


### PR DESCRIPTION
Since commit e942c074f2 changed _tasks from std::list<shared_ptr<...>> to a boost::intrusive_list, iterating yields raw compaction_task_executor objects rather than shared_ptr wrappers. The GDB script was updated to use intrusive_list() but still wrapped elements in seastar_shared_ptr(), causing 'gdb.error: There is no member or method named _p' when compaction tasks are active.

Move the seastar_shared_ptr unwrapping to the 6.2 compatibility fallback path only, since the intrusive list path yields objects directly.

Fixes: SCYLLADB-1762

**e942c074f2 is very old commit, but this flaky seems to be rare, running it locally 1000 times passed. So i think we shouldn't backport it**