### PR TITLE
alternator: add even more vector search features

### DIFF
--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1308,6 +1308,254 @@ static std::vector<float> parse_vector(const rjson::value& value, int dimensions
     return out;
 }
 
+// Converts a DynamoDB typed value (e.g. {"S": "hello"} or {"N": "42"}) to a
+// JSON value in the format expected by the vector store pre-filter.
+// If cdef is non-null, the value's DynamoDB type tag must match the declared
+// type of the column; a mismatch triggers a ValidationException.  When cdef
+// is null (e.g. for projected non-key columns whose type is not declared),
+// the type check is skipped.  Only the types S (string) and N (number) are
+// supported; any other type (L, M, SS, NS, BS, BOOL, NULL, B, ...) triggers
+// a ValidationException.
+static rjson::value value_to_prefilter_json(const rjson::value& value, const column_definition* cdef) {
+    if (!value.IsObject() || value.MemberCount() != 1) {
+        throw api_error::validation(
+            "value in VectorSearch KeyConditionExpression must be a typed DynamoDB value");
+    }
+    auto it = value.MemberBegin();
+    std::string_view type_tag = rjson::to_string_view(it->name);
+    const rjson::value& inner = it->value;
+    if (cdef) {
+        std::string expected_type = type_to_string(cdef->type);
+        if (type_tag != expected_type) {
+            throw api_error::validation(fmt::format(
+                "Type mismatch in VectorSearch KeyConditionExpression: "
+                "expected type {} for attribute {}, got type {}",
+                expected_type, cdef->name_as_text(), type_tag));
+        }
+    }
+    if (type_tag == "S") {
+        if (!inner.IsString()) {
+            throw api_error::validation("S type value must be a string");
+        }
+        return rjson::copy(inner);
+    } else if (type_tag == "N") {
+        if (!inner.IsString()) {
+            throw api_error::validation("N type value must be a string");
+        }
+        // Return the number string as-is to preserve full "decimal" type
+        // precision and range, not 64-bit double. The vector store will
+        // parse this string as BigDecimal.
+        return rjson::copy(inner);
+    }
+    throw api_error::validation(format(
+        "Type '{}' is not supported in VectorSearch KeyConditionExpression; "
+        "only S (string) and N (number) are supported", type_tag));
+}
+
+// Converts a single primitive condition from a parsed KeyConditionExpression
+// to vector store pre-filter JSON restriction(s), appended to restrictions_arr.
+// projected_cols maps projected attribute names to their column definitions;
+// any attribute not in this map triggers a ValidationException.
+static void primitive_condition_to_prefilter(
+        const parsed::primitive_condition& cond,
+        const std::unordered_map<std::string, const column_definition*>& projected_cols,
+        rjson::value& restrictions_arr)
+{
+    using ctype = parsed::primitive_condition::type;
+
+    // Return the column_definition for a parsed::value that must be a top-level
+    // attribute path referencing a projected column.
+    auto require_projected_col = [&](const parsed::value& v) -> const column_definition& {
+        const parsed::path& path = std::get<parsed::path>(v._value);
+        if (path.has_operators()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression does not support nested attribute paths");
+        }
+        auto it = projected_cols.find(path.root());
+        if (it == projected_cols.end()) {
+            throw api_error::validation(format(
+                "VectorSearch KeyConditionExpression references attribute '{}' which is not a projected "
+                "attribute of the vector index; only projected attributes can "
+                "be used for pre-filtering", path.root()));
+        }
+        return *it->second;
+    };
+
+    // Extract the resolved DynamoDB JSON value from a parsed::constant literal.
+    auto require_resolved_val = [](const parsed::value& v) -> const rjson::value& {
+        if (!v.is_constant()) {
+            throw api_error::validation(
+                "value in VectorSearch KeyConditionExpression must be a constant");
+        }
+        const parsed::constant& c = std::get<parsed::constant>(v._value);
+        // We're after resolve_condition_expression(), so only literals remain
+        // not ":name" references.
+        throwing_assert(std::holds_alternative<parsed::constant::literal>(c._value));
+        return *std::get<parsed::constant::literal>(c._value);
+    };
+
+    if (cond._op == ctype::EQ || cond._op == ctype::LT || cond._op == ctype::LE ||
+            cond._op == ctype::GT || cond._op == ctype::GE) {
+        // Binary comparison: one operand is a column path, the other a constant.
+        throwing_assert(cond._values.size() == 2);
+        bool col_left = cond._values[0].is_path();
+        bool col_right = cond._values[1].is_path();
+        if ((!col_left && !col_right) || (col_left && col_right)) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression comparison must compare an attribute to a constant");
+        }
+        const parsed::value& col_v   = col_left ? cond._values[0] : cond._values[1];
+        const parsed::value& const_v = col_left ? cond._values[1] : cond._values[0];
+        const column_definition& cdef = require_projected_col(col_v);
+
+        // The vector store only supports comparisons of the form
+        // "col OP const" where the column name is on the left, so we need to
+        // rewrite "const < col" to "col > const", flipping the comparison
+        // direction.
+        const char* op_str;
+        if (col_left) {
+            switch (cond._op) {
+            case ctype::EQ: op_str = "=="; break;
+            case ctype::LT: op_str = "<";  break;
+            case ctype::LE: op_str = "<="; break;
+            case ctype::GT: op_str = ">";  break;
+            case ctype::GE: op_str = ">="; break;
+            // The outer "if" guarantees cond._op is one of EQ/LT/LE/GT/GE;
+            // the default cases below are unreachable by construction.
+            default: on_internal_error(elogger, "can't happen");
+            }
+        } else {
+            switch (cond._op) {
+            case ctype::EQ: op_str = "=="; break;
+            case ctype::LT: op_str = ">";  break; // const < col -> col > const
+            case ctype::LE: op_str = ">="; break; // const <= col -> col >= const
+            case ctype::GT: op_str = "<";  break; // const > col -> col < const
+            case ctype::GE: op_str = "<="; break; // const >= col -> col <= const
+            default: on_internal_error(elogger, "can't happen");
+            }
+        }
+        auto rhs_json = value_to_prefilter_json(require_resolved_val(const_v), &cdef);
+        auto restriction = rjson::empty_object();
+        rjson::add(restriction, "type", rjson::from_string(op_str));
+        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "rhs", std::move(rhs_json));
+        rjson::push_back(restrictions_arr, std::move(restriction));
+
+    } else if (cond._op == ctype::IN) {
+        // IN operator: first value is the column, the remaining are constants.
+        if (cond._values.empty() || !cond._values[0].is_path()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression IN must have an attribute name as its first operand");
+        }
+        const column_definition& cdef = require_projected_col(cond._values[0]);
+        auto rhs_arr = rjson::empty_array();
+        for (size_t i = 1; i < cond._values.size(); ++i) {
+            rjson::push_back(rhs_arr, value_to_prefilter_json(
+                    require_resolved_val(cond._values[i]), &cdef));
+        }
+        auto restriction = rjson::empty_object();
+        rjson::add(restriction, "type", rjson::from_string("IN"));
+        rjson::add(restriction, "lhs", rjson::from_string(cdef.name_as_text()));
+        rjson::add(restriction, "rhs", std::move(rhs_arr));
+        rjson::push_back(restrictions_arr, std::move(restriction));
+
+    } else if (cond._op == ctype::BETWEEN) {
+        // a BETWEEN b AND c is expanded to two restrictions: a >= b AND a <= c.
+        if (cond._values.size() != 3 || !cond._values[0].is_path() ||
+                !cond._values[1].is_constant() || !cond._values[2].is_constant()) {
+            throw api_error::validation(
+                "VectorSearch KeyConditionExpression BETWEEN must have an attribute and two constant bounds");
+        }
+        const column_definition& cdef = require_projected_col(cond._values[0]);
+        auto lower_json = value_to_prefilter_json(require_resolved_val(cond._values[1]), &cdef);
+        auto upper_json = value_to_prefilter_json(require_resolved_val(cond._values[2]), &cdef);
+        auto col_json = rjson::from_string(cdef.name_as_text());
+
+        auto restr_ge = rjson::empty_object();
+        rjson::add(restr_ge, "type", rjson::from_string(">="));
+        rjson::add(restr_ge, "lhs", rjson::copy(col_json));
+        rjson::add(restr_ge, "rhs", std::move(lower_json));
+        rjson::push_back(restrictions_arr, std::move(restr_ge));
+
+        auto restr_le = rjson::empty_object();
+        rjson::add(restr_le, "type", rjson::from_string("<="));
+        rjson::add(restr_le, "lhs", std::move(col_json));
+        rjson::add(restr_le, "rhs", std::move(upper_json));
+        rjson::push_back(restrictions_arr, std::move(restr_le));
+
+    } else {
+        throw api_error::validation(
+            "VectorSearch KeyConditionExpression uses an unsupported operator for vector search "
+            "pre-filtering; supported operators are =, <, <=, >, >=, IN, BETWEEN");
+    }
+}
+
+// Parses a KeyConditionExpression from a vector search request and builds a
+// pre-filter JSON object for the vector store (same format as the CQL filter
+// in vector_search/filter.cc). The expression may only reference projected
+// attributes; currently those are the base table's key columns. Returns an
+// empty JSON object if no KeyConditionExpression is present.
+static rjson::value parse_vector_search_prefilter(
+        parsed::expression_cache& parsed_expr_cache,
+        const rjson::value& request,
+        const schema& schema,
+        std::unordered_set<std::string>& used_attribute_names,
+        std::unordered_set<std::string>& used_attribute_values)
+{
+    const rjson::value* key_cond_expr = rjson::find(request, "KeyConditionExpression");
+    if (!key_cond_expr) {
+        return rjson::empty_object();
+    }
+    if (!key_cond_expr->IsString()) {
+        throw api_error::validation("KeyConditionExpression must be a string");
+    }
+    if (key_cond_expr->GetStringLength() == 0) {
+        throw api_error::validation("KeyConditionExpression must not be empty");
+    }
+
+    parsed::condition_expression parsed_expr;
+    try {
+        parsed_expr = parsed_expr_cache.parse_condition_expression(
+                rjson::to_string_view(*key_cond_expr), "KeyConditionExpression");
+    } catch (expressions_syntax_error& e) {
+        throw api_error::validation(e.what());
+    }
+
+    const rjson::value* attr_names  = rjson::find(request, "ExpressionAttributeNames");
+    const rjson::value* attr_values = rjson::find(request, "ExpressionAttributeValues");
+    resolve_condition_expression(parsed_expr, attr_names, attr_values,
+            used_attribute_names, used_attribute_values);
+
+    // Build the map of projected attribute name -> column_definition.
+    // Currently only the base table's key columns are projected.
+    std::unordered_map<std::string, const column_definition*> projected_cols;
+    for (const column_definition& cdef : schema.partition_key_columns()) {
+        projected_cols[cdef.name_as_text()] = &cdef;
+    }
+    for (const column_definition& cdef : schema.clustering_key_columns()) {
+        projected_cols[cdef.name_as_text()] = &cdef;
+    }
+
+    // Flatten the expression into AND-connected primitive conditions.
+    // OR and NOT are rejected by condition_expression_and_list().
+    std::vector<const parsed::primitive_condition*> conditions;
+    condition_expression_and_list(parsed_expr, conditions);
+
+    auto restrictions_arr = rjson::empty_array();
+    for (const parsed::primitive_condition* cond : conditions) {
+        primitive_condition_to_prefilter(*cond, projected_cols, restrictions_arr);
+    }
+
+    if (restrictions_arr.Empty()) {
+        return rjson::empty_object();
+    }
+
+    auto result = rjson::empty_object();
+    rjson::add(result, "restrictions", std::move(restrictions_arr));
+    rjson::add(result, "allow_filtering", rjson::value(true));
+    return result;
+}
+
 // Converts a similarity score (float) to a JSON value. JSON does not support
 // infinite or NaN values, so if the score is infinite (which can happen with
 // the DOT_PRODUCT similarity function on non-normalized vectors) we clamp to
