### PR TITLE
test/alternator: stop avoiding tablets in Streams tests

### DIFF
--- a/test/alternator/test_audit.py
+++ b/test/alternator/test_audit.py
@@ -476,8 +476,7 @@ def test_audit_query_table_operations(dynamodb, cql, alternator_audit_enabled):
 #     table is pipe-separated "base_table|cdc_table". CL=LOCAL_QUORUM.
 # Produces 5 audit entries.
 def test_audit_streams_operations(dynamodb, dynamodbstreams, cql, alternator_audit_enabled):
-    # With #23838 open, we will explicitly ask for a table with vnodes.
-    with new_test_table(dynamodb, StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"}, Tags=[{'Key': 'system:initial_tablets', 'Value': 'none'}], **HASH_ONLY_SCHEMA) as table:
+    with new_test_table(dynamodb, StreamSpecification={"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"}, **HASH_ONLY_SCHEMA) as table:
         ks_name = f"alternator_{table.name}"
         client = table.meta.client
         # Write data so that stream records exist.

--- a/test/alternator/test_ttl.py
+++ b/test/alternator/test_ttl.py
@@ -656,12 +656,6 @@ def test_ttl_expiration_lsi_key(dynamodb, waits_for_expiration):
 # content), and a special userIdentity flag saying that this is not a regular
 # REMOVE but an expiration. Reproduces issue #11523.
 def test_ttl_expiration_streams(dynamodb, dynamodbstreams, waits_for_expiration):
-    # Alternator Streams currently doesn't work with tablets, so until
-    # #23838 is solved, skip this test on tablets.
-    for tag in TAGS:
-        if tag['Key'] == 'system:initial_tablets' and tag['Value'].isdigit():
-            skip_bug("Streams test skipped on tablets due to #23838")
-
     # In my experiments, a 30-minute (1800 seconds) is the typical
     # expiration delay in this test. If the test doesn't finish within
     # max_duration, we report a failure.


### PR DESCRIPTION
Alternator Streams now supports tablets, so stop skipping the TTL Streams test in tablet mode and stop forcing vnodes in the Streams audit test.

Refs SCYLLADB-463

Backport to 2026.2 since that's where the triggering changes appeared.