### PR TITLE
test/pylib: stop using random ports for MinIO and JMX

### DIFF
--- a/test/nodetool/conftest.py
+++ b/test/nodetool/conftest.py
@@ -134,11 +134,9 @@ def jmx(request, rest_api_mock_server):
                 response=[])]
     set_expected_requests(rest_api_mock_server, expected_requests)
 
-    # Our nodetool launcher script ignores the host param, so this has to be 127.0.0.1, matching the internal default.
-    jmx_ip = "127.0.0.1"
-    jmx_port = random.randint(10000, 65535)
-    while jmx_port == api_port:
-        jmx_port = random.randint(10000, 65535)
+    # Bind JMX to the same per-module loopback IP as the REST mock.
+    jmx_ip = ip
+    jmx_port = 7199
 
     jmx_process = subprocess.Popen(
             [
@@ -147,6 +145,7 @@ def jmx(request, rest_api_mock_server):
                 "-p", str(api_port),
                 "-ja", jmx_ip,
                 "-jp", str(jmx_port),
+                f"-Djava.rmi.server.hostname={jmx_ip}",
             ],
             cwd=workdir, text=True)
 

--- a/test/pylib/kmip_wrapper.py
+++ b/test/pylib/kmip_wrapper.py
@@ -204,6 +204,7 @@ def main():
         kwargs['database_path'] = opts.database_path
 
     kwargs['live_policies'] = True
+    kwargs.setdefault('hostname', '127.0.0.1')
 
     s = KMIPServerWrapper(**kwargs)
     print("Starting...")

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -11,7 +11,7 @@ import os
 import argparse
 import asyncio
 from asyncio.subprocess import Process
-from typing import Generator, Optional
+from typing import Optional
 import json
 import logging
 import pathlib
@@ -32,13 +32,16 @@ class MinioServer:
     ENV_ACCESS_KEY = 'AWS_ACCESS_KEY_ID'
     ENV_SECRET_KEY = 'AWS_SECRET_ACCESS_KEY'
     DEFAULT_REGION = 'local'
+    DEFAULT_PORT = 9000
+    DEFAULT_CONSOLE_PORT = 9001
 
     log_file: BufferedWriter
 
     def __init__(self, tempdir_base, address, logger):
         self.srv_exe = shutil.which('minio')
         self.address = address
-        self.port = None
+        self.port = self.DEFAULT_PORT
+        self.console_port = self.DEFAULT_CONSOLE_PORT
         self.tempdir_base = pathlib.Path(tempdir_base)
         tempdir = tempfile.mkdtemp(dir=tempdir_base, prefix="minio-")
         self.tempdir = pathlib.Path(tempdir)
@@ -156,12 +159,6 @@ class MinioServer:
         return {'Statement': statement,
                 'Version': '2012-10-17'}
 
-    def _get_local_ports(self, num_ports: int) -> Generator[int, None, None]:
-        with open('/proc/sys/net/ipv4/ip_local_port_range', encoding='ascii') as port_range:
-            min_port, max_port = map(int, port_range.read().split())
-        for _ in range(num_ports):
-            yield random.randint(min_port, max_port)
-
     @staticmethod
     def create_conf(url: str, region: str):
         endpoint = {'name': url,
@@ -180,7 +177,7 @@ class MinioServer:
         self.logger.info(f'Starting minio server at {self.address}:{port}')
         cmd = await asyncio.create_subprocess_exec(
             self.srv_exe,
-            *[ 'server', '--address', f'{self.address}:{port}', self.rootdir ],
+            *[ 'server', '--address', f'{self.address}:{port}', '--console-address', f'{self.address}:{self.console_port}', self.rootdir ],
             preexec_fn=os.setsid,
             stderr=self.log_file,
             stdout=self.log_file,
@@ -239,24 +236,12 @@ class MinioServer:
 
     async def start(self):
         if self.srv_exe is None:
-            self.logger.error("Minio not installed, get it from https://dl.minio.io/server/minio/release/linux-amd64/minio and put into PATH")
-            return
+            raise RuntimeError("Minio not installed, get it from https://dl.minio.io/server/minio/release/linux-amd64/minio and put into PATH")
 
         self.log_file = self.log_filename.open("wb")
         os.mkdir(self.rootdir)
 
-        retries = 42  # just retry a fixed number of times
-        for port in self._get_local_ports(retries):
-            try:
-                self.cmd = await self._run_server(port)
-                self.port = port
-            except RuntimeError:
-                pass
-            else:
-                break
-        else:
-            self.logger.error("Failed to start Minio server")
-            return
+        self.cmd = await self._run_server(self.port)
 
         self._set_environ()
 

--- a/test/pylib/object_storage.py
+++ b/test/pylib/object_storage.py
@@ -17,6 +17,7 @@ import uuid
 
 from test.pylib.minio_server import MinioServer
 from test.pylib.dockerized_service import DockerizedServer
+from test.pylib.host_registry import HostRegistry
 from operator import attrgetter
 
 import pytest
@@ -115,26 +116,41 @@ S3_Server = S3Server
 
 class MinioWrapper(S3Server):
     def __init__(self, tempdir):
-        self.server = MinioServer(tempdir,
-                                  '127.0.0.1',
-                                  logging.getLogger('minio'))
-        super().__init__(
-                tempdir,
-                self.server.address,
-                self.server.port,
-                self.server.access_key,
-                self.server.secret_key,
-                MinioServer.DEFAULT_REGION,
-                self.server.bucket_name)
+        self.host_registry = HostRegistry()
+        self.leased_host = None
+        self.server = None
+        # Fields are fully initialized by start(); base-class values are
+        # placeholders until then.
+        super().__init__(tempdir, '', 0, '', '', MinioServer.DEFAULT_REGION, '')
 
     def create_endpoint_conf(self):
         return MinioServer.create_conf(self.address, self.region)
 
     async def start(self):
-        return self.server.start()
+        self.leased_host = await self.host_registry.lease_host()
+        self.server = MinioServer(self.tempdir,
+                                  self.leased_host,
+                                  logging.getLogger('minio'))
+        try:
+            await self.server.start()
+        except Exception:
+            await self.host_registry.release_host(self.leased_host)
+            self.leased_host = None
+            raise
+        self.ip = self.server.address
+        self.port = self.server.port
+        self.address = f'http://{self.ip}:{self.port}'
+        self.acc_key = self.server.access_key
+        self.secret_key = self.server.secret_key
+        self.bucket_name = self.server.bucket_name
 
     async def stop(self):
-        return self.server.stop()
+        try:
+            await self.server.stop()
+        finally:
+            if self.leased_host is not None:
+                await self.host_registry.release_host(self.leased_host)
+                self.leased_host = None
 
 
 class GSFront:


### PR DESCRIPTION
Replace random port selection in MinIO and JMX test helpers with fixed
ports on unique per-test loopback IPs, eliminating TOCTOU races.

Commits:
- kmip_wrapper: default hostname to 127.0.0.1
- nodetool: bind JMX to the per-module loopback IP with fixed port 7199
- minio: use fixed service and console ports on a unique HostRegistry IP
  instead of probing the ephemeral range; raise on start failure

Fixes: SCYLLADB-1817

Minor improvement, no need to backport.