### PR TITLE
test: enforce get_ready_cql() before get_cql() to eliminate post-topology-change races

### DIFF
--- a/test/cluster/auth_cluster/test_attach_service_level_to_user.py
+++ b/test/cluster/auth_cluster/test_attach_service_level_to_user.py
@@ -9,7 +9,7 @@ import asyncio
 import logging
 import pytest
 from test.pylib.rest_client import read_barrier, get_host_api_address
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.cluster.auth_cluster import extra_scylla_config_options as auth_config
 
@@ -20,9 +20,8 @@ async def test_attach_service_level_to_user(request, manager: ManagerClient):
     # Start nodes with correct topology
     servers = await manager.servers_add(3, config=auth_config)
 
-    cql = manager.get_cql()
     logging.info("Waiting until driver connects to every server")
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     ips = [get_host_api_address(host) for host in hosts]
 
     logging.info("Creating User")

--- a/test/cluster/auth_cluster/test_auth_no_quorum.py
+++ b/test/cluster/auth_cluster/test_auth_no_quorum.py
@@ -54,7 +54,8 @@ async def test_auth_no_quorum(manager: ManagerClient) -> None:
     for role in roles:
         await manager.driver_connect(server=alive_server,
             auth_provider=PlainTextAuthProvider(username=role, password=role))
-    names = [row.role for row in await manager.get_cql().run_async(f"LIST ROLES", execution_profile='whitelist')]
+    cql, _ = await manager.get_ready_cql([alive_server])
+    names = [row.role for row in await cql.run_async(f"LIST ROLES", execution_profile='whitelist')]
     assert set(names) == set(roles)
 
 """

--- a/test/cluster/auth_cluster/test_auth_no_quorum.py
+++ b/test/cluster/auth_cluster/test_auth_no_quorum.py
@@ -64,9 +64,7 @@ Tests raft snapshot transfer of auth data.
 async def test_auth_raft_snapshot_transfer(manager: ManagerClient) -> None:
     servers = await manager.servers_add(1, config=auth_config)
 
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await manager.servers_see_each_other(servers)
+    cql, _ = await manager.get_ready_cql(servers)
 
     roles = ["ro" + unique_name() for _ in range(10)]
     for role in roles:

--- a/test/cluster/auth_cluster/test_connection_stage.py
+++ b/test/cluster/auth_cluster/test_connection_stage.py
@@ -28,7 +28,7 @@ import time
 import pytest
 from cassandra.auth import PlainTextAuthProvider
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for
+from test.pylib.util import wait_for
 
 
 logger = logging.getLogger(__name__)
@@ -82,8 +82,7 @@ async def test_connection_stage_ready_after_auth(manager: ManagerClient, auth_ty
         if auth_type == "password" else None
 
     await manager.driver_connect(server=server, auth_provider=auth_provider)
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
 
     async def all_connections_ready():
         rows = list(cql.execute(

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -239,7 +239,7 @@ async def test_shares_check(manager: ManagerClient):
 
     sl1 = f"sl_{unique_name()}"
     sl2 = f"sl_{unique_name()}"
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([srv])
 
     await cql.run_async(f"CREATE SERVICE LEVEL {sl1}")
     with pytest.raises(InvalidRequest, match="`shares` option can only be used when the cluster is fully upgraded to enterprise"):

--- a/test/cluster/auth_cluster/test_raft_service_levels.py
+++ b/test/cluster/auth_cluster/test_raft_service_levels.py
@@ -33,9 +33,7 @@ async def test_service_levels_snapshot(manager: ManagerClient):
         Stop 3 `old` servers and query the new server to validete if it has the same service levels.
     """
     servers = await manager.servers_add(3, config=auth_config)
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await manager.servers_see_each_other(servers)
+    cql, _ = await manager.get_ready_cql(servers)
 
     sls = ["sl" + unique_name() for _ in range(5)]
     for sl in sls:
@@ -50,8 +48,7 @@ async def test_service_levels_snapshot(manager: ManagerClient):
 
     new_server = await manager.server_add(config=auth_config)
     all_servers = servers + [new_server]
-    await wait_for_cql_and_get_hosts(cql, all_servers, time.time() + 60)
-    await manager.servers_see_each_other(all_servers)
+    await manager.get_ready_cql(all_servers)
 
     await asyncio.gather(*[manager.server_stop_gracefully(s.server_id)
                            for s in servers])
@@ -119,8 +116,7 @@ async def assert_connections_params(manager: ManagerClient, hosts, expect):
 @pytest.mark.skip_mode(mode='release', reason='cql server testing REST API is not supported in release mode')
 async def test_connections_parameters_auto_update(manager: ManagerClient, build_mode):
     servers = await manager.servers_add(3, config=auth_config, auto_rack_dc="dc1")
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     logging.info("Creating user roles and their connections")
     await asyncio.gather(*(
@@ -203,8 +199,7 @@ async def test_connections_parameters_auto_update(manager: ManagerClient, build_
 @pytest.mark.asyncio
 async def test_service_level_cache_after_restart(manager: ManagerClient):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     await cql.run_async(f"CREATE SERVICE LEVEL sl1 WITH timeout=500ms AND workload_type='batch'")
 
@@ -250,9 +245,8 @@ async def test_shares_check(manager: ManagerClient):
     await manager.server_stop_gracefully(srv.server_id)
     await manager.server_update_config(srv.server_id, "error_injections_at_startup", [])
     await manager.server_start(srv.server_id)
-    await wait_for_cql_and_get_hosts(manager.get_cql(), [srv], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([srv])
 
-    cql = manager.get_cql()
     await cql.run_async(f"CREATE SERVICE LEVEL {sl2} WITH shares=500")
     await cql.run_async(f"ALTER SERVICE LEVEL {sl1} WITH shares=100")
 
@@ -263,8 +257,7 @@ async def test_service_levels_over_limit(manager: ManagerClient):
         "error_injections_at_startup": ['allow_service_level_over_limit']
     })
     await manager.server_start(srv.server_id)
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60)
+    cql, hosts = await manager.get_ready_cql([srv])
 
     sls = []
     for i in range(MAX_USER_SERVICE_LEVELS + 1):
@@ -288,8 +281,7 @@ async def test_service_levels_over_limit(manager: ManagerClient):
 async def test_service_level_metric_name_change(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
     s = servers[0]
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60)
+    cql, [h] = await manager.get_ready_cql([s])
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     sl1 = unique_name()
@@ -332,8 +324,7 @@ async def test_reload_service_levels_after_auth_service_is_stopped(manager: Mana
 @pytest.mark.asyncio
 async def test_service_level_reuse_name(manager: ManagerClient):
     servers = await manager.servers_add(1, config=auth_config, auto_rack_dc="dc1")
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     sl1 = "sl1"
     sl2 = "sl2"
@@ -358,8 +349,7 @@ async def test_service_level_reuse_name(manager: ManagerClient):
 async def test_driver_service_level(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     logger.info("Verify that sl:driver is created properly on system startup")
@@ -390,8 +380,7 @@ async def test_driver_service_level(manager: ManagerClient) -> None:
 async def test_driver_service_creation_failure(manager: ManagerClient) -> None:
     servers = await manager.servers_add(2, config=auth_config, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     logger.info("Drop sl:driver to prepare the system state and re-create it later")
@@ -465,8 +454,7 @@ async def _verify_requests_count_metrics(manager, server, used_group, unused_gro
 async def test_driver_service_level_not_used_for_user_queries(manager: ManagerClient) -> None:
     server = await manager.server_add(config=auth_config)
 
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, [h] = await manager.get_ready_cql([server])
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     func = lambda: cql.execute(f"SELECT * from system.peers")
@@ -482,8 +470,7 @@ async def test_driver_service_level_not_used_for_user_queries(manager: ManagerCl
 async def test_driver_service_level_used_for_driver_queries(manager: ManagerClient) -> None:
     server = await manager.server_add(config=auth_config)
 
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, [h] = await manager.get_ready_cql([server])
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
     await cql.run_async(f"CREATE SERVICE LEVEL test", host=h)
@@ -512,8 +499,7 @@ async def test_driver_service_level_used_for_driver_queries(manager: ManagerClie
 async def test_anonymous_user(manager: ManagerClient) -> None:
     allow_all_config = {'authenticator':'AllowAllAuthenticator', 'authorizer':'AllowAllAuthorizer'}
     server = await manager.server_add(config=allow_all_config)
-    cql = manager.get_cql()
-    [h] = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, [h] = await manager.get_ready_cql([server])
 
     async def connections_ready():
         rows = list(cql.execute("SELECT connection_stage, username, scheduling_group FROM system.clients"))

--- a/test/cluster/lwt/test_lwt_during_tablets_migration.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_migration.py
@@ -118,6 +118,7 @@ async def test_multi_column_lwt_during_migration(manager: ManagerClient, scale_t
     }
 
     servers = await manager.servers_add(6, config=cfg)
+    await manager.get_ready_cql(servers)
     await manager.disable_tablet_balancing()
 
     rf_max = len(servers) - 1

--- a/test/cluster/lwt/test_lwt_during_tablets_resize.py
+++ b/test/cluster/lwt/test_lwt_during_tablets_resize.py
@@ -161,6 +161,7 @@ async def test_multi_column_lwt_during_split_merge(manager: ManagerClient, scale
         '--logger-log-level', 'paxos=trace'
     ]
     servers = await manager.servers_add(6, config=cfg, cmdline=cmdline, property_file=properties)
+    await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(
         manager,

--- a/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
+++ b/test/cluster/lwt/test_lwt_with_counters_during_tablets_resize_and_migrations.py
@@ -317,6 +317,7 @@ async def test_multi_column_lwt_migrate_and_random_resizes(manager: ManagerClien
     ]
 
     servers = await manager.servers_add(6, config=cfg, property_file=properties, cmdline=cmdline)
+    await manager.get_ready_cql(servers)
     
     async with new_test_keyspace(
         manager,

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -9,7 +9,6 @@
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import read_barrier
 from test.pylib.tablets import get_tablet_replicas, get_tablet_count
-from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.internal_types import ServerInfo
 from test.cluster.util import new_test_keyspace
 

--- a/test/cluster/mv/tablets/test_mv_tablets.py
+++ b/test/cluster/mv/tablets/test_mv_tablets.py
@@ -68,7 +68,7 @@ async def test_tablet_mv_create(manager: ManagerClient):
        Reproduces issue #16194.
     """
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -85,7 +85,7 @@ async def test_tablet_mv_simple(manager: ManagerClient):
        Reproduces issue #16209.
     """
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -107,7 +107,7 @@ async def test_tablet_mv_simple_6node(manager: ManagerClient):
        Reproduces #16227.
     """
     servers = await manager.servers_add(6)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")
@@ -135,7 +135,7 @@ async def test_tablet_alternator_lsi_consistency(manager: ManagerClient):
        Reproduces #16313.
     """
     servers = await manager.servers_add(2, config=alternator_config)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     alternator = get_alternator(servers[0].ip_addr)
     # Tell Alternator to create a table with just *one* tablet, via a
     # special tag.
@@ -205,7 +205,7 @@ async def test_tablet_si_create(manager: ManagerClient):
        Reproduces issue #16194.
     """
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -219,7 +219,7 @@ async def test_tablet_lsi_create(manager: ManagerClient):
        Reproduces issue #16194.
     """
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 100}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -244,7 +244,7 @@ async def test_tablet_cql_lsi(manager: ManagerClient):
        Reproduces #16371.
     """
     servers = await manager.servers_add(2)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create a table with an LSI, using tablets. Use just 1 tablets,
     # which is silly in any real-world use case, but makes this test simpler
@@ -298,7 +298,7 @@ async def test_mv_tablet_split(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk)")

--- a/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_empty_ip.py
@@ -37,7 +37,7 @@ async def test_mv_tablets_empty_ip(manager: ManagerClient):
         {"dc": "dc1", "rack": "r3"}
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
         await cql.run_async(f"CREATE materialized view {ks}.t_view AS select pk, v from {ks}.t where v is not null primary key (v, pk)")

--- a/test/cluster/mv/tablets/test_mv_tablets_merge.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_merge.py
@@ -10,7 +10,7 @@ import time
 
 from test.cluster.util import new_test_keyspace, new_test_table, new_materialized_view
 from test.pylib.tablets import get_tablet_count
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
 
@@ -22,8 +22,7 @@ async def test_mv_merge_allowed(manager):
     """
     cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
     server = await manager.server_add(config=cfg)
-    cql = manager.cql
-    _ = await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'enabled': true, 'initial': 1}}") as ks:
         async with new_test_table(manager, ks, "p int PRIMARY KEY, x int", "WITH tablets = {'min_tablet_count': 2}") as table:
             async with new_materialized_view(manager, table, "*", "x, p", "p is not null and x is not null", "WITH tablets = {'min_tablet_count': 2}") as mv:

--- a/test/cluster/mv/tablets/test_mv_tablets_replace.py
+++ b/test/cluster/mv/tablets/test_mv_tablets_replace.py
@@ -40,7 +40,7 @@ async def test_tablet_mv_replica_pairing_during_replace(manager: ManagerClient):
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r2"}
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE c IS NOT NULL AND pk IS NOT NULL PRIMARY KEY (c, pk) WITH SYNCHRONOUS_UPDATES = TRUE")

--- a/test/cluster/mv/test_mv_backlog.py
+++ b/test/cluster/mv/test_mv_backlog.py
@@ -27,7 +27,7 @@ async def test_view_backlog_increased_after_write(manager: ManagerClient) -> Non
     node_count = 2
     # Use a higher smp to make it more likely that the writes go to a different shard than the coordinator.
     servers = await manager.servers_add(node_count, cmdline=['--smp', '5'], config={'error_injections_at_startup': ['never_finish_remote_view_updates'], 'tablets_mode_for_new_keyspaces': 'enabled'})
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (base_key int, view_key int, v text, PRIMARY KEY (base_key, view_key))")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv_cf_view AS SELECT * FROM {ks}.tab "

--- a/test/cluster/mv/test_mv_building.py
+++ b/test/cluster/mv/test_mv_building.py
@@ -33,7 +33,7 @@ async def test_view_building_scheduling_group(manager: ManagerClient):
     cmdline = sum([["--logger-log-level", f"{logger}=trace"] for logger in loggers], [])
 
     server = await manager.server_add(cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (p int, c int, PRIMARY KEY (p, c))")
@@ -88,7 +88,7 @@ async def test_start_scylla_with_view_building_disabled(manager: ManagerClient):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_view_building_during_drop_index(manager: ManagerClient):
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     await manager.api.enable_injection(server.ip_addr, "view_builder_consume_end_of_partition_delay", one_shot=True)
 
     await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
@@ -123,7 +123,7 @@ async def test_interrupt_view_build_shard_registration(manager: ManagerClient):
     server = servers[0]
 
     logger.info("Populate table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     n_partitions = 1000
     ks = 'ks'
     await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets={{'enabled':false}}")
@@ -166,7 +166,7 @@ async def test_empty_build_step_after_reshard(manager: ManagerClient):
     server = await manager.server_add(cmdline=['--smp', '1', '--logger-log-level', 'view=debug'])
     partitions = random.sample(range(1000), 129) # need more than 128 to allow the first build step to finish and save the progress
     logger.info(f"Using partitions: {partitions}")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     await cql.run_async(f"CREATE KEYSPACE ks WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets={{'enabled':false}}")
     await cql.run_async(f"CREATE TABLE ks.test (p int, c int, PRIMARY KEY(p,c));")
     await asyncio.gather(*[cql.run_async(f"INSERT INTO ks.test (p, c) VALUES ({k}, {k+1});") for k in partitions])
@@ -233,7 +233,7 @@ async def test_backoff_when_node_fails_task_rpc(manager: ManagerClient):
     host_id1 = await manager.get_host_id(s1.server_id)
     host_id2 = await manager.get_host_id(s2.server_id)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s1, s2])
 
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2}")
     await cql.run_async("CREATE TABLE ks.t (pk int, ck int, v int, PRIMARY KEY (pk, ck))")

--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -60,8 +60,8 @@ async def insert_with_concurrency(cql, table, value_count, concurrency):
 @pytest.mark.skip_mode(mode='release', reason="error injections aren't enabled in release mode")
 async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) -> None:
     node_count = 2
-    await manager.servers_add(node_count, config={'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update']})
-    cql = manager.get_cql()
+    servers = await manager.servers_add(node_count, config={'error_injections_at_startup': ['view_update_limit', 'delay_before_remote_view_update']})
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, PRIMARY KEY (key, c))")
         await insert_with_concurrency(cql, f"{ks}.tab", 200, 100)
@@ -83,7 +83,7 @@ async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) 
 @pytest.mark.parametrize("permuted", [False, True])
 async def test_base_partition_deletion_with_metrics(manager: ManagerClient, permuted):
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as test_keyspace:
         async with new_test_table(manager, test_keyspace, 'p1 int, p2 int, c int, primary key ((p1,p2),c)') as table:
             # Insert into one base partition. We will delete the entire partition
@@ -132,7 +132,7 @@ async def test_base_partition_deletion_with_metrics(manager: ManagerClient, perm
 @pytest.mark.asyncio
 async def test_base_partition_deletion_in_batch_with_delete_row_with_metrics(manager: ManagerClient):
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as test_keyspace:
         async with new_test_table(manager, test_keyspace, 'p int, c int, v int, primary key ((p,c),v)') as table:
             insert = cql.prepare(f'INSERT INTO {table} (p,c,v) VALUES (?,?,?)')

--- a/test/cluster/mv/test_mv_fail_building.py
+++ b/test/cluster/mv/test_mv_fail_building.py
@@ -20,7 +20,7 @@ from cassandra.query import SimpleStatement  # type: ignore
 async def test_mv_fail_building(manager: ManagerClient) -> None:
     node_count = 3
     servers = await manager.servers_add(node_count, auto_rack_dc="dc")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, PRIMARY KEY (key, c))")
         # Insert initial rows for building an index
@@ -51,7 +51,7 @@ async def test_mv_fail_building(manager: ManagerClient) -> None:
 async def test_mv_build_during_shutdown(manager: ManagerClient):
     server = await manager.server_add()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
 

--- a/test/cluster/mv/test_mv_topology_change.py
+++ b/test/cluster/mv/test_mv_topology_change.py
@@ -38,7 +38,7 @@ async def test_mv_topology_change(manager: ManagerClient):
 
     servers = [await manager.server_add(config=cfg) for _ in range(3)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
         await cql.run_async(f"CREATE materialized view {ks}.t_view AS select pk, v from {ks}.t where v is not null primary key (v, pk)")
@@ -105,7 +105,7 @@ async def test_mv_update_on_pending_replica(manager: ManagerClient, intranode):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv1 AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (c, pk);")
@@ -187,7 +187,7 @@ async def test_mv_write_to_dead_node(manager: ManagerClient):
         {"dc": "dc1", "rack": "r3"}
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int primary key, v int)")
         await cql.run_async(f"CREATE materialized view {ks}.t_view AS select pk, v from {ks}.t where v is not null primary key (v, pk)")
@@ -210,7 +210,7 @@ async def test_mv_pairing_during_replace(manager: ManagerClient):
         {"dc": "dc1", "rack": "r1"},
         {"dc": "dc1", "rack": "r2"}
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};")
     await cql.run_async("CREATE TABLE ks.t (pk int PRIMARY KEY, v int)")
     await cql.run_async("CREATE MATERIALIZED VIEW ks.t_view AS SELECT pk, v FROM ks.t WHERE v IS NOT NULL PRIMARY KEY (v, pk)")
