### PR TITLE
test.py: stop servers still starting during cleanup

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1254,7 +1254,7 @@ class ScyllaCluster:
         # (from exit artifacts), which leads to issues (#15755). A more elegant solution would be
         # to prevent that instead of using a lock here.
         async with self.stop_lock:
-            if self.is_running:
+            if self.is_running or self.running or self.starting:
                 self.is_running = False
                 self.logger.info("Cluster %s stopping", self)
                 self.is_dirty = True
@@ -1262,7 +1262,7 @@ class ScyllaCluster:
 
     async def stop_gracefully(self) -> None:
         """Stop all running or starting servers in a clean way"""
-        if self.is_running:
+        if self.is_running or self.running or self.starting:
             self.is_running = False
             self.logger.info("Cluster %s stopping gracefully", self)
             self.is_dirty = True
@@ -1361,14 +1361,24 @@ class ScyllaCluster:
             else:
                 await server.install()
         except BaseException as exc:
+            if server is not None:
+                self.starting.pop(server.server_id, None)
             workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
                           ip_addr, workdir, str(exc))
             await handle_join_failure()
             raise
-        finally:
-            if server is not None:
-                self.starting.pop(server.server_id, None)
+
+        assert server is not None
+
+        if self.starting.get(server.server_id) is not server:
+            try:
+                await server.stop()
+            finally:
+                await handle_join_failure()
+            raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
+
+        self.starting.pop(server.server_id)
 
         if expected_error:
             await handle_join_failure()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1180,6 +1180,9 @@ class ScyllaCluster:
         self.servers = ChainMap(self.running, self.stopped)
         self.removed: Set[ServerNum] = set()                    # removed servers (might be running)
         self.starting: Dict[ServerNum, ScyllaServer] = {}       # servers starting right now, not yet running (and not included in "servers").
+        # Starting servers that were already asked to stop. They remain in self.starting until the stop path or add_server()
+        # finishes the state transition, but add_server() must treat them as cancelled immediately.
+        self.stopping_starting: Dict[ServerNum, ScyllaServer] = {}
         # The first IP assigned to a server added to the cluster.
         self.initial_seed: Optional[IPAddress] = None
         # cluster is started (but it might not have running servers)
