### PR TITLE
s3: make S3 connection pool size configurable per scheduling group

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1705,6 +1705,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , ldap_bind_passwd(this, "ldap_bind_passwd", value_status::Used, "", "Password used by LDAPRoleManager for binding to LDAP server.")
     , saslauthd_socket_path(this, "saslauthd_socket_path", value_status::Used, "", "UNIX domain socket on which saslauthd is listening.")
     , object_storage_endpoints(this, "object_storage_endpoints", liveness::LiveUpdate, value_status::Used, {}, "Object storage endpoints configuration.")
+    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", value_status::Used, 128,
+        "Maximum number of object storage connections per shard. "
+        "Connections are distributed proportionally across scheduling groups based on their shares.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")
     , topology_barrier_stall_detector_threshold_seconds(this, "topology_barrier_stall_detector_threshold_seconds", value_status::Used, 2, "Report sites blocking topology barrier if it takes longer than this.")
     , enable_tablets(this, "enable_tablets", value_status::Used, false, "Enable tablets for newly created keyspaces. (deprecated)")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1705,7 +1705,7 @@ db::config::config(std::shared_ptr<db::extensions> exts)
     , ldap_bind_passwd(this, "ldap_bind_passwd", value_status::Used, "", "Password used by LDAPRoleManager for binding to LDAP server.")
     , saslauthd_socket_path(this, "saslauthd_socket_path", value_status::Used, "", "UNIX domain socket on which saslauthd is listening.")
     , object_storage_endpoints(this, "object_storage_endpoints", liveness::LiveUpdate, value_status::Used, {}, "Object storage endpoints configuration.")
-    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", value_status::Used, 128,
+    , object_storage_connections_per_shard(this, "object_storage_connections_per_shard", liveness::LiveUpdate, value_status::Used, 128,
         "Maximum number of object storage connections per shard. "
         "Connections are distributed proportionally across scheduling groups based on their shares.")
     , error_injections_at_startup(this, "error_injections_at_startup", error_injection_value_status, {}, "List of error injections that should be enabled on startup.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -608,6 +608,7 @@ public:
     const db::extensions& extensions() const;
 
     named_value<std::vector<object_storage_endpoint_param>> object_storage_endpoints;
+    named_value<unsigned> object_storage_connections_per_shard;
 
     named_value<std::vector<error_injection_at_startup>> error_injections_at_startup;
     named_value<double> topology_barrier_stall_detector_threshold_seconds;

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -66,17 +66,17 @@ fmt::formatter<sstables::object_name>::format(const sstables::object_name& n, fm
     return fmt::format_to(ctx.out(), "{}", n.str());
 }
 
-static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory) {
+static shared_ptr<s3::client> make_s3_client(const db::object_storage_endpoint_param& ep, semaphore& memory, std::function<shared_ptr<s3::client>(std::string)> factory, unsigned connections_per_shard) {
     auto& epc = ep.get_s3_storage();
-    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory));
+    return s3::client::make(epc.endpoint, epc.region, epc.iam_role_arn, memory, std::move(factory), connections_per_shard);
 }
 
 class s3_client_wrapper : public sstables::object_storage_client {
     shared_ptr<s3::client> _client;
     shard_client_factory _cf;
 public:
-    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf)
-        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this)))
+    s3_client_wrapper(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard)
+        : _client(make_s3_client(ep, memory, std::bind_front(&s3_client_wrapper::shard_client, this), connections_per_shard))
         , _cf(std::move(cf))
     {}
     shared_ptr<s3::client> shard_client(std::string host) const {
@@ -331,9 +331,9 @@ public:
     }
 };
 
-shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf) {
+shared_ptr<object_storage_client> sstables::make_object_storage_client(const db::object_storage_endpoint_param& ep, semaphore& memory, shard_client_factory cf, unsigned connections_per_shard) {
     if (ep.is_s3_storage()) {
-        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf));
+        return seastar::make_shared<s3_client_wrapper>(ep, memory, std::move(cf), connections_per_shard);
     }
     if (ep.is_gs_storage()) {
         return seastar::make_shared<gs_client_wrapper>(ep, memory, std::move(cf));

--- a/sstables/object_storage_client.cc
+++ b/sstables/object_storage_client.cc
@@ -118,6 +118,9 @@ public:
         auto& epc = ep.get_s3_storage();
         _client->update_config_sync(epc.region, epc.iam_role_arn);
     }
