### PR TITLE
raft: use log_indexed_container for _awaited_commits/_awaited_applies

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -725,6 +725,7 @@ raft_tests = set([
     'test/raft/many_test',
     'test/raft/raft_server_test',
     'test/raft/fsm_test',
+    'test/raft/log_indexed_container_test',
     'test/raft/etcd_test',
     'test/raft/raft_sys_table_storage_test',
     'test/raft/discovery_test',
@@ -1828,6 +1829,7 @@ deps['test/raft/randomized_nemesis_test'] = ['test/raft/randomized_nemesis_test.
 deps['test/raft/failure_detector_test'] = ['test/raft/failure_detector_test.cc', 'service/direct_failure_detector/failure_detector.cc', 'test/raft/helpers.cc'] + scylla_raft_dependencies
 deps['test/raft/many_test'] = ['test/raft/many_test.cc', 'test/raft/replication.cc', 'test/raft/helpers.cc', 'test/lib/eventually.cc'] + scylla_raft_dependencies
 deps['test/raft/fsm_test'] =  ['test/raft/fsm_test.cc', 'test/raft/helpers.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
+deps['test/raft/log_indexed_container_test'] =  ['test/raft/log_indexed_container_test.cc', 'test/raft/helpers.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 deps['test/raft/etcd_test'] =  ['test/raft/etcd_test.cc', 'test/raft/helpers.cc', 'test/lib/log.cc'] + scylla_raft_dependencies
 deps['test/raft/raft_sys_table_storage_test'] = ['test/raft/raft_sys_table_storage_test.cc'] + \
     scylla_core + alternator + scylla_tests_generic_dependencies

--- a/raft/log_indexed_container.hh
+++ b/raft/log_indexed_container.hh
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+#pragma once
+
+#include <concepts>
+#include <optional>
+#include <type_traits>
+#include <boost/container/deque.hpp>
+
+#include "utils/assert.hh"
+#include "raft/raft.hh"
+
+namespace raft {
+
+// A container that maps raft log indices to values, providing O(1)
+// access by index. Internally uses a deque of optional<T> slots
+// where slot position corresponds to (index - base_index), and
+// base_index is the index of the first slot in the deque.
+//
+// The container does not require indices to be inserted in order.
+// Gaps (nullopt slots) between occupied slots are allowed.
+//
+// Invariant (1): the slot with the smallest index (the front), if
+// any, is always occupied. extract() maintains it by trimming
+// leading empty slots, which also reclaims memory. Consequently
+// peek_front() gives O(1) access to the smallest-index element,
+// letting callers consume the container from the front and stop
+// early.
+//
+// Exception safety: every public method is either noexcept or provides
+// the basic exception guarantee.
+template<std::move_constructible T>
+class log_indexed_container {
+    // Why boost::container::deque: it frees each fixed-size data block
+    // as its last element is popped, so memory tracks the live element
+    // count. std::deque frees those data blocks too; the difference is
+    // its internal map (the array of pointers to the blocks), which
+    // only grows and is recentered on push, never shrunk. That would
+    // only bite on a one-off spike in size; for this steadily draining
+    // queue the map should remain small either way, so boost is just
+    // the more conservative choice.
+    //
+    // Possible memory optimization: std::optional<T> spends an extra
+    // discriminator byte (plus padding) per slot on top of T. It is
+    // negligible for the current users, but if a future,
+    // space-sensitive T ever makes it matter, and T has a spare
+    // invalid value, the slots could switch to
+    // seastar::optimized_optional<T>, which reuses that value as the
+    // empty state and drops the byte.
+    boost::container::deque<std::optional<T>> _slots;
+    // The index corresponding to slot 0.
+    index_t _base_idx{0};
+
+    // Removes empty slots from the front of the deque, advancing
+    // _base_idx accordingly, restoring invariant (1).
+    void trim_front() noexcept {
+        while (!_slots.empty() && !_slots.front()) {
+            _slots.pop_front();
+            _base_idx = _base_idx + index_t{1};
+        }
+    }
+
+    // Position of idx in _slots. idx must be at or after _base_idx.
+    [[nodiscard]] size_t offset_of(index_t idx) const noexcept {
+        SCYLLA_ASSERT(idx >= _base_idx);
+        return (idx - _base_idx).value();
+    }
+
+public:
+    // Returns a pointer to the value at the given index,
+    // or nullptr if the slot is empty or out of range.
+    T* find(index_t idx) noexcept {
+        if (_slots.empty() || idx < _base_idx) {
+            return nullptr;
+        }
+        auto off = offset_of(idx);
+        if (off >= _slots.size()) {
+            return nullptr;
+        }
+        auto& slot = _slots[off];
+        return slot ? &*slot : nullptr;
+    }
+
+    // Inserts a value at the given index. The slot must not already be
+    // occupied. Returns a reference to the inserted value. On a throw the
+    // container is unchanged, except it might be left with some trailing
+    // empty slots.
+    T& emplace(index_t idx, T value) {
+        if (_slots.empty()) {
+            _slots.emplace_back(std::move(value));
+            _base_idx = idx;
+        } else if (idx < _base_idx) {
+            // The new index is before the current base. Prepend empty
+            // slots to accommodate it, then fill the new front slot.
+            auto count = (_base_idx - idx).value();
+            size_t added = 0;
+            try {
+                for (; added < count; ++added) {
+                    _slots.emplace_front(std::nullopt);
+                }
+                _slots.front().emplace(std::move(value));
+            } catch (...) {
+                // Roll back the prepended slots so the container (and
+                // invariant (1)) is left exactly as before.
+                for (size_t i = 0; i < added; ++i) {
+                    _slots.pop_front();
+                }
+                throw;
+            }
+            _base_idx = idx;
+        } else {
+            auto off = offset_of(idx);
+            if (off >= _slots.size()) {
+                // Grow to reach the index. If the fill below throws, the
+                // trailing empty slots are left in place: they are
+                // harmless (invariant (1) holds, the slots read as
+                // empty) and reclaimed as the container drains.
+                _slots.resize(off + 1);
+            }
+            SCYLLA_ASSERT(!_slots[off]);
+            _slots[off].emplace(std::move(value));
+        }
+        return *_slots[offset_of(idx)];
+    }
+
+    // Removes the slot at the given index and returns its value. The
+    // slot must be occupied. Trims leading empty slots afterwards, so
+    // invariant (1) is preserved and freed memory is reclaimed.
+    T extract(index_t idx) noexcept(std::is_nothrow_move_constructible_v<T>) {
+        auto off = offset_of(idx);
+        SCYLLA_ASSERT(off < _slots.size() && _slots[off]);
+        T value = std::move(*_slots[off]);
+        _slots[off].reset();
+        trim_front();
+        return value;
+    }
+
+    // By invariant (1), true iff the container holds no live elements:
+    // an all-nullopt deque cannot occur, so an empty deque is the only
+    // way to have zero elements.
+    bool empty() const noexcept {
+        return _slots.empty();
+    }
+
+    // Returns the base index (the index corresponding to slots[0]).
+    // By invariant (1), when the container is non-empty this is also
+    // the index of the smallest-index (front) element.
+    index_t base_index() const noexcept {
+        return _base_idx;
+    }
+
+    // Returns a pointer to the smallest-index (front) element, whose
+    // index is base_index(), or nullptr if the container is empty.
+    T* peek_front() noexcept {
+        return _slots.empty() ? nullptr : &*_slots.front();
+    }
+
+    // Iterates over all occupied slots in increasing index order,
+    // calling f(index_t, T&) for each. The callback may freely mutate
+    // the value through the T& reference, but must not mutate the
+    // container's structure: it must not call emplace(), extract() or
+    // clear(), as any of those would invalidate the ongoing iteration.
+    template<typename F>
+    requires std::invocable<F&, index_t, T&>
+    void for_each(F&& f) {
+        for (size_t i = 0; i < _slots.size(); ++i) {
+            if (_slots[i]) {
+                f(_base_idx + index_t{i}, *_slots[i]);
+            }
+        }
+    }
+
+    // Clears all slots.
+    void clear() noexcept {
+        _slots.clear();
+        _base_idx = index_t{0};
+    }
+};
+
+} // namespace raft

--- a/raft/server.cc
+++ b/raft/server.cc
@@ -15,7 +15,6 @@
 #include <boost/range/algorithm/copy.hpp>
 #include <boost/range/join.hpp>
 #include <boost/lexical_cast.hpp>
-#include <map>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/shared_future.hh>
@@ -28,6 +27,7 @@
 #include <seastar/core/gate.hh>
 
 #include "fsm.hh"
+#include "log_indexed_container.hh"
 #include "log.hh"
 #include "raft.hh"
 
@@ -213,8 +213,8 @@ private:
         optimized_optional<seastar::abort_source::subscription> abort; // abort subscription
     };
 
-    // Waiters for entry commit/apply status, keyed by entry index.
-    using waiters_map = std::map<index_t, op_status>;
+    // Waiters for entry commit/apply status, indexed by entry index.
+    using waiter_queue = log_indexed_container<op_status>;
 
     // Entries that have a waiter that needs to be notified when the
     // respective entry is known to be committed.
@@ -223,13 +223,13 @@ private:
     // fiber's progress (abort() fails whatever is left). Dropping the waiters
     // in a single fiber, in commit order, is what maintains the ordering
     // invariant asserted in notify_waiters().
-    waiters_map _awaited_commits;
+    waiter_queue _awaited_commits;
 
     // Entries that have a waiter that needs to be notified after
     // the respective entry is applied.
     // Waiters are inserted by wait_for_entry() and dropped by the applier
     // fiber, in apply order (abort() fails whatever is left).
-    waiters_map _awaited_applies;
+    waiter_queue _awaited_applies;
 
     // Maps each destination to the abort_source of the currently active
     // snapshot transfer.  The abort_source itself lives on the coroutine
@@ -264,7 +264,7 @@ private:
     server_requests _new_server_requests;
 
     // Called to commit entries (on a leader or otherwise).
-    void notify_waiters(waiters_map& waiters, const log_entry_ptr_list& entries);
+    void notify_waiters(waiter_queue& waiters, const log_entry_ptr_list& entries);
 
     // Drop waiters that we lost track of, can happen due to a snapshot transfer,
     // or a leader removed from cluster while some entries added on it are uncommitted.
@@ -272,7 +272,7 @@ private:
     // snapshot index are dropped, and those whose term matches the snapshot term
     // are resolved successfully, since the snapshot-term match proves they were
     // committed and included in the snapshot (by the Log Matching Property).
-    void drop_waiters(waiters_map& waiters, const snapshot_descriptor* snp = nullptr);
+    void drop_waiters(waiter_queue& waiters, const snapshot_descriptor* snp = nullptr);
 
     // Wake up all waiter that wait for entries with idx smaller of equal to the one provided
     // to be applied.
@@ -617,14 +617,16 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
     auto& container = type == wait_type::committed ? _awaited_commits : _awaited_applies;
     logger.trace("[{}] waiting for entry {}.{}", _tag, eid.term, eid.idx);
 
-    // This will track the commit/apply status of the entry
-    auto [it, inserted] = container.emplace(eid.idx, op_status{eid.term, promise<>()});
-    if (!inserted) {
+    // Check for an existing entry with the same index.
+    // This can happen when a leadership change causes a new entry to be
+    // proposed at the same index with a different term.
+    auto* existing = container.find(eid.idx);
+    if (existing) {
         // No two leaders can exist with the same term.
-        SCYLLA_ASSERT(it->second.term != eid.term);
+        SCYLLA_ASSERT(existing->term != eid.term);
 
         auto term_of_commit_idx = *_fsm->log_term_for(_fsm->commit_idx());
-        if (it->second.term > eid.term) {
+        if (existing->term > eid.term) {
             if (term_of_commit_idx > eid.term) {
                 // There are some entries committed with a term
                 // bigger than ours, our entry must have been
@@ -644,9 +646,8 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
             }
         }
         // Let's replace an older-term entry with a newer-term one.
-        auto prev_wait = std::move(it->second);
-        container.erase(it);
-        std::tie(it, inserted) = container.emplace(eid.idx, op_status{eid.term, promise<>()});
+        auto prev_wait = std::move(*existing);
+        *existing = op_status{eid.term, promise<>()};
         // Set the status of the replaced entry. Same reasoning
         // applies for choosing the right exception status as earlier.
         if (term_of_commit_idx > prev_wait.term) {
@@ -657,18 +658,24 @@ future<> server_impl::wait_for_entry(entry_id eid, wait_type type, seastar::abor
             _stats.waiters_dropped++;
         }
     }
-    SCYLLA_ASSERT(inserted);
+
+    // Get a reference to the entry: either the in-place replacement above,
+    // or a new entry at the corresponding slot.
+    auto& status = existing ? *existing : container.emplace(eid.idx, op_status{eid.term, promise<>()});
     if (as) {
-        it->second.abort = as->subscribe([this, it = it, &container] noexcept {
-            it->second.done.set_exception(
-                request_aborted(format(
-                        "Abort requested while waiting for entry with idx: {}, term: {}; last committed entry: {}, last applied entry: {}",
-                        it->first, it->second.term, _fsm->commit_idx(), _applied_idx)));
-            container.erase(it);
+        status.abort = as->subscribe([this, &container, idx = eid.idx, term = eid.term] noexcept {
+            auto ex = request_aborted(format(
+                    "Abort requested while waiting for entry with idx: {}, term: {}; last committed entry: {}, last applied entry: {}",
+                    idx, term, _fsm->commit_idx(), _applied_idx));
+            // extract() moves the op_status out of the container, and with it
+            // the subscription whose callback we are in. The captures live in
+            // that subscription, so none of them may be touched afterwards -
+            // hence the exception is constructed above, before the extraction.
+            container.extract(idx).done.set_exception(std::move(ex));
         });
-        SCYLLA_ASSERT(it->second.abort);
+        SCYLLA_ASSERT(status.abort);
     }
-    co_await it->second.done.get_future();
+    co_await status.done.get_future();
     logger.trace("[{}] done waiting for {}.{}", _tag, eid.term, eid.idx);
     co_return;
 }
@@ -966,23 +973,22 @@ void server_impl::read_quorum_reply(server_id from, struct read_quorum_reply rea
     _fsm->step(from, std::move(read_quorum_reply));
 }
 
-void server_impl::notify_waiters(waiters_map& waiters,
+void server_impl::notify_waiters(waiter_queue& waiters,
         const log_entry_ptr_list& entries) {
     index_t commit_idx = entries.back()->idx;
     index_t first_idx = entries.front()->idx;
 
-    while (waiters.size() != 0) {
-        auto it = waiters.begin();
-        if (it->first > commit_idx) {
+    while (!waiters.empty()) {
+        index_t entry_idx = waiters.base_index();
+        if (entry_idx > commit_idx) {
             break;
         }
-        auto [entry_idx, status] = std::move(*it);
 
         // if there is a waiter entry with an index smaller than first entry
         // it means that notification is out of order which is prohibited
         SCYLLA_ASSERT(entry_idx >= first_idx);
 
-        waiters.erase(it);
+        auto status = waiters.extract(entry_idx);
         if (status.term == entries[(entry_idx - first_idx).value()]->term) {
             status.done.set_value();
         } else {
@@ -997,11 +1003,10 @@ void server_impl::notify_waiters(waiters_map& waiters,
     // since there is no way they will be committed any longer (terms in
     // the log only grow).
     term_t last_committed_term = entries.back()->term;
-    while (waiters.size() != 0) {
-        auto it = waiters.begin();
-        if (it->second.term < last_committed_term) {
-            it->second.done.set_exception(dropped_entry());
-            waiters.erase(it);
+    while (auto* status = waiters.peek_front()) {
+        if (status->term < last_committed_term) {
+            status->done.set_exception(dropped_entry());
+            waiters.extract(waiters.base_index());
             _stats.waiters_awoken++;
         } else {
             break;
@@ -1009,14 +1014,13 @@ void server_impl::notify_waiters(waiters_map& waiters,
     }
 }
 
-void server_impl::drop_waiters(waiters_map& waiters, const snapshot_descriptor* snp) {
-    while (waiters.size() != 0) {
-        auto it = waiters.begin();
-        if (snp && it->first > snp->idx) {
+void server_impl::drop_waiters(waiter_queue& waiters, const snapshot_descriptor* snp) {
+    while (!waiters.empty()) {
+        index_t entry_idx = waiters.base_index();
+        if (snp && entry_idx > snp->idx) {
             break;
         }
-        auto [entry_idx, status] = std::move(*it);
-        waiters.erase(it);
+        auto status = waiters.extract(entry_idx);
         if (snp && status.term == snp->term) {
             // entry_idx <= snapshot index and the entry's term matches the snapshot term.
             // By the Log Matching Property the entry was committed and included in the snapshot.
@@ -1709,12 +1713,12 @@ future<> server_impl::abort(sstring reason) {
     // Destroy entry waiters before waiting for `abort_rpc`,
     // since the RPC implementation may wait for forwarded `modify_config` calls to finish
     // (and `modify_config` does not finish until the configuration entry is committed or an error occurs).
-    for (auto& ac: _awaited_commits) {
-        ac.second.done.set_exception(stopped_error(*_aborted));
-    }
-    for (auto& aa: _awaited_applies) {
-        aa.second.done.set_exception(stopped_error(*_aborted));
-    }
+    _awaited_commits.for_each([&](index_t, op_status& status) {
+        status.done.set_exception(stopped_error(*_aborted));
+    });
+    _awaited_applies.for_each([&](index_t, op_status& status) {
+        status.done.set_exception(stopped_error(*_aborted));
+    });
     _awaited_commits.clear();
     _awaited_applies.clear();
     if (_non_joint_conf_commit_promise) {

--- a/test/raft/CMakeLists.txt
+++ b/test/raft/CMakeLists.txt
@@ -27,6 +27,9 @@ add_scylla_test(failure_detector_test
 add_scylla_test(fsm_test
   KIND BOOST
   LIBRARIES test-raft)
+add_scylla_test(log_indexed_container_test
+  KIND BOOST
+  LIBRARIES test-raft)
 add_scylla_test(many_test
   KIND SEASTAR
   LIBRARIES test-raft)

--- a/test/raft/log_indexed_container_test.cc
+++ b/test/raft/log_indexed_container_test.cc
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026-present ScyllaDB
+ */
+
+/*
+ * SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+ */
+
+#include "raft/log_indexed_container.hh"
+#define BOOST_TEST_MODULE raft
+
+#include <boost/test/unit_test.hpp>
+
+using namespace raft;
+
+BOOST_AUTO_TEST_CASE(test_empty_container) {
+    log_indexed_container<int> c;
+    BOOST_CHECK(c.empty());
+    BOOST_CHECK(c.find(index_t{0}) == nullptr);
+    BOOST_CHECK(c.find(index_t{100}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_and_find) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{5}, 42);
+    BOOST_CHECK(!c.empty());
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{5});
+
+    auto* p = c.find(index_t{5});
+    BOOST_REQUIRE(p != nullptr);
+    BOOST_CHECK_EQUAL(*p, 42);
+
+    BOOST_CHECK(c.find(index_t{4}) == nullptr);
+    BOOST_CHECK(c.find(index_t{6}) == nullptr);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_with_gap) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{10}, 1);
+    c.emplace(index_t{13}, 2);
+
+    BOOST_CHECK_EQUAL(*c.find(index_t{10}), 1);
+    BOOST_CHECK(c.find(index_t{11}) == nullptr);
+    BOOST_CHECK(c.find(index_t{12}) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(index_t{13}), 2);
+}
+
+BOOST_AUTO_TEST_CASE(test_emplace_before_base) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{5}, 50);
+    c.emplace(index_t{7}, 70);
+
+    // Emplace before the current base index, prepending empty slots.
+    c.emplace(index_t{3}, 30);
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{3});
+    BOOST_CHECK_EQUAL(*c.find(index_t{3}), 30);
+    BOOST_CHECK(c.find(index_t{4}) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(index_t{5}), 50);
+    BOOST_CHECK(c.find(index_t{6}) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(index_t{7}), 70);
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_trims_front) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{5}, 1);
+    c.emplace(index_t{6}, 2);
+    c.emplace(index_t{7}, 3);
+
+    // extract returns the stored value and advances base_idx past the
+    // now-empty front.
+    BOOST_CHECK_EQUAL(c.extract(index_t{5}), 1);
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{6});
+    BOOST_CHECK(c.find(index_t{5}) == nullptr);
+    BOOST_CHECK_EQUAL(*c.find(index_t{6}), 2);
+
+    // Index 7 extracted but 6 is still at front, no trimming.
+    BOOST_CHECK_EQUAL(c.extract(index_t{7}), 3);
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{6});
+    BOOST_CHECK(c.find(index_t{7}) == nullptr);
+
+    // All extracted, container should be empty.
+    BOOST_CHECK_EQUAL(c.extract(index_t{6}), 2);
+    BOOST_CHECK(c.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_extract_middle_then_front) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{1}, 10);
+    c.emplace(index_t{2}, 20);
+    c.emplace(index_t{3}, 30);
+
+    // Extract the middle — no trimming.
+    c.extract(index_t{2});
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{1});
+    BOOST_CHECK(c.find(index_t{2}) == nullptr);
+
+    // Extract the front — trims past the gap.
+    c.extract(index_t{1});
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{3});
+    BOOST_CHECK_EQUAL(*c.find(index_t{3}), 30);
+}
+
+BOOST_AUTO_TEST_CASE(test_for_each) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{2}, 20);
+    c.emplace(index_t{4}, 40);
+    c.emplace(index_t{5}, 50);
+
+    std::vector<std::pair<uint64_t, int>> visited;
+    c.for_each([&](index_t idx, int& val) {
+        visited.emplace_back(idx.value(), val);
+    });
+
+    BOOST_REQUIRE_EQUAL(visited.size(), 3);
+    BOOST_CHECK_EQUAL(visited[0].first, 2);
+    BOOST_CHECK_EQUAL(visited[0].second, 20);
+    BOOST_CHECK_EQUAL(visited[1].first, 4);
+    BOOST_CHECK_EQUAL(visited[1].second, 40);
+    BOOST_CHECK_EQUAL(visited[2].first, 5);
+    BOOST_CHECK_EQUAL(visited[2].second, 50);
+}
+
+BOOST_AUTO_TEST_CASE(test_for_each_mutates_values) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{2}, 20);
+    c.emplace(index_t{4}, 40);
+
+    c.for_each([](index_t, int& val) {
+        val += 1;
+    });
+
+    BOOST_CHECK_EQUAL(*c.find(index_t{2}), 21);
+    BOOST_CHECK_EQUAL(*c.find(index_t{4}), 41);
+}
+
+BOOST_AUTO_TEST_CASE(test_peek_front_and_consume) {
+    log_indexed_container<int> c;
+    BOOST_CHECK(c.peek_front() == nullptr);
+
+    c.emplace(index_t{4}, 40);
+    c.emplace(index_t{2}, 20); // before base — becomes the new front
+
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{2});
+    BOOST_REQUIRE(c.peek_front() != nullptr);
+    BOOST_CHECK_EQUAL(*c.peek_front(), 20);
+
+    // Consume the front: extracting it trims past the gap at index 3.
+    BOOST_CHECK_EQUAL(c.extract(c.base_index()), 20);
+    BOOST_CHECK_EQUAL(c.base_index(), index_t{4});
+    BOOST_REQUIRE(c.peek_front() != nullptr);
+    BOOST_CHECK_EQUAL(*c.peek_front(), 40);
+
+    BOOST_CHECK_EQUAL(c.extract(c.base_index()), 40);
+    BOOST_CHECK(c.peek_front() == nullptr);
+    BOOST_CHECK(c.empty());
+}
+
+BOOST_AUTO_TEST_CASE(test_clear) {
+    log_indexed_container<int> c;
+    c.emplace(index_t{10}, 1);
+    c.emplace(index_t{20}, 2);
+
+    c.clear();
+    BOOST_CHECK(c.empty());
+    BOOST_CHECK(c.find(index_t{10}) == nullptr);
+
+    // Can reuse after clear.
+    c.emplace(index_t{5}, 99);
+    BOOST_CHECK_EQUAL(*c.find(index_t{5}), 99);
+}
+
+BOOST_AUTO_TEST_CASE(test_move_only_type) {
+    log_indexed_container<std::unique_ptr<int>> c;
+    c.emplace(index_t{1}, std::make_unique<int>(42));
+
+    auto* p = c.find(index_t{1});
+    BOOST_REQUIRE(p != nullptr);
+    BOOST_CHECK_EQUAL(**p, 42);
+
+    // extract moves the value out to the caller.
+    auto extracted = c.extract(index_t{1});
+    BOOST_REQUIRE(extracted != nullptr);
+    BOOST_CHECK_EQUAL(*extracted, 42);
+    BOOST_CHECK(c.empty());
+}


### PR DESCRIPTION
Replace std::map<index_t, op_status> with log_indexed_container<op_status>
for the waiter queues. This gives O(1) lookup by index instead of
O(log n) and avoids per-element heap allocation.

I ran perf_simple_query with strong consistency and these changes. I can
confirm only the ~0.8 allocs/op reduction. Differences in the other metrics
are within the run-to-run variance.

Fixes: SCYLLADB-1874

No backport: minor optimization.