### PR TITLE
repair: reject repair requests with identical start and end tokens

### DIFF
--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -353,6 +353,15 @@ void set_repair(http_context& ctx, routes& r, sharded<repair_service>& repair, s
             }
         }
 
+        // Reject repair requests where start and end tokens are the same,
+        // as this would be interpreted as a wrapping range covering the
+        // entire token ring, resulting in a full repair (see CUSTOMER-358).
+        auto st_it = options_map.find("startToken");
+        auto et_it = options_map.find("endToken");
+        if (st_it != options_map.end() && et_it != options_map.end() && st_it->second == et_it->second) {
+            throw httpd::bad_param_exception("Start and end tokens must be different");
+        }
+
         // The repair process is asynchronous: repair_start only starts it and
         // returns immediately, not waiting for the repair to finish. The user
         // then has other mechanisms to track the ongoing repair's progress,

--- a/test/rest_api/test_repair_task.py
+++ b/test/rest_api/test_repair_task.py
@@ -116,3 +116,14 @@ def test_repair_task_progress(cql, this_dc, rest_api, test_keyspace_vnodes):
                     for child_status in get_children(status_tree, status["id"]):
                         assert child_status["progress_completed"] == child_status["progress_total"], "Incorrect task progress"
     drain_module_tasks(rest_api, module_name)
+
+# Reproducer for https://scylladb.atlassian.net/browse/CUSTOMER-358
+# Repairing with identical start and end tokens must be rejected,
+# otherwise it wraps around the full token ring causing a full repair.
+def test_repair_same_start_end_token_rejected(cql, this_dc, rest_api, test_keyspace_vnodes):
+    keyspace = test_keyspace_vnodes
+    token = "1558831538804957103"
+    resp = rest_api.send("POST", f"storage_service/repair_async/{keyspace}",
+                         {"startToken": token, "endToken": token})
+    assert resp.status_code == 400, f"Expected 400 but got {resp.status_code}"
+    assert "Start and end tokens must be different" in resp.text


### PR DESCRIPTION
## Summary
- Reject repair API requests where `startToken` equals `endToken` with HTTP 400, preventing accidental full-ring repairs
- When start and end tokens are identical, the wrapping interval `(T, T]` covers the entire token ring, causing a full repair instead of the intended single-token operation
- Matches Cassandra's behavior which already rejects this case

Fixes: https://scylladb.atlassian.net/browse/CUSTOMER-358
AI-assisted: Yes
Backport: no, benign improvement
Signed-off-by: Yaniv Kaul <yaniv.kaul@scylladb.com>