### PR TITLE
pgo: fix ModuleNotFoundError in exec_cql.py by reverting safe_driver_shutdown

### DIFF
--- a/pgo/exec_cql.py
+++ b/pgo/exec_cql.py
@@ -16,7 +16,6 @@ Usage:
 import argparse, os, sys
 from typing import Sequence
 
-from test.pylib.driver_utils import safe_driver_shutdown
 
 def read_statements(path: str) -> list[tuple[int, str]]:
     stms: list[tuple[int, str]] = []
@@ -58,7 +57,7 @@ def exec_statements(statements: list[tuple[int, str]], socket_path: str, timeout
                 print(f"ERROR executing statement from file line {lineno}: {s}\n{e}", file=sys.stderr)
                 return 1
     finally:
-        safe_driver_shutdown(cluster)
+        cluster.shutdown()
     return 0
 
 def main(argv: Sequence[str]) -> int:


### PR DESCRIPTION
Commit cf237e060a introduced 'from test.pylib.driver_utils import safe_driver_shutdown' in pgo/exec_cql.py. This module runs during PGO profile training (a build step) where the test package is not on the Python path, causing an immediate ModuleNotFoundError on both x86 and ARM. Revert to plain cluster.shutdown() which is sufficient for the single-use PGO training scenario.

Fixes: SCYLLADB-1792

**cf237e060a is in 2026.2, so we need to backport this fix**

### Testing
- [x] https://jenkins.scylladb.com/job/scylla-master/job/refresh-pgo-profiles/53/