### PR TITLE
test: wait for TTL scheduling sanity metric

### DIFF
--- a/test/cluster/test_ttl_row.py
+++ b/test/cluster/test_ttl_row.py
@@ -22,6 +22,7 @@ from cassandra.protocol import InvalidRequest
 from cassandra.auth import PlainTextAuthProvider
 
 from test.pylib.manager_client import ManagerClient
+from test.pylib.util import wait_for
 from test.cluster.util import new_test_keyspace, new_test_table
 
 async def get_cpu_metrics(manager: ManagerClient):
@@ -96,15 +97,23 @@ async def test_row_ttl_scheduling_group(manager: ManagerClient):
             stmt = cql.prepare(f'INSERT INTO {table} (p, e) VALUES (?, ?)')
             stmt.consistency_level = ConsistencyLevel.ALL
             ms_streaming_before_write, ms_statement_before_write, items_deleted_before_write = await get_cpu_metrics(manager)
-            await asyncio.gather(*[cql.run_async(stmt, [p, e]) for p in range(N)])
+            async def write_rows():
+                await asyncio.gather(*[cql.run_async(stmt, [p, e]) for p in range(N)])
+            await write_rows()
 
-            ms_streaming_before, ms_statement_before, items_deleted_before = await get_cpu_metrics(manager)
             # Sanity check: the normal user writes that we did above did some
             # work in the statement scheduling group. This check shows that our
             # test is measuring the right schedling group - and when below
             # see TTL doing 0 work in the same scheduling group, it proves it
             # really doesn't work in the same scheduling group as user writes.
-            assert ms_statement_before_write < ms_statement_before
+            async def wait_for_statement_sg_work():
+                ms_streaming_before, ms_statement_before, items_deleted_before = await get_cpu_metrics(manager)
+                if ms_statement_before_write < ms_statement_before:
+                    return (ms_streaming_before, ms_statement_before, items_deleted_before)
+                await write_rows()
+                return None
+            ms_streaming_before, ms_statement_before, items_deleted_before = await wait_for(
+                wait_for_statement_sg_work, time.time() + 30)
 
             # Only now, after getting the metrics, enable TTL, so the
             # expiration scanner is guaranteed to run after this point.


### PR DESCRIPTION
The test samples `sl:default` runtime before and after setup writes to prove that it measures the scheduling group used by regular CQL writes. The metric is exported in milliseconds, so a single 200-row batch may not be visible immediately, or may be too small in some environments.

Keep the original 200-row table size, but wait up to 30 seconds for the metric to advance. If it does not, retry the same writes before TTL is enabled. The retries update the same keys, so the expiration part of the test still waits for exactly the original number of rows.

In a local 100-run with N=200 rows, the observed delta of `ms_statement_before - ms_statement_before_write` was: min=4.0, max=16.0, mean=8.13, and median=8.0. Therefore, it looks possible that in a rare corner case the delta drops even to 0.

Fixes SCYLLADB-1869

Backport to 2026.2 where https://github.com/scylladb/scylladb/pull/29447 was also fixed