+    void update_connections_per_shard(unsigned connections_per_shard) override {
+        _client->update_connections_per_shard(connections_per_shard);
+    }
     future<> close() override {
         return _client->close();
     }
@@ -322,6 +325,9 @@ public:
                 .finally([old_client = std::move(old_client), h = std::move(holder)] {
                     osclog.info("Old GCS client cleanup done, use_count={}", old_client.use_count());
                 });
+    }
+    void update_connections_per_shard(unsigned) override {
+        // GCS client does not support per-scheduling-group connection budgeting
     }
     future<> close() override {
         osclog.info("Closing GCS client...");

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -17,6 +17,7 @@
 #include <fmt/core.h>
 
 #include "utils/lister.hh"
+#include "utils/s3/creds.hh"
 
 namespace seastar {
 class abort_source;
@@ -90,7 +91,7 @@ public:
 
 using shard_client_factory = std::function<shared_ptr<object_storage_client>(std::string)>;
 
-shared_ptr<object_storage_client> make_object_storage_client(const db::object_storage_endpoint_param&, semaphore&, shard_client_factory);
+shared_ptr<object_storage_client> make_object_storage_client(const db::object_storage_endpoint_param&, semaphore&, shard_client_factory, unsigned connections_per_shard = s3::endpoint_config::default_connections_per_shard);
 
 }
 

--- a/sstables/object_storage_client.hh
+++ b/sstables/object_storage_client.hh
@@ -85,6 +85,7 @@ public:
     virtual future<> upload_file(std::filesystem::path path, object_name, utils::upload_progress& up, seastar::abort_source* = nullptr) = 0;
 
     virtual void update_config_sync(const db::object_storage_endpoint_param&) = 0;
+    virtual void update_connections_per_shard(unsigned) = 0;
 
     virtual future<> close() = 0;
 };

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -86,6 +86,7 @@ storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _object_storage_clients_memory(stm_cfg.object_storage_clients_memory)
     , _connections_per_shard(cfg.object_storage_connections_per_shard())
     , _config_updater(std::make_unique<config_updater_sync>(cfg, *this))
+    , _connections_updater(std::make_unique<connections_updater_sync>(cfg, *this))
 {
     for (auto& e : cfg.object_storage_endpoints()) {
         _object_storage_endpoints.emplace(std::make_pair(e.key(), e));
@@ -166,6 +167,18 @@ storage_manager::config_updater_sync::config_updater_sync(const db::config& cfg,
         std::erase_if(sstm._object_storage_endpoints, [&updates](const auto& e) {
             return !updates.contains(e.first);
         });
+    }))
+{}
+
+storage_manager::connections_updater_sync::connections_updater_sync(const db::config& cfg, storage_manager& sstm)
+    : observer(cfg.object_storage_connections_per_shard.observe([&sstm] (unsigned new_value) {
+        smlogger.info("connections_updater: updating connections_per_shard to {}", new_value);
+        sstm._connections_per_shard = new_value;
+        for (auto& [endpoint, ep] : sstm._object_storage_endpoints) {
+            if (ep.client) {
+                ep.client->update_connections_per_shard(new_value);
+            }
+        }
     }))
 {}
 

--- a/sstables/sstables_manager.cc
+++ b/sstables/sstables_manager.cc
@@ -84,6 +84,7 @@ storage_manager::object_storage_endpoint::object_storage_endpoint(db::object_sto
 
 storage_manager::storage_manager(const db::config& cfg, config stm_cfg)
     : _object_storage_clients_memory(stm_cfg.object_storage_clients_memory)
+    , _connections_per_shard(cfg.object_storage_connections_per_shard())
     , _config_updater(std::make_unique<config_updater_sync>(cfg, *this))
 {
     for (auto& e : cfg.object_storage_endpoints()) {
@@ -122,7 +123,7 @@ shared_ptr<sstables::object_storage_client> storage_manager::get_endpoint_client
     if (ep.client == nullptr) {
         ep.client = make_object_storage_client(ep.cfg, _object_storage_clients_memory, [&ct = container()] (std::string ep) {
             return ct.local().get_endpoint_client(ep);
-        });
+        }, _connections_per_shard);
     }
     return ep.client;
 }

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -74,6 +74,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     };
 
     semaphore _object_storage_clients_memory;
