### PR TITLE
test/cluster: wait for custom listener readiness

### DIFF
--- a/test/cluster/test_proxy_protocol.py
+++ b/test/cluster/test_proxy_protocol.py
@@ -19,6 +19,7 @@ import struct
 import time
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import ServerUpState
 from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
@@ -318,9 +319,13 @@ PROXY_SERVER_CONFIG = {
 async def proxy_server(manager: ManagerClient):
     """
     Fixture that creates a server with all proxy protocol ports enabled.
+    Waits for SERVING state to ensure proxy protocol ports are ready.
     Returns a tuple of (server, manager).
     """
-    server = await manager.server_add(config=PROXY_SERVER_CONFIG)
+    server = await manager.server_add(
+        config=PROXY_SERVER_CONFIG,
+        expected_server_up_state=ServerUpState.SERVING,
+    )
     yield (server, manager)
 
 

--- a/test/cluster/test_tools_perf.py
+++ b/test/cluster/test_tools_perf.py
@@ -10,6 +10,7 @@ import asyncio
 import pytest
 from test import path_to
 from test.pylib.host_registry import HostRegistry
+from test.pylib.internal_types import ServerUpState
 
 logger = logging.getLogger(__name__)
 
@@ -117,13 +118,11 @@ async def test_perf_cql_raw_remote(scylla_path, tmp_path, workload, manager):
 
 @pytest.mark.parametrize("workload", ["read"])
 async def test_perf_alternator_remote(scylla_path, tmp_path, workload, manager):
-    await manager.server_add(cmdline=[
+    server = await manager.server_add(cmdline=[
         "--alternator-port", "8000",
         "--alternator-write-isolation", "only_rmw_uses_lwt"
-    ])
-    servers = await manager.running_servers()
-    await manager.get_ready_cql(servers)
-    host = servers[0].ip_addr
+    ], expected_server_up_state=ServerUpState.SERVING)
+    host = server.ip_addr
     client_cmd = [
         scylla_path, "perf-alternator",
         "--workload", workload,

--- a/test/cluster/test_uninitialized_conns_semaphore.py
+++ b/test/cluster/test_uninitialized_conns_semaphore.py
@@ -9,6 +9,7 @@ import asyncio
 import pytest
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.internal_types import ServerUpState
 
 CQL_PORT = 9042
 SHARD_AWARE_PORT = 19042
@@ -22,7 +23,7 @@ async def test_uninitialized_conns_sempahore_one(manager: ManagerClient):
         "native_transport_port": CQL_PORT,
         "native_shard_aware_transport_port": SHARD_AWARE_PORT,
     }
-    server = await manager.server_add(config=config)
+    server = await manager.server_add(config=config, expected_server_up_state=ServerUpState.SERVING)
     cql, _ = await manager.get_ready_cql([server])
 
     await cql.run_async("SELECT release_version FROM system.local")


### PR DESCRIPTION
server_add() defaults to CQL_ALTERNATOR_QUERIED. That proves the regular CQL driver path is queryable, and regular Alternator ports listed in YAML config if any. It does not prove that every custom listener the test will connect to is already accepting raw TCP connections.
test_proxy_protocol_ssl_shard_aware connects directly to the shard-aware TLS proxy-protocol CQL port immediately after server startup. Wait for ServerUpState.SERVING in the fixture so the custom proxy-protocol listener is registered before opening raw sockets.
test_uninitialized_conns_semaphore opens a raw TCP connection to native_shard_aware_transport_port immediately after startup. The default readiness check can succeed through native_transport_port while the shard-aware listener is still being started, because CQL listeners are registered independently. Wait for ServerUpState.SERVING before opening raw sockets.
test_perf_alternator_remote now asks server_add() to wait for SERVING and uses the returned server address directly. This removes the redundant running_servers() plus get_ready_cql() sequence noted in review.

Fixes: SCYLLADB-1797

No backport as of now, only appeared on master.