@@ -1475,9 +1723,19 @@ static future<executor::request_return_type> query_vector(
         co_return api_error::validation(
             "VectorSearch does not support QueryFilter; use FilterExpression instead");
     }
+    // KeyConditions (the old-style API) is not supported for vector search Queries.
+    if (rjson::find(request, "KeyConditions")) {
+        co_return api_error::validation(
+            "VectorSearch does not support KeyConditions; use KeyConditionExpression instead");
+    }
     // FilterExpression: post-filter the vector search results by any attribute.
     filter flt(parsed_expr_cache, request, filter::request_type::QUERY,
                used_attribute_names, used_attribute_values);
+    // KeyConditionExpression: pre-filter sent to the vector store before ANN search.
+    // Only projected attributes (currently key columns) are allowed.
+    rjson::value pre_filter = parse_vector_search_prefilter(
+            parsed_expr_cache, request, *base_schema,
+            used_attribute_names, used_attribute_values);
     const rjson::value* expression_attribute_names = rjson::find(request, "ExpressionAttributeNames");
     verify_all_are_used(expression_attribute_names, used_attribute_names, "ExpressionAttributeNames", "Query");
     const rjson::value* expression_attribute_values = rjson::find(request, "ExpressionAttributeValues");
@@ -1492,7 +1750,6 @@ static future<executor::request_return_type> query_vector(
     // Query the vector store for the approximate nearest neighbors.
     auto timeout = executor::default_timeout();
     abort_on_expiry aoe(timeout);
-    rjson::value pre_filter = rjson::empty_object(); // TODO, implement
     auto pkeys_result = co_await vsc.ann(
             base_schema->ks_name(), std::string(index_name), base_schema,
             std::move(query_vec), limit, pre_filter, aoe.abort_source());

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1582,6 +1582,7 @@ static future<executor::request_return_type> query_vector(
     lw_shared_ptr<alternator::stats> per_table_stats = get_stats_from_schema(proxy, *base_schema);
     per_table_stats->api_operations.query++;
     stats.vector_search.query++;
+    per_table_stats->vector_search.query++;
     tracing::add_alternator_table_name(trace_state, base_schema->cf_name());
     auto mark_latency = [&stats, &per_table_stats, start_time = std::chrono::steady_clock::now()]() {
         auto duration = std::chrono::steady_clock::now() - start_time;
@@ -1766,6 +1767,7 @@ static future<executor::request_return_type> query_vector(
     }
     const std::vector<vector_search::primary_key>& pkeys = pkeys_result.value();
     stats.vector_search.query_items_from_vs += pkeys.size();
+    per_table_stats->vector_search.query_items_from_vs += pkeys.size();
 
     // For SELECT=COUNT with no filter: skip fetching from the base table and
     // just return the count of candidates returned by the vector store.
@@ -1814,6 +1816,7 @@ static future<executor::request_return_type> query_vector(
         auto count = static_cast<int>(items_json.Size());
         rjson::add(response, "Count", rjson::value(count));
         stats.vector_search.query_returned_items += count;
+        per_table_stats->vector_search.query_returned_items += count;
         stats.returned_items += count;
         stats.returned_items_histogram.add(count);
         per_table_stats->returned_items += count;
@@ -1851,6 +1854,7 @@ static future<executor::request_return_type> query_vector(
     // vector store, to preserve vector-distance ordering in the response.
     // FIXME: do this more efficiently with a batched read that preserves ordering.
     stats.vector_search.query_items_from_base_table += pkeys.size();
+    per_table_stats->vector_search.query_items_from_base_table += pkeys.size();
     for (const auto& pkey : pkeys) {
         std::vector<query::clustering_range> bounds{
                 base_schema->clustering_key_size() > 0
@@ -1931,6 +1935,7 @@ static future<executor::request_return_type> query_vector(
         auto count = static_cast<int>(items_json.Size());
         rjson::add(response, "Count", rjson::value(count));
         stats.vector_search.query_returned_items += count;
+        per_table_stats->vector_search.query_returned_items += count;
         stats.returned_items += count;
         stats.returned_items_histogram.add(count);
         per_table_stats->returned_items += count;

--- a/alternator/executor_read.cc
+++ b/alternator/executor_read.cc
@@ -1652,6 +1652,13 @@ static future<executor::request_return_type> query_vector(
     if (limit == 0) {
         co_return api_error::validation("Limit must be greater than 0");
     }
+    // The maximum limit for vector search matches the CQL constant
+    // max_ann_query_limit in vector_indexed_table_select_statement.
+    static constexpr uint32_t max_vector_search_limit = 1000;
+    if (limit > max_vector_search_limit) {
+        co_return api_error::validation(
+            format("Limit must not be greater than {}", max_vector_search_limit));
+    }
 
     // Consistent reads are not supported for vector search, just like GSI.
     if (get_read_consistency(request) != db::consistency_level::LOCAL_ONE) {

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -294,13 +294,6 @@ different way, and explicitly rejects others that have no meaningful interpretat
   reflect writes instantly, so strongly-consistent reads are impossible.
   **`ConsistentRead=true` is rejected.**
 
-- **No key condition.** A standard Query requires a `KeyConditionExpression`
-  to select which partition to read. Vector search queries the vector store
-  globally across all partitions of the table. `KeyConditions` and
-  `KeyConditionExpression` are therefore not applicable and are silently
-  ignored. (Local vector indexes, which would scope the search to a single
-  partition and use `KeyConditionExpression`, are not yet supported.)
-
 **Select parameter:**
 
 The standard DynamoDB `Select` parameter is supported for vector search queries
@@ -328,25 +321,46 @@ therefore significantly slower than returning only projected attributes with
 `ALL_PROJECTED_ATTRIBUTES`.  For latency-sensitive applications, prefer
 `ALL_PROJECTED_ATTRIBUTES` or limiting `SPECIFIC_ATTRIBUTES` to key columns.
 
-**FilterExpression:**
+**Filtering: pre-filter and post-filter:**
 
-Vector search supports `FilterExpression` for post-filtering results. This
-works the same way as `FilterExpression` on a standard DynamoDB `Query`: after
-the ANN search, the filter is applied to each candidate item and only matching
-items are returned.
+Vector search supports two complementary filtering mechanisms:
 
-**Important:** filtering happens _after_ the `Limit` nearest neighbors have
-already been selected by the vector index. If the filter discards some of
-those candidates, the response may contain **fewer than `Limit` items**. The
-server does not automatically fetch additional neighbors to replace filtered-out
-items. This is identical to how `FilterExpression` interacts with `Limit` in a
-standard DynamoDB `Query`.
+**Pre-filtering (`KeyConditionExpression`):** conditions are sent to the vector
+store before the ANN search, so the search is performed only over matching
+items. Because pre-filtering is evaluated inside the vector store, only
+attributes that are projected into the vector index can be referenced — today
+that means the base table's key columns (hash key and range key if present).
+Supported operators are `=`, `<`, `<=`, `>`, `>=`, `IN`, and `BETWEEN`;
+conditions are combined with `AND`. `OR` and `NOT` are rejected because the
+vector store's pre-filter API only accepts a flat list of conditions implicitly
+ANDed together. The `<>` (not-equal) operator is also rejected. In cases where
+`OR` would otherwise test a single attribute against multiple values, `IN` can
+often serve as a replacement: instead of `p = :v1 OR p = :v2`, write
+`p IN (:v1, :v2)`. `KeyConditions` (the legacy non-expression API) is **not**
+supported and will be rejected with a `ValidationException`.
+
+Pre-filtering searches only within the matching subset and returns the items
+most similar to the query vector, but the result count is **not** guaranteed
+to reach `Limit`: the underlying ANN algorithm explores a bounded neighborhood
+of the graph and may return fewer than `Limit` items even when enough matching
+items exist in the index. There is no automatic retry to fill missing slots.
+
+**Post-filtering (`FilterExpression`):** after the ANN search returns its `Limit`
+nearest-neighbor candidates, the filter is applied to each candidate and only
+matching items are returned. Because filtering happens _after_ the `Limit`
+candidates have already been selected, some may be discarded, and the response
+may contain **fewer than `Limit` items**. The server does not automatically
+fetch additional neighbors to replace filtered-out items. Any attribute may be
+referenced in a `FilterExpression`, not only projected columns. This is
+identical to how `FilterExpression` interacts with `Limit` in a standard
+DynamoDB `Query`. `QueryFilter` (the legacy non-expression filter API) is **not**
+supported and will be rejected with a `ValidationException`.
 
 The response always includes two count fields:
 
 | Field | Description |
 |-------|-------------|
-| `ScannedCount` | The number of candidates returned by the vector index (always equal to `Limit`, unless the table contains fewer than `Limit` items). |
+| `ScannedCount` | The number of candidates returned by the vector index. Normally equal to `Limit`, but may be less if there are fewer than `Limit` items in the table (or matching the pre-filtering condition), or if the approximate ANN search did not find enough candidates. |
 | `Count` | The number of items that passed the `FilterExpression` (or equal to `ScannedCount` when no filter is present). |
 
 **Interaction with `Select`:**
@@ -373,10 +387,6 @@ The response always includes two count fields:
   any base-table reads. When a `FilterExpression` is present, however, the full
   item must be fetched from the base table to evaluate the filter, and only the
   projected (key) attributes are returned for items that pass.
-
-> **Note:** `QueryFilter` (the legacy non-expression filter API) is **not**
-> supported for vector search queries and will be rejected with a
-> `ValidationException`. Use `FilterExpression` instead.
 
 **ReturnScores field:**
 

--- a/docs/alternator/vector-search.md
+++ b/docs/alternator/vector-search.md
@@ -269,7 +269,7 @@ response = table.query(
 | `IndexName` | Required. Must name a vector index on this table (not a GSI or LSI). |
 | `VectorSearch.QueryVector` | Required. A DynamoDB `AttributeValue` of type `L` (all elements of type `N`) or the ScyllaDB-specific type `FLOAT32VECTOR` (plain floating-point JSON numbers). |
 | QueryVector length | Must match the `Dimensions` configured for the named vector index. |
-| `Limit` | Required. Defines _k_ — how many nearest neighbors to return. Must be a positive integer. |
+| `Limit` | Required. Defines _k_ — how many nearest neighbors to return. Must be a positive integer no greater than 1000. |
 
 **Differences from standard Query:**
 
@@ -281,7 +281,9 @@ different way, and explicitly rejects others that have no meaningful interpretat
   `ExclusiveStartKey`. In vector search, `Limit` defines _k_: the ANN
   algorithm runs once and returns exactly the _k_ nearest neighbors. There
   is no natural "next page" — each page would require a full re-run of the
-  search — so **`ExclusiveStartKey` is rejected**.
+  search — so **`ExclusiveStartKey` is rejected**. Because vector search does
+  not support pagination, `Limit` is capped at 1000; if you need more results
+  you must issue separate queries with different query vectors.
 
 - **Results are ordered by vector distance, not by sort key.** A standard
   Query returns rows in sort-key order; `ScanIndexForward=false` reverses

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -510,6 +510,7 @@ def new_named_table_unauthorized(dynamodb, tabname, **kwargs):
         # table 
         dynamodb.meta.client.get_waiter('table_exists').wait(TableName=tabname)
         dynamodb.meta.client.delete_table(TableName=tabname)
+        raise
 
 
 # When a role is allowed to CreateTable, the role is automatically granted

--- a/test/alternator/test_cql_rbac.py
+++ b/test/alternator/test_cql_rbac.py
@@ -25,6 +25,7 @@ from test.pylib.skip_types import skip_env
 from .util import unique_table_name, random_string, new_test_table
 from .test_gsi_updatetable import wait_for_gsi, wait_for_gsi_gone
 from .test_gsi import assert_index_query
+from test.alternator.test_vector import vs, needs_vector_store, wait_for_vector_index_active, table_vs, add_vs_to_client, vector_store_configured, VECTOR_STORE_TIMEOUT
 
 # new_role() is a context manager for temporarily creating a new role with
 # a unique name and returning its name and the secret key needed to connect
@@ -1187,3 +1188,190 @@ def test_rbac_system_table_write(dynamodb, cql, test_table_s):
                 UpdateExpression='SET #val = :val',
                 ExpressionAttributeNames={'#val': 'value'},
                 ExpressionAttributeValues={':val': old_val}))
+
+#############################################################################
+# Tests for RBAC on vector search operations - Query with VectorSearch,
+# CreateTable with VectorIndexes, and UpdateTable with VectorIndexUpdates.
+# The tests verify that the permissions required for these operations
+# are as expected, but also that the external vector store is really able to
+# read the base-table data to perform its indexing.
+#
+# Note that unlike GSI/LSI where the index is a separate table (a materialized
+# view) with its own permissions, the vector index is *not* a CQL table so
+# it doesn't have its own permissions. Instead, the permission to do a
+# Query requires SELECT permissions on the *base* table. Having permissions
+# on the base table is also important to allow Select='ALL_ATTRIBUTES'.
+
+# new_vs_for_role() creates a boto3 resource supporting vector search API
+# extensions, authenticated with the given role and key instead of the default
+# credentials. Like new_dynamodb(), but with add_vs_to_client() applied
+# so that the connection can send/receive VectorSearch parameters.
+@contextmanager
+def new_vs_for_role(vs, role, key):
+    with new_dynamodb(vs, role, key) as d:
+        with add_vs_to_client(d.meta.client):
+            yield d
+
+# Like authorized(), but also accepts a "Vector Store is disabled" error:
+# permissions are checked before the vector store is accessed, so this
+# error still means the operation was authorized. Using this function instead
+# of authorized() will allow us to test permissions on Query even if the
+# vector store is not configured.
+def authorized_vs(fn):
+    try:
+        return authorized(fn)
+    except ClientError as e:
+        if 'Vector Store is disabled' not in e.response['Error']['Message']:
+            raise
+
+# Test that a Query with VectorSearch requires SELECT permission on the table,
+# just like a regular Query without VectorSearch does (but unlike a Query on
+# a GSI or LSI, which checks permissions on the separate index table).
+def test_rbac_vector_query(vs, cql, table_vs):
+    with new_role(cql) as (role, key):
+        with new_vs_for_role(vs, role, key) as d:
+            # Sanity check: the original superuser (vs) who created the shared
+            # table_vs can perform a vector search query on it. If the vector
+            # store is not configured, we get "Vector Store is disabled" which
+            # still means it was authorized (see authorized_vs() above).
+            authorized_vs(lambda: table_vs.query(IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+            # But in the new role's connection d, without SELECT permissions,
+            # is not allowed to perform the query:
+            tab = d.Table(table_vs.name)
+            unauthorized(lambda: tab.query(IndexName='vind',
+                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+            # Adding SELECT permission to the table, vector search must succeed:
+            with temporary_grant(cql, 'SELECT', cql_table_name(tab), role):
+                authorized_vs(lambda: tab.query(IndexName='vind',
+                    VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+                # Select=ALL_ATTRIBUTES is also allowed
+                authorized_vs(lambda: tab.query(IndexName='vind',
+                    VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1,
+                    Select='ALL_ATTRIBUTES'))
+
+# Test that creating a table with a VectorIndexes parameter requires the
+# same CREATE permission as creating a regular table without VectorIndexes.
+def test_rbac_createtable_vectorindexes(vs, cql):
+    schema = {
+        'KeySchema': [{'AttributeName': 'p', 'KeyType': 'HASH'}],
+        'AttributeDefinitions': [{'AttributeName': 'p', 'AttributeType': 'S'}],
+        'VectorIndexes': [{'IndexName': 'vind',
+                           'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}],
+    }
+    with new_role(cql) as (role, key):
+        with new_vs_for_role(vs, role, key) as d:
+            table_name = unique_table_name()
+            # Without CREATE permissions, CreateTable with VectorIndexes fails:
+            new_named_table_unauthorized(d, table_name, **schema)
+            # With CREATE permissions, CreateTable with VectorIndexes succeeds:
+            with temporary_grant(cql, 'CREATE', 'ALL KEYSPACES', role):
+                with new_named_table(d, table_name, **schema):
+                    pass
+
+# Test that adding or deleting a vector index via UpdateTable requires
+# ALTER permission on the table, just as adding or deleting a GSI does.
+# The vector index is treated as a feature of the base table (like a GSI),
+# so modifying it requires ALTER rather than CREATE/DROP.
+def test_rbac_updatetable_vectorindex(vs, cql):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        with new_role(cql) as (role, key):
+            with new_vs_for_role(vs, role, key) as d:
+                tab = d.Table(table.name)
+                create_vi = {'VectorIndexUpdates': [{'Create': {
+                    'IndexName': 'vind',
+                    'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3},
+                }}]}
+                delete_vi = {'VectorIndexUpdates': [{'Delete': {'IndexName': 'vind'}}]}
+                # Without ALTER permissions, adding a vector index is denied:
+                unauthorized(lambda: tab.meta.client.update_table(
+                    TableName=tab.name, **create_vi))
+                # With ALTER permissions, adding a vector index is allowed:
+                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
+                    authorized(lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **create_vi))
+                # Wait for the vector index to actually exist before we try
+                # to delete it. Use the admin vs connection (table) which has
+                # full permissions and a vs-patched client to parse the response.
+                if vector_store_configured(table):
+                    wait_for_vector_index_active(table, 'vind')
+                # Without ALTER permissions, deleting the vector index is denied.
+                # Use a harmless UpdateTable first to wait until the permission
+                # revocation has taken effect, same technique as in
+                # test_rbac_updatetable_gsi above.
+                unauthorized(lambda: tab.meta.client.update_table(
+                    TableName=tab.name, BillingMode='PAY_PER_REQUEST'))
+                with pytest.raises(ClientError, match='AccessDeniedException'):
+                    tab.meta.client.update_table(TableName=tab.name, **delete_vi)
+                # With ALTER permissions, deleting the vector index is allowed:
+                with temporary_grant(cql, 'ALTER', cql_table_name(tab), role):
+                    authorized(lambda: tab.meta.client.update_table(
+                        TableName=tab.name, **delete_vi))
+
+# The previous tests checked which permissions are required to create and
+# query a vector index, but didn't check that the vector store really had
+# the permissions to read the base table, and could successfully index the
+# data. For example, we can create a base table that the user has permissions
+# to ALTER and MODIFY but not SELECT, so the user can create a vector index,
+# write to the table, but not be able to Query on it - but the vector store
+# will still be able to index the data, and this index can be read by another
+# user who has permissions to SELECT the table.
+# This test is needs_vector_store, i.e., it will be skipped if the vector
+# store is not configured.
+def test_rbac_vectorstore_indexing(vs, needs_vector_store, cql):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        with new_role(cql) as (role, key):
+            with new_vs_for_role(vs, role, key) as d:
+                tab = d.Table(table.name)
+                # Grant ALTER and MODIFY to the role, but *not* SELECT.
+                with temporary_grant(cql, 'ALTER', cql_table_name(table), role):
+                    with temporary_grant(cql, 'MODIFY', cql_table_name(table), role):
+                        p1 = random_string()
+                        # The role is allowed to insert an item (we haven't
+                        # created an index yet, we'll expect this item to be
+                        # visible in prefill).
+                        authorized(lambda: tab.put_item(Item={'p': p1, 'v': [1, 0, 0]}))
+                        # Create the vector index - ALTER permission allows this.
+                        authorized(lambda: tab.meta.client.update_table(
+                            TableName=tab.name, VectorIndexUpdates=[{'Create': {
+                                'IndexName': 'vind',
+                                'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}
+                            }}]))
+                        # Without SELECT permissions, the role cannot Query
+                        # the vector index.
+                        unauthorized(lambda: tab.query(IndexName='vind',
+                            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1))
+                        # Wait for the backfill to complete. We can call
+                        # wait_for_vector_index_active() even on tab, without
+                        # SELECT permissions, because it uses DescribeTable to
+                        # check, not a Query.
+                        wait_for_vector_index_active(table, 'vind')
+                        # The superuser can query and find the prefilled item.
+                        result = table.query(IndexName='vind',
+                            VectorSearch={'QueryVector': [1, 0, 0]}, Limit=1)
+                        assert result.get('Items') and result['Items'][0]['p'] == p1
+                        # Also test the CDC path: the role writes a new item after
+                        # the index is ACTIVE and the vector store should pick it up
+                        # via the CDC log, even though the role lacks SELECT.
+                        p2 = random_string()
+                        authorized(lambda: tab.put_item(Item={'p': p2, 'v': [0, 1, 0]}))
+                        # The superuser ("table") can see the new data:
+                        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+                        while True:
+                            result = table.query(IndexName='vind',
+                                VectorSearch={'QueryVector': [0, 1, 0]}, Limit=1)
+                            if result.get('Items') and result['Items'][0]['p'] == p2:
+                                break
+                            if time.monotonic() > deadline:
+                                pytest.fail('Timed out waiting for vector store to index the item via CDC')
+                            time.sleep(0.1)
+                        # If we now grant SELECT permissions to the role, it should
+                        # be able to query and find both items:
+                        with temporary_grant(cql, 'SELECT', cql_table_name(table), role):
+                            result = authorized(lambda: tab.query(IndexName='vind',
+                                VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2))
+                            assert {item['p'] for item in result['Items']} == {p1, p2}

--- a/test/alternator/test_metrics.py
+++ b/test/alternator/test_metrics.py
@@ -427,6 +427,7 @@ def test_query_vector_operations(vs, metrics):
 #  * scylla_alternator_vector_search_query_items_from_vs,
 #  * scylla_alternator_vector_search_query_items_from_base_table
 # are incremented as needed for a vector search query.
+# Test both global and per-table versions of these metrics.
 # This test requires a configured vector store and will be skipped otherwise.
 def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
     with new_test_table(vs,
@@ -447,39 +448,59 @@ def test_query_vector_item_metrics(vs, metrics, needs_vector_store):
         vs_metric = 'scylla_alternator_vector_search_query_items_from_vs'
         returned_metric = 'scylla_alternator_vector_search_query_returned_items'
         base_metric = 'scylla_alternator_vector_search_query_items_from_base_table'
+        # The same metrics also exist per-table:
+        table_vs_metric = 'scylla_alternator_table_vector_search_query_items_from_vs'
+        table_returned_metric = 'scylla_alternator_table_vector_search_query_returned_items'
+        table_base_metric = 'scylla_alternator_table_vector_search_query_items_from_base_table'
+        table_labels = {'cf': table.name}
         the_metrics = get_metrics(metrics)
         before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        before_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='ALL_ATTRIBUTES')
         assert result['Count'] == 2
         the_metrics = get_metrics(metrics)
         after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        after_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         assert after[vs_metric] - before[vs_metric] == 2
         assert after[returned_metric] - before[returned_metric] == 2
         assert after[base_metric] - before[base_metric] == 2
+        assert after_table[table_vs_metric] - before_table[table_vs_metric] == 2
+        assert after_table[table_returned_metric] - before_table[table_returned_metric] == 2
+        assert after_table[table_base_metric] - before_table[table_base_metric] == 2
 
         # A SELECT=COUNT query doesn't return any items, so increments only
         # items_from_vs, not the other two:
         the_metrics = get_metrics(metrics)
         before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        before_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='COUNT')
         assert result['Count'] == 2
         the_metrics = get_metrics(metrics)
         after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        after_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         assert after[vs_metric] - before[vs_metric] == 2
         assert after[returned_metric] - before[returned_metric] == 0
         assert after[base_metric] - before[base_metric] == 0
+        assert after_table[table_vs_metric] - before_table[table_vs_metric] == 2
+        assert after_table[table_returned_metric] - before_table[table_returned_metric] == 0
+        assert after_table[table_base_metric] - before_table[table_base_metric] == 0
 
         # A SELECT=ALL_PROJECTED_ATTRIBUTES query increments items_from_vs
         # and returned_items, but not items_from_base_table.
         the_metrics = get_metrics(metrics)
         before = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        before_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]}, Limit=2, Select='ALL_PROJECTED_ATTRIBUTES')
         assert result['Count'] == 2
         the_metrics = get_metrics(metrics)
         after = {m: get_metric(metrics, m, None, the_metrics) for m in [vs_metric, returned_metric, base_metric]}
+        after_table = {m: get_metric(metrics, m, table_labels, the_metrics) for m in [table_vs_metric, table_returned_metric, table_base_metric]}
         assert after[vs_metric] - before[vs_metric] == 2
         assert after[returned_metric] - before[returned_metric] == 2
         assert after[base_metric] - before[base_metric] == 0
+        assert after_table[table_vs_metric] - before_table[table_vs_metric] == 2
+        assert after_table[table_returned_metric] - before_table[table_returned_metric] == 2
+        assert after_table[table_base_metric] - before_table[table_base_metric] == 0
 
 # Test counters for DescribeEndpoints:
 def test_describe_endpoints_operations(dynamodb, metrics):

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -41,13 +41,16 @@ boto3.dynamodb.types.DYNAMODB_CONTEXT = decimal.Context(prec=100)
 # Users can use exactly the same code to get vector search support in boto3,
 # but the more "official" way would be to modify botocore's JSON configuration
 # file, botocore/data/dynamodb/2012-08-10/service-2.json.
-@pytest.fixture(scope="module")
-def vs(new_dynamodb_session, dynamodb):
-    if is_aws(dynamodb):
-        skip_env('Scylla-only: vector search extensions not available on DynamoDB')
-    resource = new_dynamodb_session()
-    client = resource.meta.client
-    # Patch the client to support the new APIs:
+
+# add_vs_to_client() is a context manager that modifies the given boto3
+# client to accept the new vector-search parameters in requests and responses,
+# and also monkey-patches the global TypeSerializer/TypeDeserializer so that
+# the Vector type is serialized as FLOAT32VECTOR.
+# On exit, only the global TypeSerializer/TypeDeserializer patches are
+# restored. The per-client service-model mutations (new shapes, added
+# members, AttributeValue.FLOAT32VECTOR, etc.) are not reverted.
+@contextmanager
+def add_vs_to_client(client):
     # All the new parameter "shapes" that we will use below for the
     # new parameters of the different operations:
     new_shapes = {
@@ -197,13 +200,26 @@ def vs(new_dynamodb_session, dynamodb):
             return {'FLOAT32VECTOR': list(value)}
         return _orig_serialize(self, value)
     boto3.dynamodb.types.TypeSerializer.serialize = _serialize_with_vector
+    _sentinel = object()
+    _orig_deserialize_float32vector = getattr(boto3.dynamodb.types.TypeDeserializer, '_deserialize_float32vector', _sentinel)
     boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector = lambda self, value: Vector(value)
+    try:
+        yield
+    finally:
+        boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
+        if _orig_deserialize_float32vector is _sentinel:
+            del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
+        else:
+            boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector = _orig_deserialize_float32vector
 
-    yield resource
 
-    # Restore the original serialize method and remove the deserializer patch.
-    boto3.dynamodb.types.TypeSerializer.serialize = _orig_serialize
-    del boto3.dynamodb.types.TypeDeserializer._deserialize_float32vector
+@pytest.fixture(scope="module")
+def vs(new_dynamodb_session, dynamodb):
+    if is_aws(dynamodb):
+        skip_env('Scylla-only: vector search extensions not available on DynamoDB')
+    resource = new_dynamodb_session()
+    with add_vs_to_client(resource.meta.client):
+        yield resource
 
 # Use the Vector(list) type for test values that are meant to be stored as
 # optimized vectors (array of floats instead of JSON list of numbers).

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -929,6 +929,9 @@ def test_putitem_vectorindex_updatetable(vs):
 # global queries on it, not filtering to a specific partition, may get
 # results from other tests - so such tests will need to create their own
 # table instead of using this shared one.
+# If vector store is configured, we wait for the vector index to become
+# active before yielding the table, so tests that use this fixture can
+# read from it immediately.
 @pytest.fixture(scope="module")
 def table_vs(vs):
     with new_test_table(vs,
@@ -938,6 +941,8 @@ def table_vs(vs):
                 {'IndexName': 'vind',
                  'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}
             ]) as table:
+        if vector_store_configured(table):
+            wait_for_vector_index_active(table, 'vind')
         yield table
 
 # Test that a Query with a VectorSearch parameter without an IndexName
@@ -1113,7 +1118,7 @@ def vector_store_configured(table_vs):
 # It is assumed that if Scylla is configured to use the vector store, then
 # the reverse is also true - the vector store is configured to use Scylla,
 # so we can check the end-to-end functionality.
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def needs_vector_store(table_vs):
     if not vector_store_configured(table_vs):
         skip_env('Vector Store is not configured (run with --vs)')

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1030,6 +1030,34 @@ def test_query_vectorsearch_limit_bad(table_vs):
                 Limit=bad_limit
             )
 
+# The maximum allowed Limit for vector search. Set as max_vector_search_limit
+# in alternator/executor_read.cc, and analogous to CQL's max_ann_query_limit
+# defined in cql3/statements/select_statement.hh.
+MAX_VECTOR_SEARCH_LIMIT = 1000
+
+# Test that a Query with VectorSearch does not allow a Limit above
+# MAX_VECTOR_SEARCH_LIMIT. This limit also exists in CQL as max_ann_query_limit
+# in vector_indexed_table_select_statement (select_statement.hh). The allowed
+# Limit needs to be limited because vector search does not support pagination.
+def test_query_vectorsearch_limit_too_large(table_vs):
+    with pytest.raises(ClientError, match='ValidationException.*Limit'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [1, 2, 3]},
+            Limit=MAX_VECTOR_SEARCH_LIMIT + 1,
+        )
+
+# Test that a Query with VectorSearch with Limit=MAX_VECTOR_SEARCH_LIMIT
+# (the maximum allowed value) succeeds - it should not be rejected.
+# The query may return fewer results than the limit (the table_vs fixture
+# has few items, possibly none), but must not fail with a validation error.
+def test_query_vectorsearch_limit_at_max(table_vs, needs_vector_store):
+    table_vs.query(
+        IndexName='vind',
+        VectorSearch={'QueryVector': [1, 2, 3]},
+        Limit=MAX_VECTOR_SEARCH_LIMIT,
+    )
+
 # Test that a Query with VectorSearch does not support ConsistentRead=True,
 # just like queries on a GSI.
 def test_query_vectorsearch_consistent_read(table_vs):

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -3001,37 +3001,358 @@ def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
             time.sleep(0.1)
 
 ##############################################################################
-# CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:
-# Tests *pre-filtering* for filtering on projected attributes, which can be (if
-# we continue the implementation) pushed to the vector store or right now -
-# key columns.
-# We need to decide: In DynamoDB pre-filtering is done with
-# KeyConditionExpression NOT FilterExpression.
-# KeyConditionExpression is the traditional approach in Query, but is a bit
-# weird because these aren't really "keys" (even though in CQL CREATE TABLE
-# syntax we pretend they are - and today, they really are keys).
-# Do we want to force the user to put these pre-filtering in KeyConditionExpression
-# instead of FilterExpression, and only allow FilterExpression for post-filtering
-# that must be done in Scylla?
-# Alternatively, we could put everything in FilterExpression. This is less
-# with DynamoDB's usual semantics but simpler for users.
-############################################################################
+# Tests for vector search pre-filtering via KeyConditionExpression.
+#
+# KeyConditionExpression in a vector search query is sent to the vector store
+# as a pre-filter: only nearest neighbors from the matching set are returned.
+# Only projected attributes (currently key columns) may be referenced.
+# Operators supported: =, <, <=, >, >=, IN, BETWEEN. OR and NOT are rejected.
+##############################################################################
 
-# WRITE TEST:
-# Test that if the FilterExpression happens to only use projected attributes
-# (by default this means key attributes) - or if we decide (see above) that
-# it's KeyconditionExpression, then it can be, and is, sent to the vector
-# store and performed there. We can check that this happens by noticing that
-# we get a full LIMIT of results, and not less.
+# Test that the old-style KeyConditions (non-expression API) is rejected for
+# vector search queries (just like QueryFilter is rejected).
+def test_query_vectorsearch_key_conditions_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException.*KeyConditions'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditions={'p': {'AttributeValueList': [{'S': 'x'}], 'ComparisonOperator': 'EQ'}},
+        )
 
-# WRITE TEST:
-# Test FilterExpression for post-filtering vector search results with
-# Select=ALL_PROJECTED_ATTRIBUTES where the filter only needs projected
-# attributes (currently those are key attributes). Here it is important
-# for efficency that the vector index applies the filter and we do not need
-# to retrive the full items from the base table at all. We can verify that
-# this code path was reached by checking that we got back LIMIT results, and
-# not fewer.
+# Test that KeyConditionExpression referencing a non-projected attribute is
+# rejected with a ValidationException.
+def test_query_vectorsearch_key_condition_nonprojected(table_vs):
+    # The table 'table_vs' has only 'p' as a key column. 'v' (the vector
+    # attribute) and 'x' (a regular attribute) are not projected.
+    for bad_attr in ['v', 'x']:
+        with pytest.raises(ClientError, match='ValidationException'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression=f'{bad_attr} = :val',
+                ExpressionAttributeValues={':val': 'anything'},
+            )
+
+# Test that NOT in a KeyConditionExpression is rejected for vector search
+# pre-filtering.
+def test_query_vectorsearch_key_condition_not_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='NOT p = :p',
+            ExpressionAttributeValues={':p': 'x'},
+        )
+
+# Test that OR in a KeyConditionExpression is rejected for vector search
+# pre-filtering. This is because the vector store currently only supports
+# AND among a list of conditions given to it in the pre-filter.
+def test_query_vectorsearch_key_condition_or_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='p = :p1 OR p = :p2',
+            ExpressionAttributeValues={':p1': 'x', ':p2': 'y'},
+        )
+
+# Test that an unsupported operator (<>) in a KeyConditionExpression is
+# rejected for vector search pre-filtering. The vector store does not
+# currently support a not-equal operator.
+def test_query_vectorsearch_key_condition_ne_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='p <> :p',
+            ExpressionAttributeValues={':p': 'x'},
+        )
+
+# Test that a boolean function call (e.g. attribute_exists()) in a
+# KeyConditionExpression is rejected. attribute_exists() is valid in a
+# FilterExpression but not in a vector search KeyConditionExpression
+# because the vector store can't support it.
+def test_query_vectorsearch_key_condition_function_rejected(table_vs):
+    with pytest.raises(ClientError, match='ValidationException'):
+        table_vs.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': [0, 0, 1]},
+            Limit=1,
+            KeyConditionExpression='attribute_exists(p)',
+        )
+
+# Test that using an unsupported value type (e.g. a list) in a
+# KeyConditionExpression pre-filter is rejected with a ValidationException.
+# Only S (string) and N (number) are valid types for pre-filter comparisons.
+# Note that we can't even pass N when the attribute is a key column of type
+# S - this will be tested below (test_query_vectorsearch_prefilter_type_mismatch).
+def test_query_vectorsearch_prefilter_bad_value_type(table_vs):
+    for bad_val in [
+        ['hello', 'world'],      # List -> DynamoDB L type
+        {'key': 'val'},          # Map -> DynamoDB M type
+        b'hello',                # bytes -> DynamoDB B type
+    ]:
+        with pytest.raises(ClientError, match='ValidationException.*KeyConditionExpression'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression='p = :p',
+                ExpressionAttributeValues={':p': bad_val},
+            )
+
+# Test that passing a constant whose DynamoDB type does not match the key
+# column's declared type is rejected with a ValidationException.  table_vs
+# has a string (S) partition key 'p', so passing a numeric (N) value should
+# be rejected for all comparison operators.
+def test_query_vectorsearch_prefilter_type_mismatch(table_vs):
+    num_val = Decimal('42')
+    for kce, vals in [
+        ('p = :v',                {':v': num_val}),
+        ('p < :v',                {':v': num_val}),
+        ('p <= :v',               {':v': num_val}),
+        ('p > :v',                {':v': num_val}),
+        ('p >= :v',               {':v': num_val}),
+        ('p IN (:v)',             {':v': num_val}),
+        ('p BETWEEN :lo AND :hi', {':lo': num_val, ':hi': num_val}),
+    ]:
+        # This test doesn't request a vector store to be configured (no
+        # needs_vector_store fixture) so following query() can't succeed;
+        # But we expect to get the specific error "Type mismatch" before
+        # the query is even gets to checking if there is a vector store.
+        with pytest.raises(ClientError, match='ValidationException.*Type mismatch'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression=kce,
+                ExpressionAttributeValues=vals,
+            )
+
+# Test that using a nested attribute path (e.g. "a.b") in a
+# KeyConditionExpression pre-filter is rejected with a ValidationException.
+# Only top-level attribute names are supported; nested paths would require
+# the vector store to understand DynamoDB's nested document model.
+def test_query_vectorsearch_key_condition_nested_attr_rejected(table_vs):
+    for kce, vals in [
+        ('a.b = :v',             {':v': 'x'}),
+        ('a.b < :v',             {':v': 'x'}),
+        ('a.b IN (:v)',          {':v': 'x'}),
+        ('a.b BETWEEN :lo AND :hi', {':lo': 'x', ':hi': 'z'}),
+    ]:
+        with pytest.raises(ClientError, match='ValidationException.*nested'):
+            table_vs.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': [0, 0, 1]},
+                Limit=1,
+                KeyConditionExpression=kce,
+                ExpressionAttributeValues=vals,
+            )
+
+# Success-path test: KeyConditionExpression pre-filter is applied by the vector
+# store before ANN, so the result always contains exactly Limit items (if that
+# many matching items exist) regardless of how many non-matching items are
+# nearer to the query vector.
+#
+# Setup: 4 items in the table. 2 "keep" items have vectors far from the query
+# ([0,0,1]); 2 "drop" items have vectors very close to the query. With
+# Limit=2:
+#   - Without pre-filtering: ANN returns the 2 "drop" items (nearest), then a
+#     post-filter would keep 0 items.
+#   - With pre-filtering (KeyConditionExpression p IN ('keep1','keep2')): ANN
+#     only considers "keep" items and returns both -> Count=2, ScannedCount=2.
+def test_query_vectorsearch_prefilter_in(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_keep1, p_keep2 = random_string(), random_string()
+        p_drop1, p_drop2 = random_string(), random_string()
+        # "drop" items are nearest to the query vector [0, 0, 1].
+        # "keep" items are farther away.
+        table.put_item(Item={'p': p_drop1, 'v': Vector([0, 0, 1])})
+        table.put_item(Item={'p': p_drop2, 'v': Vector([0, 0.1, 1])})
+        table.put_item(Item={'p': p_keep1, 'v': Vector([1, 0, 0])})
+        table.put_item(Item={'p': p_keep2, 'v': Vector([0.9, 0, 0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # With Limit=2 and a pre-filter restricting to keep1/keep2, we expect
+        # exactly 2 results (both keep items), even though the 2 nearest overall
+        # items are the drop items.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            KeyConditionExpression='p IN (:k1, :k2)',
+            ExpressionAttributeValues={':k1': p_keep1, ':k2': p_keep2},
+        )
+        assert result['Count'] == 2 and result['ScannedCount'] == 2
+        assert {item['p'] for item in result['Items']} == {p_keep1, p_keep2}
+        # Let's contrast the above pre-filter with how post-filter works:
+        # without a filter, Limit=2 returns the 2 nearest items - the "drop"
+        # items. A post-FilterExpression on 'p' asking for the keep items
+        # would then return 0 results. This demonstrates why pre-filtering is
+        # important.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+        )
+        assert {item['p'] for item in result['Items']} == {p_drop1, p_drop2}
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            FilterExpression='p IN (:k1, :k2)',
+            ExpressionAttributeValues={':k1': p_keep1, ':k2': p_keep2},
+        )
+        assert result['Count'] == 0
+        assert result['ScannedCount'] == 2
+
+# Success-path test: KeyConditionExpression with equality on the partition key.
+# Similar to test_query_vectorsearch_prefilter_in but uses a single = condition.
+# With Limit=1, the pre-filter restricts the ANN to a single partition key, so
+# exactly 1 result is returned even though closer items exist.
+def test_query_vectorsearch_prefilter_equality(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p_keep = random_string()
+        p_drop = random_string()
+        table.put_item(Item={'p': p_drop, 'v': Vector([0, 0, 1])})   # nearest to query
+        table.put_item(Item={'p': p_keep, 'v': Vector([1, 0, 0])})   # farther
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression='p = :p',
+            ExpressionAttributeValues={':p': p_keep},
+        )
+        # The pre-filter restricts to p_keep only, so we get exactly 1 result
+        # even though p_drop is the nearest neighbor overall.
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_keep
+        assert result['ScannedCount'] == 1
+
+# Success-path test: KeyConditionExpression with a string inequality (<)
+# pre-filter. String comparisons in the vector store are lexicographic.
+# Also tests that when the constant is on the left-hand side of the
+# comparison (e.g. ':threshold > p'), the operator is correctly reversed
+# (treated as 'p < :threshold').
+def test_query_vectorsearch_prefilter_string_inequality(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        # All 'z_'-prefixed keys are lexicographically > 'm';
+        # the 'a_'-prefixed key is lexicographically < 'm'.
+        p_drop = 'z_' + random_string()   # nearest to query, key > 'm'
+        p_hi   = 'z_' + random_string()   # farther from query, key > 'm'
+        p_lo   = 'a_' + random_string()   # farther from query, key < 'm'
+        table.put_item(Item={'p': p_drop, 'v': Vector([0, 0, 1])})   # nearest to query
+        table.put_item(Item={'p': p_hi,   'v': Vector([1, 0, 0])})   # farther, high key
+        table.put_item(Item={'p': p_lo,   'v': Vector([0.9, 0, 0])}) # farther, low key
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Lexicographic inequality: p < 'm' keeps only p_lo ('a_...' < 'm').
+        # p_drop ('z_...') is nearest overall but is excluded by the pre-filter.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression='p < :threshold',
+            ExpressionAttributeValues={':threshold': 'm'},
+        )
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_lo
+        assert result['ScannedCount'] == 1
+        # Same inequality with the constant on the left-hand side: ':threshold > p'
+        # is equivalent to 'p < :threshold' (the operator is reversed internally).
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression=':threshold > p',
+            ExpressionAttributeValues={':threshold': 'm'},
+        )
+        assert result['Count'] == 1 and result['Items'][0]['p'] == p_lo
+        assert result['ScannedCount'] == 1
+
+# Success-path test: KeyConditionExpression with a AND on two conditions on
+# two projected attributes (the partition key and sort key). One of the
+# conditions is a BETWEEN condition on a number attribute.
+def test_query_vectorsearch_prefilter_and_number_between(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                       {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
+                                   {'AttributeName': 'c', 'AttributeType': 'N'}]) as table:
+        p = random_string()
+        # c=1 and c=2 are "keep" items (c in [1,2]); c=3 and c=4 are "drop".
+        # "drop" items are nearest to the query vector.
+        table.put_item(Item={'p': p, 'c': 3, 'v': Vector([0, 0, 1])})
+        table.put_item(Item={'p': p, 'c': 4, 'v': Vector([0, 0.1, 1])})
+        table.put_item(Item={'p': p, 'c': 1, 'v': Vector([1, 0, 0])})
+        table.put_item(Item={'p': p, 'c': 2, 'v': Vector([0.9, 0, 0])})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=2,
+            KeyConditionExpression='p = :p AND c BETWEEN :lo AND :hi',
+            ExpressionAttributeValues={':p': p, ':lo': 1, ':hi': 2},
+        )
+        assert result['Count'] == 2 and result['ScannedCount'] == 2
+        assert {item['c'] for item in result['Items']} == {Decimal(1), Decimal(2)}
+
+# Test KeyConditionExpression pre-filter with a numeric sort key value that
+# cannot be represented exactly as a 64-bit double.
+# 2^53 + 1 = 9007199254740993 is the classic example: as a double it rounds to
+# 9007199254740992 (= 2^53). If the pre-filter RHS were converted through double,
+# the equality condition 'c = 9007199254740993' would silently become
+# 'c = 9007199254740992', which matches the wrong item (c_drop) and the ANN
+# search would return c_drop (the nearest vector) rather than c_keep.
+# By keeping the value as a decimal string the comparison is exact.
+def test_query_vectorsearch_prefilter_number_big_decimal(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'},
+                       {'AttributeName': 'c', 'KeyType': 'RANGE'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'},
+                                   {'AttributeName': 'c', 'AttributeType': 'N'}]) as table:
+        p = random_string()
+        c_drop = Decimal('9007199254740992')  # 2^53, representable as double, nearest to query
+        c_keep = Decimal('9007199254740993')  # 2^53+1, NOT representable as double (rounds to c_drop)
+        table.put_item(Item={'p': p, 'c': c_drop, 'v': Vector([0, 0, 1])})  # nearest to query
+        table.put_item(Item={'p': p, 'c': c_keep, 'v': Vector([1, 0, 0])})  # farther from query
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Pre-filter c = c_keep. If the value were converted through double it
+        # would become c_drop's value (9007199254740992), and ANN would return
+        # c_drop (the nearest item) instead of c_keep.
+        result = table.query(
+            IndexName='vind',
+            VectorSearch={'QueryVector': Vector([0, 0, 1])},
+            Limit=1,
+            KeyConditionExpression='p = :p AND c = :c',
+            ExpressionAttributeValues={':p': p, ':c': c_keep},
+        )
+        assert result['Count'] == 1 and result['ScannedCount'] == 1
+        assert result['Items'][0]['c'] == c_keep
+
 
 # TODO: Like test_vector_projection_keys_only, write additional tests for
 # ProjectionType=INCLUDE with NonKeyAttributes and ProjectionType=ALL.

--- a/test/alternator/test_vector.py
+++ b/test/alternator/test_vector.py
@@ -1376,11 +1376,12 @@ def test_query_vector_cdc_lwt(vs, needs_vector_store):
 # Similar to test_query_vector_cdc, this test also that a vector search Query
 # find data inserted after the index was created. But this test adds a twist:
 # before creating the index, we insert a malformed value for the vector
-# attribute (a string). We check that this malformed is ignored by the initial
-# prefill scan, but should not prevent a later write with a well-formed vector
-# from being indexed and returned by queries.
+# attribute (a string or wrong-length vector). We check that this malformed
+# value is ignored by the initial prefill scan, but should not prevent a later
+# write with a well-formed vector from being indexed and returned by queries.
+@pytest.mark.parametrize('use_update_item', [False, True], ids=['put_item', 'update_item'])
 @pytest.mark.parametrize('malformed', ['garbage', [1,2]], ids=['string','wrong_length'])
-def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed):
+def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed, use_update_item):
     with new_test_table(vs,
             KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
             AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
@@ -1403,7 +1404,12 @@ def test_query_vector_cdc_malformed_prefill(vs, needs_vector_store, malformed):
         assert len(result['Items']) == 1 and result['Items'][0]['p'] == p2
         # Now replace the value of p1 by a properly formed vector. It should
         # be eventually picked up by CDC and indexed by the vector index:
-        table.put_item(Item={'p': p1, 'v': [1, Decimal("0.1"), 0]})
+        if use_update_item:
+            table.update_item(Key={'p': p1},
+                UpdateExpression='SET v = :v',
+                ExpressionAttributeValues={':v': [1, Decimal("0.1"), 0]})
+        else:
+            table.put_item(Item={'p': p1, 'v': [1, Decimal("0.1"), 0]})
         deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
         while True:
             result = table.query(IndexName='vind', VectorSearch={'QueryVector': [1, 0, 0]},
@@ -1645,6 +1651,18 @@ def test_batchwriteitem_vectorindex_bad_vector(table_vs):
         with table_vs.batch_writer() as batch:
             batch.put_item(Item={'p': p, 'v': [1, Decimal('1e100'), 3]})
 
+# If one item in the batch is valid and another is invalid, the entire
+# batch should be rejected and neither item should be inserted:
+def test_batchwriteitem_vectorindex_bad_and_good(table_vs):
+    p_good = random_string()
+    p_bad = random_string()
+    with pytest.raises(ClientError, match='ValidationException'):
+        with table_vs.batch_writer() as batch:
+            batch.put_item(Item={'p': p_good, 'v': [1, 2, 3]})
+            batch.put_item(Item={'p': p_bad,  'v': 'not a list'})
+    assert 'Item' not in table_vs.get_item(Key={'p': p_good}, ConsistentRead=True)
+    assert 'Item' not in table_vs.get_item(Key={'p': p_bad},  ConsistentRead=True)
+
 # Test that DeleteItem removes the item from the vector index.
 # Two variants are tested via parametrize:
 # - without clustering key (no_ck): deleting the only item in a partition
@@ -1700,6 +1718,115 @@ def test_deleteitem_vectorindex(vs, needs_vector_store, with_ck):
             if time.monotonic() > deadline:
                 pytest.fail('Timed out waiting for deleted item to disappear from vector index')
             time.sleep(0.1)
+
+# Test that PutItem or UpdateItem on an existing item replaces its vector in
+# the index: the old vector is removed and the new one is indexed. Two items
+# are inserted so we can verify the ordering changes after the replace.
+@pytest.mark.parametrize('use_update_item', [False, True], ids=['put_item', 'update_item'])
+def test_replace_vector_vectorindex(vs, needs_vector_store, use_update_item):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p1 = random_string()
+        p2 = random_string()
+        # Insert two different items and index them.
+        table.put_item(Item={'p': p1, 'v': [1, 0, 0]})
+        table.put_item(Item={'p': p2, 'v': [0, 1, 0]})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # Initially, search [1, 0, 0] returns p1 first, p2 second.
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Limit=2)
+        assert [item['p'] for item in result['Items']] == [p1, p2]
+        # Replace p1's vector with [-1, 0, 0] (opposite direction, now farthest
+        # from [1, 0, 0]), using either PutItem or UpdateItem.
+        if use_update_item:
+            table.update_item(Key={'p': p1},
+                UpdateExpression='SET v = :v',
+                ExpressionAttributeValues={':v': [-1, 0, 0]})
+        else:
+            table.put_item(Item={'p': p1, 'v': [-1, 0, 0]})
+        # Wait until the index reflects the change: p2 should now come before p1
+        # in a search for [1, 0, 0].
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(IndexName='vind',
+                                 VectorSearch={'QueryVector': [1, 0, 0]},
+                                 Limit=2)
+            got = [item['p'] for item in result.get('Items', [])]
+            if got == [p2, p1]:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f'Timed out waiting for index to reflect replaced vector; last order: {got}')
+            time.sleep(0.1)
+
+# Test that UpdateItem modifying non-vector attributes does not affect the
+# vector index: the item remains discoverable by its unchanged vector, and
+# its updated attributes are returned with Select='ALL_ATTRIBUTES'.
+def test_updateitem_nonvector_vectorindex(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'before'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        # UpdateItem to change a non-vector attribute.
+        table.update_item(Key={'p': p},
+            UpdateExpression='SET x = :newx',
+            ExpressionAttributeValues={':newx': 'after'})
+        # The item should still be findable by its vector, which didn't change.
+        # Select='ALL_ATTRIBUTES' fetches the full item from the base table (x
+        # is not projected), so the updated x should be visible immediately
+        # without any delay (note that actually, the item is read with eventual
+        # consistency so there can be a delay, on our single-node setup there
+        # won't be any consistency delay).
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Select='ALL_ATTRIBUTES',
+                             Limit=1)
+        assert result['Items'] == [{'p': p, 'v': [1, 0, 0], 'x': 'after'}]
+
+# Test that UpdateItem removing the vector attribute (but not the item itself)
+# causes the item to be removed from the vector index. The item should still
+# exist in the base table (readable via GetItem), but must no longer appear
+# in vector search results.
+def test_updateitem_remove_vector_vectorindex(vs, needs_vector_store):
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}]) as table:
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': [1, 0, 0], 'x': 'hello'})
+        table.update(VectorIndexUpdates=[{'Create':
+            {'IndexName': 'vind',
+             'VectorAttribute': {'AttributeName': 'v', 'Dimensions': 3}}}])
+        wait_for_vector_index_active(table, 'vind')
+        result = table.query(IndexName='vind',
+                             VectorSearch={'QueryVector': [1, 0, 0]},
+                             Limit=1)
+        # Verify the item was indexed
+        assert result['Items'] == [{'p': p}]
+        # Remove only the vector attribute, leaving the rest of the item intact.
+        table.update_item(Key={'p': p}, UpdateExpression='REMOVE v')
+        # The item must eventually disappear from the vector index.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(IndexName='vind',
+                                 VectorSearch={'QueryVector': [1, 0, 0]},
+                                 Limit=1)
+            if not result['Items']:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail('Timed out waiting for item to disappear from vector index after vector attribute removal')
+            time.sleep(0.1)
+        # The item itself must still exist in the base table, just without 'v'.
+        result = table.get_item(Key={'p': p}, ConsistentRead=True)
+        assert result['Item'] == {'p': p, 'x': 'hello'}
 
 # Test vector index with Alternator TTL together. A table is created without
 # TTL enabled, data is inserted with expiration time set to the past (but
