### PR TITLE
[Backport 2026.1] Rare "Vector Store request was aborted"

### DIFF
--- a/db/config.cc
+++ b/db/config.cc
@@ -1187,9 +1187,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "A comma-separated list of primary vector store node URIs. These nodes are preferred for vector search operations.")
     , vector_store_secondary_uri(this, "vector_store_secondary_uri", liveness::LiveUpdate, value_status::Used, "",
         "A comma-separated list of secondary vector store node URIs. These nodes are used as a fallback when all primary nodes are unavailable, and are typically located in a different availability zone for high availability.")
-    , vector_store_unreachable_node_detection_time_in_ms(this, "vector_store_unreachable_node_detection_time_in_ms", liveness::LiveUpdate, value_status::Used, 5000,
+    , vector_store_unreachable_node_detection_time_in_ms(this, "vector_store_unreachable_node_detection_time_in_ms", liveness::LiveUpdate, value_status::Used, 3000,
         "Time in milliseconds for detecting an unreachable vector store node. This value is applied to the TCP connect timeout, keepalive parameters, and TCP_USER_TIMEOUT. "
-        "When any of these mechanisms detects that a node is unreachable within this window, the client fails over to the next available vector store node. Minimum value is 5000.")
+        "When any of these mechanisms detects that a node is unreachable within this window, the client fails over to the next available vector store node.")
     , vector_store_encryption_options(this, "vector_store_encryption_options", value_status::Used, {},
         "Options for encrypted connections to the vector store. These options are used for HTTPS URIs in `vector_store_primary_uri` and `vector_store_secondary_uri`. The available options are:\n"
         "* truststore: (Default: <not set, use system truststore>) Location of the truststore containing the trusted certificate for authenticating remote servers.")

--- a/db/config.cc
+++ b/db/config.cc
@@ -1187,6 +1187,9 @@ db::config::config(std::shared_ptr<db::extensions> exts)
         "A comma-separated list of primary vector store node URIs. These nodes are preferred for vector search operations.")
     , vector_store_secondary_uri(this, "vector_store_secondary_uri", liveness::LiveUpdate, value_status::Used, "",
         "A comma-separated list of secondary vector store node URIs. These nodes are used as a fallback when all primary nodes are unavailable, and are typically located in a different availability zone for high availability.")
+    , vector_store_unreachable_node_detection_time_in_ms(this, "vector_store_unreachable_node_detection_time_in_ms", liveness::LiveUpdate, value_status::Used, 5000,
+        "Time in milliseconds for detecting an unreachable vector store node. This value is applied to the TCP connect timeout, keepalive parameters, and TCP_USER_TIMEOUT. "
+        "When any of these mechanisms detects that a node is unreachable within this window, the client fails over to the next available vector store node. Minimum value is 5000.")
     , vector_store_encryption_options(this, "vector_store_encryption_options", value_status::Used, {},
         "Options for encrypted connections to the vector store. These options are used for HTTPS URIs in `vector_store_primary_uri` and `vector_store_secondary_uri`. The available options are:\n"
         "* truststore: (Default: <not set, use system truststore>) Location of the truststore containing the trusted certificate for authenticating remote servers.")

--- a/db/config.hh
+++ b/db/config.hh
@@ -350,6 +350,7 @@ public:
     named_value<string_map> request_scheduler_options;
     named_value<sstring> vector_store_primary_uri;
     named_value<sstring> vector_store_secondary_uri;