+    unsigned _connections_per_shard;
     std::unordered_map<sstring, object_storage_endpoint> _object_storage_endpoints;
     std::unique_ptr<config_updater_sync> _config_updater;
     seastar::metrics::metric_groups metrics;

--- a/sstables/sstables_manager.hh
+++ b/sstables/sstables_manager.hh
@@ -67,6 +67,11 @@ class storage_manager : public peering_sharded_service<storage_manager> {
         config_updater_sync(const db::config& cfg, storage_manager&);
     };
 
+    struct connections_updater_sync {
+        utils::observer<unsigned> observer;
+        connections_updater_sync(const db::config& cfg, storage_manager&);
+    };
+
     struct object_storage_endpoint {
         db::object_storage_endpoint_param cfg;
         shared_ptr<object_storage_client> client;
@@ -77,6 +82,7 @@ class storage_manager : public peering_sharded_service<storage_manager> {
     unsigned _connections_per_shard;
     std::unordered_map<sstring, object_storage_endpoint> _object_storage_endpoints;
     std::unique_ptr<config_updater_sync> _config_updater;
+    std::unique_ptr<connections_updater_sync> _connections_updater;
     seastar::metrics::metric_groups metrics;
 
     object_storage_endpoint& get_endpoint(const sstring& ep);

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -150,6 +150,20 @@ void client::update_config_sync(std::string region, std::string ira) {
     });
 }
 
+void client::update_connections_per_shard(unsigned connections_per_shard) {
+    if (_config_update_gate.is_closed()) {
+        s3l.info("config update gate is closed");
+        return;
+    }
+    auto holder = _config_update_gate.hold();
+    (void)with_semaphore(_rebalance_sem, 1, [this, connections_per_shard] {
+        _cfg->connections_per_shard = connections_per_shard;
+        return rebalance_connections();
+    }).handle_exception([holder = std::move(holder)](auto ex) {
+        s3l.warn("Failed to rebalance connections after config update: {}", ex);
+    });
+}
+
 shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, semaphore& mem, global_factory gf) {
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{});
 }

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -10,6 +10,7 @@
 #include <exception>
 #include <initializer_list>
 #include <memory>
+#include <numeric>
 #include <regex>
 #include <stdexcept>
 #if __has_include(<rapidxml.h>)
@@ -157,13 +158,14 @@ shared_ptr<client> client::make(std::string endpoint, endpoint_config_ptr cfg, s
     return seastar::make_shared<client>(std::move(endpoint), std::move(cfg), mem, std::move(gf), private_tag{}, std::move(rs));
 }
 
-shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf) {
+shared_ptr<client> client::make(std::string ep, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf, unsigned connections_per_shard) {
     auto url = utils::http::parse_simple_url(ep);
     endpoint_config cfg = {
         .port = url.port,
         .use_https = url.is_https(),
         .region = std::move(region),
         .role_arn = std::move(iam_role_arn),
+        .connections_per_shard = connections_per_shard,
     };
     return make(url.host, make_lw_shared<endpoint_config>(std::move(cfg)), memory, gf);
 }
@@ -269,23 +271,67 @@ void client::group_client::register_metrics(std::string class_name, std::string 
     });
 }
 