@@ -2802,6 +2929,55 @@ def test_query_vectorsearch_return_similarity_dot_product_overflow2(vs, needs_ve
         assert scores[1] == pytest.approx(0.5, abs=1e-5)
         # The highly dissimilar item's score should be large and negative.
         assert scores[2] < -BIG
+
+# In virtually all the tests above, we used vectors of dimension 3 as an
+# example. But dimensions up to MAX_VECTOR_DIMENSION are allowed, so let's
+# have at least one test that actually uses MAX_VECTOR_DIMENSION to check
+# that it works end-to-end - indexing (via either prefill or CDC) and
+# querying.
+@pytest.mark.parametrize('via_cdc', [False, True], ids=['prefill', 'cdc'])
+def test_query_vector_max_dimension(vs, needs_vector_store, via_cdc):
+    dim = MAX_VECTOR_DIMENSION
+    with new_test_table(vs,
+            KeySchema=[{'AttributeName': 'p', 'KeyType': 'HASH'}],
+            AttributeDefinitions=[{'AttributeName': 'p', 'AttributeType': 'S'}],
+            **({} if not via_cdc else
+               {'VectorIndexes': [{'IndexName': 'vind',
+                                   'VectorAttribute': {'AttributeName': 'v',
+                                                       'Dimensions': dim}}]}
+            )) as table:
+        if via_cdc:
+            # The index was already created in new_test_table above. Wait for
+            # it to become ACTIVE so that subsequent writes are picked up via
+            # CDC rather than prefill.
+            wait_for_vector_index_active(table, 'vind')
+        # Build a query vector: all zeros except the first element which is 1.
+        # The item we insert has exactly this vector, so it is the nearest
+        # neighbor of the query.
+        query_vec = Vector([1.0] + [0.0] * (dim - 1))
+        p = random_string()
+        table.put_item(Item={'p': p, 'v': query_vec})
+        if not via_cdc:
+            # For the prefill case the index is created after the data, so
+            # we create it now and wait for the prefill scan to complete.
+            table.update(VectorIndexUpdates=[{'Create':
+                {'IndexName': 'vind',
+                 'VectorAttribute': {'AttributeName': 'v', 'Dimensions': dim}}}])
+            wait_for_vector_index_active(table, 'vind')
+        # Retry the query until the item appears in the results.
+        deadline = time.monotonic() + VECTOR_STORE_TIMEOUT
+        while True:
+            result = table.query(
+                IndexName='vind',
+                VectorSearch={'QueryVector': query_vec},
+                Limit=1,
+            )
+            if result.get('Items') and result['Items'][0]['p'] == p:
+                break
+            if time.monotonic() > deadline:
+                pytest.fail(f'Timed out waiting for MAX_VECTOR_DIMENSION={dim} item to appear via '
+                            f'{"CDC" if via_cdc else "prefill"}')
+            time.sleep(0.1)
 
 ##############################################################################
 # CONTINUE HERE - MAKE A DECISION! PRE-FILTERING:


### PR DESCRIPTION
This series continues to implement features of Alternator vector search which have not yet implemented. 

The main feature added in this series is **pre-filtering** (filter passed to vector store), using `KeyConditionExpression`. Currently, the vector store only has access to the base table's **key** columns, so only those can be used in pre-filtering. In a later, separate, pull request (#29959) we will add the ability to _project_ additional columns into the vector store and use those in pre-filtering.

Additional smaller improvements included in this series:

* Additional tests for already existing Alternator vector search features.
* Cap the "Limit" of a vector-search Query to 1000. This is the same limit that is enforced in CQL vector-search.
* Fix some metrics whose per-table versions we forgot to update.

We've decided not to backport improvements to the Alternator vector search feature, so do not backport this one either.