+    named_value<uint32_t> vector_store_unreachable_node_detection_time_in_ms;
     named_value<string_map> vector_store_encryption_options;
     named_value<sstring> authenticator;
     named_value<sstring> internode_authenticator;

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -27,7 +27,7 @@ namespace {
 
 logging::logger client_test_logger("client_test");
 
-const auto REQUEST_TIMEOUT = utils::updateable_value<uint32_t>{100};
+const auto UNREACHABLE_NODE_DETECTION_WINDOW = utils::updateable_value<uint32_t>{std::chrono::milliseconds(test::vector_search::STANDARD_WAIT).count()};
 constexpr auto PATH = "/api/v1/indexes/ks/idx/ann";
 constexpr auto CONTENT = R"({"vector": [0.1, 0.2, 0.3], "limit": 10})";
 
@@ -47,7 +47,7 @@ future<std::unique_ptr<vs_mock_server>> make_available(std::unique_ptr<unavailab
 
 SEASTAR_TEST_CASE(is_up_after_construction) {
     auto server = co_await make_vs_mock_server();
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     BOOST_CHECK(client.is_up());
 
@@ -58,7 +58,7 @@ SEASTAR_TEST_CASE(is_up_after_construction) {
 SEASTAR_TEST_CASE(is_up_when_server_returned_ok_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
@@ -73,7 +73,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_client_error_status) {
     abort_source_timeout as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::bad_request, "Bad request"});
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
@@ -89,7 +89,7 @@ SEASTAR_TEST_CASE(is_up_when_request_is_aborted) {
     abort_source as;
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::ok, "{}"});
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     as.request_abort();
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as);
@@ -107,7 +107,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_server_error_status) {
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::internal_server_error, "Internal Server Error"});
 
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
@@ -124,7 +124,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
     auto server = co_await make_vs_mock_server();
     server->next_ann_response(vs_mock_server::response{seastar::http::reply::status_type::service_unavailable, "Service Unavailable"});
 