@@ -1225,10 +1228,20 @@ class ScyllaCluster:
         Call this function only if the cluster is stopped and will not be started again."""
         assert not self.running
         assert not self.starting
+        assert not self.stopping_starting
         self.logger.info("Cluster %s releases ips %s", self, self.leased_ips)
         while self.leased_ips:
             ip = self.leased_ips.pop()
             await self.host_registry.release_host(Host(ip))
+
+    def _is_still_starting(self, server: ScyllaServer) -> bool:
+        return self.starting.get(server.server_id) is server and self.stopping_starting.get(server.server_id) is not server
+
+    def _remove_starting(self, server: ScyllaServer) -> None:
+        if self.starting.get(server.server_id) is server:
+            self.starting.pop(server.server_id)
+        if self.stopping_starting.get(server.server_id) is server:
+            self.stopping_starting.pop(server.server_id)
 
     async def _stop_servers(self, gracefully: bool) -> None:
         """Stop all servers with live or potentially live processes."""
@@ -1236,10 +1249,20 @@ class ScyllaCluster:
             running = list(self.running.items())
             starting = list(self.starting.items())
 
-            if gracefully:
-                await gather_safely(*(server.stop_gracefully() for _, server in itertools.chain(running, starting)))
-            else:
-                await gather_safely(*(server.stop() for _, server in itertools.chain(running, starting)))
+            for server_id, server in starting:
+                if self.starting.get(server_id) is server:
+                    self.stopping_starting[server_id] = server
+
+            try:
+                if gracefully:
+                    await gather_safely(*(server.stop_gracefully() for _, server in itertools.chain(running, starting)))
+                else:
+                    await gather_safely(*(server.stop() for _, server in itertools.chain(running, starting)))
+            except BaseException:
+                for server_id, server in starting:
+                    if self.stopping_starting.get(server_id) is server:
+                        self.stopping_starting.pop(server_id)
+                raise
 
             for server_id, server in running:
                 if self.running.get(server_id) is server:
@@ -1247,6 +1270,8 @@ class ScyllaCluster:
             for server_id, server in starting:
                 if self.starting.get(server_id) is server:
                     self.stopped[server_id] = self.starting.pop(server_id)
+                if self.stopping_starting.get(server_id) is server:
+                    self.stopping_starting.pop(server_id)
 
     async def stop(self) -> None:
         """Stop all running or starting servers ASAP"""
@@ -1354,7 +1379,7 @@ class ScyllaCluster:
             self.logger.info("Cluster %s adding server...", self)
             if start:
                 def check_still_starting() -> None:
-                    if self.starting.get(server.server_id) is not server:
+                    if not self._is_still_starting(server):
                         raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
 
                 await server.install_and_start(self.api, expected_error, expected_server_up_state, before_start=check_still_starting)
@@ -1362,7 +1387,7 @@ class ScyllaCluster:
                 await server.install()
         except BaseException as exc:
             if server is not None:
-                self.starting.pop(server.server_id, None)
+                self._remove_starting(server)
             workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
                           ip_addr, workdir, str(exc))
@@ -1371,14 +1396,15 @@ class ScyllaCluster:
 
         assert server is not None
 
-        if self.starting.get(server.server_id) is not server:
+        if not self._is_still_starting(server):
+            self._remove_starting(server)
             try:
                 await server.stop()
             finally:
                 await handle_join_failure()
             raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
 
-        self.starting.pop(server.server_id)
+        self._remove_starting(server)
 
         if expected_error:
             await handle_join_failure()
@@ -1519,18 +1545,26 @@ class ScyllaCluster:
             server = self.running[server_id]
         else:
             server = self.starting[server_id]
+            self.stopping_starting[server_id] = server
         # Remove the server from `running` only after we successfully stop it.
         # Stopping may fail and if we removed it from `running` now it might leak.
-        if gracefully:
-            await server.stop_gracefully()
-        else:
-            await server.stop()
+        try:
+            if gracefully:
+                await server.stop_gracefully()
+            else:
+                await server.stop()
+        except BaseException:
+            if self.stopping_starting.get(server_id) is server:
+                self.stopping_starting.pop(server_id)
+            raise
         if server_id in self.running:
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
             if self.starting.get(server_id) is server:
                 self.stopped[server_id] = self.starting.pop(server_id)
+            if self.stopping_starting.get(server_id) is server:
+                self.stopping_starting.pop(server_id)
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -568,7 +568,7 @@ class ScyllaServer:
             if before_start is not None:
                 before_start()
             self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
-            await self.start(api, expected_error, expected_server_up_state)
+            await self.start(api, expected_error, expected_server_up_state, before_start=before_start)
         except:
             await self.stop()
             raise
@@ -902,7 +902,8 @@ class ScyllaServer:
                     expected_error: Optional[str] = None,
                     expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
                     cmdline_options_override: list[str] | None = None,
-                    append_env_override: dict[str, str] | None = None) -> None:
+                    append_env_override: dict[str, str] | None = None,
+                    before_start: Callable[[], None] | None = None) -> None:
         """Start an installed server.
 
         Use `cmdline_options_override` and `append_env_override` instead of `self.cmdline_options` and
@@ -917,6 +918,10 @@ class ScyllaServer:
         env.update(self.append_env if append_env_override is None else append_env_override)
         env['UBSAN_OPTIONS'] = f'halt_on_error=1:abort_on_error=1:suppressions={TOP_SRC_DIR / "ubsan-suppressions.supp"}'
         env['ASAN_OPTIONS'] = f'disable_coredump=0:abort_on_error=1:detect_stack_use_after_return=1'
+
+        if before_start is not None:
+            # Close the window between install_and_start()'s pre-start check and spawning the process.
+            before_start()
 
         # Set up socket for receiving sd_notify messages from Scylla
         self._setup_notify_socket()

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1170,7 +1170,7 @@ class ScyllaCluster:
         self.name = str(uuid.uuid1())
         self.replicas = replicas
         self.create_server = create_server