-client::group_client& client::find_or_create_client() {
+future<client::group_client&> client::find_or_create_client() {
     auto sg = current_scheduling_group();
-    auto it = _https.find(sg);
-    if (it == _https.end()) [[unlikely]] {
-        auto factory = std::make_unique<utils::http::dns_connection_factory>(_host, _cfg->port, _cfg->use_https, s3l);
-        // Limit the maximum number of connections this group's http client
-        // may have proportional to its shares. Shares are typically in the
-        // range of 100...1000, thus resulting in 1..10 connections
-        unsigned max_connections = _cfg->max_connections.has_value() ? *_cfg->max_connections : std::max((unsigned)(sg.get_shares() / 100), 1u);
-        it = _https.emplace(std::piecewise_construct,
-            std::forward_as_tuple(sg),
-            std::forward_as_tuple(std::move(factory), max_connections)
-        ).first;
-
-        it->second.register_metrics(sg.name(), _host);
+    if (const auto it = _https.find(sg); it != _https.end()) [[likely]] {
+        return make_ready_future<client::group_client&>(it->second);
     }
-    return it->second;
+    return find_or_create_client_slow();
+}
+
+future<client::group_client&> client::find_or_create_client_slow() {
+    // Slow path: serialize creation + rebalance
+    auto sg = current_scheduling_group();
+    auto units = co_await get_units(_rebalance_sem, 1);
+    // Re-check after acquiring lock (another fiber may have created it)
+    auto it = _https.find(sg);
+    if (it != _https.end()) {
+        co_return it->second;
+    }
+
+    auto factory = std::make_unique<utils::http::dns_connection_factory>(_host, _cfg->port, _cfg->use_https, s3l);
+    unsigned max_connections = _cfg->max_connections.value_or(1);
+    it = _https.emplace(std::piecewise_construct,
+        std::forward_as_tuple(sg),
+        std::forward_as_tuple(std::move(factory), max_connections)
+    ).first;
+    it->second.register_metrics(sg.name(), _host);
+    if (!_cfg->max_connections) {
+        co_await rebalance_connections();
+    }
+    co_return it->second;
+}
+
+future<> client::rebalance_connections() {
+    auto total_shares = std::accumulate(_https.begin(), _https.end(), 0.0f, [](float sum, const auto& entry) { return sum + entry.first.get_shares(); });
+    unsigned total_assigned = 0;
+    scheduling_group max_shares_sg;
+    float max_shares = 0;
+    unsigned max_shares_connections = 0;
+
+    for (auto& [sg, gc] : _https) {
+        unsigned max_connections = std::max(static_cast<unsigned>(_cfg->connections_per_shard * sg.get_shares() / total_shares), 1u);
+        total_assigned += max_connections;
+        if (sg.get_shares() > max_shares) {
+            max_shares = sg.get_shares();
+            max_shares_sg = sg;
+            max_shares_connections = max_connections;
+        }
+        s3l.debug("Rebalancing S3 client for scheduling group '{}' (shares={}, total_shares={}, connections_per_shard={}): max_connections={}",
+                  sg.name(),
+                  sg.get_shares(),
+                  total_shares,
+                  _cfg->connections_per_shard,
+                  max_connections);
+        co_await gc.http.set_maximum_connections(max_connections);
+    }
+
+    // Assign remainder to the group with the most shares
+    unsigned remainder;
+    if (!__builtin_sub_overflow(_cfg->connections_per_shard, total_assigned, &remainder) && remainder > 0) {
+        s3l.debug("Assigning {} remainder connections to scheduling group '{}'", remainder, max_shares_sg.name());
+        co_await _https.at(max_shares_sg).http.set_maximum_connections(max_shares_connections + remainder);
+    }
 }
 
 [[noreturn]] void map_s3_client_exception(std::exception_ptr ex) {
@@ -401,7 +447,7 @@ future<> client::make_request(http::request req,
     auto request = std::move(req);
     auto handler = wrap_handler(request, std::move(handle), expected);
     co_await authorize(request);
-    auto& gc = find_or_create_client();
+    auto& gc = co_await find_or_create_client();
 
     co_await gc.http.make_request(request, handler, rs, std::nullopt, as).handle_exception([err_handler = std::move(err_handler)](auto ex) {
         err_handler(std::move(ex));
@@ -414,11 +460,11 @@ future<> client::make_request(http::request req,
                               error_handler err_handler,
                               std::optional<http::reply::status_type> expected,
                               seastar::abort_source* as) {
-    auto& gc = find_or_create_client();
+    auto& gc = co_await find_or_create_client();
     auto handle = [&gc, handle = std::move(handle_ex)] (const http::reply& rep, input_stream<char>&& in) {
         return handle(gc, rep, std::move(in));
     };
-    return make_request(std::move(req), std::move(handle), rs, std::move(err_handler), expected, as);
+    co_await make_request(std::move(req), std::move(handle), rs, std::move(err_handler), expected, as);
 }
 
 future<> client::make_request(http::request req, reply_handler_ext handle_ex, std::optional<http::reply::status_type> expected, seastar::abort_source* as) {
@@ -1311,7 +1357,7 @@ class client::chunked_download_source final : public seastar::data_source_impl {
                 }
 
                 if (auto units = try_get_units(_client->_memory, _socket_buff_size); !_is_finished && !_buffers.empty() && !units) {
-                    auto& gc = _client->find_or_create_client();
+                    auto& gc = co_await _client->find_or_create_client();
                     ++gc.downloads_blocked_on_memory;
                     co_await _bg_fiber_cv.when([this] {
                         return _is_finished || _buffers.empty() || try_get_units(_client->_memory, _socket_buff_size);

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -230,6 +230,7 @@ public:
                          seastar::abort_source* = nullptr);
 
     void update_config_sync(std::string reg, std::string ira);
+    void update_connections_per_shard(unsigned connections_per_shard);
 
     struct handle {
         std::string _host;

--- a/utils/s3/client.hh
+++ b/utils/s3/client.hh
@@ -141,6 +141,7 @@ class client : public enable_shared_from_this<client> {
         void register_metrics(std::string class_name, std::string host);
     };
     std::unordered_map<seastar::scheduling_group, group_client> _https;
+    semaphore _rebalance_sem{1};
     using global_factory = std::function<shared_ptr<client>(std::string)>;
     global_factory _gf;
     semaphore& _memory;
@@ -152,7 +153,9 @@ class client : public enable_shared_from_this<client> {
 
     future<> update_credentials_and_rearm();
     future<> authorize(http::request&);
-    group_client& find_or_create_client();
+    future<group_client&> find_or_create_client();
+    future<group_client&> find_or_create_client_slow();
+    future<> rebalance_connections();
 
     using error_handler = std::function<void(std::exception_ptr)>;
     using reply_handler_ext = noncopyable_function<future<>(group_client&, const http::reply&, input_stream<char>&& body)>;
@@ -188,7 +191,7 @@ public:
     client(std::string host, endpoint_config_ptr cfg, semaphore& mem, global_factory gf, private_tag, std::unique_ptr<seastar::http::retry_strategy> rs = nullptr);
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, global_factory gf = {});
     static shared_ptr<client> make(std::string endpoint, endpoint_config_ptr cfg, semaphore& memory, std::unique_ptr<seastar::http::retry_strategy> rs, global_factory gf = {});
-    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {});
+    static shared_ptr<client> make(std::string url, std::string region, std::string iam_role_arn, semaphore& memory, global_factory gf = {}, unsigned connections_per_shard = endpoint_config::default_connections_per_shard);
 
     future<uint64_t> get_object_size(sstring object_name, seastar::abort_source* = nullptr);
     future<stats> get_object_stats(sstring object_name, seastar::abort_source* = nullptr);

--- a/utils/s3/creds.hh
+++ b/utils/s3/creds.hh
@@ -27,12 +27,15 @@ struct aws_credentials {
 };
 
 struct endpoint_config {
+    static constexpr unsigned default_connections_per_shard = 128;
+
     unsigned port;
     bool use_https;
     std::string region;
     // Amazon Resource Names (ARNs) to access AWS resources
     std::string role_arn;
     std::optional<unsigned> max_connections;
+    unsigned connections_per_shard = default_connections_per_shard;
 
     std::strong_ordering operator<=>(const endpoint_config& o) const = default;
 };


### PR DESCRIPTION
The S3 client creates a separate HTTP connection pool per scheduling group. Previously, the pool size was hardcoded as shares/100, yielding 1-10 connections. This was not tunable and could under-provision connections for groups with low share counts.
**Changes**
- A missing include (short_streams.hh) in sstables_loader.cc is added first to fix CMake builds where the header is not transitively included.
- The hardcoded per-share divisor is replaced with a per-shard connection budget. The new `object_storage_connections_per_shard` config option (default 128) specifies the total number of connections available on each shard. Connections are distributed proportionally across scheduling groups based on their shares: `max_connections = budget * group_shares / total_shares`. Remainder connections are assigned to the group with the most shares. When a new scheduling group client is created, all existing groups are rebalanced via `set_maximum_connections`. Creation and rebalance are serialized with a semaphore to prevent concurrent rebalances from racing.
- The config option is made live-updateable: a `storage_manager` observer propagates changes to all existing S3 clients, triggering rebalance under the same semaphore.
Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1704
No backport needed since this change affects KS on object storage which is not operational yet.