### PR TITLE
LWT: avoid oversized contiguous allocation in save_paxos_proposal/decision

### DIFF
--- a/service/paxos/paxos_state.cc
+++ b/service/paxos/paxos_state.cc
@@ -30,6 +30,11 @@
 #include "idl/frozen_mutation.dist.hh"
 #include "idl/frozen_mutation.dist.impl.hh"
 
+#include "bytes_ostream.hh"
+#include "mutation/mutation.hh"
+#include "mutation/atomic_cell.hh"
+#include "mutation/timestamp.hh"
+
 namespace service::paxos {
 
 logging::logger paxos_state::logger("paxos");
@@ -581,20 +586,51 @@ future<> paxos_store::save_paxos_promise(const schema& s, const partition_key& k
 
 future<> paxos_store::save_paxos_proposal(const schema& s, const proposal& proposal, db::timeout_clock::time_point timeout) {
     const auto state_schema = co_await get_paxos_state_schema(s, timeout);
+
+    // The following code is equivalent to the CQL statement:
+    // UPDATE state_schema USING TIMESTAMP ? AND TTL ? SET promise = ?,
+    //    proposal_ballot = ?, proposal = ? WHERE row_key = ?
+    // But "proposal" can be large and CQL requires a contiguous bytes
+    // buffer for blob parameters (this was issue #8183). So we build the
+    // mutation directly using bytes_ostream for proposal's serialization.
     partition_key_view key = proposal.update.key();
-    co_await execute_cql_with_timeout(
-            format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET promise = ?, proposal_ballot = ?, proposal = ? WHERE row_key = ?{}", 
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
-            timeout,
-            utils::UUID_gen::micros_timestamp(proposal.ballot),
-            paxos_ttl_sec(s),
-            proposal.ballot,
-            proposal.ballot,
-            ser::serialize_to_buffer<bytes>(proposal.update),
-            to_legacy(*key.get_compound_type(s), key.representation())
-        );
+    mutation m{state_schema, partition_key::from_single_value(
+        *state_schema,
+        to_legacy(*key.get_compound_type(s), key.representation()))};
+
+    // Clustering key: cf_id for system.paxos (vnodes), empty for per-table
+    // paxos (tablets).
+    const clustering_key ck = state_schema->cf_name() == db::system_keyspace::PAXOS
+        ? clustering_key::from_single_value(*state_schema, uuid_type->decompose(data_value(s.id().uuid())))
+        : clustering_key::make_empty();
+
+    const api::timestamp_type ts = utils::UUID_gen::micros_timestamp(proposal.ballot);
+    const gc_clock::duration ttl_dur{paxos_ttl_sec(s)};
+    const gc_clock::time_point expiry = gc_clock::now() + ttl_dur;
+
+    // Write proposal.ballot to both "promise" and "proposal_ballot" columns.
+    const auto ballot_bytes = timeuuid_type->decompose(data_value(timeuuid_native_type{proposal.ballot}));
+    const column_definition& promise_cdef = *state_schema->get_column_definition("promise");
+    const column_definition& proposal_ballot_cdef = *state_schema->get_column_definition("proposal_ballot");
+    m.set_clustered_cell(ck, promise_cdef,
+        atomic_cell::make_live(*promise_cdef.type, ts, bytes_view(ballot_bytes), expiry, ttl_dur));
+    m.set_clustered_cell(ck, proposal_ballot_cdef,
+        atomic_cell::make_live(*proposal_ballot_cdef.type, ts, bytes_view(ballot_bytes), expiry, ttl_dur));
+
+    // Write the serialized proposal.update to the "proposal" column,
+    // without a contiguous allocation for the entire serialized blob.
+    const column_definition& proposal_cdef = *state_schema->get_column_definition("proposal");
+    bytes_ostream serialized_proposal;
+    ser::serialize(serialized_proposal, proposal.update);
+    auto it = serialized_proposal.begin();
+    const bytes_view first_frag = it != serialized_proposal.end() ? *it++ : bytes_view{};
+    const ser::buffer_view<bytes_ostream::fragment_iterator> proposal_bv{
+        first_frag, serialized_proposal.size(), it};
+    m.set_clustered_cell(ck, proposal_cdef,
+        atomic_cell::make_live(*proposal_cdef.type, ts, proposal_bv, expiry, ttl_dur));
+
+    co_await _sys_ks.query_processor().proxy().mutate_locally(
+        m, nullptr, db::commitlog::force_sync(state_schema->static_props().wait_for_sync_to_commitlog), timeout);
 }
 
 future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decision, db::timeout_clock::time_point timeout) {
@@ -607,19 +643,44 @@ future<> paxos_store::save_paxos_decision(const schema& s, const proposal& decis
     // sp::begin_and_repair_paxos will exclude an accepted proposal if it is older than the most
     // recent commit.
     partition_key_view key = decision.update.key();
-    co_await execute_cql_with_timeout(
-            format("UPDATE \"{}\".\"{}\" USING TIMESTAMP ? AND TTL ? SET proposal_ballot = null, proposal = null, "
-                   "most_recent_commit_at = ?, most_recent_commit = ? WHERE row_key = ?{}",
-                state_schema->ks_name(), state_schema->cf_name(), 
-                paxos_state_cf_filter(s, *state_schema)
-            ),
-            timeout,
-            utils::UUID_gen::micros_timestamp(decision.ballot),
-            paxos_ttl_sec(s),
-            decision.ballot,
-            ser::serialize_to_buffer<bytes>(decision.update),
-            to_legacy(*key.get_compound_type(s), key.representation())
-        );
+
+    const auto row_key = to_legacy(*key.get_compound_type(s), key.representation());
+    mutation m{state_schema, partition_key::from_single_value(*state_schema, row_key)};
+
+    const clustering_key ck = state_schema->cf_name() == db::system_keyspace::PAXOS
+        ? clustering_key::from_single_value(*state_schema, uuid_type->decompose(data_value(s.id().uuid())))
+        : clustering_key::make_empty();
+
+    const api::timestamp_type ts = utils::UUID_gen::micros_timestamp(decision.ballot);
+    const gc_clock::duration ttl_dur{paxos_ttl_sec(s)};
+    const gc_clock::time_point expiry = gc_clock::now() + ttl_dur;
+    const gc_clock::time_point now = gc_clock::now();
+
+    const column_definition& proposal_ballot_cdef = *state_schema->get_column_definition("proposal_ballot");
+    const column_definition& proposal_cdef = *state_schema->get_column_definition("proposal");
+    const column_definition& most_recent_commit_at_cdef = *state_schema->get_column_definition("most_recent_commit_at");
+    const column_definition& most_recent_commit_cdef = *state_schema->get_column_definition("most_recent_commit");
+
+    // SET proposal_ballot = null, proposal = null: create tombstones.
+    m.set_clustered_cell(ck, proposal_ballot_cdef, atomic_cell::make_dead(ts, now));
+    m.set_clustered_cell(ck, proposal_cdef, atomic_cell::make_dead(ts, now));
+
+    const auto ballot_bytes = timeuuid_type->decompose(data_value(timeuuid_native_type{decision.ballot}));
+    m.set_clustered_cell(ck, most_recent_commit_at_cdef,
+        atomic_cell::make_live(*most_recent_commit_at_cdef.type, ts, bytes_view(ballot_bytes), expiry, ttl_dur));
+
+    // Pass the serialized_decision as a fragmented buffer_view to avoid a large contiguous allocation.
+    bytes_ostream serialized_decision;
+    ser::serialize(serialized_decision, decision.update);
+    auto it = serialized_decision.begin();
+    const bytes_view first_frag = it != serialized_decision.end() ? *it++ : bytes_view{};
+    const ser::buffer_view<bytes_ostream::fragment_iterator> decision_bv{
+        first_frag, serialized_decision.size(), it};
+    m.set_clustered_cell(ck, most_recent_commit_cdef,
+        atomic_cell::make_live(*most_recent_commit_cdef.type, ts, decision_bv, expiry, ttl_dur));
+
+    co_await _sys_ks.query_processor().proxy().mutate_locally(
+        m, nullptr, db::commitlog::force_sync(state_schema->static_props().wait_for_sync_to_commitlog), timeout);
 }
 
 future<> paxos_store::delete_paxos_decision(const schema& s, const partition_key& key, utils::UUID ballot, db::timeout_clock::time_point timeout) {

--- a/test/alternator/test_logs.py
+++ b/test/alternator/test_logs.py
@@ -35,7 +35,7 @@ from botocore.exceptions import ClientError
 
 from test.pylib.skip_types import skip_env
 
-from .util import new_test_table, scylla_config_temporary
+from .util import new_test_table, scylla_config_temporary, random_string, full_query
 from .test_cql_rbac import new_dynamodb, new_role
 
 # Utility function for trying to find a local process which is listening to
@@ -158,7 +158,7 @@ def wait_for_log(logfile, pattern, re_flags=re.MULTILINE, timeout=5):
     contents = logfile.read()
     prog = re.compile(pattern, re_flags)
     if prog.search(contents):
-        return
+        return contents
     end = time.time() + timeout
     while time.time() < end:
         s = logfile.read()
@@ -168,7 +168,7 @@ def wait_for_log(logfile, pattern, re_flags=re.MULTILINE, timeout=5):
             # the entire content since the beginning of this wait :-(
             contents = contents + s
             if prog.search(contents):
-                return
+                return contents
         time.sleep(0.1)
     pytest.fail(f'Timed out ({timeout} seconds) looking for {pattern} in log file. Got:\n' + contents)
 
@@ -273,3 +273,36 @@ def test_log_authorization_failure(dynamodb, cql, logfile, test_table_s, enforce
                 else:
                     assert operation_succeeded
                 wait_for_log(logfile, f'^WARN .*SELECT access on table.*{test_table_s.name} is denied to role {role}.*client address')
+
+
+# A variant of test_batch.py::test_batch_write_item_large that uses the
+# always_use_lwt write isolation mode, so the large batch is guaranteed
+# to be written using LWT. This reproduced issue #8183: a large LWT write
+# from BatchWriteItem could cause an oversized contiguous allocation inside
+# paxos_response_handler::accept_proposal. Before the fix for #8183, this
+# test would elicit an "oversized allocation" error in Scylla's log, which
+# this test detects.
+def test_batch_write_item_large_lwt_allocation(dynamodb, logfile):
+    with new_test_table(dynamodb,
+            Tags=[{'Key': 'system:write_isolation', 'Value': 'always_use_lwt'}],
+            KeySchema=[ { 'AttributeName': 'p', 'KeyType': 'HASH' }, { 'AttributeName': 'c', 'KeyType': 'RANGE' } ],
+            AttributeDefinitions=[ { 'AttributeName': 'p', 'AttributeType': 'S' }, { 'AttributeName': 'c', 'AttributeType': 'N' } ]) as table:
+        long_content = 'x'*50000
+        p = random_string()
+        request_items = {
+            table.name: [{'PutRequest': {'Item': {'p': p, 'c': i, 'content': long_content}}} for i in range(25)]
+        }
+        write_reply = table.meta.client.batch_write_item(RequestItems=request_items)
+        # In Alternator (all tests in this file are scylla_only) so the
+        # entire batch write is accepted - there are no WCU limits.
+        assert write_reply['UnprocessedItems'] == {}
+        # Sanity check - check that the write was successfully done by
+        # reading the items back.
+        assert full_query(table, KeyConditionExpression='p=:p', ExpressionAttributeValues={':p': p}
+            ) == [{'p': p, 'c': i, 'content': long_content} for i in range(25)]
+    # Wait for the log message about the table being dropped. Any log
+    # messages related to the earlier batch write will have to have been
+    # flushed earlier and we'll be able to see them.
+    contents = wait_for_log(logfile, f'Dropping keyspace alternator_{table.name}')
+    # Check that no "oversized allocation" error was logged.
+    assert 'oversized allocation' not in contents


### PR DESCRIPTION
This patch fixes an oversized contiguous allocation when LWT is used to write a large mutation. The large allocation was reported in issue #8183 in the context of Alternator: a large `BatchWriteItem` request that uses `always_use_lwt` write isolation mode triggered an oversized allocation warning.

`paxos_store::save_paxos_proposal` and `save_paxos_decision` previously serialized the `frozen_mutation` as a CQL blob parameter using `ser::serialize_to_buffer<bytes>()`. Because `bytes` is a contiguous sstring, this allocated a single buffer large enough to hold the entire serialized mutation. For a large `BatchWriteItem` request going through the `always_use_lwt` write isolation mode (25 items × ~50 KB each), this produced a ~1.2 MB contiguous allocation per item, triggering seastar's oversized-allocation warnings. Reported as issue #8183.

Unfortunately, the CQL interface used in these functions *has* to use the contiguous "bytes", because data_value for blob columns stores a "bytes" object - there is no managed_bytes alternative.

So the workaround is to bypass CQL and instead construct a `mutation` object manually and call `mutate_locally()`. The frozen mutation is serialized into a `bytes_ostream` (fragmented, no large contiguous allocation), and passed to `atomic_cell::make_live()` via a `ser::buffer_view<bytes_ostream::fragment_iterator>`, which stores it in `managed_bytes` (also fragmented). This eliminates the oversized allocation on the write path without changing the on-disk or on-wire format.

Note: the bug was not reproducible since commit 76a766cab0 (Apr 2024), which switched the Alternator test suite from `always_use_lwt` to `only_rmw_uses_lwt`, causing plain writes to bypass the Paxos path entirely.
A new test `test_batch_write_item_large_lwt_allocation` in   `test/alternator/test_logs.py` explicitly exercises the `always_use_lwt` mode to reproduce the bug and verify its fix - the test looks for the  "oversized allocation" message in the log.


Fixes #8183

No need to backport this patch, this problem is known for five years and the sky didn't fall.