-        # Every ScyllaServer is in one of self.running, self.stopped.
+        # Every ScyllaServer is in one of self.running, self.stopped, self.starting.
         # These dicts are disjoint.
         # A server ID present in self.removed may be either in self.running or in self.stopped.
         self.running: Dict[ServerNum, ScyllaServer] = {}        # started servers
@@ -1222,13 +1222,32 @@ class ScyllaCluster:
         """Release all IPs leased from the host registry by this cluster.
         Call this function only if the cluster is stopped and will not be started again."""
         assert not self.running
+        assert not self.starting
         self.logger.info("Cluster %s releases ips %s", self, self.leased_ips)
         while self.leased_ips:
             ip = self.leased_ips.pop()
             await self.host_registry.release_host(Host(ip))
 
+    async def _stop_servers(self, gracefully: bool) -> None:
+        """Stop all servers with live or potentially live processes."""
+        while self.running or self.starting:
+            running = list(self.running.items())
+            starting = list(self.starting.items())
+
+            if gracefully:
+                await gather_safely(*(server.stop_gracefully() for _, server in itertools.chain(running, starting)))
+            else:
+                await gather_safely(*(server.stop() for _, server in itertools.chain(running, starting)))
+
+            for server_id, server in running:
+                if self.running.get(server_id) is server:
+                    self.stopped[server_id] = self.running.pop(server_id)
+            for server_id, server in starting:
+                if self.starting.get(server_id) is server:
+                    self.stopped[server_id] = self.starting.pop(server_id)
+
     async def stop(self) -> None:
-        """Stop all running servers ASAP"""
+        """Stop all running or starting servers ASAP"""
         # FIXME: the lock is necessary because test.py calls `stop()` and `uninstall()` concurrently
         # (from exit artifacts), which leads to issues (#15755). A more elegant solution would be
         # to prevent that instead of using a lock here.
@@ -1237,21 +1256,15 @@ class ScyllaCluster:
                 self.is_running = False
                 self.logger.info("Cluster %s stopping", self)
                 self.is_dirty = True
-                # If self.running is empty, no-op
-                await gather_safely(*(server.stop() for server in self.running.values()))
-                self.stopped.update(self.running)
-                self.running.clear()
+                await self._stop_servers(gracefully=False)
 
     async def stop_gracefully(self) -> None:
-        """Stop all running servers in a clean way"""
+        """Stop all running or starting servers in a clean way"""
         if self.is_running:
             self.is_running = False
             self.logger.info("Cluster %s stopping gracefully", self)
             self.is_dirty = True
-            # If self.running is empty, no-op
-            await gather_safely(*(server.stop_gracefully() for server in self.running.values()))
-            self.stopped.update(self.running)
-            self.running.clear()
+            await self._stop_servers(gracefully=True)
 
     def _seeds(self) -> List[IPAddress]:
         # If the cluster is empty, all servers must use self.initial_seed to not start separate clusters.
@@ -1327,9 +1340,11 @@ class ScyllaCluster:
 
         async def handle_join_failure():
             if not replace_cfg or not replace_cfg.reuse_ip_addr:
-                self.leased_ips.remove(ip_addr)
-                await self.host_registry.release_host(Host(ip_addr))
-            self.stopped[server.server_id] = server
+                if ip_addr in self.leased_ips:
+                    self.leased_ips.remove(ip_addr)
+                    await self.host_registry.release_host(Host(ip_addr))
+            if server is not None:
+                self.stopped[server.server_id] = server
 
         try:
             server = self.create_server(params)
@@ -1339,14 +1354,15 @@ class ScyllaCluster:
                 await server.install_and_start(self.api, expected_error, expected_server_up_state)
             else:
                 await server.install()
-        except Exception as exc:
+        except BaseException as exc:
             workdir = '<unknown>' if server is None else server.workdir.name
             self.logger.error("Failed to start Scylla server at host %s in %s: %s",
                           ip_addr, workdir, str(exc))
             await handle_join_failure()
             raise
         finally:
-            del self.starting[server.server_id]
+            if server is not None:
+                self.starting.pop(server.server_id, None)
 
         if expected_error:
             await handle_join_failure()
