### PR TITLE
transport/server: drop expired responses waiting in the send queue

### DIFF
--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -46,7 +46,7 @@ class query_options;
 using cql_warnings_vec = std::vector<sstring>;
 
 class cql_statement {
-    timeout_config_selector _timeout_config_selector;
+    timeout_info _timeout_info;
     audit::audit_info_ptr _audit_info;
 public:
     // CQL statement text
@@ -57,13 +57,13 @@ public:
         return false;
     }
 
-    explicit cql_statement(timeout_config_selector timeout_selector) : _timeout_config_selector(timeout_selector) {}
+    explicit cql_statement(timeout_info ti) : _timeout_info(ti) {}
     cql_statement(cql_statement&& o) = default;
-    cql_statement(const cql_statement& o) : _timeout_config_selector(o._timeout_config_selector), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr) { }
+    cql_statement(const cql_statement& o) : _timeout_info(o._timeout_info), _audit_info(o._audit_info ? std::make_unique<audit::audit_info>(*o._audit_info) : nullptr) { }
     virtual ~cql_statement()
     { }
 
-    timeout_config_selector get_timeout_config_selector() const { return _timeout_config_selector; }
+    timeout_config_selector get_timeout_config_selector() const { return _timeout_info.selector; }
 
     virtual uint32_t get_bound_terms() const = 0;
 

--- a/cql3/cql_statement.hh
+++ b/cql3/cql_statement.hh
@@ -12,6 +12,7 @@
 
 #include "timeout_config.hh"
 #include "service/raft/raft_group0_client.hh"
+#include "service/client_state.hh"
 #include "audit/audit.hh"
 #include "utils/chunked_string.hh"
 
@@ -19,7 +20,6 @@ namespace service {
 
 class storage_proxy;
 class query_state;
-class client_state;
 
 }
 
@@ -64,6 +64,11 @@ public:
     { }
 
     timeout_config_selector get_timeout_config_selector() const { return _timeout_info.selector; }
+    const timeout_info& get_timeout_info() const { return _timeout_info; }
+
+    virtual db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const {
+        return state.get_timeout_config().*get_timeout_config_selector();
+    }
 
     virtual uint32_t get_bound_terms() const = 0;
 
@@ -120,6 +125,9 @@ public:
     void set_audit_info(audit::audit_info_ptr&& info) { _audit_info = std::move(info); }
 
     virtual void sanitize_audit_info() {}
+
+protected:
+    void set_timeout_write_type(db::write_type wt) { _timeout_info.write_type = wt; }
 };
 
 class cql_statement_no_metadata : public cql_statement {

--- a/cql3/query_processor.cc
+++ b/cql3/query_processor.cc
@@ -41,6 +41,34 @@ using namespace statements;
 using namespace cql_transport::messages;
 
 logging::logger log("query_processor");
+
+// Record the send-queue deadline, anchored at the request start time (on the
+// service_permit) so execution time doesn't extend it. Internal queries have no
+// start time and are skipped.
+static void set_response_deadline(
+        result_message& msg,
+        const cql_statement& stmt,
+        const service::query_state& query_state,
+        const query_options& options) {
+    if (msg.is_exception()) {
+        return;
+    }
+    auto permit = query_state.get_permit();
+    auto start_time = permit.start_time();
+    if (!start_time) {
+        return;
+    }
+    auto info = stmt.get_timeout_info();
+    if (!info.has_send_queue_deadline) {
+        return;
+    }
+    permit.set_deadline(*start_time + stmt.get_timeout(query_state.get_client_state(), options));
+    permit.set_timeout_ctx(timeout_context{
+        .cl = options.get_consistency(),
+        .is_write = info.is_write,
+        .wt = info.write_type,
+    });
+}
 logging::logger prep_cache_log("prepared_statements_cache");
 logging::logger authorized_prepared_statements_cache_log("authorized_prepared_statements_cache");
 
@@ -723,10 +751,13 @@ query_processor::process_authorized_statement(const ::shared_ptr<cql_statement> 
 
     auto msg = co_await statement->execute_without_checking_exception_message(*this, query_state, options, std::move(guard));
 
-    if (msg) {
-       co_return std::move(msg);
+    if (!msg) {
+        msg = ::make_shared<result_message::void_message>();
     }
-    co_return ::make_shared<result_message::void_message>();
+
+    set_response_deadline(*msg, *statement, query_state, options);
+
+    co_return std::move(msg);
 }
 
 future<::shared_ptr<cql_transport::messages::result_message::prepared>>
@@ -1104,7 +1135,11 @@ query_processor::execute_batch_without_checking_exception_message(
         }
         log.trace("execute_batch({}): {}", batch->get_statements().size(), oss.str());
     }
-    co_return co_await batch->execute(*this, query_state, options, std::nullopt);
+    auto msg = co_await batch->execute(*this, query_state, options, std::nullopt);
+    if (msg) {
+        set_response_deadline(*msg, *batch, query_state, options);
+    }
+    co_return msg;
 }
 
 future<service::broadcast_tables::query_result>
@@ -1298,10 +1333,10 @@ shared_ptr<cql_transport::messages::result_message> query_processor::bounce_to_n
         locator::tablet_replica replica,
         cql3::computed_function_values cached_fn_calls,
         seastar::lowres_clock::time_point timeout,
-        bool is_write,
+        timeout_context timeout_ctx,
         locator::host_id_or_exception_callback on_forwarding_finished) {
     get_cql_stats().forwarded_requests++;
-    return ::make_shared<cql_transport::messages::result_message::bounce>(replica.host, replica.shard, std::move(cached_fn_calls), timeout, is_write, std::move(on_forwarding_finished));
+    return ::make_shared<cql_transport::messages::result_message::bounce>(replica.host, replica.shard, std::move(cached_fn_calls), timeout, timeout_ctx, std::move(on_forwarding_finished));
 }
 
 query_processor::consistency_level_set query_processor::to_consistency_level_set(const query_processor::cl_option_list& levels) {

--- a/cql3/query_processor.hh
+++ b/cql3/query_processor.hh
@@ -525,7 +525,7 @@ public:
             locator::tablet_replica replica,
             cql3::computed_function_values cached_fn_calls,
             seastar::lowres_clock::time_point timeout,
-            bool is_write,
+            timeout_context timeout_ctx,
             locator::host_id_or_exception_callback on_forwarding_finished = {});
 
     void update_authorized_prepared_cache_config();

