### PR TITLE
test/cluster: fix server-starting functions to wait for all ports

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -2216,8 +2216,6 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
             });
 
             if (cfg->maintenance_mode()) {
-                checkpoint(stop_signal, "entering maintenance mode");
-
                 // Notify maintenance auth service that maintenance mode is starting
                 maintenance_auth_service.invoke_on_all([](auth::service& svc) {
                     auth::set_maintenance_mode(svc);
@@ -2225,6 +2223,10 @@ To start the scylla server proper, simply invoke as: scylla server (or just scyl
                 }).get();
 
                 start_cql(*cql_maintenance_server_ctl, stop_maintenance_cql, "maintenance native server");
+
+                // Notify after the maintenance CQL server is listening, so that
+                // clients can connect as soon as they receive this notification.
+                checkpoint(stop_signal, "entering maintenance mode");
 
                 ss.local().start_maintenance_mode().get();
 

--- a/test/cluster/test_alternator_proxy_protocol.py
+++ b/test/cluster/test_alternator_proxy_protocol.py
@@ -25,7 +25,6 @@ import pytest
 
 from test.pylib.manager_client import ManagerClient
 from test.pylib.rest_client import inject_error
-from test.pylib.internal_types import ServerUpState
 
 logger = logging.getLogger(__name__)
 
@@ -198,13 +197,9 @@ ALTERNATOR_PROXY_SERVER_CONFIG = {
 
 @pytest.fixture(scope="function")
 async def alternator_proxy_server(manager: ManagerClient):
-    """Fixture that creates a server with Alternator proxy protocol ports enabled.
-
-    Waits for SERVING state to ensure Alternator ports are ready.
-    """
+    """Fixture that creates a server with Alternator proxy protocol ports enabled."""
     server = await manager.server_add(
         config=ALTERNATOR_PROXY_SERVER_CONFIG,
-        expected_server_up_state=ServerUpState.SERVING
     )
     yield (server, manager)
 

--- a/test/cluster/test_proxy_protocol.py
+++ b/test/cluster/test_proxy_protocol.py
@@ -19,7 +19,6 @@ import struct
 import time
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.internal_types import ServerUpState
 from test.pylib.util import wait_for
 
 logger = logging.getLogger(__name__)
@@ -319,12 +318,10 @@ PROXY_SERVER_CONFIG = {
 async def proxy_server(manager: ManagerClient):
     """
     Fixture that creates a server with all proxy protocol ports enabled.
-    Waits for SERVING state to ensure proxy protocol ports are ready.
     Returns a tuple of (server, manager).
     """
     server = await manager.server_add(
         config=PROXY_SERVER_CONFIG,
-        expected_server_up_state=ServerUpState.SERVING,
     )
     yield (server, manager)
 

--- a/test/cluster/test_tools_perf.py
+++ b/test/cluster/test_tools_perf.py
@@ -10,7 +10,6 @@ import asyncio
 import pytest
 from test import path_to
 from test.pylib.host_registry import HostRegistry
-from test.pylib.internal_types import ServerUpState
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +120,7 @@ async def test_perf_alternator_remote(scylla_path, tmp_path, workload, manager):
     server = await manager.server_add(cmdline=[
         "--alternator-port", "8000",
         "--alternator-write-isolation", "only_rmw_uses_lwt"
-    ], expected_server_up_state=ServerUpState.SERVING)
+    ])
     host = server.ip_addr
     client_cmd = [
         scylla_path, "perf-alternator",

--- a/test/cluster/test_uninitialized_conns_semaphore.py
+++ b/test/cluster/test_uninitialized_conns_semaphore.py
@@ -9,7 +9,6 @@ import asyncio
 import pytest
 
 from test.pylib.manager_client import ManagerClient
-from test.pylib.internal_types import ServerUpState
 
 CQL_PORT = 9042
 SHARD_AWARE_PORT = 19042
@@ -23,7 +22,7 @@ async def test_uninitialized_conns_sempahore_one(manager: ManagerClient):
         "native_transport_port": CQL_PORT,
         "native_shard_aware_transport_port": SHARD_AWARE_PORT,
     }
-    server = await manager.server_add(config=config, expected_server_up_state=ServerUpState.SERVING)
+    server = await manager.server_add(config=config)
     cql, _ = await manager.get_ready_cql([server])
 
     await cql.run_async("SELECT release_version FROM system.local")

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -389,7 +389,7 @@ class ManagerClient:
                            seeds: list[IPAddress] | None = None,
                            timeout: float | None = None,
                            connect_driver: bool = True,
-                           expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
+                           expected_server_up_state: ServerUpState = ServerUpState.SERVING,
                            cmdline_options_override: list[str] | None = None,
                            append_env_override: dict[str, str] | None = None,
                            auth_provider: dict[str, str] | None = None) -> None:

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -393,8 +393,16 @@ class ManagerClient:
                            cmdline_options_override: list[str] | None = None,
                            append_env_override: dict[str, str] | None = None,
                            auth_provider: dict[str, str] | None = None) -> None:
