### PR TITLE
test/cluster: fix test_lwt_fencing_upgrade flakiness during rolling upgrade

### DIFF
--- a/test/cluster/test_fencing.py
+++ b/test/cluster/test_fencing.py
@@ -376,7 +376,7 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
                                         },
                                         auto_rack_dc='dc1',
                                         version=scylla_2025_1)
-    (cql, hosts) = await manager.get_ready_cql(servers)
+    (cql, _) = await manager.get_ready_cql(servers)
 
     logger.info("Create a test keyspace")
     async with new_test_keyspace(manager, "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 3}") as ks:
@@ -429,13 +429,7 @@ async def test_lwt_fencing_upgrade(manager: ManagerClient, scylla_2025_1: Scylla
             # so the LWT workload doesn’t fail if the driver suddenly sees all nodes as “down”.
             if s == servers[-1]:
                 logger.info("Wait all nodes are up")
-                async def all_hosts_are_alive():
-                    for h in hosts:
-                        if not h.is_up:
-                            logger.info(f"Host {h} is down, continue waiting")
-                            return None
-                    return True
-                await wait_for(all_hosts_are_alive, deadline=time.time() + 60, period=0.1)
+                await wait_for_cql_and_get_hosts(cql, servers, time.time() + 60)
             logger.info(f"Upgrading {s.server_id}")
             await manager.server_change_version(s.server_id, scylla_binary)
             await manager.server_sees_others(s.server_id, 2, interval=60.0)


### PR DESCRIPTION
Replace the naive host.is_up check with `wait_for_cql_and_get_hosts()` which actually executes a query against each host, ensuring the driver's connection pool is fully re-established before proceeding to stop the last server.

The is_up flag is set asynchronously via gossip and doesn't guarantee the connection pool has live TCP connections. After a server restart, the flag may be True while the pool still holds stale connections. When the pool monitor later discovers them dead it briefly marks the host DOWN, causing NoHostAvailable if another server is being stopped concurrently.

Fixes SCYLLADB-1840

backport: not needed -- this is a flaky test fix; backporting consumes a considerable amount of attention, we can do it if it's really needed