@@ -267,7 +267,7 @@ async def test_mv_rf_change(manager: ManagerClient, delayed_replica: str, altere
     servers.append(await manager.server_add(config={'rf_rack_valid_keyspaces': False}, property_file={'dc': f'dc2', 'rack': 'myrack1'}))
     servers.append(await manager.server_add(config={'rf_rack_valid_keyspaces': False}, property_file={'dc': f'dc2', 'rack': 'myrack2'}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1, 'dc2': 1} AND tablets = {'initial': 1}")
     await cql.run_async("CREATE TABLE ks.base (pk int, ck int, PRIMARY KEY (pk, ck))")
     await cql.run_async("CREATE MATERIALIZED VIEW ks.mv AS SELECT pk, ck FROM ks.base WHERE ck IS NOT NULL PRIMARY KEY (ck, pk)")
@@ -337,7 +337,7 @@ async def test_mv_first_replica_in_dc(manager: ManagerClient, delayed_replica: s
     servers.append(await manager.server_add(cmdline=['--smp', '1'], config={"rf_rack_valid_keyspaces": "false"}, property_file={'dc': f'dc1', 'rack': 'myrack1'}))
     servers.append(await manager.server_add(cmdline=['--smp', '1'], property_file={'dc': f'dc2', 'rack': 'myrack1'}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE IF NOT EXISTS ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1} AND tablets = {'initial': 1}")
     await cql.run_async("CREATE TABLE ks.base (pk int, ck int, PRIMARY KEY (pk, ck))")
     await cql.run_async("CREATE MATERIALIZED VIEW ks.mv AS SELECT pk, ck FROM ks.base WHERE ck IS NOT NULL PRIMARY KEY (ck, pk)")
@@ -398,7 +398,7 @@ async def test_mv_write_during_migration(manager: ManagerClient, migration_type:
     cmdline = ['--smp', '2', '--logger-log-level', 'raft_topology=debug', "--allowed-repair-based-node-ops", "replace,removenode,rebuild,bootstrap,decommission"]
 
     servers = await manager.servers_add(3, cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await manager.disable_tablet_balancing()
 
     tablets_enabled = migration_type.startswith("tablets")
@@ -487,7 +487,7 @@ async def test_mv_write_during_migration(manager: ManagerClient, migration_type:
 async def test_mv_write_during_node_join(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'storage_service=debug', '--logger-log-level', 'raft_topology=debug']
     servers = await manager.servers_add(1, cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': false}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (id int PRIMARY KEY, val int)")

--- a/test/cluster/mv/test_mv_with_tablets_restrictions.py
+++ b/test/cluster/mv/test_mv_with_tablets_restrictions.py
@@ -194,7 +194,7 @@ async def test_add_node_in_new_rack_restriction_with_mv(manager: ManagerClient):
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
     await cql.run_async("CREATE TABLE ks.t (p int PRIMARY KEY, v int)")
@@ -238,7 +238,7 @@ async def test_remove_node_violating_rf_rack(manager: ManagerClient, op: str):
         {"dc": "dc1", "rack": "r3"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
     await cql.run_async("CREATE TABLE ks.t (p int PRIMARY KEY, v int)")

--- a/test/cluster/object_store/test_backup.py
+++ b/test/cluster/object_store/test_backup.py
@@ -60,7 +60,7 @@ async def test_simple_backup(manager: ManagerClient, object_storage, move_files)
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
@@ -107,7 +107,7 @@ async def test_backup_with_non_existing_parameters(manager: ManagerClient, objec
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
@@ -139,7 +139,7 @@ async def test_backup_endpoint_config_is_live_updateable(manager: ManagerClient,
            }
     cmd = ['--logger-log-level', 'sstables_manager=debug']
     server = await manager.server_add(config=cfg, cmdline=cmd)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
@@ -182,8 +182,9 @@ async def do_test_backup_helper(manager: ManagerClient, object_storage,
            'task_ttl_in_seconds': 300
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
-    server = (await manager.servers_add(num_servers, config=cfg, cmdline=cmd))[0]
-    cql = manager.get_cql()
+    servers = await manager.servers_add(num_servers, config=cfg, cmdline=cmd)
+    server = servers[0]
+    cql, _ = await manager.get_ready_cql(servers)
     cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} ( name text primary key, value text );")
@@ -269,7 +270,7 @@ async def test_simple_backup_and_restore(manager: ManagerClient, object_storage,
     cmd = ['--logger-log-level', 'sstables_loader=debug:sstable_directory=trace:snapshots=trace:s3=trace:sstable=debug:http=debug:encryption=debug:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     workdir = await manager.server_get_workdir(server.server_id)
 
     # This test is sensitive not to share the bucket with any other test
@@ -376,7 +377,7 @@ async def do_abort_restore(manager: ManagerClient, object_storage):
     servers = await manager.servers_add(servers_num=3, config=config, auto_rack_dc='dc1')
 
     # Obtain the CQL interface from the manager.
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create keyspace, table, and fill data
     logger.info("Creating keyspace and table, then inserting data...")
@@ -689,7 +690,7 @@ async def do_test_streaming_scopes(build_mode: str, manager: ManagerClient, topo
     servers, host_ids = await create_cluster(topology, manager, logger, sstables_storage.object_storage)
 
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     num_keys = 10
     original_min_tablet_count=5
@@ -748,7 +749,7 @@ async def test_restore_with_non_existing_sstable(manager: ManagerClient, object_
            }
     cmd = ['--logger-log-level', 'snapshots=trace:task_manager=trace:api=info']
     server = await manager.server_add(config=cfg, cmdline=cmd)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     print('Create keyspace')
     cf = 'test_cf'
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': '1'}") as ks:
@@ -775,7 +776,7 @@ async def test_backup_broken_streaming(manager: ManagerClient, s3_storage):
     server = await manager.server_add(config=config, cmdline=cmd)
 
     # Obtain the CQL interface from the manager.
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     scylla_path = await manager.server_get_exe(server.server_id)
 
     async with new_test_keyspace(manager,
@@ -880,7 +881,7 @@ async def test_restore_primary_replica(manager: ManagerClient, object_storage, d
     servers, host_ids = await create_cluster(topology, manager, logger, object_storage)
 
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, replication_str) as ks:
         cql.execute(f"CREATE TABLE {ks}.{cf} ( pk text primary key, value int );")

--- a/test/cluster/object_store/test_basic.py
+++ b/test/cluster/object_store/test_basic.py
@@ -47,7 +47,7 @@ async def test_basic(manager: ManagerClient, object_storage, tmp_path, mode, rep
         server = await manager.server_add(config=cfg, property_file=property_file)
         servers.append(server)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     workdir = await manager.server_get_workdir(servers[0].server_id)
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage, rf=replication_factor)) as ks:
@@ -121,7 +121,7 @@ async def test_garbage_collect(manager: ManagerClient, object_storage):
     cmd = ['--logger-log-level', 's3=trace:http=debug:gcp_storage=trace']
     server = await manager.server_add(config=cfg, cmdline=cmd)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
@@ -164,7 +164,7 @@ async def test_populate_from_quarantine(manager: ManagerClient, object_storage):
            'experimental_features': ['keyspace-storage-options']}
     server = await manager.server_add(config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
@@ -203,7 +203,7 @@ async def test_misconfigured_storage(manager: ManagerClient, object_storage):
            'experimental_features': ['keyspace-storage-options']}
     server = await manager.server_add(config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     print(f'Create keyspace (storage server listening at {object_storage.address})')
     replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
                                       'replication_factor': '1'})
@@ -228,7 +228,7 @@ async def test_memtable_flush_retries(manager: ManagerClient, tmpdir, object_sto
            'experimental_features': ['keyspace-storage-options']}
     server = await manager.server_add(config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     print(f'Create keyspace (storage server listening at {object_storage.address})')
 
     async with new_test_keyspace(manager, keyspace_options(object_storage)) as ks:
@@ -285,7 +285,7 @@ async def test_get_object_store_endpoints(manager: ManagerClient, config_with_fu
     assert json.loads(endpoints[name]) == objconf[0]
 
     print('Check that system.config contains the object storage endpoints')
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     res = json.loads(cql.execute("SELECT value FROM system.config WHERE name = 'object_storage_endpoints';").one().value)
     assert name in res
     assert json.loads(res[name]) == objconf[0]
@@ -295,7 +295,7 @@ async def test_get_object_store_endpoints(manager: ManagerClient, config_with_fu
 async def test_create_keyspace_after_config_update(manager: ManagerClient, object_storage):
     print('Trying to create a keyspace with an endpoint not configured in object_storage_endpoints should trip storage_manager::is_known_endpoint()')
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     endpoint = object_storage.address  
     replication_opts = format_tuples({'class': 'NetworkTopologyStrategy',
                                       'replication_factor': '1'})

--- a/test/cluster/tasks/test_node_ops_tasks.py
+++ b/test/cluster/tasks/test_node_ops_tasks.py
@@ -202,7 +202,7 @@ async def test_node_ops_tasks_tree(manager: ManagerClient):
     servers = [await manager.server_add(cmdline=cmdline) for _ in range(3)]
     assert module_name in await tm.list_modules(servers[0].ip_addr), "node_ops module wasn't registered"
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({1}, {1});")

--- a/test/cluster/tasks/test_tablet_tasks.py
+++ b/test/cluster/tasks/test_tablet_tasks.py
@@ -283,7 +283,7 @@ async def prepare_migration_test(manager: ManagerClient):
 
     await make_server()
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
     await make_server()
@@ -486,7 +486,7 @@ async def test_tablet_resize_task(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     table1 = "test1"
     table2 = "test2"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
@@ -527,7 +527,7 @@ async def test_tablet_resize_list(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     table1 = "test1"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
         await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
@@ -587,7 +587,7 @@ async def test_tablet_resize_revoked(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     table1 = "test1"
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as keyspace:
         await cql.run_async(f"CREATE TABLE {keyspace}.{table1} (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")

--- a/test/cluster/test_aggregation.py
+++ b/test/cluster/test_aggregation.py
@@ -13,7 +13,7 @@ from cassandra.cluster import NoHostAvailable  # type: ignore
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for
 from test.cluster.util import new_test_keyspace, new_test_table
 
 logger = logging.getLogger(__name__)
@@ -32,8 +32,7 @@ async def test_cancel_mapreduce(manager: ManagerClient):
     assert len(running_servers) >= 2
 
     s1, s2 = running_servers[0], running_servers[1]
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, [s1, s2], time.time() + 30)
+    cql, hosts = await manager.get_ready_cql([s1, s2])
 
     await manager.api.set_logger_level(s1.ip_addr, "forward_service", "debug")
 

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1311,6 +1311,7 @@ async def test_alternator_invalid_shard_for_lwt(manager: ManagerClient):
         '--logger-log-level', 'paxos=trace'
     ]
     server = await manager.server_add(config=config, cmdline=cmdline)
+    await manager.get_ready_cql([server])
     alternator = get_alternator(server.ip_addr)
 
     await manager.disable_tablet_balancing()

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -604,7 +604,7 @@ async def test_alternator_enforce_authorization_true(manager: ManagerClient):
     }
     servers = await manager.servers_add(1, config=config,
         driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')})
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     # Any requests from a non-existent user with garbage password is
     # rejected - even requests that don't need special permissions
     alternator = get_alternator(servers[0].ip_addr, 'nonexistent_user', 'garbage')
@@ -1414,8 +1414,9 @@ async def test_deferred_stream_enablement_on_tablets(manager: ManagerClient):
        attempted (must be blocked), then an increase (must succeed). After
        disabling streams, a shrinkage is attempted (must succeed).
     """
-    server = (await manager.servers_add(1, config=alternator_config))[0]
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, config=alternator_config)
+    server = servers[0]
+    cql, _ = await manager.get_ready_cql(servers)
     alternator = get_alternator(server.ip_addr)
 
     async def get_table_id(ks, table_name):

--- a/test/cluster/test_alternator.py
+++ b/test/cluster/test_alternator.py
@@ -1180,6 +1180,10 @@ async def test_zero_token_node_load_balancer(manager, tablets):
     # Add a fifth node, with zero tokens (no data), by setting join_ring=false:
     zero_token_server = await manager.server_add(config=alternator_config | {'join_ring': False},
                                                  property_file={'dc': 'dc1', 'rack': 'rack-zero-token'})
+    # Wait until the driver sees the token-owning servers before issuing
+    # cql queries. The zero-token node never becomes a CQL host visible to
+    # the driver, so we only wait on the token-owning servers here.
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Get an Alternator connection to the zero-token node:
     alternator = get_alternator(zero_token_server.ip_addr)
@@ -1206,7 +1210,7 @@ async def test_zero_token_node_load_balancer(manager, tablets):
     # we want this to be just the first four nodes in "servers", not the
     # fifth node zero_token_server.
     ks = f"alternator_{table.name}"
-    repl = get_replication(manager.get_cql(), ks)
+    repl = get_replication(cql, ks)
     if type(repl["dc1"]) is list:
         expected = { await manager.get_host_id(s.server_id) for s in servers if s.rack in repl["dc1"] }
     else:

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -206,6 +206,7 @@ async def alternator_proxy_server(manager: ManagerClient):
         config=ALTERNATOR_PROXY_SERVER_CONFIG,
         expected_server_up_state=ServerUpState.SERVING
     )
+    await manager.get_ready_cql([server])
     yield (server, manager)
 
 

--- a/test/cluster/test_audit.py
+++ b/test/cluster/test_audit.py
@@ -231,7 +231,7 @@ class AuditTester:
                 needed, enable_compact_storage, rf, user, auth_provider,
                 property_file=property_file, cmdline=cmdline)
 
-        cql = self.manager.get_cql()
+        cql, _ = await self.manager.get_ready_cql(await self.manager.running_servers())
         cql.get_execution_profile(EXEC_PROFILE_DEFAULT).consistency_level = ConsistencyLevel.ONE
         audit_mode = needed.get("audit") or ""
         if "table" not in audit_mode:

--- a/test/cluster/test_bti_index.py
+++ b/test/cluster/test_bti_index.py
@@ -64,7 +64,7 @@ async def test_bti_index_enable(manager: ManagerClient) -> None:
         ],
         'column_index_size_in_kb': 1,
     })
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     workdirs = await asyncio.gather(*[manager.server_get_workdir(s.server_id) for s in servers])
 
     logger.info("Step 1: Creating keyspace and table")

--- a/test/cluster/test_cdc_generation_clearing.py
+++ b/test/cluster/test_cdc_generation_clearing.py
@@ -43,8 +43,7 @@ async def test_cdc_generation_clearing(manager: ManagerClient):
         await log_file1.wait_for("CDC generation publisher fiber has nothing to do. Sleeping.", from_mark=mark)
         new_mark = await log_file1.mark()
 
-        cql = manager.get_cql()
-        hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        cql, hosts = await manager.get_ready_cql(servers)
         new_gen_ids = {r.id for r in await cql.run_async(query_gen_ids)}
 
         return (new_mark, new_gen_ids, hosts)
@@ -100,9 +99,8 @@ async def test_unpublished_cdc_generations_arent_cleared(manager: ManagerClient)
         'error_injections_at_startup': ['clean_obsolete_cdc_generations_change_ts_ub']
     })
 
-    cql = manager.get_cql()
     logger.info("Waiting for driver")
-    [host1] = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, [host1] = await manager.get_ready_cql(servers)
 
     logging.info("Waiting for the first CDC generation publishing")
     await wait_for_cdc_generations_publishing(cql, [host1], time.time() + 60)

--- a/test/cluster/test_cdc_generation_data.py
+++ b/test/cluster/test_cdc_generation_data.py
@@ -27,7 +27,7 @@ async def test_send_data_in_parts(manager: ManagerClient):
 
     await check_token_ring_and_group0_consistency(manager)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     rows = await cql.run_async("SELECT description FROM system.group0_history")
 
     for row in rows:

--- a/test/cluster/test_cdc_generation_publishing.py
+++ b/test/cluster/test_cdc_generation_publishing.py
@@ -5,7 +5,7 @@
 #
 from test.pylib.manager_client import ManagerClient, ServerInfo
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for
 
 from cassandra.cluster import ConsistencyLevel # type: ignore # pylint: disable=no-name-in-module
 from cassandra.query import SimpleStatement # type: ignore # pylint: disable=no-name-in-module
@@ -33,8 +33,7 @@ async def test_cdc_generations_are_published(request, manager: ManagerClient):
     gen_timestamps = set[datetime]()
 
     async def new_gen_appeared() -> Optional[set[datetime]]:
-        cql = manager.get_cql()
-        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        cql, _ = await manager.get_ready_cql(servers)
         new_gen_timestamps = {r.time for r in await cql.run_async(query_gen_timestamps)}
         assert len(gen_timestamps) + 1 >= len(new_gen_timestamps)
         if gen_timestamps < new_gen_timestamps:
@@ -93,8 +92,7 @@ async def test_multiple_unpublished_cdc_generations(request, manager: ManagerCli
         logger.info("Bootstrapping other nodes")
         servers += await manager.servers_add(3)
 
-        cql = manager.get_cql()
-        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        cql, _ = await manager.get_ready_cql(servers)
 
         gen_timestamps = set[datetime]()
 

--- a/test/cluster/test_cdc_with_alter.py
+++ b/test/cluster/test_cdc_with_alter.py
@@ -26,7 +26,7 @@ async def test_add_and_drop_column_with_cdc(manager: ManagerClient):
     """
 
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
@@ -83,7 +83,7 @@ async def test_cdc_compatible_schema(manager: ManagerClient):
     """
 
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     log = await manager.server_open_log(servers[0].server_id)
 
@@ -120,8 +120,8 @@ async def test_recreate_column_too_soon(manager: ManagerClient):
         same name before the drop timestamp has passed results in a proper error
         message, preventing potential data corruption.
     """
-    await manager.servers_add(1, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int, dropped_col int) WITH cdc={{'enabled': true}}")
@@ -154,7 +154,7 @@ async def test_concurrent_writes_and_drop_column_with_cdc_preimage(manager: Mana
         Reproduces #26340.
     """
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int, dropped_col int) WITH cdc={{'enabled': true, 'preimage': 'full'}}")

--- a/test/cluster/test_cdc_with_tablets.py
+++ b/test/cluster/test_cdc_with_tablets.py
@@ -36,7 +36,7 @@ class CdcStreamState(IntEnum):
 @pytest.mark.asyncio
 async def test_create_cdc_with_tablets(manager: ManagerClient, with_alter: bool):
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         if with_alter:
             await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int)")
@@ -74,7 +74,7 @@ async def test_create_cdc_with_tablets(manager: ManagerClient, with_alter: bool)
 @pytest.mark.asyncio
 async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: ManagerClient):
     servers = await manager.servers_add(1)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks1:
         await cql.run_async(f"CREATE TABLE {ks1}.test1 (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
         rows = await cql.run_async("SELECT * FROM system.cdc_streams_state")
@@ -107,8 +107,8 @@ async def test_drop_table_and_drop_keyspace_removes_cdc_streams(manager: Manager
 # Verify streams are created and cleaned up correctly.
 @pytest.mark.asyncio
 async def test_drop_and_recreate_cdc(manager: ManagerClient):
-    await manager.servers_add(1)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1)
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
         await cql.run_async(f"ALTER TABLE {ks}.test1 WITH cdc={{'enabled': false}}")
@@ -174,7 +174,7 @@ async def validate_virtual_tables(manager, servers, cql, log_table_id, ks, table
 async def test_cdc_virtual_tables(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
     servers = await manager.servers_add(1, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
 
         assert [] == await cql.run_async("SELECT * FROM system.cdc_timestamps")
@@ -214,7 +214,7 @@ async def test_cdc_virtual_tables(manager: ManagerClient):
 async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
     servers = await manager.servers_add(1, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     N = 3
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         for i in range(N):
@@ -253,7 +253,7 @@ async def test_cdc_virtual_tables_with_multiple_cdc_tables(manager: ManagerClien
 async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1 }
     servers = await manager.servers_add(1, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}} AND tablets = {{'min_tablet_count': 2}}")
 
@@ -316,7 +316,7 @@ async def test_cdc_stream_split_and_merge_basic(manager: ManagerClient):
 async def test_cdc_colocation(manager: ManagerClient):
     # Create 2-node cluster to test co-location
     servers = await manager.servers_add(2)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true}}")
@@ -378,7 +378,7 @@ async def test_cdc_colocation(manager: ManagerClient):
 async def test_cdc_stream_garbage_collection(manager: ManagerClient):
     cfg = { 'tablet_load_stats_refresh_interval_in_seconds': 1, 'error_injections_at_startup': ['short_cdc_streams_gc_refresh_interval' ] }
     servers = await manager.servers_add(1, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH cdc={{'enabled': true, 'ttl': 3600}}")
 

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -29,6 +29,7 @@ async def test_change_two(manager, random_tables, build_mode):
     """Stop two nodes, change their IPs and start, check the cluster is
     functional"""
     servers = await manager.running_servers()
+    await manager.get_ready_cql(servers)
     host_ids = {s.server_id: await manager.get_host_id(s.server_id) for s in servers}
     table = await random_tables.add_table(name='t1', pks=1, columns=[
         Column("pk", IntType),

--- a/test/cluster/test_change_ip.py
+++ b/test/cluster/test_change_ip.py
@@ -140,10 +140,11 @@ async def test_change_two(manager, random_tables, build_mode):
     await table.add_column(column=Column("str_c", TextType))
     await random_tables.verify_schema()
 
-    host0 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[0]], time.time() + 60))[0]
-    await manager.get_cql().run_async(f"USE {random_tables.keyspace}")
-    await manager.get_cql().run_async("insert into t1(pk, int_c, str_c) values (1, 2, 'test-val')", host=host0)
-    rows = list(await manager.get_cql().run_async("select * from t1", host=host0))
+    cql, hosts = await manager.get_ready_cql(servers)
+    host0 = next(h for h in hosts if h.address == servers[0].ip_addr)
+    await cql.run_async(f"USE {random_tables.keyspace}")
+    await cql.run_async("insert into t1(pk, int_c, str_c) values (1, 2, 'test-val')", host=host0)
+    rows = list(await cql.run_async("select * from t1", host=host0))
     assert len(rows) == 1
     row = rows[0]
     assert row.pk == 1

--- a/test/cluster/test_change_replication_factor_1_to_0.py
+++ b/test/cluster/test_change_replication_factor_1_to_0.py
@@ -11,7 +11,6 @@ import time
 from cassandra import ConsistencyLevel  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace, wait_for_token_ring_and_group0_consistency
 from test.pylib.util import wait_for
 
@@ -29,17 +28,17 @@ logger = logging.getLogger(__name__)
 async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:
     CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled" if use_tablets else "disabled"}
     logger.info("Creating a new cluster")
+    servers = []
     for i in range(2):
-        await manager.server_add(
+        servers.append(await manager.server_add(
             config=CONFIG,
-            property_file={'dc': f'dc{i}', 'rack': f'myrack{i}'})
+            property_file={'dc': f'dc{i}', 'rack': f'myrack{i}'}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'dc0': 1, 'dc1': 1}") as ks:
         await cql.run_async(f"create table {ks}.t (pk int primary key)")
 
         srvs = await manager.running_servers()
-        await wait_for_cql_and_get_hosts(cql, srvs, time.time() + 60)
 
         stmt = cql.prepare(f"SELECT * FROM {ks}.t where pk = ?")
         stmt.consistency_level = ConsistencyLevel.LOCAL_QUORUM
@@ -81,20 +80,19 @@ async def test_change_replication_factor_1_to_0(request: pytest.FixtureRequest, 
 async def test_change_replication_factor_1_to_0_and_decommission(request: pytest.FixtureRequest, manager: ManagerClient, use_tablets: bool) -> None:
     CONFIG = {"endpoint_snitch": "GossipingPropertyFileSnitch", "tablets_mode_for_new_keyspaces": "enabled" if use_tablets else "disabled"}
     logger.info("Creating a new cluster")
+    servers = []
     for i in range(2):
-        await manager.server_add(
+        servers.append(await manager.server_add(
             config=CONFIG,
-            property_file={'dc': f'dc{i}', 'rack': 'myrack'})
+            property_file={'dc': f'dc{i}', 'rack': 'myrack'}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'dc0': 1, 'dc1': 1}") as ks:
         await cql.run_async(f"create table {ks}.t (pk int primary key)")
 
         srvs = await manager.running_servers()
         sorted(srvs, key=lambda si: si.datacenter)
         assert(srvs[1].datacenter == "dc1")
-
-        await wait_for_cql_and_get_hosts(cql, srvs, time.time() + 60)
 
         keys = range(256)
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk) VALUES ({k});") for k in keys])

--- a/test/cluster/test_cluster_features.py
+++ b/test/cluster/test_cluster_features.py
@@ -68,8 +68,7 @@ async def test_rolling_upgrade_happy_path(manager: ManagerClient) -> None:
     """
     servers = await manager.running_servers()
 
-    cql = manager.cql
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     for srv in servers:
         host = (await wait_for_cql_and_get_hosts(cql, [srv], time.time() + 60))[0]
@@ -102,7 +101,7 @@ async def test_downgrade_after_partial_upgrade(manager: ManagerClient) -> None:
     servers = await manager.running_servers()
     upgrading_servers = servers[1:] if len(servers) > 0 else []
 
-    cql = manager.cql
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Upgrade
     for srv in upgrading_servers:
@@ -140,7 +139,6 @@ async def test_joining_old_node_fails(manager: ManagerClient) -> None:
     cql = await reconnect_driver(manager)
 
     # Wait until the feature is considered enabled by all nodes
-    cql = manager.cql
     hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     logging.info(f"Waiting until {TEST_FEATURE_NAME} is enabled on all nodes")
     await asyncio.gather(*(wait_for_feature(TEST_FEATURE_NAME, cql, h, time.time() + 60) for h in hosts))

--- a/test/cluster/test_commitlog.py
+++ b/test/cluster/test_commitlog.py
@@ -34,8 +34,7 @@ async def test_reboot(request, manager: ManagerClient):
     server_info = await manager.server_add(config={
         'commitlog_sync': 'batch'
     })
-    cql = manager.cql
-    await wait_for_cql_and_get_hosts(cql, [server_info], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server_info])
     logger.info("Node started")
 
     random_tables = RandomTables(request.node.name, manager, "ks", 1)

--- a/test/cluster/test_commitlog_segment_data_resurrection.py
+++ b/test/cluster/test_commitlog_segment_data_resurrection.py
@@ -41,7 +41,7 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ManagerClient):
         "commitlog_segment_size_in_mb": 1,
         "enable_cache": False
     })
-    cql = manager.cql
+    cql, _ = await manager.get_ready_cql([server])
 
     def commitlog_path():
         return json.loads(cql.execute("SELECT value FROM system.config WHERE name = 'commitlog_directory'").one().value)
@@ -127,6 +127,6 @@ async def test_pinned_cl_segment_doesnt_resurrect_data(manager: ManagerClient):
 
         manager.driver_close()
         await manager.driver_connect()
-        cql = manager.cql
+        cql, _ = await manager.get_ready_cql([server])
 
         assert len(list(cql.execute(f"SELECT * FROM {tbl2} WHERE pk = {pk1}"))) == 0

--- a/test/cluster/test_compaction_backpressure.py
+++ b/test/cluster/test_compaction_backpressure.py
@@ -49,7 +49,7 @@ async def test_intranode_migration_not_blocked_by_backpressure(manager: ManagerC
     cmdline = ['--smp', '1']
     servers = [await manager.server_add(cmdline=cmdline)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     extra_ks_param = "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}"
     async with new_test_keyspace(manager, extra_ks_param) as ks:
         extra_table_param = "WITH compaction = {'class' : 'IncrementalCompactionStrategy', 'max_threshold': 64} and compression = {}"

--- a/test/cluster/test_counters_with_tablets.py
+++ b/test/cluster/test_counters_with_tablets.py
@@ -40,7 +40,7 @@ async def test_counter_updates_during_tablet_migration(manager: ManagerClient, m
     cmdline = ['--smp', '2', '--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'storage_service=debug']
 
     servers = await manager.servers_add(node_count, cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await manager.disable_tablet_balancing()
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets={'initial': 1}") as ks:

--- a/test/cluster/test_crash_coordinator_before_streaming.py
+++ b/test/cluster/test_crash_coordinator_before_streaming.py
@@ -48,6 +48,7 @@ async def test_kill_coordinator_during_op(manager: ManagerClient, failure_detect
         '--logger-log-level', 'raft_topology=trace',
     ]
     nodes = [await manager.server_add(config=config, cmdline=cmdline) for _ in range(5)]
+    await manager.get_ready_cql(nodes)
     coordinators_ids = await get_coordinator_host_ids(manager)
     assert len(coordinators_ids) == 1, "At least 1 coordinator id should be found"
 

--- a/test/cluster/test_create_table_during_node_shutdown.py
+++ b/test/cluster/test_create_table_during_node_shutdown.py
@@ -18,7 +18,7 @@ async def test_create_table_notification_deadlock_with_shutdown(manager: Manager
     Reproduces scylladb/scylladb#27364
     """
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "") as ks:
         pause_in_notif_injection = "pause_in_allocate_tablets_for_new_table"
         await manager.api.enable_injection(server.ip_addr, pause_in_notif_injection, one_shot=True)

--- a/test/cluster/test_data_resurrection_after_cleanup.py
+++ b/test/cluster/test_data_resurrection_after_cleanup.py
@@ -25,7 +25,7 @@ async def test_data_resurrection_after_cleanup(manager: ManagerClient):
     ]
     servers = [await manager.server_add(cmdline=cmdline)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         table = f"{ks}.test"

--- a/test/cluster/test_data_resurrection_in_memtable.py
+++ b/test/cluster/test_data_resurrection_in_memtable.py
@@ -14,7 +14,7 @@ from cassandra.query import SimpleStatement  # type: ignore
 
 from test.cluster.util import new_test_keyspace
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
+from test.pylib.util import execute_with_tracing
 
 
 logger = logging.getLogger(__name__)
@@ -42,9 +42,7 @@ async def run_test_cache_tombstone_gc(manager: ManagerClient, statement_pairs: l
 
     node1, node2, node3 = nodes
 
-    cql = manager.get_cql()
-
-    host1, host2, host3 = await wait_for_cql_and_get_hosts(cql, nodes, time.time() + 30)
+    cql, [host1, host2, host3] = await manager.get_ready_cql(nodes)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = { 'enabled': true }") as ks:
         cql.execute(f"CREATE TABLE {ks}.tbl (pk int, ck int, v int, PRIMARY KEY (pk, ck))"

--- a/test/cluster/test_deprecating_cluster_features.py
+++ b/test/cluster/test_deprecating_cluster_features.py
@@ -7,7 +7,6 @@ import asyncio
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 
 
@@ -74,5 +73,5 @@ async def test_features_suppress_works(manager: ManagerClient, build_mode) -> No
     await manager.server_stop_gracefully(srv.server_id)
     await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, [])
     await manager.server_start(srv.server_id)
-    await wait_for_cql_and_get_hosts(manager.get_cql(), [srv], time.time() + 60)
+    await manager.get_ready_cql([srv])
     await check_features_status(manager.get_cql(), features_to_suppress, True)

--- a/test/cluster/test_deprecating_cluster_features.py
+++ b/test/cluster/test_deprecating_cluster_features.py
@@ -68,10 +68,11 @@ async def test_features_suppress_works(manager: ManagerClient, build_mode) -> No
         ]
     })
     await manager.server_start(srv.server_id)
-    await check_features_status(manager.get_cql(), features_to_suppress, False)
+    cql, _ = await manager.get_ready_cql([srv])
+    await check_features_status(cql, features_to_suppress, False)
 
     await manager.server_stop_gracefully(srv.server_id)
     await manager.server_update_config(srv.server_id, ERROR_INJECTIONS_AT_STARTUP_CONFIG_KEY, [])
     await manager.server_start(srv.server_id)
-    await manager.get_ready_cql([srv])
-    await check_features_status(manager.get_cql(), features_to_suppress, True)
+    cql, _ = await manager.get_ready_cql([srv])
+    await check_features_status(cql, features_to_suppress, True)

--- a/test/cluster/test_describe.py
+++ b/test/cluster/test_describe.py
@@ -25,7 +25,7 @@ import os
 async def test_large_create_statement(manager: ManagerClient):
     cmdline = ["--logger-log-level", "describe=trace"]
     srv = await manager.server_add(cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([srv])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         async with new_test_table(manager, ks, "p int PRIMARY KEY") as table:
@@ -67,8 +67,8 @@ async def test_describe_cluster_sanity(manager: ManagerClient, mode: str):
     """
 
     if mode == "normal":
-        await manager.server_add()
-        cql = manager.get_cql()
+        srv = await manager.server_add()
+        cql, _ = await manager.get_ready_cql([srv])
     else:  # maintenance mode
         srv = await manager.server_add(config={"maintenance_mode": True}, connect_driver=False)
         maintenance_socket_path = await manager.server_get_maintenance_socket_path(srv.server_id)

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -17,7 +17,6 @@ import json
 import uuid
 
 from test.pylib.manager_client import ManagerClient, ServerInfo
-from test.pylib.util import wait_for_cql_and_get_hosts
 from test.pylib.tablets import get_all_tablet_replicas
 
 from test.cqlpy import nodetool
@@ -54,8 +53,7 @@ async def test_file_streaming_respects_encryption(manager: ManagerClient, workdi
     servers.append(await manager.server_add(config=cfg, cmdline=cmdline))
     await manager.disable_tablet_balancing()
 
-    cql = manager.cql
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
     cql.execute("CREATE KEYSPACE ks WITH REPLICATION = {'class' : 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
     cql.execute(f"""CREATE TABLE ks.t(pk text primary key) WITH scylla_encryption_options = {{
         'cipher_algorithm' : 'AES/ECB/PKCS5Padding',
@@ -155,8 +153,7 @@ async def _smoke_test(manager: ManagerClient, key_provider: KeyProviderFactory,
     cfg = options | key_provider.configuration_parameters()
 
     servers: list[ServerInfo] = await manager.servers_add(servers_num = num_servers, config=cfg, auto_rack_dc='dc1')
-    cql = manager.cql
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with await create_ks(manager, replication_factor = num_servers) as ks:
         # to reduce test time, create one cf for every alg/len combo we test.
@@ -443,8 +440,7 @@ async def test_system_auth_encryption(manager: ManagerClient, tmpdir):
 
     servers: list[ServerInfo] = await manager.servers_add(servers_num = 1, config=cfg, 
                                                           driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')})
-    cql = manager.cql
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async def grep_database_files(pattern: str, path: str, files: str, expect:bool):
         pattern_found_counter = 0

--- a/test/cluster/test_encryption.py
+++ b/test/cluster/test_encryption.py
@@ -343,7 +343,7 @@ async def validate_sstables_encryption(manager: ManagerClient, server: ServerInf
 async def test_alter(manager, key_provider):
     """Tests altering encrypted CF:s and verify sstable data"""
     async def restart(manager: ManagerClient, servers: list[ServerInfo], table_names: list[str]):
-        cql = manager.cql
+        cql, _ = await manager.get_ready_cql(servers)
         expected_data = [list(row._asdict().values()) 
                          for row in cql.execute(f"SELECT * FROM {table_names[0]}")]
         logger.info("expected_data=%s", expected_data)
@@ -354,7 +354,6 @@ async def test_alter(manager, key_provider):
                                                table_names[0], True,
                                                expected_data=expected_data)
         # disable encryption
-        cql = manager.cql
         cql.execute(f"ALTER TABLE {table_names[0]} with "
                     "scylla_encryption_options={'key_provider':'none'}")
         table_desc = cql.execute(f"DESC {table_names[0]}").one().create_statement

--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -89,11 +89,9 @@ async def test_fence_writes(request, manager: ManagerClient, tablets_enabled: bo
         Column("pk", IntType),
         Column('counter_c', CounterType)
     ])
-    cql = manager.get_cql()
-    await cql.run_async(f"USE {random_tables.keyspace}")
-
     logger.info('Waiting for cql and hosts')
-    host2 = (await wait_for_cql_and_get_hosts(cql, [servers[2]], time.time() + 60))[0]
+    cql, [host2] = await manager.get_ready_cql([servers[2]])
+    await cql.run_async(f"USE {random_tables.keyspace}")
 
     # Run cleanup_all so the global barrier distributes fence_version := version to all nodes.
     # It must be invoked on the same host where version and fence_version are decremented.
@@ -152,11 +150,9 @@ async def test_fence_hints(request, manager: ManagerClient):
         Column("pk", IntType),
         Column('int_c', IntType)
     ])
-    cql = manager.get_cql()
-    await cql.run_async(f"USE {random_tables.keyspace}")
-
     logger.info(f'Waiting for cql and hosts')
-    hosts = await wait_for_cql_and_get_hosts(cql, [s0, s2], time.time() + 60)
+    cql, hosts = await manager.get_ready_cql([s0, s2])
+    await cql.run_async(f"USE {random_tables.keyspace}")
 
     host2 = host_by_server(hosts, s2)
     new_version = (await get_topology_version(cql, host2)) + 1

--- a/test/cluster/test_gossiper_race.py
+++ b/test/cluster/test_gossiper_race.py
@@ -28,6 +28,7 @@ async def test_gossiper_race_on_decommission(manager: ManagerClient):
 
     # Create cluster with more nodes to increase gossip traffic
     servers = await manager.servers_add(3, cmdline=cmdline)
+    await manager.get_ready_cql(servers)
 
     coordinator = await get_coordinator_host(manager=manager)
     coordinator_log = await manager.server_open_log(server_id=coordinator.server_id)

--- a/test/cluster/test_guardrails.py
+++ b/test/cluster/test_guardrails.py
@@ -13,7 +13,7 @@ from cassandra.protocol import ConfigurationException, InvalidRequest
 from cassandra.query import SimpleStatement
 
 from test.pylib.async_cql import _wrap_future
-from test.pylib.manager_client import ManagerClient, wait_for_cql_and_get_hosts
+from test.pylib.manager_client import ManagerClient
 from test.pylib.util import unique_name
 from test.cluster.util import new_test_keyspace
 

--- a/test/cluster/test_guardrails.py
+++ b/test/cluster/test_guardrails.py
@@ -52,11 +52,13 @@ async def test_default_rf(manager: ManagerClient):
     #   scylladb/scylladb#23071 and scylladb/scylla-dtest#5633.
     cfg = {"rf_rack_valid_keyspaces": False}
 
-    await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"})
-    await manager.server_add(config=cfg, property_file={"dc": "dc2", "rack": "r1"})
-    await manager.server_add(config=cfg, property_file={"dc": "dc3", "rack": "r1"})
+    servers = [
+        await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"}),
+        await manager.server_add(config=cfg, property_file={"dc": "dc2", "rack": "r1"}),
+        await manager.server_add(config=cfg, property_file={"dc": "dc3", "rack": "r1"}),
+    ]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks_name = unique_name()
     rf = {"dc1": 2, "dc2": 3, "dc3": 0}
     options = ", ".join([f"'{dc}':{rf_val}" for dc, rf_val in rf.items()])
@@ -87,8 +89,8 @@ async def test_all_rf_limits(manager: ManagerClient):
     }
 
     dc = "dc1"
-    await manager.server_add(config=cfg, property_file={"dc": dc, "rack": "r1"})
-    cql = manager.get_cql()
+    server = await manager.server_add(config=cfg, property_file={"dc": dc, "rack": "r1"})
+    cql, _ = await manager.get_ready_cql([server])
 
     for rf in range(MIN_FAIL_THRESHOLD - 1, MAX_FAIL_THRESHOLD + 1):
         ks_name = unique_name()

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -63,7 +63,7 @@ async def test_write_cl_any_to_dead_node_generates_hints(manager: ManagerClient)
             return None
         assert await wait_for(aux, time.time() + timeout)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         uses_tablets = await keyspace_has_tablets(manager, ks)
         # If the keyspace uses tablets, let's explicitly require the table to use multiple tablets.
@@ -101,6 +101,7 @@ async def test_limited_concurrency_of_writes(manager: ManagerClient):
     }, property_file = {"dc":"dc1", "rack":"rack1"})
     node2 = await manager.server_add(property_file = {"dc":"dc1", "rack":"rack2"})
 
+    await manager.get_ready_cql([node1, node2])
     cql = await manager.get_cql_exclusive(node1)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         table = f"{ks}.t"
@@ -131,7 +132,7 @@ async def test_sync_point(manager: ManagerClient):
     node_count = 3
     [node1, node2, node3] = await manager.servers_add(node_count, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([node1, node2, node3])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         table = f"{ks}.t"
         await cql.run_async(f"CREATE TABLE {table} (pk int primary key, v int)")
@@ -271,6 +272,7 @@ async def test_hints_consistency_during_replace(manager: ManagerClient):
     servers = await manager.servers_add(3, config={
         "error_injections_at_startup": ["decrease_hints_flush_period"]
     })
+    await manager.get_ready_cql(servers)
     cql = await manager.get_cql_exclusive(servers[0])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
@@ -312,7 +314,7 @@ async def test_draining_hints(manager: ManagerClient):
 
     s1, s2, s3 = await manager.servers_add(3, auto_rack_dc="dc")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s1, s2, s3])
 
     await manager.api.set_logger_level(s1.ip_addr, "hints_manager", "trace")
 
@@ -342,7 +344,7 @@ async def test_canceling_hint_draining(manager: ManagerClient):
     """
     s1, s2, s3 = await manager.servers_add(3, auto_rack_dc="dc")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s1, s2, s3])
     host_id2 = await manager.get_host_id(s2.server_id)
 
     await manager.api.set_logger_level(s1.ip_addr, "hints_manager", "trace")

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -399,6 +399,7 @@ async def test_hint_to_pending(manager: ManagerClient):
         {"dc": "dc1", "rack": "r1"},
         {"dc": "dc1", "rack": "r1"},
     ])
+    await manager.get_ready_cql(servers)
     cql = await manager.get_cql_exclusive(servers[0])
     await manager.disable_tablet_balancing()
 
@@ -458,6 +459,7 @@ async def test_hint_to_leaving_when_reducing_rf(manager: ManagerClient):
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
     ], cmdline=cmdline)
+    await manager.get_ready_cql(servers)
     cql = await manager.get_cql_exclusive(servers[0])
     await manager.disable_tablet_balancing()
 

--- a/test/cluster/test_hints.py
+++ b/test/cluster/test_hints.py
@@ -190,7 +190,7 @@ async def test_hints_consistency_during_decommission(manager: ManagerClient):
     (server1, server2, server3) = await manager.servers_add(3, config={
         "error_injections_at_startup": ["decrease_hints_flush_period"]
     })
-    cql = manager.cql
+    cql, _ = await manager.get_ready_cql([server1, server2, server3])
 
     logger.info("Creatting a keyspace with RF=1 and a table")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = { 'enabled': false }") as ks:

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -666,6 +666,7 @@ async def test_incremental_repair_tablet_time_metrics(manager: ManagerClient):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(manager):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
+    await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
@@ -692,6 +693,7 @@ async def test_incremental_repair_finishes_when_tablet_skips_end_repair_stage(ma
 async def test_incremental_repair_rejoin_do_tablet_operation(manager):
     cmdline = ['--logger-log-level', 'raft_topology=debug']
     servers = await manager.servers_add(3, auto_rack_dc="dc1", cmdline=cmdline)
+    await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:
@@ -740,6 +742,7 @@ async def test_incremental_repair_rejoin_do_tablet_operation(manager):
 async def test_incremental_retry_end_repair_stage(manager):
     config = {'tablet_load_stats_refresh_interval_in_seconds': 1}
     servers = await manager.servers_add(3, auto_rack_dc="dc1", config=config)
+    await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
         async with new_test_table(manager, ks, "pk int PRIMARY KEY, t text") as cf:

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -794,7 +794,7 @@ async def test_repair_sigsegv_with_diff_shard_count(manager: ManagerClient, use_
     servers = await manager.servers_add(1, cmdline=cmdline0, auto_rack_dc="dc1")
     servers.append(await manager.server_add(cmdline=cmdline1, property_file={'dc': 'dc1', 'rack': 'rack2'}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 2}} AND TABLETS = {{ 'enabled': {str(use_tablet).lower()} }}  ") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")

--- a/test/cluster/test_incremental_repair.py
+++ b/test/cluster/test_incremental_repair.py
@@ -9,7 +9,6 @@ from test.pylib.repair import load_tablet_sstables_repaired_at, load_tablet_repa
 from test.pylib.tablets import get_all_tablet_replicas
 from test.cluster.tasks.task_manager_client import TaskManagerClient
 from test.cluster.util import reconnect_driver, find_server_by_host_id, get_topology_coordinator, ensure_group0_leader_on, new_test_keyspace, new_test_table, trigger_stepdown, create_new_test_keyspace
-from test.pylib.util import wait_for_cql_and_get_hosts
 
 from cassandra.query import ConsistencyLevel, SimpleStatement
 
@@ -1394,10 +1393,8 @@ async def test_tombstone_gc_no_resurrection_propagation_delay(manager: ManagerCl
 
     # Restart servers[2]; D and T are not on its disk yet.
     await manager.server_start(servers[2].server_id)
-    await manager.servers_see_each_other(servers)
     await reconnect_driver(manager)
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # Repair: hints flush sends D and T to servers[2] before the repairing snapshot.
     # After row sync, mark_sstable_as_repaired() promotes D and T to repaired on servers[2].
@@ -1489,10 +1486,8 @@ async def test_tombstone_gc_mv_optimization_safe_via_hints(manager: ManagerClien
 
     # Restart servers[2]; view hints (D_view + T_mv) are still pending.
     await manager.server_start(servers[2].server_id)
-    await manager.servers_see_each_other(servers)
     await reconnect_driver(manager)
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # MV tablet repair:
     #   flush_hints() → hints_for_views_manager replays D_view + T_mv to servers[2] before snapshot
@@ -1613,10 +1608,8 @@ async def test_tombstone_gc_mv_safe_staging_processor_delay(manager: ManagerClie
 
     # Restart servers[0]; still no D_base on base or D_view on MV for servers[0].
     await manager.server_start(servers[0].server_id)
-    await manager.servers_see_each_other(servers)
     await reconnect_driver(manager)
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # Block the staging processor on servers[0] BEFORE running base repair, so that
     # the staged D_base (written by row-sync during base repair) never gets dispatched

--- a/test/cluster/test_internode_compression.py
+++ b/test/cluster/test_internode_compression.py
@@ -132,7 +132,7 @@ async def do_test_internode_compression_between_datacenters(manager: ManagerClie
     # And connect the driver.
     await manager.driver_connect(servers[0][0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s for s, _ in servers])
 
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 }") as ks:
         async with new_test_table(manager, ks, "key int PRIMARY KEY, val TEXT") as table:

--- a/test/cluster/test_ip_mappings.py
+++ b/test/cluster/test_ip_mappings.py
@@ -23,6 +23,8 @@ async def test_broken_bootstrap(manager: ManagerClient):
     server_a = await manager.server_add()
     server_b = await manager.server_add(start=False)
 
+    await manager.get_ready_cql([server_a])
+
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         table = f"{ks}.test"
         await manager.cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int)")

--- a/test/cluster/test_left_node_notification.py
+++ b/test/cluster/test_left_node_notification.py
@@ -36,7 +36,7 @@ async def test_left_node_notification(manager: ManagerClient) -> None:
     # "zero replica after the removal" or "can not find new node in local dc" errors when
     # removing dc1 nodes, we alter the audit keyspace to have replicas only in dc2.
     # Only alter if the audit keyspace exists (it might not exist if audit is disabled).
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([dc1_node_a, dc1_node_b, dc2_node])
     result = await cql.run_async("SELECT * FROM system_schema.keyspaces WHERE keyspace_name = 'audit'")
     if result:
         await cql.run_async("ALTER KEYSPACE audit WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'dc2': 1}")

--- a/test/cluster/test_logstor.py
+++ b/test/cluster/test_logstor.py
@@ -21,8 +21,8 @@ logger = logging.getLogger(__name__)
 async def test_property(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t_enabled (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
@@ -48,8 +48,8 @@ async def test_config_option_consistency(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     # Logstor feature is NOT enabled
     cfg = {'experimental_features': []}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         # Should fail because logstor feature is not enabled
@@ -60,8 +60,8 @@ async def test_config_option_consistency(manager: ManagerClient):
 async def test_basic_write_and_read(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
 
@@ -104,8 +104,8 @@ async def test_basic_write_and_read(manager: ManagerClient):
 async def test_range_read(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
@@ -132,8 +132,8 @@ async def test_range_read(manager: ManagerClient):
 async def test_parallel_writes(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
@@ -151,8 +151,8 @@ async def test_parallel_writes(manager: ManagerClient):
 async def test_overwrites(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=debug']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v int) WITH storage_engine = 'logstor'")
@@ -174,8 +174,8 @@ async def test_parallel_big_writes(manager: ManagerClient):
     """
     cmdline = ['--logger-log-level', 'logstor=debug', '--smp=1']
     cfg = {'experimental_features': ['logstor']}
-    await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -211,7 +211,7 @@ async def test_recovery_basic(manager: ManagerClient, fail_separator_flush: bool
     cmdline = ['--logger-log-level', 'logstor=trace']
     cfg = {'experimental_features': ['logstor']}
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     if fail_separator_flush:
         await manager.api.enable_injection(servers[0].ip_addr, "fail_flush_separator_buffer", one_shot=False)
@@ -304,7 +304,7 @@ async def test_recovery_with_segment_reuse(manager: ManagerClient):
         'experimental_features': ['logstor']
     }
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -355,7 +355,7 @@ async def test_compaction(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=trace', '--smp=1']
     cfg = {'experimental_features': ['logstor']}
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH tablets={'initial':1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -396,7 +396,7 @@ async def test_drop_table(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'logstor=trace']
     cfg = {'experimental_features': ['logstor']}
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH tablets={'initial': 4}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test1 (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -470,7 +470,7 @@ async def test_trigger_separator_flush(manager: ManagerClient):
         'experimental_features': ['logstor']
     }
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH tablets={'initial':2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, v text) WITH storage_engine = 'logstor'")
@@ -513,7 +513,7 @@ async def test_tablet_split_trigger_by_size(manager: ManagerClient):
         'experimental_features': ['logstor'],
     }
     servers = [await manager.server_add(cmdline=cmdline, config=cfg)]
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     s0_log = await manager.server_open_log(servers[0].server_id)
 
@@ -559,7 +559,7 @@ async def test_tablet_split_and_merge(manager: ManagerClient):
     }
     servers = [await manager.server_add(config=cfg, cmdline=cmdline)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1 AND storage_engine='logstor';")
 

--- a/test/cluster/test_lwt_semaphore.py
+++ b/test/cluster/test_lwt_semaphore.py
@@ -5,9 +5,7 @@
 #
 
 import asyncio
-import time
 from test.pylib.rest_client import inject_error
-from test.pylib.util import wait_for_cql_and_get_hosts
 import pytest
 from cassandra.protocol import WriteTimeout
 from test.cluster.util import new_test_keyspace
@@ -19,7 +17,7 @@ async def test_cas_semaphore(manager):
     """ This is a regression test for scylladb/scylladb#19698 """
     servers = await manager.servers_add(1, cmdline=['--smp', '1', '--write-request-timeout-in-ms', '500'])
 
-    host = await wait_for_cql_and_get_hosts(manager.cql, {servers[0]}, time.time() + 60)
+    _, host = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH REPLICATION = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         table = f"{ks}.test"

--- a/test/cluster/test_maintenance_mode.py
+++ b/test/cluster/test_maintenance_mode.py
@@ -37,6 +37,7 @@ async def test_maintenance_mode(manager: ManagerClient):
     """
     max_rf = 3
     servers = await manager.servers_add(max_rf, auto_rack_dc='dc1')
+    await manager.get_ready_cql(servers)
     server_a = servers[0]
     host_id_a = await manager.get_host_id(server_a.server_id)
     socket_endpoint = UnixSocketEndPoint(await manager.server_get_maintenance_socket_path(server_a.server_id))

--- a/test/cluster/test_major_compaction.py
+++ b/test/cluster/test_major_compaction.py
@@ -42,11 +42,12 @@ async def test_major_compaction_consider_only_existing_data(manager: ManagerClie
     cmdline = [
         '--tablets-initial-scale-factor=1' # The test assumes 1 compaction group per shard because of injection point trap
     ]
-    server = (await manager.servers_add(1, cmdline=cmdline))[0]
+    servers = await manager.servers_add(1, cmdline=cmdline)
+    server = servers[0]
 
     logger.info("Creating table")
     cf = "test_consider_only_existing_data"
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
@@ -113,7 +114,7 @@ async def test_major_compaction_flush_all_tables(manager: ManagerClient, compact
 
     logger.info("Creating table")
     cf = "test_flush_all_tables"
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
@@ -161,7 +162,7 @@ async def test_shutdown_drain_during_compaction(manager: ManagerClient):
 
     logger.info("Creating table")
     cf = "test_shutdown_drain_during_compaction"
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY);")
         await disable_autocompaction_across_keyspaces(manager, server.ip_addr, ks)
@@ -213,7 +214,7 @@ async def test_alter_compaction_strategy_during_compaction(manager: ManagerClien
     7. Verify no unexpected errors in logs
     """
     node1 = await manager.server_add(cmdline=['--logger-log-level', 'compaction=debug'])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([node1])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         logger.info("Create table")
@@ -262,7 +263,7 @@ async def test_disable_autocompaction_during_major_compaction(manager: ManagerCl
     await disable_autocompaction_across_keyspaces(manager, server.ip_addr, "system", "system_schema")
 
     cf = "cf"
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         logger.info("Creating table")
         await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY)")

--- a/test/cluster/test_metadata_id.py
+++ b/test/cluster/test_metadata_id.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 
 async def create_server_and_cqls(manager, cqls_num):
     server = await manager.server_add()
+    await manager.get_ready_cql([server])
 
     def create_cluster_connection():
         return cluster_con([server.ip_addr],

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -61,13 +61,15 @@ async def test_putget_2dc_with_rf(
     table_name = "test_table_name"
     columns = [Column("name", TextType), Column("value", TextType)]
     logger.info("Create two servers in different DC's")
+    servers = []
     for rack_idx, dc_idx in enumerate(nodes_list):
         s_info = await manager.server_add(
             config=CONFIG,
             property_file={"dc": f"dc{dc_idx}", "rack": f"rack{rack_idx}"},
         )
         logger.info(s_info)
-    conn = manager.get_cql()
+        servers.append(s_info)
+    conn, _ = await manager.get_ready_cql(servers)
     random_tables = RandomTables(request.node.name, manager, ks, rf)
     logger.info("Add table")
     await random_tables.add_table(ncolumns=2, columns=columns, pks=1, name=table_name)
@@ -348,13 +350,14 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"}))
     servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r2"}))
     servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r3"}))
+
     # Zero-token node. This rack should behave as if it didn't exist.
-    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc1", "rack": "r4"})
+    await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc1", "rack": "r4"})
 
     # Arbiter DC.
-    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r1"})
-    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r2"})
-    _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r3"})
+    await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r1"})
+    await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r2"})
+    await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r3"})
 
     # Only token-owning servers become CQL hosts visible to the driver, so we
     # only wait on the regular DC1 nodes here.
@@ -428,7 +431,7 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager:
     s3 = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r3"})
     s4 = await manager.server_add(config=cfg_false, property_file={"dc": "dc2", "rack": "r4"})
     # Note: This rack should behave as if it never existed.
-    _ = await manager.server_add(config={"join_ring": "false", "rf_rack_valid_keyspaces": "false"}, property_file={"dc": "dc1", "rack": "rzerotoken"})
+    await manager.server_add(config={"join_ring": "false", "rf_rack_valid_keyspaces": "false"}, property_file={"dc": "dc1", "rack": "rzerotoken"})
 
     # Current situation:
     # DC1: {r1, r2, r3}, DC2: {r4}
@@ -536,9 +539,9 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces_but_not_
 
     # One DC, 4 racks.
     dc = "dc1"
-    s1, _, _, _ = await manager.servers_add(4, config=cfg, auto_rack_dc=dc)
+    s1, s2, s3, s4 = await manager.servers_add(4, config=cfg, auto_rack_dc=dc)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s1, s2, s3, s4])
     # We need to set `max_schema_agreement_wait` to 0 to speed up this test.
     assert hasattr(cql.cluster, "max_schema_agreement_wait")
     cql.cluster.max_schema_agreement_wait = 0
@@ -602,8 +605,9 @@ async def test_warn_create_and_alter_rf_rack_invalid_ks(manager: ManagerClient):
         manager.server_add(config=cfg, property_file={"dc": "dc2", "rack": "r5"}),
     ]
     await asyncio.gather(*start_node_tasks)
+    servers = await manager.running_servers()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     # We need to set `max_schema_agreement_wait` to 0 to speed up this test.
     # Without it, the test takes 50 seconds (or 16 seconds if cases run in parallel).
     # With it, the test takes about 9 seconds. All results on my local machine of course.

--- a/test/cluster/test_multidc.py
+++ b/test/cluster/test_multidc.py
@@ -224,9 +224,12 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
     # Step 1.
     # -------
     # dc1: r1=1, rzerotoken=1 (Note: zero-token nodes have NO impact. In this case, this rack should behave as if it never existed).
-    _ = await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}, config=cfg)
+    normal_servers = []
+    normal_servers.append(await manager.server_add(property_file={"dc": "dc1", "rack": "r1"}, config=cfg))
     _ = await manager.server_add(property_file={"dc": "dc1", "rack": "rzerotoken"}, config=cfg_zero_token)
-    cql = manager.get_cql()
+    # The zero-token node never becomes a CQL host visible to the driver, so
+    # we only wait on the token-owning servers here.
+    cql, _ = await manager.get_ready_cql(normal_servers)
 
     ks1 = await create_ok([1])
     await create_ok([0])
@@ -246,7 +249,8 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
     # -------
     # dc1: r1=1, rzerotoken=1.
     # dc2: r1=1.
-    _ = await manager.server_add(property_file={"dc": "dc2", "rack": "r1"}, config=cfg)
+    normal_servers.append(await manager.server_add(property_file={"dc": "dc2", "rack": "r1"}, config=cfg))
+    await manager.get_ready_cql(normal_servers)
 
     ks2 = await create_ok([1, 1])
 
@@ -294,7 +298,8 @@ async def test_create_and_alter_keyspace_with_altering_rf_and_racks(manager: Man
     # -------
     # dc1: r1=1, r2=1, rzerotoken=1.
     # dc2: r1=1.
-    _ = await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}, config=cfg)
+    normal_servers.append(await manager.server_add(property_file={"dc": "dc1", "rack": "r2"}, config=cfg))
+    await manager.get_ready_cql(normal_servers)
 
     ks3 = await create_ok([2, 1])
     # RF = 1 is always OK!
@@ -339,9 +344,10 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     zero_token_cfg = {"rf_rack_valid_keyspaces": "true", "join_ring": "false"}
 
     # Regular DC.
-    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"})
-    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r2"})
-    _ = await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r3"})
+    servers = []
+    servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r1"}))
+    servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r2"}))
+    servers.append(await manager.server_add(config=cfg, property_file={"dc": "dc1", "rack": "r3"}))
     # Zero-token node. This rack should behave as if it didn't exist.
     _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc1", "rack": "r4"})
 
@@ -350,7 +356,9 @@ async def test_arbiter_dc_rf_rack_valid_keyspaces(manager: ManagerClient):
     _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r2"})
     _ = await manager.server_add(config=zero_token_cfg, property_file={"dc": "dc2", "rack": "r3"})
 
-    cql = manager.get_cql()
+    # Only token-owning servers become CQL hosts visible to the driver, so we
+    # only wait on the regular DC1 nodes here.
+    cql, _ = await manager.get_ready_cql(servers)
 
     async def create_aux(ks: str, rfs: Union[List[int], int]):
         if type(rfs) is int:
@@ -416,16 +424,18 @@ async def test_startup_with_keyspaces_violating_rf_rack_valid_keyspaces(manager:
     cfg_false = {"rf_rack_valid_keyspaces": "false"}
 
     s1 = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r1"})
-    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r2"})
-    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r3"})
-    _ = await manager.server_add(config=cfg_false, property_file={"dc": "dc2", "rack": "r4"})
+    s2 = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r2"})
+    s3 = await manager.server_add(config=cfg_false, property_file={"dc": "dc1", "rack": "r3"})
+    s4 = await manager.server_add(config=cfg_false, property_file={"dc": "dc2", "rack": "r4"})
     # Note: This rack should behave as if it never existed.
     _ = await manager.server_add(config={"join_ring": "false", "rf_rack_valid_keyspaces": "false"}, property_file={"dc": "dc1", "rack": "rzerotoken"})
 
     # Current situation:
     # DC1: {r1, r2, r3}, DC2: {r4}
 
-    cql = manager.get_cql()
+    # The zero-token node never becomes a CQL host visible to the driver, so
+    # we only wait on the token-owning servers here.
+    cql, _ = await manager.get_ready_cql([s1, s2, s3, s4])
 
     async def create_keyspace(rfs: List[int], tablets: bool) -> str:
         dcs = ", ".join([f"'dc{i + 1}': {rf}" for i, rf in enumerate(rfs)])

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -35,7 +35,7 @@ async def test_mv_tombstone_gc_setting(manager):
     is not supported on a single node, which is why this test needs to
     be here and not in the single-node cqlpy.
     """
-    cql = manager.cql
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     async with new_test_keyspace(manager, ksdef) as keyspace:
         async with new_test_table(manager, keyspace, "p int primary key, x int") as table:
             # Adding "WITH tombstone_gc = ..." In the CREATE MATERIALIZED VIEW:
@@ -58,8 +58,7 @@ async def test_mv_tombstone_gc_not_inherited(manager):
     This behavior is not explicitly documented anywhere, but this test
     demonstrates the existing behavior.
     """
-    await manager.get_ready_cql(await manager.running_servers())
-    cql = manager.cql
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     async with new_test_keyspace(manager, ksdef) as keyspace:
         async with new_test_table(manager, keyspace, "p int primary key, x int", "WITH tombstone_gc = {'mode': 'immediate'}") as table:
             s = list(cql.execute(f"DESC {table}"))[0].create_statement

--- a/test/cluster/test_mv.py
+++ b/test/cluster/test_mv.py
@@ -58,6 +58,7 @@ async def test_mv_tombstone_gc_not_inherited(manager):
     This behavior is not explicitly documented anywhere, but this test
     demonstrates the existing behavior.
     """
+    await manager.get_ready_cql(await manager.running_servers())
     cql = manager.cql
     async with new_test_keyspace(manager, ksdef) as keyspace:
         async with new_test_table(manager, keyspace, "p int primary key, x int", "WITH tombstone_gc = {'mode': 'immediate'}") as table:

--- a/test/cluster/test_node_isolation.py
+++ b/test/cluster/test_node_isolation.py
@@ -29,7 +29,7 @@ async def test_banned_node_notification(manager: ManagerClient, failure_detector
         'failure_detector_timeout_in_ms': failure_detector_timeout
     }
     srvs = await manager.servers_add(3, config=config, auto_rack_dc="dc")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(srvs)
 
     # Pause one of the servers so other nodes mark it as dead and we can remove it.
     # We deliberately don't shut it down, but only pause it - we want to test

--- a/test/cluster/test_node_shutdown_waits_for_pending_requests.py
+++ b/test/cluster/test_node_shutdown_waits_for_pending_requests.py
@@ -8,7 +8,6 @@ from test.pylib.rest_client import inject_error_one_shot
 from cassandra.query import SimpleStatement # type: ignore
 from cassandra.cluster import ConsistencyLevel # type: ignore
 from cassandra.protocol import ReadTimeout # type: ignore
-from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import new_test_keyspace, reconnect_driver
 
 
@@ -22,10 +21,8 @@ async def test_node_shutdown_waits_for_pending_requests(manager: ManagerClient) 
 
     logger.info('start two nodes')
     servers = await manager.servers_add(servers_num=2, auto_rack_dc="dc")
-    cql = manager.get_cql()
-
     logger.info(f'wait for host for the node {servers[0]}, servers {servers}')
-    h0 = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60))[0]
+    cql, [h0] = await manager.get_ready_cql([servers[0]])
 
     logger.info('create keyspace and table')
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:

--- a/test/cluster/test_not_enough_token_owners.py
+++ b/test/cluster/test_not_enough_token_owners.py
@@ -8,7 +8,7 @@ import logging
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import unique_name, wait_for_cql_and_get_hosts
+from test.pylib.util import unique_name
 from test.cluster.util import new_test_keyspace
 
 
@@ -50,9 +50,7 @@ async def test_not_enough_token_owners(manager: ManagerClient):
     logging.info('Adding a normal server')
     server_c = await manager.server_add(property_file={"dc": "dc1", "rack": "r2"})
 
-    cql = manager.get_cql()
-
-    await wait_for_cql_and_get_hosts(cql, [server_a, server_c], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server_a, server_c])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = { 'enabled': true }") as ks_name:
         await cql.run_async(f'CREATE TABLE {ks_name}.tbl (pk int PRIMARY KEY, v int)')

--- a/test/cluster/test_prepare_race.py
+++ b/test/cluster/test_prepare_race.py
@@ -16,7 +16,7 @@ from test.pylib.rest_client import inject_error_one_shot
 @pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
 async def test_prepare_fails_if_cached_statement_is_invalidated_mid_prepare(manager: ManagerClient):
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     log = await manager.server_open_log(server.server_id)
     
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:

--- a/test/cluster/test_proxy_protocol.py
+++ b/test/cluster/test_proxy_protocol.py
@@ -369,7 +369,7 @@ async def test_proxy_protocol_shard_aware(proxy_server):
     # The test harness runs with --smp 2 by default
     num_shards = 2
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     fake_src_addr = "203.0.113.43"
     base_port = 10000
@@ -477,7 +477,7 @@ async def test_proxy_protocol_port_preserved_in_system_clients(proxy_server):
         await do_cql_handshake(reader, writer)
 
         # Now query system.clients using the driver to see our connection
-        cql = manager.get_cql()
+        cql, _ = await manager.get_ready_cql([server])
         rows = await wait_for_results(
             cql,
             'SELECT address, port FROM system.clients',
@@ -538,7 +538,7 @@ async def test_proxy_protocol_ssl_shard_aware(proxy_server):
     # The test harness runs with --smp 2 by default
     num_shards = 2
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     fake_src_addr = "203.0.113.51"
     base_port = 20000
@@ -693,7 +693,7 @@ async def test_proxy_protocol_ssl_port_preserved(proxy_server):
             ssl_sock.recv(4096)
 
         # Now query system.clients using the driver to see our connection
-        cql = manager.get_cql()
+        cql, _ = await manager.get_ready_cql([server])
         rows = await wait_for_results(
             cql,
             'SELECT address, port, ssl_enabled FROM system.clients',

--- a/test/cluster/test_query_rebounce.py
+++ b/test/cluster/test_query_rebounce.py
@@ -43,7 +43,7 @@ async def test_query_rebounce(manager: ManagerClient):
     servers = await manager.servers_add(1, cmdline=cmdline)
 
     servers = await manager.running_servers()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         await cql.run_async(f"create table {ks}.lwt (a int, b int, primary key(a));")

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -41,7 +41,8 @@ async def test_downgrade_after_successful_upgrade_fails(manager: ManagerClient) 
 
 @pytest.mark.asyncio
 async def test_partial_upgrade_can_be_finished_with_removenode(manager: ManagerClient) -> None:
-    await manager.servers_add(3, auto_rack_dc="dc1")
+    servers = await manager.servers_add(3, auto_rack_dc="dc1")
+    await manager.get_ready_cql(servers)
     await test_cluster_features.test_partial_upgrade_can_be_finished_with_removenode(manager)
 
 

--- a/test/cluster/test_raft_cluster_features.py
+++ b/test/cluster/test_raft_cluster_features.py
@@ -10,7 +10,7 @@ import asyncio
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_feature
+from test.pylib.util import wait_for_feature
 from test.cluster import test_cluster_features
 import pytest
 
@@ -81,6 +81,5 @@ async def test_cannot_disable_cluster_feature_after_all_declare_support(manager:
     await manager.server_start(servers[0].server_id)
 
     # Nodes should start supporting the feature
-    cql = cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     await asyncio.gather(*(wait_for_feature('TEST_ONLY_FEATURE', cql, h, time.time() + 60) for h in hosts))

--- a/test/cluster/test_raft_no_quorum.py
+++ b/test/cluster/test_raft_no_quorum.py
@@ -202,8 +202,9 @@ async def test_cannot_run_operations(manager: ManagerClient, raft_op_timeout: in
     servers += await manager.servers_add(servers_num=2, property_file={"dc": "dc1", "rack": "rack2"})
 
     logger.info('create keyspace and table')
-    ks = await create_new_test_keyspace(manager.get_cql(), "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
-    await manager.get_cql().run_async(f'create table {ks}.test_table (pk int primary key)')
+    cql, _ = await manager.get_ready_cql(servers)
+    ks = await create_new_test_keyspace(cql, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
+    await cql.run_async(f'create table {ks}.test_table (pk int primary key)')
 
     logger.info("stopping the second and third nodes")
     await asyncio.gather(manager.server_stop_gracefully(servers[1].server_id),
@@ -229,7 +230,7 @@ async def test_cannot_run_operations(manager: ManagerClient, raft_op_timeout: in
 
     with pytest.raises(Exception, match="raft operation \\[read_barrier\\] timed out, "
                                         "there is no raft quorum, total voters count 3, alive voters count 1"):
-        await manager.get_cql().run_async(f'drop table {ks}.test_table', timeout=60)
+        await cql.run_async(f'drop table {ks}.test_table', timeout=60)
 
     logger.info("done")
 

--- a/test/cluster/test_raft_snapshot_request.py
+++ b/test/cluster/test_raft_snapshot_request.py
@@ -22,10 +22,9 @@ async def test_raft_snapshot_request(manager: ManagerClient):
         '--logger-log-level', 'raft=trace',
         ]
     servers = await manager.servers_add(3, cmdline=cmdline)
-    cql = manager.get_cql()
 
     s1 = servers[0]
-    h1 = (await wait_for_cql_and_get_hosts(cql, [s1], time.time() + 60))[0]
+    cql, [h1] = await manager.get_ready_cql([s1])
 
     # Verify that snapshotting updates the snapshot ID and truncates the log.
     log_size = await get_raft_log_size(cql, h1)

--- a/test/cluster/test_raft_snapshot_truncation.py
+++ b/test/cluster/test_raft_snapshot_truncation.py
@@ -10,7 +10,7 @@ import time
 import logging
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for
 from test.cluster.util import reconnect_driver, trigger_snapshot, get_topology_coordinator, get_raft_log_size, get_raft_snap_id, create_new_test_keyspace
 from test.pylib.rest_client import inject_error_one_shot
 
@@ -40,10 +40,9 @@ async def test_raft_snapshot_truncation(manager: ManagerClient):
         '--logger-log-level', 'raft=trace',
     ]
     servers = await manager.servers_add(3, cmdline=cmdline)
-    cql = manager.get_cql()
 
     s1 = servers[0]
-    h1 = (await wait_for_cql_and_get_hosts(cql, [s1], time.time() + 60))[0]
+    cql, [h1] = await manager.get_ready_cql([s1])
 
     log_size = await get_raft_log_size(cql, h1)
     logger.info(f"Log size on {s1}: {log_size}")

--- a/test/cluster/test_raft_voters.py
+++ b/test/cluster/test_raft_voters.py
@@ -222,6 +222,9 @@ async def test_raft_limited_voters_retain_coordinator(manager: ManagerClient):
 
     assert len(dc_servers) == len(dc_setup)
 
+    all_servers = [s for dc in dc_servers for s in dc]
+    await manager.get_ready_cql(all_servers)
+
     coordinator_ids = await get_coordinator_host_ids(manager)
     assert coordinator_ids, "At least 1 coordinator id should be found"
 

--- a/test/cluster/test_random_tables.py
+++ b/test/cluster/test_random_tables.py
@@ -16,8 +16,7 @@ pytestmark = pytest.mark.prepare_3_racks_cluster
 # Simple test of schema helper
 @pytest.mark.asyncio
 async def test_new_table(manager, random_tables):
-    cql = manager.cql
-    assert cql is not None
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     table = await random_tables.add_table(ncolumns=5)
     # Before performing data queries, make sure that the token ring
     # has converged (we're using ring_delay = 0).
@@ -45,8 +44,7 @@ async def test_new_table(manager, random_tables):
 @pytest.mark.asyncio
 async def test_alter_verify_schema(manager, random_tables):
     """Verify table schema"""
-    cql = manager.cql
-    assert cql is not None
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     await random_tables.add_tables(ntables=4, ncolumns=5)
     await random_tables.verify_schema()
     # Manually remove a column
@@ -58,8 +56,7 @@ async def test_alter_verify_schema(manager, random_tables):
 
 @pytest.mark.asyncio
 async def test_new_table_insert_one(manager, random_tables):
-    cql = manager.cql
-    assert cql is not None
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     table = await random_tables.add_table(ncolumns=5)
     await table.insert_seq()
     pk_col = table.columns[0]
@@ -74,8 +71,7 @@ async def test_new_table_insert_one(manager, random_tables):
 @pytest.mark.asyncio
 async def test_drop_column(manager, random_tables):
     """Drop a random column from a table"""
-    cql = manager.cql
-    assert cql is not None
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     table = await random_tables.add_table(ncolumns=5)
     await table.insert_seq()
     await table.drop_column()
@@ -102,8 +98,7 @@ async def test_add_index(random_tables):
 @pytest.mark.asyncio
 async def test_paged_result(manager, random_tables):
     """Test run_async with paged results"""
-    cql = manager.cql
-    assert cql is not None
+    cql, _ = await manager.get_ready_cql(await manager.running_servers())
     table = await random_tables.add_table(ncolumns=5)
     inserts = []
     nrows = 21

--- a/test/cluster/test_read_repair.py
+++ b/test/cluster/test_read_repair.py
@@ -15,7 +15,7 @@ from cassandra.cluster import ConsistencyLevel, Session  # type: ignore
 from cassandra.query import SimpleStatement  # type: ignore
 from cassandra.pool import Host  # type: ignore
 
-from test.pylib.util import wait_for_cql_and_get_hosts, execute_with_tracing
+from test.pylib.util import execute_with_tracing
 from test.pylib.internal_types import ServerInfo
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
@@ -199,9 +199,7 @@ async def test_incremental_read_repair(data_class: DataClass, manager: ManagerCl
     nodes = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
     node1, node2 = nodes
 
-    cql = manager.get_cql()
-
-    host1, host2 = await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
+    cql, [host1, host2] = await manager.get_ready_cql([node1, node2])
 
     # The test generates and uploads sstables, assuming their specific
     # contents. These assumptions are not held with tablets, which
@@ -317,9 +315,8 @@ async def test_read_repair_with_trace_logging(request, manager):
 
     [node1, node2] = await manager.servers_add(2, cmdline=cmdline, config=config, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
     srvs = await manager.running_servers()
-    await wait_for_cql_and_get_hosts(cql, srvs, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(srvs)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk bigint, ck bigint, c int, PRIMARY KEY (pk, ck));")

--- a/test/cluster/test_refresh.py
+++ b/test/cluster/test_refresh.py
@@ -110,7 +110,7 @@ async def test_refresh_deletes_uploaded_sstables(manager: ManagerClient):
 
     servers = await manager.servers_add(2)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await manager.disable_tablet_balancing()
 

--- a/test/cluster/test_remove_rpc_client_with_pending_requests.py
+++ b/test/cluster/test_remove_rpc_client_with_pending_requests.py
@@ -38,11 +38,12 @@ async def test_remove_rpc_client_with_pending_requests(request, manager: Manager
     test_rows_count = 10
     futures = []
     expected_data = []
+    cql, _ = await manager.get_ready_cql(servers)
     for i in range(0, test_rows_count):
         k = f'key_{i}'
         v = f'value_{i}'
         expected_data.append((k, v))
-        futures.append(manager.get_cql().run_async("insert into ks.test_table(key, value) values (%s, %s)",
+        futures.append(cql.run_async("insert into ks.test_table(key, value) values (%s, %s)",
                                                    parameters=[k, v], host=host0))
     await asyncio.gather(*futures)
     expected_data.sort()
@@ -57,7 +58,7 @@ async def test_remove_rpc_client_with_pending_requests(request, manager: Manager
     reads_count = 0
     start_time = time.time()
     while not third_node_future.done():
-        result_set = await manager.get_cql().run_async(SimpleStatement("select * from ks.test_table",
+        result_set = await cql.run_async(SimpleStatement("select * from ks.test_table",
                                                                        consistency_level=ConsistencyLevel.ALL),
                                                        host=host0)
         actual_data = []

--- a/test/cluster/test_remove_rpc_client_with_pending_requests.py
+++ b/test/cluster/test_remove_rpc_client_with_pending_requests.py
@@ -25,7 +25,7 @@ async def test_remove_rpc_client_with_pending_requests(request, manager: Manager
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
     logger.info(f"wait_for_cql_and_get_hosts for the first node {servers[0]}")
-    host0 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[0]], time.time() + 60))[0]
+    _, [host0] = await manager.get_ready_cql([servers[0]])
 
     logger.info(f"creating test table")
     random_tables = RandomTables(request.node.name, manager, "ks", 2)

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -247,9 +247,9 @@ async def test_vnode_keyspace_describe_ring(manager: ManagerClient):
     }
     servers = await manager.servers_add(2, config=cfg)
 
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         keys = dict()
-        cql, _ = await manager.get_ready_cql(servers)
         await cql.run_async(f"CREATE TABLE {ks}.tbl (pk int PRIMARY KEY)")
         for i in range(100):
             key = random.randint(-1000000000, 1000000000)

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -46,14 +46,13 @@ async def test_enable_compacting_data_for_streaming_and_repair_live_update(manag
     cmdline = ["--enable-compacting-data-for-streaming-and-repair", "0", "--smp", "1", "--logger-log-level", "api=trace"]
     node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, [host1, host2] = await manager.get_ready_cql([node1, node2])
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY)")
 
     config_item = "enable_compacting_data_for_streaming_and_repair"
 
-    host1, host2 = await wait_for_cql_and_get_hosts(cql, [node1, node2], time.time() + 30)
 
     for host in (host1, host2):
         res = list(cql.execute(f"SELECT value FROM system.config WHERE name = '{config_item}'", host=host))
@@ -291,13 +290,12 @@ async def test_repair_timtestamp_difference(manager):
     cmdline = [ "--smp", "1", "--logger-log-level", "api=trace", "--hinted-handoff-enabled", "0" ]
     node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, [host1, host2] = await manager.get_ready_cql([node1, node2])
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck UUID, v text, PRIMARY KEY (pk, ck))")
 
     nodes = [node1, node2]
-    host1, host2 = await wait_for_cql_and_get_hosts(cql, nodes, time.time() + 30)
 
     pk = 1
     ck = uuid.uuid1()

--- a/test/cluster/test_repair.py
+++ b/test/cluster/test_repair.py
@@ -94,7 +94,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
             "--logger-log-level", "api=trace:database=trace"]
     node1, node2 = await manager.servers_add(2, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([node1, node2])
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH compaction = {'class': 'NullCompactionStrategy'}")
@@ -156,7 +156,7 @@ async def test_tombstone_gc_for_streaming_and_repair(manager):
 @pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
 async def test_repair_succeeds_with_unitialized_bm(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {'mode': 'repair'}")
@@ -177,7 +177,7 @@ async def do_batchlog_flush_in_repair(manager, cache_time_in_ms):
     cmdline = ["--repair-hints-batchlog-flush-cache-time-in-ms", str(cache_time_in_ms), "--smp", "1", "--logger-log-level", "api=trace"]
     node1, node2 = await manager.servers_add(2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([node1, node2])
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int PRIMARY KEY) WITH tombstone_gc = {'mode': 'repair'}")
 
@@ -232,9 +232,9 @@ async def test_keyspace_drop_during_data_sync_repair(manager):
         'tablets_mode_for_new_keyspaces': 'disabled',
         'error_injections_at_startup': ['get_keyspace_erms_throw_no_such_keyspace']
     }
-    await manager.server_add(config=cfg)
+    server = await manager.server_add(config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {'mode': 'repair'}")
@@ -250,7 +250,7 @@ async def test_vnode_keyspace_describe_ring(manager: ManagerClient):
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         keys = dict()
-        cql = manager.get_cql()
+        cql, _ = await manager.get_ready_cql(servers)
         await cql.run_async(f"CREATE TABLE {ks}.tbl (pk int PRIMARY KEY)")
         for i in range(100):
             key = random.randint(-1000000000, 1000000000)
@@ -345,7 +345,7 @@ async def test_repair_timtestamp_difference(manager):
 async def test_small_table_optimization_repair(manager):
     servers = await manager.servers_add(2, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     cql.execute("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND TABLETS = {'enabled': false}")
     cql.execute("CREATE TABLE ks.tbl (pk int, ck int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {'mode': 'repair'}")

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -31,7 +31,7 @@ async def test_replace_different_ip(manager: ManagerClient, failure_detector_tim
     replaced_server = servers[0]
     replace_cfg = ReplaceConfig(replaced_id = replaced_server.server_id, reuse_ip_addr = False, use_host_id = False)
     new_server = await manager.server_add(replace_cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([new_server])
     servers = await manager.running_servers()
     all_ips = set([s.rpc_address for s in servers])
     logger.info(f"new server {new_server} started, all ips {all_ips}, "

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -79,7 +79,7 @@ async def test_replace_different_ip_using_host_id(manager: ManagerClient, failur
 async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detector_timeout) -> None:
     """Replace an existing node with new node using the same IP address"""
     servers = await manager.servers_add(3, config={'failure_detector_timeout_in_ms': failure_detector_timeout}, auto_rack_dc="dc1")
-    host2 = (await wait_for_cql_and_get_hosts(manager.get_cql(), [servers[2]], time.time() + 60))[0]
+    _, [host2] = await manager.get_ready_cql([servers[2]])
 
     logger.info(f"creating test table")
     random_tables = RandomTables(request.node.name, manager, "ks", 3)

--- a/test/cluster/test_replace.py
+++ b/test/cluster/test_replace.py
@@ -91,6 +91,7 @@ async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detecto
     await manager.server_stop_gracefully(servers[0].server_id)
     replace_cfg = ReplaceConfig(replaced_id = servers[0].server_id, reuse_ip_addr = True, use_host_id = False)
     replace_future = asyncio.create_task(manager.server_add(replace_cfg, property_file=servers[0].property_file()))
+    cql, _ = await manager.get_ready_cql([s for s in servers if s.server_id != servers[0].server_id])
     start_time = time.time()
     next_id = 0
     logger.info(f"running write requests in a loop while the replacing node is starting")
@@ -101,7 +102,7 @@ async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detecto
         k = f'key_{i}'
         v = f'value_{i}'
         expected_data.append((k, v))
-        await manager.get_cql().run_async(SimpleStatement("insert into ks.test_table(key, value) values (%s, %s)",
+        await cql.run_async(SimpleStatement("insert into ks.test_table(key, value) values (%s, %s)",
                                                           consistency_level=ConsistencyLevel.QUORUM),
                                           parameters=[k, v],
                                           host=host2)
@@ -115,7 +116,7 @@ async def test_replace_reuse_ip(request, manager: ManagerClient, failure_detecto
     errs = await log.grep("storage_proxy - Failed to apply mutation from", from_mark=m)
     assert len(errs) == 0
 
-    result_set = await manager.get_cql().run_async(SimpleStatement("select * from ks.test_table",
+    result_set = await cql.run_async(SimpleStatement("select * from ks.test_table",
                                                                    consistency_level=ConsistencyLevel.QUORUM),
                                                    host=host2, all_pages=True)
     read_data = [(row.key, row.value) for row in result_set]

--- a/test/cluster/test_restart_cluster.py
+++ b/test/cluster/test_restart_cluster.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 async def test_restart_cluster(manager: ManagerClient) -> None:
     """Test that cluster can restart fine after all nodes are stopped gracefully"""
     servers = await manager.servers_add(3)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     logger.info(f"Servers {servers}, gracefully stopping servers {[s.server_id for s in servers]} to check if all will go up")
     for s in servers:

--- a/test/cluster/test_resurrection.py
+++ b/test/cluster/test_resurrection.py
@@ -45,7 +45,7 @@ async def test_resurrection_while_file_streaming(manager: ManagerClient):
     s0_host_id = await manager.get_host_id(servers[0].server_id)
     s1_host_id = await manager.get_host_id(servers[1].server_id)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds = 0;")
 

--- a/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
+++ b/test/cluster/test_reversed_queries_during_simulated_upgrade_process.py
@@ -26,9 +26,9 @@ async def test_reversed_queries_during_upgrade(manager: ManagerClient) -> None:
     in order to test both native and legacy reversed formats.
     """
     cmdline = ["--hinted-handoff-enabled", "0"]
-    node1, _ = await manager.servers_add(2, cmdline, auto_rack_dc="dc1")
+    node1, node2 = await manager.servers_add(2, cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([node1, node2])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck1 int, ck2 int, PRIMARY KEY (pk, ck1, ck2));")

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -63,7 +63,7 @@ async def test_basic(manager: ManagerClient) -> None:
     logger.info(f"Booting initial cluster")
     servers = await manager.servers_add(servers_num=2, config=cfg, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     replication_factor = 2
     async with new_test_keyspace(manager, f"with replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {replication_factor}}}") as ks:
@@ -110,7 +110,7 @@ async def test_dict_training(manager: ManagerClient) -> None:
     logger.info(f"Booting initial cluster")
     servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     replication_factor = 2
     async with new_test_keyspace(manager, f"with replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {replication_factor}}}") as ks:
@@ -172,7 +172,7 @@ async def test_external_dicts(manager: ManagerClient) -> None:
     logger.info(f"Booting initial cluster")
     servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     replication_factor = 2
     async with new_test_keyspace(manager, f"with replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {replication_factor}}}") as ks:
@@ -235,7 +235,7 @@ async def test_external_dicts_sanity(manager: ManagerClient) -> None:
     logger.info(f"Booting initial cluster")
     servers = await manager.servers_add(servers_num=2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     replication_factor = 2
     async with new_test_keyspace(manager, f"with replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {replication_factor}}}") as ks:

--- a/test/cluster/test_rpc_compression.py
+++ b/test/cluster/test_rpc_compression.py
@@ -8,7 +8,7 @@ Test RPC compression
 """
 from test.pylib.internal_types import ServerInfo
 from test.pylib.rest_client import ScyllaMetrics
-from test.pylib.util import wait_for_cql_and_get_hosts, unique_name
+from test.pylib.util import unique_name
 from test.pylib.manager_client import ManagerClient
 from test.cluster.util import new_test_keyspace
 
@@ -26,8 +26,7 @@ import functools
 logger = logging.getLogger(__name__)
 
 async def live_update_config(manager: ManagerClient, servers: list[ServerInfo], key: str, value: str):
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, deadline = time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     await asyncio.gather(*[cql.run_async("UPDATE system.config SET value=%s WHERE name=%s", [value, key], host=host) for host in hosts])
 
 def uncompressed_sent(metrics: list[ScyllaMetrics], algo: str) -> float:

--- a/test/cluster/test_select_from_mutation_fragments.py
+++ b/test/cluster/test_select_from_mutation_fragments.py
@@ -16,9 +16,9 @@ from test.pylib.manager_client import ManagerClient
 
 @pytest.mark.asyncio
 async def test_sticky_coordinator_enforced(manager: ManagerClient) -> None:
-    await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'], auto_rack_dc="dc1")
+    servers = await manager.servers_add(2, cmdline=['--logger-log-level', 'paging=trace'], auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         await cql.run_async(f"create table {ks}.tbl (pk int, ck int, v int, primary key (pk, ck))")

--- a/test/cluster/test_shutdown_hang.py
+++ b/test/cluster/test_shutdown_hang.py
@@ -30,7 +30,7 @@ async def test_hints_manager_shutdown_hang(manager: ManagerClient) -> None:
     s2 = await manager.server_add(property_file={"dc": "dc1", "rack": "rack2"})
     await wait_for_token_ring_and_group0_consistency(manager, time.time() + 30)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s2])
 
     logger.info("Create keyspace and table")
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:

--- a/test/cluster/test_size_based_load_balancing.py
+++ b/test/cluster/test_size_based_load_balancing.py
@@ -44,7 +44,7 @@ async def test_balance_empty_tablets(manager: ManagerClient):
     servers = [await manager.server_add(config=cfg_large, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'r1'})]
     large_host_id = await manager.get_host_id(servers[0].server_id)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
         for table in ('t1', 't2', 't3'):

--- a/test/cluster/test_snapshot_with_tablets.py
+++ b/test/cluster/test_snapshot_with_tablets.py
@@ -72,13 +72,14 @@ async def test_snapshot_on_all_nodes(manager: ManagerClient):
     topology = topo(rf = 3, nodes = 3, racks = 3, dcs = 1)
 
     servers, _ = await create_cluster(topology, manager, logger)
+    cql, _ = await manager.get_ready_cql(servers)
 
     snapshot_name = unique_name('snap_')
 
     async with new_test_keyspace(manager, f"WITH REPLICATION = {{ 'replication_factor' : {topology.rf} }} AND tablets = {{'initial': 20 }}") as ks:
         async with new_test_table(manager, ks, "key int, c1 text, c2 text, PRIMARY KEY (key)", "") as tbl:
             cf = tbl.split('.')[1]
-            await prepare_write_workload(manager.get_cql(), tbl, flush=False)
+            await prepare_write_workload(cql, tbl, flush=False)
             await manager.api.take_cluster_snapshot(servers[0].ip_addr, ks, tag=snapshot_name, tables=[cf])
             try:
                 # Collect snapshot files from each server

--- a/test/cluster/test_sstable_cleanup_stop.py
+++ b/test/cluster/test_sstable_cleanup_stop.py
@@ -23,7 +23,7 @@ async def test_cleanup_stop(manager: ManagerClient):
     ]
     servers = [await manager.server_add(cmdline=cmdline)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'enabled': 'false'};") as ks:
         table = f"{ks}.test"

--- a/test/cluster/test_sstable_compression_config.py
+++ b/test/cluster/test_sstable_compression_config.py
@@ -169,8 +169,7 @@ async def test_alternator_tables_respect_compression_config(manager: ManagerClie
 
     # Connect to Alternator and CQL
     alternator = get_alternator(server.ip_addr)
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
 
     # Create a table with GSI, LSI and Streams
     table = alternator.create_table(TableName='base',
@@ -248,8 +247,7 @@ async def test_cql_base_tables_respect_compression_config(manager: ManagerClient
     }
     server = await manager.server_add(config=compression_config)
 
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
 
     ks = f"cql_aux_test_{int(time.time())}"
     await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
@@ -290,8 +288,7 @@ async def test_cql_aux_tables_respect_compression_config(manager: ManagerClient)
     }
     server = await manager.server_add(config=compression_config)
 
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
 
     ks = f"cql_aux_test_{int(time.time())}"
     await cql.run_async(f"CREATE KEYSPACE {ks} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")

--- a/test/cluster/test_sstable_compression_config.py
+++ b/test/cluster/test_sstable_compression_config.py
@@ -127,7 +127,7 @@ async def test_default_compression_on_upgrade(manager: ManagerClient, scylla_202
     servers = await manager.servers_add(2, version=scylla_2025_1)
 
     logger.info("Creating a test keyspace")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE test_ks WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}")
 
     await create_table_and_check_compression(cql, "test_ks", "table_before_upgrade", "org.apache.cassandra.io.compress.LZ4Compressor", "before upgrade")

--- a/test/cluster/test_sstable_compression_dictionaries_autotrain.py
+++ b/test/cluster/test_sstable_compression_dictionaries_autotrain.py
@@ -67,7 +67,7 @@ async def test_autoretrain_dict(manager: ManagerClient):
     ], auto_rack_dc="dc1", config=cfg)
 
     logger.info("Creating table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks_name = "test"
     cf_name = "test"
     await cql.run_async(

--- a/test/cluster/test_sstable_compression_dictionaries_basic.py
+++ b/test/cluster/test_sstable_compression_dictionaries_basic.py
@@ -87,7 +87,7 @@ async def test_retrain_dict(manager: ManagerClient):
     ], auto_rack_dc="dc1"))
 
     logger.info("Creating table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async(
         f"CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}}"
     )
@@ -197,7 +197,7 @@ async def test_estimate_compression_ratios(manager: ManagerClient):
         *common_debug_cli_options,
     ], auto_rack_dc="dc1"))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     logger.info("Creating table")
     await cql.run_async(
@@ -314,7 +314,7 @@ async def test_dict_memory_limit(manager: ManagerClient):
     rf = 1
 
     # Create keyspace and table
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async(
         f"CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}}"
@@ -377,7 +377,7 @@ async def test_sstable_compression_dictionaries_enable_writing(manager: ManagerC
 
     # Create keyspace and table
     logger.info("Creating tables")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     dict_algorithms = ['LZ4WithDicts', 'ZstdWithDicts']
     nondict_algorithms = ['Snappy', 'LZ4', 'Deflate', 'Zstd']

--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -37,7 +37,7 @@ async def test_upgrade_and_rollback(manager: ManagerClient, scylla_2025_1: Scyll
     ], version=scylla_2025_1))
 
     logger.info("Creating tables")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4WithDicts', 'ZstdWithDicts']
     initial_algorithms = ['Zstd', 'LZ4', 'Snappy', 'Deflate', 'LZ4', 'Zstd']

--- a/test/cluster/test_sstable_set.py
+++ b/test/cluster/test_sstable_set.py
@@ -8,7 +8,6 @@ import pytest
 import time
 import logging
 from test.pylib.manager_client import ManagerClient
-from test.pylib.util import wait_for_cql_and_get_hosts
 from test.cluster.util import create_new_test_keyspace
 
 logger = logging.getLogger(__name__)
@@ -25,8 +24,7 @@ async def test_partitioned_sstable_set(manager: ManagerClient, mode):
     server = await manager.server_add(config=cfg, cmdline=cmdline)
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [server], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([server])
 
     if mode == 'tablet':
         ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4};")

--- a/test/cluster/test_streaming_deadlock.py
+++ b/test/cluster/test_streaming_deadlock.py
@@ -35,7 +35,7 @@ async def test_streaming_deadlock_removenode(request, manager: ManagerClient):
     ]
 
     servers = await manager.servers_add(3, config=cfg, cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int, v text);")

--- a/test/cluster/test_strong_consistency.py
+++ b/test/cluster/test_strong_consistency.py
@@ -389,7 +389,7 @@ async def test_sc_persistence_restart_with_smp_increase(manager: ManagerClient):
             await manager.server_update_cmdline(server.server_id, ['--smp=4'])
             await manager.server_restart(server.server_id)
             await reconnect_driver(manager)
-            cql = manager.get_cql()
+            cql, _ = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.
@@ -442,7 +442,7 @@ async def test_sc_persistence_with_compaction(manager: ManagerClient):
             # Restart to verify compacted SSTables are correctly readable by raft server
             await manager.server_restart(server.server_id)
             await reconnect_driver(manager)
-            cql = manager.get_cql()
+            cql, _ = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.
@@ -480,7 +480,7 @@ async def test_sc_persistence_after_crash(manager: ManagerClient):
 
             await manager.server_start(server.server_id)
             await reconnect_driver(manager)
-            cql = manager.get_cql()
+            cql, _ = await manager.get_ready_cql([server])
 
             # We can't read the internal raft state directly, so we perform extra writes
             # which should cause raft table updates based on the loaded state after restart.

--- a/test/cluster/test_table_drop.py
+++ b/test/cluster/test_table_drop.py
@@ -24,7 +24,7 @@ async def test_drop_table_during_flush(manager: ManagerClient):
 
     await manager.api.enable_injection(servers[0].ip_addr, "flush_tables_on_all_shards_table_drop", True)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(64)])
@@ -52,7 +52,7 @@ async def test_drop_table_during_load_and_stream(manager: ManagerClient):
     """
     server = await manager.server_add()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     ks = unique_name("ks_")
     cf = "test"

--- a/test/cluster/test_tablet_repair_scheduler.py
+++ b/test/cluster/test_tablet_repair_scheduler.py
@@ -347,14 +347,13 @@ async def prepare_multi_dc_repair(manager) -> tuple[list[ServerInfo], CassandraS
     servers = [await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R1'}),
                await manager.server_add(property_file = {'dc': 'DC1', 'rack' : 'R2'}),
                await manager.server_add(property_file = {'dc': 'DC2', 'rack' : 'R3'})]
-    cql = manager.get_cql()
+    cql, hosts = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', "
                   "'DC1': 2, 'DC2': 1} AND tablets = {'initial': 8};")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
     table_id = await manager.get_table_id(ks, "test")
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     return (servers, cql, hosts, ks, table_id)
 
 @pytest.mark.asyncio
@@ -496,8 +495,7 @@ async def test_tablet_repair_multiple_rows_merge_fragments_size(manager: Manager
     await run_tablet_repair_multiple_rows_merge(manager, "row_level_repair_max_fragments_size", "1000")
 
 async def live_update_config(manager: ManagerClient, servers: list[ServerInfo], key: str, value: str):
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, deadline = time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     await asyncio.gather(*[cql.run_async("UPDATE system.config SET value=%s WHERE name=%s", [value, key], host=host) for host in hosts])
 
 async def config_auto_repair(manager, servers, ks, table, auto_repair_enabled, auto_repair_threshold, config_per_table = False):

--- a/test/cluster/test_tablet_stats.py
+++ b/test/cluster/test_tablet_stats.py
@@ -26,7 +26,7 @@ async def test_load_stats_on_coordinator_failover(manager: ManagerClient):
     }
     servers = await manager.servers_add(3, config=cfg)
     host_ids = [await manager.get_host_id(s.server_id) for s in servers]
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     coord = await get_topology_coordinator(manager)
     coord_idx = host_ids.index(coord)

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -48,7 +48,7 @@ async def test_tablet_replication_factor_enough_nodes(manager: ManagerClient):
     cfg = cfg | {'rf_rack_valid_keyspaces': False}
     servers = await manager.servers_add(2, config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     res = await cql.run_async("SELECT data_center FROM system.local")
     this_dc = res[0].data_center
 
@@ -66,7 +66,7 @@ async def test_tablet_scaling_option_is_respected(manager: ManagerClient):
     cfg = {'tablets_mode_for_new_keyspaces': 'enabled', 'tablets_initial_scale_factor': 32}
     servers = await manager.servers_add(1, config=cfg, cmdline=['--smp', '2'])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async(f"CREATE KEYSPACE test WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
@@ -87,7 +87,7 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
     ])
 
     logger.info("Creating table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -113,10 +113,11 @@ async def test_tablet_cannot_decommision_below_replication_factor(manager: Manag
 async def test_reshape_with_tablets(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     cfg = {'enable_user_defined_functions': False, 'tablets_mode_for_new_keyspaces': 'enabled'}
-    server = (await manager.servers_add(1, config=cfg, cmdline=['--smp', '1', '--logger-log-level', 'compaction=debug']))[0]
+    servers = await manager.servers_add(1, config=cfg, cmdline=['--smp', '1', '--logger-log-level', 'compaction=debug'])
+    server = servers[0]
 
     logger.info("Creating table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     number_of_tablets = 2
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} and tablets = {{'initial': {number_of_tablets} }}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -153,7 +154,7 @@ async def test_tablet_rf_change(manager: ManagerClient, direction):
     servers = await manager.servers_add(2, config=cfg, auto_rack_dc="dc1")
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     res = await cql.run_async("SELECT data_center FROM system.local")
     this_dc = res[0].data_center
 
@@ -228,7 +229,7 @@ async def test_tablet_mutation_fragments_unowned_partition(manager: ManagerClien
         {"dc": "dc1", "rack": "r2"}
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -254,7 +255,7 @@ async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
     servers += await manager.servers_add(2, property_file={'dc': f'dc1', 'rack': 'rack3'})
     await manager.disable_tablet_balancing()
     hosts = { await manager.get_host_id(s.server_id): s.ip_addr for s in servers }
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     expected_tablet_count = 4
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH TABLETS = {{'min_tablet_count': {expected_tablet_count}, 'max_tablet_count': {expected_tablet_count}}};")
@@ -304,8 +305,8 @@ async def test_tablets_api_consistency(manager: ManagerClient, endpoint):
 # enforcing RF-rack-valid keyspaces to be able to perform more flexible alterations.
 @pytest.mark.asyncio
 async def test_singledc_alter_tablets_rf(manager: ManagerClient):
-    await manager.server_add(config={"rf_rack_valid_keyspaces": "false", "enable_tablets": "true"}, property_file={"dc": "dc1", "rack": "r1"})
-    cql = manager.get_cql()
+    server = await manager.server_add(config={"rf_rack_valid_keyspaces": "false", "enable_tablets": "true"}, property_file={"dc": "dc1", "rack": "r1"})
+    cql, _ = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 1}") as ks:
         async def change_rf(rf):
@@ -330,13 +331,13 @@ async def test_singledc_alter_tablets_rf(manager: ManagerClient):
 async def test_arbitrary_multi_rf_change_fails(manager: ManagerClient):
     config = {"rf_rack_valid_keyspaces": "false", "enable_tablets": "true", "tablet_load_stats_refresh_interval_in_seconds": 1}
     cmdline = ['--logger-log-level', 'raft_topology=debug', '--logger-log-level', 'load_balancer=debug']
-    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
-    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r2"})
-    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r3"})
-    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc2", "rack": "r4"})
-    await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc3", "rack": "r7"})
+    s1 = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r1"})
+    s2 = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r2"})
+    s3 = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc1", "rack": "r3"})
+    s4 = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc2", "rack": "r4"})
+    s5 = await manager.server_add(config=config, cmdline=cmdline, property_file={"dc": "dc3", "rack": "r7"})
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([s1, s2, s3, s4, s5])
 
     err_msg = "Only one DC's RF can be changed at a time and not by more than 1"
 
@@ -767,7 +768,7 @@ async def test_multi_rf_change_0_N(request: pytest.FixtureRequest, manager: Mana
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2a'}),
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b']} AND tablets = {'initial': 4}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY)")
@@ -880,7 +881,7 @@ async def test_multi_rf_decrease_abort_0_N(request: pytest.FixtureRequest, manag
 
     dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c'], 'dc2': ['rack2a', 'rack2b', 'rack2c']}} and tablets = {{'initial': 4}};")
     await cql.run_async("create table ks1.t (pk int primary key, v int);")
@@ -1191,7 +1192,7 @@ async def test_failed_tablet_rebuild_is_retried(request: pytest.FixtureRequest, 
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']}} and tablets = {{'initial': 4}};")
     await cql.run_async("create table ks1.t (pk int primary key);")
@@ -1245,7 +1246,7 @@ async def test_failed_tablet_rebuild_is_retried_on_alter(manager: ManagerClient)
                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1b'}),
                await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1c'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']}} and tablets = {{'initial': 4}};")
     await cql.run_async("create table ks1.t (pk int primary key);")
@@ -1280,7 +1281,7 @@ async def test_saved_readers_tablet_migration(manager: ManagerClient, build_mode
     servers = await manager.servers_add(2, config=cfg)
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH"
                         " replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
@@ -1355,7 +1356,7 @@ async def test_read_of_pending_replica_during_migration(manager: ManagerClient, 
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv1 AS \
@@ -1414,7 +1415,7 @@ async def test_read_of_pending_replica_during_migration(manager: ManagerClient, 
 async def test_keyspace_creation_cql_vs_config_sanity(manager: ManagerClient, tablets_mode_for_new_keyspaces, cql_tablets_params, replication_strategy):
     cfg = {'tablets_mode_for_new_keyspaces': tablets_mode_for_new_keyspaces}
     server = await manager.server_add(config=cfg)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     """
     tablets_mode_for_new_keyspaces |       enabled      |      disabled      |      enforced      |
@@ -1481,7 +1482,7 @@ async def test_tablet_streaming_with_unbuilt_view(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info("Create table, populate it and flush the table to disk")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         num_of_rows = 64
@@ -1546,7 +1547,7 @@ async def test_tablet_streaming_with_staged_sstables(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info("Create the test table, populate few rows and flush to disk")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(64)])
@@ -1635,7 +1636,7 @@ async def test_orphaned_sstables_on_startup(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info("Create the test table, populate few rows and flush to disk")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k%3});") for k in range(256)])
@@ -1730,7 +1731,7 @@ async def test_excludenode(manager: ManagerClient):
     servers = await manager.servers_add(servers_num=3, auto_rack_dc='dc1')
     await manager.server_add(property_file={'dc': 'dc1', 'rack': 'rack2'})
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', "
                                           "'dc1': ['rack1', 'rack2']} AND tablets = { 'initial': 8 }") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -1771,7 +1772,7 @@ async def test_excludenode_shrink_rf(manager: ManagerClient):
     dc1_servers = await manager.servers_add(servers_num=2, config=config, cmdline=cmdline, property_file={'dc': 'dc1', 'rack': 'rack1'})
     dc2_server = await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2'})
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(dc1_servers + [dc2_server])
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', "
                                           "'dc1': 1, 'dc2': 1} AND tablets = { 'initial': 4 }") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -1957,7 +1958,7 @@ async def test_drop_with_tablet_migration_cleanup(manager: ManagerClient):
     cmdline = ['--smp', '2' ]
     server = await manager.server_add(cmdline=cmdline, config=cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     # We don't want the load balancer to migrate tablets during the test
     await manager.disable_tablet_balancing()
@@ -2059,7 +2060,7 @@ async def test_tablet_split_finalization_with_migrations(manager: ManagerClient)
     servers = await manager.servers_add(2, cmdline=cmdline, config=cfg)
 
     logger.info("Create and populate test table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4};")
     await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
     await manager.api.disable_autocompaction(servers[0].ip_addr, "test")
@@ -2168,7 +2169,7 @@ async def check_tablet_rebuild_with_repair(manager: ManagerClient, fail: bool):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -2329,7 +2330,7 @@ async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
     await manager.api.enable_injection(coord_srv.ip_addr, "tablet_keep_repairing", one_shot=False)
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy'}}") as ks:
-        cql = manager.get_cql()
+        cql, _ = await manager.get_ready_cql(servers)
         log = await manager.server_open_log(coord_srv.server_id)
         mark = await log.mark()
 
@@ -2354,7 +2355,7 @@ async def test_table_creation_wakes_up_balancer(manager: ManagerClient):
     """
     server = await manager.server_add()
     log = await manager.server_open_log(server.server_id)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8}") as ks:
         # Block coordinator right before going to sleep

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -401,9 +401,9 @@ async def test_alter_tablets_rf_dc_drop(request: pytest.FixtureRequest, manager:
     await manager.servers_add(2, config=config, auto_rack_dc="dc1")
     await manager.servers_add(2, config=config, auto_rack_dc="dc2")
 
-    cql = manager.get_cql()
     servers = await manager.running_servers()
-    host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    cql, hosts = await manager.get_ready_cql([servers[0]])
+    host = hosts[0]
 
     async def check_rf(ks: str, expected_dc1_rf: int, expected_dc2_rf: int):
         await read_barrier(manager.api, servers[0].ip_addr)
@@ -452,7 +452,7 @@ async def test_numeric_rf_to_rack_list_conversion(request: pytest.FixtureRequest
 
     host_ids = [await manager.get_host_id(s.server_id) for s in servers]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}} and tablets = {{'initial': 4}};")
@@ -554,7 +554,7 @@ async def test_enforce_rack_list_option(request: pytest.FixtureRequest, manager:
                 await manager.server_add(config=config, cmdline=['--smp=2'], property_file={'dc': 'dc2', 'rack': 'rack2a'}),
                 await manager.server_add(config=config, cmdline=['--smp=2'], property_file={'dc': 'dc2', 'rack': 'rack2b'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}} and tablets = {{'initial': 4}};")
@@ -665,8 +665,8 @@ async def test_multi_rf_change_multi_dc_0_N(request: pytest.FixtureRequest, mana
     dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
     dc2_host_ids = [await manager.get_host_id(s.server_id) for s in servers[3:6]]
 
-    cql = manager.get_cql()
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    cql, dc1_hosts = await manager.get_ready_cql([servers[0]])
+    dc1_host = dc1_hosts[0]
 
     # Create keyspace with RF=3 in dc1 only.
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
@@ -723,9 +723,9 @@ async def test_multi_rf_change_colocated_tables_0_N(request: pytest.FixtureReque
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2b'}),
                 await manager.server_add(config=config, cmdline=cmdline, property_file={'dc': 'dc2', 'rack': 'rack2c'})]
 
-    cql = manager.get_cql()
+    cql, dc1_hosts = await manager.get_ready_cql([servers[0]])
 
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    dc1_host = dc1_hosts[0]
 
     await cql.run_async("create keyspace ks1 with replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']} and tablets = {'initial': 4};")
     await cql.run_async("create table ks1.t (pk int primary key, v int);")
@@ -803,9 +803,9 @@ async def test_multi_rf_increase_abort_0_N(request: pytest.FixtureRequest, manag
 
     dc1_host_ids = [await manager.get_host_id(s.server_id) for s in servers[0:3]]
 
-    cql = manager.get_cql()
+    cql, dc1_hosts = await manager.get_ready_cql([servers[0]])
 
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    dc1_host = dc1_hosts[0]
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
     await cql.run_async("create table ks1.t (pk int primary key, v int);")
@@ -953,9 +953,9 @@ async def test_multi_rf_of_many_keyspaces_0_N(request: pytest.FixtureRequest, ma
 
     dc2_host_ids = [await manager.get_host_id(s.server_id) for s in servers[3:6]]
 
-    cql = manager.get_cql()
+    cql, dc1_hosts = await manager.get_ready_cql([servers[0]])
 
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    dc1_host = dc1_hosts[0]
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a']}} and tablets = {{'initial': 4}};")
     await cql.run_async("create table ks1.t (pk int primary key, v int);")
@@ -1040,9 +1040,9 @@ async def test_multi_rf_increase_before_decrease_0_N(request: pytest.FixtureRequ
 
     host_ids = [await manager.get_host_id(s.server_id) for s in servers]
 
-    cql = manager.get_cql()
+    cql, dc1_hosts = await manager.get_ready_cql([servers[0]])
 
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
+    dc1_host = dc1_hosts[0]
 
     # Start with dc1 only (dc2: 0).
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': ['rack1a', 'rack1b', 'rack1c']}} and tablets = {{'initial': 4}};")
@@ -1133,7 +1133,7 @@ async def test_numeric_rf_to_rack_list_conversion_abort(request: pytest.FixtureR
 
     host_ids = [await manager.get_host_id(s.server_id) for s in servers]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     host = (await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 30))[0]
 
     await cql.run_async(f"create keyspace ks1 with replication = {{'class': 'NetworkTopologyStrategy', 'dc1': 1}} and tablets = {{'initial': 4}};")
@@ -1912,8 +1912,7 @@ async def test_drop_keyspace_while_split(manager: ManagerClient):
 
     s0_log = await manager.server_open_log(servers[0].server_id)
 
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60)
+    cql, _ = await manager.get_ready_cql([servers[0]])
 
     await manager.disable_tablet_balancing()
 
@@ -2130,7 +2129,7 @@ async def test_two_tablets_concurrent_repair_and_migration_repair_writer_level(m
 
     cql = await safe_rolling_restart(manager, [servers[0]], with_down=insert_with_down)
 
-    await wait_for_cql_and_get_hosts(manager.get_cql(), servers, time.time() + 30)
+    cql, _ = await manager.get_ready_cql(servers)
 
     all_replicas = await get_all_tablet_replicas(manager, servers[1], ks, "test")
     migration_replicas = all_replicas[0]
@@ -2400,8 +2399,8 @@ async def test_multi_rf_increase_auto_abort_excluded_node(request: pytest.Fixtur
     servers = [dc1_server, dc2_rack1_server, dc2_rack2_server]
     dc1_host_id = await manager.get_host_id(dc1_server.server_id)
 
-    cql = manager.get_cql()
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
+    cql, dc1_hosts = await manager.get_ready_cql([dc1_server])
+    dc1_host = dc1_hosts[0]
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")
@@ -2461,8 +2460,8 @@ async def test_rf_extend_abort_with_down_node(request: pytest.FixtureRequest, ma
 
     dc1_host_id = await manager.get_host_id(dc1_server.server_id)
 
-    cql = manager.get_cql()
-    dc1_host = (await wait_for_cql_and_get_hosts(cql, [dc1_server], time.time() + 30))[0]
+    cql, dc1_hosts = await manager.get_ready_cql([dc1_server])
+    dc1_host = dc1_hosts[0]
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['rack1']} AND tablets = {'initial': 4}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int);")

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -2327,6 +2327,7 @@ async def test_disabling_balancing_preempts_balancer(manager: ManagerClient):
     coord_srv = servers[0]
     await manager.api.enable_injection(coord_srv.ip_addr, "tablet_allocator_shuffle", one_shot=False)
     await manager.api.enable_injection(coord_srv.ip_addr, "tablet_keep_repairing", one_shot=False)
+    await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy'}}") as ks:
         cql, _ = await manager.get_ready_cql(servers)

--- a/test/cluster/test_tablets.py
+++ b/test/cluster/test_tablets.py
@@ -1684,11 +1684,14 @@ async def test_remove_failure_with_no_normal_token_owners_in_dc(manager: Manager
     # if testing with no zero-token-node, add an additional node to dc2 to maintain raft quorum
     extra_node = 0 if with_zero_token_node else 1
     servers['dc2'] = await manager.servers_add(servers_num=2 + extra_node, property_file={'dc': 'dc2', 'rack': 'rack2'})
+    # Capture token-owning servers before adding zero-token nodes; only these
+    # become CQL hosts visible to the driver.
+    token_owning_servers = servers['dc1'] + servers['dc2']
     if with_zero_token_node:
         servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -1806,11 +1809,14 @@ async def test_remove_failure_then_replace(manager: ManagerClient, with_zero_tok
         {'dc': 'dc1', 'rack': 'rack1_1'},
         {'dc': 'dc1', 'rack': 'rack1_2'}])
     servers['dc2'] = await manager.servers_add(servers_num=2, property_file={'dc': 'dc2', 'rack': 'rack2'})
+    # Capture token-owning servers before adding zero-token nodes; only these
+    # become CQL hosts visible to the driver.
+    token_owning_servers = servers['dc1'] + servers['dc2']
     if with_zero_token_node:
         servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -1845,11 +1851,14 @@ async def test_replace_with_no_normal_token_owners_in_dc(manager: ManagerClient,
     # if testing with no zero-token-node, add an additional node to dc2 to maintain raft quorum
     extra_node = 0 if with_zero_token_node else 1
     servers['dc2'] = await manager.servers_add(servers_num=2 + extra_node, property_file={'dc': 'dc2', 'rack': 'rack2'})
+    # Capture token-owning servers before adding zero-token nodes; only these
+    # become CQL hosts visible to the driver.
+    token_owning_servers = servers['dc1'] + servers['dc2']
     if with_zero_token_node:
         servers['dc1'].append(await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc1', 'rack': 'rack1_1'}))
         servers['dc3'] = [await manager.server_add(config={'join_ring': False}, property_file={'dc': 'dc3', 'rack': 'rack3'})]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(token_owning_servers)
     async with new_test_keyspace(manager, "WITH replication = { 'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1 } AND tablets = { 'initial': 1 }") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -119,8 +119,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
         manager.driver_close()
         await manager.server_start(s0, wait_others=2)
         await manager.driver_connect(server=servers[0])
-        cql = manager.get_cql()
-        await wait_for_cql_and_get_hosts(cql, [servers[0]], time.time() + 60)
+        cql, _ = await manager.get_ready_cql([servers[0]])
 
         # Trigger a schema change to invoke schema agreement waiting to make sure that s0 has the latest schema
         async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as test_dummy:
@@ -497,11 +496,9 @@ async def test_tablet_cleanup(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     logger.info("Populate table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     n_tablets = 32
     n_partitions = 1000
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(1000)])
@@ -570,11 +567,9 @@ async def test_tablet_cleanup_failure(manager: ManagerClient):
     # not attempt to migrate the tablet back to the first node.
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     n_tablets = 1
     n_partitions = 1000
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
@@ -1076,8 +1071,7 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
     moved_sstable_files = move_sstables_to_upload(table_dir, dst_table_dir)
 
     await manager.server_start(servers[0].server_id)
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     rows = await cql.run_async(f"SELECT * FROM {ks}.test BYPASS CACHE;")
     assert len(rows) == 0
@@ -1151,8 +1145,7 @@ async def test_tablet_storage_freeing(manager: ManagerClient):
     logger.info("Start first node")
     servers = [await manager.server_add()]
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     logger.info("Create a table with two tablets and populate it with a moderate amount of data.")
     n_tablets = 2
@@ -1193,10 +1186,8 @@ async def test_schema_change_during_cleanup(manager: ManagerClient):
     logger.info("Start first node")
     servers = [await manager.server_add()]
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
-    cql = manager.get_cql()
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -1526,11 +1517,9 @@ async def test_tablet_cleanup_vs_snapshot_race(manager: ManagerClient):
     servers = [await manager.server_add(cmdline=cmdline)]
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     n_tablets = 1
     n_partitions = 1000
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    await manager.servers_see_each_other(servers)
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY);")
         await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk) VALUES ({k});") for k in range(n_partitions)])
@@ -1865,8 +1854,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
         move_sstables_to_upload(table_dir)
 
         await manager.server_start(servers[0].server_id)
-        cql = manager.get_cql()
-        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        cql, _ = await manager.get_ready_cql(servers)
 
         rows = await cql.run_async(f"SELECT * FROM {ks}.test BYPASS CACHE;")
         assert len(rows) == 0

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -95,6 +95,7 @@ async def test_tablet_metadata_propagates_with_schema_changes_in_snapshot_mode(m
         '--logger-log-level', 'rpc=trace',
         ]
     servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc="dc1")
+    await manager.get_ready_cql(servers)
 
     s0 = servers[0].server_id
     not_s0 = servers[1:]
@@ -157,7 +158,7 @@ async def test_scans(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 8}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -179,7 +180,7 @@ async def test_table_drop_with_auto_snapshot(manager: ManagerClient):
     cfg = { 'auto_snapshot': True }
     servers = await manager.servers_add(3, config = cfg)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Increases the chance of tablet migration concurrent with schema change
     await inject_error_on(manager, "tablet_allocator_shuffle", servers)
@@ -198,7 +199,7 @@ async def test_topology_changes(manager: ManagerClient):
     logger.info("Bootstrapping cluster")
     servers = await manager.servers_add(3)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -244,7 +245,7 @@ async def get_two_servers_to_move_tablet(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -350,7 +351,7 @@ async def test_streaming_is_guarded_by_topology_guard(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -425,7 +426,7 @@ async def test_table_dropped_during_streaming(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE TABLE {ks}.test2 (pk int PRIMARY KEY, c int);")
@@ -621,7 +622,7 @@ async def test_tablet_resharding(manager: ManagerClient):
     server = servers[0]
 
     logger.info("Populate table")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     n_tablets = 32
     n_partitions = 1000
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': {n_tablets}}}")
@@ -651,7 +652,7 @@ async def test_tablet_split(manager: ManagerClient, injection_error: str):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -724,7 +725,7 @@ async def test_correctness_of_tablet_split_finalization_after_restart(manager: M
         'error_injections_at_startup': ['delay_split_compaction']
     }, cmdline=cmdline))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH compaction = {{'class': 'NullCompactionStrategy'}};")
 
@@ -789,7 +790,7 @@ async def test_concurrent_tablet_migration_and_major(manager: ManagerClient, inj
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -846,7 +847,7 @@ async def test_concurrent_table_drop_and_major(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -934,7 +935,7 @@ async def test_tablet_count_metric_per_shard(manager: ManagerClient):
     await manager.disable_tablet_balancing()
 
     # When two tables are created
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.mytable1 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
         await cql.run_async(f"CREATE TABLE {ks}.mytable2 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
@@ -1022,7 +1023,7 @@ async def test_tablet_load_and_stream(manager: ManagerClient, primary_replica_on
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async def create_table(tablet_count : int) -> str:
         # Creates multiple tablets in the same shard
@@ -1118,7 +1119,7 @@ async def test_storage_service_api_uneven_ownership_keyspace_and_table_params_us
     servers = await manager.servers_add(2, cmdline=cmdline)
 
     # When table is created with initial tablets set to 1
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.mytable1 (col1 timestamp, col2 text, col3 blob, PRIMARY KEY (col1));")
 
@@ -1243,7 +1244,7 @@ async def test_tombstone_gc_correctness_during_tablet_split(manager: ManagerClie
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH gc_grace_seconds=0;")
 
@@ -1568,7 +1569,7 @@ async def test_drop_table_and_truncate_after_migration(manager: ManagerClient, o
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND TABLETS = {{'initial': 4}}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -1613,7 +1614,7 @@ async def test_drop_table_during_streaming(manager: ManagerClient, streaming_mod
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     inj = 'take_storage_snapshot' if streaming_mode == "sstables_during_snapshot" else 'wait_before_tablet_stream_files_after_snapshot'
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
@@ -1672,7 +1673,7 @@ async def test_truncate_during_topology_change(manager: ManagerClient):
 
     # Start 3 node cluster
     servers = await manager.servers_add(3, config = { 'enable_tablets': True }, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (k int PRIMARY KEY, v int)")
 
@@ -1708,7 +1709,7 @@ async def test_concurrent_schema_change_with_compaction_completion(manager: Mana
 
     await manager.api.enable_injection(servers[0].ip_addr, "sstable_list_builder_delay", one_shot=False)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         table = f"{ks}.test"
         await cql.run_async(f"CREATE TABLE {table} (a int PRIMARY KEY, b int);")
@@ -1754,7 +1755,7 @@ async def test_split_correctness_on_tablet_count_change(manager: ManagerClient):
 
     logger.info(f'server_id = {server.server_id}')
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     await manager.disable_tablet_balancing()
 
@@ -1824,7 +1825,7 @@ async def test_tablet_load_and_stream_and_split_synchronization(manager: Manager
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     initial_tablets = 1
 
@@ -1913,7 +1914,7 @@ async def test_update_load_stats_after_rebuild(manager: ManagerClient):
     s0_host_id = await manager.get_host_id(servers[0].server_id)
     s1_host_id = await manager.get_host_id(servers[1].server_id)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async def get_tablet_sizes(table):
         return await cql.run_async(f"SELECT * FROM system.tablet_sizes WHERE table_id = {table}")
@@ -1963,7 +1964,7 @@ async def test_update_load_stats_after_migration(manager: ManagerClient):
     s0_host_id = await manager.get_host_id(servers[0].server_id)
     s1_host_id = await manager.get_host_id(servers[1].server_id)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async def get_tablet_sizes(table):
         return await cql.run_async(f"SELECT * FROM system.tablet_sizes WHERE table_id = {table}")
@@ -2024,7 +2025,7 @@ async def test_crash_on_missing_table_from_load_stats(manager: ManagerClient):
         {"dc": "dc1", "rack": "rack1"},
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
@@ -2069,7 +2070,7 @@ async def test_tablets_barrier_waits_for_replica_erms(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -2142,7 +2143,7 @@ async def test_split_and_incremental_repair_synchronization(manager: ManagerClie
     ]
     servers = await manager.servers_add(2, cmdline=cmdline, config=cfg, auto_rack_dc="dc1")
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await manager.disable_tablet_balancing()
 
@@ -2233,7 +2234,7 @@ async def test_split_and_intranode_synchronization(manager: ManagerClient):
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
     server = servers[0]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await manager.disable_tablet_balancing()
 
@@ -2309,7 +2310,7 @@ async def test_split_stopped_on_shutdown(manager: ManagerClient):
 
     logger.info(f'server_id = {server.server_id}')
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     await manager.disable_tablet_balancing()
 

--- a/test/cluster/test_tablets2.py
+++ b/test/cluster/test_tablets2.py
@@ -1312,6 +1312,7 @@ async def create_cluster(manager: ManagerClient, num_dcs: int, num_racks: int, n
             rack_servers = await manager.servers_add(nodes_per_rack, config=config, property_file={"dc": f"dc{dc}", "rack": f"rack{rack}"})
             for s in rack_servers:
                 servers[s.server_id] = s
+    await manager.get_ready_cql(list(servers.values()))
     logger.debug(f"Created servers={list(servers.values())}")
     return servers
 

--- a/test/cluster/test_tablets_colocation.py
+++ b/test/cluster/test_tablets_colocation.py
@@ -61,7 +61,7 @@ async def test_base_view_colocation(manager: ManagerClient):
     ]
     servers = await manager.servers_add(1, config=cfg, cmdline=cmdline)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     min_tablet_count = 8
 
@@ -108,7 +108,7 @@ async def test_move_tablet(manager: ManagerClient, move_table: str):
     servers = await manager.servers_add(2, config=cfg, cmdline=cmdline)
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         # The base and view table should be co-located on one of the nodes with a single tablet each.
@@ -189,7 +189,7 @@ async def test_tablet_split_and_merge(manager: ManagerClient, with_merge: bool):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=1 AND bloom_filter_fp_chance=1;")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL AND pk > 1000000 PRIMARY KEY (pk, c)")
@@ -311,7 +311,7 @@ async def test_create_colocated_table_while_base_is_migrating(manager: ManagerCl
     servers = await manager.servers_add(2, config=cfg, cmdline=cmdline)
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -398,7 +398,7 @@ async def test_repair_colocated_base_and_view(manager: ManagerClient):
     servers = await manager.servers_add(2, config=cfg, cmdline=cmdline, auto_rack_dc="dc1")
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c)")
@@ -440,7 +440,7 @@ async def test_repair_colocated_base_and_view(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_colocated_tables_gc_mode(manager: ManagerClient):
     servers = await manager.servers_add(3, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     def check_tombstone_gc_mode_timeout(cql, table):
         s = list(cql.execute(f"DESC {table}"))[0].create_statement

--- a/test/cluster/test_tablets_cql.py
+++ b/test/cluster/test_tablets_cql.py
@@ -30,20 +30,21 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
     logger.info("starting a second node (the follower)")
     servers += [await manager.server_add(config=config)]
 
-    ks = await create_new_test_keyspace(manager.get_cql(), "with "
+    cql, _ = await manager.get_ready_cql(servers)
+    ks = await create_new_test_keyspace(cql, "with "
                                       "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} and "
                                       "tablets = {'enabled': true}")
-    await manager.get_cql().run_async(f"create table {ks}.t (pk int primary key)")
+    await cql.run_async(f"create table {ks}.t (pk int primary key)")
 
     logger.info(f"injecting wait-after-topology-coordinator-gets-event into the leader node {servers[0]}")
     injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
                                                     'wait-after-topology-coordinator-gets-event')
 
     async def alter_tablets_ks_without_waiting_to_complete():
-        res = await manager.get_cql().run_async("select data_center from system.local")
+        res = await cql.run_async("select data_center from system.local")
         # ALTER tablets KS only accepts a specific DC, it rejects the generic 'replication_factor' tag
         this_dc = res[0].data_center
-        await manager.get_cql().run_async(f"alter keyspace {ks} "
+        await cql.run_async(f"alter keyspace {ks} "
                                     f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': 1}}")
 
     # by creating a task this way we ensure it's immediately executed, but we won't wait until it's completed
@@ -55,8 +56,8 @@ async def test_alter_dropped_tablets_keyspace(manager: ManagerClient) -> None:
 
     logger.info(f"dropping KS from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
                 f"wakes up with the drop applied")
-    host = manager.get_cql().cluster.metadata.get_host(servers[1].ip_addr)
-    await manager.get_cql().run_async(f"drop keyspace {ks}", host=host)
+    host = cql.cluster.metadata.get_host(servers[1].ip_addr)
+    await cql.run_async(f"drop keyspace {ks}", host=host)
 
     logger.info("Waking up the leader to continue processing ALTER with KS that doesn't exist (has been just dropped)")
     await injection_handler.message()
@@ -82,10 +83,11 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
     logger.info("starting a second node (the follower)")
     servers += [await manager.server_add(config=config, property_file={"dc": this_dc, "rack": "r2"})]
 
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "with replication = {'class': 'NetworkTopologyStrategy', "
                                           f"'{this_dc}': ['r1']"
                                           "} and tablets = {'initial': 2}") as ks:
-        await manager.get_cql().run_async(f"create table {ks}.t (pk int primary key)")
+        await cql.run_async(f"create table {ks}.t (pk int primary key)")
 
         logger.info(f"injecting wait-before-committing-rf-change-event into the leader node {servers[0]}")
         injection_handler = await inject_error_one_shot(manager.api, servers[0].ip_addr,
@@ -93,7 +95,7 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
 
         async def alter_tablets_ks_without_waiting_to_complete():
             logger.info("scheduling ALTER KS to change the RF from 1 to 2")
-            await manager.get_cql().run_async(f"alter keyspace {ks} "
+            await cql.run_async(f"alter keyspace {ks} "
                                             f"with replication = {{'class': 'NetworkTopologyStrategy', '{this_dc}': ['r1','r2']}}")
 
         # by creating a task this way we ensure it's immediately executed,
@@ -107,9 +109,9 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
 
         logger.info(f"creating another keyspace from the follower node {servers[1]} so that the leader, which hangs on injected sleep, "
                     f"wakes up with a changed schema")
-        host = manager.get_cql().cluster.metadata.get_host(servers[1].ip_addr)
-        with disable_schema_agreement_wait(manager.get_cql()):
-            ks2 = await create_new_test_keyspace(manager.get_cql(), "with "
+        host = cql.cluster.metadata.get_host(servers[1].ip_addr)
+        with disable_schema_agreement_wait(cql):
+            ks2 = await create_new_test_keyspace(cql, "with "
                                             "replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
                                             "and tablets = {'enabled': true}", host=host)
 
@@ -124,6 +126,6 @@ async def test_alter_tablets_keyspace_concurrent_modification(manager: ManagerCl
         assert matches
 
         # ensure that the ALTER has eventually succeeded and we changed RF from 1 to 2
-        assert get_replication(manager.get_cql(), ks)[this_dc] == ['r1', 'r2']
+        assert get_replication(cql, ks)[this_dc] == ['r1', 'r2']
 
-        await manager.get_cql().run_async(f"drop keyspace {ks2}")
+        await cql.run_async(f"drop keyspace {ks2}")

--- a/test/cluster/test_tablets_intranode.py
+++ b/test/cluster/test_tablets_intranode.py
@@ -36,7 +36,7 @@ async def test_intranode_migration(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -71,7 +71,7 @@ async def test_crash_during_intranode_migration(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 4}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -139,7 +139,7 @@ async def test_cross_shard_migration(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -51,8 +51,7 @@ async def test_lwt(manager: ManagerClient):
         '--logger-log-level', 'paxos=trace'
     ]
     servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc='my_dc')
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
     quorum = len(hosts) // 2 + 1
 
     await manager.disable_tablet_balancing()
@@ -231,7 +230,8 @@ async def test_lwt_state_is_preserved_on_tablet_migration(manager: ManagerClient
         '--logger-log-level', 'paxos=trace'
     ]
     servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc='my_dc')
-    cql = manager.get_cql()
+    logger.info("Resolve hosts")
+    cql, hosts = await manager.get_ready_cql(servers)
 
     async def set_injection(set_to: list[ServerInfo], injection: str):
         logger.info(f"Injecting {injection} on {set_to}")
@@ -239,9 +239,6 @@ async def test_lwt_state_is_preserved_on_tablet_migration(manager: ManagerClient
         unset_from = [s for s in servers if s not in set_to]
         logger.info(f"Disabling {injection} on {unset_from}")
         await disable_injection_on(manager, injection, unset_from)
-
-    logger.info("Resolve hosts")
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
 
     logger.info("Disable tablet balancing")
     await manager.disable_tablet_balancing()
@@ -347,10 +344,8 @@ async def test_lwt_state_is_preserved_on_tablet_rebuild(manager: ManagerClient):
         '--logger-log-level', 'paxos=trace'
     ]
     servers = await manager.servers_add(3, cmdline=cmdline, auto_rack_dc='my_dc')
-    cql = manager.get_cql()
-
     logger.info("Resolve hosts")
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     logger.info("Disable tablet balancing")
     await manager.disable_tablet_balancing()

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -102,7 +102,7 @@ async def test_lwt(manager: ManagerClient):
         # so the table must be dropped from all replicas, not just a quorum.
         assert await check_paxos_state_table(False, len(hosts))
 
-    await manager.get_cql().run_async(f"DROP KEYSPACE \"{ks}\"")
+    await cql.run_async(f"DROP KEYSPACE \"{ks}\"")
 
 
 @pytest.mark.asyncio

--- a/test/cluster/test_tablets_lwt.py
+++ b/test/cluster/test_tablets_lwt.py
@@ -310,9 +310,9 @@ async def test_no_lwt_with_tablets_feature(manager: ManagerClient):
             }
         ]
     }
-    await manager.server_add(config=config)
+    server = await manager.server_add(config=config)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (key int PRIMARY KEY, val int)")
         await cql.run_async(f"INSERT INTO {ks}.test (key, val) VALUES(1, 0)")
@@ -427,7 +427,7 @@ async def test_lwt_concurrent_base_table_recreation(manager: ManagerClient):
     ]
 
     server = await manager.server_add(cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     logger.info("Create a keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
@@ -478,7 +478,7 @@ async def test_lwt_timeout_while_creating_paxos_state_table(manager: ManagerClie
 
     logger.info("Bootstrap a cluster with three nodes")
     servers = await manager.servers_add(3, config=config)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     logger.info("Create a keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
@@ -610,7 +610,7 @@ async def test_lwt_coordinator_shard(manager: ManagerClient):
         '--smp', '2'
     ]
     servers = [await manager.server_add(cmdline=cmdline)]
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     logger.info("Disable tablet balancing")
     await manager.disable_tablet_balancing()
@@ -780,8 +780,8 @@ async def test_lwts_for_special_tables(manager: ManagerClient):
     cmdline = [
         '--logger-log-level', 'paxos=trace'
     ]
-    await manager.servers_add(1, cmdline=cmdline)
-    cql = manager.get_cql()
+    servers = await manager.servers_add(1, cmdline=cmdline)
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1 } AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int, c int, v int, PRIMARY KEY(pk, c)) WITH cdc = {{'enabled': true}}")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.tv AS SELECT * FROM {ks}.test WHERE pk IS NOT NULL AND c IS NOT NULL PRIMARY KEY (pk, c)")

--- a/test/cluster/test_tablets_merge.py
+++ b/test/cluster/test_tablets_merge.py
@@ -49,7 +49,7 @@ async def test_tablet_merge_simple(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
 
@@ -196,7 +196,7 @@ async def test_tablet_split_and_merge_with_concurrent_topology_changes(manager: 
                await manager.server_add(config=config, cmdline=cmdline),
                await manager.server_add(config=config, cmdline=cmdline)]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH gc_grace_seconds=0 AND bloom_filter_fp_chance=1;")
 
@@ -387,7 +387,7 @@ async def test_tablet_split_merge_with_many_tables(build_mode: str, manager: Man
         rack = f'rack{rack_id+1}'
         servers.extend(await manager.servers_add(3, config=config, cmdline=cmdline, property_file={'dc': 'mydc', 'rack': rack}))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} AND tablets = {{'initial': 1}}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c blob) WITH compression = {{'sstable_compression': ''}};")
     num_tables = 200 if build_mode != 'debug' else 20
@@ -459,7 +459,7 @@ async def test_missing_data(manager: ManagerClient):
 
     logger.info(f'server_id = {server.server_id}')
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     await manager.disable_tablet_balancing()
 
@@ -527,7 +527,7 @@ async def test_merge_with_drop(manager: ManagerClient):
 
     logger.info(f'server_id = {server.server_id}')
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     await manager.disable_tablet_balancing()
 

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -53,7 +53,7 @@ async def test_tablet_transition_sanity(manager: ManagerClient, action):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 2} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -141,7 +141,7 @@ async def test_node_failure_during_tablet_migration(manager: ManagerClient, fail
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
@@ -291,7 +291,7 @@ async def test_tablet_back_and_forth_migration(manager: ManagerClient):
 
     await make_server()
     await manager.disable_tablet_balancing()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await make_server()
@@ -332,7 +332,7 @@ async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: M
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
         await cql.run_async(f"CREATE MATERIALIZED VIEW {ks}.mv1 AS \
@@ -439,7 +439,7 @@ async def test_restart_leaving_replica_during_cleanup(manager: ManagerClient, mi
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
 
@@ -515,7 +515,7 @@ async def test_restart_in_cleanup_stage_after_cleanup(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 8}};")
 

--- a/test/cluster/test_tablets_migration.py
+++ b/test/cluster/test_tablets_migration.py
@@ -387,8 +387,7 @@ async def test_staging_backlog_is_preserved_with_file_based_streaming(manager: M
         s0_sstables_in_staging = sstable_count_in_staging(s0_table_dir)
 
         await manager.server_start(servers[0].server_id)
-        cql = manager.get_cql()
-        await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+        cql, _ = await manager.get_ready_cql(servers)
 
         tablet_token = 0 # Doesn't matter since there is one tablet
         replica = await get_tablet_replica(manager, servers[0], ks, 'test', tablet_token)

--- a/test/cluster/test_tablets_parallel_decommission.py
+++ b/test/cluster/test_tablets_parallel_decommission.py
@@ -47,7 +47,7 @@ async def test_tablets_are_drained_in_parallel(manager: ManagerClient):
     ])
     await ensure_group0_leader_on(manager, servers[0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -117,7 +117,7 @@ async def test_tablets_are_rebuilt_in_parallel(manager: ManagerClient, same_rack
     await ensure_group0_leader_on(manager, servers[0])
     coord_srv = servers[0]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -176,7 +176,7 @@ async def test_decommission_can_be_canceled(manager: ManagerClient):
     await ensure_group0_leader_on(manager, servers[0])
     coord_serv = servers[0]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -260,7 +260,7 @@ async def test_decommission_is_rejected_when_another_one_is_still_pending(manage
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -308,7 +308,7 @@ async def test_remove_is_canceled_if_there_is_node_down(manager: ManagerClient):
 
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                         " 'dc1': ['rack1', 'rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -330,7 +330,7 @@ async def test_decommission_start_time_is_stable(manager: ManagerClient):
     servers = await manager.servers_add(2, property_file={"dc": "dc1", "rack": "rack1"})
     await ensure_group0_leader_on(manager, servers[0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -377,7 +377,7 @@ async def test_decommission_can_not_be_canceled_once_running(manager: ManagerCli
     servers = await manager.servers_add(2, property_file={"dc": "dc1", "rack": "rack1"})
     await ensure_group0_leader_on(manager, servers[0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -433,7 +433,7 @@ async def test_decommission_fails_if_capacity_is_gone_during_draining(manager: M
     ])
     await ensure_group0_leader_on(manager, servers[0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack2']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")
@@ -479,7 +479,7 @@ async def test_node_lost_during_decommission_drain(manager: ManagerClient):
     ])
     await ensure_group0_leader_on(manager, servers[0])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy',"
                                           " 'dc1': ['rack1']} AND tablets = {'initial': 32};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (pk int PRIMARY KEY);")

--- a/test/cluster/test_tablets_removenode.py
+++ b/test/cluster/test_tablets_removenode.py
@@ -42,7 +42,7 @@ async def test_removenode_with_coordinator_restart(manager: ManagerClient):
     cmdline = ['--logger-log-level', 'load_balancer=debug']
 
     servers = await manager.servers_add(3, cmdline=cmdline)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     ks1 = await create_keyspace(cql, 3, rf=1)
     await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
@@ -72,7 +72,7 @@ async def test_replace(manager: ManagerClient):
     config = {"rf_rack_valid_keyspaces": False}
     servers = await manager.servers_add(3, cmdline=cmdline, config=config)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     ks1 = await create_keyspace(cql, 32, rf=1)
     await cql.run_async(f"CREATE TABLE {ks1}.test (pk int PRIMARY KEY, c int);")
@@ -152,7 +152,7 @@ async def test_removenode(manager: ManagerClient):
     # 4 nodes so that we can find new tablet replica for the RF=3 table on removenode
     servers = await manager.servers_add(4, cmdline=cmdline, config=config)
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # RF=1
     ks1 = await create_keyspace(cql, 32, rf=1)
@@ -222,7 +222,7 @@ async def test_removenode_with_ignored_node(manager: ManagerClient):
         {"dc": "dc1", "rack": "r3"}
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     ks = await create_keyspace(cql, 32, rf=3)
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")

--- a/test/cluster/test_tls.py
+++ b/test/cluster/test_tls.py
@@ -30,7 +30,7 @@ async def test_upgrade_to_ssl(manager: ManagerClient) -> None:
     cf = 'cf'
 
     servers = await manager.running_servers()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.{cf} (pk int PRIMARY KEY) WITH tombstone_gc = {{'mode': 'immediate'}}")
 

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -108,9 +108,7 @@ async def test_group0_tombstone_gc(manager: ManagerClient):
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r2"}])
 
-    cql = manager.get_cql()
-    hosts = [(await wait_for_cql_and_get_hosts(cql, [s], time.time() + 60))[0]
-             for s in servers]
+    cql, hosts = await manager.get_ready_cql(servers)
 
     host_primary = hosts[0]
 

--- a/test/cluster/test_tombstone_gc.py
+++ b/test/cluster/test_tombstone_gc.py
@@ -30,8 +30,8 @@ def check_tombstone_gc_mode(cql, table, mode):
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc(manager: ManagerClient, rf: int, tablets: bool):
-    _ = await manager.servers_add(2, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
     tablets_enabled = "true" if tablets else "false"
     async with new_test_keyspace(manager, f"with replication = {{ 'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} and tablets = {{ 'enabled': {tablets_enabled} }}") as keyspace:
         async with new_test_table(manager, keyspace, "p int primary key, x int") as table:
@@ -42,8 +42,8 @@ async def test_default_tombstone_gc(manager: ManagerClient, rf: int, tablets: bo
 @pytest.mark.parametrize("rf", [1, 2])
 @pytest.mark.parametrize("tablets", [True, False])
 async def test_default_tombstone_gc_does_not_override(manager: ManagerClient, rf: int, tablets: bool):
-    _ = await manager.servers_add(2, auto_rack_dc="dc1")
-    cql = manager.get_cql()
+    servers = await manager.servers_add(2, auto_rack_dc="dc1")
+    cql, _ = await manager.get_ready_cql(servers)
     tablets_enabled = "true" if tablets else "false"
     async with new_test_keyspace(manager, f"with replication = {{ 'class': 'NetworkTopologyStrategy', 'replication_factor': {rf}}} and tablets = {{ 'enabled': {tablets_enabled} }}") as keyspace:
         async with new_test_table(manager, keyspace, "p int primary key, x int", " with tombstone_gc = {'mode': 'disabled'}") as table:

--- a/test/cluster/test_topology_failure_recovery.py
+++ b/test/cluster/test_topology_failure_recovery.py
@@ -59,7 +59,7 @@ async def test_tablet_drain_failure_during_decommission(manager: ManagerClient):
     # We fail a single streaming during decommission, we don't want to catch a background migration instead.
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 32}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 

--- a/test/cluster/test_topology_ops_with_rf_rack_valid.py
+++ b/test/cluster/test_topology_ops_with_rf_rack_valid.py
@@ -35,7 +35,7 @@ async def test_add_node_in_new_rack_violating_rf_rack(manager: ManagerClient, en
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
 
@@ -96,7 +96,7 @@ async def test_remove_node_violating_rf_rack(manager: ManagerClient, enforce: bo
         {"dc": "dc1", "rack": "r3"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 3} AND tablets = {'enabled': true}")
 
@@ -150,7 +150,7 @@ async def test_keyspace_creation_during_node_join(manager: ManagerClient, inject
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     inj_before_bootstrap = "topology_coordinator_pause_after_accept_node"
     inj_after_bootstrap = "topology_coordinator_pause_after_updating_cdc_generation"
@@ -254,7 +254,7 @@ async def test_keyspace_creation_during_node_remove(manager: ManagerClient, op: 
         {"dc": "dc1", "rack": "r2"},
         {"dc": "dc1", "rack": "r3"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     if op == "remove":
         inj = "topology_coordinator_pause_after_start_removenode"
@@ -330,7 +330,7 @@ async def test_remove_node_violating_rf_rack_with_rack_list(manager: ManagerClie
         {"dc": "dc1", "rack": "r4"},
         {"dc": "dc1", "rack": "r5"},
     ])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create keyspace with explicit rack list - only uses racks r1, r2, r4
     await cql.run_async("CREATE KEYSPACE ks WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': ['r1', 'r2', 'r4']} AND tablets = {'enabled': true}")

--- a/test/cluster/test_truncate_concurrent_writes.py
+++ b/test/cluster/test_truncate_concurrent_writes.py
@@ -34,7 +34,7 @@ async def test_validate_truncate_with_concurrent_writes(manager: ManagerClient):
         {"dc": "dc1", "rack": "r3"},
     ])
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, f"WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 3}}")
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int, ck int, val int, PRIMARY KEY(pk, ck));")
 

--- a/test/cluster/test_truncate_with_drop.py
+++ b/test/cluster/test_truncate_with_drop.py
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.asyncio
 async def test_truncation_on_drop(manager: ManagerClient):
-    await manager.server_add()
-    cql = manager.get_cql()
+    server = await manager.server_add()
+    cql, _ = await manager.get_ready_cql([server])
 
     # Create a keyspace
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
@@ -42,7 +42,7 @@ async def test_truncation_on_drop(manager: ManagerClient):
 @pytest.mark.asyncio
 async def test_truncation_records_pruned_on_dirty_restart(manager: ManagerClient):
     server = await manager.server_add()
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([server])
 
     async def restart():
         await manager.server_stop(server.server_id)

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -30,7 +30,7 @@ async def test_truncate_while_migration(manager: ManagerClient):
     servers = []
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
@@ -227,7 +227,7 @@ async def test_truncate_while_truncate_already_waiting(manager: ManagerClient):
     servers = []
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
@@ -273,7 +273,7 @@ async def test_replay_position_check_during_truncate(manager):
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
     server = servers[0]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int);")
 
@@ -311,7 +311,7 @@ async def test_parallel_truncate(manager: ManagerClient):
     servers = []
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
@@ -375,7 +375,7 @@ async def test_split_emitted_during_truncate(manager: ManagerClient):
     servers = await manager.servers_add(1, cmdline=cmdline, config=cfg)
     server = servers[0]
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tablets = {{'min_tablet_count': 1}};")
 

--- a/test/cluster/test_truncate_with_tablets.py
+++ b/test/cluster/test_truncate_with_tablets.py
@@ -84,8 +84,7 @@ async def test_truncate_with_concurrent_drop(manager: ManagerClient):
     servers.append(await manager.server_add(config=cfg))
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
@@ -133,8 +132,7 @@ async def test_truncate_while_node_restart(manager: ManagerClient):
     servers.append(await manager.server_add(config=cfg))
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:
@@ -180,8 +178,7 @@ async def test_truncate_with_coordinator_crash(manager: ManagerClient):
     servers.append(await manager.server_add(config=cfg))
     servers.append(await manager.server_add(config=cfg))
 
-    cql = manager.get_cql()
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, hosts = await manager.get_ready_cql(servers)
 
     # Create a keyspace with tablets and initial_tablets == 2, then insert data
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 2}") as ks:

--- a/test/cluster/test_ttl_row.py
+++ b/test/cluster/test_ttl_row.py
@@ -69,7 +69,7 @@ async def test_row_ttl_scheduling_group(manager: ManagerClient):
     }
     servers = await manager.servers_add(3, config=config, auto_rack_dc='dc1',
         driver_connect_opts={'auth_provider': PlainTextAuthProvider(username='cassandra', password='cassandra')})
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     # We need to run "ALTER TABLE" below to enable TTL on the table only after
     # we get the "before" CPU metrics, to ensure that we account all TTL work.
     # But we don't want the "ALTER TABLE" operation itself to be accounted as
@@ -171,7 +171,7 @@ async def test_row_ttl_multinode_expiration(manager: ManagerClient, with_down_no
         # work with one node down.
         await manager.server_stop_gracefully(servers[2].server_id) 
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers[:2] if with_down_node else servers)
 
     ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 }"
     async with new_test_keyspace(manager, ksdef) as keyspace:
@@ -300,7 +300,7 @@ async def test_row_ttl_multi_dc(manager: ManagerClient):
         for rack in range(3):
             futures.append(manager.servers_add(1, config=config, property_file={'dc': f'dc{dc+1}', 'rack': f'rack{rack+1}'}))
     servers = [x[0] for x in await asyncio.gather(*futures)]
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     # Setting replication_factor:3 means RF=3 for each of the two DCs.
     # (this is the so-called "auto-expansion" feature).
     ksdef = "WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'replication_factor': 3 }"

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -6,7 +6,7 @@
 import pytest
 import time
 import asyncio
-from test.pylib.util import wait_for_cql_and_get_hosts, wait_for_view
+from test.pylib.util import wait_for_view
 from test.pylib.manager_client import ManagerClient
 from test.pylib.scylla_cluster import ReplaceConfig
 from test.cluster.util import trigger_snapshot, wait_for, create_new_test_keyspace
@@ -178,14 +178,13 @@ async def test_view_build_status_snapshot(manager: ManagerClient):
     # Add a new server which will recover from the snapshot
     new_server = await manager.server_add()
     all_servers = servers + [new_server]
-    await wait_for_cql_and_get_hosts(cql, all_servers, time.time() + 60)
-    await manager.servers_see_each_other(all_servers)
+    await manager.get_ready_cql(all_servers)
 
     await asyncio.gather(*(manager.server_stop_gracefully(s.server_id) for s in servers))
 
     # Read the table on the new server, verify it contains all the previous table content
     await manager.driver_connect(server=new_server)
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql([new_server])
     await wait_for_view(cql, "vt1", 4)
     await wait_for_view(cql, "vt2", 4)
 

--- a/test/cluster/test_view_build_status.py
+++ b/test/cluster/test_view_build_status.py
@@ -237,7 +237,7 @@ async def test_view_build_status_with_replace_node(manager: ManagerClient):
     added_host_id = await manager.get_host_id(servers[-1].server_id)
 
     await manager.driver_connect(server=servers[1])
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
 
     # wait for the old node rows to be removed and new node rows to be added
     async def node_rows_replaced():

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -610,9 +610,8 @@ async def test_concurrent_tablet_migrations(manager: ManagerClient):
     await manager.disable_tablet_balancing()
     await pause_view_building_tasks(manager)
 
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} AND tablets = {'initial': 2}") as ks:
-        cql, _ = await manager.get_ready_cql(servers)
-
         # The base and the view are colocated, so their tablets are always migrated together.
         # With 2 tablets per table and RF=3, we will have 2 tablet groups (base+view) per node.
         await cql.run_async(f"CREATE TABLE {ks}.base (pk int, ck int, v int, PRIMARY KEY (pk, ck))")

--- a/test/cluster/test_view_building_coordinator.py
+++ b/test/cluster/test_view_building_coordinator.py
@@ -512,7 +512,7 @@ async def test_view_building_while_tablet_streaming_fail(manager: ManagerClient)
     servers = [await manager.server_add(cmdline=cmdline_loggers)]
     await manager.disable_tablet_balancing()
 
-    cql = manager.get_cql()
+    cql, _ = await manager.get_ready_cql(servers)
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};") as ks:
         await cql.run_async(f"CREATE TABLE {ks}.tab (key int, c int, v text, PRIMARY KEY (key, c))")
         await populate_base_table(cql, ks, "tab")
@@ -611,7 +611,7 @@ async def test_concurrent_tablet_migrations(manager: ManagerClient):
     await pause_view_building_tasks(manager)
 
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': 2, 'dc2': 1} AND tablets = {'initial': 2}") as ks:
-        cql = manager.get_cql()
+        cql, _ = await manager.get_ready_cql(servers)
 
         # The base and the view are colocated, so their tablets are always migrated together.
         # With 2 tablets per table and RF=3, we will have 2 tablet groups (base+view) per node.

--- a/test/cluster/test_writes_to_previous_cdc_generations.py
+++ b/test/cluster/test_writes_to_previous_cdc_generations.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
 #
 from test.pylib.manager_client import ManagerClient, ServerInfo
-from test.pylib.util import wait_for, wait_for_cql_and_get_hosts
+from test.pylib.util import wait_for
 
 from cassandra.cluster import ConsistencyLevel, NoHostAvailable, Session
 from cassandra.protocol import InvalidRequest
@@ -63,10 +63,8 @@ async def test_writes_to_recent_previous_cdc_generations(request, manager: Manag
         'error_injections_at_startup': ['increase_cdc_generation_leeway']
     })
 
-    cql = manager.get_cql()
-
     logger.info("Waiting for driver")
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 
@@ -113,10 +111,8 @@ async def test_writes_to_old_previous_cdc_generation(request, manager: ManagerCl
     logger.info("Bootstrapping nodes")
     servers = await manager.servers_add(2, cmdline=['--ring-delay', '5000'])
 
-    cql = manager.get_cql()
-
     logger.info("Waiting for driver")
-    await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
+    cql, _ = await manager.get_ready_cql(servers)
 
     gen_timestamps = await wait_for_publishing_generations(cql, servers)
 

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -61,6 +61,7 @@ class ManagerClient:
         self.ccluster: Optional[CassandraCluster] = None
         self.cql: Optional[CassandraSession] = None
         self.exclusive_clusters: List[CassandraCluster] = []
+        self._get_ready_cql_was_called: bool = False
         # A client for communicating with ScyllaClusterManager (server)
         self.sock_path = sock_path
         self.client_for_asyncio_loop = {asyncio.get_running_loop(): UnixRESTClient(sock_path)}
@@ -124,8 +125,16 @@ class ManagerClient:
         self.cql = None
 
     def get_cql(self) -> CassandraSession:
-        """Precondition: driver is connected"""
+        """Precondition: get_ready_cql() has been called at least once on the
+        current driver session, ensuring the cluster topology is synchronized
+        and all nodes are ready to serve CQL.
+        """
         assert self.cql
+        assert self._get_ready_cql_was_called, (
+            "get_cql() called before get_ready_cql(); the CQL session may "
+            "route requests to nodes that have not yet completed bootstrap. "
+            "Call manager.get_ready_cql(servers) first."
+        )
         return self.cql
 
     # More robust version of get_cql, when topology changes
@@ -133,6 +142,7 @@ class ManagerClient:
     # it may fail unless we perform additional readiness checks
     async def get_ready_cql(self, servers: List[ServerInfo]) -> tuple[CassandraSession, list[Host]]:
         """Precondition: driver is connected"""
+        self._get_ready_cql_was_called = True
         cql = self.get_cql()
         await self.servers_see_each_other(servers)
         hosts = await wait_for_cql_and_get_hosts(cql, servers, time() + 60)

--- a/test/pylib/repair.py
+++ b/test/pylib/repair.py
@@ -5,14 +5,13 @@
 #
 
 from test.pylib.internal_types import ServerInfo
-from test.pylib.util import wait_for_cql_and_get_hosts, Host
+from test.pylib.util import Host
 from test.cluster.util import create_new_test_keyspace
 from test.pylib.rest_client import read_barrier
 
 from cassandra.cluster import Session as CassandraSession
 
 import asyncio
-import time
 import logging
 import json
 
@@ -75,14 +74,13 @@ async def create_table_insert_data_for_repair(manager, rf = 3 , tablets = 8, fas
         config.update({'repair_hints_batchlog_flush_cache_time_in_ms': 0})
     servers = await manager.servers_add(3, config=config, cmdline=cmdline,
                                         property_file=[{"dc": "dc1", "rack": f"r{i % rf}"} for i in range(rf)])
-    cql = manager.get_cql()
+    cql, hosts = await manager.get_ready_cql(servers)
+    logging.info(f'Got hosts={hosts}');
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))
     await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int) WITH tombstone_gc = {{'mode':'repair'}};")
     keys = range(nr_keys)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES ({k}, {k});") for k in keys])
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
-    logging.info(f'Got hosts={hosts}');
     table_id = await manager.get_table_id(ks, "test")
     return (servers, cql, hosts, ks, table_id)
 
@@ -102,11 +100,10 @@ async def create_table_insert_data_for_repair_multiple_rows(manager, rf = 3 , ta
 
     servers = await manager.servers_add(3, config=config, cmdline=cmdline,
                                         property_file=[{"dc": "dc1", "rack": f"r{i % rf}"} for i in range(rf)])
-    cql = manager.get_cql()
+    cql, hosts = await manager.get_ready_cql(servers)
     ks = await create_new_test_keyspace(cql, "WITH replication = {{'class': 'NetworkTopologyStrategy', "
                   "'replication_factor': {}}} AND tablets = {{'initial': {}}};".format(rf, tablets))
     create_table_cql = f"CREATE TABLE IF NOT EXISTS {ks}.test ( pk int, ck int, data int, PRIMARY KEY (pk, ck)) WITH tombstone_gc = {{'mode':'repair'}};"
     await cql.run_async(create_table_cql)
-    hosts = await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
     table_id = await manager.get_table_id(ks, "test")
     return (servers, cql, hosts, ks, table_id)


### PR DESCRIPTION
This series hardens the Python cluster tests against a recurring class of flakiness where DDL or queries are issued immediately after a topology change, before the driver's control connection has converged on the new set of nodes. Symptoms include spurious AlreadyExists and requests routed to nodes that have not yet completed bootstrap.

The fix is to consistently use manager.get_ready_cql(servers), which atomically waits for nodes to be reachable and visible to the driver before returning a CQL session, and then to enforce that convention with an assertion in get_cql().

The commits are split by call-site shape rather than bundled together to ease the review.

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1681

Backport: no, it's many changes may be difficult to backport, it's a test only change