-        """Start specified server and optionally wait for it to learn of other servers.
+        """Start specified server.
 
+        When expected_error is None, waits until Scylla reports that all
+        configured listeners (including any non-default ports) are ready
+        (ServerUpState.SERVING). Pass a lower expected_server_up_state to
+        return earlier. When expected_error is set, no readiness wait is
+        performed. When connect_driver=False, the effective wait state is
+        capped at HOST_ID_QUERIED regardless of expected_server_up_state.
+
+        Optionally waits for it to learn of other servers (wait_others).
         Replace CLI options and environment variables with `cmdline_options_override` and `append_env_override`
         if provided.
 
@@ -542,7 +550,14 @@ class ManagerClient:
                          server_encryption: str = "none",
                          expected_server_up_state: ServerUpState = ServerUpState.SERVING,
                          connect_driver: bool = True) -> ServerInfo:
-        """Add a new server"""
+        """Add a new server.
+
+        When start=True and expected_error is None, waits until Scylla reports
+        that all configured listeners (including any non-default ports) are ready
+        (ServerUpState.SERVING). Pass a lower expected_server_up_state to return
+        earlier. When start=False or expected_error is set, no readiness wait is
+        performed. When connect_driver=False, the effective wait state is capped
+        at HOST_ID_QUERIED regardless of expected_server_up_state."""
         if expected_error is not None:
             self.ignore_log_patterns.append(re.escape(expected_error))
 
@@ -600,6 +615,12 @@ class ManagerClient:
                           server_encryption: str = "none",
                           auto_rack_dc: Optional[str] = None) -> List[ServerInfo]:
         """Add new servers concurrently.
+
+        When start=True and expected_error is None, waits until Scylla reports
+        that all configured listeners (including any non-default ports) are ready
+        (ServerUpState.SERVING). When start=False or expected_error is set, no
+        readiness wait is performed.
+
         This function can be called only if the cluster uses consistent topology changes, which support
         concurrent bootstraps. If your test does not fulfill this condition and you want to add multiple
         servers, you should use multiple server_add calls."""

--- a/test/pylib/manager_client.py
+++ b/test/pylib/manager_client.py
@@ -540,7 +540,7 @@ class ManagerClient:
                          seeds: Optional[List[IPAddress]] = None,
                          timeout: Optional[float] = ScyllaServer.TOPOLOGY_TIMEOUT,
                          server_encryption: str = "none",
-                         expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
+                         expected_server_up_state: ServerUpState = ServerUpState.SERVING,
                          connect_driver: bool = True) -> ServerInfo:
         """Add a new server"""
         if expected_error is not None:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -779,12 +779,15 @@ class ScyllaServer:
                     # See the comment above about `auth::standard_role_manager`. We execute
                     # a 'real' query to ensure that the auth service has finished initializing.
                     session.execute("SELECT key FROM system.local where key = 'local'")
