### PR TITLE
sstables/trie: add preemption point in trie_writer::complete_until_depth()

### DIFF
--- a/sstables/trie/trie_writer.hh
+++ b/sstables/trie/trie_writer.hh
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include <seastar/core/thread.hh>
 #include <seastar/util/log.hh>
 #include <map>
 #include <set>
@@ -254,6 +255,7 @@ inline void trie_writer<Output>::lay_out_children(ptr<writer_node> x) {
     }
 
     while (unwritten_children.size()) {
+        seastar::thread::maybe_yield();
         // Find the smallest child which doesn't fit.
         // (If all fit, then this will be the past-the-end iterator).
         // Its predecessor will be the biggest child which does fit.
@@ -350,6 +352,7 @@ template <trie_writer_sink Output>
 inline void trie_writer<Output>::complete_until_depth(size_t depth) {
     expensive_log("writer_node::complete_until_depth: start,_stack={}, depth={}, _current_depth={}", _stack.size(), depth, _current_depth);
     while (_current_depth > depth) {
+        seastar::thread::maybe_yield();
         // Every node must be smaller than a page, and the transition chain
         // must be short enough to ensure that.
         //


### PR DESCRIPTION
The BTI partition index trie writer flushes all buffered nodes at the end of each SSTable via complete_until_depth(0), called from bti_partition_index_writer_impl::finish(). This is a tight synchronous loop that writes trie nodes through file_writer::write(), which uses a buffered output_stream: individual writes that fit in the buffer are plain memcpy operations returning a ready future, so .get() never yields. As a result the reactor can stall for several milliseconds on large SSTables.

The entire call chain runs inside seastar::async() (via sstable::write_components()), so seastar::thread::maybe_yield() is safe to call here. Add it at the top of both tight loops: 
- complete_until_depth(), which iterates over trie depth
- lay_out_children(), which iterates over child branches per node

Fixes SCYLLADB-1885

Backport: vulnerable code is in 2025.4, need backport to 2025.4