@@ -1497,7 +1513,7 @@ class ScyllaCluster:
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
-            self.starting.pop(server_id)
+            self.starting.pop(server_id, None)
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -558,14 +558,16 @@ class ScyllaServer:
     async def install_and_start(self,
                                 api: ScyllaRESTAPIClient,
                                 expected_error: Optional[str] = None,
-                                expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED) -> None:
+                                expected_server_up_state: ServerUpState = ServerUpState.CQL_ALTERNATOR_QUERIED,
+                                before_start: Callable[[], None] | None = None) -> None:
         """Setup and start this server."""
 
         await self.install()
 
-        self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
-
         try:
+            if before_start is not None:
+                before_start()
+            self.logger.info("starting server at host %s in %s...", self.ip_addr, self.workdir.name)
             await self.start(api, expected_error, expected_server_up_state)
         except:
             await self.stop()
@@ -1351,7 +1353,11 @@ class ScyllaCluster:
             self.starting[server.server_id] = server
             self.logger.info("Cluster %s adding server...", self)
             if start:
-                await server.install_and_start(self.api, expected_error, expected_server_up_state)
+                def check_still_starting() -> None:
+                    if self.starting.get(server.server_id) is not server:
+                        raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
+
+                await server.install_and_start(self.api, expected_error, expected_server_up_state, before_start=check_still_starting)
             else:
                 await server.install()
         except BaseException as exc:
@@ -1513,7 +1519,8 @@ class ScyllaCluster:
             self.running.pop(server_id)
             self.stopped[server_id] = server
         else:
-            self.starting.pop(server_id, None)
+            if self.starting.get(server_id) is server:
+                self.stopped[server_id] = self.starting.pop(server_id)
 
     def server_mark_removed(self, server_id: ServerNum) -> None:
         """Mark server as removed."""

--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -1188,6 +1188,8 @@ class ScyllaCluster:
         # Starting servers that were already asked to stop. They remain in self.starting until the stop path or add_server()
         # finishes the state transition, but add_server() must treat them as cancelled immediately.
         self.stopping_starting: Dict[ServerNum, ScyllaServer] = {}
+        # add_server() paths still using a server object after a stop request removed it from self.starting.
+        self.starting_done: Dict[ServerNum, asyncio.Event] = {}
         # The first IP assigned to a server added to the cluster.
         self.initial_seed: Optional[IPAddress] = None
         # cluster is started (but it might not have running servers)
@@ -1220,6 +1222,7 @@ class ScyllaCluster:
         self.is_dirty = True
         self.logger.info("Uninstalling cluster %s", self)
         await self.stop()
+        await self._wait_for_starting_done()
         await gather_safely(*(srv.uninstall() for srv in self.stopped.values()))
         # Close API client to release connector resources
         if self.api is not None:
@@ -1247,6 +1250,10 @@ class ScyllaCluster:
             self.starting.pop(server.server_id)
         if self.stopping_starting.get(server.server_id) is server:
             self.stopping_starting.pop(server.server_id)
+
+    async def _wait_for_starting_done(self) -> None:
+        while self.starting_done:
+            await gather_safely(*(event.wait() for event in list(self.starting_done.values())))
 
     async def _stop_servers(self, gracefully: bool) -> None:
         """Stop all servers with live or potentially live processes."""
@@ -1369,6 +1376,7 @@ class ScyllaCluster:
         )
 
         server = None
+        starting_done: asyncio.Event | None = None
 
         async def handle_join_failure():
             if not replace_cfg or not replace_cfg.reuse_ip_addr:
@@ -1379,48 +1387,56 @@ class ScyllaCluster:
                 self.stopped[server.server_id] = server
 
         try:
-            server = self.create_server(params)
-            self.starting[server.server_id] = server
-            self.logger.info("Cluster %s adding server...", self)
-            if start:
-                def check_still_starting() -> None:
-                    if not self._is_still_starting(server):
-                        raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
-
-                await server.install_and_start(self.api, expected_error, expected_server_up_state, before_start=check_still_starting)
-            else:
-                await server.install()
-        except BaseException as exc:
-            if server is not None:
-                self._remove_starting(server)
-            workdir = '<unknown>' if server is None else server.workdir.name
-            self.logger.error("Failed to start Scylla server at host %s in %s: %s",
-                          ip_addr, workdir, str(exc))
-            await handle_join_failure()
-            raise
-
-        assert server is not None
-
-        if not self._is_still_starting(server):
-            self._remove_starting(server)
             try:
-                await server.stop()
-            finally:
+                server = self.create_server(params)
+                starting_done = asyncio.Event()
+                self.starting_done[server.server_id] = starting_done
+                self.starting[server.server_id] = server
+                self.logger.info("Cluster %s adding server...", self)
+                if start:
+                    def check_still_starting() -> None:
+                        if not self._is_still_starting(server):
+                            raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
+
+                    await server.install_and_start(self.api, expected_error, expected_server_up_state, before_start=check_still_starting)
+                else:
+                    await server.install()
+            except BaseException as exc:
+                if server is not None:
+                    self._remove_starting(server)
+                workdir = '<unknown>' if server is None else server.workdir.name
+                self.logger.error("Failed to start Scylla server at host %s in %s: %s",
+                              ip_addr, workdir, str(exc))
                 await handle_join_failure()
-            raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
+                raise
 
-        self._remove_starting(server)
+            assert server is not None
 
-        if expected_error:
-            await handle_join_failure()
-        else:
-            if start:
-                self.running[server.server_id] = server
+            if not self._is_still_starting(server):
+                self._remove_starting(server)
+                try:
+                    await server.stop()
+                finally:
+                    await handle_join_failure()
+                raise RuntimeError(f"Server {server.server_id} was stopped while it was being added")
+
+            self._remove_starting(server)
+
+            if expected_error:
+                await handle_join_failure()
             else:
-                self.stopped[server.server_id] = server
-            self.logger.info("Cluster %s added %s", self, server)
+                if start:
+                    self.running[server.server_id] = server
+                else:
+                    self.stopped[server.server_id] = server
+                self.logger.info("Cluster %s added %s", self, server)
 
-        return server.server_info()
+            return server.server_info()
+        finally:
+            if server is not None and starting_done is not None:
+                if self.starting_done.get(server.server_id) is starting_done:
+                    self.starting_done.pop(server.server_id)
+                starting_done.set()
 
     async def add_servers(self, servers_num: int = 1,
                           cmdline: Optional[List[str]] = None,

--- a/test/pylib_test/test_scylla_cluster.py
+++ b/test/pylib_test/test_scylla_cluster.py
@@ -1,0 +1,134 @@
+#
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+#
+
+import asyncio
+import logging
+import pathlib
+
+import pytest
+
+from test.pylib.host_registry import Host
+from test.pylib.internal_types import IPAddress, ServerInfo, ServerNum
+from test.pylib.scylla_cluster import ScyllaCluster
+
+
+class FakeHostRegistry:
+    def __init__(self) -> None:
+        self.next_host_id = 0
+        self.released_hosts: list[Host] = []
+
+    async def lease_host(self) -> Host:
+        self.next_host_id += 1
+        return Host(f"127.0.0.{self.next_host_id}")
+
+    async def release_host(self, host: Host) -> None:
+        self.released_hosts.append(host)
+
+
+class SlowInstallingServer:
+    def __init__(self, server_id: ServerNum, ip_addr: IPAddress) -> None:
+        self.server_id = server_id
+        self.ip_addr = ip_addr
+        self.rpc_address = ip_addr
+        self.datacenter = "dc1"
+        self.rack = "rack1"
+        self.workdir = pathlib.Path(f"server-{server_id}")
+        self.install_started = asyncio.Event()
+        self.finish_install = asyncio.Event()
+        self.started = False
+        self.stop_calls = 0
+        self.stop_gracefully_calls = 0
+
+    async def install(self) -> None:
+        self.install_started.set()
+        await self.finish_install.wait()
+
+    async def install_and_start(self, api, expected_error=None, expected_server_up_state=None, before_start=None) -> None:
+        await self.install()
+        try:
+            if before_start is not None:
+                before_start()
+            self.started = True
+        except BaseException:
+            await self.stop()
+            raise
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+
+    async def stop_gracefully(self) -> None:
+        self.stop_gracefully_calls += 1
+
+    def server_info(self) -> ServerInfo:
+        return ServerInfo(self.server_id, self.ip_addr, self.rpc_address, self.datacenter, self.rack, 0)
+
+
+def make_cluster() -> tuple[ScyllaCluster, FakeHostRegistry, dict[str, SlowInstallingServer]]:
+    host_registry = FakeHostRegistry()
+    created_servers: dict[str, SlowInstallingServer] = {}
+
+    def create_server(params: ScyllaCluster.CreateServerParams) -> SlowInstallingServer:
+        server = SlowInstallingServer(ServerNum(1), params.ip_addr)
+        created_servers["server"] = server
+        return server
+
+    cluster = ScyllaCluster(logging.getLogger("test_scylla_cluster"), host_registry, replicas=0, create_server=create_server)
+    cluster.is_running = True
+    return cluster, host_registry, created_servers
+
+
+async def start_adding_server(cluster: ScyllaCluster, created_servers: dict[str, SlowInstallingServer]) -> tuple[asyncio.Task, SlowInstallingServer]:
+    add_task = asyncio.create_task(cluster.add_server())
+    while "server" not in created_servers:
+        await asyncio.sleep(0)
+    server = created_servers["server"]
+    await server.install_started.wait()
+    assert cluster.starting[server.server_id] is server
+    return add_task, server
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_method", ["stop", "stop_gracefully"])
+async def test_cluster_stop_cancels_server_still_installing(stop_method: str) -> None:
+    """Regression test for stopping a cluster while add_server() is still installing a server."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+
+    await getattr(cluster, stop_method)()
+    assert not cluster.starting
+
+    server.finish_install.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+async def test_server_stop_cancels_server_still_installing() -> None:
+    """Regression test for stopping a specific starting server before its process exists."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+
+    await cluster.server_stop(server.server_id, gracefully=False)
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+
+    server.finish_install.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]