-    client client{client_test_logger, make_endpoint(server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
@@ -139,7 +139,7 @@ SEASTAR_TEST_CASE(is_up_when_server_returned_service_unavailable_status) {
 SEASTAR_TEST_CASE(is_down_when_server_is_not_available) {
     abort_source_timeout as;
     auto down_server = co_await make_unavailable_server();
-    client client{client_test_logger, make_endpoint(down_server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(down_server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
 
@@ -154,7 +154,7 @@ SEASTAR_TEST_CASE(is_down_when_server_is_not_available) {
 SEASTAR_TEST_CASE(becomes_up_when_server_status_is_serving) {
     abort_source_timeout as;
     auto down_server = co_await make_unavailable_server();
-    client client{client_test_logger, make_endpoint(down_server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+    client client{client_test_logger, make_endpoint(down_server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
     auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
     auto server = co_await make_available(down_server);
@@ -179,7 +179,7 @@ SEASTAR_TEST_CASE(remains_down_when_server_status_is_not_serving) {
     };
     for (auto const& status : non_serving_statuses) {
         auto down_server = co_await make_unavailable_server();
-        client client{client_test_logger, make_endpoint(down_server), REQUEST_TIMEOUT, shared_ptr<seastar::tls::certificate_credentials>{}};
+        client client{client_test_logger, make_endpoint(down_server), UNREACHABLE_NODE_DETECTION_WINDOW, shared_ptr<seastar::tls::certificate_credentials>{}};
 
         co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
         auto server = co_await make_available(down_server);
@@ -214,7 +214,7 @@ SEASTAR_TEST_CASE(is_down_when_connection_times_out) {
     co_await client.close();
 }
 
-SEASTAR_TEST_CASE(connection_timeout_cannot_be_smaller_than_5s) {
+SEASTAR_TEST_CASE(unreachable_node_detection_window_cannot_be_smaller_than_5s) {
     abort_source_timeout as;
     auto unreachable = co_await make_unreachable_socket();
     client client{client_test_logger, client::endpoint_type{unreachable.host, unreachable.port, seastar::net::inet_address(unreachable.host)},

--- a/test/vector_search/client_test.cc
+++ b/test/vector_search/client_test.cc
@@ -214,32 +214,42 @@ SEASTAR_TEST_CASE(is_down_when_connection_times_out) {
     co_await client.close();
 }
 
-SEASTAR_TEST_CASE(unreachable_node_detection_window_cannot_be_smaller_than_5s) {
-    abort_source_timeout as;
-    auto unreachable = co_await make_unreachable_socket();
-    client client{client_test_logger, client::endpoint_type{unreachable.host, unreachable.port, seastar::net::inet_address(unreachable.host)},
-            utils::updateable_value<uint32_t>{1000}, shared_ptr<seastar::tls::certificate_credentials>{}};
-
-
-    auto start = std::chrono::steady_clock::now();
-    auto res = co_await client.request(operation_type::POST, PATH, CONTENT, as.reset());
-    auto duration = std::chrono::steady_clock::now() - start;
-
-    BOOST_CHECK(duration >= 5s);
-
-    co_await unreachable.close();
-    co_await client.close();
-}
-
 BOOST_AUTO_TEST_CASE(test_get_keepalive_parameters) {
 
-    auto params1 = get_keepalive_parameters(10s);
-    BOOST_CHECK_EQUAL(params1.idle.count(), 4);
-    BOOST_CHECK_EQUAL(params1.interval.count(), 2);
-    BOOST_CHECK_EQUAL(params1.count, 3);
+    auto params_10s = get_keepalive_parameters(10s);
+    BOOST_CHECK_EQUAL(params_10s.idle.count(), 4);
+    BOOST_CHECK_EQUAL(params_10s.interval.count(), 2);
+    BOOST_CHECK_EQUAL(params_10s.count, 3);
 
-    auto params2 = get_keepalive_parameters(5s);
-    BOOST_CHECK_EQUAL(params2.idle.count(), 2);
-    BOOST_CHECK_EQUAL(params2.interval.count(), 1);
-    BOOST_CHECK_EQUAL(params2.count, 3);
+    auto params_5s = get_keepalive_parameters(5s);
+    BOOST_CHECK_EQUAL(params_5s.idle.count(), 2);
+    BOOST_CHECK_EQUAL(params_5s.interval.count(), 1);
+    BOOST_CHECK_EQUAL(params_5s.count, 3);
+
+    auto params_3s = get_keepalive_parameters(3s);
+    BOOST_CHECK_EQUAL(params_3s.idle.count(), 1);
+    BOOST_CHECK_EQUAL(params_3s.interval.count(), 1);
+    BOOST_CHECK_EQUAL(params_3s.count, 2);
+
+    auto params_2s = get_keepalive_parameters(2s);
+    BOOST_CHECK_EQUAL(params_2s.idle.count(), 1);
+    BOOST_CHECK_EQUAL(params_2s.interval.count(), 1);
+    BOOST_CHECK_EQUAL(params_2s.count, 1);
+
+    auto params_1s = get_keepalive_parameters(1s);
+    BOOST_CHECK_EQUAL(params_1s.idle.count(), 0);
+    BOOST_CHECK_EQUAL(params_1s.interval.count(), 1);
+    BOOST_CHECK_EQUAL(params_1s.count, 1);
+
+    // For timeout < 1s the function should return minimal valid parameters.
+    auto params_500ms = get_keepalive_parameters(std::chrono::milliseconds(500));
+    BOOST_CHECK_GE(params_500ms.idle.count(), 0);
+    BOOST_CHECK_GE(params_500ms.interval.count(), 1);
+    BOOST_CHECK_GE(static_cast<int>(params_500ms.count), 1);
+
+    // For timeout < 1s the function should return minimal valid parameters.
+    auto params_0ms = get_keepalive_parameters(std::chrono::milliseconds(0));
+    BOOST_CHECK_GE(params_0ms.idle.count(), 0);
+    BOOST_CHECK_GE(params_0ms.interval.count(), 1);
+    BOOST_CHECK_GE(static_cast<int>(params_0ms.count), 1);
 }

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -923,7 +923,7 @@ SEASTAR_TEST_CASE(vector_store_client_single_status_check_after_concurrent_failu
             }));
 }
 
-SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_request_timeout_cfg) {
+SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_connection_timeout_cfg) {
     auto unavail_s = co_await make_unavailable_server();
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unavail.node:{}", unavail_s->port()));
@@ -936,7 +936,7 @@ SEASTAR_TEST_CASE(vector_store_client_updates_backoff_max_time_from_read_request
                 vs.start_background_tasks();
 
                 // Set request timeout to 100ms, hence max backoff time is 2x100ms = 200ms.
-                cfg.db_config->read_request_timeout_in_ms.set(100);
+                cfg.db_config->vector_store_unreachable_node_detection_time_in_ms.set(100);
                 // Trigger status checking by making ANN request to unavailable server.
                 co_await vs.ann("ks", "idx", schema, std::vector<float>{0.1, 0.2, 0.3}, 2, rjson::empty_object(), as.reset());
                 co_await repeat_until([&unavail_s]() -> future<bool> {
@@ -1184,8 +1184,9 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unreachable.node:{}", unreachable.port));
     cfg.db_config->vector_store_secondary_uri.set(format("http://server.node:{}", server->port()));
-    cfg.db_config->request_timeout_in_ms.set(5000);                   // connection timeout to the vector store
-    cfg.query_timeout = make_query_timeout(std::chrono::seconds(10)); // CQL SELECT query timeout longer than connection timeout
+    cfg.db_config->vector_store_unreachable_node_detection_time_in_ms.set(5000); // unreachable node detection time for vector store
+    cfg.query_timeout = make_query_timeout(
+            std::chrono::seconds(10)); // CQL query timeout longer than vector store unreachable node detection time, to allow for fallback to secondary URI
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "test");
@@ -1196,7 +1197,7 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
                 auto result = co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding) USING 'vector_index'");
 
                 // Execute an ANN SELECT. The primary URI points to an unreachable socket,
-                // so the client's connection attempt to the primary will fail (request_timeout_in_ms = 5000).
+                // so the client's connection attempt to the primary will fail (vector_store_unreachable_node_detection_time_in_ms = 5000).
                 // The client is expected to transparently fall back to the secondary URI and
                 // complete the request successfully. The entire operation must complete within
                 // the configured CQL query timeout (10s), so the test expects a normal rows result.

--- a/test/vector_search/vector_store_client_test.cc
+++ b/test/vector_search/vector_store_client_test.cc
@@ -1184,9 +1184,9 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
     auto cfg = make_config();
     cfg.db_config->vector_store_primary_uri.set(format("http://unreachable.node:{}", unreachable.port));
     cfg.db_config->vector_store_secondary_uri.set(format("http://server.node:{}", server->port()));
-    cfg.db_config->vector_store_unreachable_node_detection_time_in_ms.set(5000); // unreachable node detection time for vector store
+    cfg.db_config->vector_store_unreachable_node_detection_time_in_ms.set(3000); // unreachable node detection time for vector store
     cfg.query_timeout = make_query_timeout(
-            std::chrono::seconds(10)); // CQL query timeout longer than vector store unreachable node detection time, to allow for fallback to secondary URI
+            std::chrono::seconds(4)); // CQL query timeout longer than vector store unreachable node detection time, to allow for fallback to secondary URI
     co_await do_with_cql_env(
             [&](cql_test_env& env) -> future<> {
                 auto schema = co_await create_test_table(env, "ks", "test");
@@ -1197,10 +1197,11 @@ SEASTAR_TEST_CASE(vector_store_client_high_availability_unreachable) {
                 auto result = co_await env.execute_cql("CREATE CUSTOM INDEX idx ON ks.test (embedding) USING 'vector_index'");
 
                 // Execute an ANN SELECT. The primary URI points to an unreachable socket,
-                // so the client's connection attempt to the primary will fail (vector_store_unreachable_node_detection_time_in_ms = 5000).
+                // so the client's connection attempt to the primary will fail (vector_store_unreachable_node_detection_time_in_ms = 3000).
                 // The client is expected to transparently fall back to the secondary URI and
                 // complete the request successfully. The entire operation must complete within
-                // the configured CQL query timeout (10s), so the test expects a normal rows result.
+                // the configured CQL query timeout (4s: 3s for the timeout on primary + 1s buffer for the request to the secondary),
+                // so the test expects a normal rows result.
                 auto msg = co_await env.execute_cql("SELECT * FROM ks.test ORDER BY embedding ANN OF [0.1, 0.2, 0.3] LIMIT 5;");
 
                 BOOST_CHECK(dynamic_pointer_cast<cql_transport::messages::result_message::rows>(msg));

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -70,11 +70,11 @@ class client_connection_factory : public http::experimental::connection_factory 
     shared_ptr<tls::certificate_credentials> _creds;
 
 public:
-    explicit client_connection_factory(
-            client::endpoint_type endpoint, shared_ptr<tls::certificate_credentials> creds, utils::updateable_value<uint32_t> connect_timeout_in_ms)
+    explicit client_connection_factory(client::endpoint_type endpoint, shared_ptr<tls::certificate_credentials> creds,
+            utils::updateable_value<uint32_t> unreachable_node_detection_time_in_ms)
         : _endpoint(std::move(endpoint))
         , _creds(std::move(creds))
-        , _connect_timeout_in_ms(std::move(connect_timeout_in_ms)) {
+        , _unreachable_node_detection_time_in_ms(std::move(unreachable_node_detection_time_in_ms)) {
     }
 
     future<connected_socket> make([[maybe_unused]] abort_source* as) override {
@@ -111,14 +111,14 @@ private:
 
     std::chrono::milliseconds timeout() const {
         constexpr std::chrono::milliseconds MIN_TIMEOUT = 5s;
-        auto timeout_ms = std::chrono::milliseconds(_connect_timeout_in_ms.get());
+        auto timeout_ms = std::chrono::milliseconds(_unreachable_node_detection_time_in_ms.get());
         if (timeout_ms < MIN_TIMEOUT) {
             timeout_ms = MIN_TIMEOUT;
         }
         return timeout_ms;
     }
 
-    utils::updateable_value<uint32_t> _connect_timeout_in_ms;
+    utils::updateable_value<uint32_t> _unreachable_node_detection_time_in_ms;
 };
 
 bool is_server_unavailable(std::exception_ptr& err) {
@@ -144,12 +144,12 @@ auto constexpr BACKOFF_RETRY_MIN_TIME = 100ms;
 
 } // namespace
 
-client::client(logging::logger& logger, endpoint_type endpoint_, utils::updateable_value<uint32_t> request_timeout_in_ms,
+client::client(logging::logger& logger, endpoint_type endpoint_, utils::updateable_value<uint32_t> unreachable_node_detection_time_in_ms,
         ::shared_ptr<seastar::tls::certificate_credentials> credentials)
     : _endpoint(std::move(endpoint_))
-    , _http_client(std::make_unique<client_connection_factory>(_endpoint, std::move(credentials), request_timeout_in_ms))
+    , _http_client(std::make_unique<client_connection_factory>(_endpoint, std::move(credentials), unreachable_node_detection_time_in_ms))
     , _logger(logger)
-    , _request_timeout(std::move(request_timeout_in_ms)) {
+    , _unreachable_node_detection_time_in_ms(std::move(unreachable_node_detection_time_in_ms)) {
 }
 
 seastar::future<client::request_result> client::request(
@@ -237,7 +237,7 @@ bool client::is_checking_status_in_progress() const {
 }
 
 std::chrono::milliseconds client::backoff_retry_max() const {
-    std::chrono::milliseconds ret{_request_timeout.get()};
+    std::chrono::milliseconds ret{_unreachable_node_detection_time_in_ms.get()};
     return ret * 2;
 }
 

--- a/vector_search/client.cc
+++ b/vector_search/client.cc
@@ -78,7 +78,7 @@ public:
     }
 
     future<connected_socket> make([[maybe_unused]] abort_source* as) override {
-        auto t = timeout();
+        auto t = std::chrono::milliseconds(_unreachable_node_detection_time_in_ms.get());
         auto socket = co_await connect(t, as);
         socket.set_nodelay(true);
         socket.set_keepalive_parameters(get_keepalive_parameters(t));
@@ -107,15 +107,6 @@ private:
             co_await coroutine::return_exception_ptr(std::move(err));
         }
         co_return co_await std::move(f);
-    }
-
-    std::chrono::milliseconds timeout() const {
-        constexpr std::chrono::milliseconds MIN_TIMEOUT = 5s;
-        auto timeout_ms = std::chrono::milliseconds(_unreachable_node_detection_time_in_ms.get());
-        if (timeout_ms < MIN_TIMEOUT) {
-            timeout_ms = MIN_TIMEOUT;
-        }
-        return timeout_ms;
     }
 
     utils::updateable_value<uint32_t> _unreachable_node_detection_time_in_ms;

--- a/vector_search/client.hh
+++ b/vector_search/client.hh
@@ -41,7 +41,7 @@ public:
     using request_error = std::variant<aborted_error, service_unavailable_error>;
     using request_result = std::expected<response, request_error>;
 
-    explicit client(logging::logger& logger, endpoint_type endpoint_, utils::updateable_value<uint32_t> request_timeout_in_ms,
+    explicit client(logging::logger& logger, endpoint_type endpoint_, utils::updateable_value<uint32_t> unreachable_node_detection_time_in_ms,
             ::shared_ptr<seastar::tls::certificate_credentials> credentials);
 
     seastar::future<request_result> request(
@@ -71,7 +71,7 @@ private:
     seastar::future<> _checking_status_future = seastar::make_ready_future();
     seastar::abort_source _as;
     logging::logger& _logger;
-    utils::updateable_value<uint32_t> _request_timeout;
+    utils::updateable_value<uint32_t> _unreachable_node_detection_time_in_ms;
 };
 
 } // namespace vector_search

--- a/vector_search/clients.cc
+++ b/vector_search/clients.cc
@@ -51,8 +51,8 @@ auto make_unexpected(const auto& err) {
 
 } // namespace
 
-clients::clients(
-        logging::logger& logger, refresh_trigger_callback trigger_refresh, utils::updateable_value<uint32_t> request_timeout_in_ms, truststore& truststore)
+clients::clients(logging::logger& logger, refresh_trigger_callback trigger_refresh, utils::updateable_value<uint32_t> unreachable_node_detection_time_in_ms,
+        truststore& truststore)
     : _producer([&]() -> future<clients_vec> {
         return try_with_gate(_gate, [this] -> future<clients_vec> {
             _trigger_refresh();
@@ -63,7 +63,7 @@ clients::clients(
     , _trigger_refresh(std::move(trigger_refresh))
     , _timeout(WAIT_FOR_CLIENT_TIMEOUT)
     , _logger(logger)
-    , _request_timeout_in_ms(std::move(request_timeout_in_ms))
+    , _unreachable_node_detection_time_in_ms(std::move(unreachable_node_detection_time_in_ms))
     , _truststore(truststore) {
 }
 
@@ -172,7 +172,7 @@ future<> clients::close_old_clients() {
 
 seastar::future<seastar::lw_shared_ptr<client>> clients::make_client(const uri& uri_, const seastar::net::inet_address& addr_) {
     auto creds = uri_.schema == uri::schema_type::https ? co_await _truststore.get() : nullptr;
-    auto c = make_lw_shared<client>(_logger, client::endpoint_type{uri_.host, uri_.port, addr_}, _request_timeout_in_ms, creds);
+    auto c = make_lw_shared<client>(_logger, client::endpoint_type{uri_.host, uri_.port, addr_}, _unreachable_node_detection_time_in_ms, creds);
     co_return c;
 }
 

--- a/vector_search/clients.hh
+++ b/vector_search/clients.hh
@@ -36,8 +36,8 @@ public:
     using get_clients_error = std::variant<aborted_error, addr_unavailable_error>;
     using get_clients_result = std::expected<clients_vec, get_clients_error>;
 
-    explicit clients(
-            logging::logger& logger, refresh_trigger_callback trigger_refresh, utils::updateable_value<uint32_t> request_timeout_in_ms, truststore& truststore);
+    explicit clients(logging::logger& logger, refresh_trigger_callback trigger_refresh, utils::updateable_value<uint32_t> unreachable_node_detection_time_in_ms,
+            truststore& truststore);
 
     seastar::future<request_result> request(
             seastar::httpd::operation_type method, seastar::sstring path, std::optional<seastar::sstring> content, seastar::abort_source& as);
@@ -67,7 +67,7 @@ private:
     std::chrono::milliseconds _timeout;
     clients_vec _old_clients;
     logging::logger& _logger;
-    utils::updateable_value<uint32_t> _request_timeout_in_ms;
+    utils::updateable_value<uint32_t> _unreachable_node_detection_time_in_ms;
     truststore& _truststore;
 };
 

--- a/vector_search/utils.hh
+++ b/vector_search/utils.hh
@@ -11,6 +11,8 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/net/api.hh>
+#include <algorithm>
+#include <chrono>
 #include <vector>
 
 namespace vector_search {
@@ -30,26 +32,32 @@ inline seastar::sstring response_content_to_sstring(const std::vector<seastar::t
 }
 
 inline seastar::net::tcp_keepalive_params get_keepalive_parameters(std::chrono::milliseconds timeout) {
-    constexpr unsigned retry_count = 3;
+    constexpr unsigned min_count = 1;
+    constexpr unsigned max_count = 3;
     constexpr auto min_interval = std::chrono::seconds(1);
 
-    // Divide total time by (count + 2) to balance Probing vs. Idle (~60/40)
-    auto target_duration = std::chrono::duration_cast<std::chrono::seconds>(timeout);
-    auto interval = target_duration / (retry_count + 2);
+    auto timeout_s = std::chrono::duration_cast<std::chrono::seconds>(timeout);
 
-    // Ensure minimum 1s interval
-    if (interval < min_interval) {
-        interval = min_interval;
+    if (timeout_s < min_interval) {
+        return seastar::net::tcp_keepalive_params{
+                .idle = std::chrono::seconds(0),
+                .interval = min_interval,
+                .count = min_count,
+        };
     }
 
-    auto idle = target_duration - (interval * retry_count);
+    auto count = std::max(min_count, std::min(max_count, static_cast<unsigned>(timeout_s / min_interval) - 1));
+    auto interval = std::max(min_interval, timeout_s / (count + 1));
+    auto idle = timeout_s - (interval * count);
+    if (idle < std::chrono::seconds(0)) {
+        idle = std::chrono::seconds(0);
+    }
 
     return seastar::net::tcp_keepalive_params{
             .idle = idle,
             .interval = interval,
-            .count = retry_count,
+            .count = count,
     };
 }
-
 
 } // namespace vector_search

--- a/vector_search/vector_store_client.cc
+++ b/vector_search/vector_store_client.cc
@@ -245,7 +245,7 @@ struct vector_store_client::impl {
     clients _secondary_clients;
 
     impl(utils::config_file::named_value<sstring> primary_uris, utils::config_file::named_value<sstring> secondary_uris,
-            utils::config_file::named_value<uint32_t> read_request_timeout_in_ms,
+            utils::config_file::named_value<uint32_t> unreachable_node_detection_time_in_ms,
             utils::config_file::named_value<utils::config_file::string_map> encryption_options, invoke_on_others_func invoke_on_others)
         : _primary_uri_observer(primary_uris.observe([this](seastar::sstring uris_csv) {
             handle_uris_changed(std::move(uris_csv), _primary_uris, _primary_clients);
@@ -272,14 +272,14 @@ struct vector_store_client::impl {
                   [this]() {
                       dns.trigger_refresh();
                   },
-                  read_request_timeout_in_ms, _truststore)
+                  unreachable_node_detection_time_in_ms, _truststore)
 
         , _secondary_clients(
                   vslogger,
                   [this]() {
                       dns.trigger_refresh();
                   },
-                  read_request_timeout_in_ms, _truststore) {
+                  unreachable_node_detection_time_in_ms, _truststore) {
         _metrics.add_group("vector_store", {seastar::metrics::make_gauge("dns_refreshes", seastar::metrics::description("Number of DNS refreshes"), [this] {
             return dns_refreshes;
         }).aggregate({seastar::metrics::shard_label})});
@@ -354,7 +354,7 @@ struct vector_store_client::impl {
 };
 
 vector_store_client::vector_store_client(config const& cfg)
-    : _impl(std::make_unique<impl>(cfg.vector_store_primary_uri, cfg.vector_store_secondary_uri, cfg.read_request_timeout_in_ms,
+    : _impl(std::make_unique<impl>(cfg.vector_store_primary_uri, cfg.vector_store_secondary_uri, cfg.vector_store_unreachable_node_detection_time_in_ms,
               cfg.vector_store_encryption_options, [this](auto func) {
                   return container().invoke_on_others([func = std::move(func)](auto& self) {
                       return func(*self._impl);


### PR DESCRIPTION
Manual backport, as automation failed due to: https://github.com/scylladb/scylladb/pull/28675#issuecomment-4266864693.

==
To ensure the high-availability logic fits within the default 10s CQL timeout, the default unreachable node detection time has been decreased from 5s to 3s. Consequently, this value has been decoupled from the
read_request_timeout and dedicated configuration options have been introduced: vector_store_unreachable_node_detection_time_in_ms.

Fixes SCYLLADB-1855

Backports to 2025.4 and 2026.1 are required, as spurious CQL timeouts in high-availability scenarios are affecting
these releases in vector search XCloud deployments.

- (cherry picked from commit 9269ca9cf7914ce77485c44daccaf9cbcc25f0c1)
- (cherry picked from commit c643f321af09cb226ac8ae7c3664910025acc448)

Parent PR: https://github.com/scylladb/scylladb/pull/28675