-                    self.control_cluster = Cluster(execution_profiles=
-                                                        {EXEC_PROFILE_DEFAULT: profile},
-                                                   contact_points=contact_points,
-                                                   control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                                                   auth_provider=self.auth_provider)
-                    self.control_connection = self.control_cluster.connect()
+                    # Only create the persistent control connection once; re-creating it on
+                    # every successful CQL check would leak driver connections.
+                    if self.control_connection is None:
+                        self.control_cluster = Cluster(execution_profiles=
+                                                            {EXEC_PROFILE_DEFAULT: profile},
+                                                       contact_points=contact_points,
+                                                       control_connection_timeout=self.TOPOLOGY_TIMEOUT,
+                                                       auth_provider=self.auth_provider)
+                        self.control_connection = self.control_cluster.connect()
                     cql_queried = True
         except (NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:
             self.logger.debug("Exception when checking if CQL is up: %s", exc)
@@ -972,7 +975,11 @@ class ScyllaServer:
             if await self.try_get_host_id(api):
                 if server_up_state == ServerUpState.PROCESS_STARTED:
                     server_up_state = ServerUpState.HOST_ID_QUERIED
-                server_up_state = await self.get_cql_alternator_up_state() or server_up_state
+                # Only poll CQL/Alternator until they are known to be up.
+                # Once CQL_ALTERNATOR_QUERIED is reached, skip the poll to avoid
+                # repeatedly recreating driver connections while waiting for sd_notify.
+                if server_up_state < ServerUpState.CQL_ALTERNATOR_QUERIED:
+                    server_up_state = await self.get_cql_alternator_up_state() or server_up_state
                 # Check for SERVING state via sd_notify. This is authoritative: Scylla sends
                 # STATUS=serving once all configured listeners are ready, and
                 # STATUS=entering maintenance mode once the maintenance socket is ready.

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -835,8 +835,9 @@ class ScyllaServer:
                         loop.call_soon_threadsafe(f.set_result, True)
                         return
                     if 'STATUS=entering maintenance mode' in message:
-                        logger.debug("Receive sd_notify 'entering maintenance mode'")
-                        break
+                        logger.debug("Received sd_notify 'entering maintenance mode' message")
+                        loop.call_soon_threadsafe(f.set_result, True)
+                        return
                 except socket.timeout:
                     pass
                 except Exception as e:
@@ -972,8 +973,11 @@ class ScyllaServer:
                 if server_up_state == ServerUpState.PROCESS_STARTED:
                     server_up_state = ServerUpState.HOST_ID_QUERIED
                 server_up_state = await self.get_cql_alternator_up_state() or server_up_state
-                # Check for SERVING state (sd_notify "serving" message)
-                if server_up_state >= ServerUpState.CQL_ALTERNATOR_QUERIED and self.check_serving_notification():
+                # Check for SERVING state via sd_notify. This is authoritative: Scylla sends
+                # STATUS=serving once all configured listeners are ready, and
+                # STATUS=entering maintenance mode once the maintenance socket is ready.
+                # Both mean the server is fully started and we don't need to wait further.
+                if self.check_serving_notification():
                     server_up_state = ServerUpState.SERVING
                 if server_up_state >= expected_server_up_state:
                     if expected_error is not None:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1508,7 +1508,7 @@ class ScyllaCluster:
                            server_id: ServerNum,
                            expected_error: str | None = None,
                            seeds: list[IPAddress] | None = None,
-                           expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
+                           expected_server_up_state: ServerUpState = ServerUpState.SERVING,
                            cmdline_options_override: list[str] | None = None,
                            append_env_override: dict[str, str] | None = None,
                            auth_provider: dict[str, str] | None = None) -> None:
@@ -1991,7 +1991,7 @@ class ScyllaClusterManager:
             server_id=server_id,
             expected_error=data.get("expected_error"),
             seeds=data.get("seeds"),
-            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "CQL_ALTERNATOR_QUERIED")),
+            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "SERVING")),
             cmdline_options_override=data.get("cmdline_options_override"),
             append_env_override=data.get("append_env_override"),
             auth_provider=data.get("auth_provider"),

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -763,17 +763,19 @@ class ScyllaServer:
             contact_points=[self.rpc_address]
         connected = False
         cql_queried = False
+        cluster_kwargs = dict(
+            execution_profiles={EXEC_PROFILE_DEFAULT: profile},
+            contact_points=contact_points,
+            protocol_version=4,  # This is the latest version Scylla supports
+            control_connection_timeout=self.TOPOLOGY_TIMEOUT,
+            auth_provider=self.auth_provider,
+        )
         try:
             # In a cluster setup, it's possible that the CQL
             # here is directed to a node different from the initial contact
             # point, so make sure we execute the checks strictly via
             # this connection
-            with Cluster(execution_profiles={EXEC_PROFILE_DEFAULT: profile},
-                         contact_points=contact_points,
-                         # This is the latest version Scylla supports
-                         protocol_version=4,
-                         control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                         auth_provider=self.auth_provider) as cluster:
+            with Cluster(**cluster_kwargs) as cluster:
                 with cluster.connect() as session:
                     connected = True
                     # See the comment above about `auth::standard_role_manager`. We execute
@@ -782,11 +784,7 @@ class ScyllaServer:
                     # Only create the persistent control connection once; re-creating it on
                     # every successful CQL check would leak driver connections.
                     if self.control_connection is None:
-                        self.control_cluster = Cluster(execution_profiles=
-                                                            {EXEC_PROFILE_DEFAULT: profile},
-                                                       contact_points=contact_points,
-                                                       control_connection_timeout=self.TOPOLOGY_TIMEOUT,
-                                                       auth_provider=self.auth_provider)
+                        self.control_cluster = Cluster(**cluster_kwargs)
                         self.control_connection = self.control_cluster.connect()
                     cql_queried = True
         except (NoHostAvailable, InvalidRequest, OperationTimedOut) as exc:

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -835,18 +835,18 @@ class ScyllaServer:
                     message = data.decode('utf-8', errors='replace')
                     if 'STATUS=serving' in message:
                         logger.debug("Received sd_notify 'serving' message")
