### PR TITLE
schema: fix DESCRIBE showing NullCompactionStrategy when compaction is disabled

### DIFF
--- a/schema/schema.cc
+++ b/schema/schema.cc
@@ -1227,7 +1227,7 @@ fragmented_ostringstream& schema::schema_properties(const schema_describe_helper
     map_as_cql_param(os, caching_options().to_map());
     os << "}";
     os << "\n    AND comment = " << cql3::util::single_quote(comment());
-    os << "\n    AND compaction = {'class': '" <<  compaction::compaction_strategy::name(compaction_strategy()) << "'";
+    os << "\n    AND compaction = {'class': '" <<  compaction::compaction_strategy::name(configured_compaction_strategy()) << "'";
     map_as_cql_param(os, compaction_strategy_options(), false) << "}";
     os << "\n    AND compression = {";
     map_as_cql_param(os,  get_compressor_params().get_options());

--- a/test/cqlpy/test_compaction_strategy_validation.py
+++ b/test/cqlpy/test_compaction_strategy_validation.py
@@ -57,6 +57,19 @@ def test_incremental_compaction_strategy_options(cql, table1, scylla_only):
     assert_throws(cql, table1, r"space_amplification_goal value \(2.2\) must be greater than 1.0 and less than or equal to 2.0", "ALTER TABLE %s WITH compaction = { 'class' : 'IncrementalCompactionStrategy', 'space_amplification_goal' : 2.2 }")
     assert_throws(cql, table1, r"min_threshold value \(1\) must be bigger or equal to 2", "ALTER TABLE %s WITH compaction = { 'class' : 'IncrementalCompactionStrategy', 'min_threshold' : 1 }")
 
+# Reproducer for https://github.com/scylladb/scylladb/issues/SCYLLADB-1353
+# When compaction is disabled via 'enabled': 'false', DESCRIBE should still
+# show the actual compaction strategy class, not NullCompactionStrategy.
+def test_describe_shows_real_strategy_when_disabled(cql, test_keyspace):
+    with new_test_table(cql, test_keyspace, "a int PRIMARY KEY, b int",
+                        "WITH compaction = {'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': '160'}") as table:
+        # Disable compaction
+        cql.execute(f"ALTER TABLE {table} WITH compaction = {{'class': 'LeveledCompactionStrategy', 'sstable_size_in_mb': '160', 'enabled': 'false'}}")
+        # DESCRIBE should show LeveledCompactionStrategy, not NullCompactionStrategy
+        desc = cql.execute(f"DESCRIBE TABLE {table}").one().create_statement
+        assert 'LeveledCompactionStrategy' in desc, f"Expected LeveledCompactionStrategy in DESCRIBE output but got: {desc}"
+        assert 'NullCompactionStrategy' not in desc, f"NullCompactionStrategy should not appear in DESCRIBE output but got: {desc}"
+
 def test_not_allowed_options(cql, table1):
     def scylla_error(**kwargs):
         template = "Invalid compaction strategy options {{{}}} for chosen strategy type"


### PR DESCRIPTION
When a table's compaction is disabled via 'enabled': 'false', the DESCRIBE output incorrectly showed NullCompactionStrategy instead of the actual strategy. This happened because schema_properties() called compaction_strategy(), which returns compaction_strategy_type::null when compaction is disabled. Fix it by using configured_compaction_strategy(), which always returns the real strategy type - consistent with how schema_tables.cc serializes it to disk.

Fixes SCYLLADB-1353

Backport: bug is present since describe was introduced, need backport to all releases.