### PR TITLE
utils: log original exception when on_internal_error is called during stack unwinding

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -526,6 +526,7 @@ ldap_tests = set([
 scylla_tests = set([
     'test/boost/combined_tests',
     'test/boost/UUID_test',
+    'test/boost/on_internal_error_test',
     'test/boost/url_parse_test',
     'test/boost/advanced_rpc_compressor_test',
     'test/boost/allocation_strategy_test',
@@ -610,6 +611,7 @@ scylla_tests = set([
     'test/boost/nonwrapping_interval_test',
     'test/boost/object_storage_upload_test',
     'test/boost/observable_test',
+    'test/boost/on_internal_error_test',
     'test/boost/partitioner_test',
     'test/boost/pretty_printers_test',
     'test/boost/radix_tree_test',
@@ -1593,6 +1595,7 @@ pure_boost_tests = set([
     'test/boost/map_difference_test',
     'test/boost/nonwrapping_interval_test',
     'test/boost/observable_test',
+    'test/boost/on_internal_error_test',
     'test/boost/wrapping_interval_test',
     'test/boost/range_tombstone_list_test',
     'test/boost/reservoir_sampling_test',
@@ -1744,6 +1747,7 @@ deps['test/boost/bytes_ostream_test'] = [
 ]
 deps['test/boost/input_stream_test'] = ['test/boost/input_stream_test.cc']
 deps['test/boost/UUID_test'] = ['clocks-impl.cc', 'utils/UUID_gen.cc', 'test/boost/UUID_test.cc', 'utils/uuid.cc', 'utils/dynamic_bitset.cc', 'utils/hashers.cc', 'utils/on_internal_error.cc']
+deps['test/boost/on_internal_error_test'] = ['test/boost/on_internal_error_test.cc', 'utils/on_internal_error.cc']
 deps['test/boost/url_parse_test'] = ['utils/http.cc', 'test/boost/url_parse_test.cc', ]
 deps['test/boost/murmur_hash_test'] = ['bytes.cc', 'utils/murmur_hash.cc', 'test/boost/murmur_hash_test.cc']
 deps['test/boost/allocation_strategy_test'] = ['test/boost/allocation_strategy_test.cc', 'utils/logalloc.cc', 'utils/dynamic_bitset.cc', 'utils/labels.cc']

--- a/service/raft/raft_group0.cc
+++ b/service/raft/raft_group0.cc
@@ -455,6 +455,9 @@ future<> raft_group0::start_server_for_group0(raft::group_id group0_id, service:
     co_await with_scheduling_group(_sg, [this, &srv_for_group0, group0_id] (this auto self) -> future<> {
         auto& state_machine = dynamic_cast<group0_state_machine&>(srv_for_group0.state_machine);
         co_await _raft_gr.start_server_for_group(std::move(srv_for_group0));
+        if (utils::get_local_injector().is_enabled("group0_fail_before_emplace")) {
+            throw std::runtime_error("injection: group0_fail_before_emplace - simulated failure after server registration");
+        }
         // Set _group0 immediately after the server is registered in _raft_gr._servers.
         // This ensures abort_and_drain()/destroy() can find and clean up the server
         // even if enable_in_memory_state_machine() or later steps throw.

--- a/service/raft/raft_group_registry.cc
+++ b/service/raft/raft_group_registry.cc
@@ -18,6 +18,7 @@
 #include "idl/raft_util.dist.hh"
 #include "utils/composite_abort_source.hh"
 #include "utils/error_injection.hh"
+#include "utils/on_internal_error.hh"
 #include <seastar/core/shared_future.hh>
 
 #include <chrono>
@@ -288,7 +289,7 @@ const raft::server_id& raft_group_registry::get_my_raft_id() {
 
 seastar::future<> raft_group_registry::stop() {
     if (_servers.size() > 0) {
-        on_internal_error(rslog, format("stop(): server for group {} is not destroyed", _servers.begin()->first));
+        utils::on_internal_error(format("stop(): server for group {} is not destroyed", _servers.begin()->first));
     }
     co_await uninit_rpc_verbs();
     _direct_fd_subscription.reset();

--- a/test/boost/on_internal_error_test.cc
+++ b/test/boost/on_internal_error_test.cc
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+// Test for utils::on_internal_error() behavior during stack unwinding.
+// See CUSTOMER-340: on_internal_error called during stack unwinding hides the
+// original exception by throwing (which triggers std::terminate).
+
+#define BOOST_TEST_MODULE core
+
+#include <boost/test/unit_test.hpp>
+#include <stdexcept>
+#include <cstdlib>
+#include <cstring>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "utils/on_internal_error.hh"
+#include <seastar/core/on_internal_error.hh>
+
+// A helper RAII class whose destructor calls on_internal_error during unwinding.
+struct call_on_internal_error_in_destructor {
+    ~call_on_internal_error_in_destructor() noexcept(false) {
+        // This is called during stack unwinding due to the original exception.
+        // Before the fix, this would throw and trigger std::terminate.
+        // After the fix, this should abort (not throw), logging the original exception.
+        utils::on_internal_error("on_internal_error called from destructor during unwinding");
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_on_internal_error_throws_when_not_unwinding) {
+    // When not unwinding, on_internal_error should throw (with abort disabled)
+    seastar::set_abort_on_internal_error(false);
+    BOOST_REQUIRE_THROW(utils::on_internal_error("test error"), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE(test_on_internal_error_aborts_during_unwinding) {
+    // Fork a child process to test that on_internal_error aborts during unwinding
+    // instead of throwing (which would cause std::terminate with no useful info).
+    //
+    // The child process:
+    // 1. Throws an exception ("original exception")
+    // 2. During unwinding, a destructor calls on_internal_error
+    // 3. The fix should cause abort (SIGABRT) instead of std::terminate
+    //
+    // We verify the child is killed by SIGABRT.
+
+    seastar::set_abort_on_internal_error(false);
+
+    pid_t pid = fork();
+    BOOST_REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        // Child process
+        try {
+            call_on_internal_error_in_destructor guard;
+            throw std::runtime_error("original exception that should be logged");
+        } catch (...) {
+            // Should not reach here - the destructor should abort
+            _exit(0);
+        }
+        _exit(0);
+    }
+
+    // Parent: wait for child
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    // Child should have been killed by SIGABRT (from on_fatal_internal_error)
+    BOOST_REQUIRE(WIFSIGNALED(status));
+    BOOST_REQUIRE_EQUAL(WTERMSIG(status), SIGABRT);
+}
+
+BOOST_AUTO_TEST_CASE(test_on_internal_error_logs_original_exception_during_unwinding) {
+    // Fork a child process and capture stderr to verify that the unwinding
+    // situation is logged before aborting.
+
+    seastar::set_abort_on_internal_error(false);
+
+    int pipefd[2];
+    BOOST_REQUIRE(pipe(pipefd) == 0);
+
+    pid_t pid = fork();
+    BOOST_REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        // Child: redirect stderr to pipe
+        close(pipefd[0]);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+        try {
+            call_on_internal_error_in_destructor guard;
+            throw std::runtime_error("the_original_exception_message");
+        } catch (...) {
+            _exit(0);
+        }
+        _exit(0);
+    }
+
+    // Parent: read child's stderr
+    close(pipefd[1]);
+
+    std::string output;
+    char buf[4096];
+    ssize_t n;
+    while ((n = read(pipefd[0], buf, sizeof(buf) - 1)) > 0) {
+        buf[n] = '\0';
+        output += buf;
+    }
+    close(pipefd[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    // Child should abort
+    BOOST_REQUIRE(WIFSIGNALED(status));
+    BOOST_REQUIRE_EQUAL(WTERMSIG(status), SIGABRT);
+
+    // The output should mention that on_internal_error was called during
+    // stack unwinding, so the developer has a clear indication of what happened.
+    BOOST_REQUIRE_MESSAGE(output.find("during stack unwinding") != std::string::npos, "Expected 'during stack unwinding' in output, got: " + output);
+}
+
+// A helper that calls on_internal_error from within a catch block while another
+// exception is unwinding above it. In this scenario std::current_exception()
+// returns the caught exception, so we can log it.
+struct call_on_internal_error_in_nested_catch_destructor {
+    ~call_on_internal_error_in_nested_catch_destructor() noexcept(false) {
+        try {
+            throw std::runtime_error("inner_triggering_exception");
+        } catch (...) {
+            // Now std::current_exception() returns "inner_triggering_exception"
+            // and std::uncaught_exceptions() > 0 because of the outer exception.
+            utils::on_internal_error("on_internal_error in nested catch");
+        }
+    }
+};
+
+BOOST_AUTO_TEST_CASE(test_on_internal_error_logs_caught_exception_during_unwinding) {
+    // When on_internal_error is called from a catch block during unwinding,
+    // std::current_exception() is available and should be logged.
+
+    seastar::set_abort_on_internal_error(false);
+
+    int pipefd[2];
+    BOOST_REQUIRE(pipe(pipefd) == 0);
+
+    pid_t pid = fork();
+    BOOST_REQUIRE(pid >= 0);
+
+    if (pid == 0) {
+        close(pipefd[0]);
+        dup2(pipefd[1], STDERR_FILENO);
+        close(pipefd[1]);
+
+        try {
+            call_on_internal_error_in_nested_catch_destructor guard;
+            throw std::runtime_error("outer_exception");
+        } catch (...) {
+            _exit(0);
+        }
+        _exit(0);
+    }
+
+    close(pipefd[1]);
+
+    std::string output;
+    char buf[4096];
+    ssize_t n;
+    while ((n = read(pipefd[0], buf, sizeof(buf) - 1)) > 0) {
+        buf[n] = '\0';
+        output += buf;
+    }
+    close(pipefd[0]);
+
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    BOOST_REQUIRE(WIFSIGNALED(status));
+    BOOST_REQUIRE_EQUAL(WTERMSIG(status), SIGABRT);
+
+    // Should log the unwinding situation
+    BOOST_REQUIRE_MESSAGE(output.find("during stack unwinding") != std::string::npos, "Expected 'during stack unwinding' in output, got: " + output);
+    // Should log the currently handled exception
+    BOOST_REQUIRE_MESSAGE(output.find("inner_triggering_exception") != std::string::npos, "Expected 'inner_triggering_exception' in output, got: " + output);
+}

--- a/test/cluster/test_on_internal_error_during_unwinding.py
+++ b/test/cluster/test_on_internal_error_during_unwinding.py
@@ -1,0 +1,80 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+# Test for on_internal_error behavior when triggered during shutdown
+# after a startup failure leaves a raft server not properly destroyed.
+#
+# Related: CUSTOMER-340
+
+import logging
+
+import pytest
+from test.pylib.manager_client import ManagerClient
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(
+    mode="release", reason="error injections are not supported in release mode"
+)
+async def test_on_internal_error_during_shutdown_after_startup_failure(
+    manager: ManagerClient,
+) -> None:
+    """Test that on_internal_error during shutdown reports the original failure.
+
+    This test reproduces the CUSTOMER-340 scenario using error injections:
+    1. Node starts, group0 is established normally
+    2. Node is stopped and restarted with the group0_fail_before_emplace
+       injection enabled at startup. This causes the server to be registered
+       in raft_group_registry but _group0 is never set, so destroy() is
+       never called. During shutdown, raft_group_registry::stop() finds the
+       undestroyed server and calls on_internal_error.
+
+    The test verifies:
+    - The node fails to start (crashes due to on_internal_error abort)
+    - The "server for group ... is not destroyed" message is logged
+    - The original injection error message is visible in the log
+    """
+    # Tell the manager to ignore the intentional abort from our error injection
+    manager.ignore_cores_log_patterns.append("server for group.*is not destroyed")
+
+    # Start a node normally so group0 is established
+    srv = await manager.server_add()
+    logger.info("Server %s started successfully", srv.server_id)
+
+    # Stop the node gracefully
+    await manager.server_stop_gracefully(srv.server_id)
+
+    # Restart with the injection that throws after server registration
+    # but before _group0.emplace, leaving the server undestroyed
+    logger.info("Restarting with group0_fail_before_emplace injection")
+    await manager.server_update_config(
+        srv.server_id,
+        key="error_injections_at_startup",
+        value=["group0_fail_before_emplace"],
+    )
+
+    log = await manager.server_open_log(srv.server_id)
+    # The injection throws after start_server_for_group registers the server
+    # but before _group0.emplace. During shutdown, raft_group_registry::stop()
+    # finds the undestroyed server and calls utils::on_internal_error which aborts.
+    await manager.server_start(
+        srv.server_id, expected_error="server for group.*is not destroyed"
+    )
+
+    # Verify the on_internal_error message is logged
+    matches = await log.grep("server for group.*is not destroyed")
+    assert len(matches) > 0, (
+        "Expected 'server for group ... is not destroyed' error message in the log"
+    )
+
+    # Verify our fix detected the stack unwinding condition
+    matches = await log.grep("on_internal_error called during stack unwinding")
+    assert len(matches) > 0, (
+        "Expected 'on_internal_error called during stack unwinding' in the log"
+    )
+
+    logger.info("Verified: on_internal_error properly reported during shutdown")

--- a/utils/on_internal_error.cc
+++ b/utils/on_internal_error.cc
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
  */
 
+#include <exception>
+
 #include <seastar/core/on_internal_error.hh>
 #include <seastar/util/log.hh>
 #include <seastar/core/format.hh>
@@ -17,6 +19,22 @@ static seastar::logger on_internal_error_logger("on_internal_error");
 namespace utils {
 
 [[noreturn]] void on_internal_error(std::string_view reason) {
+    if (std::uncaught_exceptions() > 0) {
+        // We are being called during stack unwinding. Throwing here would
+        // trigger std::terminate and hide the original exception. Log the
+        // situation and abort instead of throwing.
+        on_internal_error_logger.error("on_internal_error called during stack unwinding: {}", reason);
+        if (auto ep = std::current_exception()) {
+            try {
+                std::rethrow_exception(ep);
+            } catch (const std::exception& e) {
+                on_internal_error_logger.error("original exception that is being handled: {}", e.what());
+            } catch (...) {
+                on_internal_error_logger.error("original exception that is being handled is not a std::exception");
+            }
+        }
+        seastar::on_fatal_internal_error(on_internal_error_logger, reason);
+    }
     seastar::on_internal_error(on_internal_error_logger, reason);
 }
 
@@ -25,8 +43,7 @@ namespace utils {
 }
 
 [[noreturn]] void __assert_fail_on_internal_error(const char* expr, const char* file, int line, const char* function) {
-    on_internal_error(fmt::format("Assertion '{}' failed at {}:{} in {}",
-        expr, file, line, function));
+    on_internal_error(fmt::format("Assertion '{}' failed at {}:{} in {}", expr, file, line, function));
 }
 
 } // namespace utils

--- a/utils/on_internal_error.hh
+++ b/utils/on_internal_error.hh
@@ -29,6 +29,11 @@ namespace utils {
 /// this will either abort or throw a std::runtime_error.
 /// In both cases an error will be logged, containing \p reason and the
 /// current backtrace.
+///
+/// If called during stack unwinding (std::uncaught_exceptions() > 0),
+/// logs that on_internal_error was triggered during unwinding and the
+/// original exception (if available via std::current_exception()), then
+/// aborts instead of throwing (which would trigger std::terminate).
 [[noreturn]] void on_internal_error(std::string_view reason);
 
 /// Report an internal error and abort unconditionally
@@ -38,4 +43,4 @@ namespace utils {
 /// setting.
 [[noreturn]] void on_fatal_internal_error(std::string_view reason) noexcept;
 
-}
+} // namespace utils


### PR DESCRIPTION
## Summary

- Fix `utils::on_internal_error()` to detect when it's called during stack unwinding (`std::uncaught_exceptions() > 0`) and abort instead of throwing, which would trigger `std::terminate` and hide the original exception
- Log the original exception message (when available via `std::current_exception()`) before aborting, so the root cause is preserved in logs
- Add unit tests verifying the behavior in both normal and stack-unwinding scenarios

## Context

Addresses the scenario from [CUSTOMER-340](https://scylladb.atlassian.net/browse/CUSTOMER-340) where `raft_group_registry::stop()` calls `on_internal_error` from a deferred action destructor during shutdown. The original exception that caused the shutdown failure was being hidden, making production debugging very difficult.

## Changes

- `utils/on_internal_error.cc`: Check `std::uncaught_exceptions()` before throwing; if unwinding, log context and abort via `on_fatal_internal_error`
- `test/boost/on_internal_error_test.cc`: New test file with 4 test cases covering normal throw, abort-during-unwinding, and original-exception-logging scenarios
- `configure.py`: Register the new test

[CUSTOMER-340]: https://scylladb.atlassian.net/browse/CUSTOMER-340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