### PR TITLE
toolchain: move cassandra-stress and minio to nested containers

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -87,7 +87,6 @@ fedora_packages=(
     systemd-devel
     cryptopp-devel
     git
-    git-lfs
     python
     sudo
     patchelf
@@ -331,26 +330,7 @@ node_exporter_url() {
     echo "https://github.com/prometheus/node_exporter/releases/download/v$NODE_EXPORTER_VERSION/$(node_exporter_filename)"
 }
 
-MINIO_BINARIES_DIR=/usr/local/bin
 
-minio_server_url() {
-    echo "https://dl.minio.io/server/minio/release/linux-$(go_arch)/minio"
-}
-
-minio_client_url() {
-    echo "https://dl.min.io/client/mc/release/linux-$(go_arch)/mc"
-}
-
-minio_download_jobs() {
-    cfile=$(mktemp)
-    echo $(curl -s "$(minio_server_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/minio" > $cfile
-    echo $(curl -s "$(minio_client_url).sha256sum" | cut -f1 -d' ') "${MINIO_BINARIES_DIR}/mc" >> $cfile
-    sha256sum -c $cfile | grep -F FAILED | sed \
-        -e 's/:.*$//g' \
-        -e "s#${MINIO_BINARIES_DIR}/minio#$(minio_server_url) -o ${MINIO_BINARIES_DIR}/minio#" \
-        -e "s#${MINIO_BINARIES_DIR}/mc#$(minio_client_url) -o ${MINIO_BINARIES_DIR}/mc#"
-    rm -f ${cfile}
-}
 
 print_usage() {
     echo "Usage: install-dependencies.sh [OPTION]..."
@@ -451,11 +431,13 @@ elif [ "$ID" = "fedora" ]; then
         exit 1
     fi
     dnf install -y "${fedora_packages[@]}" "${fedora_python3_packages[@]}"
+    # Install git-lfs separately with --setopt=tsflags=noscripts to skip the post-install
+    # scriptlet, which runs 'git lfs install' (a Go binary) and crashes under QEMU
+    # x86_64 emulation on aarch64 hosts due to a Go/QEMU tagged-pointer incompatibility.
+    dnf install -y --setopt=tsflags=noscripts git-lfs
 
     install_antlr3
 
-    # Fedora 45 tightened key checks, and cassandra-stress is not signed yet.
-    dnf install --no-gpgchecks -y https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm
 
     PIP_DEFAULT_ARGS="--only-binary=:all: -v"
     pip_constrained_packages=""
@@ -518,15 +500,6 @@ elif [ "$ID" == "arch" ]; then
 fi
 
 cargo --config net.git-fetch-with-cli=true install cxxbridge-cmd --version 1.0.83 --root /usr/local
-
-CURL_ARGS=$(minio_download_jobs)
-if [ ! -z "${CURL_ARGS}" ]; then
-    curl -fSL --remove-on-error --parallel --parallel-immediate ${CURL_ARGS}
-    chmod +x "${MINIO_BINARIES_DIR}/minio"
-    chmod +x "${MINIO_BINARIES_DIR}/mc"
-else
-    echo "Minio server and client are up-to-date, skipping download"
-fi
 
 if $FUTURE ; then
     toxyproxy_version="v2.12.0"

--- a/pgo/pgo.py
+++ b/pgo/pgo.py
@@ -550,9 +550,11 @@ async def with_cluster(executable: PathLike, workdir: PathLike, cpusets: Optiona
 # cassandra-stress utilities
 
 def cs_command(cmd: list[str], n: int, node: str, cl: str, pop: Optional[str] = None, warmup: bool = False, rate: str = "threads=200", schema: Optional[str] = None) -> list[str]:
-    """Strings together a cassandra-stress command from given options."""
-    return [
-        "cassandra-stress",
+    """Strings together a cassandra-stress command from given options.
+    Runs cassandra-stress inside a nested container via podman.
+    """
+    from test.pylib.nested_container import CASSANDRA_STRESS_IMAGE, _runtime
+    cs_args = [
         *cmd,
         f"n={n}",
         f"cl={cl}",
@@ -563,6 +565,8 @@ def cs_command(cmd: list[str], n: int, node: str, cl: str, pop: Optional[str] = 
         "-rate", rate,
     ] + (["-schema", schema] if schema else []) + [
     ]
+    return [_runtime(), 'run', '--rm', '--network', 'host',
+            CASSANDRA_STRESS_IMAGE] + cs_args
 
 async def cs(run_kwargs: dict[str, Any] = {}, **params: Any) -> Process:
     """Runs a cassandra-stress process.

--- a/test/cluster/dtest/ccmlib/scylla_node.py
+++ b/test/cluster/dtest/ccmlib/scylla_node.py
@@ -554,18 +554,21 @@ class ScyllaNode:
 
     def stress(self, stress_options: list[str], **kwargs):
         """
-        Run `cassandra-stress` against this node.
+        Run `cassandra-stress` against this node via a nested container.
         This method does not do any result parsing.
 
         :param stress_options: List of options to pass to `cassandra-stress`.
         :param kwargs: Additional arguments to pass to `subprocess.Popen()`.
         :return: Named tuple with `stdout`, `stderr`, and `rc` (return code).
         """
+        from test.pylib.nested_container import CASSANDRA_STRESS_IMAGE, _runtime
 
-        cmd_args = ["cassandra-stress"] + stress_options
+        cs_args = list(stress_options)
+        if not any(opt in cs_args for opt in ("-d", "-node", "-cloudconf")):
+            cs_args.extend(["-node", self.address()])
 
-        if not any(opt in cmd_args for opt in ("-d", "-node", "-cloudconf")):
-            cmd_args.extend(["-node", self.address()])
+        cmd_args = [_runtime(), 'run', '--rm', '--network', 'host',
+                    CASSANDRA_STRESS_IMAGE] + cs_args
 
         p = subprocess.Popen(
             cmd_args,

--- a/test/pylib/minio_server.py
+++ b/test/pylib/minio_server.py
@@ -24,6 +24,10 @@ import socket
 import string
 import yaml
 from io import BufferedWriter
+from test.pylib.nested_container import (
+    MINIO_IMAGE, ensure_image, run_container, kill_container, rm_container,
+    mc_in_container, _runtime
+)
 
 class MinioServer:
     ENV_ADDRESS = 'S3_SERVER_ADDRESS_FOR_TEST'
@@ -36,7 +40,6 @@ class MinioServer:
     log_file: BufferedWriter
 
     def __init__(self, tempdir_base, address, logger):
-        self.srv_exe = shutil.which('minio')
         self.address = address
         self.port = None
         self.tempdir_base = pathlib.Path(tempdir_base)
@@ -45,6 +48,7 @@ class MinioServer:
         self.rootdir = self.tempdir / 'minio_root'
         self.mcdir = self.tempdir / 'mc'
         self.logger = logger
+        self.container_name: Optional[str] = None
         self.cmd: Optional[Process] = None
         self.default_user = 'minioadmin'
         self.default_pass = 'minioadmin'
@@ -76,14 +80,13 @@ class MinioServer:
     async def mc(self, *args, ignore_failure=False, timeout=0):
         retry_until: float = time.time() + timeout
         retry_step: float = 0.1
-        cmd = ['mc',
-               '--debug',
-               '--config-dir', self.mcdir]
-        cmd.extend(args)
 
         while True:
             try:
-                subprocess.check_call(cmd, stdout=self.log_file, stderr=self.log_file)
+                mc_in_container(MINIO_IMAGE, ['--debug'] + list(args),
+                                config_dir=str(self.mcdir),
+                                container_name=self.container_name,
+                                stdout=self.log_file, stderr=self.log_file)
             except subprocess.CalledProcessError:
                 if ignore_failure:
                     self.log_to_file('ignoring')
@@ -166,24 +169,28 @@ class MinioServer:
         return [endpoint]
 
     async def _run_server(self, port):
-        self.logger.info(f'Starting minio server at {self.address}:{port}')
+        self.logger.info(f'Starting minio server container at {self.address}:{port}')
+        self.container_name = f'minio-test-{port}'
+
+        # Remove any stale container with the same name
+        rm_container(self.container_name)
+
         cmd = await asyncio.create_subprocess_exec(
-            self.srv_exe,
-            *[ 'server', '--address', f'{self.address}:{port}', self.rootdir ],
+            _runtime(), 'run', '--rm',
+            '--name', self.container_name,
+            '--network', 'host',
+            '-e', 'MINIO_BROWSER=off',
+            '-e', 'MINIO_FS_OSYNC=off',
+            '-v', f'{self.rootdir}:/data',
+            MINIO_IMAGE,
+            'server', '--address', f'{self.address}:{port}', '/data',
             preexec_fn=os.setsid,
             stderr=self.log_file,
             stdout=self.log_file,
-            env={
-                **os.environ,
-                'MINIO_BROWSER': 'off',
-                'MINIO_FS_OSYNC': 'off',
-            },
         )
         timeout = time.time() + 30
         while time.time() < timeout:
             if cmd.returncode is not None:
-                # the minio server exits before it starts to server. maybe the
-                # port is used by another server?
                 self.logger.info('minio exited with %s', cmd.returncode)
                 raise RuntimeError("Failed to start minio server")
             if self.check_server(port):
@@ -227,9 +234,12 @@ class MinioServer:
         print('\n'.join(msgs))
 
     async def start(self):
-        if self.srv_exe is None:
-            self.logger.error("Minio not installed, get it from https://dl.minio.io/server/minio/release/linux-amd64/minio and put into PATH")
-            return
+        from test import TOP_SRC_DIR
+        containerfile_dir = str(TOP_SRC_DIR / 'tools' / 'toolchain' / 'containers' / 'minio')
+        try:
+            ensure_image(MINIO_IMAGE, containerfile_dir=containerfile_dir)
+        except Exception as e:
+            raise RuntimeError(f"Minio container image not available: {e}") from e
 
         self.log_file = self.log_filename.open("wb")
         os.mkdir(self.rootdir)
@@ -244,8 +254,7 @@ class MinioServer:
             else:
                 break
         else:
-            self.logger.error("Failed to start Minio server")
-            return
+            raise RuntimeError("Failed to start Minio server after all retries")
 
         self._set_environ()
 
@@ -259,25 +268,30 @@ class MinioServer:
             await self.mc('admin', 'user', 'add', alias, self.access_key, self.secret_key)
             self.log_to_file(f'Configuring bucket {self.bucket_name}')
             await self.mc('mb', f'{alias}/{self.bucket_name}')
-            with tempfile.NamedTemporaryFile(mode='w', encoding='UTF-8', suffix='.json') as policy_file:
-                json.dump(self._bucket_policy(), policy_file, indent=2)
-                policy_file.flush()
-                await self.mc('admin', 'policy', 'create', alias, 'test-policy', policy_file.name)
+            # Write policy file into the container's mounted volume so it's
+            # accessible from inside the container at /data/
+            policy_path = pathlib.Path(self.rootdir) / 'policy.json'
+            policy_path.write_text(json.dumps(self._bucket_policy(), indent=2), encoding='UTF-8')
+            try:
+                await self.mc('admin', 'policy', 'create', alias, 'test-policy', '/data/policy.json')
+            finally:
+                policy_path.unlink(missing_ok=True)
             await self.mc('admin', 'policy', 'attach', alias, 'test-policy', '--user', self.access_key)
 
         except Exception as e:
             self.logger.error(f'MC failed: {e}')
             await self.stop()
+            raise RuntimeError(f"Failed to configure Minio server: {e}") from e
 
     async def stop(self):
-        self.logger.info('Killing minio server')
+        self.logger.info('Killing minio server container')
         if not self.cmd:
             return
 
-        # so the test's process environment is not polluted by a test case
-        # which launches the MinioServer by itself.
         self._unset_environ()
         try:
+            if self.container_name:
+                kill_container(self.container_name)
             self.cmd.kill()
         except ProcessLookupError:
             pass
@@ -286,6 +300,7 @@ class MinioServer:
         finally:
             self.logger.info('Killed minio server')
             self.cmd = None
+            self.container_name = None
             shutil.rmtree(self.tempdir)
 
 

--- a/test/pylib/nested_container.py
+++ b/test/pylib/nested_container.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python3
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+"""Helpers for running nested containers (podman-in-podman) in the toolchain."""
+
+import asyncio
+import logging
+import shutil
+import subprocess
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+CONTAINER_RUNTIME = 'podman'
+
+# Image references for nested containers
+CASSANDRA_STRESS_IMAGE = 'ghcr.io/scylladb/cassandra-stress:latest'
+MINIO_IMAGE = 'ghcr.io/scylladb/minio:latest'
+ANTLR3_IMAGE = 'ghcr.io/scylladb/antlr3:latest'
+
+
+def _runtime() -> str:
+    """Return the container runtime binary path."""
+    runtime = shutil.which(CONTAINER_RUNTIME)
+    if runtime is None:
+        raise RuntimeError(f"{CONTAINER_RUNTIME} not found in PATH")
+    return runtime
+
+
+def build_image(containerfile_dir: str, tag: str) -> None:
+    """Build a container image from a Containerfile directory."""
+    subprocess.check_call([
+        _runtime(), 'build', '-t', tag, '-f', 'Containerfile', '.'
+    ], cwd=containerfile_dir)
+
+
+def ensure_image(image: str, containerfile_dir: Optional[str] = None) -> None:
+    """Ensure image is available locally; build from Containerfile if not pullable."""
+    try:
+        subprocess.check_call(
+            [_runtime(), 'image', 'exists', image],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except subprocess.CalledProcessError:
+        if containerfile_dir:
+            logger.info(f"Building image {image} from {containerfile_dir}")
+            build_image(containerfile_dir, image)
+        else:
+            logger.info(f"Pulling image {image}")
+            subprocess.check_call([_runtime(), 'pull', image])
+
+
+async def run_container(image: str, args: list[str],
+                        name: Optional[str] = None,
+                        network: str = 'host',
+                        env: Optional[dict[str, str]] = None,
+                        volumes: Optional[list[str]] = None,
+                        detach: bool = False,
+                        remove: bool = True,
+                        stdout=None, stderr=None) -> asyncio.subprocess.Process:
+    """Run a container with the given arguments.
+
+    Args:
+        image: Container image to run.
+        args: Arguments to pass to the container entrypoint.
+        name: Optional container name.
+        network: Network mode (default: host).
+        env: Environment variables to set.
+        volumes: Volume mounts in format 'host:container'.
+        detach: Run in background.
+        remove: Remove container after exit.
+        stdout: stdout redirect for the process.
+        stderr: stderr redirect for the process.
+
+    Returns:
+        The subprocess.Process handle.
+    """
+    cmd = [_runtime(), 'run']
+    if name:
+        cmd.extend(['--name', name])
+    if network:
+        cmd.extend(['--network', network])
+    if remove:
+        cmd.append('--rm')
+    if detach:
+        cmd.append('-d')
+    if env:
+        for k, v in env.items():
+            cmd.extend(['-e', f'{k}={v}'])
+    if volumes:
+        for vol in volumes:
+            cmd.extend(['-v', vol])
+    cmd.append(image)
+    cmd.extend(args)
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=stdout,
+        stderr=stderr,
+    )
+    return proc
+
+
+def run_container_sync(image: str, args: list[str],
+                       network: str = 'host',
+                       env: Optional[dict[str, str]] = None,
+                       volumes: Optional[list[str]] = None,
+                       remove: bool = True,
+                       **kwargs) -> subprocess.CompletedProcess:
+    """Run a container synchronously.
+
+    Returns:
+        subprocess.CompletedProcess
+    """
+    cmd = [_runtime(), 'run']
+    if network:
+        cmd.extend(['--network', network])
+    if remove:
+        cmd.append('--rm')
+    if env:
+        for k, v in env.items():
+            cmd.extend(['-e', f'{k}={v}'])
+    if volumes:
+        for vol in volumes:
+            cmd.extend(['-v', vol])
+    cmd.append(image)
+    cmd.extend(args)
+
+    return subprocess.run(cmd, **kwargs)
+
+
+def stop_container(name: str) -> None:
+    """Stop a running container by name."""
+    subprocess.run([_runtime(), 'stop', name],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def kill_container(name: str) -> None:
+    """Kill a running container by name."""
+    subprocess.run([_runtime(), 'kill', name],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def rm_container(name: str) -> None:
+    """Remove a container by name."""
+    subprocess.run([_runtime(), 'rm', '-f', name],
+                   stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def mc_in_container(minio_image: str, args: list[str],
+                    config_dir: Optional[str] = None,
+                    container_name: Optional[str] = None,
+                    stdout=None, stderr=None) -> None:
+    """Run the minio client (mc) command.
+
+    If a container_name is provided, uses 'podman exec' to run mc inside the
+    existing minio container (avoids starting a second nested container).
+    Otherwise starts a new container.
+    """
+    if container_name:
+        cmd = [_runtime(), 'exec', container_name, 'mc']
+        cmd.extend(args)
+        subprocess.check_call(cmd, stdout=stdout, stderr=stderr)
+        return
+
+    cmd = [_runtime(), 'run', '--rm', '--network', 'host']
+    if config_dir:
+        cmd.extend(['-v', f'{config_dir}:/root/.mc'])
+    cmd.extend(['--entrypoint', 'mc', minio_image])
+    cmd.extend(args)
+    subprocess.check_call(cmd, stdout=stdout, stderr=stderr)

--- a/tools/toolchain/containers/cassandra-stress/Containerfile
+++ b/tools/toolchain/containers/cassandra-stress/Containerfile
@@ -1,0 +1,7 @@
+FROM registry.fedoraproject.org/fedora:43
+
+RUN dnf install -y java-openjdk-headless snappy \
+    && dnf install --no-gpgchecks -y https://github.com/scylladb/cassandra-stress/releases/download/v3.18.1/cassandra-stress-java21-3.18.1-1.noarch.rpm \
+    && dnf clean all
+
+ENTRYPOINT ["cassandra-stress"]

--- a/tools/toolchain/containers/minio/Containerfile
+++ b/tools/toolchain/containers/minio/Containerfile
@@ -1,0 +1,17 @@
+FROM registry.fedoraproject.org/fedora:43
+
+ARG TARGETARCH
+
+RUN arch=$(uname -m) && \
+    case "$arch" in \
+        x86_64) goarch=amd64 ;; \
+        aarch64) goarch=arm64 ;; \
+        *) echo "Unsupported architecture: $arch" && exit 1 ;; \
+    esac && \
+    curl -fSL -o /usr/local/bin/minio "https://dl.minio.io/server/minio/release/linux-${goarch}/minio" && \
+    curl -fSL -o /usr/local/bin/mc "https://dl.min.io/client/mc/release/linux-${goarch}/mc" && \
+    chmod +x /usr/local/bin/minio /usr/local/bin/mc
+
+EXPOSE 9000
+ENTRYPOINT ["minio"]
+CMD ["server", "/data"]

--- a/tools/toolchain/image
+++ b/tools/toolchain/image
@@ -1,1 +1,1 @@
-docker.io/scylladb/scylla-toolchain:fedora-43-20260304
+docker.io/scylladb/scylla-toolchain:fedora-43-20260507


### PR DESCRIPTION
Remove cassandra-stress (Java RPM) and minio (static binaries) from the frozen toolchain image. Instead, run them as nested containers via podman during build, tests, and PGO training.

antlr3 and Java remain in the toolchain image as antlr3 is too integral to the build to be containerized.

New files:
- tools/toolchain/containers/cassandra-stress/Containerfile
- tools/toolchain/containers/minio/Containerfile
- test/pylib/nested_container.py (helper for podman-in-podman)

- regenerate frozen toolchain with optimized clang from
  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-aarch64.tar.gz
  https://devpkg.scylladb.com/clang/clang-21.1.8-Fedora-43-x86_64.tar.gz

Fixes: SCYLLADB-1858

**toolchain improvement, no need for backport**