### PR TITLE
topology: enhance quiesce_topology to wait for tablet load balancer

### DIFF
--- a/gms/feature_service.hh
+++ b/gms/feature_service.hh
@@ -185,6 +185,7 @@ public:
     gms::feature large_data_guardrails { *this, "LARGE_DATA_GUARDRAILS"sv };
     gms::feature keyspace_multi_rf_change { *this, "KEYSPACE_MULTI_RF_CHANGE"sv };
     gms::feature view_building_tasks_min_task_id { *this, "VIEW_BUILDING_TASKS_MIN_TASK_ID"sv };
+    gms::feature quiesce_topology_enhanced { *this, "QUIESCE_TOPOLOGY_ENHANCED"sv };
 public:
 
     const std::unordered_map<sstring, std::reference_wrapper<feature>>& registered_features() const;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -965,6 +965,20 @@ public:
     size_t external_memory_usage() const;
     bool has_replica_on(host_id) const;
 
+    // Returns true if no table has a pending resize decision (split or merge)
+    // that replicas are still processing locally. A table may have needs_split()
+    // or needs_merge() set while replicas compact/prepare, but the balancer won't
+    // include it in the plan until all replicas report readiness. This check
+    // catches the window where plan.empty() is true but work is still in progress.
+    bool is_idle() const {
+        for (auto& [table, tmap_ptr] : _tablets) {
+            if (tmap_ptr->has_transitions() || tmap_ptr->needs_split() || tmap_ptr->needs_merge()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     // get all tables with their tablet maps, including both base and children tables.
     // for a child table we get the tablet map of the base table.
     const table_to_tablet_map& all_tables_ungrouped() const { return _tablets; }

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5922,7 +5922,30 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
     }
 }
 
+future<utils::UUID> storage_service::submit_quiesce_topology_request() {
+    while (true) {
+        auto guard = co_await _group0->client().start_operation(_group0_as, raft_timeout{});
+        auto request_id = guard.new_group0_state_id();
 
+        topology_mutation_builder builder(guard.write_timestamp());
+        builder.queue_global_topology_request_id(request_id);
+
+        topology_request_tracking_mutation_builder rtbuilder(request_id, _feature_service.topology_requests_type_column);
+        rtbuilder.set("done", false)
+                 .set("request_type", global_topology_request::quiesce);
+
+        topology_change change{{builder.build(), rtbuilder.build()}};
+        group0_command g0_cmd = _group0->client().prepare_command(std::move(change), guard,
+            ::format("quiesce topology request from {}", _group0->group0_server().id()));
+
+        try {
+            co_await _group0->client().add_entry(std::move(g0_cmd), std::move(guard), _group0_as, raft_timeout{});
+            co_return request_id;
+        } catch (group0_concurrent_modification&) {
+            slogger.debug("quiesce: concurrent modification while submitting request, retrying");
+        }
+    }
+}
 
 future<> storage_service::await_topology_quiesced() {
     auto holder = _async_gate.hold();
@@ -5935,8 +5958,33 @@ future<> storage_service::await_topology_quiesced() {
         co_return;
     }
 
-    co_await _group0->group0_server().read_barrier(&_group0_as);
-    co_await _topology_state_machine.await_not_busy();
+    if (!_feature_service.quiesce_topology_enhanced
+            || !_feature_service.topology_global_request_queue) {
+        // Old behavior — fallback for mixed-version clusters.
+        co_await _group0->group0_server().read_barrier(&_group0_as);
+        co_await _topology_state_machine.await_not_busy();
+        co_return;
+    }
+
+    // New behavior — submit a topology request and retry until the
+    // coordinator observes an empty tablet balance plan with fresh stats.
+    while (true) {
+        auto request_id = co_await submit_quiesce_topology_request();
+        auto error = co_await wait_for_topology_request_completion(request_id);
+        if (error.empty()) {
+            co_return;
+        }
+        if (error.starts_with("quiesce request failed")) {
+            slogger.warn("quiesce request {}: {}", request_id, error);
+        } else {
+            slogger.debug("quiesce request {}: topology not idle: {}", request_id, error);
+        }
+        // Wait locally for topology to settle before resubmitting.
+        co_await _topology_state_machine.await_not_busy();
+        co_await _topology_state_machine.event.when([this] {
+            return get_token_metadata_ptr()->tablets().is_idle();
+        });
+    }
 }
 
 future<bool> storage_service::verify_topology_quiesced(token_metadata::version_t expected_version) {

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -971,6 +971,7 @@ public:
     future<> restore_tablets(table_id, sstring snap_name, sstring endpoint, sstring bucket);
     future<> set_tablet_balancing_enabled(bool);
 
+    future<utils::UUID> submit_quiesce_topology_request();
     future<> await_topology_quiesced();
     // Verifies topology is not busy, and also that topology version hasn't changed since the one provided
     // by the caller.

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4218,6 +4218,14 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     // Returns true if the state machine was transitioned into tablet migration path.
     future<bool> maybe_retry_failed_rf_change_tablet_rebuilds(group0_guard guard);
 
+    using require_live_nodes = bool_class<struct require_live_nodes_tag>;
+
+    struct tablet_load_stats_collect_result {
+        locator::load_stats_ptr stats;
+        bool complete;
+    };
+
+    future<tablet_load_stats_collect_result> collect_tablet_load_stats(require_live_nodes require);
     future<> refresh_tablet_load_stats();
     future<> start_tablet_load_stats_refresher();
 
@@ -4431,7 +4439,7 @@ future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(
     co_return true;
 }
 
-future<> topology_coordinator::refresh_tablet_load_stats() {
+future<topology_coordinator::tablet_load_stats_collect_result> topology_coordinator::collect_tablet_load_stats(require_live_nodes require) {
     co_await utils::get_local_injector().inject("refresh_tablet_load_stats_pause", utils::wait_for_message(5min));
     auto tm = get_token_metadata_ptr();
 
@@ -4465,7 +4473,7 @@ future<> topology_coordinator::refresh_tablet_load_stats() {
 
             locator::load_stats node_stats;
             if (!_gossiper.is_alive(dst)) {
-                if (_load_stats_per_node.contains(dst) &&
+                if (require == require_live_nodes::no && _load_stats_per_node.contains(dst) &&
                         !utils::get_local_injector().enter("force_down_node_load_stats_invalid")) {
                     node_stats = _load_stats_per_node[dst];
                 } else {
@@ -4536,10 +4544,17 @@ future<> topology_coordinator::refresh_tablet_load_stats() {
         stats.tables.clear();
     }
 
-    rtlogger.debug("raft topology: Refreshed table load stats for all DC(s).");
+    co_return tablet_load_stats_collect_result{
+        .stats = make_lw_shared<const locator::load_stats>(std::move(stats)),
+        .complete = !table_load_stats_invalid,
+    };
+}
 
-    _tablet_allocator.set_load_stats(make_lw_shared<const locator::load_stats>(std::move(stats)));
+future<> topology_coordinator::refresh_tablet_load_stats() {
+    auto [load_stats, _] = co_await collect_tablet_load_stats(require_live_nodes::no);
+    _tablet_allocator.set_load_stats(std::move(load_stats));
     _topo_sm.event.broadcast(); // wake up load balancer.
+    rtlogger.debug("raft topology: Refreshed table load stats for all DC(s).");
 }
 
 future<> topology_coordinator::start_tablet_load_stats_refresher() {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -4212,8 +4212,31 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
     // Returns the guard if no work done. Otherwise, transitions the state machine into tablet migration path.
     future<std::optional<group0_guard>> maybe_start_tablet_migration(group0_guard);
 
-    // Returns the guard if no work done. Otherwise, transitions the state machine into tablet resize finalization path.
-    future<std::optional<group0_guard>> maybe_start_tablet_resize_finalization(group0_guard, const table_resize_plan& plan);
+    // Returns true if migration updates were generated.
+    // Appends migration mutations + tablet_migration transition state to `updates`.
+    future<bool> generate_tablet_migration_state_updates(
+            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan);
+
+    // Generates tablet migration or resize finalization mutations from a non-empty plan.
+    // Appends to `updates`. Does not commit. Caller is responsible for committing.
+    // Returns true if updates were generated, false if nothing was produced (injection postponed).
+    // Precondition: !plan.empty().
+    future<bool> generate_tablet_transition_updates(
+            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan);
+
+    // Generates a single resize finalization mutation (set tstate + version bump).
+    // Appends to `updates`. Does not commit.
+    void generate_tablet_resize_finalization_update(
+            utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard) {
+        auto resize_finalization_transition_state = [this] {
+            return _feature_service.tablet_merge ? topology::transition_state::tablet_resize_finalization : topology::transition_state::tablet_split_finalization;
+        };
+        updates.emplace_back(
+            topology_mutation_builder(guard.write_timestamp())
+                .set_transition_state(resize_finalization_transition_state())
+                .set_version(_topo_sm._topology.version + 1)
+                .build());
+    }
 
     // Returns true if the state machine was transitioned into tablet migration path.
     future<bool> maybe_retry_failed_rf_change_tablet_rebuilds(group0_guard guard);
@@ -4325,20 +4348,9 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
     }
 
     utils::chunked_vector<canonical_mutation> updates;
-
-    co_await generate_migration_updates(updates, guard, plan);
-
-    // We only want to consider transitioning into tablet resize finalization path, if there's no other work
-    // to be done (e.g. start migration or/and emit split decision).
-    if (updates.empty()) {
-        co_return co_await maybe_start_tablet_resize_finalization(std::move(guard), plan.resize_plan());
+    if (!co_await generate_tablet_transition_updates(updates, guard, plan)) {
+        co_return std::move(guard);
     }
-
-    updates.emplace_back(
-        topology_mutation_builder(guard.write_timestamp())
-            .set_transition_state(topology::transition_state::tablet_migration)
-            .set_version(_topo_sm._topology.version + 1)
-            .build());
 
     if (plan.requires_schema_changes()) {
         co_await update_topology_state_with_mixed_change(std::move(guard), std::move(updates), "Starting tablet migration");
@@ -4348,28 +4360,37 @@ future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_mig
     co_return std::nullopt;
 }
 
-future<std::optional<group0_guard>> topology_coordinator::maybe_start_tablet_resize_finalization(group0_guard guard, const table_resize_plan& plan) {
-    if (plan.finalize_resize.empty()) {
-        co_return std::move(guard);
+future<bool> topology_coordinator::generate_tablet_migration_state_updates(
+        utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan) {
+    auto initial_size = updates.size();
+    co_await generate_migration_updates(updates, guard, plan);
+
+    if (updates.size() > initial_size) {
+        updates.emplace_back(
+            topology_mutation_builder(guard.write_timestamp())
+                .set_transition_state(topology::transition_state::tablet_migration)
+                .set_version(_topo_sm._topology.version + 1)
+                .build());
+        co_return true;
     }
-    if (utils::get_local_injector().enter("tablet_split_finalization_postpone")) {
-        co_return std::move(guard);
+    co_return false;
+}
+
+future<bool> topology_coordinator::generate_tablet_transition_updates(
+        utils::chunked_vector<canonical_mutation>& updates, const group0_guard& guard, migration_plan& plan) {
+    if (co_await generate_tablet_migration_state_updates(updates, guard, plan)) {
+        co_return true;
     }
 
-    auto resize_finalization_transition_state = [this] {
-        return _feature_service.tablet_merge ? topology::transition_state::tablet_resize_finalization : topology::transition_state::tablet_split_finalization;
-    };
+    if (!plan.resize_plan().finalize_resize.empty()) {
+        if (utils::get_local_injector().enter("tablet_split_finalization_postpone")) {
+            co_return false;
+        }
+        generate_tablet_resize_finalization_update(updates, guard);
+        co_return true;
+    }
 
-    utils::chunked_vector<canonical_mutation> updates;
-
-    updates.emplace_back(
-        topology_mutation_builder(guard.write_timestamp())
-            .set_transition_state(resize_finalization_transition_state())
-            .set_version(_topo_sm._topology.version + 1)
-            .build());
-
-    co_await update_topology_state(std::move(guard), std::move(updates), "Started tablet resize finalization");
-    co_return std::nullopt;
+    co_return false;
 }
 
 future<bool> topology_coordinator::maybe_retry_failed_rf_change_tablet_rebuilds(group0_guard guard) {

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1244,6 +1244,55 @@ class topology_coordinator : public endpoint_lifecycle_subscriber
             co_await update_topology_state(std::move(guard), std::move(updates), "no-op request completed");
         }
         break;
+        case global_topology_request::quiesce: {
+            std::optional<sstring> error;
+            utils::chunked_vector<canonical_mutation> updates;
+            bool requires_schema_changes = false;
+
+            try {
+                rtlogger.debug("quiesce topology request: refreshing tablet load stats");
+                auto [load_stats, complete] = co_await collect_tablet_load_stats(require_live_nodes::yes);
+                if (!complete) {
+                    error = "incomplete load stats";
+                } else {
+                    auto tm = get_token_metadata_ptr();
+                    _tablet_allocator.set_load_stats(load_stats);
+                    _topo_sm.event.broadcast();
+                    auto plan = co_await _tablet_allocator.balance_tablets(tm, &_topo_sm._topology, &_sys_ks, {}, {});
+                    if (!plan.empty()) {
+                        error = "tablet balance plan is not empty";
+                        co_await generate_tablet_transition_updates(updates, guard, plan);
+                        requires_schema_changes = plan.requires_schema_changes();
+                    } else if (!tm->tablets().is_idle()) {
+                        error = "tablet resize in progress";
+                    }
+                }
+            } catch (...) {
+                error = fmt::format("quiesce request failed: {}", std::current_exception());
+                updates.clear();
+            }
+
+            updates.push_back(canonical_mutation(
+                    topology_mutation_builder(guard.write_timestamp())
+                         .drop_first_global_topology_request_id(_topo_sm._topology.global_requests_queue, req_id)
+                         .build()));
+            updates.push_back(canonical_mutation(
+                    topology_request_tracking_mutation_builder(req_id)
+                         .set("start_time", db_clock::now())
+                         .done(error)
+                         .build()));
+            if (error) {
+                auto reason = fmt::format("quiesce request deferred: {}", *error);
+                if (requires_schema_changes) {
+                    co_await update_topology_state_with_mixed_change(std::move(guard), std::move(updates), reason);
+                } else {
+                    co_await update_topology_state(std::move(guard), std::move(updates), reason);
+                }
+            } else {
+                co_await update_topology_state(std::move(guard), std::move(updates), "quiesce request completed");
+            }
+        }
+        break;
         case global_topology_request::snapshot_tables: {
             rtlogger.info("SNAPSHOT TABLES requested");
             topology_mutation_builder builder(guard.write_timestamp());

--- a/service/topology_state_machine.cc
+++ b/service/topology_state_machine.cc
@@ -211,6 +211,7 @@ static std::unordered_map<global_topology_request, sstring> global_topology_requ
     {global_topology_request::snapshot_tables, "snapshot_tables"},
     {global_topology_request::noop_request, "noop_request"},
     {global_topology_request::finalize_migration, "finalize_migration"},
+    {global_topology_request::quiesce, "quiesce"},
 };
 
 global_topology_request global_topology_request_from_string(const sstring& s) {

--- a/service/topology_state_machine.hh
+++ b/service/topology_state_machine.hh
@@ -90,6 +90,7 @@ enum class global_topology_request: uint16_t {
     noop_request,
     snapshot_tables,
     finalize_migration,
+    quiesce,
 };
 
 struct ring_slice {

--- a/test/cluster/test_quiesce_topology.py
+++ b/test/cluster/test_quiesce_topology.py
@@ -1,0 +1,192 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+"""
+Targeted tests for the enhanced quiesce_topology API.
+
+The enhanced API ensures that after quiesce_topology returns:
+- The tablet load balancer has evaluated cluster balance using freshly
+  refreshed load stats from all live nodes.
+- Any migrations, splits, or merges deemed necessary have completed.
+- The topology is in a stable state with no pending transitions.
+"""
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.tablets import get_replica_count_by_host
+from test.cluster.util import new_test_keyspace, get_topology_coordinator, find_server_by_host_id
+import pytest
+import asyncio
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Debug log levels needed for quiesce log messages
+QUIESCE_DEBUG_CMDLINE = [
+    '--logger-log-level', 'raft_topology=debug',
+    '--logger-log-level', 'storage_service=debug',
+]
+
+
+@pytest.mark.asyncio
+async def test_quiesce_waits_for_balancer(manager: ManagerClient):
+    """
+    Verify that quiesce_topology waits for the balancer to refresh stats
+    and complete migrations.
+    """
+    logger.info("Starting cluster with 2 nodes")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
+    servers = await manager.servers_add(2, config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE)
+
+    # Disable balancing so we can create imbalance without interference
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', "
+                                 "'replication_factor': 1} AND tablets = {'initial': 16}") as ks:
+        await manager.get_cql().run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+        # Insert some data and flush to create sstables (so load stats have something to report)
+        cql = manager.get_cql()
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({i}, {i})") for i in range(100)])
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        # Add a third node — creates imbalance (16 tablets on 2 nodes, 0 on new node)
+        logger.info("Adding third node to create imbalance")
+        servers.append(await manager.server_add(config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE))
+
+        logger.info(f"Calling quiesce_topology on node {servers[0].ip_addr}")
+        # Enable balancing and quiesce — quiesce always does a fresh refresh,
+        # so even if balancing finishes quickly, quiesce verifies correctness.
+        await manager.enable_tablet_balancing()
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+
+        # Verify balance: 16 tablets / 3 nodes = 5 or 6 per node
+        replicas = await get_replica_count_by_host(manager, servers[0], ks, 't')
+        logger.info(f"Replica distribution after quiesce: {replicas}")
+        assert len(replicas) == 3, f"Expected tablets on all 3 nodes, got: {replicas}"
+        for host_id, count in replicas.items():
+            assert 5 <= count <= 6, f"Node {host_id} has {count} tablets, expected 5 or 6"
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_quiesce_blocks_until_refresh_completes(manager: ManagerClient):
+    """
+    Verify that quiesce blocks while the load stats refresh is stalled.
+    Uses the refresh_tablet_load_stats_pause injection to pause the refresh,
+    then releases it and confirms quiesce completes.
+    """
+    logger.info("Starting cluster with 2 nodes")
+    # Use a very long refresh interval to prevent periodic refreshes from
+    # consuming the injection before quiesce triggers one.
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 3600}
+    servers = await manager.servers_add(2, config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE)
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', "
+                                 "'replication_factor': 1} AND tablets = {'initial': 8}") as ks:
+        await manager.get_cql().run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+        cql = manager.get_cql()
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({i}, {i})") for i in range(100)])
+
+        # Wait for initial stats refresh to complete (triggered on coordinator start).
+        leader_host = await get_topology_coordinator(manager)
+        leader = await find_server_by_host_id(manager, servers, leader_host)
+        log = await manager.server_open_log(leader.server_id)
+        await log.wait_for("Refreshed table load stats for all DC", timeout=30)
+
+        # Enable the refresh pause injection on the leader
+        await manager.api.enable_injection(leader.ip_addr, "refresh_tablet_load_stats_pause", one_shot=True)
+
+        # Start quiesce — it should trigger a fresh refresh which will block on the injection
+        await manager.enable_tablet_balancing()
+        mark = await log.mark()
+        quiesce_task = asyncio.create_task(
+            manager.api.quiesce_topology(leader.ip_addr))
+
+        # Wait for the quiesce-triggered refresh to start. Once we see this log,
+        # the refresh is in progress and blocked by the injection.
+        await log.wait_for("refresh_tablet_load_stats_pause: waiting", from_mark=mark, timeout=30)
+        # Verify that quiesce is blocked while refresh is paused
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(quiesce_task), timeout=2)
+
+        # Release the refresh by sending the message
+        await manager.api.message_injection(leader.ip_addr, "refresh_tablet_load_stats_pause")
+
+        # Quiesce should now complete
+        await asyncio.wait_for(quiesce_task, timeout=60)
+        logger.info("Quiesce completed after refresh was released")
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip_mode(mode='release', reason='error injections are not supported in release mode')
+async def test_quiesce_retries_until_balance_plan_is_empty(manager: ManagerClient):
+    """
+    Verify that quiesce retries after the balancer reports work. If the first
+    request observes a non-empty plan, the API retries and only returns after a
+    later request observes an empty plan.
+    """
+    logger.info("Starting cluster with 2 nodes")
+    cfg = {'tablet_load_stats_refresh_interval_in_seconds': 1}
+    servers = await manager.servers_add(2, config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE)
+
+    await manager.disable_tablet_balancing()
+
+    async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', "
+                                 "'replication_factor': 1} AND tablets = {'initial': 32}") as ks:
+        await manager.get_cql().run_async(f"CREATE TABLE {ks}.t (pk int PRIMARY KEY, v int)")
+
+        # Insert data and flush
+        cql = manager.get_cql()
+        await asyncio.gather(*[cql.run_async(f"INSERT INTO {ks}.t (pk, v) VALUES ({i}, {i})") for i in range(200)])
+        await manager.api.flush_keyspace(servers[0].ip_addr, ks)
+
+        # Add two more nodes — significant imbalance requiring balancing work.
+        logger.info("Adding two more nodes to create significant imbalance")
+        servers.append(await manager.server_add(config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE))
+        servers.append(await manager.server_add(config=cfg, cmdline=QUIESCE_DEBUG_CMDLINE))
+
+        # Block the coordinator before enabling balancing. This makes the first
+        # quiesce request run before the balancer can start migrations, so it
+        # must observe a non-empty plan and retry.
+        leader_host = await get_topology_coordinator(manager)
+        leader = await find_server_by_host_id(manager, servers, leader_host)
+        leader_log = await manager.server_open_log(leader.server_id)
+        leader_mark = await leader_log.mark()
+        await manager.api.enable_injection(leader.ip_addr,
+                                           "topology_coordinator_pause_before_processing_backlog",
+                                           one_shot=True)
+
+        await manager.enable_tablet_balancing()
+        await leader_log.wait_for("topology_coordinator_pause_before_processing_backlog: waiting", from_mark=leader_mark, timeout=30)
+
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        quiesce_task = asyncio.create_task(manager.api.quiesce_topology(servers[0].ip_addr))
+        # Verify that quiesce is blocked behind the paused coordinator
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(quiesce_task), timeout=2)
+        await manager.api.message_injection(leader.ip_addr, "topology_coordinator_pause_before_processing_backlog")
+        await asyncio.wait_for(quiesce_task, timeout=120)
+
+        # Verify that at least one retry was needed.
+        matches = await log.grep("topology not idle", from_mark=mark)
+        assert matches, "Expected quiesce to retry after observing a non-empty plan"
+
+        # Verify balance: all 4 nodes should have exactly 8 tablets each
+        replicas = await get_replica_count_by_host(manager, servers[0], ks, 't')
+        logger.info(f"Replica distribution after quiesce: {replicas}")
+        assert len(replicas) == 4, f"Expected tablets on all 4 nodes, got: {replicas}"
+        for host_id, count in replicas.items():
+            assert count == 8, f"Node {host_id} has {count} tablets, expected 8"
+
+        # Second quiesce should not trigger any work
+        mark = await log.mark()
+        await manager.api.quiesce_topology(servers[0].ip_addr)
+        matches = await log.grep("topology not idle", from_mark=mark)
+        assert not matches, "Second quiesce should not have retried"


### PR DESCRIPTION
The existing quiesce_topology API only waits for the active topology transition state (tstate) to clear. It does not wait for tablet migrations, load stats refresh, or splits/merges.

This PR enhances the API by implementing quiesce_topology as a global topology request. The coordinator processes the request by collecting tablet load stats in strict mode (requiring all live nodes to report) and asking the tablet allocator whether the resulting balance plan is empty. If load stats are incomplete, the plan contains work, or tablets have a pending resize decision, the request completes with an error. When the plan is non-empty, the request completion is committed atomically with starting the migrations, so the coordinator immediately begins working on the imbalance.

The caller waits for topology state changes before re-submitting, avoiding unnecessary requests while the coordinator is busy. The API returns only after a quiesce request observes an empty plan with idle tablets. The request can be issued from any node; leadership changes, parallel invocations, request tracking, and completion are handled by the existing global topology request infrastructure.

Fixes: https://scylladb.atlassian.net/browse/SCYLLADB-763

An improvement. No backport needed.