### PR TITLE
Record all compaction types in history and add script to reconstruct logs from history

### DIFF
--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -457,11 +457,11 @@ future<compaction_result> compaction_task_executor::compact_sstables(compaction_
 
     co_return co_await ::compaction::compact_sstables(std::move(descriptor), cdata, t, _progress_monitor);
 }
-future<> compaction_task_executor::update_history(compaction_group_view& t, compaction_result&& res, const ::compaction::compaction_data& cdata) {
+future<> compaction_manager::update_history(compaction_group_view& t, compaction_result&& res, const ::compaction::compaction_data& cdata) {
     auto started_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.stats.started_at.time_since_epoch());
     auto ended_at = std::chrono::duration_cast<std::chrono::milliseconds>(res.stats.ended_at.time_since_epoch());
 
-    if (auto sys_ks = _cm._sys_ks.get_permit()) {
+    if (auto sys_ks = _sys_ks.get_permit()) {
         co_await utils::get_local_injector().inject("update_history_wait", utils::wait_for_message(120s));
         std::unordered_map<int32_t, int64_t> rows_merged;
         for (size_t id=0; id<res.stats.reader_statistics.rows_merged_histogram.size(); ++id) {
@@ -1601,9 +1601,10 @@ private:
             auto on_replace = compacting.update_on_sstable_replacement();
 
             try {
-                compaction_result _ = co_await compact_sstables(std::move(*desc), _compaction_data, on_replace,
+                compaction_result res = co_await compact_sstables(std::move(*desc), _compaction_data, on_replace,
                                                                           compaction_manager::can_purge_tombstones::no,
                                                                           sstables::offstrategy::yes);
+                co_await update_history(*_compacting_table, std::move(res), _compaction_data);
             } catch (compaction_stopped_exception&) {
                 // If off-strategy compaction stopped on user request, let's not discard the partial work.
                 // Therefore, both un-reshaped and reshaped data will be integrated into main set, allowing
@@ -1980,7 +1981,9 @@ private:
                     compaction_descriptor::default_max_sstable_bytes,
                     sst->run_identifier(),
                     compaction_type_options::make_scrub(compaction_type_options::scrub::mode::validate, _quarantine_sstables));
-            co_return co_await ::compaction::compact_sstables(std::move(desc), _compaction_data, *_compacting_table, _progress_monitor);
+            auto res = co_await ::compaction::compact_sstables(std::move(desc), _compaction_data, *_compacting_table, _progress_monitor);
+            co_await update_history(*_compacting_table, compaction_result(res), _compaction_data);
+            co_return res;
         } catch (compaction_stopped_exception&) {
             // ignore, will be handled by can_proceed()
         } catch (storage_io_error& e) {
@@ -2370,7 +2373,8 @@ compaction_manager::maybe_split_new_sstable(sstables::shared_sstable sst, compac
         std::move(d.new_sstables.begin(), d.new_sstables.end(), std::back_inserter(ret));
     };
 
-    co_await compact_sstables(std::move(desc), info, t, monitor);
+    auto res = co_await compact_sstables(std::move(desc), info, t, monitor);
+    co_await update_history(t, std::move(res), info);
     co_await sst->unlink();
 
     co_return ret;

--- a/compaction/compaction_manager.cc
+++ b/compaction/compaction_manager.cc
@@ -385,12 +385,8 @@ future<compaction_result> compaction_task_executor::compact_sstables_and_update_
         co_return compaction_result{};
     }
 
-    bool should_update_history = this->should_update_history(descriptor.options.type());
     compaction_result res = co_await compact_sstables(std::move(descriptor), cdata, on_replace, std::move(can_purge));
-
-    if (should_update_history) {
-        co_await update_history(*_compacting_table, compaction_result(res), cdata);
-    }
+    co_await update_history(*_compacting_table, compaction_result(res), cdata);
 
     co_return res;
 }
@@ -1444,27 +1440,24 @@ protected:
             std::exception_ptr ex;
 
             try {
-                bool should_update_history = this->should_update_history(descriptor.options.type());
                 compaction_result res = co_await compact_sstables(std::move(descriptor), _compaction_data, on_replace);
                 cmlog.debug("Finished minor compaction old_sstables={} new_sstables={} sstables_reapired_at={} range={} uuid={} compaction_uuid={}",
                         old_sstables, res.new_sstables, compacting_table()->get_sstables_repaired_at(), compacting_table()->token_range(), uuid, _compaction_data.compaction_uuid);
                 finish_compaction();
-                if (should_update_history) {
-                    // update_history can take a long time compared to
-                    // compaction, as a call issued on shard S1 can be
-                    // handled on shard S2. If the other shard is under
-                    // heavy load, we may unnecessarily block kicking off a
-                    // new compaction. Normally it isn't a problem, but there were
-                    // edge cases where the described behaviour caused
-                    // compaction to fail to keep up with excessive
-                    // flushing, leading to too many sstables on disk and
-                    // OOM during a read.  There is no need to wait with
-                    // next compaction until history is updated, so release
-                    // the weight earlier to remove unnecessary
-                    // serialization.
-                    weight_r.deregister();
-                    co_await update_history(*_compacting_table, std::move(res), _compaction_data);
-                }
+                // update_history can take a long time compared to
+                // compaction, as a call issued on shard S1 can be
+                // handled on shard S2. If the other shard is under
+                // heavy load, we may unnecessarily block kicking off a
+                // new compaction. Normally it isn't a problem, but there were
+                // edge cases where the described behaviour caused
+                // compaction to fail to keep up with excessive
+                // flushing, leading to too many sstables on disk and
+                // OOM during a read.  There is no need to wait with
+                // next compaction until history is updated, so release
+                // the weight earlier to remove unnecessary
+                // serialization.
+                weight_r.deregister();
+                co_await update_history(*_compacting_table, std::move(res), _compaction_data);
                 _cm.reevaluate_postponed_compactions();
                 continue;
             } catch (...) {

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -583,9 +583,6 @@ protected:
                                 compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes,
                                 sstables::offstrategy offstrategy = sstables::offstrategy::no);
     future<> update_history(::compaction::compaction_group_view& t, compaction_result&& res, const compaction_data& cdata);
-    bool should_update_history(compaction_type ct) {
-        return ct == compaction_type::Compaction || ct == compaction_type::Major;
-    }
 public:
     compaction_manager::compaction_stats_opt get_stats() const noexcept {
         return _stats;

--- a/compaction/compaction_manager.hh
+++ b/compaction/compaction_manager.hh
@@ -159,6 +159,8 @@ private:
     compaction_controller _compaction_controller;
     compaction_backlog_manager _backlog_manager;
     optimized_optional<abort_source::subscription> _early_abort_subscription;
+    future<> update_history(compaction_group_view& t, compaction_result&& res, const compaction_data& cdata);
+
     serialized_action _update_compaction_static_shares_action;
     utils::observer<float> _compaction_static_shares_observer;
     utils::observer<float> _compaction_max_shares_observer;
@@ -582,7 +584,10 @@ protected:
     future<compaction_result> compact_sstables(compaction_descriptor descriptor, compaction_data& cdata, on_replacement&,
                                 compaction_manager::can_purge_tombstones can_purge = compaction_manager::can_purge_tombstones::yes,
                                 sstables::offstrategy offstrategy = sstables::offstrategy::no);
-    future<> update_history(::compaction::compaction_group_view& t, compaction_result&& res, const compaction_data& cdata);
+    // Delegates to compaction_manager::update_history
+    future<> update_history(::compaction::compaction_group_view& t, compaction_result&& res, const compaction_data& cdata) {
+        return _cm.update_history(t, std::move(res), cdata);
+    }
 public:
     compaction_manager::compaction_stats_opt get_stats() const noexcept {
         return _stats;

--- a/scripts/inject_compaction_log.py
+++ b/scripts/inject_compaction_log.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+Reconstruct compaction start/end log entries from system.compaction_history
+and merge them into an existing Scylla log file.
+
+Usage:
+    python3 inject_compaction_log.py --log scylla.log --history compaction_history.txt -o merged.log
+
+The history input is the text output of `nodetool compactionhistory`.
+The script produces a merged log containing original log lines plus
+synthetic compaction start and finish entries, sorted by timestamp.
+
+The synthetic entries mimic the format produced by compaction::setup()
+(report_start_desc) and compaction::finish() (report_finish_desc) when
+the compaction logger is at debug level:
+
+  DEBUG ... compaction - [<type> <ks>.<cf> <uuid>] <Verb> [<sstables>]
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timezone, timedelta
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# Scylla log timestamp format: "INFO  2024-04-29 12:00:00,123 [shard ..."
+# or sometimes: "2024-04-29T12:00:00.123+0000 ..."
+LOG_TS_PATTERNS = [
+    # Standard Scylla: "INFO  2024-04-29 12:00:00,123"
+    re.compile(r'^[A-Z]+\s+(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d{3})'),
+    # ISO-ish: "2024-04-29T12:00:00.123"
+    re.compile(r'^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.,]\d{3})'),
+]
+
+
+@dataclass
+class HistoryEntry:
+    id: str
+    shard_id: int
+    ks: str
+    cf: str
+    compaction_type: str
+    started_at: datetime
+    compacted_at: datetime
+    bytes_in: int
+    bytes_out: int
+    rows_merged: str
+    sstables_in: str
+    sstables_out: str
+
+
+# Map compaction_type to the verbs used in log messages
+COMPACTION_TYPE_START_VERB = {
+    "Compaction": "Compacting",
+    "Major":      "Compacting",
+    "Cleanup":    "Cleaning",
+    "Scrub":      "Scrubbing",
+    "Reshape":    "Reshaping",
+    "Reshard":    "Resharding",
+    "Upgrade":    "Upgrading",
+    "Split":      "Splitting",
+}
+
+COMPACTION_TYPE_FINISH_VERB = {
+    "Compaction": "Compacted",
+    "Major":      "Compacted",
+    "Cleanup":    "Cleaned",
+    "Scrub":      "Finished scrubbing",
+    "Reshape":    "Reshaped",
+    "Reshard":    "Resharded",
+    "Upgrade":    "Upgraded",
+    "Split":      "Split",
+}
+
+
+def pretty_size(nbytes: int) -> str:
+    for unit in ("bytes", "KB", "MB", "GB", "TB"):
+        if abs(nbytes) < 1024:
+            if unit == "bytes":
+                return f"{nbytes} {unit}"
+            return f"{nbytes:.2f} {unit}"
+        nbytes /= 1024.0
+    return f"{nbytes:.2f} PB"
+
+
+def pretty_throughput(nbytes: int, duration_ms: int) -> str:
+    if duration_ms <= 0:
+        return "N/A"
+    bps = nbytes / (duration_ms / 1000.0)
+    return f"{pretty_size(int(bps))}/s"
+
+
+def parse_log_timestamp(line: str) -> Optional[datetime]:
+    for pat in LOG_TS_PATTERNS:
+        m = pat.match(line)
+        if m:
+            ts_str = m.group(1)
+            ts_str = ts_str.replace(",", ".")
+            ts_str = ts_str.replace("T", " ")
+            try:
+                return datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f")
+            except ValueError:
+                pass
+    return None
+
+
+def format_ts_for_log(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%d %H:%M:%S,%f")[:23]
+
+
+def parse_history_ts(ts_str: str) -> datetime:
+    ts_str = ts_str.strip()
+    # Handle variable fractional second precision
+    try:
+        return datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S.%f")
+    except ValueError:
+        return datetime.strptime(ts_str, "%Y-%m-%dT%H:%M:%S")
+
+
+def format_sstable_list(sstables: list) -> str:
+    """Format a list of sstable dicts into the log representation."""
+    if not sstables:
+        return "N/A"
+    parts = []
+    for sst in sstables:
+        if isinstance(sst, dict):
+            gen = sst.get("generation", "?")
+            origin = sst.get("origin", "?")
+            size = sst.get("size", 0)
+            parts.append(f"gen={gen}:origin={origin}:size={size}")
+        else:
+            parts.append(str(sst))
+    return ",".join(parts)
+
+
+def parse_compaction_history_json(history_file: str) -> list:
+    """Parse JSON output of `nodetool compactionhistory -F json`."""
+    with open(history_file, "r") as f:
+        data = json.load(f)
+
+    history_list = data.get("CompactionHistory", data) if isinstance(data, dict) else data
+
+    entries = []
+    for e in history_list:
+        started_at_ms = e.get("started_at")
+        compacted_at_ms = e.get("compacted_at")
+
+        # JSON timestamps are either epoch millis (int) or ISO strings
+        if isinstance(started_at_ms, int):
+            started_at = datetime.fromtimestamp(started_at_ms / 1000.0)
+        else:
+            started_at = parse_history_ts(str(started_at_ms))
+
+        if isinstance(compacted_at_ms, int):
+            compacted_at = datetime.fromtimestamp(compacted_at_ms / 1000.0)
+        else:
+            compacted_at = parse_history_ts(str(compacted_at_ms))
+
+        sstables_in = e.get("sstables_in", [])
+        sstables_out = e.get("sstables_out", [])
+
+        entries.append(HistoryEntry(
+            id=e.get("id", ""),
+            shard_id=int(e.get("shard_id", 0)),
+            ks=e.get("keyspace_name", e.get("ks", "")),
+            cf=e.get("columnfamily_name", e.get("cf", "")),
+            compaction_type=e.get("compaction_type", ""),
+            started_at=started_at,
+            compacted_at=compacted_at,
+            bytes_in=int(e.get("bytes_in", 0)),
+            bytes_out=int(e.get("bytes_out", 0)),
+            rows_merged=str(e.get("rows_merged", {})),
+            sstables_in=format_sstable_list(sstables_in),
+            sstables_out=format_sstable_list(sstables_out),
+        ))
+    return entries
+
+
+def parse_compaction_history_text(history_file: str) -> list:
+    """Parse the text output of `nodetool compactionhistory`."""
+    entries = []
+
+    with open(history_file, "r") as f:
+        lines = f.readlines()
+
+    # Find header line to get column positions
+    header_idx = None
+    for i, line in enumerate(lines):
+        if "id" in line and "keyspace_name" in line and "compaction_type" in line:
+            header_idx = i
+            break
+
+    if header_idx is None:
+        print("Error: could not find header row in compaction history text output", file=sys.stderr)
+        sys.exit(1)
+
+    header = lines[header_idx]
+
+    # Extract column names and their start positions
+    col_names = header.split()
+    col_starts = []
+    pos = 0
+    for name in col_names:
+        idx = header.index(name, pos)
+        col_starts.append(idx)
+        pos = idx + len(name)
+
+    def extract_columns(line: str) -> dict:
+        parts = {}
+        for i, name in enumerate(col_names):
+            start = col_starts[i]
+            end = col_starts[i + 1] if i + 1 < len(col_names) else len(line)
+            parts[name] = line[start:end].strip()
+        return parts
+
+    for line in lines[header_idx + 1:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        cols = extract_columns(line)
+
+        try:
+            entry = HistoryEntry(
+                id=cols.get("id", ""),
+                shard_id=int(cols.get("shard_id", "0")),
+                ks=cols.get("keyspace_name", ""),
+                cf=cols.get("columnfamily_name", ""),
+                compaction_type=cols.get("compaction_type", ""),
+                started_at=parse_history_ts(cols.get("started_at", "")),
+                compacted_at=parse_history_ts(cols.get("compacted_at", "")),
+                bytes_in=int(cols.get("bytes_in", "0")),
+                bytes_out=int(cols.get("bytes_out", "0")),
+                rows_merged=cols.get("rows_merged", "{}"),
+                sstables_in=cols.get("sstables_in", "N/A"),
+                sstables_out=cols.get("sstables_out", "N/A"),
+            )
+            entries.append(entry)
+        except (ValueError, KeyError) as e:
+            print(f"Warning: skipping malformed history line: {stripped!r} ({e})", file=sys.stderr)
+
+    return entries
+
+
+def parse_compaction_history(history_file: str) -> list:
+    """Auto-detect format (JSON or text) and parse accordingly."""
+    with open(history_file, "r") as f:
+        first_chars = f.read(64).lstrip()
+
+    if first_chars.startswith("{") or first_chars.startswith("["):
+        print("Detected JSON format for compaction history input.", file=sys.stderr)
+        return parse_compaction_history_json(history_file)
+    else:
+        print("Detected text format for compaction history input.", file=sys.stderr)
+        print("Hint: for best results, use `nodetool compactionhistory -F json` to generate the input.",
+              file=sys.stderr)
+        return parse_compaction_history_text(history_file)
+
+
+def make_start_line(entry: HistoryEntry) -> str:
+    """Generate a synthetic log line for compaction start."""
+    verb = COMPACTION_TYPE_START_VERB.get(entry.compaction_type, "Compacting")
+    ts = format_ts_for_log(entry.started_at)
+
+    return (
+        f"DEBUG {ts} [shard {entry.shard_id}] compaction - "
+        f"[{entry.compaction_type} {entry.ks}.{entry.cf} {entry.id}] "
+        f"{verb} [{entry.sstables_in}]"
+    )
+
+
+def make_finish_line(entry: HistoryEntry) -> str:
+    """Generate a synthetic log line for compaction finish."""
+    verb = COMPACTION_TYPE_FINISH_VERB.get(entry.compaction_type, "Compacted")
+    ts = format_ts_for_log(entry.compacted_at)
+
+    duration_ms = int((entry.compacted_at - entry.started_at).total_seconds() * 1000)
+    ratio = (entry.bytes_out / entry.bytes_in * 100) if entry.bytes_in > 0 else 0
+    throughput = pretty_throughput(entry.bytes_in, duration_ms)
+
+    # Count input sstables from the sstables_in field
+    num_sstables_in = entry.sstables_in.count("gen=") if entry.sstables_in != "N/A" else 0
+
+    return (
+        f"DEBUG {ts} [shard {entry.shard_id}] compaction - "
+        f"[{entry.compaction_type} {entry.ks}.{entry.cf} {entry.id}] "
+        f"{verb} {num_sstables_in} sstables to [{entry.sstables_out}]. "
+        f"{pretty_size(entry.bytes_in)} to {pretty_size(entry.bytes_out)} "
+        f"(~{int(ratio)}% of original) in {duration_ms}ms = {throughput}."
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge compaction history entries into a Scylla log as synthetic compaction start/end messages."
+    )
+    parser.add_argument("--log", required=True, help="Path to the original Scylla log file")
+    parser.add_argument("--history", required=True,
+                        help="Path to the nodetool compactionhistory text output")
+    parser.add_argument("-o", "--output", default="-",
+                        help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    entries = parse_compaction_history(args.history)
+    if not entries:
+        print("Warning: no compaction history entries found", file=sys.stderr)
+
+    # Build list of (timestamp, line) for synthetic entries
+    synthetic = []
+    for e in entries:
+        synthetic.append((e.started_at, make_start_line(e)))
+        synthetic.append((e.compacted_at, make_finish_line(e)))
+
+    synthetic.sort(key=lambda x: x[0])
+
+    # Read original log
+    with open(args.log, "r") as f:
+        log_lines = f.readlines()
+
+    # Merge: walk through log lines and synthetic entries together
+    out_lines = []
+    syn_idx = 0
+
+    for line in log_lines:
+        log_ts = parse_log_timestamp(line)
+
+        # Insert any synthetic entries that come before this log line
+        while syn_idx < len(synthetic) and log_ts is not None and synthetic[syn_idx][0] <= log_ts:
+            out_lines.append(synthetic[syn_idx][1] + "\n")
+            syn_idx += 1
+
+        out_lines.append(line if line.endswith("\n") else line + "\n")
+
+    # Append any remaining synthetic entries (after the last log line)
+    while syn_idx < len(synthetic):
+        out_lines.append(synthetic[syn_idx][1] + "\n")
+        syn_idx += 1
+
+    if args.output == "-":
+        sys.stdout.writelines(out_lines)
+    else:
+        with open(args.output, "w") as f:
+            f.writelines(out_lines)
+
+    print(f"Injected {len(synthetic)} synthetic compaction log entries "
+          f"({len(entries)} start + {len(entries)} finish) from {len(entries)} history records.",
+          file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Since the compaction log was demoted to debug level, the compaction
history system table is the primary way to reconstruct what happened.

Previously only regular (minor) and major compactions were recorded.
Remove the should_update_history() filter entirely so all compaction
types (Cleanup, Scrub, Upgrade, Reshape, Reshard, etc.) are persisted,
giving operators full visibility into compaction activity.

--
Since the compaction log was demoted to debug level, operators lost
visibility into compaction activity in production logs. This script
reconstructs synthetic compaction start/end log entries from
system.compaction_history and merges them into an existing Scylla log,
sorted by timestamp.

It accepts JSON (recommended) or text output from
`nodetool compactionhistory` and produces log entries matching the
format of report_start_desc() and report_finish_desc().

Example input log:

```
  INFO  2026-04-29 10:00:00,100 [shard 0] init - starting
  INFO  2026-04-29 10:00:12,000 [shard 0] compaction_manager - task
  INFO  2026-04-29 10:01:00,000 [shard 0] database - flush
```

Example compaction history entry (JSON):

```
  {"id":"aaa...","shard_id":0,"keyspace_name":"ks1",
   "columnfamily_name":"cf1","compaction_type":"Compaction",
   "started_at":"2026-04-29T10:00:10.000",
   "compacted_at":"2026-04-29T10:00:25.300",
   "bytes_in":67108864,"bytes_out":33554432,
   "sstables_in":[{"generation":"42","origin":"local","size":33554432},
                  {"generation":"43","origin":"local","size":33554432}],
   "sstables_out":[{"generation":"44","origin":"local","size":33554432}]}
```

Example output (merged):

```
  INFO  2026-04-29 10:00:00,100 [shard 0] init - starting
  DEBUG 2026-04-29 10:00:10,000 [shard 0] compaction - [Compaction ks1.cf1 aaa...] Compacting [gen=42:origin=local:size=33554432,gen=43:origin=local:size=33554432]
  INFO  2026-04-29 10:00:12,000 [shard 0] compaction_manager - task
  DEBUG 2026-04-29 10:00:25,300 [shard 0] compaction - [Compaction ks1.cf1 aaa...] Compacted 2 sstables to [gen=44:origin=local:size=33554432]. 64.00 MB to 32.00 MB (~50% of original) in 15300ms = 4.18 MB/s.
  INFO  2026-04-29 10:01:00,000 [shard 0] database - flush
```

Usage:
```
  nodetool compactionhistory -F json > history.json
  python3 scripts/inject_compaction_log.py \
    --log scylla.log --history history.json -o merged.log
```


Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1773.