### PR TITLE
prevent gossiper from marking nodes as down in tests unexpectedly

### DIFF
--- a/gms/gossiper.cc
+++ b/gms/gossiper.cc
@@ -964,8 +964,7 @@ future<> gossiper::failure_detector_loop_for_node(locator::host_id host_id, gene
         diff = now - last;
         if (!failed) {
             last = now;
-        }
-        if (diff > max_duration) {
+        } else if (diff > max_duration) {
             logger.info("failure_detector_loop: Mark node {}/{} as DOWN", host_id, node);
             co_await container().invoke_on(0, [host_id] (gms::gossiper& g) {
                 return g.convict(host_id);

--- a/test/cluster/conftest.py
+++ b/test/cluster/conftest.py
@@ -398,4 +398,4 @@ async def key_provider(request, tmpdir, scylla_binary):
 
 @pytest.fixture(scope="function")
 def failure_detector_timeout(build_mode):
-    return 2000 * MODES_TIMEOUT_FACTOR[build_mode]
+    return 5000 * MODES_TIMEOUT_FACTOR[build_mode]


### PR DESCRIPTION
This PR includes two changes that make gossiper much less likely to mark
nodes as down in tests unexpectedly, and cause test flakiness in issues
like SCYLLADB-864:
- fixing false node conviction when echo succeeds,
- increasing the failure_detector_timeout fixture.

Fixes: SCYLLADB-864

No need for backport: related CI failures are rare, and merging #29522
made them even more unlikely (I haven't seen one since then, but it's
still possible to reproduce locally on dev machines).