### PR TITLE
 db: add large data metrics for rows, cells, and collections

### DIFF
--- a/db/large_data_handler.hh
+++ b/db/large_data_handler.hh
@@ -29,6 +29,9 @@ class large_data_handler {
 public:
     struct stats {
         int64_t partitions_bigger_than_threshold = 0; // number of large partition updates exceeding threshold_bytes
+        int64_t rows_bigger_than_threshold = 0; // number of large row updates exceeding row_threshold_bytes
+        int64_t cells_bigger_than_threshold = 0; // number of large cell updates exceeding cell_threshold_bytes
+        int64_t collections_bigger_than_threshold = 0; // number of large collection updates exceeding collection_elements_count_threshold
     };
 
 private:
@@ -82,6 +85,7 @@ public:
             const clustering_key_prefix* clustering_key, uint64_t row_size) {
         SCYLLA_ASSERT(running());
         if (row_size > _row_threshold_bytes) [[unlikely]] {
+            ++_stats.rows_bigger_than_threshold;
             return with_sem([&sst, &partition_key, clustering_key, row_size, this] {
                 return record_large_rows(sst, partition_key, clustering_key, row_size);
             }).then([] {
@@ -102,6 +106,8 @@ public:
             const clustering_key_prefix* clustering_key, const column_definition& cdef, uint64_t cell_size, uint64_t collection_elements) {
         SCYLLA_ASSERT(running());
         above_threshold_result above_threshold{.size = cell_size > _cell_threshold_bytes, .elements = collection_elements > _collection_elements_count_threshold};
+        _stats.cells_bigger_than_threshold += above_threshold.size;
+        _stats.collections_bigger_than_threshold += above_threshold.elements;
         if (above_threshold.size || above_threshold.elements) [[unlikely]] {
             return with_sem([&sst, &partition_key, clustering_key, &cdef, cell_size, collection_elements, this] {
                 return record_large_cells(sst, partition_key, clustering_key, cdef, cell_size, collection_elements);

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -726,6 +726,18 @@ database::setup_metrics() {
             sm::description("Number of large partitions exceeding compaction_large_partition_warning_threshold_mb. "
                 "Large partitions have performance impact and should be avoided, check the documentation for details.")),
 
+        sm::make_counter("large_rows_exceeding_threshold", [this] { return _large_data_handler->stats().rows_bigger_than_threshold; },
+            sm::description("Number of large rows exceeding compaction_large_row_warning_threshold_mb. "
+                "Large rows have performance impact and should be avoided, check the documentation for details.")),
+
+        sm::make_counter("large_cell_exceeding_threshold", [this] { return _large_data_handler->stats().cells_bigger_than_threshold; },
+            sm::description("Number of large cells exceeding compaction_large_cell_warning_threshold_mb. "
+                "Large cells have performance impact and should be avoided, check the documentation for details.")),
+
+        sm::make_counter("large_collection_exceeding_threshold", [this] { return _large_data_handler->stats().collections_bigger_than_threshold; },
+            sm::description("Number of large collections exceeding compaction_collection_elements_count_warning_threshold. "
+                "Large collections have performance impact and should be avoided, check the documentation for details.")),
+
         sm::make_total_operations("total_view_updates_pushed_local", _cf_stats.total_view_updates_pushed_local,
                 sm::description("Total number of view updates generated for tables and applied locally."))(basic_level),
 

--- a/test/boost/sstable_3_x_test.cc
+++ b/test/boost/sstable_3_x_test.cc
@@ -5939,3 +5939,106 @@ SEASTAR_TEST_CASE(test_alter_compression_during_write) {
         assertions.produces_end_of_stream();
     });
 }
+
+SEASTAR_THREAD_TEST_CASE(test_large_data_stats_large_rows) {
+    simple_schema s;
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto pk = s.make_pkey();
+    mutation m(s.schema(), pk);
+    auto ck1 = s.make_ckey("ck1");
+    s.add_row(m, ck1, "foo");
+    auto ck2 = s.make_ckey("ck2");
+    s.add_row(m, ck2, "a_long_value_exceeding_threshold");
+    auto ck3 = s.make_ckey("ck3");
+    s.add_row(m, ck3, "another_long_value_exceeding_threshold");
+
+    auto sc = s.schema();
+    auto mt = make_memtable(sc, {m}).get();
+
+    for (auto version : writable_sstable_versions) {
+        large_data_test_handler handler(std::numeric_limits<uint64_t>::max(), 21,
+            std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(),
+            std::numeric_limits<uint64_t>::max());
+
+        BOOST_REQUIRE_EQUAL(handler.stats().rows_bigger_than_threshold, 0);
+
+        sstables::test_env::do_with_async([&] (auto& env) {
+            auto sst = env.make_sstable(sc, version);
+            sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()),
+                1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        }, { &handler }).get();
+
+        BOOST_REQUIRE_GE(handler.stats().rows_bigger_than_threshold, 2);
+        BOOST_REQUIRE_EQUAL(handler.stats().partitions_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().cells_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().collections_bigger_than_threshold, 0);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_large_data_stats_large_cells) {
+    simple_schema s;
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto pk = s.make_pkey();
+    mutation m(s.schema(), pk);
+    auto ck1 = s.make_ckey("ck1");
+    s.add_row(m, ck1, "foo");
+    auto ck2 = s.make_ckey("ck2");
+    s.add_row(m, ck2, "foo bar baz");
+
+    auto sc = s.schema();
+    auto mt = make_memtable(sc, {m}).get();
+
+    for (auto version : writable_sstable_versions) {
+        large_data_test_handler handler(std::numeric_limits<uint64_t>::max(),
+            std::numeric_limits<uint64_t>::max(), 5,
+            std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max());
+
+        BOOST_REQUIRE_EQUAL(handler.stats().cells_bigger_than_threshold, 0);
+
+        sstables::test_env::do_with_async([&] (auto& env) {
+            auto sst = env.make_sstable(sc, version);
+            sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()),
+                1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        }, { &handler }).get();
+
+        BOOST_REQUIRE_GT(handler.stats().cells_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().partitions_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().rows_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().collections_bigger_than_threshold, 0);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_large_data_stats_large_collections) {
+    simple_schema s(simple_schema::with_static::no, simple_schema::with_collection::yes);
+    tests::reader_concurrency_semaphore_wrapper semaphore;
+    auto pk = s.make_pkey();
+    mutation m(s.schema(), pk);
+
+    std::map<bytes, bytes> kv_map;
+    for (int i = 0; i < 15; i++) {
+        kv_map[to_bytes(format("key{}", i))] = to_bytes(format("val{}", i));
+    }
+    s.add_row_with_collection(m, s.make_ckey("ck1"), kv_map);
+
+    auto sc = s.schema();
+    auto mt = make_memtable(sc, {m}).get();
+
+    for (auto version : writable_sstable_versions) {
+        large_data_test_handler handler(std::numeric_limits<uint64_t>::max(),
+            std::numeric_limits<uint64_t>::max(), std::numeric_limits<uint64_t>::max(),
+            std::numeric_limits<uint64_t>::max(), 10);
+
+        BOOST_REQUIRE_EQUAL(handler.stats().collections_bigger_than_threshold, 0);
+
+        sstables::test_env::do_with_async([&] (auto& env) {
+            auto sst = env.make_sstable(sc, version);
+            sst->write_components(mt->make_mutation_reader(sc, semaphore.make_permit()),
+                1, sc, env.manager().configure_writer("test"), encoding_stats{}).get();
+        }, { &handler }).get();
+
+        BOOST_REQUIRE_GT(handler.stats().collections_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().cells_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().partitions_bigger_than_threshold, 0);
+        BOOST_REQUIRE_EQUAL(handler.stats().rows_bigger_than_threshold, 0);
+    }
+}


### PR DESCRIPTION
- Add `large_rows_exceeding_threshold`, `large_cell_exceeding_threshold`, and `large_collection_exceeding_threshold` metrics to complement the existing `large_partition_exceeding_threshold`
- Add unit tests verifying stats counters increment correctly during SSTable writes

Backport is not needed 

Fixes https://scylladb.atlassian.net/browse/SCYLLADB-1095