-                        loop.call_soon_threadsafe(f.set_result, True)
+                        loop.call_soon_threadsafe(lambda: f.done() or f.set_result(True))
                         return
                     if 'STATUS=entering maintenance mode' in message:
                         logger.debug("Received sd_notify 'entering maintenance mode' message")
-                        loop.call_soon_threadsafe(f.set_result, True)
+                        loop.call_soon_threadsafe(lambda: f.done() or f.set_result(True))
                         return
                 except socket.timeout:
                     pass
                 except Exception as e:
                     logger.debug("Error reading from notify socket: %s", e)
                     break
-            loop.call_soon_threadsafe(f.set_result, False)
+            loop.call_soon_threadsafe(lambda: f.done() or f.set_result(False))
 
         self.serving_signal = loop.create_future()
         t = threading.Thread(target=poll_status, args=[self.notify_socket, self.serving_signal, self.logger], daemon=True)

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1268,7 +1268,7 @@ class ScyllaCluster:
                          seeds: Optional[List[IPAddress]] = None,
                          server_encryption: str = "none",
                          expected_error: Optional[str] = None,
-                         expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED) -> ServerInfo:
+                         expected_server_up_state: ServerUpState = ServerUpState.SERVING) -> ServerInfo:
         """Add a new server to the cluster"""
         self.is_dirty = True
 
@@ -2026,7 +2026,7 @@ class ScyllaClusterManager:
             seeds=data.get("seeds"),
             server_encryption=data.get("server_encryption", "none"),
             expected_error=data.get("expected_error"),
-            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "CQL_ALTERNATOR_QUERIED")),
+            expected_server_up_state=getattr(ServerUpState, data.get("expected_server_up_state", "SERVING")),
         )
         return s_info.as_dict()
 

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -873,7 +873,7 @@ class ScyllaServer:
         if self.serving_signal.done():
             self._received_serving = self.serving_signal.result()
             self.serving_signal = None
-        return False
+        return self._received_serving
 
     async def try_get_host_id(self, api: ScyllaRESTAPIClient) -> Optional[HostID]:
         """Try to get the host id (also tests Scylla REST API is serving)"""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -558,7 +558,7 @@ class ScyllaServer:
     async def install_and_start(self,
                                 api: ScyllaRESTAPIClient,
                                 expected_error: Optional[str] = None,
-                                expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED) -> None:
+                                expected_server_up_state: ServerUpState = ServerUpState.SERVING) -> None:
         """Setup and start this server."""
 
         await self.install()
@@ -899,7 +899,7 @@ class ScyllaServer:
     async def start(self,
                     api: ScyllaRESTAPIClient,
                     expected_error: Optional[str] = None,
-                    expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
+                    expected_server_up_state: ServerUpState = ServerUpState.SERVING,
                     cmdline_options_override: list[str] | None = None,
                     append_env_override: dict[str, str] | None = None) -> None:
         """Start an installed server.


### PR DESCRIPTION
This series fixes a recurring source of flaky tests in the cluster test suite.

When a test configures Scylla to listen on non-default ports (e.g. a custom Alternator port, proxy-protocol port or shard-aware port), server_add() and server_start() would declare the server ready by polling the hardcoded standard CQL and Alternator ports. Those ports can become available slightly before the custom ports finish binding, so the test could start using the custom port before it was open — causing intermittent failures.

The fix for each affected test was to pass `expected_server_up_state=ServerUpState.SERVING` explicitly, which waits for Scylla's sd_notify("STATUS=serving") signal instead. That signal is sent only after all configured listeners are fully open, so it is always the right readiness signal regardless of the port configuration. This workaround was applied again in PR #29737 and will keep being needed for every new test that uses a non-default port.

This series makes ServerUpState.SERVING the default at every level of the server start/add call stack so no test needs to remember it:

* Make server_add(), servers_add(), server_start() et al. all  default to ServerUpState.SERVING.
* Document that server_add/server_start wait for all ports to be  ready,  so future test authors understand what the functions guarantee.
* Remove now-redundant expected_server_up_state=SERVING from exiting tests.
* A small optimization: Fix check_serving_notification() returning False on first completion. When the sd_notify future completed, the function correctly updated _received_serving but still returned False, wasting one 100ms polling interval. Return self._received_serving directly.

