### PR TITLE
Skip per-query HEAD on S3-backed sstable reads 

### DIFF
--- a/sstables/storage.cc
+++ b/sstables/storage.cc
@@ -808,8 +808,14 @@ s3_storage::make_source(sstable& sst, component_type type, file f, uint64_t offs
     if (offset == 0) {
         co_return co_await object_storage_base::make_source(sst, type, std::move(f), offset, len, std::move(options));
     }
-    co_return make_file_data_source(
-        co_await maybe_wrap_file(sst, type, open_flags::ro, _client->make_readable_file(make_object_name(sst, type), abort_source())), offset, len, std::move(options));
+    // Reuse the file passed in by the caller. Its underlying file_impl
+    // (s3::client::readable_file) already had its stats populated at
+    // sstable open time via update_info_for_opened_data, so reads from
+    // it skip the per-query HEAD that a freshly-constructed readable_file
+    // would otherwise issue. The file is already wrapped with the
+    // configured file_io_extensions (applied at open_component time), so
+    // no further wrapping is needed.
+    co_return make_file_data_source(std::move(f), offset, len, std::move(options));
 }
 
 future<data_sink> object_storage_base::make_component_sink(sstable& sst, component_type type, open_flags oflags, file_output_stream_options options) {

--- a/utils/s3/client.cc
+++ b/utils/s3/client.cc
@@ -1733,7 +1733,8 @@ public:
     }
 
     virtual future<uint64_t> size(void) override {
-        return _client->get_object_size(_object_name);
+        co_await maybe_update_stats();
+        co_return _stats->size;
     }
 
     virtual future<struct stat> stat(void) override {


### PR DESCRIPTION
Performance testing of S3-backed keyspaces showed roughly 1 GET + 1 HEAD per uncached read, with average S3 latency around 50 ms. Root cause, s3_storage::make_source ignored its file f parameter and created a new readable_file from scratch for every read.                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               
  
Benchmark results (single node, 8 CPU / 8 GB RAM, MinIO, latte with BYPASS CACHE):
30% improvement in throughput. 
Workload: random point reads on 200K rows (200 partitions × 1,000 rows/partition, 10 columns × 512 bytes each, ~1 GB total), BTI format SSTables, row cache disabled

no backport needed : Keyspace over object storage is experimental feature

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-1562