### PR TITLE
test: limits: optimize test_max_cells to avoid large allocations and fragmentation

### DIFF
--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -246,18 +246,21 @@ class TestLimits(Tester):
             size <<= 1
             self._do_test_max_batch_size(session, node, size - 1)
 
-    def _do_test_max_cell_count(self, session, cells):
-        print("Testing max cells count for %i" % cells)
-        keys = ""
+    def _create_max_cell_count_table(self, session):
         keys_create = ""
-        columns = MAX_CELLS_COLUMNS
-        for i in range(columns):
-            keys += "key" + str(i) + ", "
+        for i in range(MAX_CELLS_COLUMNS):
             keys_create += "key" + str(i) + " int, "
-        values = "1, " * columns
 
         c = """CREATE TABLE test1 (%s blub int PRIMARY KEY,)""" % keys_create
         session.execute(c)
+
+    def _do_test_max_cell_count(self, session, cells):
+        print("Testing max cells count for %i" % cells)
+        keys = ""
+        columns = MAX_CELLS_COLUMNS
+        for i in range(columns):
+            keys += "key" + str(i) + ", "
+        values = "1, " * columns
 
         batch_size = MAX_CELLS_BATCH_SIZE
         rows = cells // columns
@@ -269,7 +272,7 @@ class TestLimits(Tester):
                 session.execute(c)
                 c = "BEGIN UNLOGGED  BATCH\n"
 
-        session.execute("""DROP TABLE test1""")
+        session.execute("""TRUNCATE test1""")
 
     def test_max_cells(self):
         if self.cluster.scylla_mode == "debug":
@@ -281,6 +284,7 @@ class TestLimits(Tester):
 
         session = self.patient_cql_connection(node)
         create_ks(session, "ks", 1)
+        self._create_max_cell_count_table(session)
 
         cells = MAX_CELLS_COLUMNS
         while cells <= MAX_CELLS:

--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -254,23 +254,24 @@ class TestLimits(Tester):
         c = """CREATE TABLE test1 (%s blub int PRIMARY KEY,)""" % keys_create
         session.execute(c)
 
-    def _do_test_max_cell_count(self, session, cells):
-        print("Testing max cells count for %i" % cells)
+    def _prepare_max_cell_count_insert(self, session):
         keys = ""
         columns = MAX_CELLS_COLUMNS
         for i in range(columns):
             keys += "key" + str(i) + ", "
-        values = "1, " * columns
 
-        batch_size = MAX_CELLS_BATCH_SIZE
+        values = "?, " * columns
+        c = "insert into ks.test1 (%s blub) values (%s ?)" % (keys, values)
+        return session.prepare(c)
+
+    def _do_test_max_cell_count(self, session, stmt, cells):
+        print("Testing max cells count for %i" % cells)
+        columns = MAX_CELLS_COLUMNS
+        values = (1,) * columns
+
         rows = cells // columns
-        c = "BEGIN UNLOGGED  BATCH\n"
         for i in range(rows):
-            c += "insert into ks.test1  (%s blub) values (%s %i);\n" % (keys, values, i)
-            if i == rows - 1 or (i + 1) % batch_size == 0:
-                c += "APPLY BATCH;\n"
-                session.execute(c)
-                c = "BEGIN UNLOGGED  BATCH\n"
+            session.execute(stmt, values + (i,))
 
         session.execute("""TRUNCATE test1""")
 
@@ -285,8 +286,9 @@ class TestLimits(Tester):
         session = self.patient_cql_connection(node)
         create_ks(session, "ks", 1)
         self._create_max_cell_count_table(session)
+        stmt = self._prepare_max_cell_count_insert(session)
 
         cells = MAX_CELLS_COLUMNS
         while cells <= MAX_CELLS:
-            self._do_test_max_cell_count(session, cells - 1)
+            self._do_test_max_cell_count(session, stmt, cells - 1)
             cells <<= 1

--- a/test/cluster/dtest/limits_test.py
+++ b/test/cluster/dtest/limits_test.py
@@ -282,7 +282,7 @@ class TestLimits(Tester):
         session = self.patient_cql_connection(node)
         create_ks(session, "ks", 1)
 
-        cells = 1
-        for i in range(int(math.log(MAX_CELLS, 2))):
-            cells <<= 1
+        cells = MAX_CELLS_COLUMNS
+        while cells <= MAX_CELLS:
             self._do_test_max_cell_count(session, cells - 1)
+            cells <<= 1


### PR DESCRIPTION
The `test_max_cells` test was flaky due to `std::bad_alloc` caused by Seastar buddy allocator fragmentation. The root causes are:
1. The doubling loop with 24 iterations of CREATE/INSERT/DROP fragmented the allocator
2. The test built the whole batch as a single string that takes contiguous memory

Also, some iterations inserted zero rows, but still did CREATE/DROP table which also contributed to the fragmentation.

This patch series:
- Skips iterations that insert zero rows
- Creates the table once, truncates it after each test iteration
- Switches to prepared statements

Investigation results are presented in detail in https://scylladb.atlassian.net/browse/SCYLLADB-1645

Fixes SCYLLADB-1645

CI stability improvement. Backport to versions that have this test.