--- a/test/pylib_test/test_scylla_cluster.py
+++ b/test/pylib_test/test_scylla_cluster.py
@@ -46,6 +46,10 @@ class SlowInstallingServer:
         self.first_stop_started = asyncio.Event()
         self.second_stop_started = asyncio.Event()
         self.finish_stop = asyncio.Event()
+        self.stop_finished = asyncio.Event()
+        self.uninstall_started = asyncio.Event()
+        self.install_finished = False
+        self.uninstalled_before_install_finished = False
         self.started = False
         self.stop_calls = 0
         self.stop_gracefully_calls = 0
@@ -53,6 +57,7 @@ class SlowInstallingServer:
     async def install(self) -> None:
         self.install_started.set()
         await self.finish_install.wait()
+        self.install_finished = True
 
     async def install_and_start(self, api, expected_error=None, expected_server_up_state=None, before_start=None) -> None:
         await self.install()
@@ -79,10 +84,15 @@ class SlowInstallingServer:
                 self.second_stop_started.set()
             await self.finish_stop.wait()
         self.started = False
+        self.stop_finished.set()
 
     async def stop_gracefully(self) -> None:
         self.stop_gracefully_calls += 1
         self.started = False
+
+    async def uninstall(self) -> None:
+        self.uninstall_started.set()
+        self.uninstalled_before_install_finished = not self.install_finished
 
     def server_info(self) -> ServerInfo:
         return ServerInfo(self.server_id, self.ip_addr, self.rpc_address, self.datacenter, self.rack, 0)