--- a/cql3/statements/authentication_statement.hh
+++ b/cql3/statements/authentication_statement.hh
@@ -19,7 +19,7 @@ namespace statements {
 
 class authentication_statement : public raw::parsed_statement, public cql_statement_no_metadata {
 public:
-    authentication_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    authentication_statement() : cql_statement_no_metadata(other_timeout_info) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/authorization_statement.hh
+++ b/cql3/statements/authorization_statement.hh
@@ -23,7 +23,7 @@ namespace statements {
 
 class authorization_statement : public raw::parsed_statement, public cql_statement_no_metadata {
 public:
-    authorization_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    authorization_statement() : cql_statement_no_metadata(other_timeout_info) {}
 
     uint32_t get_bound_terms() const override;
 

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -30,11 +30,15 @@ namespace statements {
 
 logging::logger batch_statement::_logger("BatchStatement");
 
-timeout_config_selector
+timeout_info
 timeout_for_type(batch_statement::type t) {
-    return t == batch_statement::type::COUNTER
-            ? &timeout_config::counter_write_timeout
-            : &timeout_config::write_timeout;
+    if (t == batch_statement::type::COUNTER) {
+        return counter_write_timeout_info;
+    } else if (t == batch_statement::type::UNLOGGED) {
+        return unlogged_batch_write_timeout_info;
+    } else {
+        return batch_write_timeout_info;
+    }
 }
 
 db::timeout_clock::duration batch_statement::get_timeout(const service::client_state& state, const query_options& options) const {

--- a/cql3/statements/batch_statement.cc
+++ b/cql3/statements/batch_statement.cc
@@ -63,6 +63,8 @@ batch_statement::batch_statement(int bound_terms, type type_,
         // build_cas_result_set_metadata right from the constructor to avoid crash trying to access
         // uninitialized batch metadata.
         build_cas_result_set_metadata();
+        // CAS so a dropped response matches the storage proxy's CAS timeout.
+        set_timeout_write_type(db::write_type::CAS);
     }
 }
 

--- a/cql3/statements/batch_statement.hh
+++ b/cql3/statements/batch_statement.hh
@@ -151,8 +151,8 @@ private:
             const query_options& options,
             service::query_state& state) const;
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
 public:
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
     // FIXME: no cql_statement::to_string() yet
 #if 0
     sstring to_string() const {

--- a/cql3/statements/broadcast_modification_statement.cc
+++ b/cql3/statements/broadcast_modification_statement.cc
@@ -37,7 +37,7 @@ broadcast_modification_statement::broadcast_modification_statement(
     uint32_t bound_terms,
     schema_ptr schema,
     broadcast_tables::prepared_update query)
-    : cql_statement_opt_metadata{&timeout_config::write_timeout}
+    : cql_statement_opt_metadata{write_timeout_info}
     , _bound_terms{bound_terms}
     , _schema{schema}
     , _query{std::move(query)}

--- a/cql3/statements/describe_statement.cc
+++ b/cql3/statements/describe_statement.cc
@@ -515,7 +515,7 @@ std::vector<std::vector<managed_bytes_opt>> serialize_descriptions(utils::chunke
 
 
 // DESCRIBE STATEMENT
-describe_statement::describe_statement() : cql_statement(&timeout_config::other_timeout) {}
+describe_statement::describe_statement() : cql_statement(other_timeout_info) {}
 
 uint32_t describe_statement::get_bound_terms() const { return 0; }
 

--- a/cql3/statements/drop_index_statement.cc
+++ b/cql3/statements/drop_index_statement.cc
@@ -24,7 +24,7 @@ namespace cql3 {
 namespace statements {
 
 drop_index_statement::drop_index_statement(::shared_ptr<index_name> index_name, bool if_exists)
-    : schema_altering_statement{index_name->get_cf_name(), &timeout_config::truncate_timeout}
+    : schema_altering_statement{index_name->get_cf_name(), truncate_timeout_info}
     , _index_name{index_name->get_idx()}
     , _if_exists{if_exists}
 {

--- a/cql3/statements/drop_keyspace_statement.cc
+++ b/cql3/statements/drop_keyspace_statement.cc
@@ -24,7 +24,7 @@ namespace cql3 {
 namespace statements {
 
 drop_keyspace_statement::drop_keyspace_statement(const sstring& keyspace, bool if_exists)
-    : schema_altering_statement(&timeout_config::truncate_timeout)
+    : schema_altering_statement(truncate_timeout_info)
     , _keyspace{keyspace}
     , _if_exists{if_exists}
 {

--- a/cql3/statements/drop_table_statement.cc
+++ b/cql3/statements/drop_table_statement.cc
@@ -22,7 +22,7 @@ namespace cql3 {
 namespace statements {
 
 drop_table_statement::drop_table_statement(cf_name cf_name, bool if_exists)
-    : schema_altering_statement{std::move(cf_name), &timeout_config::truncate_timeout}
+    : schema_altering_statement{std::move(cf_name), truncate_timeout_info}
     , _if_exists{if_exists}
 {
 }

--- a/cql3/statements/drop_view_statement.cc
+++ b/cql3/statements/drop_view_statement.cc
@@ -22,7 +22,7 @@ namespace cql3 {
 namespace statements {
 
 drop_view_statement::drop_view_statement(cf_name view_name, bool if_exists)
-    : schema_altering_statement{std::move(view_name), &timeout_config::truncate_timeout}
+    : schema_altering_statement{std::move(view_name), truncate_timeout_info}
     , _if_exists{if_exists}
 {
 }

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -44,12 +44,12 @@ namespace cql3 {
 
 namespace statements {
 
-timeout_config_selector
+timeout_info
 modification_statement_timeout(const schema& s) {
     if (s.is_counter()) {
-        return &timeout_config::counter_write_timeout;
+        return counter_write_timeout_info;
     } else {
-        return &timeout_config::write_timeout;
+        return write_timeout_info;
     }
 }
 

--- a/cql3/statements/modification_statement.cc
+++ b/cql3/statements/modification_statement.cc
@@ -644,6 +644,10 @@ modification_statement::prepare(data_dictionary::database db, prepare_context& c
     if (!prepared_stmt->has_conditions() && prepared_stmt->_restrictions) {
         ctx.clear_pk_function_calls_cache();
     }
+    if (prepared_stmt->has_conditions()) {
+        // CAS so a dropped response matches the storage proxy's CAS timeout.
+        prepared_stmt->set_timeout_write_type(db::write_type::CAS);
+    }
     prepared_stmt->_may_use_token_aware_routing = ctx.get_partition_key_bind_indexes(*schema).size() != 0;
     return prepared_stmt;
 }

--- a/cql3/statements/modification_statement.hh
+++ b/cql3/statements/modification_statement.hh
@@ -268,7 +268,7 @@ public:
 
     virtual ::shared_ptr<broadcast_modification_statement> prepare_for_broadcast_tables() const;
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 
 protected:
     /**

--- a/cql3/statements/schema_altering_statement.cc
+++ b/cql3/statements/schema_altering_statement.cc
@@ -22,15 +22,15 @@ namespace statements {
 
 static logging::logger logger("schema_altering_statement");
 
-schema_altering_statement::schema_altering_statement(timeout_config_selector timeout_selector)
+schema_altering_statement::schema_altering_statement(timeout_info ti)
     : cf_statement(cf_name())
-    , cql_statement_no_metadata(timeout_selector)
+    , cql_statement_no_metadata(ti)
     , _is_column_family_level{false} {
 }
 
-schema_altering_statement::schema_altering_statement(cf_name name, timeout_config_selector timeout_selector)
+schema_altering_statement::schema_altering_statement(cf_name name, timeout_info ti)
     : cf_statement{std::move(name)}
-    , cql_statement_no_metadata(timeout_selector)
+    , cql_statement_no_metadata(ti)
     , _is_column_family_level{true} {
 }
 

--- a/cql3/statements/schema_altering_statement.hh
+++ b/cql3/statements/schema_altering_statement.hh
@@ -38,9 +38,9 @@ private:
     const bool _is_column_family_level;
 
 protected:
-    explicit schema_altering_statement(timeout_config_selector timeout_selector = &timeout_config::other_timeout);
+    explicit schema_altering_statement(timeout_info ti = other_timeout_info);
 
-    schema_altering_statement(cf_name name, timeout_config_selector timeout_selector = &timeout_config::other_timeout);
+    schema_altering_statement(cf_name name, timeout_info ti = other_timeout_info);
     
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -187,12 +187,12 @@ select_statement::parameters::orderings_type const& select_statement::parameters
     return _orderings;
 }
 
-timeout_config_selector
+timeout_info
 select_timeout(const restrictions::statement_restrictions& restrictions) {
     if (restrictions.is_key_range()) {
-        return &timeout_config::range_read_timeout;
+        return range_read_timeout_info;
     } else {
-        return &timeout_config::read_timeout;
+        return read_timeout_info;
     }
 }
 

--- a/cql3/statements/select_statement.hh
+++ b/cql3/statements/select_statement.hh
@@ -158,7 +158,7 @@ public:
 
     bool has_group_by() const { return _group_by_cell_indices && !_group_by_cell_indices->empty(); }
 
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 
 protected:
     uint64_t get_limit(const query_options& options, const std::optional<expr::expression>& limit, bool is_per_partition_limit = false) const;

--- a/cql3/statements/service_level_statement.hh
+++ b/cql3/statements/service_level_statement.hh
@@ -41,7 +41,7 @@ public:
 
 class service_level_statement : public raw::parsed_statement, public cql_statement_no_metadata {
 public:
-    service_level_statement() : cql_statement_no_metadata(&timeout_config::other_timeout) {}
+    service_level_statement() : cql_statement_no_metadata(other_timeout_info) {}
 
     virtual bool needs_guard(query_processor& qp, service::query_state& state) const override;
 

--- a/cql3/statements/strong_consistency/modification_statement.cc
+++ b/cql3/statements/strong_consistency/modification_statement.cc
@@ -21,7 +21,7 @@ namespace cql3::statements::strong_consistency {
 static logging::logger logger("sc_modification_statement");
 
 modification_statement::modification_statement(shared_ptr<base_statement> statement)
-    : cql_statement_opt_metadata(&timeout_config::write_timeout)
+    : cql_statement_opt_metadata(write_timeout_info)
     , _statement(std::move(statement))
 {
 }

--- a/cql3/statements/strong_consistency/statement_helpers.cc
+++ b/cql3/statements/strong_consistency/statement_helpers.cc
@@ -27,7 +27,14 @@ future<::shared_ptr<cql_transport::messages::result_message>> redirect_statement
     const auto my_host_id = qp.db().real_database().get_token_metadata().get_topology().my_host_id();
     if (target.host != my_host_id) {
         ++(is_write ? stats.write_node_bounces : stats.read_node_bounces);
-        co_return qp.bounce_to_node(target, std::move(func_values_cache), timeout, is_write, std::move(on_forwarding_finished));
+        // SC operations report the client's CL and (for writes) SIMPLE write_type,
+        // matching the local SC path's timeout exception.
+        co_return qp.bounce_to_node(target, std::move(func_values_cache), timeout,
+                timeout_context{
+                        .cl = options.get_consistency(),
+                        .is_write = is_write,
+                        .wt = db::write_type::SIMPLE},
+                std::move(on_forwarding_finished));
     }
     ++(is_write ? stats.write_shard_bounces : stats.read_shard_bounces);
     co_return qp.bounce_to_shard(target.shard, std::move(func_values_cache));

--- a/cql3/statements/truncate_statement.cc
+++ b/cql3/statements/truncate_statement.cc
@@ -47,7 +47,7 @@ std::unique_ptr<prepared_statement> truncate_statement::prepare(data_dictionary:
 } // namespace raw
 
 truncate_statement::truncate_statement(schema_ptr schema, std::unique_ptr<attributes> prepared_attrs)
-    : cql_statement_no_metadata(&timeout_config::truncate_timeout)
+    : cql_statement_no_metadata(truncate_timeout_info)
     , _schema{std::move(schema)}
     , _attrs(std::move(prepared_attrs))
 {

--- a/cql3/statements/truncate_statement.hh
+++ b/cql3/statements/truncate_statement.hh
@@ -42,7 +42,7 @@ public:
     virtual future<::shared_ptr<cql_transport::messages::result_message>>
     execute(query_processor& qp, service::query_state& state, const query_options& options, std::optional<service::group0_guard> guard) const override;
 private:
-    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const;
+    db::timeout_clock::duration get_timeout(const service::client_state& state, const query_options& options) const override;
 };
 
 }

--- a/cql3/statements/use_statement.cc
+++ b/cql3/statements/use_statement.cc
@@ -19,7 +19,7 @@ namespace cql3 {
 namespace statements {
 
 use_statement::use_statement(sstring keyspace)
-        : cql_statement_no_metadata(&timeout_config::other_timeout)
+        : cql_statement_no_metadata(other_timeout_info)
         , _keyspace(keyspace)
 {
 }

--- a/service_permit.hh
+++ b/service_permit.hh
@@ -8,22 +8,59 @@
 
 #pragma once
 
+#include <optional>
+
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include "db/timeout_clock.hh"
+#include "timeout_config.hh"
+
 class service_permit {
-    seastar::lw_shared_ptr<seastar::semaphore_units<>> _permit;
-    service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<seastar::semaphore_units<>>(std::move(u))) {}
+    struct impl {
+        seastar::semaphore_units<> units;
+        std::optional<db::timeout_clock::time_point> start_time;
+        db::timeout_clock::time_point deadline = db::timeout_clock::time_point::max();
+        timeout_context timeout_ctx;
+    };
+    seastar::lw_shared_ptr<impl> _permit;
+    service_permit(seastar::semaphore_units<>&& u) : _permit(seastar::make_lw_shared<impl>()) {
+        _permit->units = std::move(u);
+    }
     friend service_permit make_service_permit(seastar::semaphore_units<>&& permit);
     friend service_permit empty_service_permit();
 public:
-    size_t count() const { return _permit ? _permit->count() : 0; };
+    size_t count() const { return _permit ? _permit->units.count() : 0; };
     // Merge additional semaphore units into this permit.
     // Used to grow the permit after the actual resource cost is known.
     void adopt(seastar::semaphore_units<>&& units) {
         if (_permit) {
-            _permit->adopt(std::move(units));
+            _permit->units.adopt(std::move(units));
         }
+    }
+    void set_start_time(db::timeout_clock::time_point t) {
+        if (_permit) {
+            _permit->start_time = t;
+        }
+    }
+    std::optional<db::timeout_clock::time_point> start_time() const {
+        return _permit ? _permit->start_time : std::nullopt;
+    }
+    void set_deadline(db::timeout_clock::time_point d) {
+        if (_permit) {
+            _permit->deadline = d;
+        }
+    }
+    db::timeout_clock::time_point deadline() const {
+        return _permit ? _permit->deadline : db::timeout_clock::time_point::max();
+    }
+    void set_timeout_ctx(timeout_context ctx) {
+        if (_permit) {
+            _permit->timeout_ctx = ctx;
+        }
+    }
+    timeout_context timeout_ctx() const {
+        return _permit ? _permit->timeout_ctx : timeout_context{};
     }
 };
 

--- a/test/cluster/test_response_timeout_in_send_queue.py
+++ b/test/cluster/test_response_timeout_in_send_queue.py
@@ -1,0 +1,494 @@
+# Copyright (C) 2026-present ScyllaDB
+#
+# SPDX-License-Identifier: LicenseRef-ScyllaDB-Source-Available-1.1
+
+"""
+Test that the response timeout accounting extends through the send queue.
+
+Responses that have already exceeded their request timeout while waiting
+in the send queue should be replaced with a typed timeout error
+(ReadTimeout/WriteTimeout) rather than sent to the client as a successful
+result. This prevents a cascade effect where expired responses block fresh
+ones, causing unnecessary additional timeouts.
+"""
+
+import asyncio
+import pytest
+
+from cassandra import WriteType  # type: ignore
+from cassandra.cluster import OperationTimedOut  # type: ignore
+from cassandra.protocol import ReadTimeout, WriteTimeout  # type: ignore
+
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error
+from test.pylib.tablets import get_tablet_replicas
+from test.pylib.util import gather_safely
+
+from .util import new_test_keyspace, new_test_table
+
+REQUESTS_DROPPED_METRIC = "scylla_transport_requests_dropped_due_to_timeout"
+REQUESTS_SENT_AFTER_TIMEOUT_METRIC = "scylla_transport_requests_sent_after_timeout"
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_read_response_replaced_with_read_timeout_in_send_queue(manager: ManagerClient):
+    """A SELECT whose response expires in the send queue must produce ReadTimeout."""
+    config = {
+        "read_request_timeout_in_ms": 500,
+        "write_request_timeout_in_ms": 500,
+        "range_read_request_timeout_in_ms": 500,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                # Fire the SELECT; it completes but the response is held in the send queue.
+                query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Sleep past the server timeout while the response is held.
+                await asyncio.sleep(1.5)
+
+                # Release - the server should replace the RESULT with ReadTimeout.
+                await handler.message()
+
+                # Server sends a ReadTimeout; the driver's request_timeout (200s) is
+                # far larger, so the typed error arrives first.
+                with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(query_task, timeout=10.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to increase, "
+                f"but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_write_response_replaced_with_write_timeout_in_send_queue(manager: ManagerClient):
+    """An INSERT whose response expires in the send queue must produce WriteTimeout."""
+    config = {
+        "read_request_timeout_in_ms": 500,
+        "write_request_timeout_in_ms": 500,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                # Fire off an INSERT - it will complete but the response is held.
+                query_task = cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (2, 2)")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Sleep past the server timeout while the response is held.
+                await asyncio.sleep(1.5)
+
+                # Release - the server should replace the RESULT with WriteTimeout.
+                await handler.message()
+
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(query_task, timeout=10.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to increase, "
+                f"but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_using_timeout_drives_send_queue_deadline(manager: ManagerClient):
+    """USING TIMEOUT should drive the send-queue deadline, not the default server timeout."""
+    # Use a large default timeout - USING TIMEOUT should override it.
+    config = {
+        "read_request_timeout_in_ms": 60000,
+        "write_request_timeout_in_ms": 60000,
+        "range_read_request_timeout_in_ms": 60000,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                # USING TIMEOUT 500ms overrides the 60s default.
+                query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1 USING TIMEOUT 500ms")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Sleep past USING TIMEOUT but well below the configured default.
+                await asyncio.sleep(1.5)
+
+                await handler.message()
+
+                # Should get a ReadTimeout from the transport layer, proving that
+                # USING TIMEOUT drove the send-queue deadline.
+                with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(query_task, timeout=10.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to increase "
+                f"when using USING TIMEOUT 500ms, but it went from "
+                f"{dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_fresh_response_not_dropped_in_send_queue(manager: ManagerClient):
+    """A response that has not exceeded its deadline must be delivered, not dropped.
+
+    With a large timeout the response is well within its deadline when it leaves
+    the send queue, so it must arrive intact and the dropped metric must not move.
+    """
+    config = {
+        "read_request_timeout_in_ms": 60000,
+        "write_request_timeout_in_ms": 60000,
+        "range_read_request_timeout_in_ms": 60000,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Release immediately - the brief hold is far below the 60s
+                # deadline, so the response must not be dropped.
+                await handler.message()
+
+                result = await asyncio.wait_for(query_task, timeout=10.0)
+                assert len(result) == 1 and result[0].v == 1, (
+                    f"Expected [(p=1, v=1)] but got {result}")
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after == dropped_before, (
+                f"Expected requests_dropped_due_to_timeout metric to stay flat "
+                f"for a fresh response, but it went from {dropped_before} to {dropped_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_response_sent_after_timeout_is_counted(manager: ManagerClient):
+    """Responses that expire during write/flush are sent but counted via requests_sent_after_timeout.
+
+    When a response's deadline expires during write_message()/flush(), we cannot
+    replace it (a partial CQL frame may already be on the wire). Instead, the
+    response is sent and counted via the requests_sent_after_timeout metric.
+    """
+    config = {
+        "read_request_timeout_in_ms": 500,
+        "write_request_timeout_in_ms": 500,
+        "range_read_request_timeout_in_ms": 500,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            sent_after_before = metrics_before.get(REQUESTS_SENT_AFTER_TIMEOUT_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            # transport_pre_flush_delay fires after the frame header and body are
+            # written but before flush(), so the response can't be replaced (partial
+            # frame); the deadline expires mid-write and the response is sent but counted.
+            async with inject_error(manager.api, host_ip, "transport_pre_flush_delay") as handler:
+                query_task = cql.run_async(f"SELECT * FROM {tbl} WHERE p = 1")
+
+                await log.wait_for("transport_pre_flush_delay: waiting", from_mark=mark)
+
+                # Sleep past the configured timeout while write is "in progress"
+                await asyncio.sleep(1.5)
+
+                await handler.message()
+
+                # The response was SENT, not replaced: the deadline expired during
+                # write/flush, which the server counts but can't abort. A ReadTimeout
+                # here would mean it was replaced, which must not happen mid-write.
+                # The driver's request_timeout (200s, see conftest) is far larger, so
+                # the result usually still arrives; the metric is what we verify.
+                try:
+                    result = await asyncio.wait_for(query_task, timeout=10.0)
+                    assert len(result) == 1 and result[0].v == 1, (
+                        f"Expected [(p=1, v=1)] but got {result}")
+                except OperationTimedOut:
+                    # Driver gave up waiting; the server still sent it, metric still valid.
+                    pass
+
+            metrics_after = await manager.metrics.query(host_ip)
+            sent_after_after = metrics_after.get(REQUESTS_SENT_AFTER_TIMEOUT_METRIC) or 0
+            assert sent_after_after > sent_after_before, (
+                f"Expected requests_sent_after_timeout metric to increase, "
+                f"but it went from {sent_after_before} to {sent_after_after}."
+            )
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_truncate_and_drop_responses_not_dropped_in_send_queue(manager: ManagerClient):
+    """TRUNCATE and DROP responses must never be replaced with a timeout error.
+
+    They opt out of send-queue dropping (has_send_queue_deadline=false): even when
+    held past the truncate timeout they must arrive intact and not increment the
+    dropped metric, since the operation was already performed.
+    """
+    config = {
+        # Small so the deadline would be exceeded by the hold below if these
+        # operations participated in send-queue dropping (which they must not).
+        "truncate_request_timeout_in_ms": 500,
+    }
+
+    servers = await manager.servers_add(1, config=config)
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async def assert_held_response_delivered(stmt: str):
+        """Run stmt with its response held in the send queue past the deadline."""
+        metrics_before = await manager.metrics.query(host_ip)
+        dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+        log = await manager.server_open_log(servers[0].server_id)
+        mark = await log.mark()
+
+        async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+            task = cql.run_async(stmt)
+
+            await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+            # Hold well past the 500ms truncate timeout.
+            await asyncio.sleep(1.5)
+
+            await handler.message()
+
+            # Must be delivered, not replaced with a WriteTimeout.
+            await asyncio.wait_for(task, timeout=10.0)
+
+        metrics_after = await manager.metrics.query(host_ip)
+        dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+        assert dropped_after == dropped_before, (
+            f"{stmt!r} response was dropped (metric {dropped_before} -> {dropped_after}); "
+            f"TRUNCATE/DROP responses must always be delivered."
+        )
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.t (p int PRIMARY KEY, v int)")
+        await cql.run_async(f"INSERT INTO {ks}.t (p, v) VALUES (1, 1)")
+
+        await assert_held_response_delivered(f"TRUNCATE {ks}.t")
+        await assert_held_response_delivered(f"DROP TABLE {ks}.t")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_shard_bounced_response_replaced_in_send_queue(manager: ManagerClient):
+    """A response built on a bounced-to shard must still be dropped if it expires.
+
+    An LWT can run on a different shard (a shard bounce) with a fresh permit, so
+    the request start time must cross the shard boundary for the response to carry
+    a deadline. Force a bounce, hold past the deadline, expect a dropped+counted timeout.
+    """
+    config = {
+        "read_request_timeout_in_ms": 500,
+        "write_request_timeout_in_ms": 500,
+    }
+
+    servers = await manager.servers_add(1, config=config, cmdline=['--smp=2'])
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            await cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1)")
+
+            metrics_before = await manager.metrics.query(host_ip)
+            dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            # Force the update to bounce to another shard (reached via invoke_on),
+            # the path that must carry the request start time across the boundary.
+            await manager.api.enable_injection(host_ip, "forced_bounce_to_shard_counter",
+                                               one_shot=False, parameters={'value': '2'})
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                # Conditional update -> LWT/CAS, runs on the cas_shard via a bounce.
+                query_task = cql.run_async(f"UPDATE {tbl} SET v = 2 WHERE p = 1 IF v = 1")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Sleep past the server timeout while the response is held.
+                await asyncio.sleep(1.5)
+
+                await handler.message()
+
+                # Expired in the send queue -> replaced with a typed timeout error.
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded"):
+                    await asyncio.wait_for(query_task, timeout=10.0)
+
+            metrics_after = await manager.metrics.query(host_ip)
+            dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+            assert dropped_after > dropped_before, (
+                f"Expected requests_dropped_due_to_timeout to increase for a "
+                f"shard-bounced response, but it went from {dropped_before} to {dropped_after}. "
+                f"This means the bounced response carried no send-queue deadline.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_cas_response_replaced_with_cas_write_timeout_in_send_queue(manager: ManagerClient):
+    """A dropped LWT (CAS) response must report write_type=CAS, not SIMPLE.
+
+    So a driver handles it like any other CAS timeout, matching the write_type
+    the storage proxy's CAS path reports.
+    """
+    config = {
+        "read_request_timeout_in_ms": 500,
+        "write_request_timeout_in_ms": 500,
+    }
+
+    # Single shard so the CAS runs locally (no bounce), isolating the write_type.
+    servers = await manager.servers_add(1, config=config, cmdline=['--smp=1'])
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ip = servers[0].ip_addr
+
+    async with new_test_keyspace(manager, "WITH REPLICATION = { 'replication_factor' : '1' }", hosts[0]) as ks:
+        async with new_test_table(manager, ks, "p int PRIMARY KEY, v int", "", hosts[0]) as tbl:
+            log = await manager.server_open_log(servers[0].server_id)
+            mark = await log.mark()
+
+            async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+                # Conditional INSERT -> LWT/CAS.
+                query_task = cql.run_async(f"INSERT INTO {tbl} (p, v) VALUES (1, 1) IF NOT EXISTS")
+
+                await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+                # Sleep past the server timeout while the response is held.
+                await asyncio.sleep(1.5)
+
+                await handler.message()
+
+                with pytest.raises(WriteTimeout, match="Request timeout exceeded") as excinfo:
+                    await asyncio.wait_for(query_task, timeout=10.0)
+                # Driver may expose write_type as code or name; accept either.
+                assert excinfo.value.write_type in (WriteType.CAS, "CAS"), (
+                    f"Expected write_type CAS for a dropped LWT response, "
+                    f"got {excinfo.value.write_type!r}.")
+
+
+@pytest.mark.skip_mode(mode="release", reason="error injections are not supported in release mode")
+async def test_forwarded_response_replaced_in_send_queue(manager: ManagerClient):
+    """A forwarded response that expires in the send queue must be replaced.
+
+    An SC read issued on a non-leader node is forwarded to the leader and written
+    back from the receiving node, which must apply the request-anchored deadline
+    and bounce timeout context. An expired forwarded read must be a ReadTimeout
+    (is_write=false carried on the bounce), not a WriteTimeout.
+    """
+    config = {
+        'experimental_features': ['strongly-consistent-tables'],
+        # Large enough for the strongly-consistent read to complete, small enough
+        # that the send-queue hold below exceeds the request deadline.
+        'read_request_timeout_in_ms': 2000,
+        'write_request_timeout_in_ms': 2000,
+    }
+
+    servers = await manager.servers_add(2, config=config, auto_rack_dc='my_dc')
+    cql, hosts = await manager.get_ready_cql(servers)
+    host_ids = await gather_safely(*[manager.get_host_id(s.server_id) for s in servers])
+
+    async with new_test_keyspace(manager,
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} "
+            "AND tablets = {'initial': 1} AND consistency = 'global'") as ks:
+        await cql.run_async(f"CREATE TABLE {ks}.test (pk int PRIMARY KEY, c int)")
+        await cql.run_async(f"INSERT INTO {ks}.test (pk, c) VALUES (1, 10)")
+
+        # The single tablet has one replica, which is the Raft leader. An SC read
+        # issued on the other (non-replica) node is forwarded to that leader.
+        tablet_replicas = await get_tablet_replicas(manager, servers[0], ks, "test", 0)
+        replica_host_ids = {str(r[0]) for r in tablet_replicas}
+        non_replica_idx = next(i for i, hid in enumerate(host_ids)
+                               if str(hid) not in replica_host_ids)
+        non_replica_server = servers[non_replica_idx]
+        non_replica_host = hosts[non_replica_idx]
+        host_ip = non_replica_server.ip_addr
+
+        metrics_before = await manager.metrics.query(host_ip)
+        dropped_before = metrics_before.get(REQUESTS_DROPPED_METRIC) or 0
+
+        log = await manager.server_open_log(non_replica_server.server_id)
+        mark = await log.mark()
+
+        async with inject_error(manager.api, host_ip, "transport_write_response_delay") as handler:
+            # Issued on the non-replica node -> forwarded to the leader.
+            query_task = cql.run_async(f"SELECT * FROM {ks}.test WHERE pk = 1", host=non_replica_host)
+
+            await log.wait_for("transport_write_response_delay: waiting", from_mark=mark)
+
+            # Hold past the 2s request timeout while the forwarded response waits.
+            await asyncio.sleep(4)
+
+            await handler.message()
+
+            with pytest.raises(ReadTimeout, match="Request timeout exceeded"):
+                await asyncio.wait_for(query_task, timeout=15.0)
+
+        metrics_after = await manager.metrics.query(host_ip)
+        dropped_after = metrics_after.get(REQUESTS_DROPPED_METRIC) or 0
+        assert dropped_after > dropped_before, (
+            f"Expected requests_dropped_due_to_timeout to increase on the "
+            f"forwarding node, but it went from {dropped_before} to {dropped_after}.")

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "db/timeout_clock.hh"
+#include "db/write_type.hh"
 #include "utils/updateable_value.hh"
 
 namespace db { class config; }
@@ -54,3 +55,20 @@ struct updateable_timeout_config {
 using timeout_config_selector = db::timeout_clock::duration (timeout_config::*);
 
 extern const timeout_config infinite_timeout_config;
+
+struct timeout_info {
+    timeout_config_selector selector;
+    bool is_write;
+    db::write_type write_type = db::write_type::SIMPLE;
+    // Whether responses participate in send-queue timeout accounting.
+    bool has_send_queue_deadline = true;
+};
+
+constexpr timeout_info read_timeout_info = {.selector = &timeout_config::read_timeout, .is_write = false};
+constexpr timeout_info range_read_timeout_info = {.selector = &timeout_config::range_read_timeout, .is_write = false};
+constexpr timeout_info write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true};
+constexpr timeout_info counter_write_timeout_info = {.selector = &timeout_config::counter_write_timeout, .is_write = true, .write_type = db::write_type::COUNTER};
+constexpr timeout_info truncate_timeout_info = {.selector = &timeout_config::truncate_timeout, .is_write = true, .write_type = db::write_type::SIMPLE, .has_send_queue_deadline = false};
+constexpr timeout_info other_timeout_info = {.selector = &timeout_config::other_timeout, .is_write = false, .write_type = db::write_type::SIMPLE, .has_send_queue_deadline = false};
+constexpr timeout_info batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::BATCH};
+constexpr timeout_info unlogged_batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::UNLOGGED_BATCH};

--- a/timeout_config.hh
+++ b/timeout_config.hh
@@ -11,6 +11,7 @@
 
 #include "db/timeout_clock.hh"
 #include "db/write_type.hh"
+#include "db/consistency_level_type.hh"
 #include "utils/updateable_value.hh"
 
 namespace db { class config; }
@@ -72,3 +73,13 @@ constexpr timeout_info truncate_timeout_info = {.selector = &timeout_config::tru
 constexpr timeout_info other_timeout_info = {.selector = &timeout_config::other_timeout, .is_write = false, .write_type = db::write_type::SIMPLE, .has_send_queue_deadline = false};
 constexpr timeout_info batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::BATCH};
 constexpr timeout_info unlogged_batch_write_timeout_info = {.selector = &timeout_config::write_timeout, .is_write = true, .write_type = db::write_type::UNLOGGED_BATCH};
+
+// Runtime context captured at statement execution, used to build a typed timeout
+// error (ReadTimeout/WriteTimeout) if the response expires in the send queue.
+// Unlike timeout_info (static per-statement metadata), it carries the request's
+// actual consistency level, so it travels on the service_permit with the deadline.
+struct timeout_context {
+    db::consistency_level cl = db::consistency_level::ONE;
+    bool is_write = false;
+    db::write_type wt = db::write_type::SIMPLE; // only meaningful when is_write == true
+};

--- a/transport/messages/result_message.hh
+++ b/transport/messages/result_message.hh
@@ -19,6 +19,7 @@
 
 #include "transport/messages/result_message_base.hh"
 #include "transport/event.hh"
+#include "timeout_config.hh"
 #include "exceptions/coordinator_result.hh"
 #include "locator/host_id.hh"
 #include "types/types.hh"
@@ -99,18 +100,21 @@ class result_message::bounce : public result_message {
     unsigned _shard;
     cql3::computed_function_values _cached_fn_calls;
     std::optional<seastar::lowres_clock::time_point> _timeout;
-    std::optional<bool> _is_write;
+    // Request timeout context, so the forwarding coordinator can type the timeout
+    // error correctly. Set by the bouncing statement (see redirect_statement);
+    // empty for shard bounces, which never forward.
+    std::optional<timeout_context> _timeout_ctx;
     locator::host_id_or_exception_callback _on_forwarding_finished;
 
 public:
     bounce(locator::host_id host, unsigned shard, cql3::computed_function_values cached_fn_calls,
-           std::optional<seastar::lowres_clock::time_point> timeout = std::nullopt, std::optional<bool> is_write = std::nullopt,
+           std::optional<seastar::lowres_clock::time_point> timeout = std::nullopt, std::optional<timeout_context> timeout_ctx = std::nullopt,
            locator::host_id_or_exception_callback on_forwarding_finished = {})
         : _host(host)
         , _shard(shard)
         , _cached_fn_calls(std::move(cached_fn_calls))
         , _timeout(std::move(timeout))
-        , _is_write(std::move(is_write))
+        , _timeout_ctx(std::move(timeout_ctx))
         , _on_forwarding_finished(std::move(on_forwarding_finished))
     {}
     virtual void accept(result_message::visitor& v) const override {
@@ -132,8 +136,8 @@ public:
         return _timeout;
     }
 
-    std::optional<bool> is_write() const {
-        return _is_write;
+    std::optional<timeout_context> timeout_ctx() const {
+        return _timeout_ctx;
     }
 
     cql3::computed_function_values&& take_cached_pk_function_calls() {

--- a/transport/response.hh
+++ b/transport/response.hh
@@ -8,7 +8,10 @@
 
 #pragma once
 
+#include <seastar/core/lowres_clock.hh>
+
 #include "server.hh"
+#include "timeout_config.hh"
 
 namespace cql_transport {
 
@@ -38,6 +41,12 @@ class response {
     cql_binary_opcode _opcode;
     uint8_t           _flags = 0; // a bitwise OR mask of zero or more cql_frame_flags values
     bytes_ostream _body;
+    // Request deadline for send-queue timeout accounting; an expired response is
+    // replaced with a typed error before writing. Defaults to max() (no deadline).
+    seastar::lowres_clock::time_point _deadline = seastar::lowres_clock::time_point::max();
+    // Context for constructing a typed timeout error when the deadline expires
+    // in the send queue. Populated from the service_permit's timeout context.
+    timeout_context _timeout_ctx;
 public:
     template<typename T>
     class placeholder;
@@ -93,11 +102,24 @@ public:
     cql_binary_opcode opcode() const {
         return _opcode;
     }
+    int16_t stream() const {
+        return _stream;
+    }
     size_t size() const {
         return _body.size();
     }
     uint8_t flags() const {
         return _flags;
+    }
+    void set_deadline(seastar::lowres_clock::time_point deadline, timeout_context ctx) noexcept {
+        _deadline = deadline;
+        _timeout_ctx = ctx;
+    }
+    seastar::lowres_clock::time_point deadline() const noexcept {
+        return _deadline;
+    }
+    const timeout_context& timeout_ctx() const noexcept {
+        return _timeout_ctx;
     }
 
     bytes_ostream extract_body() && {

--- a/transport/server.cc
+++ b/transport/server.cc
@@ -367,6 +367,15 @@ cql_server::cql_server(sharded<cql3::query_processor>& qp, auth::service& auth_s
         sm::make_counter("requests_shed", _stats.requests_shed,
                         sm::description("Holds an incrementing counter with the requests that were shed due to overload (threshold configured via max_concurrent_requests_per_shard). "
                                             "The first derivative of this value shows how often we shed requests due to overload in the \"CQL transport\" component."))(basic_level),
+        sm::make_counter("requests_dropped_due_to_timeout", _stats.requests_dropped_due_to_timeout,
+                        sm::description("Holds an incrementing counter with the responses that were replaced with a timeout error "
+                                            "(ReadTimeout/WriteTimeout) because the request timeout was exceeded while the response "
+                                            "was waiting in the send queue. A growing value indicates send queue backpressure causing "
+                                            "response delivery to exceed the configured request timeout."))(basic_level).set_skip_when_empty(),
+        sm::make_counter("requests_sent_after_timeout", _stats.requests_sent_after_timeout,
+                        sm::description("Holds an incrementing counter with the responses that were sent to the client even though the request timeout "
+                                            "had expired during write/flush. These responses could not be dropped because a partial CQL frame "
+                                            "may already have been written to the socket."))(basic_level).set_skip_when_empty(),
         sm::make_counter("connections_shed", _shed_connections,
             sm::description("Holds an incrementing counter with the CQL connections that were shed due to concurrency semaphore timeout (threshold configured via uninitialized_connections_semaphore_cpu_concurrency). "
                                             "This typically can happen during connection storm. ")),
@@ -559,7 +568,7 @@ cql_server::forward_cql(
     locator::host_id target_host,
     unsigned target_shard,
     seastar::lowres_clock::time_point timeout,
-    bool is_write,
+    timeout_context timeout_ctx,
     uint16_t stream,
     tracing::trace_state_ptr trace_state,
     forward_cql_execute_request req,
@@ -581,21 +590,21 @@ cql_server::forward_cql(
                 if (on_forwarding_finished) {
                     on_forwarding_finished(eptr);
                 }
-                eptr = is_write
+                eptr = timeout_ctx.is_write
                     ? std::make_exception_ptr(exceptions::mutation_write_timeout_exception(
-                        format("Write request timed out while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, db::write_type::SIMPLE))
+                        format("Write request timed out while forwarding to {}", target_host), timeout_ctx.cl, 0, 0, timeout_ctx.wt))
                     : std::make_exception_ptr(exceptions::read_timeout_exception(
-                        format("Read request timed out while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, false));
+                        format("Read request timed out while forwarding to {}", target_host), timeout_ctx.cl, 0, 0, false));
             } else if (try_catch<seastar::rpc::closed_error>(eptr)) {
                 clogger.debug("Forwarding CQL request to {} shard {} failed due to RPC closed connection. Will return blanket failure exception", target_host, target_shard);
                 if (on_forwarding_finished) {
                     on_forwarding_finished(eptr);
                 }
-                eptr = is_write
+                eptr = timeout_ctx.is_write
                     ? std::make_exception_ptr(exceptions::mutation_write_failure_exception(
-                        format("Write request failed while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, 0, db::write_type::SIMPLE))
+                        format("Write request failed while forwarding to {}", target_host), timeout_ctx.cl, 0, 0, 0, timeout_ctx.wt))
                     : std::make_exception_ptr(exceptions::read_failure_exception(
-                        format("Read request failed while forwarding to {}", target_host), db::consistency_level::ONE, 0, 0, 0, false));
+                        format("Read request failed while forwarding to {}", target_host), timeout_ctx.cl, 0, 0, 0, false));
             } else {
                 clogger.debug("Forwarding CQL request to {} shard {} failed with an unexpected error: {}. Will return this error to the client", target_host, target_shard, eptr);
             }
@@ -604,14 +613,18 @@ cql_server::forward_cql(
 
         auto response = response_fut.get();
         switch (response.status) {
-        case forward_cql_status::success:
+        case forward_cql_status::success: {
             _stats.requests_forwarded_successfully++;
             clogger.trace("Forwarded CQL request executed successfully on replica: {}", target_host);
             tracing::trace(trace_state, "Forwarded CQL request executed successfully on replica: {}", target_host);
             if (on_forwarding_finished) {
                 on_forwarding_finished(current_host);
             }
-            co_return std::make_unique<cql_transport::response>(stream, cql_binary_opcode::RESULT, response.response_flags, std::move(response.response_body));
+            auto result = std::make_unique<cql_transport::response>(stream, cql_binary_opcode::RESULT, response.response_flags, std::move(response.response_body));
+            // The send-queue deadline is applied by the caller (cql_server::process()),
+            // which holds the bounce message carrying timeout()/timeout_ctx().
+            co_return std::move(result);
+        }
         case forward_cql_status::error: {
             _stats.requests_forwarded_failed++;
             clogger.trace("Forwarded CQL request failed on replica: {}", target_host);
@@ -1285,6 +1298,8 @@ future<> cql_server::connection::process_request() {
           semaphore_units<> mem_permit = mem_permit_fut.get();
           return this->read_and_decompress_frame(length, flags).then([this, op, stream, flags, tracing_requested, mem_permit = make_service_permit(std::move(mem_permit)), request_start_time, request_start_timestamp] (fragmented_temporary_buffer buf) mutable {
 
+            mem_permit.set_start_time(request_start_time);
+
             ++_server._stats.requests_served;
             ++_server._stats.requests_serving;
             ++_server.get_cql_sg_stats()._requests_serving;
@@ -1560,7 +1575,8 @@ future<std::unique_ptr<cql_server::response>> cql_server::connection::process_op
 
 std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
-        cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata = false);
+        cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata = false,
+        const service_permit& permit = empty_service_permit());
 
 static inline cql_server::result_with_foreign_response_ptr convert_error_message_to_coordinator_result(messages::result_message* msg) {
     return std::move(*dynamic_cast<messages::result_message::exception*>(msg)).get_exception();
@@ -1616,7 +1632,7 @@ process_query_internal(service::client_state& client_state, sharded<cql3::query_
         } else {
             tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
 
-            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, cql_metadata_id_wrapper{}, skip_metadata)));
+            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, cql_metadata_id_wrapper{}, skip_metadata, q_state->query_state.get_permit())));
         }
     });
 }
@@ -1734,7 +1750,7 @@ process_execute_internal(service::client_state& client_state, sharded<cql3::quer
             return cql_server::process_fn_return_type(convert_error_message_to_coordinator_result(msg.get()));
         } else {
             tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
-            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, std::move(metadata_id), skip_metadata)));
+            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, q_state->query_state.get_trace_state(), version, std::move(metadata_id), skip_metadata, q_state->query_state.get_permit())));
         }
     });
 }
@@ -1876,7 +1892,7 @@ process_batch_internal(service::client_state& client_state, sharded<cql3::query_
         } else {
             tracing::trace(q_state->query_state.get_trace_state(), "Done processing - preparing a result");
 
-            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, trace_state, version, cql_metadata_id_wrapper{})));
+            return cql_server::process_fn_return_type(make_foreign(make_result(stream, *msg, trace_state, version, cql_metadata_id_wrapper{}, false, q_state->query_state.get_permit())));
         }
     });
 }
@@ -1930,14 +1946,22 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
             auto sg = _config.bounce_request_smp_service_group;
             auto gcs = client_state.move_to_other_shard();
             auto gt = tracing::global_trace_state_ptr(trace_state);
-            msg = co_await container().invoke_on(shard, sg, [&, stream, dialect, version, request_start_timestamp] (cql_server& server) -> future<process_fn_return_type> {
+            // The service_permit can't cross shards, so carry the request start
+            // time by value and apply it to a fresh permit on the target shard,
+            // so its response participates in send-queue accounting.
+            auto start_time = permit.start_time();
+            msg = co_await container().invoke_on(shard, sg, [&, stream, dialect, version, request_start_timestamp, start_time] (cql_server& server) -> future<process_fn_return_type> {
                 bytes_ostream linearization_buffer;
                 request_reader in(is, linearization_buffer);
                 auto local_client_state = gcs.get(&server._abort_source);
                 auto local_trace_state = gt.get();
                 auto& local_sg_stats = server.get_cql_sg_stats();
+                /* FIXME */ auto local_permit = empty_service_permit();
+                if (start_time) {
+                    local_permit.set_start_time(*start_time);
+                }
                 co_return co_await process_fn(local_client_state, server._query_processor, in, stream, version,
-                        /* FIXME */empty_service_permit(), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp);
+                        std::move(local_permit), std::move(local_trace_state), false, cached_vals, dialect, local_sg_stats, request_start_timestamp);
             });
         } else {
             // Node bounce
@@ -1961,9 +1985,26 @@ cql_server::process(uint16_t stream, request_reader in, service::client_state& c
                 .cached_fn_calls = std::move(cached_fn_calls),
             };
 
+            // bounce timeout() is anchored at redirect time; re-anchor to request
+            // receipt (start_time + timeout) by subtracting elapsed time, so the
+            // forwarded response gets no more time than a local one. Internal
+            // requests have no start time; keep the bounce timeout.
+            auto request_deadline = (*bounce_msg)->timeout().value();
+            if (auto start = permit.start_time()) {
+                request_deadline -= db::timeout_clock::now() - *start;
+            }
+            // Carried on the bounce; types both the RPC error and the send-queue error.
+            auto timeout_ctx = (*bounce_msg)->timeout_ctx().value();
+
             auto response = co_await forward_cql(
-                target_host, shard, (*bounce_msg)->timeout().value(), (*bounce_msg)->is_write().value(),
+                target_host, shard, (*bounce_msg)->timeout().value(), timeout_ctx,
                 stream, trace_state, std::move(req), (*bounce_msg)->on_forwarding_finished());
+
+            // Apply the request deadline + context to the forwarded response so the
+            // send queue can drop it if it expired, as for local statements.
+            if (response && response->opcode() == cql_binary_opcode::RESULT) {
+                response->set_deadline(request_deadline, timeout_ctx);
+            }
 
             co_return cql_server::result_with_foreign_response_ptr(std::move(response));
         }
@@ -2150,7 +2191,8 @@ public:
 
 std::unique_ptr<cql_server::response>
 make_result(int16_t stream, messages::result_message& msg, const tracing::trace_state_ptr& tr_state,
-        cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata) {
+        cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata,
+        const service_permit& permit) {
     auto response = std::make_unique<cql_server::response>(stream, cql_binary_opcode::RESULT, tr_state);
     if (!msg.warnings().empty() && version > 3) [[unlikely]] {
         response->set_frame_flag(cql_frame_flags::warning);
@@ -2162,6 +2204,8 @@ make_result(int16_t stream, messages::result_message& msg, const tracing::trace_
     }
     cql_server::fmt_visitor fmt{version, *response, skip_metadata, std::move(metadata_id)};
     msg.accept(fmt);
+    // Carry the permit's deadline + context so write_response can drop an expired response.
+    response->set_deadline(permit.deadline(), permit.timeout_ctx());
     return response;
 }
 
@@ -2206,9 +2250,63 @@ cql_server::connection::make_client_routes_change_event(const event::client_rout
 void cql_server::connection::write_response(foreign_ptr<std::unique_ptr<cql_server::response>>&& response, cql_compression compression)
 {
     _ready_to_respond = _ready_to_respond.then([this, compression, response = std::move(response)] () mutable {
-        cql_server::response& r = *response;
-        auto del = make_deleter([response = std::move(response)] {});
-        return r.write_message(_write_buf, _version, compression, std::move(del));
+        auto do_write = [this, compression, response = std::move(response)] () mutable {
+            auto deadline = response->deadline();
+            // Replace a successful RESULT that exceeded its request timeout while
+            // waiting in the send queue with a typed ReadTimeout/WriteTimeout:
+            // expired responses otherwise block fresher ones, and the client is
+            // freed immediately with a proper CQL error. Error responses are sent
+            // as-is (they carry diagnostics); a max() deadline is a no-op.
+            if (response->opcode() == cql_binary_opcode::RESULT && db::timeout_clock::now() > deadline) {
+                ++_server._stats.requests_dropped_due_to_timeout;
+                auto stream = response->stream();
+                auto ctx = response->timeout_ctx();
+                response = {};
+                std::unique_ptr<cql_server::response> err;
+                sstring msg = "Request timeout exceeded while response was waiting in send queue";
+                // received=0, blockfor=1 (data_present=false for reads) report a
+                // timeout where no replica acked. We don't keep the real counts
+                // (the op completed; the response just expired here), and these
+                // values make the default driver retry policies treat the error as
+                // non-retriable: reads retry only when received >= blockfor, writes
+                // key off write_type (only BATCH_LOG, never reported here). So the
+                // client isn't pushed into a retry storm for an already-executed request.
+                //
+                // Empty trace_state: the original request is already recorded; the
+                // replacement error is a synthetic transport artifact, not traced.
+                if (ctx.is_write) {
+                    err = _server.make_mutation_write_timeout_error(stream,
+                            exceptions::exception_code::WRITE_TIMEOUT, std::move(msg),
+                            ctx.cl, 0, 1, ctx.wt, tracing::trace_state_ptr());
+                } else {
+                    err = _server.make_read_timeout_error(stream,
+                            exceptions::exception_code::READ_TIMEOUT, std::move(msg),
+                            ctx.cl, 0, 1, false, tracing::trace_state_ptr());
+                }
+                cql_server::response& r = *err;
+                auto del = make_deleter([err = std::move(err)] {});
+                return r.write_message(_write_buf, _version, compression, std::move(del));
+            }
+            cql_server::response& r = *response;
+            auto del = make_deleter([response = std::move(response)] {});
+            auto write_fut = r.write_message(_write_buf, _version, compression, std::move(del));
+            if (deadline == db::timeout_clock::time_point::max()) {
+                return write_fut;
+            }
+            // Account for responses that expired during write_message()/flush().
+            // We cannot abort mid-write without corrupting the CQL binary
+            // protocol framing, so these are sent but tracked separately.
+            return std::move(write_fut).then([this, deadline] {
+                if (db::timeout_clock::now() > deadline) {
+                    ++_server._stats.requests_sent_after_timeout;
+                }
+            });
+        };
+        // The injection runs before the deadline check so tests can hold a
+        // ready response in this connection's send queue until it expires.
+        // inject() is a zero-cost no-op when error injection is compiled out.
+        return utils::get_local_injector().inject("transport_write_response_delay",
+                utils::wait_for_message(60s)).then(std::move(do_write));
     });
 }
 
@@ -2225,7 +2323,14 @@ future<> cql_server::response::write_message(output_stream<char>& out, uint8_t v
             temporary_buffer<char> buf(reinterpret_cast<char*>(const_cast<signed char*>(fragment.data())), fragment.size(), del.share());
             return out.write(std::move(buf));
         }).then([&out] {
-            return out.flush();
+            // Inject a delay before flush() so tests can expire a response during
+            // write/flush. The frame header and body are already in the output
+            // buffer, so the response can't be dropped here.
+            // inject() is a zero-cost no-op when error injection is compiled out.
+            return utils::get_local_injector().inject("transport_pre_flush_delay",
+                    utils::wait_for_message(60s)).then([&out] {
+                return out.flush();
+            });
         });
     });
 }

--- a/transport/server.hh
+++ b/transport/server.hh
@@ -220,6 +220,8 @@ private:
         uint32_t requests_serving = 0;
         uint64_t requests_blocked_memory = 0;
         uint64_t requests_shed = 0;
+        uint64_t requests_dropped_due_to_timeout = 0;
+        uint64_t requests_sent_after_timeout = 0;
         // forwarding stats
         uint64_t requests_forwarded_successfully = 0;
         uint64_t requests_forwarded_failed = 0;
@@ -284,7 +286,8 @@ private:
     class fmt_visitor;
     friend class connection;
     friend std::unique_ptr<cql_server::response> make_result(int16_t stream, messages::result_message& msg,
-            const tracing::trace_state_ptr& tr_state, cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata);
+            const tracing::trace_state_ptr& tr_state, cql_protocol_version_type version, cql_metadata_id_wrapper&& metadata_id, bool skip_metadata,
+            const service_permit& permit);
 
     static std::unique_ptr<cql_server::response> make_unavailable_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t required, int32_t alive, const tracing::trace_state_ptr& tr_state);
     static std::unique_ptr<cql_server::response> make_read_timeout_error(int16_t stream, exceptions::exception_code err, sstring msg, db::consistency_level cl, int32_t received, int32_t blockfor, bool data_present, const tracing::trace_state_ptr& tr_state);
@@ -393,7 +396,7 @@ private:
     future<forward_cql_execute_response> handle_forward_execute(service::query_state& qs, forward_cql_execute_request& req);
 
     future<foreign_ptr<std::unique_ptr<cql_transport::response>>> forward_cql(locator::host_id target_host, unsigned target_shard, seastar::lowres_clock::time_point timeout,
-            bool is_write, uint16_t stream, tracing::trace_state_ptr trace_state, forward_cql_execute_request req,
+            timeout_context timeout_ctx, uint16_t stream, tracing::trace_state_ptr trace_state, forward_cql_execute_request req,
             const locator::host_id_or_exception_callback& on_forwarding_finished = {});
 
     virtual shared_ptr<generic_server::connection> make_connection(socket_address server_addr, connected_socket&& fd, socket_address addr, named_semaphore& sem, semaphore_units<named_semaphore_exception_factory> initial_sem_units) override;


### PR DESCRIPTION
Extend request timeout accounting to include the time a CQL response
spends waiting in the send queue before being written to the OS socket.
Currently, responses that have already exceeded their request timeout
remain in the send queue, blocking fresher responses behind them and
causing a cascade of timeouts. With this change, the transport layer
checks the request deadline before writing each RESULT response and,
if the deadline has passed, replaces it with a typed
ReadTimeout/WriteTimeout error. This frees the client immediately with
a proper CQL error instead of leaving it to wait for its driver-side timeout.

Additionally, responses that expire during write/flush (where we cannot
abort without corrupting the CQL binary protocol framing) are tracked
via a separate `requests_sent_after_timeout` metric.

Key design points:
- The request start time is recorded on the service_permit when the request
  is first read. Statement execution stores the computed deadline back on
  the permit.
- CAS paths record the transport deadline via `get_timeout()` so that
  `USING TIMEOUT` is respected
- Error responses are never dropped (they carry diagnostic information)
- The test error injection is behind `SCYLLA_ENABLE_ERROR_INJECTION` to
  avoid overhead in release builds
- Administrative operations (DDL, USE, auth, TRUNCATE, DROP) opt out of
  send-queue timeout accounting, so their responses are always delivered.

Fixes: SCYLLADB-1716

Minor enhancement, no need to backport.

Note that the implementation deliberately replaces expired responses with
a typed timeout error only before starting to write the CQL frame. Enforcing
the timeout after write_message() has started would require aborting/closing
the whole connection, because a partial CQL frame may already have been
written and dropping only that response would corrupt the protocol stream.
Closing the connection could fail unrelated in-flight requests on the same
connection and may amplify retries, so this patch takes the safer approach:
replace already-expired responses with a typed timeout error before they
block fresher responses, and separately account for responses that expire
during write/flush.