### PR TITLE
test/cluster/auth_cluster: use CREATE ROLE IF NOT EXISTS to fix flaky test

### DIFF
--- a/test/cluster/auth_cluster/test_group0_batch_barrier.py
+++ b/test/cluster/auth_cluster/test_group0_batch_barrier.py
@@ -69,7 +69,10 @@ async def test_create_role_mixed_cluster(manager: ManagerClient,
     new_host = next(h for h in hosts if h.address == new_server[0].ip_addr)
 
     role = "r" + unique_name()
-    await cql.run_async(f"CREATE ROLE {role}", host=new_host)
+    # Use IF NOT EXISTS to work around the Python driver bug where connection
+    # pool renewal after concurrent node bootstraps can cause the statement
+    # to be executed twice (scylladb/python-driver#317).
+    await cql.run_async(f"CREATE ROLE IF NOT EXISTS {role}", host=new_host)
 
     deadline = time.time() + 180
     for host in hosts:


### PR DESCRIPTION
test_create_role_mixed_cluster calls servers_add(2) to bootstrap two old nodes concurrently, then adds a new node before issuing CREATE ROLE.  The concurrent bootstraps trigger the well-known Python driver bug (scylladb/python-driver#317): two on_add notifications race in update_created_pools, causing a second pool to be created for a host whose pool was already established.  If CREATE ROLE is in-flight on the old pool when it is closed, the driver retries on the new pool, executing the statement twice.  The second execution fails with "Role ... already exists", making the test flaky.

Fix by using CREATE ROLE IF NOT EXISTS.  This is safe because unique_name() generates a timestamp+random suffix that is guaranteed to be unique; the role can "already exist" only due to the driver double-execution bug, never due to a real conflict.

This is the same workaround that has been applied many times elsewhere in our test suite for exactly the same root cause:
- CREATE KEYSPACE was changed to CREATE KEYSPACE IF NOT EXISTS (scylladb#18368, later generalised in scylladb#22399 via new_test_keyspace helpers)
- DROP KEYSPACE was changed to DROP KEYSPACE IF EXISTS (scylladb#29487)

Fixes: SCYLLADB-1742

We saw this test fail on CI in 2025.1, so should be backported all the way to 2025.1.