### PR TITLE
alternator/doc: update Streams compatibility docs

### DIFF
--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -277,53 +277,29 @@ is different, or can be configured in Alternator:
   The `alternator_describe_table_info_cache_validity_in_seconds` parameter allows
   users to change this timeout - the default value in seconds is set to 21600 (6 hours).
 
-## Experimental API features
+## Alternator Streams
 
-Some DynamoDB API features are supported by Alternator, but considered
-**experimental** in this release. An experimental feature in ScyllaDB is a
-feature whose functionality is complete, or mostly complete, but it is not
-as thoroughly tested or optimized as regular features. Also, an experimental
-feature's implementation is still subject to change and upgrades may not be
-possible if such a feature is used. For these reasons, experimental features
-are not recommended for mission-critical uses, and they need to be
-individually enabled with the "--experimental-features" configuration option.
-See [Enabling Experimental Features](../operating-scylla/admin.rst#enabling-experimental-features) for details.
+The API for CDC in DynamoDB is supported by Alternator, however
+Alternator Streams differ in some respects from DynamoDB Streams:
 
-In this release, the following DynamoDB API features are considered
-experimental:
-
-* The DynamoDB Streams API for capturing change is supported, but still
-  considered experimental so needs to be enabled explicitly with the
-  `--experimental-features=alternator-streams` configuration option.
-
-  Alternator streams also differ in some respects from DynamoDB Streams:
-  * The number of separate "shards" in Alternator's streams is significantly
-    larger than is typical on DynamoDB.
-    <https://github.com/scylladb/scylla/issues/13080>
-  * While in DynamoDB data usually appears in the stream less than a second
-    after it was written, in Alternator Streams there is currently a 10
-    second delay by default.
-    <https://github.com/scylladb/scylla/issues/6929>
-  * Some events are represented differently in Alternator Streams. For
-    example, a single PutItem is represented by a REMOVE + MODIFY event,
-    instead of just a single MODIFY or INSERT.
-    <https://github.com/scylladb/scylla/issues/6930>
-    <https://github.com/scylladb/scylla/issues/6918>
-  * In GetRecords responses, Alternator sets `eventSource` to
-    `scylladb:alternator`, rather than `aws:dynamodb`, and doesn't set the
-    `SizeBytes` subfield inside the `dynamodb` field.
-    <https://github.com/scylladb/scylla/issues/6931>
-  * The optional ShardFilter parameter to DescribeStream, added to DynamoDB
-    in July 2025 to optimize shard discovery, is not yet implemented in
-    Alternator.
-    <https://github.com/scylladb/scylla/issues/25160>
-  * With the ``alternator_streams_increased_compatibility`` configuration
-    option enabled, operations that do not change the database state
-    (e.g., deleting a non-existent item, removing a non-existent
-    attribute, or re-inserting an identical item) will not produce
-    stream events. Without this option, such no-op operations may still
-    generate spurious stream events.
-    <https://github.com/scylladb/scylladb/issues/28368>
+* The number of separate "shards" in Alternator's streams is significantly
+  larger than is typical on DynamoDB.
+  <https://github.com/scylladb/scylla/issues/13080>
+* While in DynamoDB data usually appears in the stream less than a second
+  after it was written, in Alternator Streams there is currently a 10
+  second delay by default.
+  <https://github.com/scylladb/scylla/issues/6929>
+* In GetRecords responses, Alternator sets `eventSource` to
+  `scylladb:alternator`, rather than `aws:dynamodb`, and doesn't set the
+  `SizeBytes` subfield inside the `dynamodb` field.
+  <https://github.com/scylladb/scylla/issues/6931>
+* With the `alternator_streams_increased_compatibility` configuration
+  option enabled, operations that do not change the database state
+  (e.g., deleting a non-existent item, removing a non-existent
+  attribute, or re-inserting an identical item) will not produce
+  stream events. Without this option, such no-op operations may still
+  generate spurious stream events.
+  <https://github.com/scylladb/scylladb/issues/28368>
 
 ## Unimplemented API features
 

--- a/docs/alternator/compatibility.md
+++ b/docs/alternator/compatibility.md
@@ -277,60 +277,49 @@ is different, or can be configured in Alternator:
   The `alternator_describe_table_info_cache_validity_in_seconds` parameter allows
   users to change this timeout - the default value in seconds is set to 21600 (6 hours).
 
-## Experimental API features
+## Alternator Streams
 
-Some DynamoDB API features are supported by Alternator, but considered
-**experimental** in this release. An experimental feature in ScyllaDB is a
-feature whose functionality is complete, or mostly complete, but it is not
-as thoroughly tested or optimized as regular features. Also, an experimental
-feature's implementation is still subject to change and upgrades may not be
-possible if such a feature is used. For these reasons, experimental features
-are not recommended for mission-critical uses, and they need to be
-individually enabled with the "--experimental-features" configuration option.
-See [Enabling Experimental Features](../operating-scylla/admin.rst#enabling-experimental-features) for details.
+The DynamoDB Streams API for change data capture is supported by Alternator, however
+Alternator Streams differ in some respects from DynamoDB Streams:
 
-In this release, the following DynamoDB API features are considered
-experimental:
+* The number of separate "shards" in Alternator's streams is significantly
+  larger than is typical on DynamoDB.
+  <https://github.com/scylladb/scylla/issues/13080>
+* While in DynamoDB data usually appears in the stream less than a second
+  after it was written, in Alternator Streams there is currently a 10
+  second delay by default.
+  <https://github.com/scylladb/scylla/issues/6929>
+* In GetRecords responses, Alternator sets `eventSource` to
+  `scylladb:alternator`, rather than `aws:dynamodb`, and doesn't set the
+  `SizeBytes` subfield inside the `dynamodb` field.
+  <https://github.com/scylladb/scylla/issues/6931>
+* By default (with `alternator_streams_increased_compatibility` off)
+  Alternator Streams are optimized for performance: write operations
+  do not read the previous state of the item, which has two
+  consequences:
+  1. Operations that did not really modify the data (e.g., deleting
+     a non-existent item, removing a non-existent attribute, or
+     re-inserting an identical item) may still produce spurious
+     stream events.
+  2. Alternator cannot distinguish between an INSERT (new item) and
+     a MODIFY (overwrite of an existing item), so event types may
+     be inaccurate — for example, a PutItem that overwrites an
+     existing item will be reported as INSERT instead of MODIFY.
 
-* The DynamoDB Streams API for capturing change is supported, but still
-  considered experimental so needs to be enabled explicitly with the
-  `--experimental-features=alternator-streams` configuration option.
-
-  Alternator streams also differ in some respects from DynamoDB Streams:
-  * The number of separate "shards" in Alternator's streams is significantly
-    larger than is typical on DynamoDB.
-    <https://github.com/scylladb/scylla/issues/13080>
-  * While in DynamoDB data usually appears in the stream less than a second
-    after it was written, in Alternator Streams there is currently a 10
-    second delay by default.
-    <https://github.com/scylladb/scylla/issues/6929>
-  * Some events are represented differently in Alternator Streams. For
-    example, a single PutItem is represented by a REMOVE + MODIFY event,
-    instead of just a single MODIFY or INSERT.
-    <https://github.com/scylladb/scylla/issues/6930>
-    <https://github.com/scylladb/scylla/issues/6918>
-  * In GetRecords responses, Alternator sets `eventSource` to
-    `scylladb:alternator`, rather than `aws:dynamodb`, and doesn't set the
-    `SizeBytes` subfield inside the `dynamodb` field.
-    <https://github.com/scylladb/scylla/issues/6931>
-  * The optional ShardFilter parameter to DescribeStream, added to DynamoDB
-    in July 2025 to optimize shard discovery, is not yet implemented in
-    Alternator.
-    <https://github.com/scylladb/scylla/issues/25160>
-  * With the ``alternator_streams_increased_compatibility`` configuration
-    option enabled, operations that do not change the database state
-    (e.g., deleting a non-existent item, removing a non-existent
-    attribute, or re-inserting an identical item) will not produce
-    stream events. Without this option, such no-op operations may still
-    generate spurious stream events.
-    <https://github.com/scylladb/scylladb/issues/28368>
-  * When a stream is disabled, no new records are written but the existing
-    stream data is preserved and remains readable through its original
-    StreamArn. The data expires via TTL after 24 hours. Re-enabling the
-    stream purges the old data immediately and produces a new StreamArn.
-    In contrast, DynamoDB keeps the old stream and its data readable for
-    24 hours through the old StreamArn even after re-enabling.
-    <https://scylladb.atlassian.net/browse/SCYLLADB-1873>
+  Enabling `alternator_streams_increased_compatibility` forces every
+  write to read the pre-image of the item, which fixes both issues
+  but at a performance cost — it effectively forces all writes
+  through the slower LWT (lightweight transaction) path. Enable this
+  option only if your application relies on the distinction between
+  INSERT and MODIFY events, or needs no-op writes to be silent.
+  <https://github.com/scylladb/scylladb/issues/28368>
+* When a stream is disabled, no new records are written but the existing
+  stream data is preserved and remains readable through its original
+  StreamArn. The data expires via TTL after 24 hours. Re-enabling the
+  stream purges the old data immediately and produces a new StreamArn.
+  In contrast, DynamoDB keeps the old stream and its data readable for
+  24 hours through the old StreamArn even after re-enabling.
+  <https://scylladb.atlassian.net/browse/SCYLLADB-1873>
 
 ## Unimplemented API features
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -126,10 +126,9 @@ To configure using :code:`scylla.yaml` file:
 
    .. code-block:: yaml
 
-      # Example: enabling UDF and Alternator Streams features
+      # Example: enabling the UDF feature
       experimental_features:
          - udf
-         - alternator-streams
 
 3. Save the file and exit.
 4. Restart the node.
@@ -142,13 +141,12 @@ To configure using :code:`scylla.yaml` file:
    
    :code:`$ docker stop <your_node> && docker start <your_node>`
 
-Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Alternator Streams:
+Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF:
 
 .. code-block:: console
 
    $ docker run --name <your_node> -d scylladb/scylla \
-       --experimental-features=udf \
-       --experimental-features=alternator-streams
+       --experimental-features=udf
 
 You should now be able to use the specified experimental features.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -126,10 +126,10 @@ To configure using :code:`scylla.yaml` file:
 
    .. code-block:: yaml
 
-      # Example: enabling UDF and Alternator Streams features
+      # Example: enabling UDF and Strongly Consistent Tables features
       experimental_features:
          - udf
-         - alternator-streams
+         - strongly-consistent-tables
 
 3. Save the file and exit.
 4. Restart the node.
@@ -142,13 +142,13 @@ To configure using :code:`scylla.yaml` file:
    
    :code:`$ docker stop <your_node> && docker start <your_node>`
 
-Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Alternator Streams:
+Alternately, starting from ScyllaDB 3.3, you can enable features directly via command line flags the :code:`--experimental-features` flag as follows. This command line options can be repeated multiple times. For example, to enable UDF and Strongly Consistent Tables:
 
 .. code-block:: console
 
    $ docker run --name <your_node> -d scylladb/scylla \
        --experimental-features=udf \
-       --experimental-features=alternator-streams
+       --experimental-features=strongly-consistent-tables
 
 You should now be able to use the specified experimental features.
 


### PR DESCRIPTION
Following #29604:
- Remove obsolete documentation that describes Alternator Streams as experimental.
- Remove the outdated `--experimental-features=alternator-streams` FAQ example.
- Drop stale implemented limitations for `ShardFilter` and PutItem stream events.

Fixes SCYLLADB-462

Needs to be backported to 2026.2 to align with the functionality described by the modified doc.