@@ -263,5 +273,36 @@ async def test_stop_cancels_starting_server_before_stop_finishes(stop_action: st
     assert not cluster.running
     assert not cluster.starting
     assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+async def test_cluster_uninstall_waits_for_cancelled_starting_server_to_finish_adding() -> None:
+    """Regression test for uninstall racing with a stopped add_server() still inside install()."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+    server.block_stop_until_released = True
+
+    uninstall_task = asyncio.create_task(cluster.uninstall())
+    await server.first_stop_started.wait()
+    server.finish_stop.set()
+    await server.stop_finished.wait()
+
+    for _ in range(10):
+        if server.uninstall_started.is_set():
+            break
+        await asyncio.sleep(0)
+    assert not server.uninstall_started.is_set()
+
+    server.finish_install.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+    await uninstall_task
+
+    assert server.uninstall_started.is_set()
+    assert not server.uninstalled_before_install_finished
+    assert not cluster.running
+    assert not cluster.starting
     assert not cluster.leased_ips
     assert host_registry.released_hosts == [Host(server.ip_addr)]

--- a/test/pylib_test/test_scylla_cluster.py
+++ b/test/pylib_test/test_scylla_cluster.py
@@ -41,6 +41,11 @@ class SlowInstallingServer:
         self.pause_after_before_start = False
         self.before_start_checked = asyncio.Event()
         self.continue_after_before_start = asyncio.Event()
+        self.start_finished = asyncio.Event()
+        self.block_stop_until_released = False
+        self.first_stop_started = asyncio.Event()
+        self.second_stop_started = asyncio.Event()
+        self.finish_stop = asyncio.Event()
         self.started = False
         self.stop_calls = 0
         self.stop_gracefully_calls = 0
@@ -58,12 +63,19 @@ class SlowInstallingServer:
             if self.pause_after_before_start:
                 await self.continue_after_before_start.wait()
             self.started = True
+            self.start_finished.set()
         except BaseException:
             await self.stop()
             raise
 
     async def stop(self) -> None:
         self.stop_calls += 1
+        if self.block_stop_until_released:
+            if self.stop_calls == 1:
+                self.first_stop_started.set()
+            elif self.stop_calls == 2:
+                self.second_stop_started.set()
+            await self.finish_stop.wait()
         self.started = False
 
     async def stop_gracefully(self) -> None:
@@ -179,6 +191,46 @@ async def test_server_stop_cancels_server_still_installing() -> None:
     server.finish_install.set()
     with pytest.raises(RuntimeError, match="stopped while it was being added"):
         await add_task
+
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_action", ["server_stop", "cluster_stop"])
+async def test_stop_cancels_starting_server_before_stop_finishes(stop_action: str) -> None:
+    """Regression test for stop waiting on an in-progress start before it can remove starting."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+    server.block_stop_until_released = True
+
+    if stop_action == "server_stop":
+        stop_task = asyncio.create_task(cluster.server_stop(server.server_id, gracefully=False))
+    else:
+        stop_task = asyncio.create_task(cluster.stop())
+    await server.first_stop_started.wait()
+
+    server.finish_install.set()
+    second_stop_task = asyncio.create_task(server.second_stop_started.wait())
+    start_finished_task = asyncio.create_task(server.start_finished.wait())
+    _, pending = await asyncio.wait({second_stop_task, start_finished_task}, return_when=asyncio.FIRST_COMPLETED)
+    for task in pending:
+        task.cancel()
+    await asyncio.gather(*pending, return_exceptions=True)
+
+    if not server.second_stop_started.is_set():
+        server.finish_stop.set()
+        await asyncio.gather(add_task, stop_task, return_exceptions=True)
+    assert server.second_stop_started.is_set()
+
+    server.finish_stop.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+    await stop_task
 
     assert not server.started
     assert not cluster.running

--- a/test/pylib_test/test_scylla_cluster.py
+++ b/test/pylib_test/test_scylla_cluster.py
@@ -38,6 +38,9 @@ class SlowInstallingServer:
         self.workdir = pathlib.Path(f"server-{server_id}")
         self.install_started = asyncio.Event()
         self.finish_install = asyncio.Event()
+        self.pause_after_before_start = False
+        self.before_start_checked = asyncio.Event()
+        self.continue_after_before_start = asyncio.Event()
         self.started = False
         self.stop_calls = 0
         self.stop_gracefully_calls = 0
@@ -51,6 +54,9 @@ class SlowInstallingServer:
         try:
             if before_start is not None:
                 before_start()
+            self.before_start_checked.set()
+            if self.pause_after_before_start:
+                await self.continue_after_before_start.wait()
             self.started = True
         except BaseException:
             await self.stop()
@@ -58,9 +64,11 @@ class SlowInstallingServer:
 
     async def stop(self) -> None:
         self.stop_calls += 1
+        self.started = False
 
     async def stop_gracefully(self) -> None:
         self.stop_gracefully_calls += 1
+        self.started = False
 
     def server_info(self) -> ServerInfo:
         return ServerInfo(self.server_id, self.ip_addr, self.rpc_address, self.datacenter, self.rack, 0)
@@ -101,6 +109,52 @@ async def test_cluster_stop_cancels_server_still_installing(stop_method: str) ->
     assert not cluster.starting
 
     server.finish_install.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+async def test_cluster_stop_cancels_server_still_installing_before_cluster_is_running() -> None:
+    """Regression test for cleanup racing with initial cluster startup before is_running is set."""
+    cluster, host_registry, created_servers = make_cluster()
+    cluster.is_running = False
+    add_task, server = await start_adding_server(cluster, created_servers)
+
+    await cluster.stop()
+    assert not cluster.starting
+
+    server.finish_install.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+async def test_cluster_stop_after_start_check_still_prevents_server_from_running() -> None:
+    """Regression test for stop landing after add_server() checks starting, but before start completes."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+    server.pause_after_before_start = True
+
+    server.finish_install.set()
+    await server.before_start_checked.wait()
+    await cluster.stop()
+    assert not cluster.starting
+
+    server.continue_after_before_start.set()
     with pytest.raises(RuntimeError, match="stopped while it was being added"):
         await add_task
 

--- a/test/pylib_test/test_scylla_cluster.py
+++ b/test/pylib_test/test_scylla_cluster.py
@@ -62,6 +62,8 @@ class SlowInstallingServer:
             self.before_start_checked.set()
             if self.pause_after_before_start:
                 await self.continue_after_before_start.wait()
+            if before_start is not None:
+                before_start()
             self.started = True
             self.start_finished.set()
         except BaseException:
@@ -170,6 +172,31 @@ async def test_cluster_stop_after_start_check_still_prevents_server_from_running
     with pytest.raises(RuntimeError, match="stopped while it was being added"):
         await add_task
 
+    assert not server.started
+    assert not cluster.running
+    assert not cluster.starting
+    assert cluster.stopped[server.server_id] is server
+    assert not cluster.leased_ips
+    assert host_registry.released_hosts == [Host(server.ip_addr)]
+
+
+@pytest.mark.asyncio
+async def test_cluster_stop_after_start_check_does_not_start_after_releasing_ip() -> None:
+    """Regression test for cleanup releasing the IP before add_server() leaves the start path."""
+    cluster, host_registry, created_servers = make_cluster()
+    add_task, server = await start_adding_server(cluster, created_servers)
+    server.pause_after_before_start = True
+
+    server.finish_install.set()
+    await server.before_start_checked.wait()
+    await cluster.stop()
+    await cluster.release_ips()
+
+    server.continue_after_before_start.set()
+    with pytest.raises(RuntimeError, match="stopped while it was being added"):
+        await add_task
+
+    assert not server.start_finished.is_set()
     assert not server.started
     assert not cluster.running
     assert not cluster.starting


### PR DESCRIPTION
Fixes #29780

## Problem

A cluster test can time out while `add_server()` is still waiting for a newly spawned Scylla process to reach the requested ready state. During that window the server is stored in `ScyllaCluster.starting`, not `ScyllaCluster.running`.

Cluster teardown previously stopped only `running` servers, then released all leased IPs. If a `starting` server had already bound its ports, the process could remain alive while its IP was returned to the host registry. Later tests could then reuse the same IP and fail with `Address already in use`.

## Summary

- Stop both `running` and `starting` servers during cluster teardown.
- Assert that `release_ips()` is not called while either set still contains servers.
- Make `add_server()` cleanup idempotent for cancellation/teardown races:
  - tolerate a starting server already being removed by cleanup,
  - avoid double IP release,
  - clean up on `BaseException` so `CancelledError` is handled and re-raised.
- Make `server_stop()` tolerate concurrent removal from `starting`.

## Testing

- Not run: repo-ci failed before execution while relearning workflows:

```text
failed to parse /extra/scylladb/scylladb/.github/workflows/call_jira_sync.yml: deserializing from YAML containing more than one document is not supported
```
