### PR TITLE
test: fix flaky test_delete_partition_rows_from_table_with_mv in debug mode

### DIFF
--- a/test/cluster/mv/test_mv_delete_partitions.py
+++ b/test/cluster/mv/test_mv_delete_partitions.py
@@ -11,6 +11,7 @@ import time
 import logging
 from test.pylib.util import wait_for_view
 from test.cluster.util import new_test_keyspace, new_test_table, new_materialized_view
+from cassandra.cluster import NoHostAvailable  # type: ignore
 from cassandra.cqltypes import Int32Type
 
 logger = logging.getLogger(__name__)
@@ -72,7 +73,23 @@ async def test_delete_partition_rows_from_table_with_mv(manager: ManagerClient) 
         await wait_for_view(cql, "mv_cf_view", node_count)
 
         logger.info(f"Deleting all rows from partition with key 0")
-        await cql.run_async(f"DELETE FROM {ks}.tab WHERE key = 0", timeout=300)
+        # In debug mode, the view update backlog may still be elevated when
+        # the DELETE is attempted, causing the coordinator to reject it with
+        # "View update backlog is too high". Retry on this specific error with
+        # exponential backoff to allow the backlog to drain.
+        delay = 0.5
+        for attempt in range(15):
+            try:
+                await cql.run_async(f"DELETE FROM {ks}.tab WHERE key = 0", timeout=300)
+                break
+            except NoHostAvailable as e:
+                if not any("View update backlog is too high" in str(err) for err in e.errors.values()):
+                    raise
+                if attempt == 14:
+                    raise
+                logger.info(f"View update backlog too high, retrying in {delay:.1f}s (attempt {attempt + 1}/15)")
+                await asyncio.sleep(delay)
+                delay = min(delay * 2, 5.0)
 
 # Test deleting a large partition when there is a view with the same partition
 # key, and verify that view updates metrics is increased by exactly 1. Deleting


### PR DESCRIPTION

In debug mode, the view update backlog may still be elevated when the DELETE is attempted after MV build completes. The coordinator rejects the write with 'View update backlog is too high' because the artificially low 250KB limit (from the view_update_limit error injection) combined with the 500ms delay (from delay_before_remote_view_update) causes the backlog to drain too slowly.

Add a targeted retry loop that only retries on this specific overloaded error with exponential backoff, allowing the backlog to drain. Any other error is re-raised immediately, preserving test strictness.

Note the symptoms this tests are bad_alloc during the delete, not throttling due to hints.

Passed 1000 runs in debug mode.

Fixes: SCYLLADB-1795

Rarely seen failure, not backporting.