### PR TITLE
test: update get_scylla_2025_1_executable() to use 2025.1.12 (improvement)

### DIFF
--- a/test/cluster/test_sstable_compression_dictionaries_upgrade.py
+++ b/test/cluster/test_sstable_compression_dictionaries_upgrade.py
@@ -34,7 +34,7 @@ async def test_upgrade_and_rollback(manager: ManagerClient, scylla_2025_1: Scyll
         '--logger-log-level=database=debug',
         '--abort-on-seastar-bad-alloc',
         '--dump-memory-diagnostics-on-alloc-failure-kind=all',
-    ], version=scylla_2025_1))
+    ], config={'rf_rack_valid_keyspaces': False}, version=scylla_2025_1))
 
     logger.info("Creating tables")
     cql = manager.get_cql()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -235,7 +235,7 @@ async def get_scylla_2025_1_executable(build_mode: str) -> str:
     is_debug = build_mode == 'debug' or build_mode == 'sanitize'
     package = "scylla-debug" if is_debug else "scylla"
     arch = platform.machine()
-    url = f'https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2025.1/{package}-2025.1.0-0.20250325.9dca28d2b818.{arch}.tar.gz'
+    url = f'https://downloads.scylladb.com/downloads/scylla/relocatable/scylladb-2025.1/{package}-2025.1.12-0.20260329.1d372670365f.{arch}.tar.gz'
 
     return await get_scylla_executable(url)
 


### PR DESCRIPTION
## Summary
- Update the hardcoded 2025.1.0 binary URL in `get_scylla_2025_1_executable()` to the latest 2025.1.12 release for upgrade tests.
- Disable `rf_rack_valid_keyspaces` in `test_sstable_compression_dictionaries_upgrade` since 2025.1.12 enforces this option and the test creates a 2-node/single-rack cluster with RF=2, violating the constraint.

Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>
AI-Assisted: yes
Backport: no, benign improvement to using the latest 2025.1.x instead of 2025.1.0 in tests